### PR TITLE
EVAKA-3885: new output mode for occupancy report

### DIFF
--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -1724,7 +1724,8 @@ export const fi = {
         valueOnReport: 'Näytä tiedot',
         valuesOnReport: {
           percentage: 'Prosentteina',
-          headcount: 'Lukumääränä'
+          headcount: 'Lukumääränä',
+          raw: 'Summa ja kasvattajamäärä erikseen'
         }
       },
       average: 'Keskiarvo'

--- a/frontend/packages/employee-frontend/src/components/reports/Occupancies.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/Occupancies.tsx
@@ -149,12 +149,12 @@ function getDisplayCells(
         const occupancy = row.occupancies[formatDate(date, DATE_FORMAT_ISO)]
         cells.push(
           typeof occupancy?.sum === 'number'
-            ? `${occupancy.sum.toFixed(1).replace('.', ',')} %`
+            ? occupancy.sum.toFixed(1).replace('.', ',')
             : '0'
         )
         cells.push(
           typeof occupancy?.caretakers === 'number'
-            ? `${occupancy.caretakers.toFixed(1).replace('.', ',')} %`
+            ? occupancy.caretakers.toFixed(1).replace('.', ',')
             : '0'
         )
       }

--- a/frontend/packages/employee-frontend/src/components/reports/Occupancies.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/Occupancies.tsx
@@ -96,7 +96,7 @@ function getFilename(
   return `${prefix}-${time}-${careAreaName}.csv`.replace(/ /g, '_')
 }
 
-type ValueOnReport = 'percentage' | 'headcount'
+type ValueOnReport = 'percentage' | 'headcount' | 'raw'
 
 function getOccupancyAverage(
   row: OccupancyReportRow,
@@ -143,36 +143,54 @@ function getDisplayCells(
   usedValues: ValueOnReport
 ): string[][] {
   return reportRows.map((row) => {
-    const average =
-      usedValues === 'headcount'
-        ? getHeadCountAverage(row, dates)
-        : getOccupancyAverage(row, dates)
-
-    const roundedAverage =
-      average !== null ? Math.round(10 * average) / 10 : undefined
-
-    return [
-      row.unitName,
-      row.groupName,
-
-      // average
-      (usedValues === 'percentage'
-        ? formatPercentage(roundedAverage)
-        : formatDecimal(roundedAverage)) ?? '',
-
-      // daily values
-      ...dates.map((date) => {
+    if (usedValues === 'raw') {
+      const cells: string[] = []
+      for (const date of dates) {
         const occupancy = row.occupancies[formatDate(date, DATE_FORMAT_ISO)]
+        cells.push(
+          typeof occupancy?.sum === 'number'
+            ? `${occupancy.sum.toFixed(1).replace('.', ',')} %`
+            : '0'
+        )
+        cells.push(
+          typeof occupancy?.caretakers === 'number'
+            ? `${occupancy.caretakers.toFixed(1).replace('.', ',')} %`
+            : '0'
+        )
+      }
+      return cells
+    } else {
+      const average =
+        usedValues === 'headcount'
+          ? getHeadCountAverage(row, dates)
+          : getOccupancyAverage(row, dates)
 
-        if (usedValues === 'percentage') {
-          return typeof occupancy?.percentage === 'number'
-            ? formatPercentage(occupancy.percentage)
-            : ''
-        } else {
-          return occupancy?.[usedValues] ?? ''
-        }
-      })
-    ].filter((cell) => cell !== undefined) as string[]
+      const roundedAverage =
+        average !== null ? Math.round(10 * average) / 10 : undefined
+
+      return [
+        row.unitName,
+        row.groupName,
+
+        // average
+        (usedValues === 'percentage'
+          ? formatPercentage(roundedAverage)
+          : formatDecimal(roundedAverage)) ?? '',
+
+        // daily values
+        ...dates.map((date) => {
+          const occupancy = row.occupancies[formatDate(date, DATE_FORMAT_ISO)]
+
+          if (usedValues === 'percentage') {
+            return typeof occupancy?.percentage === 'number'
+              ? formatPercentage(occupancy.percentage)
+              : ''
+          } else {
+            return occupancy?.[usedValues] ?? ''
+          }
+        })
+      ].filter((cell) => cell !== undefined) as string[]
+    }
   })
 }
 
@@ -203,6 +221,11 @@ function Occupancies() {
   const displayCells: string[][] = isSuccess(rows)
     ? getDisplayCells(rows.data, dates, usedValues)
     : []
+  const dateCols = dates.reduce((cols, date) => {
+    cols.push(date)
+    if (usedValues === 'raw') cols.push(date)
+    return cols
+  }, [] as Date[])
 
   const includeGroups = filters.type.startsWith('GROUP_')
 
@@ -302,21 +325,23 @@ function Occupancies() {
             <ReactSelect
               options={[
                 {
-                  value: 'percentage',
+                  value: 'percentage' as ValueOnReport,
                   label:
                     i18n.reports.occupancies.filters.valuesOnReport.percentage
                 },
                 {
-                  value: 'headcount',
+                  value: 'headcount' as ValueOnReport,
                   label:
                     i18n.reports.occupancies.filters.valuesOnReport.headcount
+                },
+                {
+                  value: 'raw' as ValueOnReport,
+                  label: i18n.reports.occupancies.filters.valuesOnReport.raw
                 }
               ]}
               onChange={(value) => {
                 if (value && 'value' in value) {
-                  setUsedValues(
-                    value.value === 'headcount' ? 'headcount' : 'percentage'
-                  )
+                  setUsedValues(value.value)
                 }
               }}
               styles={reactSelectStyles}
@@ -332,8 +357,10 @@ function Occupancies() {
                 [
                   i18n.reports.common.unitName,
                   includeGroups ? i18n.reports.common.groupName : undefined,
-                  i18n.reports.occupancies.average,
-                  ...dates.map((date) => formatDate(date, 'dd.MM.'))
+                  usedValues !== 'raw'
+                    ? i18n.reports.occupancies.average
+                    : undefined,
+                  ...dateCols.map((date) => formatDate(date, 'dd.MM.'))
                 ].filter((label) => label !== undefined),
                 ...displayCells
               ]}
@@ -350,9 +377,11 @@ function Occupancies() {
                 <Tr>
                   <Th>{i18n.reports.common.unitName}</Th>
                   {includeGroups && <Th>{i18n.reports.common.groupName}</Th>}
-                  <Th>{i18n.reports.occupancies.average}</Th>
-                  {dates.map((date) => (
-                    <Th key={date.toDateString()}>
+                  {usedValues !== 'raw' && (
+                    <Th>{i18n.reports.occupancies.average}</Th>
+                  )}
+                  {dateCols.map((date, i) => (
+                    <Th key={`${date.toDateString()}:${i}`}>
                       {formatDate(date, 'dd.MM.')}
                     </Th>
                   ))}

--- a/frontend/packages/employee-frontend/src/components/reports/Occupancies.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/Occupancies.tsx
@@ -144,17 +144,19 @@ function getDisplayCells(
 ): string[][] {
   return reportRows.map((row) => {
     if (usedValues === 'raw') {
-      const cells: string[] = []
+      const cells = [row.unitName, row.groupName].filter(
+        (cell) => cell !== undefined
+      ) as string[]
       for (const date of dates) {
         const occupancy = row.occupancies[formatDate(date, DATE_FORMAT_ISO)]
         cells.push(
           typeof occupancy?.sum === 'number'
-            ? occupancy.sum.toFixed(1).replace('.', ',')
+            ? occupancy.sum.toFixed(2).replace('.', ',')
             : '0'
         )
         cells.push(
           typeof occupancy?.caretakers === 'number'
-            ? occupancy.caretakers.toFixed(1).replace('.', ',')
+            ? occupancy.caretakers.toFixed(2).replace('.', ',')
             : '0'
         )
       }
@@ -229,6 +231,9 @@ function Occupancies() {
 
   const includeGroups = filters.type.startsWith('GROUP_')
 
+  const months = monthOptions()
+  const years = yearOptions()
+
   return (
     <Container>
       <ReturnButton />
@@ -239,7 +244,10 @@ function Occupancies() {
           <FlexRow>
             <Wrapper>
               <ReactSelect
-                options={monthOptions()}
+                options={months}
+                value={months.find(
+                  (opt) => opt.value === filters.month.toString()
+                )}
                 onChange={(value) => {
                   if (value && 'value' in value) {
                     const month = parseInt(value.value)
@@ -251,7 +259,10 @@ function Occupancies() {
             </Wrapper>
             <Wrapper>
               <ReactSelect
-                options={yearOptions()}
+                options={years}
+                value={years.find(
+                  (opt) => opt.value === filters.year.toString()
+                )}
                 onChange={(value) => {
                   if (value && 'value' in value) {
                     const year = parseInt(value.value)
@@ -289,6 +300,10 @@ function Occupancies() {
                   label: i18n.reports.occupancies.filters.types.GROUP_REALIZED
                 }
               ]}
+              value={{
+                value: filters.type,
+                label: i18n.reports.occupancies.filters.types[filters.type]
+              }}
               onChange={(value) => {
                 if (value && 'value' in value) {
                   setFilters({
@@ -339,6 +354,11 @@ function Occupancies() {
                   label: i18n.reports.occupancies.filters.valuesOnReport.raw
                 }
               ]}
+              value={{
+                value: usedValues,
+                label:
+                  i18n.reports.occupancies.filters.valuesOnReport[usedValues]
+              }}
               onChange={(value) => {
                 if (value && 'value' in value) {
                   setUsedValues(value.value)


### PR DESCRIPTION
#### Summary
Report now has a mode which outputs capacity sum and caretaker count for each day in separate columns to better support calculating different averages and other statistics from the data.

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
Might be easiest to test in staging env.

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```
