### PR TITLE
Allow unit staff to upsert attendances

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
@@ -54,7 +54,7 @@ class StaffAttendanceController(
     ): ResponseEntity<Unit> {
         Audit.StaffAttendanceUpdate.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
-            .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR)
+            .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR, STAFF)
         if (staffAttendance.count == null) {
             throw BadRequest("Count can't be null")
         }


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

The permissions are too strict, and normal staff should be able to upsert the attendance counts