### PR TITLE
EVAKA-HOTFIX removed test.only that was left in by mistake

### DIFF
--- a/frontend/e2e-test/test/e2e/specs/2_employee-2/paper-application.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/2_employee-2/paper-application.spec.ts
@@ -126,8 +126,7 @@ test('Service worker fills paper application with minimal info and saves it', as
   await t.expect(applicationEditPage.readView.exists).ok()
 })
 
-// eslint-disable-next-line
-test.only('Service worker fills paper application with second guardian contact info and agreement status', async (t) => {
+test('Service worker fills paper application with second guardian contact info and agreement status', async (t) => {
   await childInforationPage.openCreateApplicationModal()
   await childInforationPage.clickCreateApplicationModalCreateApplicationButton()
   await applicationEditPage.fillStartDate(new Date())


### PR DESCRIPTION
#### Summary
Left in `test.only` by mistake. This pr removes this and all tests will be run.