### PR TITLE
Add PostgreSQL leak checking and TCP timeouts

### DIFF
--- a/message-service/buildSrc/src/main/kotlin/Version.kt
+++ b/message-service/buildSrc/src/main/kotlin/Version.kt
@@ -27,7 +27,6 @@ object Version {
     const val postgresDriver = "42.2.14"
     const val springBoot = "2.3.3.RELEASE"
     const val springFox = "2.9.2"
-    const val springCloud = "Greenwich.SR3"
     const val testContainers = "1.14.3"
 
     object GradlePlugin {

--- a/message-service/buildSrc/src/main/kotlin/Version.kt
+++ b/message-service/buildSrc/src/main/kotlin/Version.kt
@@ -24,7 +24,7 @@ object Version {
     const val logstashEncoder = "6.3"
     const val mockito = "3.4.6"
     const val mockitoKotlin = "2.2.0"
-    const val postgresDriver = "42.2.14"
+    const val postgresDriver = "42.2.16"
     const val springBoot = "2.3.3.RELEASE"
     const val springFox = "2.9.2"
     const val testContainers = "1.14.3"

--- a/message-service/src/main/kotlin/fi/espoo/evaka/msg/config/DatabaseConfig.kt
+++ b/message-service/src/main/kotlin/fi/espoo/evaka/msg/config/DatabaseConfig.kt
@@ -60,6 +60,7 @@ class DatabaseConfig {
                 username = dataSourceUsername
                 password = env["voltti.datasource.password"]
                 leakDetectionThreshold = TimeUnit.MINUTES.convert(1, TimeUnit.MILLISECONDS)
+                addDataSourceProperty("socketTimeout", TimeUnit.MINUTES.convert(15, TimeUnit.SECONDS).toInt())
             }
         )
     }

--- a/message-service/src/main/kotlin/fi/espoo/evaka/msg/config/DatabaseConfig.kt
+++ b/message-service/src/main/kotlin/fi/espoo/evaka/msg/config/DatabaseConfig.kt
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.env.Environment
 import org.springframework.core.env.get
+import java.util.concurrent.TimeUnit
 import javax.sql.DataSource
 
 @Configuration
@@ -58,6 +59,7 @@ class DatabaseConfig {
                 jdbcUrl = env["voltti.datasource.url"]
                 username = dataSourceUsername
                 password = env["voltti.datasource.password"]
+                leakDetectionThreshold = TimeUnit.MINUTES.convert(1, TimeUnit.MILLISECONDS)
             }
         )
     }

--- a/service/buildSrc/src/main/kotlin/Version.kt
+++ b/service/buildSrc/src/main/kotlin/Version.kt
@@ -27,7 +27,7 @@ object Version {
     const val logstashEncoder = "6.3"
     const val mockito = "3.4.6"
     const val mockitoKotlin = "1.6.0"
-    const val postgresDriver = "42.2.14"
+    const val postgresDriver = "42.2.16"
     const val springBoot = "2.3.3.RELEASE"
     const val testContainers = "1.14.3"
 

--- a/service/buildSrc/src/main/kotlin/Version.kt
+++ b/service/buildSrc/src/main/kotlin/Version.kt
@@ -29,16 +29,11 @@ object Version {
     const val mockitoKotlin = "1.6.0"
     const val postgresDriver = "42.2.14"
     const val springBoot = "2.3.3.RELEASE"
-    const val springCloud = "Greenwich.SR3"
     const val testContainers = "1.14.3"
 
     object GradlePlugin {
         const val detekt = "1.10.0"
         const val ktlint = "9.3.0"
         const val versions = "0.29.0"
-    }
-
-    object Voltti {
-        const val integrationInvoiceCommon = "0.1.9"
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -75,7 +75,7 @@ class DaycareService(
             daycareDAO.deleteGroup(daycareId, groupId)
         }
     } catch (e: UnableToExecuteStatementException) {
-        throw (e.cause as? PSQLException)?.takeIf { it.serverErrorMessage.sqlState == PSQLState.FOREIGN_KEY_VIOLATION.state }
+        throw (e.cause as? PSQLException)?.takeIf { it.serverErrorMessage?.sqlState == PSQLState.FOREIGN_KEY_VIOLATION.state }
             ?.let { Conflict("Cannot delete group which is still referred to from other data") }
             ?: e
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
@@ -44,6 +44,7 @@ class DatabaseConfig {
                 password = env.getRequiredProperty("spring.datasource.password")
                 maximumPoolSize = 20
                 leakDetectionThreshold = TimeUnit.MINUTES.convert(1, TimeUnit.MILLISECONDS)
+                addDataSourceProperty("socketTimeout", TimeUnit.MINUTES.convert(15, TimeUnit.SECONDS).toInt())
             }
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
@@ -12,6 +12,7 @@ import org.jdbi.v3.core.Jdbi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.env.Environment
+import java.util.concurrent.TimeUnit
 import javax.sql.DataSource
 
 @Configuration
@@ -42,6 +43,7 @@ class DatabaseConfig {
                 username = dataSourceUsername
                 password = env.getRequiredProperty("spring.datasource.password")
                 maximumPoolSize = 20
+                leakDetectionThreshold = TimeUnit.MINUTES.convert(1, TimeUnit.MILLISECONDS)
             }
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -79,7 +79,7 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
     jdbi.registerArgument(closedPeriodArgumentFactory)
     jdbi.registerArgument(periodArgumentFactory)
     jdbi.registerArgument(coordinateArgumentFactory)
-    jdbi.registerArgument(indentityArgumentFactory)
+    jdbi.registerArgument(identityArgumentFactory)
     jdbi.registerColumnMapper(ClosedPeriod::class.java, closedPeriodColumnMapper)
     jdbi.registerColumnMapper(Period::class.java, periodColumnMapper)
     jdbi.registerColumnMapper(Coordinate::class.java, coordinateColumnMapper)


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

* upgrade PostgreSQL driver
* borrowed connections longer than 1 minute are considered leaked and will be logged by HikariCP
* PostgreSQL TCP connections with no activity in 15 minutes are timed out -> in practice this sets a maximum limit to query durations, but also reveals connections that are stuck due to network problems and were effectively leaked and never returned to the pool