### PR TITLE
[EVAKA-HOTFIX] Fix ChildInformation title size

### DIFF
--- a/frontend/packages/employee-frontend/src/components/ChildInformation.tsx
+++ b/frontend/packages/employee-frontend/src/components/ChildInformation.tsx
@@ -173,7 +173,7 @@ const ChildInformation = React.memo(function ChildInformation({
       <ContentArea opaque>
         <div className="child-information-wrapper" data-person-id={id}>
           <HeaderRow>
-            <Title size={2}>{i18n.childInformation.title}</Title>
+            <Title size={1}>{i18n.childInformation.title}</Title>
             <div>
               {isSuccess(person) && person.data.restrictedDetailsEnabled && (
                 <WarningLabel text={i18n.childInformation.restrictedDetails} />


### PR DESCRIPTION
#### Summary
- Should be h1 instead of h2, like in PersonProfile and other top-level pages

#### Dependencies
None

#### Testing instructions
1. Run app
1. Looks correct, compared to person profile & reports page

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [x] The change has been tested locally
- [x] The change conforms to the UX specifications
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```