### PR TITLE
EVAKA-3882 Better E2E test development flow

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -55,6 +55,13 @@ Run integration tests (needs to have docker daemon running):
 ./gradlew integrationTest
 ```
 
+To start dev server connected to integration test database (suitable for e.g. running E2E tests without cluttering
+ development data):
+```sh
+./gradlew bootRunTest
+```
+Edit `gradle.properties` to run flyway commands against integration test database.
+
 Run linter autofix:
 
 ```sh

--- a/service/README.md
+++ b/service/README.md
@@ -60,7 +60,7 @@ To start dev server connected to integration test database (suitable for e.g. ru
 ```sh
 ./gradlew bootRunTest
 ```
-Edit `gradle.properties` to run flyway commands against integration test database.
+Enable running flyway commands against integration test database in `gradle.properties`
 
 Run linter autofix:
 

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -193,4 +193,15 @@ tasks {
         // If you want to develop against VTJ, add vtj-dev here
         systemProperty("spring.profiles.active", "local")
     }
+
+    create("bootRunTest", org.springframework.boot.gradle.tasks.run.BootRun::class) {
+        main = "fi.espoo.evaka.MainKt"
+        classpath = sourceSets["main"].runtimeClasspath
+        systemProperty("spring.profiles.active", "local")
+        systemProperty("spring.datasource.url", "jdbc:postgresql://localhost:15432/evaka_it")
+        systemProperty("spring.datasource.username", "evaka_it")
+        systemProperty("spring.datasource.password", "evaka_it")
+        systemProperty("flyway.username", "evaka_it")
+        systemProperty("flyway.password", "evaka_it")
+    }
 }

--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -12,5 +12,12 @@ flyway.password=flyway
 flyway.placeholders.application_user=evaka_application_local
 flyway.placeholders.migration_user=evaka_migration_local
 
+# Properties for integration test DB (comment out above)
+#flyway.url=jdbc:postgresql://localhost:15432/evaka_it
+#flyway.user=evaka_it
+#flyway.password=evaka_it
+#flyway.placeholders.migration_user=evaka_it
+#flyway.placeholders.application_user=evaka_it
+
 org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.unsafe.watch-fs=true


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
Sometimes it was painful to develop E2E tests against dev DB because it was easiest to just clean the database after failed E2E test in order to avoid duplicate data entries when running the test again. But that strategy may have lost some valuable development data (e.g. fee decisions invoices, placements). So:
- Added possibility to run dev server against integration test database
- Added comments to `gradle.properties` to easily configure flyway to take effect in integration test DB

So if you want to develop E2E tests against integration test DB just start the server with `./gradlew bootRunTest`

To clean integration test database:
- edit `gradle.properties` (configs are commented out in the file)
- run `./gradlew flywayClean`
- restart the server