### PR TITLE
[EVAKA-HOTFIX] apigw: fix CI Docker build

### DIFF
--- a/apigw/Dockerfile
+++ b/apigw/Dockerfile
@@ -5,17 +5,19 @@
 FROM evaka-base:latest
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG NODEJS_PACKAGE=nodejs_12.18.4-deb-1nodesource1_amd64.deb
 
 USER root
 RUN set -euxo pipefail \
     && apt-get update && apt-get -y --no-install-recommends install \
        curl=7.68.* \
        gnupg2=2.2.* \
-    && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && curl -O "https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/${NODEJS_PACKAGE}" \
+    && apt-get -y --no-install-recommends install "./${NODEJS_PACKAGE}" \
+    && rm "$NODEJS_PACKAGE" \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update && apt-get -y --no-install-recommends install \
-       nodejs \
        yarn=1.22.* \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
#### Summary
- There is some weird issue that results in 'EPERM: operation not permitted' _only_ in CI
  - Testing if pinning nodejs to a version that was known to build succesfully works

#### Dependencies
None

#### Testing instructions
1. CI Docker build works
1. Local Docker build works

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] The code is consistent with the existing code base
- ~[ ] Tests have been written for the change (e2e, integration tests)~
- [x] The change has been tested locally
- ~[ ] The change conforms to the UX specifications~
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```