### PR TITLE
[EVAKA-HOTFIX] CI: Upgrade Docker engine to 19.03.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ aliases:
   - &yarn_cache .yarn_cache
   # SSH key fingerprint for checking out other eVaka repositories
   - &ci_evaka_fingerprint 86:d0:b3:3d:aa:fc:d5:b9:6b:69:1e:c7:f5:56:66:aa
+  # Version of remote Docker engine used with setup_remote_docker (not including machine executors)
+  - &remote_docker_version '19.03.13'
   - &ubuntu_machine_image ubuntu-1604:201903-01
   - &builder_aws_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:1a7e0dec664ec27fa49d3eb76992be870c3f5b99
 
@@ -481,7 +483,8 @@ jobs:
     steps:
       - *restore_repo
       - *attach_workspace
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: *remote_docker_version
       - run:
           name: Build base image
           working_directory: *workspace_evaka_base
@@ -523,7 +526,8 @@ jobs:
     steps:
       - *restore_repo
       - *attach_workspace
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: *remote_docker_version
       - load_base_image
       - build_docker_image:
           image: evaka/api-gateway
@@ -538,7 +542,8 @@ jobs:
     executor: aws_executor
     steps:
       - *attach_workspace
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: *remote_docker_version
       - push_docker_image:
           image: evaka/api-gateway
           dir: *workspace_apigw
@@ -642,7 +647,8 @@ jobs:
     executor: aws_executor
     steps:
       - *restore_repo
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: *remote_docker_version
       - build_docker_image:
           image: evaka/proxy
           dir: *workspace_proxy
@@ -674,7 +680,8 @@ jobs:
     steps:
       - *restore_repo
       - *attach_workspace
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: *remote_docker_version
       - run:
           name: Unzip executable
           working_directory: *workspace_service
@@ -716,7 +723,8 @@ jobs:
     steps:
       - *restore_repo
       - *attach_workspace
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: *remote_docker_version
       - push_docker_image:
           image: evaka/service
           dir: *workspace_service
@@ -765,7 +773,8 @@ jobs:
     steps:
       - *restore_repo
       - *attach_workspace
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: *remote_docker_version
       - run:
           name: Unzip executable
           working_directory: *workspace_message_service

--- a/apigw/Dockerfile
+++ b/apigw/Dockerfile
@@ -5,19 +5,17 @@
 FROM evaka-base:latest
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG NODEJS_PACKAGE=nodejs_12.18.4-deb-1nodesource1_amd64.deb
 
 USER root
 RUN set -euxo pipefail \
     && apt-get update && apt-get -y --no-install-recommends install \
        curl=7.68.* \
        gnupg2=2.2.* \
-    && curl -O "https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/${NODEJS_PACKAGE}" \
-    && apt-get -y --no-install-recommends install "./${NODEJS_PACKAGE}" \
-    && rm "$NODEJS_PACKAGE" \
+    && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update && apt-get -y --no-install-recommends install \
+       nodejs \
        yarn=1.22.* \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
#### Summary
Reverts hotfix in #21

- CI: upgrade _remote_ Docker engine to 19.03.13
  - CircleCI remote Docker engine [defaults to 17.09.0-ce](https://circleci.com/docs/2.0/configuration-reference/#setup_remote_docker), explicitly upgrade to [19.03.13](https://circleci.com/docs/2.0/building-docker-images/#docker-version)
- **NOTE:** Still haven't figured out what the exact issue is with the `nodejs` + Docker engine version combination is but this at least fixes the situation and allows us to still use the latest 12.x Node.js releases
  - Related: <https://discuss.circleci.com/t/docker-build-fails-with-nonsensical-eperm-operation-not-permitted-copyfile/37364/12> and <https://discuss.circleci.com/t/cgo-docker-build-failing-at-link-stage-operation-not-permitted/37100>

#### Dependencies
None

#### Testing instructions
None

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] The code is consistent with the existing code base
- ~[ ] Tests have been written for the change (e2e, integration tests)~
- [x] The change has been tested locally
- ~[ ] The change conforms to the UX specifications~
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```