### PR TITLE
Fix pool configuration parameters

### DIFF
--- a/message-service/src/main/kotlin/fi/espoo/evaka/msg/config/DatabaseConfig.kt
+++ b/message-service/src/main/kotlin/fi/espoo/evaka/msg/config/DatabaseConfig.kt
@@ -59,8 +59,8 @@ class DatabaseConfig {
                 jdbcUrl = env["voltti.datasource.url"]
                 username = dataSourceUsername
                 password = env["voltti.datasource.password"]
-                leakDetectionThreshold = TimeUnit.MINUTES.convert(1, TimeUnit.MILLISECONDS)
-                addDataSourceProperty("socketTimeout", TimeUnit.MINUTES.convert(15, TimeUnit.SECONDS).toInt())
+                leakDetectionThreshold = TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES)
+                addDataSourceProperty("socketTimeout", TimeUnit.SECONDS.convert(15, TimeUnit.MINUTES).toInt())
             }
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
@@ -43,8 +43,8 @@ class DatabaseConfig {
                 username = dataSourceUsername
                 password = env.getRequiredProperty("spring.datasource.password")
                 maximumPoolSize = 20
-                leakDetectionThreshold = TimeUnit.MINUTES.convert(1, TimeUnit.MILLISECONDS)
-                addDataSourceProperty("socketTimeout", TimeUnit.MINUTES.convert(15, TimeUnit.SECONDS).toInt())
+                leakDetectionThreshold = TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES)
+                addDataSourceProperty("socketTimeout", TimeUnit.SECONDS.convert(15, TimeUnit.MINUTES).toInt())
             }
         )
     }


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

Fix time unit order in conversions (correct form is `destUnit.convert(src, srcUnit)`) :facepalm: 
Both parameters ended up being 0 (disabled) because of this mistake.