### PR TITLE
EVAKA 3941 add parttime and fulltime info to application in employee frontend

### DIFF
--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -168,7 +168,7 @@ export const fi = {
       name: 'Lapsen nimi/hetu',
       dueDate: 'Käsiteltävä',
       startDate: 'Aloitus',
-      unit: 'Yksikkö',
+      preferredUnits: 'Toive',
       status: 'Tila',
       basis: 'Perusteet',
       lessthan3: 'Alle 3-vuotias hoidontarpeen alkaessa',
@@ -287,7 +287,10 @@ export const fi = {
       preparatoryValue: 'Haen myös valmistavaan opetukseen',
       assistanceLabel: 'Tuen tarve',
       assistanceValue: 'Lapsella on tuen tarve',
-      assistanceDesc: 'Tuen tarpeen kuvaus'
+      assistanceDesc: 'Tuen tarpeen kuvaus',
+      partTime: 'Osa-aikainen',
+      fullTime: 'Kokoaikainen',
+      partTimeLabel: 'Osa- tai kokoaikainen'
     },
     clubDetails: {
       wasOnClubCareLabel: 'Kerhossa edellisenä toimintakautena',
@@ -1724,8 +1727,7 @@ export const fi = {
         valueOnReport: 'Näytä tiedot',
         valuesOnReport: {
           percentage: 'Prosentteina',
-          headcount: 'Lukumääränä',
-          raw: 'Summa ja kasvattajamäärä erikseen'
+          headcount: 'Lukumääränä'
         }
       },
       average: 'Keskiarvo'

--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -168,7 +168,7 @@ export const fi = {
       name: 'Lapsen nimi/hetu',
       dueDate: 'Käsiteltävä',
       startDate: 'Aloitus',
-      preferredUnits: 'Toive',
+      unit: 'Yksikkö',
       status: 'Tila',
       basis: 'Perusteet',
       lessthan3: 'Alle 3-vuotias hoidontarpeen alkaessa',
@@ -1727,7 +1727,8 @@ export const fi = {
         valueOnReport: 'Näytä tiedot',
         valuesOnReport: {
           percentage: 'Prosentteina',
-          headcount: 'Lukumääränä'
+          headcount: 'Lukumääränä',
+          raw: 'Summa ja kasvattajamäärä erikseen'
         }
       },
       average: 'Keskiarvo'

--- a/frontend/packages/employee-frontend/src/components/application-page/ApplicationEditView.tsx
+++ b/frontend/packages/employee-frontend/src/components/application-page/ApplicationEditView.tsx
@@ -154,6 +154,33 @@ export default React.memo(function ApplicationEditView({
                 }
                 dataQa="checkbox-urgent"
               />
+
+              {serviceNeed !== null && (
+                <>
+                  <Label>{i18n.application.serviceNeed.partTimeLabel}</Label>
+                  <div>
+                    <Radio
+                      label={i18n.application.serviceNeed.partTime}
+                      checked={serviceNeed.partTime === true}
+                      onChange={() => {
+                        setApplication(
+                          set('form.preferences.serviceNeed.partTime', true)
+                        )
+                      }}
+                    />
+                    <Gap size="xs" />
+                    <Radio
+                      label={i18n.application.serviceNeed.fullTime}
+                      checked={serviceNeed.partTime === false}
+                      onChange={() => {
+                        setApplication(
+                          set('form.preferences.serviceNeed.partTime', false)
+                        )
+                      }}
+                    />
+                  </div>
+                </>
+              )}
             </>
           )}
 

--- a/frontend/packages/employee-frontend/src/components/application-page/ApplicationReadView.tsx
+++ b/frontend/packages/employee-frontend/src/components/application-page/ApplicationReadView.tsx
@@ -136,6 +136,17 @@ function ApplicationReadView({
                 value={urgent}
                 selectedLabel={i18n.application.serviceNeed.urgentValue}
               />
+
+              {serviceNeed !== null && (
+                <>
+                  <Label>{i18n.application.serviceNeed.partTimeLabel}</Label>
+                  {serviceNeed.partTime ? (
+                    <span>{i18n.application.serviceNeed.partTime}</span>
+                  ) : (
+                    <span>{i18n.application.serviceNeed.fullTime}</span>
+                  )}
+                </>
+              )}
             </>
           )}
 


### PR DESCRIPTION
#### Summary

Application was missing the info if the application was a part time or full time application. This PR adds the missing info to the read and edit views.