### PR TITLE
Add provider type to Koski study rights when required

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.koski
 
+import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.derivePreschoolTerm
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import org.jdbi.v3.core.mapper.Nested
@@ -26,6 +27,7 @@ data class KoskiChildRaw(
 
 data class KoskiUnitRaw(
     val daycareLanguage: String,
+    val daycareProviderType: ProviderType,
     val ophUnitOid: String,
     val ophOrganizationOid: String,
     val ophOrganizerOid: String
@@ -48,6 +50,13 @@ data class KoskiUnitRaw(
         suorituskieli = Suorituskieli(daycareLanguage.toUpperCase()),
         tyyppi = SuorituksenTyyppi(SuorituksenTyyppiKoodi.PRESCHOOL)
     )
+    fun haeJärjestämisMuoto() = when (daycareProviderType) {
+        ProviderType.PURCHASED -> Järjestämismuoto(JärjestämismuotoKoodi.PURCHASED)
+        ProviderType.PRIVATE_SERVICE_VOUCHER -> Järjestämismuoto(JärjestämismuotoKoodi.PRIVATE_SERVICE_VOUCHER)
+        ProviderType.MUNICIPAL -> null
+        ProviderType.PRIVATE -> null
+        ProviderType.MUNICIPAL_SCHOOL -> null
+    }
 }
 
 data class KoskiVoidedDataRaw(
@@ -78,7 +87,8 @@ data class KoskiVoidedDataRaw(
             lähdejärjestelmä = Lähdejärjestelmä(koodiarvo = sourceSystem)
         ),
         tyyppi = OpiskeluoikeudenTyyppi(type),
-        lisätiedot = null
+        lisätiedot = null,
+        järjestämismuoto = unit.haeJärjestämisMuoto()
     )
 }
 
@@ -189,7 +199,8 @@ data class KoskiActiveDataRaw(
                 lähdejärjestelmä = Lähdejärjestelmä(koodiarvo = sourceSystem)
             ),
             tyyppi = OpiskeluoikeudenTyyppi(type),
-            lisätiedot = if (type == OpiskeluoikeudenTyyppiKoodi.PREPARATORY) null else haeLisätiedot()
+            lisätiedot = if (type == OpiskeluoikeudenTyyppiKoodi.PREPARATORY) null else haeLisätiedot(),
+            järjestämismuoto = unit.haeJärjestämisMuoto()
         )
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
@@ -73,6 +73,7 @@ SELECT
     kvsr.*,
     ksr.id AS study_right_id, ksr.study_right_oid,
     d.language AS daycare_language,
+    d.provider_type AS daycare_provider_type,
     pr.social_security_number ssn,
     pr.first_name,
     pr.last_name
@@ -93,6 +94,7 @@ SELECT
     kasr.*,
     ksr.id AS study_right_id, ksr.study_right_oid,
     d.language AS daycare_language,
+    d.provider_type AS daycare_provider_type,
     um.name AS approver_name,
     pr.social_security_number ssn,
     pr.first_name,

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/Oppija.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/Oppija.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.koski
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import java.time.LocalDate
@@ -33,9 +34,22 @@ data class Suorituskieli(override val koodiarvo: String) :
 data class Lähdejärjestelmä(override val koodiarvo: String) :
     Koodistokoodiviite<String>("lahdejarjestelma")
 
+// https://koski.opintopolku.fi/koski/dokumentaatio/koodisto/vardajarjestamismuoto/latest
+data class Järjestämismuoto(override val koodiarvo: JärjestämismuotoKoodi) :
+    Koodistokoodiviite<JärjestämismuotoKoodi>("vardajarjestamismuoto")
+
 // https://github.com/Opetushallitus/koski/blob/bb25022e3eff22675246eb73f17a1c718c6f07f9/src/main/scala/fi/oph/koski/schema/Koodiviite.scala#L17
 abstract class Koodistokoodiviite<T>(val koodistoUri: String) {
     abstract val koodiarvo: T
+}
+
+// https://koski.opintopolku.fi/koski/dokumentaatio/koodisto/vardajarjestamismuoto/latest
+enum class JärjestämismuotoKoodi {
+    @JsonProperty("JM02")
+    PURCHASED,
+
+    @JsonProperty("JM03")
+    PRIVATE_SERVICE_VOUCHER
 }
 
 // https://koski.opintopolku.fi/koski/dokumentaatio/koodisto/koulutus/latest
@@ -105,7 +119,9 @@ data class Opiskeluoikeus(
     val oid: String?,
     val tyyppi: OpiskeluoikeudenTyyppi,
     val lähdejärjestelmänId: LähdejärjestelmäId,
-    val lisätiedot: Lisätiedot?
+    val lisätiedot: Lisätiedot?,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val järjestämismuoto: Järjestämismuoto?
 )
 
 // https://github.com/Opetushallitus/koski/blob/1f1d05bb80cbac46cd873419975ed421370b5035/src/main/scala/fi/oph/koski/schema/Opiskeluoikeus.scala#L226


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

Apparently the provider affects access control, so it needs to be included when submitting study rights to purchased or voucher daycares