### PR TITLE
EVAKA-HOTFIX fixed broken assistance need in application edit view

### DIFF
--- a/frontend/packages/employee-frontend/src/components/application-page/ApplicationEditView.tsx
+++ b/frontend/packages/employee-frontend/src/components/application-page/ApplicationEditView.tsx
@@ -327,8 +327,10 @@ export default React.memo(function ApplicationEditView({
               <Label>{i18n.application.serviceNeed.assistanceDesc}</Label>
               <TextArea
                 value={child.assistanceDescription}
-                onChange={(value) => {
-                  setApplication(set('form.child.assistanceDescription', value))
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+                  setApplication(
+                    set('form.child.assistanceDescription', e.target.value)
+                  )
                 }}
               />
             </>


### PR DESCRIPTION
#### Summary
Assistance need field was broken when upgrading to new components. This PR fixes the problem (the old component used value directly when the new one uses an event).