### PR TITLE
Evaka 3948 fix dates on applications decision section

### DIFF
--- a/frontend/packages/employee-frontend/src/components/application-page/ApplicationDecisionsSection.tsx
+++ b/frontend/packages/employee-frontend/src/components/application-page/ApplicationDecisionsSection.tsx
@@ -3,25 +3,28 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
+import { Link } from 'react-router-dom'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
 import { faFilePdf, faGavel } from 'icon-set'
 import { Label } from '~components/shared/Typography'
 import CollapsibleSection from '~components/shared/molecules/CollapsibleSection'
 import ListGrid from '~components/shared/layout/ListGrid'
 import { useTranslation } from '~state/i18n'
 import { Decision } from 'types/decision'
-import { Link } from 'react-router-dom'
 import {
   FixedSpaceColumn,
   FixedSpaceRow
 } from 'components/shared/layout/flex-helpers'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import DecisionResponse from 'components/application-page/DecisionResponse'
 import { UUID } from 'types'
+import LocalDate from '@evaka/lib-common/src/local-date'
 
 type Props = {
   applicationId: UUID
   decisions: Decision[]
   reloadApplication: () => void
+  preferredStartDate: LocalDate | null
 }
 
 const isPending = (decision: Decision) => decision.status === 'PENDING'
@@ -38,7 +41,8 @@ const isBlocked = (decisions: Decision[], decision: Decision) =>
 export default React.memo(function ApplicationDecisionsSection({
   applicationId,
   decisions,
-  reloadApplication
+  reloadApplication,
+  preferredStartDate
 }: Props) {
   const { i18n } = useTranslation()
 
@@ -92,6 +96,7 @@ export default React.memo(function ApplicationDecisionsSection({
                       applicationId={applicationId}
                       decision={decision}
                       reloadApplication={reloadApplication}
+                      preferredStartDate={preferredStartDate}
                     />
                   )}
                 </>

--- a/frontend/packages/employee-frontend/src/components/application-page/ApplicationReadView.tsx
+++ b/frontend/packages/employee-frontend/src/components/application-page/ApplicationReadView.tsx
@@ -450,6 +450,9 @@ function ApplicationReadView({
       <ApplicationDecisionsSection
         applicationId={application.application.id}
         decisions={decisions}
+        preferredStartDate={
+          application.application.form.preferences.preferredStartDate
+        }
         reloadApplication={reloadApplication}
       />
 

--- a/frontend/packages/employee-frontend/src/components/application-page/DecisionResponse.tsx
+++ b/frontend/packages/employee-frontend/src/components/application-page/DecisionResponse.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useContext, useState } from 'react'
+
 import { Decision } from 'types/decision'
 import {
   FixedSpaceColumn,
@@ -15,17 +16,20 @@ import { DatePicker } from 'components/common/DatePicker'
 import { acceptDecision, rejectDecision } from 'api/applications'
 import { UIContext } from 'state/ui'
 import { UUID } from 'types'
+import LocalDate from '@evaka/lib-common/src/local-date'
 
 interface Props {
   applicationId: UUID
   decision: Decision
   reloadApplication: () => void
+  preferredStartDate: LocalDate | null
 }
 
 export default React.memo(function DecisionResponse({
   applicationId,
   decision,
-  reloadApplication
+  reloadApplication,
+  preferredStartDate
 }: Props) {
   const { i18n } = useTranslation()
   const { setErrorMessage } = useContext(UIContext)
@@ -70,7 +74,11 @@ export default React.memo(function DecisionResponse({
           date={acceptDate}
           onChange={setAcceptDate}
           minDate={decision.startDate.subMonths(1)}
-          maxDate={decision.endDate}
+          maxDate={
+            preferredStartDate
+              ? preferredStartDate.addWeeks(2)
+              : decision.endDate
+          }
         />
       </FixedSpaceRow>
       <Radio

--- a/frontend/packages/employee-frontend/src/components/decision-draft/DecisionDraft.tsx
+++ b/frontend/packages/employee-frontend/src/components/decision-draft/DecisionDraft.tsx
@@ -342,14 +342,22 @@ const Decision = memo(function Decision({
                         label: i18n.decisionDraft.selectedUnit,
                         value: (
                           <UnitSelectContainer>
-                            <Select
-                              onChange={(value) =>
-                                value && 'value' in value
-                                  ? onUnitSelect(value.value)
-                                  : undefined
-                              }
-                              options={unitOptions}
-                            />
+                            {isSuccess(units) && (
+                              <Select
+                                onChange={(value) =>
+                                  value && 'value' in value
+                                    ? onUnitSelect(value.value)
+                                    : undefined
+                                }
+                                options={unitOptions}
+                                value={units.data
+                                  .filter((elem) => selectedUnit.id === elem.id)
+                                  .map((elem) => ({
+                                    label: elem.name,
+                                    value: elem.id
+                                  }))}
+                              />
+                            )}
                             <WarningContainer
                               visible={
                                 decisionDraftGroup.data.unit.id !==

--- a/frontend/packages/employee-frontend/src/components/decision-draft/DecisionDraft.tsx
+++ b/frontend/packages/employee-frontend/src/components/decision-draft/DecisionDraft.tsx
@@ -44,7 +44,7 @@ import { AlertBox, InfoBox } from '~components/common/MessageBoxes'
 import { TitleContext, TitleState } from '~state/title'
 import { EspooColours } from '~utils/colours'
 import { formatName } from '~utils'
-import { FixedSpaceColumn } from '~components/shared/layout/flex-helpers'
+import { FixedSpaceRow } from '~components/shared/layout/flex-helpers'
 
 const ColumnTitle = styled.div`
   font-weight: 600;
@@ -515,7 +515,7 @@ const Decision = memo(function Decision({
               />
             )}
             <SendButtonContainer>
-              <FixedSpaceColumn>
+              <FixedSpaceRow>
                 <Button
                   dataQa="cancel-decisions-button"
                   onClick={RedirectToMainPage}
@@ -542,7 +542,7 @@ const Decision = memo(function Decision({
                   }}
                   text={i18n.common.save}
                 />
-              </FixedSpaceColumn>
+              </FixedSpaceRow>
             </SendButtonContainer>
           </Fragment>
         )}


### PR DESCRIPTION
#### Summary
When accepting decision on behalf of the enduser the acceptance date selector was using decisions maximum date and that could lead to situations where employees could accept decisions much further into the future that should be possible.

Changed the date selectors maximum date to use the endusers preferred start date + two weeks (the same as the enduser can choose).