### PR TITLE
EVAKA-3942 Improve SSN sanitizing

### DIFF
--- a/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
+++ b/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
@@ -38,8 +38,8 @@ Sanitized default appender logback configuration provided for import
           <pattern>
             {
             <!--Hide social security numbers in message and in stack trace-->
-            "message": "%replace(%message){'(^|[^-])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
-            "stackTrace": "%replace(%stacktrace{60,40,32000,rootFirst,inlineHash}){'(^|[^-])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
+            "message": "%replace(%message){'(?&lt;!-|[\\dA-z])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](?!-)', 'REDACTED-SSN'}",
+            "stackTrace": "%replace(%stacktrace{60,40,32000,rootFirst,inlineHash}){'(?&lt;!-|[\\dA-z])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](?!-)', 'REDACTED-SSN'}",
             "type": "app-misc",
             "appBuild": "${APP_BUILD}",
             "appCommit": "${APP_COMMIT}",

--- a/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
+++ b/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
@@ -38,8 +38,8 @@ Sanitized default appender logback configuration provided for import
           <pattern>
             {
             <!--Hide social security numbers in message and in stack trace-->
-            "message": "%replace(%message){'(\\d{2})(\\d{2})(\\d{2})[A+-](\\d{3})[\\dA-Z]', 'REDACTED-SSN'}",
-            "stackTrace": "%replace(%stacktrace{60,40,32000,rootFirst,inlineHash}){'(\\d{2})(\\d{2})(\\d{2})[A+-](\\d{3})[\\dA-Z]', 'REDACTED-SSN'}",
+            "message": "%replace(%message){'(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
+            "stackTrace": "%replace(%stacktrace{60,40,32000,rootFirst,inlineHash}){'(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
             "type": "app-misc",
             "appBuild": "${APP_BUILD}",
             "appCommit": "${APP_COMMIT}",

--- a/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
+++ b/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
@@ -38,8 +38,8 @@ Sanitized default appender logback configuration provided for import
           <pattern>
             {
             <!--Hide social security numbers in message and in stack trace-->
-            "message": "%replace(%message){'(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
-            "stackTrace": "%replace(%stacktrace{60,40,32000,rootFirst,inlineHash}){'(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
+            "message": "%replace(%message){'(.{0}^|[^-])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
+            "stackTrace": "%replace(%stacktrace{60,40,32000,rootFirst,inlineHash}){'(.{0}^|[^-])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
             "type": "app-misc",
             "appBuild": "${APP_BUILD}",
             "appCommit": "${APP_COMMIT}",

--- a/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
+++ b/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
@@ -38,8 +38,8 @@ Sanitized default appender logback configuration provided for import
           <pattern>
             {
             <!--Hide social security numbers in message and in stack trace-->
-            "message": "%replace(%message){'(.{0}^|[^-])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
-            "stackTrace": "%replace(%stacktrace{60,40,32000,rootFirst,inlineHash}){'(.{0}^|[^-])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
+            "message": "%replace(%message){'(^|[^-])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
+            "stackTrace": "%replace(%stacktrace{60,40,32000,rootFirst,inlineHash}){'(^|[^-])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](.{0}$|[^-])', 'REDACTED-SSN'}",
             "type": "app-misc",
             "appBuild": "${APP_BUILD}",
             "appCommit": "${APP_COMMIT}",

--- a/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
+++ b/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
@@ -80,7 +80,7 @@ class AppenderTest {
             it.assertSanitized().containsExactly(event1.tuple())
             it.withLatestSanitized { actual ->
                 defaultErrorAssertions(actual, meta, exception)
-                assertThat(actual["stackTrace"] as String).doesNotContain(testSSN)
+                assertThat(actual["stackTrace"] as String).doesNotContain(UUIDWithSSN)
                 assertThat(actual["stackTrace"] as String).contains(redactedSSN)
             }
 
@@ -89,11 +89,13 @@ class AppenderTest {
             it.assertSanitized().containsExactly(event1.tuple(), event2.tuple())
             it.withLatestSanitized { actual -> defaultInfoAssertions(actual) }
 
-            logger.info { "Accidental SSN logging: $testSSN" }
-            it.withLatestSanitized { actual ->
-                defaultInfoAssertions(actual)
-                assertThat(actual["message"] as String).doesNotContain(testSSN)
-                assertThat(actual["message"] as String).contains(redactedSSN)
+            testSSNs.forEach { ssn ->
+                logger.info { "Accidental SSN logging: $ssn}" }
+                it.withLatestSanitized { actual ->
+                    defaultInfoAssertions(actual)
+                    assertThat(actual["message"] as String).doesNotContain(ssn)
+                    assertThat(actual["message"] as String).contains(redactedSSN)
+                }
             }
 
             it.assertAudit().isEmpty()
@@ -123,4 +125,4 @@ data class TestMeta(val key1: String, val key2: String) {
     }
 }
 class TestException : RuntimeException("BOOM!")
-class TestExceptionSensitive : RuntimeException("BOOM! (social_security_number)=($testSSN)")
+class TestExceptionSensitive : RuntimeException("BOOM! (social_security_number)=(${testSSNs[0]})")

--- a/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
+++ b/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
@@ -80,8 +80,6 @@ class AppenderTest {
             it.assertSanitized().containsExactly(event1.tuple())
             it.withLatestSanitized { actual ->
                 defaultErrorAssertions(actual, meta, exception)
-                assertThat(actual["message"] as String).contains(UUIDWithSSN)
-                assertThat(actual["message"] as String).doesNotContain(redactedSSN)
                 assertThat(actual["stackTrace"] as String).doesNotContain(testSSNs[0])
                 assertThat(actual["stackTrace"] as String).contains(redactedSSN)
             }
@@ -97,6 +95,14 @@ class AppenderTest {
                     defaultInfoAssertions(actual)
                     assertThat(actual["message"] as String).doesNotContain(ssn)
                     assertThat(actual["message"] as String).contains(redactedSSN)
+                }
+            }
+
+            UUIDWithSSNs.forEach { uuid ->
+                logger.info { "UUID has SSN in it: $uuid" }
+                it.withLatestSanitized { actual ->
+                    assertThat(actual["message"] as String).contains(uuid)
+                    assertThat(actual["message"] as String).doesNotContain(redactedSSN)
                 }
             }
 

--- a/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
+++ b/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
@@ -80,7 +80,9 @@ class AppenderTest {
             it.assertSanitized().containsExactly(event1.tuple())
             it.withLatestSanitized { actual ->
                 defaultErrorAssertions(actual, meta, exception)
-                assertThat(actual["stackTrace"] as String).doesNotContain(UUIDWithSSN)
+                assertThat(actual["message"] as String).contains(UUIDWithSSN)
+                assertThat(actual["message"] as String).doesNotContain(redactedSSN)
+                assertThat(actual["stackTrace"] as String).doesNotContain(testSSNs[0])
                 assertThat(actual["stackTrace"] as String).contains(redactedSSN)
             }
 

--- a/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/Utils.kt
+++ b/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/Utils.kt
@@ -18,6 +18,7 @@ import net.logstash.logback.encoder.CompositeJsonEncoder
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.groups.Tuple
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 // DSL
 
@@ -86,7 +87,7 @@ data class TestLoggers(
 
 val testSSNs = listOf("130105-0872", "130105A087A", "130105a087a", "130105+0872")
 const val redactedSSN = "REDACTED-SSN"
-const val UUIDWithSSN = "e1130765-2925-4549-b395-9abdd6c8e08a"
+val UUIDWithSSNs = listOf("e1130765-2925-4549-b395-9abdd6c8e08a", "e1130765-b9b5-4549-b395-922222a8208a")
 
 fun TestLoggers.assertAudit() =
     assertThat(audit.appender.list.map { it.toJson(audit.encoder).asMap(mapper) }).extracting(*auditEventProps)
@@ -157,7 +158,7 @@ private val auditEventProps = arrayOf(
 data class DefaultEvent(
     val userIdHash: String
 ) {
-    val message: String = "$UUIDWithSSN.message"
+    val message: String = "${UUID.randomUUID()}.message"
     private val appName: String = "test-service"
     private val type: String = "app-misc"
     private val version: Int = 1

--- a/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/Utils.kt
+++ b/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/Utils.kt
@@ -18,7 +18,6 @@ import net.logstash.logback.encoder.CompositeJsonEncoder
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.groups.Tuple
 import org.slf4j.LoggerFactory
-import java.util.UUID
 
 // DSL
 
@@ -85,8 +84,9 @@ data class TestLoggers(
 
 // assert utils
 
-const val testSSN = "130105A987A"
+val testSSNs = listOf("130105-0872", "130105A087A", "130105a087a", "130105+0872")
 const val redactedSSN = "REDACTED-SSN"
+const val UUIDWithSSN = "e1130765-2925-4549-b395-9abdd6c8e08a"
 
 fun TestLoggers.assertAudit() =
     assertThat(audit.appender.list.map { it.toJson(audit.encoder).asMap(mapper) }).extracting(*auditEventProps)
@@ -157,7 +157,7 @@ private val auditEventProps = arrayOf(
 data class DefaultEvent(
     val userIdHash: String
 ) {
-    val message: String = "${UUID.randomUUID()}.message"
+    val message: String = "$UUIDWithSSN.message"
     private val appName: String = "test-service"
     private val type: String = "app-misc"
     private val version: Int = 1

--- a/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/Utils.kt
+++ b/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/Utils.kt
@@ -87,8 +87,7 @@ data class TestLoggers(
 
 val testSSNs = listOf("130105-0872", "130105A087A", "130105a087a", "130105+0872")
 const val redactedSSN = "REDACTED-SSN"
-val UUIDWithSSNs = listOf("e1130765-2925-4549-b395-9abdd6c8e08a", "e1130765-b9b5-4549-b395-922222a8208a")
-
+val UUIDWithSSNs = listOf("e1130765-2925-4549-b395-9abdd6c8e08a", "e1130765-b9b5-4549-b395-922222a8208a", "5c0250a8-a3fa-449c-a188-6010108a000a")
 fun TestLoggers.assertAudit() =
     assertThat(audit.appender.list.map { it.toJson(audit.encoder).asMap(mapper) }).extracting(*auditEventProps)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
@@ -229,21 +229,15 @@ class VardaClient(
 
     fun createDecision(newDecision: VardaDecision): VardaDecisionResponse? {
         logger.info { "Creating a new decision to Varda (body: $newDecision)" }
-        logger.debug { "Varda: creating new decision $newDecision" }
         val (_, _, result) = Fuel.post(decisionUrl)
             .jsonBody(objectMapper.writeValueAsString(newDecision)).authenticatedResponseStringWithRetries()
 
         return when (result) {
             is Result.Success -> {
                 logger.info { "Creating a new decision to Varda succeeded (body: $newDecision)" }
-                logger.debug { "Varda: creating new decision succeeded $newDecision" }
                 objectMapper.readValue(result.get())
             }
             is Result.Failure -> {
-                logger.debug {
-                    "Varda: creating new decision failed $newDecision." +
-                        " message: ${String(result.error.errorData)}"
-                }
                 logger.error(result.getException()) {
                     "Creating new decision to Varda failed (body: $newDecision)." +
                         " message: ${String(result.error.errorData)}"

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
@@ -188,7 +188,7 @@ class VardaClient(
     }
 
     fun updateFeeData(vardaFeeDataId: Long, feeData: VardaFeeData): Boolean {
-        logger.info { "Updating fee data $vardaFeeDataId to Varda (body: $feeData)" }
+        logger.info { "Updating fee data $vardaFeeDataId to Varda" }
         val (_, _, result) = Fuel.put("$feeDataUrl$vardaFeeDataId")
             .jsonBody(objectMapper.writeValueAsString(feeData)).authenticatedResponseStringWithRetries()
 
@@ -202,6 +202,7 @@ class VardaClient(
                     "Updating fee data $vardaFeeDataId to Varda failed." +
                         " message: ${String(result.error.errorData)}"
                 }
+                logger.debug { "Updating feeData to Varda failed: (vardaId: $vardaFeeDataId, body: $feeData)" }
                 false
             }
         }


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
- no sanitization with SSNs inside UUIDs
- add case insensitivity in order to catch typo'd SSNs