### PR TITLE
[EVAKA-3838] Koski preparatory interruptions

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -271,14 +271,6 @@ internal data class StudyRightTimelines(
     val unknownAbsence: Timeline
 )
 
-/**
- * Calculates active date ranges for a Koski study right.
- *
- * Merges immediately adjacent date ranges, and provides optional clamping.
- *
- * `inclusiveRanges`: a sequence of non-overlapping date ranges that are considered *inclusive* (child is present)
- * `clampRange`: an optional clamping range. If available, all returned date ranges are guaranteed to be contained within this clamping range
- */
 internal fun calculateStudyRightTimelines(
     placementRanges: Sequence<ClosedPeriod>,
     holidays: Set<LocalDate>,
@@ -305,5 +297,5 @@ internal fun calculateStudyRightTimelines(
         present = placement.removeAll(plannedAbsence).removeAll(unknownAbsence),
         plannedAbsence = plannedAbsence,
         unknownAbsence = unknownAbsence
-    ).also { println(it) }
+    )
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -9,6 +9,8 @@ import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.derivePreschoolTerm
 import fi.espoo.evaka.shared.Timeline
 import fi.espoo.evaka.shared.domain.ClosedPeriod
+import fi.espoo.evaka.shared.domain.isWeekend
+import fi.espoo.evaka.shared.domain.toClosedPeriod
 import org.jdbi.v3.core.mapper.Nested
 import org.jdbi.v3.json.Json
 import java.time.LocalDate
@@ -127,16 +129,21 @@ data class KoskiActiveDataRaw(
     private val startTerm = derivePreschoolTerm(placementRanges.first().start)
     private val endTerm = derivePreschoolTerm(placementRanges.last().start)
 
-    private val studyRightRanges =
-        calculateStudyRightRanges(placementRanges.asSequence(), clampRange = ClosedPeriod(startTerm.start, endTerm.end))
+    private val studyRightTimelines = ClosedPeriod(startTerm.start, endTerm.end).let { clampRange ->
+        calculateStudyRightTimelines(
+            placementRanges = placementRanges.asSequence().mapNotNull { it.intersection(clampRange) },
+            holidays = holidays.asSequence().filter { clampRange.includes(it) }.toSet(),
+            absences = preparatoryAbsences.asSequence().filter { clampRange.includes(it.date) }
+        )
+    }
 
     private val approverTitle = "Esiopetusyksikön johtaja"
 
     fun toKoskiData(sourceSystem: String, today: LocalDate): KoskiData? {
         // It's possible clamping to preschool term has removed all placements -> no study right can be created
-        val lastDateRange = studyRightRanges.lastOrNull() ?: return null
+        val placementRange = studyRightTimelines.placement.spanningPeriod() ?: return null
 
-        val isQualified = lastDateRange.end.let {
+        val isQualified = placementRange.end.let {
             it.isAfter(LocalDate.of(endTerm.end.year, 4, 30)) &&
                 it.isBefore(endTerm.end.plusDays(1)) &&
                 it.isBefore(today)
@@ -153,22 +160,31 @@ data class KoskiActiveDataRaw(
     }
 
     private fun haeOpiskeluoikeusjaksot(today: LocalDate, isQualified: Boolean): List<Opiskeluoikeusjakso> {
+        val placementRange = studyRightTimelines.placement.spanningPeriod() ?: return emptyList()
+
+        val present = studyRightTimelines.present.periods()
+            .map { Opiskeluoikeusjakso.läsnä(it.start) }
+        val gaps = studyRightTimelines.placement
+            .gaps()
+            .map { Opiskeluoikeusjakso.väliaikaisestiKeskeytynyt(it.start) }
+        val holidays = studyRightTimelines.plannedAbsence.periods()
+            .map { Opiskeluoikeusjakso.loma(it.start) }
+        val absent = studyRightTimelines.unknownAbsence.periods()
+            .map { Opiskeluoikeusjakso.väliaikaisestiKeskeytynyt(it.start) }
+
         val result = mutableListOf<Opiskeluoikeusjakso>()
-        for (range in studyRightRanges.dropLast(1)) {
-            result.add(Opiskeluoikeusjakso.läsnä(range.start))
-            result.add(Opiskeluoikeusjakso.väliaikaisestiKeskeytynyt(range.end.plusDays(1)))
-        }
-        val range = studyRightRanges.last()
-        result.add(Opiskeluoikeusjakso.läsnä(range.start))
+        result.addAll((present + gaps + holidays + absent))
+
         when {
-            range.end.isAfter(today) -> {
+            placementRange.end.isAfter(today) -> {
                 // still ongoing
             }
             else -> result.add(
-                if (isQualified) Opiskeluoikeusjakso.valmistunut(range.end)
-                else Opiskeluoikeusjakso.eronnut(range.end)
+                if (isQualified) Opiskeluoikeusjakso.valmistunut(placementRange.end)
+                else Opiskeluoikeusjakso.eronnut(placementRange.end)
             )
         }
+        result.sortBy { it.alku }
         return result
     }
 
@@ -218,7 +234,7 @@ data class KoskiActiveDataRaw(
     }
 
     fun haeVahvistus() = Vahvistus(
-        päivä = studyRightRanges.last().end,
+        päivä = studyRightTimelines.placement.spanningPeriod()!!.end,
         paikkakunta = VahvistusPaikkakunta(koodiarvo = VahvistusPaikkakuntaKoodi.ESPOO),
         myöntäjäOrganisaatio = MyöntäjäOrganisaatio(oid = unit.ophOrganizerOid),
         myöntäjäHenkilöt = listOf(
@@ -243,6 +259,19 @@ data class KoskiActiveDataRaw(
 }
 
 /**
+ * Fill gaps between periods if those gaps contain only holidays or weekend days
+ */
+internal fun Timeline.fillWeekendAndHolidayGaps(holidays: Set<LocalDate>) =
+    this.addAll(this.gaps().filter { gap -> gap.dates().all { it.isWeekend() || holidays.contains(it) } })
+
+internal data class StudyRightTimelines(
+    val placement: Timeline,
+    val present: Timeline,
+    val plannedAbsence: Timeline,
+    val unknownAbsence: Timeline
+)
+
+/**
  * Calculates active date ranges for a Koski study right.
  *
  * Merges immediately adjacent date ranges, and provides optional clamping.
@@ -250,13 +279,31 @@ data class KoskiActiveDataRaw(
  * `inclusiveRanges`: a sequence of non-overlapping date ranges that are considered *inclusive* (child is present)
  * `clampRange`: an optional clamping range. If available, all returned date ranges are guaranteed to be contained within this clamping range
  */
-fun calculateStudyRightRanges(
-    inclusiveRanges: Sequence<ClosedPeriod>,
-    clampRange: ClosedPeriod? = null
-): List<ClosedPeriod> = Timeline()
-    .addAll(
-        inclusiveRanges.sortedWith(compareBy({ it.start }, { it.end }))
-            .mapNotNull { if (clampRange == null) it else clampRange.intersection(it) }
+internal fun calculateStudyRightTimelines(
+    placementRanges: Sequence<ClosedPeriod>,
+    holidays: Set<LocalDate>,
+    absences: Sequence<KoskiPreparatoryAbsence>
+): StudyRightTimelines {
+    val placement = Timeline().addAll(placementRanges)
+    val plannedAbsence = Timeline().addAll(
+        Timeline()
+            .addAll(absences.filter { it.type == AbsenceType.PLANNED_ABSENCE }.map { it.date.toClosedPeriod() })
+            .fillWeekendAndHolidayGaps(holidays)
+            .intersection(placement)
+            .periods().filter { it.durationInDays() > 7 }
     )
-    .periods()
-    .toList()
+    val unknownAbsence = Timeline().addAll(
+        Timeline()
+            .addAll(absences.filter { it.type == AbsenceType.UNKNOWN_ABSENCE }.map { it.date.toClosedPeriod() })
+            .fillWeekendAndHolidayGaps(holidays)
+            .intersection(placement)
+            .periods().filter { it.durationInDays() > 7 }
+    )
+
+    return StudyRightTimelines(
+        placement = placement,
+        present = placement.removeAll(plannedAbsence).removeAll(unknownAbsence),
+        plannedAbsence = plannedAbsence,
+        unknownAbsence = unknownAbsence
+    ).also { println(it) }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -279,8 +279,10 @@ internal fun calculateStudyRightTimelines(
     val placement = Timeline().addAll(placementRanges)
     val plannedAbsence = Timeline().addAll(
         Timeline()
-            .addAll(absences.filter { it.type == AbsenceType.PLANNED_ABSENCE || it.type == AbsenceType.OTHER_ABSENCE }
-                .map { it.date.toClosedPeriod() })
+            .addAll(
+                absences.filter { it.type == AbsenceType.PLANNED_ABSENCE || it.type == AbsenceType.OTHER_ABSENCE }
+                    .map { it.date.toClosedPeriod() }
+            )
             .fillWeekendAndHolidayGaps(holidays)
             .intersection(placement)
             .periods().filter { it.durationInDays() > 7 }

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -279,7 +279,8 @@ internal fun calculateStudyRightTimelines(
     val placement = Timeline().addAll(placementRanges)
     val plannedAbsence = Timeline().addAll(
         Timeline()
-            .addAll(absences.filter { it.type == AbsenceType.PLANNED_ABSENCE }.map { it.date.toClosedPeriod() })
+            .addAll(absences.filter { it.type == AbsenceType.PLANNED_ABSENCE || it.type == AbsenceType.OTHER_ABSENCE }
+                .map { it.date.toClosedPeriod() })
             .fillWeekendAndHolidayGaps(holidays)
             .intersection(placement)
             .periods().filter { it.durationInDays() > 7 }

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -5,10 +5,12 @@
 package fi.espoo.evaka.koski
 
 import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.derivePreschoolTerm
 import fi.espoo.evaka.shared.Timeline
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import org.jdbi.v3.core.mapper.Nested
+import org.jdbi.v3.json.Json
 import java.time.LocalDate
 import java.util.UUID
 
@@ -98,6 +100,8 @@ data class KoskiVoidedDataRaw(
     )
 }
 
+data class KoskiPreparatoryAbsence(val date: LocalDate, val type: AbsenceType)
+
 data class KoskiActiveDataRaw(
     @Nested("")
     val child: KoskiChildRaw,
@@ -107,6 +111,9 @@ data class KoskiActiveDataRaw(
     val approverName: String,
     val personOid: String?,
     val placementRanges: List<ClosedPeriod> = emptyList(),
+    val holidays: List<LocalDate> = emptyList(),
+    @Json
+    val preparatoryAbsences: List<KoskiPreparatoryAbsence> = emptyList(),
     val developmentalDisability1: List<ClosedPeriod> = emptyList(),
     val developmentalDisability2: List<ClosedPeriod> = emptyList(),
     val extendedCompulsoryEducation: ClosedPeriod? = null,

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
@@ -104,13 +104,19 @@ SELECT
     um.name AS approver_name,
     pr.social_security_number ssn,
     pr.first_name,
-    pr.last_name
+    pr.last_name,
+    holidays
 FROM koski_study_right ksr
 JOIN koski_active_study_right(:today) kasr
 ON (kasr.child_id, kasr.unit_id, kasr.type) = (ksr.child_id, ksr.unit_id, ksr.type)
 JOIN daycare d ON ksr.unit_id = d.id
 JOIN unit_manager um ON d.unit_manager_id = um.id
 JOIN person pr ON ksr.child_id = pr.id
+LEFT JOIN LATERAL (
+    SELECT array_agg(date ORDER BY date) AS holidays
+    FROM holiday h
+    WHERE date <@ kasr.full_range
+) h ON ksr.type = 'PREPARATORY'
 WHERE ksr.id = :id
         """
             ).bind("id", id).bind("today", today)

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/Oppija.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/Oppija.kt
@@ -76,7 +76,10 @@ enum class OpiskeluoikeusjaksonTilaKoodi {
     VOIDED,
 
     @JsonProperty("valiaikaisestikeskeytynyt")
-    INTERRUPTED
+    INTERRUPTED,
+
+    @JsonProperty("loma")
+    HOLIDAY
 }
 
 // https://koski.opintopolku.fi/koski/dokumentaatio/koodisto/opiskeluoikeudentyyppi/latest
@@ -162,6 +165,11 @@ data class Opiskeluoikeusjakso(
         fun väliaikaisestiKeskeytynyt(alku: LocalDate) = Opiskeluoikeusjakso(
             alku = alku,
             tila = OpiskeluoikeusjaksonTila(OpiskeluoikeusjaksonTilaKoodi.INTERRUPTED)
+        )
+
+        fun loma(alku: LocalDate) = Opiskeluoikeusjakso(
+            alku = alku,
+            tila = OpiskeluoikeusjaksonTila(OpiskeluoikeusjaksonTilaKoodi.HOLIDAY)
         )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Timeline.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Timeline.kt
@@ -44,7 +44,6 @@ class Timeline private constructor(private val periods: List<ClosedPeriod>) : It
     fun remove(period: ClosedPeriod) = this.periods.partition { it.overlaps(period) }
         .let { (conflicts, unchanged) ->
             val result = unchanged.toMutableList()
-            result.addAll(unchanged)
             for (conflict in conflicts) {
                 conflict.intersection(period)?.let { intersection ->
                     if (conflict.start != intersection.start) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Timeline.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Timeline.kt
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared
+
+import fi.espoo.evaka.shared.domain.ClosedPeriod
+import java.time.LocalDate
+
+/**
+ * A timeline is basically an immutable set of dates, but provides simple read/write operations that involve periods
+ * instead of individual dates.
+ *
+ * Invariants:
+ *   * no overlapping periods (they are merged when adding to the timeline)
+ *   * no adjacent periods (they are merged when adding to the timeline)
+ *   * functions that return dates/periods always return them in ascending order
+ *
+ * Note: this implementation is *not* very efficient
+ */
+class Timeline private constructor(private val periods: List<ClosedPeriod>) : Iterable<ClosedPeriod> by periods {
+    constructor() : this(emptyList())
+
+    fun add(period: ClosedPeriod) = this.periods.partition { it.overlaps(period) || it.adjacentTo(period) }
+        .let { (conflicts, unchanged) ->
+            val result = unchanged.toMutableList()
+            result.add(
+                conflicts.fold(period) { acc, it ->
+                    ClosedPeriod(
+                        minOf(it.start, acc.start),
+                        maxOf(it.end, acc.end)
+                    )
+                }
+            )
+            result.sortBy { it.start }
+            Timeline(result)
+        }
+
+    fun addAll(periods: Iterable<ClosedPeriod>) = periods.fold(this) { timeline, period -> timeline.add(period) }
+    fun addAll(periods: Sequence<ClosedPeriod>) = periods.fold(this) { timeline, period -> timeline.add(period) }
+
+    fun add(date: LocalDate) = this.add(ClosedPeriod(start = date, end = date))
+
+    fun remove(period: ClosedPeriod) = this.periods.partition { it.overlaps(period) }
+        .let { (conflicts, unchanged) ->
+            val result = unchanged.toMutableList()
+            result.addAll(unchanged)
+            for (conflict in conflicts) {
+                conflict.intersection(period)?.let { intersection ->
+                    if (conflict.start != intersection.start) {
+                        result.add(ClosedPeriod(start = conflict.start, end = intersection.start.minusDays(1)))
+                    }
+                    if (conflict.end != intersection.end) {
+                        result.add(ClosedPeriod(start = intersection.end.plusDays(1), end = conflict.end))
+                    }
+                }
+            }
+            result.sortBy { it.start }
+            Timeline(result)
+        }
+
+    fun remove(date: LocalDate) = this.remove(ClosedPeriod(start = date, end = date))
+    fun removeAll(periods: Iterable<ClosedPeriod>) = periods.fold(this) { timeline, period -> timeline.remove(period) }
+    fun removeAll(periods: Sequence<ClosedPeriod>) = periods.fold(this) { timeline, period -> timeline.remove(period) }
+
+    fun includes(date: LocalDate) = this.periods.any { it.includes(date) }
+    fun contains(period: ClosedPeriod) = this.periods.any { it.contains(period) }
+
+    fun periods() = this.periods.asSequence()
+    fun dates() = this.periods.asSequence().flatMap { it.dates() }
+
+    companion object {
+        fun of(): Timeline = Timeline()
+        fun of(vararg periods: ClosedPeriod): Timeline = Timeline().addAll(periods.asIterable())
+        fun of(periods: Collection<ClosedPeriod>): Timeline = Timeline().addAll(periods)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Time.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Time.kt
@@ -37,6 +37,8 @@ data class ClosedPeriod(val start: LocalDate, val end: LocalDate) {
     fun includes(value: LocalDate) = this.start <= value && value <= this.end
     fun overlaps(value: ClosedPeriod) = this.start <= value.end && value.start <= this.end
 
+    fun adjacentTo(other: ClosedPeriod) = other.end.plusDays(1) == this.start || this.end.plusDays(1) == other.start
+
     fun intersection(value: ClosedPeriod): ClosedPeriod? {
         val start = maxOf(this.start, value.start)
         val end = minOf(this.end, value.end)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Time.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Time.kt
@@ -9,6 +9,7 @@ import org.jdbi.v3.core.kotlin.mapTo
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Month
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 fun orMax(date: LocalDate?): LocalDate = date ?: LocalDate.MAX
@@ -46,6 +47,7 @@ data class ClosedPeriod(val start: LocalDate, val end: LocalDate) {
     }
 
     fun dates(): Sequence<LocalDate> = generateSequence(start) { if (it < end) it.plusDays(1) else null }
+    fun durationInDays(): Long = ChronoUnit.DAYS.between(start, end.plusDays(1)) // adjust to exclusive range
 }
 
 data class Period(val start: LocalDate, val end: LocalDate?) {
@@ -135,3 +137,6 @@ fun operationalDays(year: Int, month: Month): (Handle) -> OperationalDays = { h 
 }
 
 val isWeekday = { date: LocalDate -> date.dayOfWeek != DayOfWeek.SATURDAY && date.dayOfWeek != DayOfWeek.SUNDAY }
+
+fun LocalDate.isWeekend() = this.dayOfWeek == DayOfWeek.SATURDAY || this.dayOfWeek == DayOfWeek.SUNDAY
+fun LocalDate.toClosedPeriod(): ClosedPeriod = ClosedPeriod(this, this)

--- a/service/src/main/resources/db/migration/R__koski_views.sql
+++ b/service/src/main/resources/db/migration/R__koski_views.sql
@@ -8,7 +8,7 @@ CREATE FUNCTION koski_active_study_right(today date) RETURNS
 TABLE (
     child_id uuid, unit_id uuid, type koski_study_right_type,
     oph_unit_oid text, oph_organization_oid text, oph_organizer_oid text,
-    full_range daterange, placement_ranges daterange[], all_placements_in_past bool, preparatory_absences jsonb[],
+    full_range daterange, placement_ranges daterange[], all_placements_in_past bool, preparatory_absences jsonb,
     developmental_disability_1 daterange[], developmental_disability_2 daterange[],
     extended_compulsory_education daterange, transport_benefit daterange,
     special_assistance_decision_with_group daterange[], special_assistance_decision_without_group daterange[]
@@ -56,7 +56,7 @@ TABLE (
     JOIN daycare d ON p.unit_id = d.id
     JOIN person pr ON p.child_id = pr.id
     LEFT JOIN LATERAL (
-        SELECT array_agg(jsonb_build_object('date', a.date, 'type', a.absence_type) ORDER BY a.date) AS preparatory_absences
+        SELECT jsonb_agg(jsonb_build_object('date', a.date, 'type', a.absence_type) ORDER BY a.date) AS preparatory_absences
         FROM absence a
         WHERE a.child_id = p.child_id
         AND a.care_type = 'PRESCHOOL'

--- a/service/src/main/resources/db/migration/R__koski_views.sql
+++ b/service/src/main/resources/db/migration/R__koski_views.sql
@@ -8,7 +8,7 @@ CREATE FUNCTION koski_active_study_right(today date) RETURNS
 TABLE (
     child_id uuid, unit_id uuid, type koski_study_right_type,
     oph_unit_oid text, oph_organization_oid text, oph_organizer_oid text,
-    placement_ranges daterange[], all_placements_in_past bool,
+    full_range daterange, placement_ranges daterange[], all_placements_in_past bool, preparatory_absences jsonb[],
     developmental_disability_1 daterange[], developmental_disability_2 daterange[],
     extended_compulsory_education daterange, transport_benefit daterange,
     special_assistance_decision_with_group daterange[], special_assistance_decision_without_group daterange[]
@@ -20,8 +20,10 @@ TABLE (
         d.oph_unit_oid,
         d.oph_organization_oid,
         d.oph_organizer_oid,
+        full_range,
         placement_ranges,
         all_placements_in_past,
+        preparatory_absences,
         developmental_disability_1,
         developmental_disability_2,
         extended_compulsory_education,
@@ -53,6 +55,14 @@ TABLE (
     ) p
     JOIN daycare d ON p.unit_id = d.id
     JOIN person pr ON p.child_id = pr.id
+    LEFT JOIN LATERAL (
+        SELECT array_agg(jsonb_build_object('date', a.date, 'type', a.absence_type) ORDER BY a.date) AS preparatory_absences
+        FROM absence a
+        WHERE a.child_id = p.child_id
+        AND a.care_type = 'PRESCHOOL'
+        AND a.date <@ full_range
+        AND a.date > '2020-08-01'
+    ) pa ON p.type = 'PREPARATORY'
     JOIN LATERAL (
         SELECT
             array_agg(date_interval) FILTER (WHERE 'DEVELOPMENTAL_DISABILITY_1' = ANY(bases)) AS developmental_disability_1,

--- a/service/src/test/kotlin/fi/espoo/evaka/koski/KoskiTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/koski/KoskiTest.kt
@@ -141,7 +141,7 @@ Absent 29.3 - 6.4, and a Koski absence is generated
                 KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 30), AbsenceType.PLANNED_ABSENCE),
                 KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 31), AbsenceType.PLANNED_ABSENCE),
                 KoskiPreparatoryAbsence(LocalDate.of(2021, 4, 1), AbsenceType.PLANNED_ABSENCE),
-                KoskiPreparatoryAbsence(LocalDate.of(2021, 4, 6), AbsenceType.PLANNED_ABSENCE)
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 4, 6), AbsenceType.OTHER_ABSENCE)
             )
         )
         assertEquals(

--- a/service/src/test/kotlin/fi/espoo/evaka/koski/KoskiTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/koski/KoskiTest.kt
@@ -24,7 +24,7 @@ Week 13  29 30 31  1 HH  3 HH
 Week 14  HH  6  7  8  9 10 11
 Week 15  12 13 14 15 16 17 18
 
-Absent 22.3 - 26.3, but no Koski absence is not generated:
+Absent 22.3 - 26.3, but no Koski absence is generated:
     - the actual absence period is just 5 days
      */
     @Test

--- a/service/src/test/kotlin/fi/espoo/evaka/koski/KoskiTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/koski/KoskiTest.kt
@@ -4,63 +4,163 @@
 
 package fi.espoo.evaka.koski
 
+import fi.espoo.evaka.daycare.service.AbsenceType
+import fi.espoo.evaka.preschoolTerm2020
+import fi.espoo.evaka.shared.Timeline
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
+/*
+AA = absence
+HH = holiday
+ */
 class KoskiTest {
+    /*
+         Mo Tu We Th Fr Sa Su
+Week 12  AA AA AA AA AA 27 28
+Week 13  29 30 31  1 HH  3 HH
+Week 14  HH  6  7  8  9 10 11
+Week 15  12 13 14 15 16 17 18
+
+Absent 22.3 - 26.3, but no Koski absence is not generated:
+    - the actual absence period is just 5 days
+     */
     @Test
-    fun `calculateStudyRightRanges works correctly`() {
-        //       123456789
-        // input --
-        //         ---
-        //             -
-        //              --
-        // output
-        //       -----
-        //             ---
-        val output = calculateStudyRightRanges(
-            sequenceOf(
-                ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 1, 2)),
-                ClosedPeriod(LocalDate.of(2019, 1, 3), LocalDate.of(2019, 1, 5)),
-                ClosedPeriod(LocalDate.of(2019, 1, 7), LocalDate.of(2019, 1, 7)),
-                ClosedPeriod(LocalDate.of(2019, 1, 8), LocalDate.of(2019, 1, 9))
+    fun testSimpleAbsenceScenario1() {
+        val timelines = calculateStudyRightTimelines(
+            placementRanges = sequenceOf(preschoolTerm2020),
+            holidays = holidays,
+            absences = sequenceOf(
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 22), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 23), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 24), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 25), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 26), AbsenceType.PLANNED_ABSENCE)
             )
         )
         assertEquals(
-            listOf(
-                ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 1, 5)),
-                ClosedPeriod(LocalDate.of(2019, 1, 7), LocalDate.of(2019, 1, 9))
+            StudyRightTimelines(
+                placement = Timeline.of(preschoolTerm2020),
+                present = Timeline.of(preschoolTerm2020),
+                plannedAbsence = Timeline.of(),
+                unknownAbsence = Timeline.of()
             ),
-            output
+            timelines
         )
     }
 
+    /*
+         Mo Tu We Th Fr Sa Su
+Week 12  AA AA AA AA AA 27 28
+Week 13  AA 30 31  1 HH  3 HH
+Week 14  HH  6  7  8  9 10 11
+Week 15  12 13 14 15 16 17 18
+
+Absent 22.3 - 29.3, and a Koski absence is generated
+     */
     @Test
-    fun `calculateStudyRightRanges clamps ranges correctly`() {
-        //       123456789
-        // input --
-        //         ---
-        //             ---
-        // clamp    =====
-        // output
-        //          --
-        //             --
-        val output = calculateStudyRightRanges(
-            sequenceOf(
-                ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 1, 2)),
-                ClosedPeriod(LocalDate.of(2019, 1, 3), LocalDate.of(2019, 1, 5)),
-                ClosedPeriod(LocalDate.of(2019, 1, 7), LocalDate.of(2019, 1, 9))
-            ),
-            clampRange = ClosedPeriod(LocalDate.of(2019, 1, 4), LocalDate.of(2019, 1, 8))
+    fun testSimpleAbsenceScenario2() {
+        val timelines = calculateStudyRightTimelines(
+            placementRanges = sequenceOf(preschoolTerm2020),
+            holidays = holidays,
+            absences = sequenceOf(
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 22), AbsenceType.UNKNOWN_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 23), AbsenceType.UNKNOWN_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 24), AbsenceType.UNKNOWN_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 25), AbsenceType.UNKNOWN_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 26), AbsenceType.UNKNOWN_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 29), AbsenceType.UNKNOWN_ABSENCE)
+            )
         )
         assertEquals(
-            listOf(
-                ClosedPeriod(LocalDate.of(2019, 1, 4), LocalDate.of(2019, 1, 5)),
-                ClosedPeriod(LocalDate.of(2019, 1, 7), LocalDate.of(2019, 1, 8))
+            StudyRightTimelines(
+                placement = Timeline.of(preschoolTerm2020),
+                present = Timeline.of(
+                    ClosedPeriod(preschoolTerm2020.start, LocalDate.of(2021, 3, 21)),
+                    ClosedPeriod(LocalDate.of(2021, 3, 30), preschoolTerm2020.end)
+                ),
+                plannedAbsence = Timeline.of(),
+                unknownAbsence = Timeline.of(ClosedPeriod(LocalDate.of(2021, 3, 22), LocalDate.of(2021, 3, 29)))
             ),
-            output
+            timelines
+        )
+    }
+
+    /*
+         Mo Tu We Th Fr Sa Su
+Week 12  22 23 24 25 AA 27 28
+Week 13  AA AA AA AA HH  3 HH
+Week 14  HH  6  7  8  9 10 11
+Week 15  12 13 14 15 16 17 18
+
+Absent 26.3 - 5.4, but no Koski absence is generated:
+    - the actual absence period is just 7 days (26.3 - 1.4), since public holidays and weekend days are skipped
+     */
+    @Test
+    fun testComplexAbsenceScenario1() {
+        val timelines = calculateStudyRightTimelines(
+            placementRanges = sequenceOf(preschoolTerm2020),
+            holidays = holidays,
+            absences = sequenceOf(
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 26), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 29), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 30), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 31), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 4, 1), AbsenceType.PLANNED_ABSENCE)
+            )
+        )
+        assertEquals(
+            StudyRightTimelines(
+                placement = Timeline.of(preschoolTerm2020),
+                present = Timeline.of(preschoolTerm2020),
+                plannedAbsence = Timeline.of(),
+                unknownAbsence = Timeline.of()
+            ),
+            timelines
+        )
+    }
+
+    /*
+         Mo Tu We Th Fr Sa Su
+Week 12  22 23 24 25 26 27 28
+Week 13  AA AA AA AA HH  3 HH
+Week 14  HH AA  7  8  9 10 11
+Week 15  12 13 14 15 16 17 18
+
+Absent 29.3 - 6.4, and a Koski absence is generated
+     */
+    @Test
+    fun testComplexAbsenceScenario2() {
+        val timelines = calculateStudyRightTimelines(
+            placementRanges = sequenceOf(preschoolTerm2020),
+            holidays = holidays,
+            absences = sequenceOf(
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 29), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 30), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 3, 31), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 4, 1), AbsenceType.PLANNED_ABSENCE),
+                KoskiPreparatoryAbsence(LocalDate.of(2021, 4, 6), AbsenceType.PLANNED_ABSENCE)
+            )
+        )
+        assertEquals(
+            StudyRightTimelines(
+                placement = Timeline.of(preschoolTerm2020),
+                present = Timeline.of(
+                    ClosedPeriod(preschoolTerm2020.start, LocalDate.of(2021, 3, 28)),
+                    ClosedPeriod(LocalDate.of(2021, 4, 7), preschoolTerm2020.end)
+                ),
+                plannedAbsence = Timeline.of(ClosedPeriod(LocalDate.of(2021, 3, 29), LocalDate.of(2021, 4, 6))),
+                unknownAbsence = Timeline.of()
+            ),
+            timelines
         )
     }
 }
+
+private val holidays = setOf(
+    LocalDate.of(2021, 4, 2),
+    LocalDate.of(2021, 4, 4),
+    LocalDate.of(2021, 4, 5)
+)

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/TimelineTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/TimelineTest.kt
@@ -16,8 +16,6 @@ class TimelineTest {
     fun `an empty timeline contains nothing`() {
         val timeline = Timeline.of()
         assertFalse(timeline.contains(ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2020, 1, 1))))
-        assertFalse(timeline.includes(LocalDate.of(2019, 1, 1)))
-        assertEquals(emptyList<LocalDate>(), timeline.dates().toList())
         assertEquals(emptyList<ClosedPeriod>(), timeline.periods().toList())
     }
 
@@ -26,10 +24,7 @@ class TimelineTest {
         val period = ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2020, 1, 1))
         val timeline = Timeline.of(period)
         assertTrue(timeline.contains(period))
-        assertTrue(timeline.includes(period.start))
-        assertTrue(timeline.includes(period.end))
         assertEquals(listOf(period), timeline.periods().toList())
-        assertEquals(period.dates().toList(), timeline.dates().toList())
     }
 
     @Test
@@ -40,8 +35,6 @@ class TimelineTest {
         )
         val timeline = Timeline.of(periods)
         assertTrue(periods.all { timeline.contains(it) })
-        assertTrue(periods.all { timeline.includes(it.start) && timeline.includes(it.end) })
-        assertTrue(periods.asSequence().flatMap { it.dates() }.all { timeline.includes(it) })
         assertEquals(periods, timeline.periods().toList())
     }
 
@@ -53,8 +46,6 @@ class TimelineTest {
         )
         val timeline = Timeline.of(periods)
         assertTrue(periods.all { timeline.contains(it) })
-        assertTrue(periods.all { timeline.includes(it.start) && timeline.includes(it.end) })
-        assertTrue(periods.asSequence().flatMap { it.dates() }.all { timeline.includes(it) })
         assertEquals(listOf(ClosedPeriod(start = periods[0].start, end = periods[1].end)), timeline.periods().toList())
     }
 
@@ -67,8 +58,6 @@ class TimelineTest {
         )
         val timeline = Timeline.of(periods)
         assertTrue(periods.all { timeline.contains(it) })
-        assertTrue(periods.all { timeline.includes(it.start) && timeline.includes(it.end) })
-        assertTrue(periods.asSequence().flatMap { it.dates() }.all { timeline.includes(it) })
         assertEquals(listOf(ClosedPeriod(start = periods[0].start, end = periods[2].end)), timeline.periods().toList())
     }
 

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/TimelineTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/TimelineTest.kt
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared
+
+import fi.espoo.evaka.shared.domain.ClosedPeriod
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class TimelineTest {
+    @Test
+    fun `an empty timeline contains nothing`() {
+        val timeline = Timeline.of()
+        assertFalse(timeline.contains(ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2020, 1, 1))))
+        assertFalse(timeline.includes(LocalDate.of(2019, 1, 1)))
+        assertEquals(emptyList<LocalDate>(), timeline.dates().toList())
+        assertEquals(emptyList<ClosedPeriod>(), timeline.periods().toList())
+    }
+
+    @Test
+    fun `a period can be added to a timeline`() {
+        val period = ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2020, 1, 1))
+        val timeline = Timeline.of(period)
+        assertTrue(timeline.contains(period))
+        assertTrue(timeline.includes(period.start))
+        assertTrue(timeline.includes(period.end))
+        assertEquals(listOf(period), timeline.periods().toList())
+        assertEquals(period.dates().toList(), timeline.dates().toList())
+    }
+
+    @Test
+    fun `multiple periods can be added to a timeline`() {
+        val periods = listOf(
+            ClosedPeriod(LocalDate.of(2018, 1, 1), LocalDate.of(2018, 6, 1)),
+            ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 3, 1))
+        )
+        val timeline = Timeline.of(periods)
+        assertTrue(periods.all { timeline.contains(it) })
+        assertTrue(periods.all { timeline.includes(it.start) && timeline.includes(it.end) })
+        assertTrue(periods.asSequence().flatMap { it.dates() }.all { timeline.includes(it) })
+        assertEquals(periods, timeline.periods().toList())
+    }
+
+    @Test
+    fun `overlapping periods are merged when added to a timeline`() {
+        val periods = listOf(
+            ClosedPeriod(LocalDate.of(2018, 1, 1), LocalDate.of(2019, 6, 1)),
+            ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2020, 1, 1))
+        )
+        val timeline = Timeline.of(periods)
+        assertTrue(periods.all { timeline.contains(it) })
+        assertTrue(periods.all { timeline.includes(it.start) && timeline.includes(it.end) })
+        assertTrue(periods.asSequence().flatMap { it.dates() }.all { timeline.includes(it) })
+        assertEquals(listOf(ClosedPeriod(start = periods[0].start, end = periods[1].end)), timeline.periods().toList())
+    }
+
+    @Test
+    fun `adjacent periods are merged when added to a timeline`() {
+        val periods = listOf(
+            ClosedPeriod(LocalDate.of(2018, 1, 1), LocalDate.of(2018, 12, 31)),
+            ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 5, 31)),
+            ClosedPeriod(LocalDate.of(2019, 6, 1), LocalDate.of(2020, 1, 1))
+        )
+        val timeline = Timeline.of(periods)
+        assertTrue(periods.all { timeline.contains(it) })
+        assertTrue(periods.all { timeline.includes(it.start) && timeline.includes(it.end) })
+        assertTrue(periods.asSequence().flatMap { it.dates() }.all { timeline.includes(it) })
+        assertEquals(listOf(ClosedPeriod(start = periods[0].start, end = periods[2].end)), timeline.periods().toList())
+    }
+
+    @Test
+    fun `periods can be removed from a timeline`() {
+        val periods = listOf(
+            ClosedPeriod(LocalDate.of(2018, 1, 1), LocalDate.of(2018, 6, 1)),
+            ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 3, 1))
+        )
+        val timeline = Timeline.of(periods).removeAll(periods)
+        assertEquals(emptyList<ClosedPeriod>(), timeline.periods().toList())
+    }
+
+    @Test
+    fun `parts of periods can be removed from a timeline`() {
+        val periods = listOf(
+            ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 3, 1)),
+            ClosedPeriod(LocalDate.of(2018, 1, 1), LocalDate.of(2018, 6, 1))
+        )
+        val timeline = Timeline.of(periods).remove(ClosedPeriod(LocalDate.of(2018, 5, 2), LocalDate.of(2019, 1, 31)))
+        assertEquals(
+            listOf(
+                ClosedPeriod(LocalDate.of(2018, 1, 1), LocalDate.of(2018, 5, 1)),
+                ClosedPeriod(LocalDate.of(2019, 2, 1), LocalDate.of(2019, 3, 1))
+            ),
+            timeline.periods().toList()
+        )
+    }
+}

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/domain/TimeTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/domain/TimeTest.kt
@@ -227,4 +227,9 @@ class TimeTest {
         assertEquals(y, c.intersection(d))
         assertEquals(y, d.intersection(c))
     }
+
+    @Test
+    fun `ClosedPeriod durationInDays returns 1 for one day periods`() {
+        assertEquals(1, LocalDate.of(2019, 1, 1).toClosedPeriod().durationInDays())
+    }
 }


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

Implement temporary interruptions (holiday / unplanned absence) in Koski preparatory study rights:

- only periods of longer than 7 days are considered (exactly 7 day periods are *not*)
- only in preparatory study rights
- only from 2020 term onwards
- public holidays and weekends are effectively skipped in calculations: a 5-day absence followed by a weekend and one public holiday Monday is a 5-day absence, **not** a 8-day absence
- add (naive) Timeline data structure, and do all period calculations with it