### PR TITLE
[EVAKA-3912] Remove default apigw Google API keys, update frontend keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ aliases:
   - &ci_evaka_fingerprint 86:d0:b3:3d:aa:fc:d5:b9:6b:69:1e:c7:f5:56:66:aa
   # Version of remote Docker engine used with setup_remote_docker (not including machine executors)
   - &remote_docker_version '19.03.13'
+  - &nodejs_version '12.13'
+  - &yarn_version '1.22.\*'
   - &nodejs_image cimg/node:12.13
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202010-01
@@ -248,6 +250,12 @@ commands:
     parameters:
       suite:
         type: string
+      nodejs_version:
+        type: string
+        default: *nodejs_version
+      yarn_version:
+        type: string
+        default: *yarn_version
     steps:
       - *restore_repo
       - *attach_workspace
@@ -264,10 +272,14 @@ commands:
       - run:
           name: Install node 12 and yarn
           command: |
-            source ~/.bashrc
-            nvm install 12.13.0
-            curl --silent --show-error --location --fail --retry 3 --output - https://yarnpkg.com/install.sh | bash -s -- --version 1.22.5
-            source ~/.bashrc
+            export DEBIAN_FRONTEND=noninteractive
+            nvm install << parameters.nodejs_version >>
+            node --version
+
+            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+            echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+            sudo apt-get update && sudo apt-get --yes install --no-install-recommends yarn=<< parameters.yarn_version >>
+            yarn --version
       - run:
           name: Install chrome
           command: |
@@ -292,8 +304,7 @@ commands:
           name: Run e2e tests against compose
           working_directory: *workspace_e2e
           command: |
-            source ~/.bashrc
-            nvm use 12.13.0
+            nvm use << parameters.nodejs_version >>
             ./wait-for-dev-api.sh 'http://localhost:9999' || (cd /home/circleci/repo/compose && ./compose-e2e logs && false)
             yarn << parameters.suite >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,11 +260,11 @@ commands:
           command: |
             CI=true LOCAL_DIR='../frontend/packages' ./compose-e2e up -d
       - run:
-          name: Install node 10 and yarn
+          name: Install node 12 and yarn
           command: |
             source ~/.bashrc
-            nvm install 10.15.3
-            curl --silent --show-error --location --fail --retry 3 --output - https://yarnpkg.com/install.sh | bash
+            nvm install 12.13.0
+            curl --silent --show-error --location --fail --retry 3 --output - https://yarnpkg.com/install.sh | bash -s -- --version 1.22.5
             source ~/.bashrc
       - run:
           name: Install chrome
@@ -291,7 +291,7 @@ commands:
           working_directory: *workspace_e2e
           command: |
             source ~/.bashrc
-            nvm use 10.15.3
+            nvm use 12.13.0
             ./wait-for-dev-api.sh 'http://localhost:9999' || (cd ~/repo/compose && ./compose-e2e logs && false)
             yarn << parameters.suite >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,20 +11,22 @@ orbs:
   slack: circleci/slack@3.4.2
 
 aliases:
-  - &workspace_root ~/repo
-  - &workspace_evaka_base ~/repo/evaka-base
-  - &workspace_apigw ~/repo/apigw
-  - &workspace_frontend ~/repo/frontend
-  - &workspace_e2e ~/repo/frontend/e2e-test
-  - &workspace_proxy ~/repo/proxy
-  - &workspace_service ~/repo/service
-  - &workspace_message_service ~/repo/message-service
-  - &workspace_compose ~/repo/compose
+  - &workspace_root /home/circleci/repo
+  - &workspace_evaka_base /home/circleci/repo/evaka-base
+  - &workspace_apigw /home/circleci/repo/apigw
+  - &workspace_frontend /home/circleci/repo/frontend
+  - &workspace_e2e /home/circleci/repo/frontend/e2e-test
+  - &workspace_proxy /home/circleci/repo/proxy
+  - &workspace_service /home/circleci/repo/service
+  - &workspace_message_service /home/circleci/repo/message-service
+  - &workspace_compose /home/circleci/repo/compose
   - &yarn_cache .yarn_cache
   # SSH key fingerprint for checking out other eVaka repositories
   - &ci_evaka_fingerprint 86:d0:b3:3d:aa:fc:d5:b9:6b:69:1e:c7:f5:56:66:aa
   # Version of remote Docker engine used with setup_remote_docker (not including machine executors)
   - &remote_docker_version '19.03.13'
+  - &nodejs_image cimg/node:12.13
+  - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202010-01
   - &builder_aws_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:1a7e0dec664ec27fa49d3eb76992be870c3f5b99
 
@@ -175,11 +177,11 @@ executors:
   apigw_executor:
     <<: *node_config
     docker:
-      - image: circleci/node:lts-buster
+      - image: *nodejs_image
   frontend_executor:
     <<: *node_config
     docker:
-      - image: circleci/node:dubnium
+      - image: *nodejs_image
   e2e_executor:
     <<: *default_config
     machine:
@@ -191,7 +193,7 @@ executors:
     environment:
       GRADLE_USER_HOME: /home/circleci/repo/service/.gradle-user-home
     docker:
-      - image: circleci/openjdk:11
+      - image: *openjdk_image
   service_test_executor:
     <<: *jvm_config
     environment:
@@ -204,7 +206,7 @@ executors:
     environment:
       GRADLE_USER_HOME: /home/circleci/repo/message-service/.gradle-user-home
     docker:
-      - image: circleci/openjdk:11
+      - image: *openjdk_image
   message_service_test_executor:
     <<: *jvm_config
     environment:
@@ -234,8 +236,8 @@ commands:
   build_storybook:
     steps:
       - run:
-          name: yarn build-storybook ~/repo/frontend/packages/employee-frontend
-          working_directory: ~/repo/frontend/packages/employee-frontend
+          name: yarn build-storybook /home/circleci/repo/frontend/packages/employee-frontend
+          working_directory: /home/circleci/repo/frontend/packages/employee-frontend
           environment:
             SENTRY_NO_PROGRESS_BAR: "1"
           command: |
@@ -292,12 +294,12 @@ commands:
           command: |
             source ~/.bashrc
             nvm use 12.13.0
-            ./wait-for-dev-api.sh 'http://localhost:9999' || (cd ~/repo/compose && ./compose-e2e logs && false)
+            ./wait-for-dev-api.sh 'http://localhost:9999' || (cd /home/circleci/repo/compose && ./compose-e2e logs && false)
             yarn << parameters.suite >>
       - run:
           name: Collect error logs
           command: |
-            cd ~/repo/compose
+            cd /home/circleci/repo/compose
             ./compose-e2e logs --tail=all > /tmp/docker-compose-logs.txt
           when: on_fail
       - store_artifacts:
@@ -318,7 +320,7 @@ commands:
     steps:
       - run:
           name: Deploy (<< parameters.from >>)
-          working_directory: ~/repo/<< parameters.from >>
+          working_directory: /home/circleci/repo/<< parameters.from >>
           command: |
             aws s3 cp dist/index.html s3://evaka-static-$TARGET_ENV/<< parameters.to >>/index.html \
               --acl public-read \
@@ -342,7 +344,7 @@ commands:
     steps:
       - run:
           name: Deploy Storybook
-          working_directory: ~/repo/frontend/packages/employee-frontend
+          working_directory: /home/circleci/repo/frontend/packages/employee-frontend
           command: |
             if [ "$TARGET_ENV" = "dev" ]; then
               aws --profile voltti-dev s3 cp storybook-build/ s3://evaka-static-dev/master/storybook/ --recursive --acl public-read
@@ -519,7 +521,7 @@ jobs:
           working_directory: *workspace_apigw
           command: yarn test-ci
       - store_test_results:
-          path: ~/repo/apigw/build/test-reports
+          path: /home/circleci/repo/apigw/build/test-reports
       - notify_slack
 
   apigw_build_image:
@@ -575,11 +577,11 @@ jobs:
           command: yarn install --frozen-lockfile
       - *store_frontend_node_modules
       - build_frontend:
-          dir: ~/repo/frontend/packages/employee-frontend
+          dir: /home/circleci/repo/frontend/packages/employee-frontend
       - build_frontend:
-          dir: ~/repo/frontend/packages/enduser-frontend
+          dir: /home/circleci/repo/frontend/packages/enduser-frontend
       - build_frontend:
-          dir: ~/repo/frontend/packages/maintenance-page
+          dir: /home/circleci/repo/frontend/packages/maintenance-page
       - build_storybook
       - *persist_workspace_frontend
       - run:
@@ -589,11 +591,11 @@ jobs:
           working_directory: *workspace_frontend
           command: yarn test --maxWorkers=2
       - store_test_results:
-          path: ~/repo/frontend/packages/lib-common/test-results
+          path: /home/circleci/repo/frontend/packages/lib-common/test-results
       - store_test_results:
-          path: ~/repo/frontend/packages/employee-frontend/test-results
+          path: /home/circleci/repo/frontend/packages/employee-frontend/test-results
       - store_test_results:
-          path: ~/repo/frontend/packages/enduser-frontend/test-results
+          path: /home/circleci/repo/frontend/packages/enduser-frontend/test-results
       - notify_slack
 
   e2e-test-application:
@@ -707,16 +709,16 @@ jobs:
           working_directory: *workspace_service
           command: ./gradlew test
       - store_test_results:
-          path: ~/repo/service/build/test-results/test/
+          path: /home/circleci/repo/service/build/test-results/test/
       - run:
           working_directory: *workspace_service
           command: ./gradlew integrationTest
       - store_test_results:
-          path: ~/repo/service/build/test-results/integrationTest/
+          path: /home/circleci/repo/service/build/test-results/integrationTest/
       - store_artifacts:
-          path: ~/repo/service/build/reports/
+          path: /home/circleci/repo/service/build/reports/
       - store_artifacts:
-          path: ~/repo/service-lib/build/reports/
+          path: /home/circleci/repo/service-lib/build/reports/
       - notify_slack
 
   service_push_image:
@@ -759,14 +761,14 @@ jobs:
           working_directory: *workspace_message_service
           command: ./gradlew test
       - store_test_results:
-          path: ~/repo/message-service/build/test-results/test/
+          path: /home/circleci/repo/message-service/build/test-results/test/
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew integrationTest
       - store_test_results:
-          path: ~/repo/message-service/build/test-results/integrationTest/
+          path: /home/circleci/repo/message-service/build/test-results/integrationTest/
       - store_artifacts:
-          path: ~/repo/message-service/build/reports/
+          path: /home/circleci/repo/message-service/build/reports/
       - notify_slack
 
   message_service_build_and_push_image:

--- a/apigw/README.md
+++ b/apigw/README.md
@@ -13,8 +13,8 @@ Gateway between eVaka frontends and backend services
 
 ## Requirements
 
-- Node version 10.16
-- Yarn version 1.16
+- Node version 12.13+
+- Yarn version 1.22+ (2.x not tested)
 - (OPTIONAL) [Google Maps JavaScript API key](#google-maps-api-key)
   - If you want to use the geocoding & autocomplete endpoints
 

--- a/apigw/README.md
+++ b/apigw/README.md
@@ -8,13 +8,15 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 Gateway between eVaka frontends and backend services
 
-* enduser gateway
-* internal gateway
+- enduser gateway
+- internal gateway
 
 ## Requirements
 
-* Node version 10.16
-* Yarn version 1.16
+- Node version 10.16
+- Yarn version 1.16
+- (OPTIONAL) [Google Maps JavaScript API key](#google-maps-api-key)
+  - If you want to use the geocoding & autocomplete endpoints
 
 The service requires redis running on port 6379. Easiest way is to run it with [compose](../compose/README.md) command
 
@@ -47,6 +49,30 @@ Lint with auto-fix
 ```bash
 yarn lint
 yarn lint-fix
+```
+
+### Google Maps API key
+
+If you want to use the Google Maps geocoding and autocomplete endpoints,
+a [Google Maps JavaScript API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
+must be configured for the application. Unfortunately none can be provided for local development by default as backend
+API keys can only be restricted by IP addresses.
+
+The application can be run locally without an API key but the endpoints will respond with an error.
+
+When creating your own key, restrict it to the following APIs:
+
+- Geocoding API
+- Places API
+
+#### Instructions for Voltti Developers
+
+Fetch and export the **secret** API key from Parameter Store with:
+
+```sh
+aws --profile voltti-local ssm get-parameter \
+  --name /local/evaka/google/maps_backend_api_key \
+  --query 'Parameter.Value' --with-decryption --output text
 ```
 
 ## Generated JWTs for local testing

--- a/apigw/src/enduser/services/map.ts
+++ b/apigw/src/enduser/services/map.ts
@@ -34,6 +34,10 @@ interface GeocodeData {
 }
 
 export async function autocomplete(address: string) {
+  if (!googleApiKey) {
+    throw new Error('GOOGLE_API_KEY must be configured to use this endpoint')
+  }
+
   return axios
     .get(`${GOOGLE_MAPS_API_URL}/place/autocomplete/json`, {
       params: {
@@ -65,6 +69,10 @@ export async function autocomplete(address: string) {
 }
 
 export async function geocode(id: string) {
+  if (!googleApiKey) {
+    throw new Error('GOOGLE_API_KEY must be configured to use this endpoint')
+  }
+
   return axios
     .get(`${GOOGLE_MAPS_API_URL}/geocode/json`, {
       params: {

--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -105,10 +105,9 @@ export const evakaServiceUrl = required(
     ifNodeEnv(['local', 'test'], 'http://localhost:8888')
   )
 )
-export const googleApiKey = choose(
-  process.env.GOOGLE_API_KEY,
-  ifNodeEnv(['local', 'test'], 'AIzaSyC6obUEPu6TBU47O500tZg99JC_yW8wCJA')
-)
+// Google API requires an API key even in local development and we cannot restrict its usage to local environments
+// so none is provided by default.
+export const googleApiKey = process.env.GOOGLE_API_KEY
 export const cookieSecret = required(
   choose(
     process.env.COOKIE_SECRET,

--- a/compose/.default.gmaps.env
+++ b/compose/.default.gmaps.env
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2017-2020 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Placeholder file used in compose-e2e if no .gmaps.env exists.
+# To set a real value for GOOGLE_API_KEY, create your own .gmaps.env.
+# See README for details.
+
+GOOGLE_API_KEY=

--- a/compose/.gitignore
+++ b/compose/.gitignore
@@ -4,6 +4,9 @@
 
 db/init
 s3-mount
+# Secret Google Maps API configuration for local development, see README
+.gmaps.env
+
 # Editors & IDEs
 .idea/
 cmake-build-debug/

--- a/compose/README.md
+++ b/compose/README.md
@@ -64,7 +64,7 @@ it using your package manager. (E.g. on Ubuntu, run  `sudo apt-get install netca
 
 To use `enduser-gw`'s Google Maps backed endpoints, create a `.gmaps.env` file ([example](./.default.gmaps.env)).
 **NOTE:** By default, `compose-e2e` will copy a default file (`.default.gmaps.env`) to `.gmaps.env`, so `.gmaps.env`
-might already exist -- just fill/replace it.
+might already exist — just fill/replace it.
 
 Due to Google Maps APIs restriction capabilities (see [apigw README](../apigw/README.md#google-maps-api-key)),
 no API key can be provided by default **but `compose-e2e` can be run without an API key**.

--- a/compose/README.md
+++ b/compose/README.md
@@ -36,7 +36,7 @@ current user. Do not use elevated privileges, e.g. sudo to install
 packages.
 
 - [Node.js](https://nodejs.org/en/) – a JavaScript runtime built on Chrome's V8 JavaScript engine, version  12.13+
-- [Yarn](https://yarnpkg.com/getting-started/install) – Package manager for Node, version 1.22.10+
+- [Yarn](https://yarnpkg.com/getting-started/install) – Package manager for Node, version 1.22+
 - [JDK](https://openjdk.java.net/projects/jdk/11/) – Java Development
   Kit, version 11+. We recommend using OpenJDK implementation of JSR 384.
 - [Docker](https://docs.docker.com/get-docker/) – Docker is an open platform for developing, shipping, and running applications.

--- a/compose/README.md
+++ b/compose/README.md
@@ -20,7 +20,7 @@ We recommend using the package manager (e.g. `aptitude`, `homebrew` etc.)
 for your operating system for obtaining required software and packages.
 
 Development in Windows environment should also be possible, but we
-cannot guarantee it works out-of-the-box. In any case, we strongly recommend 
+cannot guarantee it works out-of-the-box. In any case, we strongly recommend
 installing [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
 for developing in Windows operating system.
 
@@ -31,7 +31,7 @@ environment locally. You can install them through your development
 environment's package manager, or alternatively download binaries
 from websites provided below.
 
-Please note that all the dependencies should be installed as 
+Please note that all the dependencies should be installed as
 current user. Do not use elevated privileges, e.g. sudo to install
 packages.
 
@@ -40,7 +40,7 @@ packages.
 - [JDK](https://openjdk.java.net/projects/jdk/11/) – Java Development
   Kit, version 11+. We recommend using OpenJDK implementation of JSR 384.
 - [Docker](https://docs.docker.com/get-docker/) – Docker is an open platform for developing, shipping, and running applications.
-
+- [docker-compose](https://docs.docker.com/compose/install/) - Tool for running multi-container Docker applications, version 1.26.0+
 
 ### Required tooling
 
@@ -59,6 +59,25 @@ npm install -g pm2
 You will also need the `nc/netcat` (Arbitrary TCP and UDP connections and listens) utility.
 If your operating system does not have this utility installed, please install
 it using your package manager. (E.g. on Ubuntu, run  `sudo apt-get install netcat`).
+
+### Google Maps API key
+
+To use `enduser-gw`'s Google Maps backed endpoints, create a `.gmaps.env` file ([example](./.default.gmaps.env)).
+**NOTE:** By default, `compose-e2e` will copy a default file (`.default.gmaps.env`) to `.gmaps.env`, so `.gmaps.env`
+might already exist -- just fill/replace it.
+
+Due to Google Maps APIs restriction capabilities (see [apigw README](../apigw/README.md#google-maps-api-key)),
+no API key can be provided by default **but `compose-e2e` can be run without an API key**.
+
+⚠️ **DO NOT COMMIT `.gmaps.env` to git!** ⚠️
+
+#### Instructions for Voltti developers
+
+Generate `.gmaps.env` with:
+
+```sh
+echo "GOOGLE_API_KEY=$(aws --profile voltti-local ssm get-parameter --name /local/evaka/google/maps_backend_api_key --query 'Parameter.Value' --with-decryption --output text)" > .gmaps.env
+```
 
 ## Starting all sub-projects in development mode
 
@@ -193,3 +212,7 @@ pm2 logs apigw
 
 You should be able to start all the services without any modifications
 if you have followed the instructions carefully.
+
+### GOOGLE_API_KEY must be configured to use this endpoint
+
+You must configure [a Google Maps API key](#google-maps-api-key) for `enduser-gw`.

--- a/compose/compose-e2e
+++ b/compose/compose-e2e
@@ -4,6 +4,15 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+GOOGLE_MAPS_ENV_FILE=.gmaps.env
+GOOGLE_MAPS_ENV_FILE_DEFAULT=.default.gmaps.env
+
+# Only use the default configuration if user hasn't created their own
+if [ ! -f "$GOOGLE_MAPS_ENV_FILE" ]; then
+    >&2 echo "INFO: No ${GOOGLE_MAPS_ENV_FILE} exists, replacing with default ${GOOGLE_MAPS_ENV_FILE_DEFAULT}"
+    cp -a "$GOOGLE_MAPS_ENV_FILE_DEFAULT" "$GOOGLE_MAPS_ENV_FILE"
+fi
+
 if [ "$1" = "up" ]; then
     S3_DIR=s3-mount/
     mkdir -p "$S3_DIR"

--- a/compose/docker-compose.e2e.yml
+++ b/compose/docker-compose.e2e.yml
@@ -54,7 +54,6 @@ services:
       NODE_ENV: local
       GATEWAY_ROLE: internal
       EVAKA_SERVICE_URL: ${EVAKA_SERVICE_URL}
-      GOOGLE_API_KEY: AIzaSyC6obUEPu6TBU47O500tZg99JC_yW8wCJA
       COOKIE_SECRET: cookie_secret
       REDIS_HOST: ${EVAKA_REDIS_HOST}
       REDIS_PORT: ${EVAKA_REDIS_PORT}

--- a/compose/docker-compose.e2e.yml
+++ b/compose/docker-compose.e2e.yml
@@ -26,12 +26,16 @@ services:
       - redis
     volumes:
       - ../apigw/config/test-cert:/home/evaka/test-cert
+    # NOTE: .gmaps.env should never be in git as the Google API key is a secret,
+    # so it is generated in compose-e2e.
+    env_file:
+      - .env
+      - .gmaps.env
     environment:
       VOLTTI_ENV: local
       NODE_ENV: local
       GATEWAY_ROLE: enduser
       EVAKA_SERVICE_URL: ${EVAKA_SERVICE_URL}
-      GOOGLE_API_KEY: AIzaSyC6obUEPu6TBU47O500tZg99JC_yW8wCJA
       COOKIE_SECRET: cookie_secret
       REDIS_HOST: ${EVAKA_REDIS_HOST}
       REDIS_PORT: ${EVAKA_REDIS_PORT}
@@ -39,6 +43,8 @@ services:
       JWT_PRIVATE_KEY: /home/evaka/test-cert/jwt_private_key.pem
       ENABLE_DEV_API: "true"
       PRETTY_LOGS: "false"
+      # Configured in .gmaps.env
+      # GOOGLE_API_KEY:
 
   internal-gw:
     image: ${EVAKA_GW_IMAGE}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,7 +23,7 @@ And into a shared library:
 
 - [`lib-common`](packages/lib-common/README.md)
 
-This repository uses [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) to share 
+This repository uses [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) to share
 common code between packages / applications. See further instructions below.
 
 **NOTE:** This project is currently under very active development.
@@ -48,7 +48,7 @@ from websites provided below.
 - [Node.js](https://nodejs.org/en/) – a JavaScript runtime built on
   Chrome's V8 JavaScript engine, version 12.13+
 - [Yarn](https://yarnpkg.com/getting-started/install) – Package manager
-  for Node, version 1.22.10
+  for Node, version 1.22+
 
 ## Overview of the repository structure
 

--- a/frontend/e2e-test/package.json
+++ b/frontend/e2e-test/package.json
@@ -41,6 +41,9 @@
     "testcafe": "~1.9.4",
     "testcafe-reporter-junit": "3.0.2"
   },
+  "engines": {
+    "node": ">= 12.13.0"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "yarn lint",

--- a/frontend/eslint-plugin/package.json
+++ b/frontend/eslint-plugin/package.json
@@ -4,5 +4,8 @@
   "main": "index.js",
   "devDependencies": {
     "eslint": "^7.2.0"
+  },
+  "engines": {
+    "node": ">= 12.13.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,9 @@
     "@fortawesome/pro-regular-svg-icons": "file:./vendor/fortawesome/fortawesome-pro-regular-svg-icons-5.14.0.tgz",
     "@fortawesome/pro-solid-svg-icons": "file:./vendor/fortawesome/fortawesome-pro-solid-svg-icons-5.14.0.tgz"
   },
+  "engines": {
+    "node": ">= 12.13.0"
+  },
   "workspaces": [
     "packages/*",
     "e2e-test",

--- a/frontend/packages/employee-frontend/package.json
+++ b/frontend/packages/employee-frontend/package.json
@@ -104,9 +104,8 @@
       "pre-push": "yarn type-check && yarn test"
     }
   },
-  "enginesStrict": true,
   "engines": {
-    "node": ">=10"
+    "node": ">= 12.13.0"
   },
   "browserslist": [
     "Firefox ESR"

--- a/frontend/packages/enduser-frontend/README.md
+++ b/frontend/packages/enduser-frontend/README.md
@@ -12,17 +12,17 @@ Made with [Vue](https://vuejs.org/).
 
 ## Requirements
 
-* Node version 10.16
-* Yarn version 1.16
+- Node version 12.13+
+- Yarn version 1.22+ (2.x not tested)
 
 ## Prerequisites for running locally
 
 These microservices can either be run with [compose](../../../compose/README.md) or locally with a terminal/IDE.
 
-* The following microservices have to be running locally:
-  * [service](../../../service/README.md)
-  * [enduser-gw](../../../apigw/README.md)
-  * evaka-db (through docker-compose)
+- The following microservices have to be running locally:
+  - [service](../../../service/README.md)
+  - [enduser-gw](../../../apigw/README.md)
+  - evaka-db (through docker-compose)
 
 ## Packages
 

--- a/frontend/packages/enduser-frontend/package.json
+++ b/frontend/packages/enduser-frontend/package.json
@@ -80,6 +80,9 @@
     "typescript": "^3.9.5",
     "vue-template-compiler": "^2.6.11"
   },
+  "engines": {
+    "node": ">= 12.13.0"
+  },
   "browserslist": [
     "> 1% in FI",
     "last 2 versions",

--- a/frontend/packages/enduser-frontend/src/config.ts
+++ b/frontend/packages/enduser-frontend/src/config.ts
@@ -63,7 +63,7 @@ configs._default = {
   },
 
   maps: {
-    googleApiKey: 'AIzaSyC6obUEPu6TBU47O500tZg99JC_yW8wCJA',
+    googleApiKey: 'AIzaSyDsQ-afaWGiGbIUd9JMmdknJ9zuAvXDv1k',
     espooCoordinates: { lat: 60.2051256, lng: 24.6541313 },
     styles: [
       {
@@ -180,8 +180,27 @@ configs._default = {
     selectApplicationType: true
   }
 }
+configs.dev = defaultsDeep(
+  {
+    maps: {
+      googleApiKey: 'AIzaSyCo8b3pEGS4IvVOBHExYePR7ru1SoHtKOs'
+    }
+  },
+  configs._default
+)
+configs.test = defaultsDeep(
+  {
+    maps: {
+      googleApiKey: 'AIzaSyAhPTjH3-vK8U6RJblEabS7JJYNgZmjzV8'
+    }
+  },
+  configs._default
+)
 configs.staging = defaultsDeep(
   {
+    maps: {
+      googleApiKey: 'AIzaSyBiPAcmG0YW6dfMQhXCePRh3YUgfVFJ8d8'
+    },
     sentry: {
       enabled: true
     }

--- a/frontend/packages/lib-common/package.json
+++ b/frontend/packages/lib-common/package.json
@@ -33,9 +33,8 @@
       "pre-push": "yarn type-check && yarn test"
     }
   },
-  "enginesStrict": true,
   "engines": {
-    "node": ">=10"
+    "node": ">= 12.13.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/frontend/packages/maintenance-page/README.md
+++ b/frontend/packages/maintenance-page/README.md
@@ -10,8 +10,8 @@ Displayed when eVaka sites are down for maintenance.
 
 ## Requirements
 
-* Node version >= 10
-* Yarn version >= 1.16
+- Node version 12.13+
+- Yarn version 1.22+ (2.x not tested)
 
 ## Development
 

--- a/frontend/packages/maintenance-page/package.json
+++ b/frontend/packages/maintenance-page/package.json
@@ -19,6 +19,9 @@
     "postcss-preset-env": "^6.7.0",
     "sass": "^1.23.3"
   },
+  "engines": {
+    "node": ">= 12.13.0"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "yarn lint:fix"


### PR DESCRIPTION
#### Summary
- apigw: remove default Google Maps API key
   - All Google Maps APIs require authentication even in local development and backend keys can only be restricted by IP addresses -> not restricable to local environments -> can't have a key in a public repository
   - Remove default keys (which weren't even working as they've been restricted to frontend APIs only) from apigw configs
   - Fail fast before going to Google's APIs and throw an error to indicate missing configuration when hitting Maps endpoints
    - As the endpoints are such a minor feature (only used in the enduser frontend's front page street address search), running apigw shouldn't fail without the keys and we don't want to complicate local development even further anyway
   - Allow configuring a valid set of keys for compose-e2e stack via `.gmaps.env` (ignored in git)
    - To avoid extra steps for developers, use multiple `.env` files via `env_file` configuration and setup a default configuration (a file cannot be missing in `env_file`)
      - Later on, we could use the `--env-file` argument in a similar manner but it only just released in docker-compose three days ago
   - Document fetching the API key for Voltti developers
- compose: remove Google API key for internal-gw
   - Only used in enduser-gw
- Frontend: update Google Maps API keys
   - Now using separate keys per environment (not that important for dev/test/staging but simplifies automation later on, when keys can be generated on a per-environment basis with Terraform)
-  Use Node.js v12 everywhere
  - Update all `engine` configurations to require Node.js >= 12.13.0
    - Drop `enginesStrict` (dropped in npm 3.0.0, a long time ago)
  - Use the same version of Node.js for E2E tests as otherwise
  - CI: Install a specific version of yarn instead of "latest"
    - NOTE: Once we've upgrade to Ubuntu 20.04 machine executors, yarn should be installed from apt
  - Synchronise docs for Node.js & yarn versions
-  CI: Update executor images
  - Use next-gen images from CircleCI (smaller, promised to be more frequently in cache already)
  - Update Node.js executors to 12.13
  - Hard-code workspace paths as currently builder-aws uses a different user & home (/home/circleci) to the next-gen images (/root)
-  CI: install yarn from apt
  - Also parametrize yarn and Node.js versions to avoid duplication and to make updating easier

#### Dependencies
None

#### Testing instructions

With defaults (i.e. open source developer's workflow):

1. In `compose/`, `./build.sh`
1. `./compose-e2e up -d`
1. Go to http://localhost:9999
1. In the street address search, search for something (longer than 3 letters)
1. See "internal server error" in UI/console & new error message in `enduser-gw` logs (`./compose-e2e logs enduser-gw`)

With Voltti keys:

1. Build, like before
1. Follow `compose/` README instructions for fetching API key
1. `./compose-e2e up -d`
1. See replaced `enduser-gw`
1. Same test but now working (responds with search results, no error)

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [x] The change has been tested locally
- [x] The change conforms to the UX specifications
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```