### PR TITLE
[EVAKA-3961] Fix Koski study right voiding

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -65,7 +65,7 @@ class KoskiClient(
             logger.info { "Koski upload ${msg.key}: no change in payload -> skipping" }
         } else {
             val (_, _, result) = Fuel.request(
-                method = if (data.isNew) Method.POST else Method.PUT,
+                method = if (data.operation == KoskiOperation.CREATE) Method.POST else Method.PUT,
                 path = "$baseUrl/oppija"
             )
                 .authentication()
@@ -101,7 +101,7 @@ class KoskiClient(
                     )
                 )
             )
-            logger.info { "Koski upload ${msg.key}: finished" }
+            logger.info { "Koski upload ${msg.key}: finished ${data.operation}" }
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -13,9 +13,13 @@ import java.util.UUID
 
 data class KoskiData(
     val oppija: Oppija,
-    val isNew: Boolean,
+    val operation: KoskiOperation,
     val organizerOid: String
 )
+
+enum class KoskiOperation {
+    CREATE, UPDATE, VOID
+}
 
 data class KoskiChildRaw(
     val ssn: String,
@@ -50,6 +54,7 @@ data class KoskiUnitRaw(
         suorituskieli = Suorituskieli(daycareLanguage.toUpperCase()),
         tyyppi = SuorituksenTyyppi(SuorituksenTyyppiKoodi.PRESCHOOL)
     )
+
     fun haeJärjestämisMuoto() = when (daycareProviderType) {
         ProviderType.PURCHASED -> Järjestämismuoto(JärjestämismuotoKoodi.PURCHASED)
         ProviderType.PRIVATE_SERVICE_VOUCHER -> Järjestämismuoto(JärjestämismuotoKoodi.PRIVATE_SERVICE_VOUCHER)
@@ -74,8 +79,8 @@ data class KoskiVoidedDataRaw(
             henkilö = child.toHenkilö(),
             opiskeluoikeudet = listOf(haeOpiskeluOikeus(sourceSystem))
         ),
-        isNew = false,
-        organizerOid = unit.ophOrganizerOid
+        organizerOid = unit.ophOrganizerOid,
+        operation = KoskiOperation.VOID
     )
 
     private fun haeOpiskeluOikeus(sourceSystem: String) = Opiskeluoikeus(
@@ -134,7 +139,7 @@ data class KoskiActiveDataRaw(
                 henkilö = child.toHenkilö(),
                 opiskeluoikeudet = listOf(haeOpiskeluoikeus(sourceSystem, today, isQualified))
             ),
-            isNew = studyRightOid == null,
+            operation = if (studyRightOid == null) KoskiOperation.CREATE else KoskiOperation.UPDATE,
             organizerOid = unit.ophOrganizerOid
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
@@ -35,6 +35,7 @@ FROM koski_voided_study_right(:today) kvsr
 JOIN koski_study_right ksr
 ON (kvsr.child_id, kvsr.unit_id, kvsr.type) = (ksr.child_id, ksr.unit_id, ksr.type)
 WHERE to_jsonb(kvsr) IS DISTINCT FROM ksr.input_data
+AND ksr.void_date IS NULL
 AND (:personIds = '{}' OR kvsr.child_id = ANY(:personIds))
 AND (:daycareIds = '{}' OR kvsr.unit_id = ANY(:daycareIds))
 """

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
@@ -58,7 +58,10 @@ USING (child_id, unit_id, type)
 LEFT JOIN koski_voided_study_right(:today) kvsr
 USING (child_id, unit_id, type)
 ON CONFLICT (child_id, unit_id, type)
-DO UPDATE SET void_date = excluded.void_date, input_data = excluded.input_data
+DO UPDATE SET
+    void_date = excluded.void_date,
+    input_data = excluded.input_data,
+    study_right_oid = CASE WHEN koski_study_right.void_date IS NULL THEN koski_study_right.study_right_oid END
 RETURNING id, void_date IS NOT NULL AS voided
 """
 ).bindKotlin(key)
@@ -72,7 +75,8 @@ RETURNING id, void_date IS NOT NULL AS voided
                 """
 SELECT
     kvsr.*,
-    ksr.id AS study_right_id, ksr.study_right_oid,
+    ksr.id AS study_right_id,
+    ksr.study_right_oid,
     d.language AS daycare_language,
     d.provider_type AS daycare_provider_type,
     pr.social_security_number ssn,
@@ -93,7 +97,8 @@ WHERE ksr.id = :id
                 """
 SELECT
     kasr.*,
-    ksr.id AS study_right_id, ksr.study_right_oid,
+    ksr.id AS study_right_id,
+    ksr.study_right_oid,
     d.language AS daycare_language,
     d.provider_type AS daycare_provider_type,
     um.name AS approver_name,


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

Apparently voiding actually removes the study right, so the study right OID can't be used afterwards. On our side, the study right key (child+unit+type) will be reused if the study right is activated (= a new placement is created), which led to update requests to voided (= removed) study rights.

* make sure voiding is a one-shot operation (never void a voided study right)
* if a voided study right is reactivated on our side, make sure we send a new study right instead of trying to update an old one
* update mock Koski server to be more realistic in these scenarios