### PR TITLE
Bump target Java version to 11

### DIFF
--- a/message-service/buildSrc/src/main/kotlin/Version.kt
+++ b/message-service/buildSrc/src/main/kotlin/Version.kt
@@ -13,7 +13,7 @@ object Version {
     const val flyway = "6.5.5"
     const val hikariCp = "3.4.5"
     const val jackson = "2.11.2"
-    const val java = "1.8"
+    const val java = "11"
     const val jaxbRuntime = "2.3.2"
     const val jdbi = "3.14.1"
     const val jedis = "3.3.0"

--- a/service/buildSrc/src/main/kotlin/Version.kt
+++ b/service/buildSrc/src/main/kotlin/Version.kt
@@ -14,7 +14,7 @@ object Version {
     const val fuel = "2.2.3"
     const val hikariCp = "3.4.5"
     const val jackson = "2.11.2"
-    const val java = "1.8"
+    const val java = "11"
     const val javalin = "3.10.1"
     const val jdbi = "3.14.1"
     const val jedis = "3.3.0"


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

This simply changes the generated bytecode version, but doesn't
otherwise affect the compilation. But this should provide a clear error
if somebody tries to compile with a too old Java version