### PR TITLE
[EVAKA-3964] Fix SSN add endpoint hang

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -189,9 +189,9 @@ class PersonController(
             throw BadRequest("Invalid social security number")
         }
 
-        return personService
-            .addSsn(user, personId, ExternalIdentifier.SSN.getInstance(body.ssn))
-            .let { ResponseEntity.ok(PersonJSON.from(it)) }
+        personService.addSsn(user, personId, ExternalIdentifier.SSN.getInstance(body.ssn))
+        val person = personService.getUpToDatePerson(user, personId)!!
+        return ResponseEntity.ok(PersonJSON.from(person))
     }
 
     @GetMapping("/details/ssn/{ssn}")

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -25,6 +25,7 @@ import fi.espoo.evaka.shared.config.Roles.END_USER
 import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
 import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
 import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.jdbi.v3.core.Jdbi
@@ -189,7 +190,9 @@ class PersonController(
             throw BadRequest("Invalid social security number")
         }
 
-        personService.addSsn(user, personId, ExternalIdentifier.SSN.getInstance(body.ssn))
+        jdbi.handle { h ->
+            personService.addSsn(h, user, personId, ExternalIdentifier.SSN.getInstance(body.ssn))
+        }
         val person = personService.getUpToDatePerson(user, personId)!!
         return ResponseEntity.ok(PersonJSON.from(person))
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
@@ -201,7 +201,7 @@ class PersonService(
         getPerson(id)!!
     }
 
-    fun addSsn(user: AuthenticatedUser, id: VolttiIdentifier, ssn: ExternalIdentifier.SSN): PersonDTO =
+    fun addSsn(user: AuthenticatedUser, id: VolttiIdentifier, ssn: ExternalIdentifier.SSN) =
         withSpringTx(txManager) {
             val person = getPerson(id) ?: throw NotFound("Person $id not found")
 
@@ -214,8 +214,6 @@ class PersonService(
                     personDAO.addSsn(id, ssn.toString())
                 }
             }.exhaust()
-
-            getUpToDatePerson(user, id)!!
         }
 
     fun findBySearchTerms(searchTerms: String, orderBy: String, sortDirection: String): List<PersonDTO> =

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
@@ -51,12 +51,6 @@ class PersonService(
         personDAO.getPersonByVolttiId(id)
     }
 
-    fun getPersonBySsn(ssn: String): PersonDTO? = withSpringTx(txManager) {
-        personDAO.getPersonByExternalId(
-            ExternalIdentifier.SSN.getInstance(ssn)
-        )
-    }
-
     fun getUpToDatePerson(user: AuthenticatedUser, id: VolttiIdentifier): PersonDTO? {
         val person = personDAO.getPersonByVolttiId(id) ?: return null
         if (person.identity is ExternalIdentifier.SSN && vtjDataIsStale(person)) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.identity.VolttiIdentifier
 import fi.espoo.evaka.pis.controllers.CreatePersonBody
 import fi.espoo.evaka.pis.dao.PersonDAO
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.db.withSpringTx
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.NotFound
@@ -22,32 +23,39 @@ import fi.espoo.evaka.vtjclient.service.persondetails.PersonDetails
 import fi.espoo.evaka.vtjclient.service.persondetails.PersonStorageService
 import fi.espoo.evaka.vtjclient.usecases.dto.PersonResult
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.PlatformTransactionManager
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
 @Service
-@Transactional
 class PersonService(
+    private val txManager: PlatformTransactionManager,
     private val personDAO: PersonDAO,
     private val personDetailsService: IPersonDetailsService,
     private val personStorageService: PersonStorageService
 ) {
     private val forceRefreshIntervalSeconds = 1 * 24 * 60 * 60 // 1 day
 
-    fun createEmpty() = personDAO.createEmpty()
+    fun createEmpty() = withSpringTx(txManager) { personDAO.createEmpty() }
 
-    fun createNoSsnPerson(person: CreatePersonBody): UUID =
+    fun createNoSsnPerson(person: CreatePersonBody): UUID = withSpringTx(txManager) {
         personDAO.createPerson(person)
+    }
 
-    fun getOrCreatePersonIdentity(person: PersonIdentityRequest): PersonDTO =
+    fun getOrCreatePersonIdentity(person: PersonIdentityRequest): PersonDTO = withSpringTx(txManager) {
         personDAO.getOrCreatePersonIdentity(person)
+    }
 
-    fun getPerson(id: VolttiIdentifier): PersonDTO? =
+    fun getPerson(id: VolttiIdentifier): PersonDTO? = withSpringTx(txManager) {
         personDAO.getPersonByVolttiId(id)
+    }
 
-    fun getPersonBySsn(ssn: String): PersonDTO? = personDAO.getPersonByExternalId(ExternalIdentifier.SSN.getInstance(ssn))
+    fun getPersonBySsn(ssn: String): PersonDTO? = withSpringTx(txManager) {
+        personDAO.getPersonByExternalId(
+            ExternalIdentifier.SSN.getInstance(ssn)
+        )
+    }
 
     fun getUpToDatePerson(user: AuthenticatedUser, id: VolttiIdentifier): PersonDTO? {
         val person = personDAO.getPersonByVolttiId(id) ?: return null
@@ -68,12 +76,13 @@ class PersonService(
         }
     }
 
-    fun personsLiveInTheSameAddress(user: AuthenticatedUser, person1Id: UUID, person2Id: UUID): Boolean {
-        val person1 = personDAO.getPersonByVolttiId(person1Id)
-        val person2 = personDAO.getPersonByVolttiId(person2Id)
+    fun personsLiveInTheSameAddress(user: AuthenticatedUser, person1Id: UUID, person2Id: UUID): Boolean =
+        withSpringTx(txManager) {
+            val person1 = personDAO.getPersonByVolttiId(person1Id)
+            val person2 = personDAO.getPersonByVolttiId(person2Id)
 
-        return personsHaveSameResidenceCode(person1, person2) || personsHaveSameAddress(person1, person2)
-    }
+            personsHaveSameResidenceCode(person1, person2) || personsHaveSameAddress(person1, person2)
+        }
 
     private fun personsHaveSameResidenceCode(person1: PersonDTO?, person2: PersonDTO?): Boolean {
         return person1 != null && person2 != null &&
@@ -91,25 +100,27 @@ class PersonService(
             person1.postalCode.equals(person2.postalCode)
     }
 
-    fun getDeceased(sinceDate: LocalDate): List<PersonDTO> = personDAO.getDeceased(sinceDate)
+    fun getDeceased(sinceDate: LocalDate): List<PersonDTO> =
+        withSpringTx(txManager) { personDAO.getDeceased(sinceDate) }
 
-    fun getUpToDatePersonWithChildren(user: AuthenticatedUser, id: VolttiIdentifier): PersonWithChildrenDTO? {
-        val guardian = personDAO.getPersonByVolttiId(id) ?: return null
+    fun getUpToDatePersonWithChildren(user: AuthenticatedUser, id: VolttiIdentifier): PersonWithChildrenDTO? =
+        withSpringTx(txManager) {
+            val guardian = personDAO.getPersonByVolttiId(id) ?: return@withSpringTx null
 
-        return when (guardian.identity) {
-            is ExternalIdentifier.NoID -> toPersonWithChildrenDTO(guardian)
-            is ExternalIdentifier.SSN ->
-                getPersonWithDependants(user, guardian.identity)
-                    ?.let { personStorageService.upsertVtjGuardianAndChildren(PersonResult.Result(it)) }
-                    ?.let {
-                        when (it) {
-                            is PersonResult.Error -> throw IllegalStateException(it.msg)
-                            is PersonResult.NotFound -> null
-                            is PersonResult.Result -> toPersonWithChildrenDTO(it.vtjPersonDTO)
+            when (guardian.identity) {
+                is ExternalIdentifier.NoID -> toPersonWithChildrenDTO(guardian)
+                is ExternalIdentifier.SSN ->
+                    getPersonWithDependants(user, guardian.identity)
+                        ?.let { personStorageService.upsertVtjGuardianAndChildren(PersonResult.Result(it)) }
+                        ?.let {
+                            when (it) {
+                                is PersonResult.Error -> throw IllegalStateException(it.msg)
+                                is PersonResult.NotFound -> null
+                                is PersonResult.Result -> toPersonWithChildrenDTO(it.vtjPersonDTO)
+                            }
                         }
-                    }
+            }
         }
-    }
 
     // In extremely rare cases there might be more than 2 guardians, but it was agreed with product management to use
     // just one of these as the other guardian.
@@ -117,14 +128,14 @@ class PersonService(
         user: AuthenticatedUser,
         otherGuardianId: VolttiIdentifier,
         childId: VolttiIdentifier
-    ): PersonDTO? {
-        return getGuardians(user, childId).filter { guardian -> guardian.id != otherGuardianId }.firstOrNull()
+    ): PersonDTO? = withSpringTx(txManager) {
+        getGuardians(user, childId).filter { guardian -> guardian.id != otherGuardianId }.firstOrNull()
     }
 
-    fun getGuardians(user: AuthenticatedUser, id: VolttiIdentifier): List<PersonDTO> {
-        val child = personDAO.getPersonByVolttiId(id) ?: return emptyList()
+    fun getGuardians(user: AuthenticatedUser, id: VolttiIdentifier): List<PersonDTO> = withSpringTx(txManager) {
+        val child = personDAO.getPersonByVolttiId(id) ?: return@withSpringTx emptyList()
 
-        return when (child.identity) {
+        when (child.identity) {
             is ExternalIdentifier.NoID -> emptyList()
             is ExternalIdentifier.SSN ->
                 getPersonWithGuardians(user, child.identity)
@@ -143,7 +154,7 @@ class PersonService(
         user: AuthenticatedUser,
         ssn: ExternalIdentifier.SSN,
         updateStale: Boolean = true
-    ): PersonDTO? {
+    ): PersonDTO? = withSpringTx(txManager) {
         val person = personDAO.getPersonByExternalId(ssn)
         if (person == null || (updateStale && vtjDataIsStale(person))) {
             val personDetails = personDetailsService.getBasicDetailsFor(
@@ -152,28 +163,29 @@ class PersonService(
             if (personDetails is PersonDetails.Result) {
                 val personResult = PersonResult.Result(personDetails.vtjPerson.mapToDto())
                 personStorageService.upsertVtjPerson(personResult)
-                return personDAO.getPersonByExternalId(ssn)
+                personDAO.getPersonByExternalId(ssn)
             } else {
-                return hideNonDisclosureInfo(person)
+                hideNonDisclosureInfo(person)
             }
         } else {
-            return person
+            person
         }
     }
 
-    fun getPersonFromVTJ(user: AuthenticatedUser, ssn: ExternalIdentifier.SSN): PersonDTO? {
+    fun getPersonFromVTJ(user: AuthenticatedUser, ssn: ExternalIdentifier.SSN): PersonDTO? = withSpringTx(txManager) {
         val personDetails = personDetailsService.getBasicDetailsFor(
             IPersonDetailsService.DetailsQuery(user, ssn)
         )
         if (personDetails is PersonDetails.Result) {
-            return personDetails.vtjPerson.mapToDto().let { toPersonDTO(it) }
-        } else return null
+            personDetails.vtjPerson.mapToDto().let { toPersonDTO(it) }
+        } else null
     }
 
-    fun updateEndUsersContactInfo(id: VolttiIdentifier, contactInfo: ContactInfo): Boolean =
+    fun updateEndUsersContactInfo(id: VolttiIdentifier, contactInfo: ContactInfo): Boolean = withSpringTx(txManager) {
         personDAO.updateEndUsersContactInfo(id, contactInfo)
+    }
 
-    fun patchUserDetails(id: VolttiIdentifier, data: PersonPatch): PersonDTO {
+    fun patchUserDetails(id: VolttiIdentifier, data: PersonPatch): PersonDTO = withSpringTx(txManager) {
         val person = getPerson(id) ?: throw NotFound("Person $id not found")
 
         when (person.identity) {
@@ -192,27 +204,30 @@ class PersonService(
             is ExternalIdentifier.NoID -> personDAO.updateEndUserDetails(id, data)
         }.exhaust()
 
-        return getPerson(id)!!
+        getPerson(id)!!
     }
 
-    fun addSsn(user: AuthenticatedUser, id: VolttiIdentifier, ssn: ExternalIdentifier.SSN): PersonDTO {
-        val person = getPerson(id) ?: throw NotFound("Person $id not found")
+    fun addSsn(user: AuthenticatedUser, id: VolttiIdentifier, ssn: ExternalIdentifier.SSN): PersonDTO =
+        withSpringTx(txManager) {
+            val person = getPerson(id) ?: throw NotFound("Person $id not found")
 
-        when (person.identity) {
-            is ExternalIdentifier.SSN -> throw BadRequest("User already has ssn")
-            is ExternalIdentifier.NoID -> {
-                if (personDAO.getPersonByExternalId(ssn) != null) {
-                    throw Conflict("User with same ssn already exists")
+            when (person.identity) {
+                is ExternalIdentifier.SSN -> throw BadRequest("User already has ssn")
+                is ExternalIdentifier.NoID -> {
+                    if (personDAO.getPersonByExternalId(ssn) != null) {
+                        throw Conflict("User with same ssn already exists")
+                    }
+                    personDAO.addSsn(id, ssn.toString())
                 }
-                personDAO.addSsn(id, ssn.toString())
-            }
-        }.exhaust()
+            }.exhaust()
 
-        return getUpToDatePerson(user, id)!!
-    }
+            getUpToDatePerson(user, id)!!
+        }
 
     fun findBySearchTerms(searchTerms: String, orderBy: String, sortDirection: String): List<PersonDTO> =
-        personDAO.findBySearchTerms(searchTerms, orderBy, sortDirection)
+        withSpringTx(txManager) {
+            personDAO.findBySearchTerms(searchTerms, orderBy, sortDirection)
+        }
 
     private fun vtjDataIsStale(person: PersonDTO): Boolean {
         return person.updatedFromVtj

--- a/service/src/test/kotlin/fi/espoo/evaka/pis/service/PersonServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/pis/service/PersonServiceTest.kt
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.transaction.PlatformTransactionManager
 import java.time.Instant
 
 @ExtendWith(MockitoExtension::class)
@@ -40,6 +41,9 @@ class PersonServiceTest {
 
     @Mock
     lateinit var personStorageService: PersonStorageService
+
+    @Mock
+    lateinit var txManager: PlatformTransactionManager
 
     @InjectMocks
     lateinit var service: PersonService


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

Fix `/person/{personId}/ssn` endpoint hang when a VTJ update happens. When `getUpToDatePerson` decided to do a VTJ query, there were two nested transactions that both wanted to update the same row in the `person` table -> deadlock + hang until 15 minute DB connection read timeout

The simplest fix was to run "add SSN to person row" and "get updated person data" as separate operations, so nested transactions don't happen. In the future, we should probably refactor the internal API so that VTJ queries never run inside an outer transaction, to avoid connection starvation and potential dead locks.