### PR TITLE
[EVAKA-3958] Improve absence editor styles

### DIFF
--- a/frontend/packages/employee-frontend/src/components/absences/AbsenceTable.tsx
+++ b/frontend/packages/employee-frontend/src/components/absences/AbsenceTable.tsx
@@ -72,7 +72,7 @@ function AbsenceTableRow({
             key={`${id}${date.formatIso()}`}
             className={`${
               date.isToday() ? 'absence-cell-today' : ''
-            } hover-highlight`}
+            } hover-highlight absence-cell-wrapper`}
           >
             <AbsenceCellWrapper
               careTypes={placements[date.formatIso()]}
@@ -108,8 +108,8 @@ function AbsenceTableHead({ dateCols, emptyCols }: AbsenceHeadProps) {
         {dateCols.map((item) => (
           <th
             key={item.getDate()}
-            align="center"
             className={classNames({
+              'absence-header': true,
               'absence-header-today': item.isToday(),
               'absence-header-weekday': item.isWeekend()
             })}
@@ -150,7 +150,7 @@ function AbsenceTable({ groupId, childList }: AbsenceTableProps) {
 
   const renderEmptyRow = () => (
     <tr>
-      <td className={'empty-row'}>.</td>
+      <td className={'empty-row'}></td>
     </tr>
   )
 

--- a/frontend/packages/employee-frontend/src/components/absences/Absences.scss
+++ b/frontend/packages/employee-frontend/src/components/absences/Absences.scss
@@ -22,6 +22,7 @@
     text-align: left;
     text-transform: uppercase;
     color: #6e6e6e;
+    vertical-align: bottom;
 
     &.absence-header {
       text-align: center;

--- a/frontend/packages/employee-frontend/src/components/absences/Absences.scss
+++ b/frontend/packages/employee-frontend/src/components/absences/Absences.scss
@@ -13,31 +13,36 @@
     }
   }
 
-  .container {
-    @media screen and (min-width: $screen-small) and (max-width: $screen-medium) {
-      width: 100%;
-      max-width: 100%;
-    }
-  }
-
-  .content-area {
-    margin-bottom: 20px;
+  .table {
+    border-collapse: collapse;
+    width: 100%;
   }
 
   .table th {
     text-align: left;
     text-transform: uppercase;
     color: #6e6e6e;
+
+    &.absence-header {
+      text-align: center;
+    }
   }
 
   .table td {
-    text-align: center;
+    text-align: left;
     color: #0f0f0f;
+
+    &.absence-cell-wrapper {
+      text-align: center;
+    }
+    &.absence-cell-wrapper > div {
+      margin: 0 auto;
+    }
   }
 
   .table td,
   .table th {
-    padding: 5px 2px !important;
+    padding: 5px 3px !important;
     border-bottom: none !important;
   }
 
@@ -48,6 +53,11 @@
 
   .table td {
     cursor: pointer;
+
+    &.empty-row {
+      cursor: inherit;
+      height: 20px;
+    }
   }
 
   .table .has-text-center {
@@ -135,15 +145,6 @@
     width: $cell-size;
     border-style: solid;
     border-color: transparent;
-  }
-
-  .absence-cell-left,
-  .absence-cell-right,
-  .absence-cell-selected {
-    // center cells with bigger screens
-    @media screen and (min-width: $screen-big) {
-      left: 3px;
-    }
   }
 
   .absence-cell-left {
@@ -254,6 +255,7 @@
         /* disable spin buttons Firefox */
         -moz-appearance: textfield;
         text-align: center;
+        margin: 0 auto;
         padding: 0;
         font-weight: 600;
         font-size: 0.8rem;

--- a/frontend/packages/employee-frontend/src/components/absences/Absences.tsx
+++ b/frontend/packages/employee-frontend/src/components/absences/Absences.tsx
@@ -39,6 +39,11 @@ import PeriodPicker, {
 import { TitleContext, TitleState } from '~state/title'
 import ColorInfo from '~components/absences/ColorInfo'
 import ReturnButton from 'components/shared/atoms/buttons/ReturnButton'
+import styled from 'styled-components'
+
+const AbsencesContentArea = styled(ContentArea)`
+  overflow-x: auto;
+`
 
 function Absences({ match }: RouteComponentProps<{ groupId: string }>) {
   const { i18n } = useTranslation()
@@ -182,7 +187,7 @@ function Absences({ match }: RouteComponentProps<{ groupId: string }>) {
     <div className="absences-page" data-qa="absences-page">
       <Container>
         <ReturnButton dataQa="absences-page-return-button" />
-        <ContentArea opaque>
+        <AbsencesContentArea opaque>
           {renderAbsenceModal()}
           {isSuccess(absences) ? (
             <div>
@@ -211,7 +216,7 @@ function Absences({ match }: RouteComponentProps<{ groupId: string }>) {
           {isFailure(absences) && (
             <div>Something went wrong ({absences.error.message})</div>
           )}
-        </ContentArea>
+        </AbsencesContentArea>
         <ColorInfo />
       </Container>
     </div>

--- a/frontend/packages/employee-frontend/src/components/absences/ColorInfo.scss
+++ b/frontend/packages/employee-frontend/src/components/absences/ColorInfo.scss
@@ -9,16 +9,19 @@
 .color-info {
   display: flex;
   justify-content: flex-start;
+  padding: 0 20px;
   flex-wrap: wrap;
-  padding: 0 60px;
   font-size: 15px;
-  margin-top: 32px;
+  margin: 20px auto;
+
+  > div {
+    margin: 10px;
+  }
 
   .color-info-container {
     display: flex;
     flex: auto;
     max-width: 130px;
-    margin: 0 10px;
 
     .info-ball {
       vertical-align: top;


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

* center date columns
* left align non-date columns
* use 100% table width
* fix horizontal centering of absence cells
* add table scrollbar on small screens (not the best solution, but
  better than the table going off screen)
* remove extra "dot row", replace with empty space
* add margin to color legend elements

Before vs after:

![Screenshot from 2020-10-26 16-17-57](https://user-images.githubusercontent.com/94033/97186841-79c89600-17aa-11eb-895b-9b394d5738dc.png)
