### PR TITLE
Inherit font by default in some elements

### DIFF
--- a/frontend/packages/employee-frontend/src/index.scss
+++ b/frontend/packages/employee-frontend/src/index.scss
@@ -12,6 +12,10 @@ body {
   margin: 0;
 }
 
+input, button, textarea, select {
+  font: inherit;
+}
+
 *,
 *::before,
 *::after {


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

Default fonts from browser stylesheets were used in some elements, because they did not inherit the font from parents.

For example, on my machine the input element in the absence editor used:

* Ubuntu Sans in Firefox
* Arial in Chrome

After this change, it inherits Open Sans as expected.