### PR TITLE
Hotfix: merged finance decision validity periods

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DecisionGenerator.kt
@@ -352,7 +352,7 @@ private fun generateNewFeeDecisions(
             )
         }
         .let { mergePeriods(it, ::decisionContentsAreEqual) }
-        .map { (_, decision) -> decision }
+        .map { (period, decision) -> decision.withValidity(period) }
 }
 
 private fun generateNewValueDecisions(
@@ -451,7 +451,7 @@ private fun generateNewValueDecisions(
             )
         }
         .let { mergePeriods(it, ::decisionContentsAreEqual) }
-        .map { (_, decision) -> decision }
+        .map { (period, decision) -> decision.withValidity(period) }
 }
 
 private fun getUnitsThatAreInvoiced(h: Handle): List<UUID> {


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
Fix a bug where finance decisions have wrong validity periods when two with identical contents are merged into one.
