### PR TITLE
Koski preparatory absences can lead to resignation

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -57,7 +57,6 @@ class KoskiIntegrationTest : FullApplicationTest() {
         koskiTester = KoskiTester(
             jdbi,
             KoskiClient(
-                jdbi = jdbi,
                 env = env,
                 baseUrl = "http://localhost:${koskiServer.port}",
                 asyncJobRunner = null

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -29,6 +29,7 @@ import fi.espoo.evaka.shared.dev.insertTestAssistanceNeed
 import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.ClosedPeriod
+import fi.espoo.evaka.shared.domain.toClosedPeriod
 import fi.espoo.evaka.testAreaId
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
@@ -677,6 +678,56 @@ class KoskiIntegrationTest : FullApplicationTest() {
                 Opiskeluoikeusjakso.läsnä(preschoolTerm2020.start),
                 Opiskeluoikeusjakso.loma(holiday.start),
                 Opiskeluoikeusjakso.läsnä(holiday.end.plusDays(1)),
+                Opiskeluoikeusjakso.valmistunut(preschoolTerm2020.end)
+            ),
+            opiskeluoikeus.tila.opiskeluoikeusjaksot
+        )
+    }
+
+    @Test
+    fun `preparatory is considered resigned if absence periods longer than week make up more than 30 days in total`() {
+        insertPlacement(period = preschoolTerm2020, type = PlacementType.PREPARATORY)
+        val absences = listOf(
+            ClosedPeriod(preschoolTerm2020.start.plusDays(1), preschoolTerm2020.start.plusDays(20)),
+            ClosedPeriod(preschoolTerm2020.start.plusDays(50), preschoolTerm2020.start.plusDays(80))
+        )
+        insertAbsences(testChild_1.id, AbsenceType.UNKNOWN_ABSENCE, *absences.toTypedArray())
+
+        val today = preschoolTerm2020.end.plusDays(1)
+        koskiTester.triggerUploads(today)
+
+        val opiskeluoikeus = koskiServer.getStudyRights().values.single().opiskeluoikeus
+        assertEquals(
+            listOf(
+                Opiskeluoikeusjakso.läsnä(preschoolTerm2020.start),
+                Opiskeluoikeusjakso.väliaikaisestiKeskeytynyt(absences[0].start),
+                Opiskeluoikeusjakso.läsnä(absences[0].end.plusDays(1)),
+                Opiskeluoikeusjakso.väliaikaisestiKeskeytynyt(absences[1].start),
+                Opiskeluoikeusjakso.läsnä(absences[1].end.plusDays(1)),
+                Opiskeluoikeusjakso.eronnut(preschoolTerm2020.end)
+            ),
+            opiskeluoikeus.tila.opiskeluoikeusjaksot
+        )
+        val suoritus = opiskeluoikeus.suoritukset.single()
+        assertNull(suoritus.vahvistus)
+    }
+
+    @Test
+    fun `preparatory is not considered resigned even with many random absence days which are non-contiguous`() {
+        insertPlacement(period = preschoolTerm2020, type = PlacementType.PREPARATORY)
+
+        val absencesEveryOtherDay =
+            (1..90 step 2).map { preschoolTerm2020.start.plusDays(it.toLong()).toClosedPeriod() }
+        assertEquals(45, absencesEveryOtherDay.size)
+        insertAbsences(testChild_1.id, AbsenceType.UNKNOWN_ABSENCE, *absencesEveryOtherDay.toTypedArray())
+
+        val today = preschoolTerm2020.end.plusDays(1)
+        koskiTester.triggerUploads(today)
+
+        val opiskeluoikeus = koskiServer.getStudyRights().values.single().opiskeluoikeus
+        assertEquals(
+            listOf(
+                Opiskeluoikeusjakso.läsnä(preschoolTerm2020.start),
                 Opiskeluoikeusjakso.valmistunut(preschoolTerm2020.end)
             ),
             opiskeluoikeus.tila.opiskeluoikeusjaksot

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
@@ -34,7 +34,6 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
         koskiTester = KoskiTester(
             jdbi,
             KoskiClient(
-                jdbi = jdbi,
                 env = env,
                 baseUrl = "http://localhost:${koskiServer.port}",
                 asyncJobRunner = null

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
@@ -710,7 +710,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
                                                     "koodistoUri": "arviointiasteikkoyleissivistava"
                                                 },
                                                 "kuvaus": {
-                                                    "fi": "Keskustelee sujuvasti suomeksi"
+                                                    "fi": "Suorittanut perusopetukseen valmistavan opetuksen esiopetuksen yhteydessä"
                                                 }
                                             }
                                         ],

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -22,7 +22,6 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.UploadToKoski
 import mu.KotlinLogging
 import org.jdbi.v3.core.Handle
-import org.jdbi.v3.core.Jdbi
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -31,7 +30,6 @@ private val logger = KotlinLogging.logger { }
 
 @Component
 class KoskiClient(
-    private val jdbi: Jdbi,
     private val env: Environment,
     private val baseUrl: String = env.getRequiredProperty("fi.espoo.integration.koski.url"),
     private val sourceSystem: String = env.getRequiredProperty("fi.espoo.integration.koski.source_system"),

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -62,7 +62,7 @@ class KoskiClient(
         }
         val payload = objectMapper.writeValueAsString(data.oppija)
         if (!h.isPayloadChanged(msg.key, payload)) {
-            logger.info { "Koski upload ${msg.key}: no change in payload -> skipping" }
+            logger.info { "Koski upload ${msg.key} ${data.operation}: no change in payload -> skipping" }
         } else {
             val (_, _, result) = Fuel.request(
                 method = if (data.operation == KoskiOperation.CREATE) Method.POST else Method.PUT,
@@ -78,7 +78,7 @@ class KoskiClient(
             val response: HenkilönOpiskeluoikeusVersiot = try {
                 objectMapper.readValue(result.get())
             } catch (error: FuelError) {
-                logger.error { "Koski upload ${msg.key}: ${error.response}" }
+                logger.error(error) { "Koski upload ${msg.key} ${data.operation} failed: ${error.response}" }
                 throw error
             }
             h.finishKoskiUpload(
@@ -101,7 +101,7 @@ class KoskiClient(
                     )
                 )
             )
-            logger.info { "Koski upload ${msg.key}: finished ${data.operation}" }
+            logger.info { "Koski upload ${msg.key} ${data.operation}: finished" }
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -206,7 +206,7 @@ data class KoskiActiveDataRaw(
                                 koodiarvo = ArvosanaKoodiarvo.OSALLISTUNUT
                             ),
                             kuvaus = LokalisoituTeksti(
-                                fi = "Keskustelee sujuvasti suomeksi"
+                                fi = "Suorittanut perusopetukseen valmistavan opetuksen esiopetuksen yhteydessä"
                             )
                         )
                     )

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -98,7 +98,7 @@ data class KoskiVoidedDataRaw(
         ),
         tyyppi = OpiskeluoikeudenTyyppi(type),
         lisätiedot = null,
-        järjestämismuoto = unit.haeJärjestämisMuoto()
+        järjestämismuoto = if (type == OpiskeluoikeudenTyyppiKoodi.PREPARATORY) null else unit.haeJärjestämisMuoto()
     )
 }
 
@@ -240,7 +240,7 @@ data class KoskiActiveDataRaw(
             ),
             tyyppi = OpiskeluoikeudenTyyppi(type),
             lisätiedot = if (type == OpiskeluoikeudenTyyppiKoodi.PREPARATORY) null else haeLisätiedot(),
-            järjestämismuoto = unit.haeJärjestämisMuoto()
+            järjestämismuoto = if (type == OpiskeluoikeudenTyyppiKoodi.PREPARATORY) null else unit.haeJärjestämisMuoto()
         )
     }
 


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

A **cumulative total** of 31 days or more absence days **counting only sequences longer than one week** leads to resignation in preparatory education **only in terms starting from 2020**...a lot of conditions :wink: 

Also update the "verbal grading" text.