### PR TITLE
Fix PSQLException handling

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/CaretakerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/CaretakerService.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.pis.dao.mapPSQLException
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.NotFound
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -64,7 +63,7 @@ class CaretakerService(
                 sql,
                 mapOf("groupId" to groupId, "start" to startDate, "end" to endDate, "amount" to amount)
             )
-        } catch (e: DataIntegrityViolationException) {
+        } catch (e: Exception) {
             throw mapPSQLException(e)
         }
     }
@@ -102,7 +101,7 @@ class CaretakerService(
                 sql,
                 mapOf("groupId" to groupId, "id" to id, "start" to startDate, "end" to endDate, "amount" to amount)
             ).let { updated -> if (updated == 0) throw NotFound("Caretakers $id not found") }
-        } catch (e: DataIntegrityViolationException) {
+        } catch (e: Exception) {
             throw mapPSQLException(e)
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/ParentshipService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/ParentshipService.kt
@@ -20,7 +20,6 @@ import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.domain.maxEndDate
 import mu.KotlinLogging
 import org.jdbi.v3.core.Handle
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.UUID
@@ -44,7 +43,7 @@ class ParentshipService(
         return try {
             h.createParentship(childId, headOfChildId, startDate, endDate, allowConflicts)
                 .also { sendFamilyUpdatedMessage(headOfChildId, startDate, endDate) }
-        } catch (e: DataIntegrityViolationException) {
+        } catch (e: Exception) {
             if (allowConflicts) {
                 h.transaction { t ->
                     t.createParentship(childId, headOfChildId, startDate, endDate, true)
@@ -76,7 +75,7 @@ class ParentshipService(
         try {
             val success = h.updateParentshipDuration(id, startDate, endDate)
             if (!success) throw NotFound("No parentship found with id $id")
-        } catch (e: DataIntegrityViolationException) {
+        } catch (e: Exception) {
             throw mapPSQLException(e)
         }
 
@@ -101,7 +100,7 @@ class ParentshipService(
                         endDate = it.endDate
                     )
                 }
-        } catch (e: DataIntegrityViolationException) {
+        } catch (e: Exception) {
             throw mapPSQLException(e)
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PartnershipService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PartnershipService.kt
@@ -15,7 +15,6 @@ import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.domain.maxEndDate
 import mu.KotlinLogging
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.annotation.Transactional
@@ -79,7 +78,7 @@ class PartnershipService(
         try {
             val success = dao.updatePartnershipDuration(partnershipId, startDate, endDate)
             if (!success) throw NotFound("No partnership found with id $partnershipId")
-        } catch (e: UnableToExecuteStatementException) {
+        } catch (e: Exception) {
             throw mapPSQLException(e)
         }
 
@@ -108,7 +107,7 @@ class PartnershipService(
                     }
                 }
             dao.retryPartnership(partnershipId)
-        } catch (e: DataIntegrityViolationException) {
+        } catch (e: Exception) {
             throw mapPSQLException(e)
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.NotFound
 import org.jdbi.v3.core.Handle
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.lang.Error
@@ -69,7 +68,7 @@ fun updatePlacement(
 
     try {
         h.updatePlacementStartAndEndDate(id, startDate, endDate)
-    } catch (e: DataIntegrityViolationException) {
+    } catch (e: Exception) {
         throw mapPSQLException(e)
     }
 
@@ -121,7 +120,7 @@ fun createGroupPlacement(
             // no merging needed, create new
             h.createGroupPlacement(daycarePlacementId, groupId, startDate, endDate).id!!
         }
-    } catch (e: DataIntegrityViolationException) {
+    } catch (e: Exception) {
         throw mapPSQLException(e)
     }
 }


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
Since converting database query functions from various Spring implementations into Jdbi some of the catch blocks never caught the database exceptions since Jdbi obviously does not throw Spring's `DataIntegrityViolationException`s. Change the catch blocks to catch all throwables extending `Exception` since it doesn't really matter if we pass unrelated exceptions to `mapPSQLException` as well.
