### PR TITLE
Fix empty page caused by incorrect redirect URL

### DIFF
--- a/frontend/packages/employee-frontend/src/components/fee-decision-details/FeeDecisionDetailsPage.tsx
+++ b/frontend/packages/employee-frontend/src/components/fee-decision-details/FeeDecisionDetailsPage.tsx
@@ -67,7 +67,7 @@ export default React.memo(function FeeDecisionDetailsPage() {
   const goToDecisions = useCallback(() => goBack(), [history])
 
   if (isFailure(decision)) {
-    return <Redirect to="/decisions" />
+    return <Redirect to="/finance/fee-decisions" />
   }
 
   return (

--- a/frontend/packages/employee-frontend/src/components/invoice/InvoicePage.tsx
+++ b/frontend/packages/employee-frontend/src/components/invoice/InvoicePage.tsx
@@ -52,7 +52,7 @@ const InvoiceDetailsPage = React.memo(function InvoiceDetailsPage() {
   const editable = isSuccess(invoice) && invoice.data.status === 'DRAFT'
 
   if (isFailure(invoice)) {
-    return <Redirect to="/invoices" />
+    return <Redirect to="/finance/invoices" />
   }
 
   const updateRows = (rows: InvoiceRowDetailed[]) =>


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

`/invoices` has an extra redirect so it didn't lead to an empty page, but `/decisions` is an old URL that hasn't existed for some time now. Both URLs are now correct