### PR TITLE
Do not let whole transaction fail if family relationship has expected…

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
@@ -62,7 +62,7 @@ class FridgeFamilyService(
 
             newChildrenInSameAddress.forEach { child ->
                 try {
-                    h.transaction { t ->
+                    jdbi.transaction { t ->
                         parentshipService.createParentship(
                             t,
                             childId = child.id,

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
@@ -73,7 +73,7 @@ class FridgeFamilyService(
                     }
                     logger.info("Child ${child.id} added")
                 } catch (e: Exception) {
-                    logger.info("Ignored the following:", e)
+                    logger.debug("Ignored the following:", e)
                 }
             }
             logger.info("Completed refreshing person ${msg.personId}")


### PR DESCRIPTION
… conflict

#### Summary
VTJ batch refresh async job could not marked completed because of benign psql query failure caused the whole transaction to be rolled back. 

Also do not use word "Exception" in logging so that elastic watcher does not falsely report is as an exception

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```
