### PR TITLE
Fix invalid async job runner usage

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyDecisionCreated
 import fi.espoo.evaka.shared.async.SendDecision
 import fi.espoo.evaka.shared.config.Roles
-import fi.espoo.evaka.shared.db.runAfterCommit
 import mu.KotlinLogging
 import org.jdbi.v3.core.Handle
 import org.springframework.stereotype.Component
@@ -38,7 +37,6 @@ class DecisionMessageProcessor(
         if (msg.sendAsMessage) {
             logger.info { "Sending decision pdf(s) for decision (id: $decisionId)." }
             asyncJobRunner.plan(h, listOf(SendDecision(decisionId, msg.user)))
-            runAfterCommit { asyncJobRunner.scheduleImmediateRun() }
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -126,11 +126,9 @@ class FeeDecisionController(
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         jdbi.transaction { h ->
             val confirmedDecisions = service.confirmDrafts(h, user, feeDecisionIds)
-            confirmedDecisions.forEach {
-                asyncJobRunner.plan(h, listOf(NotifyFeeDecisionApproved(it)))
-            }
-            asyncJobRunner.scheduleImmediateRun()
+            asyncJobRunner.plan(h, confirmedDecisions.map { NotifyFeeDecisionApproved(it) })
         }
+        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -155,7 +155,7 @@ class PlacementController(
                 )
             )
         }
-        runAfterCommit { asyncJobRunner.scheduleImmediateRun() }
+        asyncJobRunner.scheduleImmediateRun()
 
         return ResponseEntity.noContent().build()
     }
@@ -173,7 +173,7 @@ class PlacementController(
             val (childId, startDate, endDate) = h.cancelPlacement(placementId)
             asyncJobRunner.plan(h, listOf(NotifyPlacementPlanApplied(childId, startDate, endDate)))
         }
-        runAfterCommit { asyncJobRunner.scheduleImmediateRun() }
+        asyncJobRunner.scheduleImmediateRun()
 
         return ResponseEntity.noContent().build()
     }


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

* `scheduleImmediateRun` must be called after the transaction planning the jobs has been committed
* `runAfterCommit` only works inside Spring transactions, and is no-op otherwise