### PR TITLE
Remove handle parameter from async jobs

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
@@ -54,14 +54,14 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     @Test
     fun `person date of death`() = jdbi.handle { h ->
         createTestPerson(testPerson.copy(ssn = "010180-999A"))
-        dvvModificationsService.updatePersonsFromDvv(h, listOf("010180-999A"))
+        dvvModificationsService.updatePersonsFromDvv(listOf("010180-999A"))
         assertEquals(LocalDate.parse("2019-07-30"), h.getPersonBySSN("010180-999A")?.dateOfDeath)
     }
 
     @Test
     fun `person restricted details started`() = jdbi.handle { h ->
         createTestPerson(testPerson.copy(ssn = "020180-999Y"))
-        dvvModificationsService.updatePersonsFromDvv(h, listOf("020180-999Y"))
+        dvvModificationsService.updatePersonsFromDvv(listOf("020180-999Y"))
         val modifiedPerson = h.getPersonBySSN("020180-999Y")!!
         assertEquals(true, modifiedPerson.restrictedDetailsEnabled)
         assertEquals("", modifiedPerson.streetAddress)
@@ -72,7 +72,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     @Test
     fun `person restricted details ended and address is set`() = jdbi.handle { h ->
         createTestPerson(testPerson.copy(ssn = "030180-999L", restrictedDetailsEnabled = true, streetAddress = "", postalCode = "", postOffice = ""))
-        dvvModificationsService.updatePersonsFromDvv(h, listOf("030180-999L"))
+        dvvModificationsService.updatePersonsFromDvv(listOf("030180-999L"))
         val modifiedPerson = h.getPersonBySSN("030180-999L")!!
         assertEquals(false, modifiedPerson.restrictedDetailsEnabled)
         assertEquals(LocalDate.parse("2030-01-01"), modifiedPerson.restrictedDetailsEndDate)
@@ -84,7 +84,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     @Test
     fun `person address change`() = jdbi.handle { h ->
         createTestPerson(testPerson.copy(ssn = "040180-9998"))
-        dvvModificationsService.updatePersonsFromDvv(h, listOf("040180-9998"))
+        dvvModificationsService.updatePersonsFromDvv(listOf("040180-9998"))
         val modifiedPerson = h.getPersonBySSN("040180-9998")!!
         assertEquals("Uusitie 17 A 2", modifiedPerson.streetAddress)
         assertEquals("02940", modifiedPerson.postalCode)
@@ -95,7 +95,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     @Test
     fun `person ssn change`() = jdbi.handle { h ->
         val testId = createTestPerson(testPerson.copy(ssn = "010181-999K"))
-        dvvModificationsService.updatePersonsFromDvv(h, listOf("010181-999K"))
+        dvvModificationsService.updatePersonsFromDvv(listOf("010181-999K"))
         assertEquals(testId, h.getPersonBySSN("010281-999C")?.id)
     }
 
@@ -109,7 +109,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createVtjPerson(custodian)
         createVtjPerson(caretaker)
 
-        dvvModificationsService.updatePersonsFromDvv(h, listOf("050118A999W"))
+        dvvModificationsService.updatePersonsFromDvv(listOf("050118A999W"))
         val dvvCustodian = h.getPersonBySSN("050118A999W")!!
         assertEquals("Harri", dvvCustodian.firstName)
         assertEquals("Huollettava", dvvCustodian.lastName)
@@ -125,7 +125,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createVtjPerson(custodian)
         createVtjPerson(caretaker)
 
-        dvvModificationsService.updatePersonsFromDvv(h, listOf("060118A999J"))
+        dvvModificationsService.updatePersonsFromDvv(listOf("060118A999J"))
         val dvvCaretaker = h.getPersonBySSN("060180-999J")!!
         assertEquals("Harri", dvvCaretaker.firstName)
         assertEquals("Huoltaja", dvvCaretaker.lastName)
@@ -140,7 +140,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createTestPerson(personWithOldName)
         createVtjPerson(personWithNewName)
 
-        dvvModificationsService.updatePersonsFromDvv(h, listOf(SSN))
+        dvvModificationsService.updatePersonsFromDvv(listOf(SSN))
         val updatedPerson = h.getPersonBySSN(SSN)!!
         assertEquals("Urkki", updatedPerson.firstName)
         assertEquals("Uusinimi", updatedPerson.lastName)
@@ -156,7 +156,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         storeDvvModificationToken(h, "10000", "-2", 0, 0)
         try {
             createTestPerson(testPerson.copy(ssn = "010180-999A"))
-            assertEquals(3, dvvModificationsService.updatePersonsFromDvv(h, listOf("010180-999A")))
+            assertEquals(3, dvvModificationsService.updatePersonsFromDvv(listOf("010180-999A")))
             assertEquals("1", getNextDvvModificationToken(h))
             assertEquals(LocalDate.parse("2019-07-30"), h.getPersonBySSN("010180-999A")?.dateOfDeath)
         } finally {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -59,7 +59,8 @@ class KoskiIntegrationTest : FullApplicationTest() {
             KoskiClient(
                 env = env,
                 baseUrl = "http://localhost:${koskiServer.port}",
-                asyncJobRunner = null
+                asyncJobRunner = null,
+                jdbi = jdbi
             )
         )
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTestHelpers.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTestHelpers.kt
@@ -42,9 +42,8 @@ internal fun Handle.setUnitOids() {
 }
 
 internal class KoskiTester(private val jdbi: Jdbi, private val client: KoskiClient) {
-    fun triggerUploads(today: LocalDate, params: KoskiSearchParams = KoskiSearchParams()) = jdbi.handle {
-        it.getPendingStudyRights(today, params).forEach { request ->
-            client.uploadToKoski(it, UploadToKoski(request), today)
+    fun triggerUploads(today: LocalDate, params: KoskiSearchParams = KoskiSearchParams()) =
+        jdbi.handle { it.getPendingStudyRights(today, params) }.forEach { request ->
+            client.uploadToKoski(UploadToKoski(request), today)
         }
-    }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
@@ -36,7 +36,8 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
             KoskiClient(
                 env = env,
                 baseUrl = "http://localhost:${koskiServer.port}",
-                asyncJobRunner = null
+                asyncJobRunner = null,
+                jdbi = jdbi
             )
         )
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -91,17 +91,15 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         )
         whenever(personService.getUpToDatePersonWithChildren(user, testAdult_1.id)).thenReturn(dto)
 
-        jdbi.handle {
-            service.doVTJRefresh(it, VTJRefresh(testAdult_1.id, user.id))
-            verify(parentshipService).createParentship(
-                any(),
-                eq(testChild_1.id),
-                eq(testAdult_1.id),
-                eq(LocalDate.now()),
-                eq(lastDayBefore18YearsOld),
-                eq(false)
-            )
-        }
+        service.doVTJRefresh(VTJRefresh(testAdult_1.id, user.id))
+        verify(parentshipService).createParentship(
+            any(),
+            eq(testChild_1.id),
+            eq(testAdult_1.id),
+            eq(LocalDate.now()),
+            eq(lastDayBefore18YearsOld),
+            eq(false)
+        )
     }
 
     @Test
@@ -120,7 +118,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         )
         whenever(personService.getUpToDatePersonWithChildren(user, testAdult_1.id)).thenReturn(dto)
 
-        jdbi.handle { service.doVTJRefresh(it, VTJRefresh(testAdult_1.id, user.id)) }
+        service.doVTJRefresh(VTJRefresh(testAdult_1.id, user.id))
         verifyZeroInteractions(parentshipService)
     }
 
@@ -156,7 +154,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
             whenever(personService.getUpToDatePersonWithChildren(user, testAdult_1.id)).thenReturn(dto1)
             whenever(personService.getUpToDatePersonWithChildren(user, testAdult_2.id)).thenReturn(dto2)
 
-            service.doVTJRefresh(h, VTJRefresh(testAdult_1.id, user.id))
+            service.doVTJRefresh(VTJRefresh(testAdult_1.id, user.id))
             verify(parentshipService).createParentship(
                 any(),
                 eq(testChild_1.id),
@@ -201,7 +199,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
             whenever(personService.getUpToDatePersonWithChildren(user, testAdult_1.id)).thenReturn(dto1)
             whenever(personService.getUpToDatePersonWithChildren(user, testAdult_2.id)).thenReturn(dto2)
 
-            service.doVTJRefresh(h, VTJRefresh(testAdult_1.id, user.id))
+            service.doVTJRefresh(VTJRefresh(testAdult_1.id, user.id))
             verifyZeroInteractions(parentshipService)
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -29,9 +29,9 @@ class DvvModificationsBatchRefreshService(
         asyncJobRunner.dvvModificationsRefresh = ::doDvvModificationsRefresh
     }
 
-    fun doDvvModificationsRefresh(h: Handle, msg: DvvModificationsRefresh) {
+    fun doDvvModificationsRefresh(msg: DvvModificationsRefresh) {
         logger.info("DvvModificationsRefresh: updating ${msg.ssns.size} ssns")
-        dvvModificationsService.updatePersonsFromDvv(h, msg.ssns)
+        dvvModificationsService.updatePersonsFromDvv(msg.ssns)
     }
 
     fun scheduleBatch(): Int {

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
@@ -30,8 +30,8 @@ class DvvModificationsService(
     private val fridgeFamilyService: FridgeFamilyService
 ) {
 
-    fun updatePersonsFromDvv(h: Handle, ssns: List<String>): Int {
-        return getDvvModifications(h, ssns).let { modificationsForPersons ->
+    fun updatePersonsFromDvv(ssns: List<String>): Int {
+        return jdbi.handle { getDvvModifications(it, ssns) }.let { modificationsForPersons ->
             modificationsForPersons.map { personModifications ->
                 personModifications.tietoryhmat.map { infoGroup ->
                     try {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.db.withSpringHandle
 import fi.espoo.evaka.shared.db.withSpringTx
 import mu.KotlinLogging
 import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.Jdbi
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
 import java.time.LocalDate
@@ -30,6 +31,7 @@ class FamilyInitializerService(
     private val partnershipService: PartnershipService,
     private val txm: PlatformTransactionManager,
     private val dataSource: DataSource,
+    private val jdbi: Jdbi,
     private val asyncJobRunner: AsyncJobRunner,
     private val jackson: ObjectMapper
 ) {
@@ -39,7 +41,7 @@ class FamilyInitializerService(
         asyncJobRunner.initializeFamilyFromApplication = ::handleInitializeFamilyFromApplication
     }
 
-    fun handleInitializeFamilyFromApplication(h: Handle, msg: InitializeFamilyFromApplication) {
+    fun handleInitializeFamilyFromApplication(msg: InitializeFamilyFromApplication) = jdbi.transaction { h ->
         val user = msg.user
         val daycareForm = getForm(h, msg.applicationId)
         if (daycareForm != null) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
@@ -28,7 +28,7 @@ class VTJBatchRefreshService(
         asyncJobRunner.vtjRefresh = ::doVTJRefresh
     }
 
-    fun doVTJRefresh(h: Handle, msg: VTJRefresh) {
+    fun doVTJRefresh(msg: VTJRefresh) = jdbi.transaction { h ->
         fridgeFamilyService.doVTJRefresh(h, msg)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -26,7 +26,7 @@ private const val threadPoolSize = 1
 private const val defaultRetryCount = 24 * 60 / 5 // 24h when used with default 5 minute retry interval
 private val defaultRetryInterval = Duration.ofMinutes(5)
 
-private val noHandler = { _: Handle, msg: Any -> logger.warn("No job handler configured for $msg") }
+private val noHandler = { msg: Any -> logger.warn("No job handler configured for $msg") }
 
 class AsyncJobRunner(
     private val jdbi: Jdbi,
@@ -37,53 +37,53 @@ class AsyncJobRunner(
     private val runningCount: AtomicInteger = AtomicInteger(0)
 
     @Volatile
-    var notifyPlacementPlanApplied: (h: Handle, msg: NotifyPlacementPlanApplied) -> Unit = noHandler
+    var notifyPlacementPlanApplied: (msg: NotifyPlacementPlanApplied) -> Unit = noHandler
 
     @Volatile
-    var notifyServiceNeedUpdated: (h: Handle, msg: NotifyServiceNeedUpdated) -> Unit = noHandler
+    var notifyServiceNeedUpdated: (msg: NotifyServiceNeedUpdated) -> Unit = noHandler
 
     @Volatile
-    var notifyFamilyUpdated: (h: Handle, msg: NotifyFamilyUpdated) -> Unit = noHandler
+    var notifyFamilyUpdated: (msg: NotifyFamilyUpdated) -> Unit = noHandler
 
     @Volatile
-    var notifyFeeAlterationUpdated: (h: Handle, msg: NotifyFeeAlterationUpdated) -> Unit = noHandler
+    var notifyFeeAlterationUpdated: (msg: NotifyFeeAlterationUpdated) -> Unit = noHandler
 
     @Volatile
-    var notifyIncomeUpdated: (h: Handle, msg: NotifyIncomeUpdated) -> Unit = noHandler
+    var notifyIncomeUpdated: (msg: NotifyIncomeUpdated) -> Unit = noHandler
 
     @Volatile
-    var notifyDecisionCreated: (h: Handle, msg: NotifyDecisionCreated) -> Unit = noHandler
+    var notifyDecisionCreated: (msg: NotifyDecisionCreated) -> Unit = noHandler
 
     @Volatile
-    var sendDecision: (h: Handle, msg: SendDecision) -> Unit = noHandler
+    var sendDecision: (msg: SendDecision) -> Unit = noHandler
 
     @Volatile
-    var notifyFeeDecisionApproved: (h: Handle, msg: NotifyFeeDecisionApproved) -> Unit = noHandler
+    var notifyFeeDecisionApproved: (msg: NotifyFeeDecisionApproved) -> Unit = noHandler
 
     @Volatile
-    var notifyFeeDecisionPdfGenerated: (h: Handle, msg: NotifyFeeDecisionPdfGenerated) -> Unit = noHandler
+    var notifyFeeDecisionPdfGenerated: (msg: NotifyFeeDecisionPdfGenerated) -> Unit = noHandler
 
     @Volatile
-    var notifyVoucherValueDecisionApproved: (h: Handle, msg: NotifyVoucherValueDecisionApproved) -> Unit = noHandler
+    var notifyVoucherValueDecisionApproved: (msg: NotifyVoucherValueDecisionApproved) -> Unit = noHandler
 
     @Volatile
-    var notifyVoucherValueDecisionPdfGenerated: (h: Handle, msg: NotifyVoucherValueDecisionPdfGenerated) -> Unit =
+    var notifyVoucherValueDecisionPdfGenerated: (msg: NotifyVoucherValueDecisionPdfGenerated) -> Unit =
         noHandler
 
     @Volatile
-    var initializeFamilyFromApplication: (h: Handle, msg: InitializeFamilyFromApplication) -> Unit = noHandler
+    var initializeFamilyFromApplication: (msg: InitializeFamilyFromApplication) -> Unit = noHandler
 
     @Volatile
-    var vtjRefresh: (h: Handle, msg: VTJRefresh) -> Unit = noHandler
+    var vtjRefresh: (msg: VTJRefresh) -> Unit = noHandler
 
     @Volatile
-    var dvvModificationsRefresh: (h: Handle, msg: DvvModificationsRefresh) -> Unit = noHandler
+    var dvvModificationsRefresh: (msg: DvvModificationsRefresh) -> Unit = noHandler
 
     @Volatile
-    var uploadToKoski: (h: Handle, msg: UploadToKoski) -> Unit = noHandler
+    var uploadToKoski: (msg: UploadToKoski) -> Unit = noHandler
 
     @Volatile
-    var sendApplicationEmail: (h: Handle, msg: SendApplicationEmail) -> Unit = noHandler
+    var sendApplicationEmail: (msg: SendApplicationEmail) -> Unit = noHandler
 
     fun plan(
         h: Handle,
@@ -201,11 +201,11 @@ class AsyncJobRunner(
         }
     }
 
-    private inline fun <reified T : AsyncJobPayload> runJob(job: ClaimedJobRef, crossinline f: (h: Handle, msg: T) -> Unit) =
+    private inline fun <reified T : AsyncJobPayload> runJob(job: ClaimedJobRef, crossinline f: (msg: T) -> Unit) =
         jdbi.transaction { h ->
             startJob(h, job, T::class.java)?.let { msg ->
                 msg.user?.let { MdcKey.USER_ID.set(it.id.toString()) }
-                f(h, msg)
+                f(msg)
                 completeJob(h, job)
                 true
             } ?: false

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -151,13 +151,11 @@ class AsyncJobRunner(
     }
 
     private fun runPendingJobs(maxCount: Int) {
-        jdbi.handle { h ->
-            var remaining = maxCount
-            do {
-                val job = h.transaction { tx -> claimJob(tx) }?.also(this::runPendingJob)
-                remaining -= 1
-            } while (job != null && remaining > 0)
-        }
+        var remaining = maxCount
+        do {
+            val job = jdbi.transaction { tx -> claimJob(tx) }?.also(this::runPendingJob)
+            remaining -= 1
+        } while (job != null && remaining > 0)
     }
 
     private fun runPendingJob(job: ClaimedJobRef) {


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

We still have an open transaction in the runner, but async jobs are
expected to acquire a database connection themselves if they want to do
db stuff