### PR TITLE
Update placement plan unit list on date change

### DIFF
--- a/frontend/packages/employee-frontend/src/components/placement-draft/PlacementDraft.tsx
+++ b/frontend/packages/employee-frontend/src/components/placement-draft/PlacementDraft.tsx
@@ -184,14 +184,18 @@ function PlacementDraft({ match }: RouteComponentProps<{ id: UUID }>) {
           preschoolDaycarePeriod: placementDraft.data.preschoolDaycarePeriod
         })
         calculateOverLaps(placementDraft)
-
-        void getApplicationUnits(
-          placementDraft.data.type,
-          placementDraft.data.period.start
-        ).then(setUnits)
       }
     })
   }, [id])
+
+  useEffect(() => {
+    if (isSuccess(placementDraft)) {
+      void getApplicationUnits(
+        placementDraft.data.type,
+        placement.period?.start ?? placementDraft.data.period.start
+      ).then(setUnits)
+    }
+  }, [placementDraft, placement.period?.start])
 
   useEffect(() => {
     if (isSuccess(placementDraft)) {


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
Previously, if the placement plan's start date is for example moved to the future, units that open later in the future would not appear in the unit list.
