### PR TITLE
Use JDBI handle argument in all PersonStorageService functions

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
@@ -95,7 +95,7 @@ class PersonService(
             is ExternalIdentifier.NoID -> toPersonWithChildrenDTO(guardian)
             is ExternalIdentifier.SSN ->
                 getPersonWithDependants(user, guardian.identity)
-                    ?.let { personStorageService.upsertVtjGuardianAndChildren(PersonResult.Result(it)) }
+                    ?.let { personStorageService.upsertVtjGuardianAndChildren(h, PersonResult.Result(it)) }
                     ?.let {
                         when (it) {
                             is PersonResult.Error -> throw IllegalStateException(it.msg)

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.getEnum
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.db.handle
+import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.vtjclient.dto.NativeLanguage
 import fi.espoo.evaka.vtjclient.dto.PersonDataSource
@@ -49,7 +50,7 @@ class VtjController(
         @PathVariable(value = "personId") personId: UUID
     ): ResponseEntity<VtjPersonDTO> {
         val vtjData = getPersonDataWithChildren(user, personId)
-            .let { personStorageService.upsertVtjGuardianAndChildren(it) }
+            .let { jdbi.transaction { h -> personStorageService.upsertVtjGuardianAndChildren(h, it) } }
 
         return when (vtjData) {
             is PersonResult.Error -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

This prevents certain transaction deadlock situations, since we're not creating nested transactions.