### PR TITLE
Evaka 3988 fix broken report dropdowns

### DIFF
--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -111,7 +111,9 @@ export const fi = {
     noFirstName: 'Etunimi puuttuu',
     noLastName: 'Sukunimi puuttuu',
     noName: 'Nimi puuttuu',
-    date: 'Päivämäärä'
+    date: 'Päivämäärä',
+    month: 'Kuukausi',
+    year: 'Vuosi'
   },
   header: {
     title: 'Varhaiskasvatus',

--- a/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
@@ -99,6 +99,7 @@ function Applications() {
           <Wrapper>
             <ReactSelect
               options={[
+                { value: '', label: i18n.common.all },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)

--- a/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
@@ -99,22 +99,30 @@ function Applications() {
           <Wrapper>
             <ReactSelect
               options={[
-                { id: '', label: '' },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)
-                    ).map((s) => ({ id: s, label: s }))
+                    ).map((s) => ({ value: s, label: s }))
                   : [])
               ]}
               onChange={(option) =>
-                option && 'id' in option
+                option && 'value' in option
                   ? setDisplayFilters({
                       ...displayFilters,
-                      careArea: option.id
+                      careArea: option.value
                     })
                   : undefined
               }
+              value={
+                displayFilters.careArea !== ''
+                  ? {
+                      label: displayFilters.careArea,
+                      value: displayFilters.careArea
+                    }
+                  : undefined
+              }
               styles={reactSelectStyles}
+              placeholder={i18n.reports.occupancies.filters.areaPlaceholder}
             />
           </Wrapper>
         </FilterRow>

--- a/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
@@ -99,7 +99,6 @@ function Applications() {
           <Wrapper>
             <ReactSelect
               options={[
-                { value: '', label: i18n.common.all },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)
@@ -120,7 +119,7 @@ function Applications() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : undefined
+                  : null
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
@@ -119,7 +119,10 @@ function Applications() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : null
+                  : {
+                      label: i18n.common.all,
+                      value: ''
+                    }
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/AssistanceActions.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/AssistanceActions.tsx
@@ -92,6 +92,7 @@ function AssistanceActions() {
           <Wrapper>
             <ReactSelect
               options={[
+                { value: '', label: i18n.common.all },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)

--- a/frontend/packages/employee-frontend/src/components/reports/AssistanceActions.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/AssistanceActions.tsx
@@ -92,22 +92,30 @@ function AssistanceActions() {
           <Wrapper>
             <ReactSelect
               options={[
-                { id: '', label: '' },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)
-                    ).map((s) => ({ id: s, label: s }))
+                    ).map((s) => ({ value: s, label: s }))
                   : [])
               ]}
               onChange={(option) =>
-                option && 'id' in option
+                option && 'value' in option
                   ? setDisplayFilters({
                       ...displayFilters,
-                      careArea: option.id
+                      careArea: option.value
                     })
                   : undefined
               }
+              value={
+                displayFilters.careArea !== ''
+                  ? {
+                      label: displayFilters.careArea,
+                      value: displayFilters.careArea
+                    }
+                  : undefined
+              }
               styles={reactSelectStyles}
+              placeholder={i18n.reports.occupancies.filters.areaPlaceholder}
             />
           </Wrapper>
         </FilterRow>

--- a/frontend/packages/employee-frontend/src/components/reports/AssistanceActions.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/AssistanceActions.tsx
@@ -113,7 +113,10 @@ function AssistanceActions() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : null
+                  : {
+                      label: i18n.common.all,
+                      value: ''
+                    }
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/AssistanceActions.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/AssistanceActions.tsx
@@ -113,7 +113,7 @@ function AssistanceActions() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : undefined
+                  : null
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/AssistanceNeeds.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/AssistanceNeeds.tsx
@@ -92,6 +92,7 @@ function AssistanceNeeds() {
           <Wrapper>
             <ReactSelect
               options={[
+                { value: '', label: i18n.common.all },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)

--- a/frontend/packages/employee-frontend/src/components/reports/AssistanceNeeds.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/AssistanceNeeds.tsx
@@ -92,22 +92,30 @@ function AssistanceNeeds() {
           <Wrapper>
             <ReactSelect
               options={[
-                { id: '', label: '' },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)
-                    ).map((s) => ({ id: s, label: s }))
+                    ).map((s) => ({ value: s, label: s }))
                   : [])
               ]}
               onChange={(option) =>
-                option && 'id' in option
+                option && 'value' in option
                   ? setDisplayFilters({
                       ...displayFilters,
-                      careArea: option.id
+                      careArea: option.value
                     })
                   : undefined
               }
+              value={
+                displayFilters.careArea !== ''
+                  ? {
+                      label: displayFilters.careArea,
+                      value: displayFilters.careArea
+                    }
+                  : undefined
+              }
               styles={reactSelectStyles}
+              placeholder={i18n.reports.occupancies.filters.areaPlaceholder}
             />
           </Wrapper>
         </FilterRow>

--- a/frontend/packages/employee-frontend/src/components/reports/AssistanceNeeds.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/AssistanceNeeds.tsx
@@ -113,7 +113,10 @@ function AssistanceNeeds() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : null
+                  : {
+                      label: i18n.common.all,
+                      value: ''
+                    }
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/AssistanceNeeds.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/AssistanceNeeds.tsx
@@ -113,7 +113,7 @@ function AssistanceNeeds() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : undefined
+                  : null
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/ChildAgeLanguage.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/ChildAgeLanguage.tsx
@@ -87,6 +87,7 @@ function ChildAgeLanguage() {
           <Wrapper>
             <ReactSelect
               options={[
+                { value: '', label: i18n.common.all },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)

--- a/frontend/packages/employee-frontend/src/components/reports/ChildAgeLanguage.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/ChildAgeLanguage.tsx
@@ -108,7 +108,7 @@ function ChildAgeLanguage() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : undefined
+                  : null
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/ChildAgeLanguage.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/ChildAgeLanguage.tsx
@@ -108,7 +108,10 @@ function ChildAgeLanguage() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : null
+                  : {
+                      label: i18n.common.all,
+                      value: ''
+                    }
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/ChildAgeLanguage.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/ChildAgeLanguage.tsx
@@ -87,22 +87,30 @@ function ChildAgeLanguage() {
           <Wrapper>
             <ReactSelect
               options={[
-                { id: '', label: '' },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)
-                    ).map((s) => ({ id: s, label: s }))
+                    ).map((s) => ({ value: s, label: s }))
                   : [])
               ]}
               onChange={(option) =>
-                option && 'id' in option
+                option && 'value' in option
                   ? setDisplayFilters({
                       ...displayFilters,
-                      careArea: option.id
+                      careArea: option.value
                     })
                   : undefined
               }
+              value={
+                displayFilters.careArea !== ''
+                  ? {
+                      label: displayFilters.careArea,
+                      value: displayFilters.careArea
+                    }
+                  : undefined
+              }
               styles={reactSelectStyles}
+              placeholder={i18n.reports.occupancies.filters.areaPlaceholder}
             />
           </Wrapper>
         </FilterRow>

--- a/frontend/packages/employee-frontend/src/components/reports/ChildrenInDifferentAddress.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/ChildrenInDifferentAddress.tsx
@@ -88,7 +88,10 @@ function ChildrenInDifferentAddress() {
                       ...displayFilters,
                       careArea: option.value
                     })
-                  : null
+                  : {
+                      label: i18n.common.all,
+                      value: ''
+                    }
               }
               value={
                 displayFilters.careArea !== ''

--- a/frontend/packages/employee-frontend/src/components/reports/ChildrenInDifferentAddress.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/ChildrenInDifferentAddress.tsx
@@ -88,7 +88,7 @@ function ChildrenInDifferentAddress() {
                       ...displayFilters,
                       careArea: option.value
                     })
-                  : undefined
+                  : null
               }
               value={
                 displayFilters.careArea !== ''

--- a/frontend/packages/employee-frontend/src/components/reports/ChildrenInDifferentAddress.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/ChildrenInDifferentAddress.tsx
@@ -75,22 +75,30 @@ function ChildrenInDifferentAddress() {
           <Wrapper>
             <ReactSelect
               options={[
-                { id: '', label: '' },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)
-                    ).map((s) => ({ id: s, label: s }))
+                    ).map((s) => ({ value: s, label: s }))
                   : [])
               ]}
               onChange={(option) =>
-                option && 'id' in option
+                option && 'value' in option
                   ? setDisplayFilters({
                       ...displayFilters,
-                      careArea: option.id
+                      careArea: option.value
                     })
                   : undefined
               }
+              value={
+                displayFilters.careArea !== ''
+                  ? {
+                      label: displayFilters.careArea,
+                      value: displayFilters.careArea
+                    }
+                  : undefined
+              }
               styles={reactSelectStyles}
+              placeholder={i18n.reports.occupancies.filters.areaPlaceholder}
             />
           </Wrapper>
         </FilterRow>

--- a/frontend/packages/employee-frontend/src/components/reports/ChildrenInDifferentAddress.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/ChildrenInDifferentAddress.tsx
@@ -75,6 +75,7 @@ function ChildrenInDifferentAddress() {
           <Wrapper>
             <ReactSelect
               options={[
+                { value: '', label: i18n.common.all },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)

--- a/frontend/packages/employee-frontend/src/components/reports/EndedPlacements.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/EndedPlacements.tsx
@@ -99,6 +99,7 @@ function EndedPlacements() {
                   }
                 }}
                 styles={reactSelectStyles}
+                placeholder={i18n.common.month}
               />
             </Wrapper>
             <Wrapper>
@@ -111,6 +112,7 @@ function EndedPlacements() {
                   }
                 }}
                 styles={reactSelectStyles}
+                placeholder={i18n.common.year}
               />
             </Wrapper>
           </FlexRow>

--- a/frontend/packages/employee-frontend/src/components/reports/FamilyConflicts.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/FamilyConflicts.tsx
@@ -73,6 +73,7 @@ function FamilyConflicts() {
           <Wrapper>
             <ReactSelect
               options={[
+                { value: '', label: i18n.common.all },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)

--- a/frontend/packages/employee-frontend/src/components/reports/FamilyConflicts.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/FamilyConflicts.tsx
@@ -94,7 +94,7 @@ function FamilyConflicts() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : undefined
+                  : null
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/FamilyConflicts.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/FamilyConflicts.tsx
@@ -94,7 +94,10 @@ function FamilyConflicts() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : null
+                  : {
+                      label: i18n.common.all,
+                      value: ''
+                    }
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/FamilyConflicts.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/FamilyConflicts.tsx
@@ -73,22 +73,30 @@ function FamilyConflicts() {
           <Wrapper>
             <ReactSelect
               options={[
-                { id: '', label: '' },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)
-                    ).map((s) => ({ id: s, label: s }))
+                    ).map((s) => ({ value: s, label: s }))
                   : [])
               ]}
               onChange={(option) =>
-                option && 'id' in option
+                option && 'value' in option
                   ? setDisplayFilters({
                       ...displayFilters,
-                      careArea: option.id
+                      careArea: option.value
                     })
                   : undefined
               }
+              value={
+                displayFilters.careArea !== ''
+                  ? {
+                      label: displayFilters.careArea,
+                      value: displayFilters.careArea
+                    }
+                  : undefined
+              }
               styles={reactSelectStyles}
+              placeholder={i18n.reports.occupancies.filters.areaPlaceholder}
             />
           </Wrapper>
         </FilterRow>

--- a/frontend/packages/employee-frontend/src/components/reports/MissingHeadOfFamily.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/MissingHeadOfFamily.tsx
@@ -121,7 +121,10 @@ function MissingHeadOfFamily() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : null
+                  : {
+                      label: i18n.common.all,
+                      value: ''
+                    }
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/MissingHeadOfFamily.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/MissingHeadOfFamily.tsx
@@ -121,7 +121,7 @@ function MissingHeadOfFamily() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : undefined
+                  : null
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/MissingHeadOfFamily.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/MissingHeadOfFamily.tsx
@@ -100,22 +100,30 @@ function MissingHeadOfFamily() {
           <Wrapper>
             <ReactSelect
               options={[
-                { id: '', label: '' },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)
-                    ).map((s) => ({ id: s, label: s }))
+                    ).map((s) => ({ value: s, label: s }))
                   : [])
               ]}
               onChange={(option) =>
-                option && 'id' in option
+                option && 'value' in option
                   ? setDisplayFilters({
                       ...displayFilters,
-                      careArea: option.id
+                      careArea: option.value
                     })
                   : undefined
               }
+              value={
+                displayFilters.careArea !== ''
+                  ? {
+                      label: displayFilters.careArea,
+                      value: displayFilters.careArea
+                    }
+                  : undefined
+              }
               styles={reactSelectStyles}
+              placeholder={i18n.reports.occupancies.filters.areaPlaceholder}
             />
           </Wrapper>
         </FilterRow>

--- a/frontend/packages/employee-frontend/src/components/reports/MissingHeadOfFamily.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/MissingHeadOfFamily.tsx
@@ -100,6 +100,7 @@ function MissingHeadOfFamily() {
           <Wrapper>
             <ReactSelect
               options={[
+                { value: '', label: i18n.common.all },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)

--- a/frontend/packages/employee-frontend/src/components/reports/MissingServiceNeed.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/MissingServiceNeed.tsx
@@ -104,18 +104,27 @@ function MissingServiceNeed() {
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)
-                    ).map((s) => ({ id: s, label: s }))
+                    ).map((s) => ({ value: s, label: s }))
                   : [])
               ]}
               onChange={(option) =>
-                option && 'id' in option
+                option && 'value' in option
                   ? setDisplayFilters({
                       ...displayFilters,
-                      careArea: option.id
+                      careArea: option.value
                     })
                   : undefined
               }
+              value={
+                displayFilters.careArea !== ''
+                  ? {
+                      label: displayFilters.careArea,
+                      value: displayFilters.careArea
+                    }
+                  : undefined
+              }
               styles={reactSelectStyles}
+              placeholder={i18n.reports.occupancies.filters.areaPlaceholder}
             />
           </Wrapper>
         </FilterRow>

--- a/frontend/packages/employee-frontend/src/components/reports/MissingServiceNeed.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/MissingServiceNeed.tsx
@@ -121,7 +121,7 @@ function MissingServiceNeed() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : undefined
+                  : null
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/MissingServiceNeed.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/MissingServiceNeed.tsx
@@ -100,7 +100,7 @@ function MissingServiceNeed() {
           <Wrapper>
             <ReactSelect
               options={[
-                { id: '', label: '' },
+                { value: '', label: i18n.common.all },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)

--- a/frontend/packages/employee-frontend/src/components/reports/MissingServiceNeed.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/MissingServiceNeed.tsx
@@ -121,7 +121,10 @@ function MissingServiceNeed() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : null
+                  : {
+                      label: i18n.common.all,
+                      value: ''
+                    }
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/Occupancies.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/Occupancies.tsx
@@ -329,6 +329,7 @@ function Occupancies() {
                 }
               }}
               styles={reactSelectStyles}
+              placeholder={i18n.reports.occupancies.filters.areaPlaceholder}
             />
           </Wrapper>
         </FilterRow>

--- a/frontend/packages/employee-frontend/src/components/reports/PartnersInDifferentAddress.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/PartnersInDifferentAddress.tsx
@@ -96,7 +96,10 @@ function PartnersInDifferentAddress() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : null
+                  : {
+                      label: i18n.common.all,
+                      value: ''
+                    }
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/PartnersInDifferentAddress.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/PartnersInDifferentAddress.tsx
@@ -96,7 +96,7 @@ function PartnersInDifferentAddress() {
                       label: displayFilters.careArea,
                       value: displayFilters.careArea
                     }
-                  : undefined
+                  : null
               }
               styles={reactSelectStyles}
               placeholder={i18n.reports.occupancies.filters.areaPlaceholder}

--- a/frontend/packages/employee-frontend/src/components/reports/PartnersInDifferentAddress.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/PartnersInDifferentAddress.tsx
@@ -75,22 +75,30 @@ function PartnersInDifferentAddress() {
           <Wrapper>
             <ReactSelect
               options={[
-                { id: '', label: '' },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)
-                    ).map((s) => ({ id: s, label: s }))
+                    ).map((s) => ({ value: s, label: s }))
                   : [])
               ]}
               onChange={(option) =>
-                option && 'id' in option
+                option && 'value' in option
                   ? setDisplayFilters({
                       ...displayFilters,
-                      careArea: option.id
+                      careArea: option.value
                     })
                   : undefined
               }
+              value={
+                displayFilters.careArea !== ''
+                  ? {
+                      label: displayFilters.careArea,
+                      value: displayFilters.careArea
+                    }
+                  : undefined
+              }
               styles={reactSelectStyles}
+              placeholder={i18n.reports.occupancies.filters.areaPlaceholder}
             />
           </Wrapper>
         </FilterRow>

--- a/frontend/packages/employee-frontend/src/components/reports/PartnersInDifferentAddress.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/PartnersInDifferentAddress.tsx
@@ -75,6 +75,7 @@ function PartnersInDifferentAddress() {
           <Wrapper>
             <ReactSelect
               options={[
+                { value: '', label: i18n.common.all },
                 ...(isSuccess(rows)
                   ? distinct(
                       rows.data.map((row) => row.careAreaName)

--- a/frontend/packages/employee-frontend/src/components/reports/StartingPlacements.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/StartingPlacements.tsx
@@ -104,6 +104,7 @@ const StartingPlacements = React.memo(function StartingPlacements() {
                   }
                 }}
                 styles={reactSelectStyles}
+                placeholder={i18n.common.month}
               />
             </Wrapper>
             <Wrapper>
@@ -116,6 +117,7 @@ const StartingPlacements = React.memo(function StartingPlacements() {
                   }
                 }}
                 styles={reactSelectStyles}
+                placeholder={i18n.common.year}
               />
             </Wrapper>
           </FlexRow>


### PR DESCRIPTION
#### Summary

Fixed `ReactSelect` components in multiple report pages. Some of the reports did not have proper value and placeholder props. Also removed empty options and used `{value: xxx, label: yyy}` instead of `{id: xxx, label: yyy}` options.