### PR TITLE
Experimental database API

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.core.FuelManager
 import fi.espoo.evaka.shared.config.SharedIntegrationTestConfig
 import fi.espoo.evaka.shared.config.defaultObjectMapper
 import fi.espoo.evaka.shared.config.getTestDataSource
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.varda.integration.VardaClient
@@ -39,6 +40,7 @@ abstract class FullApplicationTest {
     protected val objectMapper: ObjectMapper = defaultObjectMapper()
 
     protected lateinit var jdbi: Jdbi
+    protected lateinit var db: Database
 
     protected lateinit var vardaTokenProvider: VardaTokenProvider
     protected lateinit var vardaClient: VardaClient
@@ -54,6 +56,7 @@ abstract class FullApplicationTest {
         assert(httpPort > 0)
         http.basePath = "http://localhost:$httpPort/"
         jdbi = configureJdbi(Jdbi.create(getTestDataSource()))
+        db = Database(jdbi)
         jdbi.handle(::resetDatabase)
         feeDecisionMinDate = LocalDate.parse(env.getRequiredProperty("fee_decision_min_date"))
         val vardaBaseUrl = "http://localhost:$httpPort/mock-integration/varda/api"

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/PureJdbiTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/PureJdbiTest.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka
 
 import fi.espoo.evaka.shared.config.getTestDataSource
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
 import fi.espoo.evaka.shared.db.handle
 import org.jdbi.v3.core.Jdbi
@@ -14,10 +15,12 @@ import org.junit.jupiter.api.TestInstance
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class PureJdbiTest {
     protected lateinit var jdbi: Jdbi
+    protected lateinit var db: Database
 
     @BeforeAll
     protected fun initializeJdbi() {
         jdbi = configureJdbi(Jdbi.create(getTestDataSource()))
+        db = Database(jdbi)
         jdbi.handle(::resetDatabase)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.invoicing.domain.VoucherValue
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevChild
@@ -388,6 +389,7 @@ fun insertGeneralTestFixtures(h: Handle) {
     )
 }
 
+fun Database.Transaction.resetDatabase() = execute("SELECT reset_database()")
 fun resetDatabase(h: Handle) {
     h.transaction { it.execute("SELECT reset_database()") }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -26,6 +26,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
@@ -87,16 +88,18 @@ WHERE id = :unitId
     }
 
     @Test
-    fun testDaycareFullTime(): Unit = jdbi.handle { h ->
+    fun testDaycareFullTime() {
         val period = ClosedPeriod(
             LocalDate.of(2020, 3, 17),
             LocalDate.of(2023, 7, 31)
         )
-        val applicationId = insertInitialData(
-            h,
-            type = PlacementType.DAYCARE,
-            period = period
-        )
+        val applicationId = db.transaction {
+            insertInitialData(
+                it,
+                type = PlacementType.DAYCARE,
+                period = period
+            )
+        }
         checkDecisionDrafts(
             applicationId,
             decisions = listOf(
@@ -112,7 +115,7 @@ WHERE id = :unitId
             otherGuardian = testAdult_6
         )
 
-        val decisions = createDecisions(h, applicationId)
+        val decisions = db.transaction { createDecisions(it.handle, applicationId) }
         assertEquals(1, decisions.size)
 
         val decision = decisions[0]
@@ -123,16 +126,18 @@ WHERE id = :unitId
     }
 
     @Test
-    fun testDaycarePartTime(): Unit = jdbi.handle { h ->
+    fun testDaycarePartTime() {
         val period = ClosedPeriod(
             LocalDate.of(2020, 3, 18),
             LocalDate.of(2023, 7, 29)
         )
-        val applicationId = insertInitialData(
-            h,
-            type = PlacementType.DAYCARE_PART_TIME,
-            period = period
-        )
+        val applicationId = db.transaction {
+            insertInitialData(
+                it,
+                type = PlacementType.DAYCARE_PART_TIME,
+                period = period
+            )
+        }
         checkDecisionDrafts(
             applicationId,
             decisions = listOf(
@@ -148,7 +153,7 @@ WHERE id = :unitId
             otherGuardian = testAdult_6
         )
 
-        val decisions = createDecisions(h, applicationId)
+        val decisions = db.transaction { createDecisions(it.handle, applicationId) }
         assertEquals(1, decisions.size)
 
         val decision = decisions[0]
@@ -159,16 +164,18 @@ WHERE id = :unitId
     }
 
     @Test
-    fun testPreschoolOnly(): Unit = jdbi.handle { h ->
+    fun testPreschoolOnly() {
         val period = ClosedPeriod(
             LocalDate.of(2020, 8, 15),
             LocalDate.of(2021, 5, 31)
         )
-        val applicationId = insertInitialData(
-            h,
-            type = PlacementType.PRESCHOOL,
-            period = period
-        )
+        val applicationId = db.transaction {
+            insertInitialData(
+                it,
+                type = PlacementType.PRESCHOOL,
+                period = period
+            )
+        }
         checkDecisionDrafts(
             applicationId,
             decisions = listOf(
@@ -192,7 +199,7 @@ WHERE id = :unitId
             otherGuardian = testAdult_6
         )
 
-        val decisions = createDecisions(h, applicationId)
+        val decisions = db.transaction { createDecisions(it.handle, applicationId) }
         assertEquals(1, decisions.size)
 
         val decision = decisions[0]
@@ -203,7 +210,7 @@ WHERE id = :unitId
     }
 
     @Test
-    fun testPreschoolAll(): Unit = jdbi.handle { h ->
+    fun testPreschoolAll() {
         val period = ClosedPeriod(
             LocalDate.of(2020, 8, 15),
             LocalDate.of(2021, 5, 31)
@@ -212,13 +219,15 @@ WHERE id = :unitId
             LocalDate.of(2020, 8, 1),
             LocalDate.of(2021, 7, 31)
         )
-        val applicationId = insertInitialData(
-            h,
-            type = PlacementType.PRESCHOOL_DAYCARE,
-            period = period,
-            preschoolDaycarePeriod = preschoolDaycarePeriod,
-            preparatoryEducation = false
-        )
+        val applicationId = db.transaction {
+            insertInitialData(
+                it,
+                type = PlacementType.PRESCHOOL_DAYCARE,
+                period = period,
+                preschoolDaycarePeriod = preschoolDaycarePeriod,
+                preparatoryEducation = false
+            )
+        }
         checkDecisionDrafts(
             applicationId,
             decisions = listOf(
@@ -242,7 +251,7 @@ WHERE id = :unitId
             otherGuardian = testAdult_6
         )
 
-        val decisions = createDecisions(h, applicationId)
+        val decisions = db.transaction { createDecisions(it.handle, applicationId) }
         assertEquals(2, decisions.size)
 
         val decision = decisions.find { it.type == DecisionType.PRESCHOOL }!!
@@ -257,7 +266,7 @@ WHERE id = :unitId
     }
 
     @Test
-    fun testPreparatoryAll(): Unit = jdbi.handle { h ->
+    fun testPreparatoryAll() {
         val period = ClosedPeriod(
             LocalDate.of(2020, 8, 15),
             LocalDate.of(2021, 5, 31)
@@ -266,13 +275,15 @@ WHERE id = :unitId
             LocalDate.of(2020, 8, 1),
             LocalDate.of(2021, 7, 31)
         )
-        val applicationId = insertInitialData(
-            h,
-            type = PlacementType.PRESCHOOL_DAYCARE,
-            period = period,
-            preschoolDaycarePeriod = preschoolDaycarePeriod,
-            preparatoryEducation = true
-        )
+        val applicationId = db.transaction {
+            insertInitialData(
+                it,
+                type = PlacementType.PRESCHOOL_DAYCARE,
+                period = period,
+                preschoolDaycarePeriod = preschoolDaycarePeriod,
+                preparatoryEducation = true
+            )
+        }
         checkDecisionDrafts(
             applicationId,
             decisions = listOf(
@@ -296,7 +307,7 @@ WHERE id = :unitId
             otherGuardian = testAdult_6
         )
 
-        val decisions = createDecisions(h, applicationId)
+        val decisions = db.transaction { createDecisions(it.handle, applicationId) }
         assertEquals(2, decisions.size)
 
         val decision = decisions.find { it.type == DecisionType.PREPARATORY_EDUCATION }!!
@@ -382,16 +393,18 @@ WHERE id = :unitId
     }
 
     @Test
-    fun testEndpointSecurity(): Unit = jdbi.handle { h ->
+    fun testEndpointSecurity() {
         val period = ClosedPeriod(
             LocalDate.of(2020, 3, 17),
             LocalDate.of(2023, 7, 31)
         )
-        val applicationId = insertInitialData(
-            h,
-            type = PlacementType.DAYCARE,
-            period = period
-        )
+        val applicationId = db.transaction {
+            insertInitialData(
+                it,
+                type = PlacementType.DAYCARE,
+                period = period
+            )
+        }
         val invalidRoleLists = listOf(
             setOf(Roles.UNIT_SUPERVISOR),
             setOf(Roles.FINANCE_ADMIN),
@@ -407,7 +420,7 @@ WHERE id = :unitId
     }
 
     private fun insertInitialData(
-        h: Handle,
+        tx: Database.Transaction,
         type: PlacementType,
         unit: UnitData.Detailed = testDaycare,
         adult: PersonData.Detailed = testAdult_5,
@@ -417,14 +430,14 @@ WHERE id = :unitId
         preparatoryEducation: Boolean = false
     ): UUID {
         val applicationId = insertTestApplication(
-            h,
+            tx.handle,
             status = ApplicationStatus.WAITING_PLACEMENT,
             guardianId = adult.id,
             childId = child.id
         )
         val preschoolDaycare = type == PlacementType.PRESCHOOL_DAYCARE
         insertTestApplicationForm(
-            h, applicationId,
+            tx.handle, applicationId,
             DaycareFormV0(
                 type = type.toFormType(),
                 partTime = type == PlacementType.DAYCARE_PART_TIME,
@@ -440,7 +453,7 @@ WHERE id = :unitId
         )
 
         applicationStateService.createPlacementPlan(
-            h,
+            tx,
             serviceWorker,
             applicationId,
             DaycarePlacementPlan(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
@@ -37,32 +37,32 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     }
 
     @Test
-    fun `get modification token for today`() = jdbi.handle { h ->
-        assertEquals("101", getNextDvvModificationToken(h))
-        val response = dvvModificationsService.getDvvModifications(h, listOf("nimenmuutos"))
+    fun `get modification token for today`() = db.transaction { tx ->
+        assertEquals("101", getNextDvvModificationToken(tx.handle))
+        val response = dvvModificationsService.getDvvModifications(tx, listOf("nimenmuutos"))
         assertEquals(1, response.size)
-        assertEquals("102", getNextDvvModificationToken(h))
-        val createdDvvModificationToken = getDvvModificationToken(h, "101")!!
+        assertEquals("102", getNextDvvModificationToken(tx.handle))
+        val createdDvvModificationToken = getDvvModificationToken(tx.handle, "101")!!
         assertEquals("101", createdDvvModificationToken.token)
         assertEquals("102", createdDvvModificationToken.nextToken)
         assertEquals(1, createdDvvModificationToken.ssnsSent)
         assertEquals(1, createdDvvModificationToken.modificationsReceived)
 
-        deleteDvvModificationToken(h, "101")
+        deleteDvvModificationToken(tx.handle, "101")
     }
 
     @Test
-    fun `person date of death`() = jdbi.handle { h ->
+    fun `person date of death`() {
         createTestPerson(testPerson.copy(ssn = "010180-999A"))
-        dvvModificationsService.updatePersonsFromDvv(listOf("010180-999A"))
-        assertEquals(LocalDate.parse("2019-07-30"), h.getPersonBySSN("010180-999A")?.dateOfDeath)
+        dvvModificationsService.updatePersonsFromDvv(db, listOf("010180-999A"))
+        assertEquals(LocalDate.parse("2019-07-30"), db.read { it.handle.getPersonBySSN("010180-999A") }?.dateOfDeath)
     }
 
     @Test
-    fun `person restricted details started`() = jdbi.handle { h ->
+    fun `person restricted details started`() {
         createTestPerson(testPerson.copy(ssn = "020180-999Y"))
-        dvvModificationsService.updatePersonsFromDvv(listOf("020180-999Y"))
-        val modifiedPerson = h.getPersonBySSN("020180-999Y")!!
+        dvvModificationsService.updatePersonsFromDvv(db, listOf("020180-999Y"))
+        val modifiedPerson = db.read { it.handle.getPersonBySSN("020180-999Y") }!!
         assertEquals(true, modifiedPerson.restrictedDetailsEnabled)
         assertEquals("", modifiedPerson.streetAddress)
         assertEquals("", modifiedPerson.postalCode)
@@ -70,10 +70,10 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     }
 
     @Test
-    fun `person restricted details ended and address is set`() = jdbi.handle { h ->
+    fun `person restricted details ended and address is set`() {
         createTestPerson(testPerson.copy(ssn = "030180-999L", restrictedDetailsEnabled = true, streetAddress = "", postalCode = "", postOffice = ""))
-        dvvModificationsService.updatePersonsFromDvv(listOf("030180-999L"))
-        val modifiedPerson = h.getPersonBySSN("030180-999L")!!
+        dvvModificationsService.updatePersonsFromDvv(db, listOf("030180-999L"))
+        val modifiedPerson = db.read { it.handle.getPersonBySSN("030180-999L") }!!
         assertEquals(false, modifiedPerson.restrictedDetailsEnabled)
         assertEquals(LocalDate.parse("2030-01-01"), modifiedPerson.restrictedDetailsEndDate)
         assertEquals("Vanhakatu 10h5 3", modifiedPerson.streetAddress)
@@ -82,10 +82,10 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     }
 
     @Test
-    fun `person address change`() = jdbi.handle { h ->
+    fun `person address change`() {
         createTestPerson(testPerson.copy(ssn = "040180-9998"))
-        dvvModificationsService.updatePersonsFromDvv(listOf("040180-9998"))
-        val modifiedPerson = h.getPersonBySSN("040180-9998")!!
+        dvvModificationsService.updatePersonsFromDvv(db, listOf("040180-9998"))
+        val modifiedPerson = db.read { it.handle.getPersonBySSN("040180-9998") }!!
         assertEquals("Uusitie 17 A 2", modifiedPerson.streetAddress)
         assertEquals("02940", modifiedPerson.postalCode)
         assertEquals("ESPOO", modifiedPerson.postOffice)
@@ -93,14 +93,14 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     }
 
     @Test
-    fun `person ssn change`() = jdbi.handle { h ->
+    fun `person ssn change`() {
         val testId = createTestPerson(testPerson.copy(ssn = "010181-999K"))
-        dvvModificationsService.updatePersonsFromDvv(listOf("010181-999K"))
-        assertEquals(testId, h.getPersonBySSN("010281-999C")?.id)
+        dvvModificationsService.updatePersonsFromDvv(db, listOf("010181-999K"))
+        assertEquals(testId, db.read { it.handle.getPersonBySSN("010281-999C") }?.id)
     }
 
     @Test
-    fun `new custodian added`() = jdbi.handle { h ->
+    fun `new custodian added`() {
         var caretaker: DevPerson = testPerson.copy(ssn = "050180-999W")
         val custodian = testPerson.copy(firstName = "Harri", lastName = "Huollettava", ssn = "050118A999W", guardians = listOf(caretaker))
         caretaker = caretaker.copy(dependants = listOf(custodian))
@@ -109,14 +109,14 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createVtjPerson(custodian)
         createVtjPerson(caretaker)
 
-        dvvModificationsService.updatePersonsFromDvv(listOf("050118A999W"))
-        val dvvCustodian = h.getPersonBySSN("050118A999W")!!
+        dvvModificationsService.updatePersonsFromDvv(db, listOf("050118A999W"))
+        val dvvCustodian = db.read { it.handle.getPersonBySSN("050118A999W") }!!
         assertEquals("Harri", dvvCustodian.firstName)
         assertEquals("Huollettava", dvvCustodian.lastName)
     }
 
     @Test
-    fun `new caretaker added`() = jdbi.handle { h ->
+    fun `new caretaker added`() {
         var custodian: DevPerson = testPerson.copy(ssn = "060118A999J")
         val caretaker = testPerson.copy(firstName = "Harri", lastName = "Huoltaja", ssn = "060180-999J", dependants = listOf(custodian))
         custodian = custodian.copy(guardians = listOf(caretaker))
@@ -125,14 +125,14 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createVtjPerson(custodian)
         createVtjPerson(caretaker)
 
-        dvvModificationsService.updatePersonsFromDvv(listOf("060118A999J"))
-        val dvvCaretaker = h.getPersonBySSN("060180-999J")!!
+        dvvModificationsService.updatePersonsFromDvv(db, listOf("060118A999J"))
+        val dvvCaretaker = db.read { it.handle.getPersonBySSN("060180-999J") }!!
         assertEquals("Harri", dvvCaretaker.firstName)
         assertEquals("Huoltaja", dvvCaretaker.lastName)
     }
 
     @Test
-    fun `name changed`() = jdbi.handle { h ->
+    fun `name changed`() {
         val SSN = "010179-9992"
         var personWithOldName: DevPerson = testPerson.copy(firstName = "Ville", lastName = "Vanhanimi", ssn = SSN)
         val personWithNewName = testPerson.copy(firstName = "Urkki", lastName = "Uusinimi", ssn = SSN)
@@ -140,27 +140,33 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createTestPerson(personWithOldName)
         createVtjPerson(personWithNewName)
 
-        dvvModificationsService.updatePersonsFromDvv(listOf(SSN))
-        val updatedPerson = h.getPersonBySSN(SSN)!!
+        dvvModificationsService.updatePersonsFromDvv(db, listOf(SSN))
+        val updatedPerson = db.read { it.handle.getPersonBySSN(SSN) }!!
         assertEquals("Urkki", updatedPerson.firstName)
         assertEquals("Uusinimi", updatedPerson.lastName)
     }
 
     @Test
-    fun `paging works`() = jdbi.handle { h ->
+    fun `paging works`() {
         // The mock server has been rigged so that if the token is negative, it will return the requested batch with
         // ajanTasalla=false and next token = token + 1 causing the dvv client to do a request for the subsequent page,
         // until token is 0 and then it will return ajanTasalla=true
         // So if the paging works correctly there should Math.abs(original_token) + 1 identical records
-        resetDatabase(h)
-        storeDvvModificationToken(h, "10000", "-2", 0, 0)
+        db.transaction {
+            resetDatabase(it.handle)
+            storeDvvModificationToken(it.handle, "10000", "-2", 0, 0)
+        }
         try {
             createTestPerson(testPerson.copy(ssn = "010180-999A"))
-            assertEquals(3, dvvModificationsService.updatePersonsFromDvv(listOf("010180-999A")))
-            assertEquals("1", getNextDvvModificationToken(h))
-            assertEquals(LocalDate.parse("2019-07-30"), h.getPersonBySSN("010180-999A")?.dateOfDeath)
+            assertEquals(3, dvvModificationsService.updatePersonsFromDvv(db, listOf("010180-999A")))
+            db.read {
+                assertEquals("1", getNextDvvModificationToken(it.handle))
+                assertEquals(LocalDate.parse("2019-07-30"), it.handle.getPersonBySSN("010180-999A")?.dateOfDeath)
+            }
         } finally {
-            deleteDvvModificationToken(h, "0")
+            db.transaction {
+                deleteDvvModificationToken(it.handle, "0")
+            }
         }
     }
 
@@ -202,8 +208,4 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         nativeLanguage = NativeLanguage(languageName = "FI", code = "fi"),
         restrictedDetails = RestrictedDetails(enabled = person.restrictedDetailsEnabled, endDate = person.restrictedDetailsEndDate)
     )
-
-    private fun deleteVtjPerson(ssn: String) {
-        MockPersonDetailsService.deletePerson(ssn)
-    }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTestBase.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTestBase.kt
@@ -31,7 +31,7 @@ class DvvModificationsServiceIntegrationTestBase : FullApplicationTest() {
         assert(httpPort > 0)
         val mockDvvBaseUrl = "http://localhost:$httpPort/mock-integration/dvv"
         dvvModificationsServiceClient = DvvModificationsServiceClient(objectMapper, noCertCheckFuelManager(), env, mockDvvBaseUrl)
-        dvvModificationsService = DvvModificationsService(jdbi, dvvModificationsServiceClient, personService, fridgeFamilyService)
+        dvvModificationsService = DvvModificationsService(dvvModificationsServiceClient, personService, fridgeFamilyService)
     }
 
     fun noCertCheckFuelManager() = FuelManager().apply {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -59,8 +59,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
             KoskiClient(
                 env = env,
                 baseUrl = "http://localhost:${koskiServer.port}",
-                asyncJobRunner = null,
-                jdbi = jdbi
+                asyncJobRunner = null
             )
         )
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
@@ -35,8 +35,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
             KoskiClient(
                 env = env,
                 baseUrl = "http://localhost:${koskiServer.port}",
-                asyncJobRunner = null,
-                jdbi = jdbi
+                asyncJobRunner = null
             )
         )
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyFamilyUpdated
 import fi.espoo.evaka.shared.config.defaultObjectMapper
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevEmployee
@@ -28,7 +29,6 @@ import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
 import fi.espoo.evaka.testDaycare
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -46,7 +46,7 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
 
     @BeforeEach
     internal fun setUp() {
-        mergeService = MergeService(jdbi, asyncJobRunnerMock)
+        mergeService = MergeService(asyncJobRunnerMock)
         jdbi.handle(::resetDatabase)
         jdbi.handle(::insertGeneralTestFixtures)
     }
@@ -62,7 +62,9 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
         val countBefore = jdbi.handle { it.createQuery("SELECT 1 FROM person WHERE id = :id").bind("id", id).map { _, _ -> 1 }.list().size }
         assertEquals(1, countBefore)
 
-        mergeService.deleteEmptyPerson(id)
+        db.transaction {
+            mergeService.deleteEmptyPerson(it, id)
+        }
 
         val countAfter = jdbi.handle { it.createQuery("SELECT 1 FROM person WHERE id = :id").bind("id", id).map { _, _ -> 1 }.list().size }
         assertEquals(0, countAfter)
@@ -82,7 +84,7 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
             )
         }
 
-        assertThrows<UnableToExecuteStatementException> { mergeService.deleteEmptyPerson(id) }
+        assertThrows<UnableToExecuteStatementException> { db.transaction { mergeService.deleteEmptyPerson(it, id) } }
     }
 
     @Test
@@ -103,13 +105,15 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
         val countBefore = jdbi.handle { it.createQuery("SELECT 1 FROM income WHERE person_id = :id").bind("id", adultIdDuplicate).map { _, _ -> 1 }.list().size }
         assertEquals(1, countBefore)
 
-        mergeService.mergePeople(adultId, adultIdDuplicate)
+        db.transaction {
+            mergeService.mergePeople(it, adultId, adultIdDuplicate)
+        }
 
         val countAfter = jdbi.handle { it.createQuery("SELECT 1 FROM income WHERE person_id = :id").bind("id", adultId).map { _, _ -> 1 }.list().size }
         assertEquals(1, countAfter)
 
         verify(asyncJobRunnerMock).plan(
-            any<Handle>(), eq(listOf(NotifyFamilyUpdated(adultId, validFrom, validTo))), any(), any(), any()
+            any<Database.Transaction>(), eq(listOf(NotifyFamilyUpdated(adultId, validFrom, validTo))), any(), any(), any()
         )
     }
 
@@ -133,7 +137,9 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
         val countBefore = jdbi.handle { it.createQuery("SELECT 1 FROM placement WHERE child_id = :id").bind("id", childIdDuplicate).map { _, _ -> 1 }.list().size }
         assertEquals(1, countBefore)
 
-        mergeService.mergePeople(childId, childIdDuplicate)
+        db.transaction {
+            mergeService.mergePeople(it, childId, childIdDuplicate)
+        }
 
         val countAfter = jdbi.handle { it.createQuery("SELECT 1 FROM placement WHERE child_id = :id").bind("id", childId).map { _, _ -> 1 }.list().size }
         assertEquals(1, countAfter)
@@ -158,10 +164,12 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
         val placementEnd = LocalDate.of(2020, 12, 30)
         jdbi.handle { it.insertTestPlacement(DevPlacement(childId = childIdDuplicate, unitId = testDaycare.id, startDate = placementStart, endDate = placementEnd)) }
 
-        mergeService.mergePeople(childId, childIdDuplicate)
+        db.transaction {
+            mergeService.mergePeople(it, childId, childIdDuplicate)
+        }
 
         verify(asyncJobRunnerMock).plan(
-            any<Handle>(),
+            any<Database.Transaction>(),
             eq(listOf(NotifyFamilyUpdated(adultId, placementStart, placementEnd))), any(), any(), any()
         )
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -28,6 +28,7 @@ import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
 import fi.espoo.evaka.testDaycare
+import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -108,7 +109,7 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
         assertEquals(1, countAfter)
 
         verify(asyncJobRunnerMock).plan(
-            any(), eq(listOf(NotifyFamilyUpdated(adultId, validFrom, validTo))), any(), any(), any()
+            any<Handle>(), eq(listOf(NotifyFamilyUpdated(adultId, validFrom, validTo))), any(), any(), any()
         )
     }
 
@@ -160,7 +161,7 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
         mergeService.mergePeople(childId, childIdDuplicate)
 
         verify(asyncJobRunnerMock).plan(
-            any(),
+            any<Handle>(),
             eq(listOf(NotifyFamilyUpdated(adultId, placementStart, placementEnd))), any(), any(), any()
         )
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -91,7 +91,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         )
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_1.id))).thenReturn(dto)
 
-        service.doVTJRefresh(VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(db, VTJRefresh(testAdult_1.id, user.id))
         verify(parentshipService).createParentship(
             any(),
             eq(testChild_1.id),
@@ -116,7 +116,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
             )
         )
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_1.id))).thenReturn(dto)
-        service.doVTJRefresh(VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(db, VTJRefresh(testAdult_1.id, user.id))
         verifyZeroInteractions(parentshipService)
     }
 
@@ -152,7 +152,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_1.id))).thenReturn(dto1)
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_2.id))).thenReturn(dto2)
 
-        service.doVTJRefresh(VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(db, VTJRefresh(testAdult_1.id, user.id))
         verify(parentshipService).createParentship(
             any(),
             eq(testChild_1.id),
@@ -196,7 +196,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_1.id))).thenReturn(dto1)
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_2.id))).thenReturn(dto2)
 
-        service.doVTJRefresh(VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(db, VTJRefresh(testAdult_1.id, user.id))
         verifyZeroInteractions(parentshipService)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
@@ -7,10 +7,10 @@ package fi.espoo.evaka.shared.async
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapJsonColumn
 import fi.espoo.evaka.shared.db.transaction
 import org.jdbi.v3.core.kotlin.mapTo
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -24,49 +24,53 @@ import java.util.UUID
 class AsyncJobQueriesTest : PureJdbiTest() {
     private val user = AuthenticatedUser(UUID.randomUUID(), setOf())
 
+    private lateinit var db: Database
+
     @BeforeEach
-    @AfterAll
-    fun clean() {
-        jdbi.open().use { h -> h.execute("TRUNCATE async_job") }
+    fun beforeEach() {
+        db = Database(jdbi)
+        db.transaction { it.execute("TRUNCATE async_job") }
     }
 
     @Test
     fun testCompleteHappyCase() {
         val id = UUID.randomUUID()
-        jdbi.open().use { h ->
-            h.transaction { tx ->
-                insertJob(tx, JobParams(NotifyDecisionCreated(id, user, sendAsMessage = false), 1234, Duration.ofMinutes(42)))
-            }
-            val runAt = h.createQuery("SELECT run_at FROM async_job").mapTo<ZonedDateTime>().one()
-
-            val ref = h.transaction { tx ->
-                claimJob(tx, listOf(AsyncJobType.DECISION_CREATED))!!
-            }
-            assertEquals(AsyncJobType.DECISION_CREATED, ref.jobType)
-            val (retryRunAt, retryCount) = h.createQuery("SELECT run_at, retry_count FROM async_job").mapTo<Retry>()
-                .one()
-            assertTrue(retryRunAt > runAt)
-            assertEquals(1233, retryCount)
-
-            h.transaction { tx ->
-                val payload = startJob(tx, ref, NotifyDecisionCreated::class.java)!!
-                assertEquals(NotifyDecisionCreated(id, user, sendAsMessage = false), payload)
-
-                completeJob(tx, ref)
-            }
-
-            val completedAt = h.createQuery("SELECT completed_at FROM async_job").mapTo<ZonedDateTime>().one()
-            assertTrue(completedAt > runAt)
+        db.transaction {
+            it.insertJob(
+                JobParams(
+                    NotifyDecisionCreated(id, user, sendAsMessage = false),
+                    1234,
+                    Duration.ofMinutes(42)
+                )
+            )
         }
+        val runAt = db.read { it.createQuery("SELECT run_at FROM async_job").mapTo<ZonedDateTime>().one() }
+
+        val ref = db.transaction { it.claimJob(listOf(AsyncJobType.DECISION_CREATED))!! }
+        assertEquals(AsyncJobType.DECISION_CREATED, ref.jobType)
+        val (retryRunAt, retryCount) = db.read {
+            it.createQuery("SELECT run_at, retry_count FROM async_job").mapTo<Retry>().one()
+        }
+        assertTrue(retryRunAt > runAt)
+        assertEquals(1233, retryCount)
+
+        db.transaction { tx ->
+            val payload = tx.startJob(ref, NotifyDecisionCreated::class.java)!!
+            assertEquals(NotifyDecisionCreated(id, user, sendAsMessage = false), payload)
+
+            tx.completeJob(ref)
+        }
+
+        val completedAt =
+            db.read { it.createQuery("SELECT completed_at FROM async_job").mapTo<ZonedDateTime>().one() }
+        assertTrue(completedAt > runAt)
     }
 
     @Test
     fun testParallelClaimContention() {
         val payloads = (0..1).map { _ -> NotifyDecisionCreated(UUID.randomUUID(), user, sendAsMessage = false) }
-        jdbi.open().use { h ->
-            h.transaction { tx ->
-                payloads.map { insertJob(tx, JobParams(it, 999, Duration.ZERO)) }
-            }
+        db.transaction { tx ->
+            payloads.map { tx.insertJob(JobParams(it, 999, Duration.ZERO)) }
         }
         val handles = (0..2).map { jdbi.open() }
         try {
@@ -75,21 +79,21 @@ class AsyncJobQueriesTest : PureJdbiTest() {
             val h2 = handles[2].begin()
 
             // Two jobs in the db -> only two claims should succeed
-            val job0 = claimJob(h0)!!
-            val job1 = claimJob(h1)!!
+            val job0 = Database.Transaction.wrap(h0).claimJob()!!
+            val job1 = Database.Transaction.wrap(h1).claimJob()!!
             assertNotEquals(job0.jobId, job1.jobId)
-            assertNull(claimJob(h2))
+            assertNull(Database.Transaction.wrap(h2).claimJob())
 
             h1.rollback()
 
             // Handle 1 rolled back -> job 1 should now be available
-            val job2 = claimJob(h2)!!
+            val job2 = Database.Transaction.wrap(h2).claimJob()!!
             assertEquals(job1.jobId, job2.jobId)
 
-            completeJob(h0, job0)
+            Database.Transaction.wrap(h0).completeJob(job0)
             h0.commit()
 
-            completeJob(h2, job2)
+            Database.Transaction.wrap(h2).completeJob(job2)
             h2.commit()
         } finally {
             handles.forEach { it.close() }
@@ -103,7 +107,7 @@ class AsyncJobQueriesTest : PureJdbiTest() {
 
     @Test
     fun testLegacyUserRoleDeserialization() {
-        val user = jdbi.open().use {
+        val user = db.read {
             it.createQuery(
                 "SELECT jsonb_build_object('id', '44e1ff31-fce4-4ca1-922a-a385fb21c69e', 'roles', jsonb_build_array('ROLE_EVAKA_ESPOO_FINANCEADMIN')) AS user"
             ).map { row -> row.mapJsonColumn<AuthenticatedUser>("user") }.asSequence().first()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
@@ -24,11 +24,8 @@ import java.util.UUID
 class AsyncJobQueriesTest : PureJdbiTest() {
     private val user = AuthenticatedUser(UUID.randomUUID(), setOf())
 
-    private lateinit var db: Database
-
     @BeforeEach
     fun beforeEach() {
-        db = Database(jdbi)
         db.transaction { it.execute("TRUNCATE async_job") }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
@@ -43,7 +43,7 @@ class AsyncJobRunnerTest {
     @BeforeEach
     @AfterAll
     fun clean() {
-        asyncJobRunner.notifyDecisionCreated = { _ -> }
+        asyncJobRunner.notifyDecisionCreated = { _, _ -> }
         jdbi.open().use { h -> h.execute("TRUNCATE async_job") }
     }
 
@@ -89,7 +89,7 @@ class AsyncJobRunnerTest {
 
     private fun <R> setAsyncJobCallback(f: (msg: NotifyDecisionCreated) -> R): Future<R> {
         val future = CompletableFuture<R>()
-        asyncJobRunner.notifyDecisionCreated = { msg ->
+        asyncJobRunner.notifyDecisionCreated = { _, msg ->
             try {
                 future.complete(f(msg))
             } catch (t: Throwable) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DatabaseTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DatabaseTest.kt
@@ -1,0 +1,59 @@
+package fi.espoo.evaka.shared.db
+
+import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.resetDatabase
+import org.jdbi.v3.core.kotlin.mapTo
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class DatabaseTest : PureJdbiTest() {
+    private lateinit var db: Database
+
+    @BeforeEach
+    fun beforeEach() {
+        db = Database(jdbi)
+        jdbi.handle { resetDatabase(it) }
+    }
+
+    @Test
+    fun `transaction savepoint should be able to recover from a database constraint exception`() {
+        db.connect { db ->
+            db.transaction { tx ->
+                tx.execute("INSERT INTO holiday (date) VALUES ('2020-01-01')")
+                assertThrows<UnableToExecuteStatementException> {
+                    tx.withSavepoint {
+                        tx.execute("INSERT INTO holiday (date) VALUES ('2020-01-01')")
+                    }
+                }
+                tx.execute("INSERT INTO holiday (date) VALUES ('2020-01-02')")
+            }
+            assertEquals(
+                listOf(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 2)),
+                db.read { it.createQuery("SELECT date FROM holiday ORDER BY date").mapTo<LocalDate>().toList() }
+            )
+        }
+    }
+
+    @Test
+    fun `transaction savepoint should be able to recover from an application exception`() {
+        db.connect { db ->
+            db.transaction { tx ->
+                tx.execute("INSERT INTO holiday (date) VALUES ('2020-01-01')")
+                assertThrows<RuntimeException> {
+                    tx.withSavepoint<Unit> {
+                        tx.execute("INSERT INTO holiday (date) VALUES ('2020-01-02')")
+                        throw RuntimeException("Test")
+                    }
+                }
+            }
+            assertEquals(
+                listOf(LocalDate.of(2020, 1, 1)),
+                db.read { it.createQuery("SELECT date FROM holiday ORDER BY date").mapTo<LocalDate>().toList() }
+            )
+        }
+    }
+}

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DatabaseTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DatabaseTest.kt
@@ -25,7 +25,7 @@ class DatabaseTest : PureJdbiTest() {
             db.transaction { tx ->
                 tx.execute("INSERT INTO holiday (date) VALUES ('2020-01-01')")
                 assertThrows<UnableToExecuteStatementException> {
-                    tx.withSavepoint {
+                    tx.subTransaction {
                         tx.execute("INSERT INTO holiday (date) VALUES ('2020-01-01')")
                     }
                 }
@@ -44,7 +44,7 @@ class DatabaseTest : PureJdbiTest() {
             db.transaction { tx ->
                 tx.execute("INSERT INTO holiday (date) VALUES ('2020-01-01')")
                 assertThrows<RuntimeException> {
-                    tx.withSavepoint<Unit> {
+                    tx.subTransaction<Unit> {
                         tx.execute("INSERT INTO holiday (date) VALUES ('2020-01-02')")
                         throw RuntimeException("Test")
                     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DatabaseTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DatabaseTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 package fi.espoo.evaka.shared.db
 
 import fi.espoo.evaka.PureJdbiTest

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DatabaseTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DatabaseTest.kt
@@ -11,12 +11,9 @@ import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 
 class DatabaseTest : PureJdbiTest() {
-    private lateinit var db: Database
-
     @BeforeEach
     fun beforeEach() {
-        db = Database(jdbi)
-        jdbi.handle { resetDatabase(it) }
+        db.transaction { it.resetDatabase() }
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -17,7 +17,9 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.PlacementType
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
+import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestChild
@@ -802,7 +804,9 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
     }
 
     private fun updateFeeData(h: Handle) {
-        updateFeeData(h, vardaClient, objectMapper, personService)
+        h.transaction {
+            updateFeeData(Database.Transaction.wrap(it), vardaClient, objectMapper, personService)
+        }
     }
 
     private fun createDecisionsAndPlacements(

--- a/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
@@ -24,7 +24,7 @@ class DecisionMessageProcessor(
     private val decisionService: DecisionService
 ) {
     init {
-        asyncJobRunner.notifyDecisionCreated = { msg -> runCreateJob(Database(jdbi), msg) }
+        asyncJobRunner.notifyDecisionCreated = ::runCreateJob
         asyncJobRunner.sendDecision = ::runSendJob
     }
 
@@ -43,7 +43,7 @@ class DecisionMessageProcessor(
         }
     }
 
-    fun runSendJob(msg: SendDecision) = jdbi.transaction { h ->
+    fun runSendJob(db: Database, msg: SendDecision) = jdbi.transaction { h ->
         val decisionId = msg.decisionId
 
         decisionService.deliverDecisionToGuardians(h, decisionId)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/enduser/ApplicationSerializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/enduser/ApplicationSerializer.kt
@@ -21,7 +21,7 @@ import fi.espoo.evaka.application.persistence.club.ClubFormV0
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import org.jdbi.v3.core.Handle
+import fi.espoo.evaka.shared.db.Database
 import org.springframework.stereotype.Component
 
 fun objectMapper(): ObjectMapper {
@@ -33,14 +33,14 @@ fun objectMapper(): ObjectMapper {
 @Component
 class ApplicationSerializer(private val personService: PersonService) {
     fun serialize(
-        h: Handle,
+        tx: Database.Transaction,
         user: AuthenticatedUser,
         application: ApplicationDetails,
         requireFreshPersonData: Boolean = true
     ): ApplicationJson {
-        val otherGuardian = if (requireFreshPersonData) personService.getOtherGuardian(h, user, application.guardianId, application.childId) else null
+        val otherGuardian = if (requireFreshPersonData) personService.getOtherGuardian(tx, user, application.guardianId, application.childId) else null
         val guardiansLiveInSameAddress = if (otherGuardian != null && requireFreshPersonData) personService.personsLiveInTheSameAddress(
-            h,
+            tx,
             user,
             application.guardianId,
             otherGuardian.id

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.daycare.service
 
 import fi.espoo.evaka.backupcare.GroupBackupCare
 import fi.espoo.evaka.daycare.getDaycare
-import fi.espoo.evaka.pis.service.PersonService
+import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -24,7 +24,7 @@ import java.util.UUID
 private val logger = KotlinLogging.logger { }
 
 @Service
-class AbsenceService(private val db: Jdbi, private val personService: PersonService) {
+class AbsenceService(private val db: Jdbi) {
     fun getAbsencesByMonth(groupId: UUID, year: Int, month: Int): AbsenceGroup {
         val startDate = LocalDate.of(year, month, 1)
         val endDate = startDate.with(lastDayOfMonth())
@@ -96,7 +96,7 @@ class AbsenceService(private val db: Jdbi, private val personService: PersonServ
             val absenceList = getAbsencesByChildByRange(childId, period, h)
             val backupCareList = h.getBackupCaresAffectingChild(childId, period)
             val child =
-                personService.getPerson(h, childId) ?: throw BadRequest("Error: Could not find child with id: $childId")
+                h.getPersonById(childId) ?: throw BadRequest("Error: Could not find child with id: $childId")
             AbsenceChildMinimal(
                 id = child.id,
                 firstName = child.firstName ?: "",

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
@@ -85,6 +85,7 @@ class DecisionController(
 
     @GetMapping("/{id}/download", produces = [MediaType.APPLICATION_PDF_VALUE])
     fun downloadDecisionPdf(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable("id") decisionId: UUID
     ): ResponseEntity<ByteArray> {
@@ -93,7 +94,7 @@ class DecisionController(
         val roles = acl.getRolesForDecision(user, decisionId)
         roles.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.ADMIN, Roles.UNIT_SUPERVISOR, Roles.END_USER)
 
-        return Database(jdbi).transaction { tx ->
+        return db.transaction { tx ->
             if (user.hasOneOfRoles(Roles.END_USER)) {
                 if (!getDecisionsByGuardian(tx.handle, user.id, AclAuthorization.All).any { it.id == decisionId }) {
                     throw Forbidden("Access denied")

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -275,7 +275,7 @@ class DecisionService(
     }
 
     private fun calculateDecisionFileName(h: Handle, decision: Decision, lang: String): String {
-        val child = personService.getPerson(h, decision.childId)
+        val child = h.getPersonById(decision.childId)
         val childName = "${child?.firstName}_${child?.lastName}"
         val prefix = getLocalizedFilename(decision.type, lang)
         return "${prefix}_$childName.pdf".replace(" ", "_")

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -27,7 +27,7 @@ class DvvModificationsBatchRefreshService(
     private val dvvModificationsService: DvvModificationsService
 ) {
     init {
-        asyncJobRunner.dvvModificationsRefresh = { msg -> doDvvModificationsRefresh(Database(jdbi), msg) }
+        asyncJobRunner.dvvModificationsRefresh = ::doDvvModificationsRefresh
     }
 
     fun doDvvModificationsRefresh(db: Database, msg: DvvModificationsRefresh) {

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailAsyncJobs.kt
@@ -7,23 +7,21 @@ package fi.espoo.evaka.emailclient
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.SendApplicationEmail
-import fi.espoo.evaka.shared.db.handle
-import org.jdbi.v3.core.Jdbi
+import fi.espoo.evaka.shared.db.Database
 import org.springframework.stereotype.Component
 
 @Component
 class EmailAsyncJobs(
     asyncJobRunner: AsyncJobRunner,
-    private val emailClient: IEmailClient,
-    private val jdbi: Jdbi
+    private val emailClient: IEmailClient
 ) {
 
     init {
         asyncJobRunner.sendApplicationEmail = ::runSendApplicationEmail
     }
 
-    private fun runSendApplicationEmail(msg: SendApplicationEmail) {
-        val guardian = jdbi.handle { it.getPersonById(msg.guardianId) }
+    private fun runSendApplicationEmail(db: Database, msg: SendApplicationEmail) {
+        val guardian = db.read { it.handle.getPersonById(msg.guardianId) }
             ?: throw Exception("Didn't find guardian when sending application email (guardianId: ${msg.guardianId})")
         emailClient.sendApplicationEmail(guardian.id, guardian.email, msg.language)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.async.NotifyFeeAlterationUpdated
 import fi.espoo.evaka.shared.async.NotifyIncomeUpdated
 import fi.espoo.evaka.shared.async.NotifyPlacementPlanApplied
 import fi.espoo.evaka.shared.async.NotifyServiceNeedUpdated
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Period
 import mu.KotlinLogging
@@ -33,27 +34,27 @@ class FeeDecisionGenerationJobProcessor(
         asyncJobRunner.notifyServiceNeedUpdated = ::runJob
     }
 
-    fun runJob(msg: NotifyFamilyUpdated) = jdbi.transaction { h ->
+    fun runJob(db: Database, msg: NotifyFamilyUpdated) = jdbi.transaction { h ->
         logger.info { "Handling family updated event for person (id: ${msg.adultId})" }
         generator.handleFamilyUpdate(h, msg.adultId, Period(msg.startDate, msg.endDate))
     }
 
-    fun runJob(msg: NotifyFeeAlterationUpdated) = jdbi.transaction { h ->
+    fun runJob(db: Database, msg: NotifyFeeAlterationUpdated) = jdbi.transaction { h ->
         logger.info { "Handling fee alteration updated event ($msg)" }
         generator.handleFeeAlterationChange(h, msg.personId, Period(msg.startDate, msg.endDate))
     }
 
-    fun runJob(msg: NotifyIncomeUpdated) = jdbi.transaction { h ->
+    fun runJob(db: Database, msg: NotifyIncomeUpdated) = jdbi.transaction { h ->
         logger.info { "Handling income updated event ($msg)" }
         generator.handleIncomeChange(h, msg.personId, Period(msg.startDate, msg.endDate))
     }
 
-    fun runJob(msg: NotifyPlacementPlanApplied) = jdbi.transaction { h ->
+    fun runJob(db: Database, msg: NotifyPlacementPlanApplied) = jdbi.transaction { h ->
         logger.info { "Handling placement plan accepted event ($msg)" }
         generator.handlePlacement(h, msg.childId, Period(msg.startDate, msg.endDate))
     }
 
-    fun runJob(msg: NotifyServiceNeedUpdated) = jdbi.transaction { h ->
+    fun runJob(db: Database, msg: NotifyServiceNeedUpdated) = jdbi.transaction { h ->
         logger.info { "Handling service need updated event for child (id: ${msg.childId})" }
         generator.handleServiceNeed(h, msg.childId, Period(msg.startDate, msg.endDate))
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.async.NotifyFeeDecisionApproved
 import fi.espoo.evaka.shared.async.NotifyFeeDecisionPdfGenerated
 import fi.espoo.evaka.shared.async.NotifyVoucherValueDecisionApproved
 import fi.espoo.evaka.shared.async.NotifyVoucherValueDecisionPdfGenerated
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.transaction
 import mu.KotlinLogging
 import org.jdbi.v3.core.Jdbi
@@ -32,27 +33,27 @@ class InvoicingAsyncJobs(
         asyncJobRunner.notifyVoucherValueDecisionPdfGenerated = ::runSendVoucherValueDecisionPdf
     }
 
-    fun runCreateFeeDecisionPdf(msg: NotifyFeeDecisionApproved) = jdbi.transaction { h ->
+    fun runCreateFeeDecisionPdf(db: Database, msg: NotifyFeeDecisionApproved) = jdbi.transaction { h ->
         val decisionId = msg.decisionId
         feeService.createFeeDecisionPdf(h, decisionId)
         logger.info { "Successfully created fee decision pdf (id: $decisionId)." }
         asyncJobRunner.plan(h, listOf(NotifyFeeDecisionPdfGenerated(decisionId)))
     }
 
-    fun runSendFeeDecisionPdf(msg: NotifyFeeDecisionPdfGenerated) = jdbi.transaction { h ->
+    fun runSendFeeDecisionPdf(db: Database, msg: NotifyFeeDecisionPdfGenerated) = jdbi.transaction { h ->
         val decisionId = msg.decisionId
         feeService.sendDecision(h, decisionId)
         logger.info { "Successfully sent fee decision msg to suomi.fi (id: $decisionId)." }
     }
 
-    fun runCreateVoucherValueDecisionPdf(msg: NotifyVoucherValueDecisionApproved) = jdbi.transaction { h ->
+    fun runCreateVoucherValueDecisionPdf(db: Database, msg: NotifyVoucherValueDecisionApproved) = jdbi.transaction { h ->
         val decisionId = msg.decisionId
         valueDecisionService.createDecisionPdf(h, decisionId)
         logger.info { "Successfully created voucher value decision pdf (id: $decisionId)." }
         asyncJobRunner.plan(h, listOf(NotifyVoucherValueDecisionPdfGenerated(decisionId)))
     }
 
-    fun runSendVoucherValueDecisionPdf(msg: NotifyVoucherValueDecisionPdfGenerated) = jdbi.transaction { h ->
+    fun runSendVoucherValueDecisionPdf(db: Database, msg: NotifyVoucherValueDecisionPdfGenerated) = jdbi.transaction { h ->
         val decisionId = msg.decisionId
         valueDecisionService.sendDecision(h, decisionId)
         logger.info { "Successfully sent fee decision msg to suomi.fi (id: $decisionId)." }

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -20,7 +20,7 @@ import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.UploadToKoski
-import fi.espoo.evaka.shared.db.transaction
+import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
 import org.jdbi.v3.core.Jdbi
 import org.springframework.core.env.Environment
@@ -50,18 +50,18 @@ class KoskiClient(
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     init {
-        asyncJobRunner?.uploadToKoski = { msg -> uploadToKoski(msg, today = LocalDate.now()) }
+        asyncJobRunner?.uploadToKoski = { msg -> uploadToKoski(Database(jdbi), msg, today = LocalDate.now()) }
     }
 
-    fun uploadToKoski(msg: UploadToKoski, today: LocalDate) = jdbi.transaction { h ->
+    fun uploadToKoski(db: Database, msg: UploadToKoski, today: LocalDate) = db.transaction { tx ->
         logger.info { "Koski upload ${msg.key}: starting" }
-        val data = h.beginKoskiUpload(sourceSystem, msg.key, today)
+        val data = tx.beginKoskiUpload(sourceSystem, msg.key, today)
         if (data == null) {
             logger.info { "Koski upload ${msg.key}: no data -> skipping" }
             return@transaction
         }
         val payload = objectMapper.writeValueAsString(data.oppija)
-        if (!h.isPayloadChanged(msg.key, payload)) {
+        if (!tx.isPayloadChanged(msg.key, payload)) {
             logger.info { "Koski upload ${msg.key} ${data.operation}: no change in payload -> skipping" }
         } else {
             val (_, _, result) = Fuel.request(
@@ -81,7 +81,7 @@ class KoskiClient(
                 logger.error(error) { "Koski upload ${msg.key} ${data.operation} failed: ${error.response}" }
                 throw error
             }
-            h.finishKoskiUpload(
+            tx.finishKoskiUpload(
                 KoskiUploadResponse(
                     id = response.opiskeluoikeudet[0].lähdejärjestelmänId.id,
                     studyRightOid = response.opiskeluoikeudet[0].oid,

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -22,7 +22,6 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.UploadToKoski
 import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
-import org.jdbi.v3.core.Jdbi
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -36,7 +35,6 @@ class KoskiClient(
     private val sourceSystem: String = env.getRequiredProperty("fi.espoo.integration.koski.source_system"),
     private val koskiUser: String = env.getRequiredProperty("fi.espoo.integration.koski.user"),
     private val koskiSecret: String = env.getRequiredProperty("fi.espoo.integration.koski.secret"),
-    private val jdbi: Jdbi,
     asyncJobRunner: AsyncJobRunner?
 ) {
     // Use a local Jackson instance so the configuration doesn't get changed accidentally if the global defaults change.
@@ -50,7 +48,7 @@ class KoskiClient(
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     init {
-        asyncJobRunner?.uploadToKoski = { msg -> uploadToKoski(Database(jdbi), msg, today = LocalDate.now()) }
+        asyncJobRunner?.uploadToKoski = { db, msg -> uploadToKoski(db, msg, today = LocalDate.now()) }
     }
 
     fun uploadToKoski(db: Database, msg: UploadToKoski, today: LocalDate) = db.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
@@ -8,9 +8,7 @@ import fi.espoo.evaka.invoicing.controller.parseUUID
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.UploadToKoski
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import mu.KotlinLogging
-import org.jdbi.v3.core.Jdbi
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -25,17 +23,17 @@ data class KoskiSearchParams(
 
 @Service
 class KoskiUpdateService(
-    private val jdbi: Jdbi,
     private val env: Environment,
     private val asyncJobRunner: AsyncJobRunner
 ) {
     fun update(
+        db: Database,
         personIds: String?,
         daycareIds: String?
     ) {
         val isEnabled: Boolean = env.getRequiredProperty("fi.espoo.integration.koski.enabled", Boolean::class.java)
         if (isEnabled) {
-            Database(jdbi).transaction { tx ->
+            db.transaction { tx ->
                 val params = KoskiSearchParams(
                     personIds = personIds?.split(",")?.map(::parseUUID) ?: listOf(),
                     daycareIds = daycareIds?.split(",")?.map(::parseUUID) ?: listOf()

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.pis.service.PersonPatch
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.pis.service.PersonWithChildrenDTO
 import fi.espoo.evaka.pis.service.VTJBatchRefreshService
+import fi.espoo.evaka.pis.updatePersonContactInfo
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles.ADMIN
@@ -159,7 +160,7 @@ class PersonController(
     ): ResponseEntity<ContactInfo> {
         Audit.PersonContactInfoUpdate.log(targetId = personId)
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
-        return if (jdbi.transaction { personService.updateEndUsersContactInfo(it, personId, contactInfo) }) {
+        return if (jdbi.transaction { it.updatePersonContactInfo(personId, contactInfo) }) {
             ResponseEntity.ok().body(contactInfo)
         } else {
             ResponseEntity.notFound().build()

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -187,7 +187,7 @@ class PersonController(
     ): ResponseEntity<Unit> {
         Audit.PersonDelete.log(targetId = personId)
         user.requireOneOfRoles(ADMIN)
-        mergeService.deleteEmptyPerson(personId)
+        Database(jdbi).transaction { mergeService.deleteEmptyPerson(it, personId) }
         return ResponseEntity.noContent().build()
     }
 
@@ -261,7 +261,9 @@ class PersonController(
     ): ResponseEntity<Unit> {
         Audit.PersonMerge.log(targetId = body.master, objectId = body.duplicate)
         user.requireOneOfRoles(ADMIN)
-        mergeService.mergePeople(master = body.master, duplicate = body.duplicate)
+        Database(jdbi).transaction { tx ->
+            mergeService.mergePeople(tx, master = body.master, duplicate = body.duplicate)
+        }
         asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.ok().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -62,7 +62,7 @@ class FamilyInitializerService(
             }
 
             try {
-                tx.withSavepoint {
+                tx.subTransaction {
                     createParentship(
                         tx,
                         childId = members.fridgeChildId,
@@ -75,7 +75,7 @@ class FamilyInitializerService(
 
             if (members.fridgePartnerId != null) {
                 try {
-                    tx.withSavepoint {
+                    tx.subTransaction {
                         createPartnership(tx, members.headOfFamilyId, members.fridgePartnerId)
                     }
                 } catch (e: Throwable) {
@@ -85,7 +85,7 @@ class FamilyInitializerService(
 
             members.fridgeSiblingIds.forEach { siblingId ->
                 try {
-                    tx.withSavepoint {
+                    tx.subTransaction {
                         createParentship(tx, childId = siblingId, headOfChildId = members.headOfFamilyId)
                     }
                 } catch (e: Throwable) {
@@ -161,7 +161,7 @@ class FamilyInitializerService(
             logger.debug("Similar parentship already exists between $headOfChildId and $childId")
         } else {
             try {
-                tx.withSavepoint {
+                tx.subTransaction {
                     tx.handle.createParentship(
                         childId = childId,
                         headOfChildId = headOfChildId,
@@ -195,7 +195,7 @@ class FamilyInitializerService(
             logger.debug("Similar partnership already exists between $personId1 and $personId2")
         } else {
             try {
-                tx.withSavepoint {
+                tx.subTransaction {
                     tx.handle.createPartnership(
                         personId1 = personId1,
                         personId2 = personId2,

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -105,7 +105,7 @@ class FamilyInitializerService(
     )
 
     private fun parseFridgeFamilyMembersFromApplication(
-        db: Database.Transaction,
+        tx: Database.Transaction,
         user: AuthenticatedUser,
         application: ApplicationDetails
     ): FridgeFamilyMembers {
@@ -116,16 +116,16 @@ class FamilyInitializerService(
         val otherGuardianId = application.otherGuardianId
         val fridgePartnerSSN = if (
             otherGuardianId != null &&
-            personService.personsLiveInTheSameAddress(db.handle, user, headOfFamilyId, otherGuardianId)
+            personService.personsLiveInTheSameAddress(tx, user, headOfFamilyId, otherGuardianId)
         ) {
-            (db.handle.getPersonById(otherGuardianId)?.identity as? SSN)?.ssn
+            (tx.handle.getPersonById(otherGuardianId)?.identity as? SSN)?.ssn
         } else {
             application.form.otherPartner?.socialSecurityNumber
         }
 
         val fridgePartnerId = fridgePartnerSSN
             ?.let { stringToSSN(it) }
-            ?.let { personService.getOrCreatePerson(db.handle, user, it, updateStale) }
+            ?.let { personService.getOrCreatePerson(tx, user, it, updateStale) }
             ?.id
 
         val fridgeChildId = application.childId
@@ -133,7 +133,7 @@ class FamilyInitializerService(
         val fridgeSiblingIds = application.form.otherChildren
             .mapNotNull { it.socialSecurityNumber }
             .mapNotNull { stringToSSN(it) }
-            .mapNotNull { personService.getOrCreatePerson(db.handle, user, it, updateStale)?.id }
+            .mapNotNull { personService.getOrCreatePerson(tx, user, it, updateStale)?.id }
 
         return FridgeFamilyMembers(headOfFamilyId, fridgePartnerId, fridgeChildId, fridgeSiblingIds)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -17,7 +17,6 @@ import fi.espoo.evaka.shared.async.InitializeFamilyFromApplication
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
-import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -26,14 +25,12 @@ import java.util.UUID
 @Service
 class FamilyInitializerService(
     private val personService: PersonService,
-    private val jdbi: Jdbi,
     asyncJobRunner: AsyncJobRunner
 ) {
     private val logger = KotlinLogging.logger {}
 
     init {
-        asyncJobRunner.initializeFamilyFromApplication =
-            { msg -> handleInitializeFamilyFromApplication(Database(jdbi), msg) }
+        asyncJobRunner.initializeFamilyFromApplication = ::handleInitializeFamilyFromApplication
     }
 
     fun handleInitializeFamilyFromApplication(db: Database, msg: InitializeFamilyFromApplication) =

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.pis.getPersonBySSN
 import fi.espoo.evaka.pis.updatePersonContactInfo
 import fi.espoo.evaka.pis.updatePersonDetails
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.NotFound
@@ -24,7 +25,6 @@ import fi.espoo.evaka.vtjclient.service.persondetails.IPersonDetailsService
 import fi.espoo.evaka.vtjclient.service.persondetails.PersonDetails
 import fi.espoo.evaka.vtjclient.service.persondetails.PersonStorageService
 import fi.espoo.evaka.vtjclient.usecases.dto.PersonResult
-import org.jdbi.v3.core.Handle
 import org.springframework.stereotype.Service
 import java.time.Instant
 import java.time.LocalDate
@@ -37,8 +37,9 @@ class PersonService(
 ) {
     private val forceRefreshIntervalSeconds = 1 * 24 * 60 * 60 // 1 day
 
-    fun getUpToDatePerson(h: Handle, user: AuthenticatedUser, id: VolttiIdentifier): PersonDTO? {
-        val person = h.getPersonById(id) ?: return null
+    // Does a request to VTJ if data is stale
+    fun getUpToDatePerson(tx: Database.Transaction, user: AuthenticatedUser, id: VolttiIdentifier): PersonDTO? {
+        val person = tx.handle.getPersonById(id) ?: return null
         return if (person.identity is ExternalIdentifier.SSN && vtjDataIsStale(person)) {
             val personDetails =
                 personDetailsService.getBasicDetailsFor(
@@ -46,8 +47,8 @@ class PersonService(
                 )
             if (personDetails is PersonDetails.Result) {
                 val personResult = PersonResult.Result(personDetails.vtjPerson.mapToDto())
-                personStorageService.upsertVtjPerson(h, personResult)
-                h.getPersonById(id)
+                personStorageService.upsertVtjPerson(tx, personResult)
+                tx.handle.getPersonById(id)
             } else {
                 hideNonDisclosureInfo(person)
             }
@@ -56,9 +57,9 @@ class PersonService(
         }
     }
 
-    fun personsLiveInTheSameAddress(h: Handle, user: AuthenticatedUser, person1Id: UUID, person2Id: UUID): Boolean {
-        val person1 = h.getPersonById(person1Id)
-        val person2 = h.getPersonById(person2Id)
+    fun personsLiveInTheSameAddress(db: Database.Read, user: AuthenticatedUser, person1Id: UUID, person2Id: UUID): Boolean {
+        val person1 = db.handle.getPersonById(person1Id)
+        val person2 = db.handle.getPersonById(person2Id)
 
         return personsHaveSameResidenceCode(person1, person2) || personsHaveSameAddress(person1, person2)
     }
@@ -79,18 +80,24 @@ class PersonService(
             person1.postalCode.equals(person2.postalCode)
     }
 
+    // Does a request to VTJ if SSN is present
     fun getUpToDatePersonWithChildren(
-        h: Handle,
+        tx: Database.Transaction,
         user: AuthenticatedUser,
         id: VolttiIdentifier
     ): PersonWithChildrenDTO? {
-        val guardian = h.getPersonById(id) ?: return null
+        val guardian = tx.handle.getPersonById(id) ?: return null
 
         return when (guardian.identity) {
             is ExternalIdentifier.NoID -> toPersonWithChildrenDTO(guardian)
             is ExternalIdentifier.SSN ->
                 getPersonWithDependants(user, guardian.identity)
-                    ?.let { personStorageService.upsertVtjGuardianAndChildren(h, PersonResult.Result(it)) }
+                    ?.let {
+                        personStorageService.upsertVtjGuardianAndChildren(
+                            tx,
+                            PersonResult.Result(it)
+                        )
+                    }
                     ?.let {
                         when (it) {
                             is PersonResult.Error -> throw IllegalStateException(it.msg)
@@ -104,20 +111,21 @@ class PersonService(
     // In extremely rare cases there might be more than 2 guardians, but it was agreed with product management to use
     // just one of these as the other guardian.
     fun getOtherGuardian(
-        h: Handle,
+        tx: Database.Transaction,
         user: AuthenticatedUser,
         otherGuardianId: VolttiIdentifier,
         childId: VolttiIdentifier
-    ): PersonDTO? = getGuardians(h, user, childId).firstOrNull { guardian -> guardian.id != otherGuardianId }
+    ): PersonDTO? = getGuardians(tx, user, childId).firstOrNull { guardian -> guardian.id != otherGuardianId }
 
-    fun getGuardians(h: Handle, user: AuthenticatedUser, id: VolttiIdentifier): List<PersonDTO> {
-        val child = h.getPersonById(id) ?: return emptyList()
+    // Does a request to VTJ if SSN is present
+    fun getGuardians(tx: Database.Transaction, user: AuthenticatedUser, id: VolttiIdentifier): List<PersonDTO> {
+        val child = tx.handle.getPersonById(id) ?: return emptyList()
 
         return when (child.identity) {
             is ExternalIdentifier.NoID -> emptyList()
             is ExternalIdentifier.SSN ->
                 getPersonWithGuardians(user, child.identity)
-                    ?.let { personStorageService.upsertVtjChildAndGuardians(h, PersonResult.Result(it)) }
+                    ?.let { personStorageService.upsertVtjChildAndGuardians(tx, PersonResult.Result(it)) }
                     ?.let {
                         when (it) {
                             is PersonResult.Error -> throw IllegalStateException(it.msg)
@@ -128,21 +136,22 @@ class PersonService(
         }
     }
 
+    // Does a request to VTJ if data is stale
     fun getOrCreatePerson(
-        h: Handle,
+        tx: Database.Transaction,
         user: AuthenticatedUser,
         ssn: ExternalIdentifier.SSN,
         updateStale: Boolean = true
     ): PersonDTO? {
-        val person = h.getPersonBySSN(ssn.ssn)
+        val person = tx.handle.getPersonBySSN(ssn.ssn)
         return if (person == null || (updateStale && vtjDataIsStale(person))) {
             val personDetails = personDetailsService.getBasicDetailsFor(
                 IPersonDetailsService.DetailsQuery(user, ssn)
             )
             if (personDetails is PersonDetails.Result) {
                 val personResult = PersonResult.Result(personDetails.vtjPerson.mapToDto())
-                personStorageService.upsertVtjPerson(h, personResult)
-                h.getPersonBySSN(ssn.ssn)
+                personStorageService.upsertVtjPerson(tx, personResult)
+                tx.handle.getPersonBySSN(ssn.ssn)
             } else {
                 hideNonDisclosureInfo(person)
             }
@@ -151,6 +160,7 @@ class PersonService(
         }
     }
 
+    // Expensive VTJ request
     fun getPersonFromVTJ(user: AuthenticatedUser, ssn: ExternalIdentifier.SSN): PersonDTO? {
         val personDetails = personDetailsService.getBasicDetailsFor(
             IPersonDetailsService.DetailsQuery(user, ssn)
@@ -160,11 +170,11 @@ class PersonService(
         } else null
     }
 
-    fun patchUserDetails(h: Handle, id: VolttiIdentifier, data: PersonPatch): PersonDTO {
-        val person = h.getPersonById(id) ?: throw NotFound("Person $id not found")
+    fun patchUserDetails(tx: Database.Transaction, id: VolttiIdentifier, data: PersonPatch): PersonDTO {
+        val person = tx.handle.getPersonById(id) ?: throw NotFound("Person $id not found")
 
         when (person.identity) {
-            is ExternalIdentifier.SSN -> h.updatePersonContactInfo(
+            is ExternalIdentifier.SSN -> tx.handle.updatePersonContactInfo(
                 id,
                 ContactInfo(
                     email = data.email ?: person.email ?: "",
@@ -176,22 +186,22 @@ class PersonService(
                     forceManualFeeDecisions = data.forceManualFeeDecisions ?: person.forceManualFeeDecisions ?: false
                 )
             )
-            is ExternalIdentifier.NoID -> h.updatePersonDetails(id, data)
+            is ExternalIdentifier.NoID -> tx.handle.updatePersonDetails(id, data)
         }.exhaust()
 
-        return h.getPersonById(id)!!
+        return tx.handle.getPersonById(id)!!
     }
 
-    fun addSsn(h: Handle, user: AuthenticatedUser, id: VolttiIdentifier, ssn: ExternalIdentifier.SSN) {
-        val person = h.getPersonById(id) ?: throw NotFound("Person $id not found")
+    fun addSsn(tx: Database.Transaction, user: AuthenticatedUser, id: VolttiIdentifier, ssn: ExternalIdentifier.SSN) {
+        val person = tx.handle.getPersonById(id) ?: throw NotFound("Person $id not found")
 
         when (person.identity) {
             is ExternalIdentifier.SSN -> throw BadRequest("User already has ssn")
             is ExternalIdentifier.NoID -> {
-                if (h.getPersonBySSN(ssn.ssn) != null) {
+                if (tx.handle.getPersonBySSN(ssn.ssn) != null) {
                     throw Conflict("User with same ssn already exists")
                 }
-                h.addSSNToPerson(id, ssn.toString())
+                tx.handle.addSSNToPerson(id, ssn.toString())
             }
         }.exhaust()
     }
@@ -201,12 +211,14 @@ class PersonService(
             ?.let { it < Instant.now().minusSeconds(forceRefreshIntervalSeconds.toLong()) } ?: true
     }
 
+    // Does a request to VTJ
     fun getPersonWithDependants(user: AuthenticatedUser, ssn: ExternalIdentifier.SSN): VtjPersonDTO? {
         return personDetailsService.getPersonWithDependants(IPersonDetailsService.DetailsQuery(user, ssn))
             .let { it as? PersonDetails.Result }
             ?.let { result -> result.vtjPerson.mapToDto() }
     }
 
+    // Does a request to VTJ
     private fun getPersonWithGuardians(user: AuthenticatedUser, ssn: ExternalIdentifier.SSN): VtjPersonDTO? {
         return personDetailsService.getPersonWithGuardians(IPersonDetailsService.DetailsQuery(user, ssn))
             .let { it as? PersonDetails.Result }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
@@ -26,7 +26,7 @@ class VTJBatchRefreshService(
 ) {
 
     init {
-        asyncJobRunner.vtjRefresh = { msg -> fridgeFamilyService.doVTJRefresh(Database(jdbi), msg) }
+        asyncJobRunner.vtjRefresh = ::doVTJRefresh
     }
 
     fun doVTJRefresh(db: Database, msg: VTJRefresh) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.pis.service
 
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.VTJRefresh
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.transaction
 import mu.KotlinLogging
 import org.jdbi.v3.core.Handle
@@ -25,11 +26,11 @@ class VTJBatchRefreshService(
 ) {
 
     init {
-        asyncJobRunner.vtjRefresh = ::doVTJRefresh
+        asyncJobRunner.vtjRefresh = { msg -> fridgeFamilyService.doVTJRefresh(Database(jdbi), msg) }
     }
 
-    fun doVTJRefresh(msg: VTJRefresh) {
-        fridgeFamilyService.doVTJRefresh(msg)
+    fun doVTJRefresh(db: Database, msg: VTJRefresh) {
+        fridgeFamilyService.doVTJRefresh(db, msg)
     }
 
     fun scheduleBatch(): Int {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
@@ -6,17 +6,20 @@ package fi.espoo.evaka.shared.config
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import fi.espoo.evaka.shared.db.DatabaseSpringSupport
 import fi.espoo.evaka.shared.db.configureJdbi
 import org.flywaydb.core.Flyway
 import org.jdbi.v3.core.Jdbi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 import org.springframework.core.env.Environment
 import org.springframework.core.env.getProperty
 import java.util.concurrent.TimeUnit
 import javax.sql.DataSource
 
 @Configuration
+@Import(DatabaseSpringSupport::class)
 class DatabaseConfig {
     @Bean
     fun jdbi(dataSource: DataSource) = configureJdbi(Jdbi.create(dataSource))

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.application.removeOldDrafts
 import fi.espoo.evaka.dvv.DvvModificationsBatchRefreshService
 import fi.espoo.evaka.koski.KoskiUpdateService
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.varda.VardaUpdateService
 import org.jdbi.v3.core.Jdbi
@@ -35,10 +36,11 @@ class ScheduledOperationController(
 
     @PostMapping("/koski/update")
     fun koskiUpdate(
+        db: Database,
         @RequestParam(required = false) personIds: String?,
         @RequestParam(required = false) daycareIds: String?
     ): ResponseEntity<Unit> {
-        koskiUpdateService.update(personIds, daycareIds)
+        koskiUpdateService.update(db, personIds, daycareIds)
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
@@ -111,7 +111,7 @@ class Database(private val jdbi: Jdbi) {
         fun prepareBatch(@Language("sql") sql: String): PreparedBatch = handle.prepareBatch(sql)
         fun execute(@Language("sql") sql: String, vararg args: Any): Int = handle.execute(sql, *args)
 
-        inline fun <reified T> withSavepoint(crossinline f: () -> T): T {
+        inline fun <reified T> subTransaction(crossinline f: () -> T): T {
             val savepointName = nextSavepoint()
             handle.savepoint(savepointName)
             val result = try {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
@@ -153,7 +153,7 @@ class Database(private val jdbi: Jdbi) {
         fun prepareBatch(@Language("sql") sql: String): PreparedBatch = handle.prepareBatch(sql)
         fun execute(@Language("sql") sql: String, vararg args: Any): Int = handle.execute(sql, *args)
 
-        inline fun <reified T> subTransaction(crossinline f: () -> T): T {
+        fun <T> subTransaction(f: () -> T): T {
             val savepointName = nextSavepoint()
             handle.savepoint(savepointName)
             val result = try {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.db
+
+import org.intellij.lang.annotations.Language
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.statement.PreparedBatch
+import org.jdbi.v3.core.statement.Query
+import org.jdbi.v3.core.statement.Update
+
+private data class ThreadId(val id: Long = Thread.currentThread().id) {
+    fun assertCurrentThread() = assert(Thread.currentThread().id == id) { "Database accessed from the wrong thread" }
+}
+
+/**
+ * A database reference that can be used to obtain *one database connection at a time*.
+ *
+ * Tied to the thread that created it, and throws `IllegalStateException` if used in the wrong thread.
+ */
+class Database(private val jdbi: Jdbi) {
+    private val threadId = ThreadId()
+    private var connected = false
+
+    /**
+     * Opens a database connection, runs the given function, and closes the connection.
+     *
+     * Throws `IllegalStateException` if a connection is already open
+     */
+    fun <T> connect(f: (db: Connection) -> T): T {
+        threadId.assertCurrentThread()
+        check(!connected) { "Already connected to database" }
+        try {
+            connected = true
+            return jdbi.open().use {
+                f(Connection(it))
+            }
+        } finally {
+            connected = false
+        }
+    }
+
+    /**
+     * Opens a database connection in read mode, runs the given function, and closes the connection.
+     *
+     * Throws `IllegalStateException` if a connection is already open
+     */
+    fun <T> read(f: (db: Read) -> T): T = connect { it.read(f) }
+
+    /**
+     * Opens a database connection, runs the given function within a transaction, and closes the connection.
+     *
+     * Throws `IllegalStateException` if a connection is already open
+     */
+    fun <T> transaction(f: (db: Transaction) -> T): T = connect { it.transaction(f) }
+
+    /**
+     * A single database connection tied to a single thread
+     */
+    inner class Connection internal constructor(private val handle: Handle) {
+        /**
+         * Enters read mode, runs the given function, and exits read mode regardless of any exceptions the function may have thrown.
+         *
+         * Throws `IllegalStateException` if this database connection is already in read mode or a transaction
+         */
+        fun <T> read(f: (db: Read) -> T): T {
+            threadId.assertCurrentThread()
+            check(!handle.isInTransaction) { "Already in a transaction" }
+            handle.isReadOnly = true
+            try {
+                return handle.inTransaction<T, Exception> { f(Read(handle)) }
+            } finally {
+                handle.isReadOnly = false
+            }
+        }
+
+        /**
+         * Starts a transaction, runs the given function, and commits or rolls back the transaction depending on whether
+         * the function threw an exception or not.
+         *
+         * Throws `IllegalStateException` if this database connection is already in read mode or a transaction.
+         */
+        fun <T> transaction(f: (db: Transaction) -> T): T {
+            threadId.assertCurrentThread()
+            check(!handle.isInTransaction) { "Already in a transaction" }
+            return handle.inTransaction<T, Exception> { f(Transaction(handle)) }
+        }
+    }
+
+    /**
+     * A single database connection in read mode.
+     *
+     * Tied to the thread that created it, and throws `IllegalStateException` if used in the wrong thread.
+     */
+    open inner class Read internal constructor(val handle: Handle) {
+        fun createQuery(@Language("sql") sql: String): Query = handle.createQuery(sql)
+    }
+
+    /**
+     * A single database connection running a transaction.
+     *
+     * Tied to the thread that created it, and throws `IllegalStateException` if used in the wrong thread.
+     */
+    inner class Transaction internal constructor(handle: Handle) : Database.Read(handle) {
+        fun createUpdate(@Language("sql") sql: String): Update = handle.createUpdate(sql)
+        fun prepareBatch(@Language("sql") sql: String): PreparedBatch = handle.prepareBatch(sql)
+        fun execute(@Language("sql") sql: String, vararg args: Any): Int = handle.execute(sql, *args)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
@@ -11,9 +11,20 @@ import org.jdbi.v3.core.statement.PreparedBatch
 import org.jdbi.v3.core.statement.Query
 import org.jdbi.v3.core.statement.Update
 
-internal data class ThreadId(val id: Long = Thread.currentThread().id) {
-    fun assertCurrentThread() = assert(Thread.currentThread().id == id) { "Database accessed from the wrong thread" }
-}
+// What does it mean when a function accepts a Database/Database.* parameter?
+//
+//     fun doStuff(db: Database):
+//         To call this function, you need to have a database reference *without* an active connection or transaction.
+//         The can connect/disconnect from the database 0 to N times, and do whatever it wants using the connection(s).
+//     fun doStuff(db: Database.Connection)
+//         To call this function, you need to have an active database connection *without* an active transaction.
+//         The function can read/write the database and freely execute 0 to N individual transactions.
+//     fun doStuff(tx: Database.Read)
+//         To call this function, you need to have an active read-only transaction.
+//         The function can only read the database, and can't manage transactions by itself.
+//     fun doStuff(tx: Database.Transaction)
+//         To call this function, you need to have an active transaction.
+//         The function can read/write the database, and can't manage transactions by itself.
 
 /**
  * A database reference that can be used to obtain *one database connection at a time*.
@@ -167,4 +178,8 @@ class Database(private val jdbi: Jdbi) {
             }
         }
     }
+}
+
+internal data class ThreadId(val id: Long = Thread.currentThread().id) {
+    fun assertCurrentThread() = assert(Thread.currentThread().id == id) { "Database accessed from the wrong thread" }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/DatabaseSpringSupport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/DatabaseSpringSupport.kt
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.db
+
+import org.jdbi.v3.core.Jdbi
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class DatabaseSpringSupport(private val jdbi: Jdbi) : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(object : HandlerMethodArgumentResolver {
+            override fun supportsParameter(parameter: MethodParameter): Boolean =
+                Database::class.java.isAssignableFrom(parameter.parameterType)
+
+            override fun resolveArgument(
+                parameter: MethodParameter,
+                mavContainer: ModelAndViewContainer?,
+                webRequest: NativeWebRequest,
+                binderFactory: WebDataBinderFactory?
+            ) = Database(jdbi)
+        })
+        super.addArgumentResolvers(resolvers)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.varda
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.espoo.evaka.pis.service.PersonService
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.varda.integration.VardaClient
 import fi.espoo.evaka.varda.integration.VardaTokenProvider
@@ -65,6 +66,8 @@ fun updateAll(
         updateChildren(h, client, organizer)
         updateDecisions(h, client)
         updatePlacements(h, client)
-        updateFeeData(h, client, mapper, personService)
+    }
+    Database(jdbi).transaction { tx ->
+        updateFeeData(tx, client, mapper, personService)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -47,10 +47,10 @@ class VtjController(
 ) {
     @GetMapping("/uuid/{personId}")
     fun getDetails(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: UUID
     ): ResponseEntity<VtjPersonDTO> {
-        val db = Database(jdbi)
         val vtjData = getPersonDataWithChildren(db, user, personId)
             .let { db.transaction { tx -> personStorageService.upsertVtjGuardianAndChildren(tx, it) } }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -11,10 +11,10 @@ import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getEnum
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.vtjclient.dto.NativeLanguage
 import fi.espoo.evaka.vtjclient.dto.PersonDataSource
@@ -50,8 +50,9 @@ class VtjController(
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: UUID
     ): ResponseEntity<VtjPersonDTO> {
-        val vtjData = getPersonDataWithChildren(user, personId)
-            .let { jdbi.transaction { h -> personStorageService.upsertVtjGuardianAndChildren(h, it) } }
+        val db = Database(jdbi)
+        val vtjData = getPersonDataWithChildren(db, user, personId)
+            .let { db.transaction { tx -> personStorageService.upsertVtjGuardianAndChildren(tx, it) } }
 
         return when (vtjData) {
             is PersonResult.Error -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
@@ -61,6 +62,7 @@ class VtjController(
     }
 
     private fun getPersonDataWithChildren(
+        db: Database,
         user: AuthenticatedUser,
         personId: VolttiIdentifier
     ): PersonResult {
@@ -71,15 +73,15 @@ class VtjController(
                     PersonResult.Error("Query not allowed")
                         .also { logger.error { "Error preparing request for person data: ${it.msg}" } }
                 } else {
-                    personResult(user, personId)
+                    personResult(db, user, personId)
                 }
             }
             else -> failAuthentication()
         }
     }
 
-    private fun personResult(user: AuthenticatedUser, personId: VolttiIdentifier): PersonResult {
-        val guardianResult = jdbi.handle { it.getPersonById(personId) }
+    private fun personResult(db: Database, user: AuthenticatedUser, personId: VolttiIdentifier): PersonResult {
+        val guardianResult = db.read { it.handle.getPersonById(personId) }
             ?.let { person ->
                 when (person.identity) {
                     is ExternalIdentifier.NoID -> mapPisPerson(person)

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.vtjclient.controllers
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.identity.VolttiIdentifier
+import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -78,7 +79,7 @@ class VtjController(
     }
 
     private fun personResult(user: AuthenticatedUser, personId: VolttiIdentifier): PersonResult {
-        val guardianResult = jdbi.handle { personService.getPerson(it, personId) }
+        val guardianResult = jdbi.handle { it.getPersonById(personId) }
             ?.let { person ->
                 when (person.identity) {
                     is ExternalIdentifier.NoID -> mapPisPerson(person)

--- a/service/src/test/kotlin/fi/espoo/evaka/application/enduser/club/ClubApplicationSerializerTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/application/enduser/club/ClubApplicationSerializerTest.kt
@@ -27,7 +27,7 @@ import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
-import org.jdbi.v3.core.Handle
+import fi.espoo.evaka.shared.db.Database
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -51,7 +51,7 @@ class ClubApplicationSerializerTest {
     lateinit var personService: PersonService
 
     @Mock
-    lateinit var handle: Handle
+    lateinit var tx: Database.Transaction
 
     @InjectMocks
     lateinit var serializer: ApplicationSerializer
@@ -72,7 +72,7 @@ class ClubApplicationSerializerTest {
     @Test
     fun toEnduserJSONFromClubApplication() {
         val user = AuthenticatedUser(requestingUserId, setOf(Roles.END_USER))
-        val clubJSON = serializer.serialize(handle, user, mockEnduserClubApplication())
+        val clubJSON = serializer.serialize(tx, user, mockEnduserClubApplication())
         assertTrue(clubJSON.form is EnduserClubFormJSON)
     }
 
@@ -89,7 +89,7 @@ class ClubApplicationSerializerTest {
     fun `enduser serialized json matches expected`() {
         val user = AuthenticatedUser(requestingUserId, setOf(Roles.END_USER))
         val expectedApplication = mockEnduserClubApplication()
-        val applicationJson = serializer.serialize(handle, user, expectedApplication)
+        val applicationJson = serializer.serialize(tx, user, expectedApplication)
         assertTrue(ReflectionEquals(mockEnduserClubFormJson(expectedApplication)).matches(applicationJson.form))
     }
 

--- a/service/src/test/kotlin/fi/espoo/evaka/application/enduser/daycare/DaycareApplicationSerializerTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/application/enduser/daycare/DaycareApplicationSerializerTest.kt
@@ -28,7 +28,7 @@ import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
-import org.jdbi.v3.core.Handle
+import fi.espoo.evaka.shared.db.Database
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -52,7 +52,7 @@ class DaycareApplicationSerializerTest {
     lateinit var personService: PersonService
 
     @Mock
-    lateinit var handle: Handle
+    lateinit var tx: Database.Transaction
 
     @InjectMocks
     lateinit var serializer: ApplicationSerializer
@@ -80,7 +80,7 @@ class DaycareApplicationSerializerTest {
     @Test
     fun `enduser serialized daycare json matches expected`() {
         val user = AuthenticatedUser(requestingUserId, setOf(Roles.END_USER))
-        val json = serializer.serialize(handle, user, expectedEnduserDaycareApplication)
+        val json = serializer.serialize(tx, user, expectedEnduserDaycareApplication)
         assertTrue(json.form is EnduserDaycareFormJSON)
         assertEquals(expectedEnduserDaycareFormJSON, json.form)
     }


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

Make transaction boundaries explicit -> functions either require a transaction to be active (`tx: Database.Transaction` / `tx: Database.Read`), or require a transaction to *not* be active (`db: Database.Connection` / `db: Database`).

* add "subtransaction" API using savepoints for scenarios where we need to try/catch an operation inside a transaction
* use the new API in FamilIyInitializerService / PersonService where we have the most complicated code involving transactions