### PR TITLE
EVAKA-3977: Make backup care placements use the regular group placement form

### DIFF
--- a/frontend/e2e-test/test/e2e/specs/5_employee/backup-care.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/5_employee/backup-care.spec.ts
@@ -16,7 +16,7 @@ import UnitPage, {
   missingPlacementElement
 } from '../../pages/employee/units/unit-page'
 import { logConsoleMessages } from '../../utils/fixture'
-import BackupCareGroupModal from '../../pages/employee/units/backup-care-group-modal'
+import GroupPlacementModal from '../../pages/employee/units/group-placement-modal'
 import { ApplicationPersonDetail, BackupCare } from '../../dev-api/types'
 import {
   insertBackupCareFixtures,
@@ -28,7 +28,7 @@ import { formatISODateString } from '../../utils/dates'
 const adminHome = new AdminHome()
 const employeeHome = new EmployeeHome()
 const unitPage = new UnitPage()
-const backupCareGroupModal = new BackupCareGroupModal()
+const groupPlacementModal = new GroupPlacementModal()
 let fixtures: AreaAndPersonFixtures
 let cleanUp: () => Promise<void>
 let childFixture: ApplicationPersonDetail
@@ -88,8 +88,8 @@ test('backup care child can be placed into a group and removed from it', async (
     unitPage.missingPlacementRows.nth(0)
   )
   await missingPlacement.addToGroup()
-  await t.expect(backupCareGroupModal.root.visible).ok()
-  await backupCareGroupModal.submit()
+  await t.expect(groupPlacementModal.root.visible).ok()
+  await groupPlacementModal.submit()
 
   // no more missing placements
   await t.expect(unitPage.missingPlacementRows.count).eql(0)

--- a/frontend/packages/employee-frontend/src/components/unit/tab-groups/MissingGroupPlacements.tsx
+++ b/frontend/packages/employee-frontend/src/components/unit/tab-groups/MissingGroupPlacements.tsx
@@ -26,7 +26,6 @@ import CareTypeLabel, {
   careTypesFromPlacementType
 } from '~components/common/CareTypeLabel'
 import { UnitBackupCare } from '~types/child'
-import BackupCareGroupModal from './missing-group-placements/BackupCareGroupModal'
 import { formatName } from '~utils'
 import PlacementCircle from '~components/shared/atoms/PlacementCircle'
 import { MissingGroupPlacement } from '~api/unit'
@@ -104,7 +103,6 @@ export default React.memo(function MissingGroupPlacements({
   canManageChildren,
   groups,
   missingGroupPlacements,
-  backupCares,
   savePosition,
   reloadUnitData
 }: Props) {
@@ -130,10 +128,6 @@ export default React.memo(function MissingGroupPlacements({
     (p: MissingGroupPlacement) => p.placementPeriod.start,
     (p: MissingGroupPlacement) => p.gap.start
   ])
-
-  const activeBackupCare =
-    activeMissingPlacement &&
-    backupCares.find((bc) => bc.id === activeMissingPlacement.placementId)
 
   return (
     <>
@@ -169,20 +163,14 @@ export default React.memo(function MissingGroupPlacements({
           </Tbody>
         </Table>
       </div>
-      {uiMode == 'group-placement' && activeMissingPlacement && (
-        <GroupPlacementModal
-          groups={groups}
-          missingPlacement={activeMissingPlacement}
-          reload={reloadUnitData}
-        />
-      )}
-      {uiMode == 'backup-care-group' && activeBackupCare && (
-        <BackupCareGroupModal
-          backupCare={activeBackupCare}
-          groups={groups}
-          reload={reloadUnitData}
-        />
-      )}
+      {['group-placement', 'backup-care-group'].includes(uiMode) &&
+        activeMissingPlacement && (
+          <GroupPlacementModal
+            groups={groups}
+            missingPlacement={activeMissingPlacement}
+            reload={reloadUnitData}
+          />
+        )}
     </>
   )
 })


### PR DESCRIPTION
#### Summary

Filter missing group placements by time range. At the moment such filtering is done for missing group placements, but not for backup cares. This leads to an inconsistent UX due to [how](https://github.com/espoon-voltti/evaka/blob/a28f087bb88136e03ac392817cfb3223ea5c9e0c/frontend/packages/employee-frontend/src/components/unit/tab-groups/MissingGroupPlacements.tsx#L134-L136) missing group placements are mapped to backup cares in the frontend.