### PR TITLE
Use new database API - part 2

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
@@ -11,12 +11,12 @@ import fi.espoo.evaka.shared.config.defaultObjectMapper
 import fi.espoo.evaka.shared.config.getTestDataSource
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.varda.integration.VardaClient
 import fi.espoo.evaka.varda.integration.VardaTempTokenProvider
 import fi.espoo.evaka.varda.integration.VardaTokenProvider
 import fi.espoo.evaka.vtjclient.VtjIntegrationTestConfig
 import org.jdbi.v3.core.Jdbi
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
@@ -40,7 +40,6 @@ abstract class FullApplicationTest {
     protected val objectMapper: ObjectMapper = defaultObjectMapper()
 
     protected lateinit var jdbi: Jdbi
-    protected lateinit var db: Database
 
     protected lateinit var vardaTokenProvider: VardaTokenProvider
     protected lateinit var vardaClient: VardaClient
@@ -51,17 +50,26 @@ abstract class FullApplicationTest {
     protected lateinit var feeDecisionMinDate: LocalDate
     protected lateinit var vardaOrganizerName: String
 
+    protected lateinit var db: Database.Connection
+
+    protected fun dbInstance(): Database = Database(jdbi)
+
     @BeforeAll
     protected fun beforeAll() {
         assert(httpPort > 0)
         http.basePath = "http://localhost:$httpPort/"
         jdbi = configureJdbi(Jdbi.create(getTestDataSource()))
-        db = Database(jdbi)
-        jdbi.handle(::resetDatabase)
+        db = Database(jdbi).connect()
+        db.transaction { it.resetDatabase() }
         feeDecisionMinDate = LocalDate.parse(env.getRequiredProperty("fee_decision_min_date"))
         val vardaBaseUrl = "http://localhost:$httpPort/mock-integration/varda/api"
         vardaTokenProvider = VardaTempTokenProvider(env, objectMapper, vardaBaseUrl)
         vardaClient = VardaClient(vardaTokenProvider, env, objectMapper, vardaBaseUrl)
         vardaOrganizerName = env.getProperty("fi.espoo.varda.organizer", "Espoo")
+    }
+
+    @AfterAll
+    protected fun afterAll() {
+        db.close()
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/PureJdbiTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/PureJdbiTest.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka
 import fi.espoo.evaka.shared.config.getTestDataSource
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
-import fi.espoo.evaka.shared.db.handle
 import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
@@ -21,6 +20,6 @@ abstract class PureJdbiTest {
     protected fun initializeJdbi() {
         jdbi = configureJdbi(Jdbi.create(getTestDataSource()))
         db = Database(jdbi)
-        jdbi.handle(::resetDatabase)
+        db.transaction { it.resetDatabase() }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -1389,7 +1389,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // when
             service.respondToPlacementProposal(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 PlacementPlanConfirmationStatus.ACCEPTED
@@ -1445,13 +1445,13 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                     endDate = draft.endDate,
                     planned = false
                 )
-            }.let { updates -> decisionDraftService.updateDecisionDrafts(tx.handle, applicationId, updates) }
+            }.let { updates -> decisionDraftService.updateDecisionDrafts(tx, applicationId, updates) }
             service.sendPlacementProposal(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
             service.respondToPlacementProposal(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 PlacementPlanConfirmationStatus.ACCEPTED
@@ -1545,7 +1545,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // when / then
             service.respondToPlacementProposal(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 PlacementPlanConfirmationStatus.REJECTED,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -37,7 +37,6 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
@@ -96,73 +95,91 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     @BeforeEach
     private fun beforeEach() {
         MockEvakaMessageClient.clearMessages()
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
         }
     }
 
     @Test
-    fun `sendApplication - preschool has due date same as sent date`() = jdbi.handle { h ->
-        // given
-        insertDraftApplication(h, appliedType = PlacementType.PRESCHOOL)
+    fun `sendApplication - preschool has due date same as sent date`() {
+        db.transaction { tx ->
+            // given
+            insertDraftApplication(tx.handle, appliedType = PlacementType.PRESCHOOL)
+        }
 
-        // when
-        service.sendApplication(h, serviceWorker, applicationId)
+        db.transaction { tx ->
+            // when
+            service.sendApplication(tx, serviceWorker, applicationId)
+        }
 
-        // then
-        val application = fetchApplicationDetails(h, applicationId)!!
-        assertEquals(ApplicationStatus.SENT, application.status)
-        assertEquals(LocalDate.now(), application.sentDate)
-        assertEquals(LocalDate.now(), application.dueDate)
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(ApplicationStatus.SENT, application.status)
+            assertEquals(LocalDate.now(), application.sentDate)
+            assertEquals(LocalDate.now(), application.dueDate)
+        }
     }
 
     @Test
-    fun `sendApplication - daycare has due date after 4 months if not urgent`() = jdbi.handle { h ->
-        // given
-        insertDraftApplication(h, appliedType = PlacementType.DAYCARE, urgent = false)
-
-        // when
-        service.sendApplication(h, serviceWorker, applicationId)
-
-        // then
-        val application = fetchApplicationDetails(h, applicationId)!!
-        assertEquals(LocalDate.now().plusMonths(4), application.dueDate)
+    fun `sendApplication - daycare has due date after 4 months if not urgent`() {
+        db.transaction { tx ->
+            // given
+            insertDraftApplication(tx.handle, appliedType = PlacementType.DAYCARE, urgent = false)
+        }
+        db.transaction { tx ->
+            // when
+            service.sendApplication(tx, serviceWorker, applicationId)
+        }
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(LocalDate.now().plusMonths(4), application.dueDate)
+        }
     }
 
     @Test
-    fun `sendApplication - daycare has due date after 2 weeks if urgent`() = jdbi.handle { h ->
-        // given
-        insertDraftApplication(h, appliedType = PlacementType.DAYCARE, urgent = true)
-
-        // when
-        service.sendApplication(h, serviceWorker, applicationId)
-
-        // then
-        val application = fetchApplicationDetails(h, applicationId)!!
-        assertEquals(LocalDate.now().plusWeeks(2), application.dueDate)
+    fun `sendApplication - daycare has due date after 2 weeks if urgent`() {
+        db.transaction { tx ->
+            // given
+            insertDraftApplication(tx.handle, appliedType = PlacementType.DAYCARE, urgent = true)
+        }
+        db.transaction { tx ->
+            // when
+            service.sendApplication(tx, serviceWorker, applicationId)
+        }
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(LocalDate.now().plusWeeks(2), application.dueDate)
+        }
     }
 
     @Test
-    fun `sendApplication - daycare has not due date if a transfer application`() = jdbi.handle { h ->
-        // given
-        val draft = insertDraftApplication(h, appliedType = PlacementType.DAYCARE, urgent = false)
-        h.insertTestPlacement(
-            DevPlacement(
-                childId = draft.childId,
-                unitId = testDaycare2.id,
-                startDate = draft.form.preferences.preferredStartDate!!,
-                endDate = draft.form.preferences.preferredStartDate!!.plusYears(1)
+    fun `sendApplication - daycare has not due date if a transfer application`() {
+        db.transaction { tx ->
+            // given
+            val draft = insertDraftApplication(tx.handle, appliedType = PlacementType.DAYCARE, urgent = false)
+            tx.handle.insertTestPlacement(
+                DevPlacement(
+                    childId = draft.childId,
+                    unitId = testDaycare2.id,
+                    startDate = draft.form.preferences.preferredStartDate!!,
+                    endDate = draft.form.preferences.preferredStartDate!!.plusYears(1)
+                )
             )
-        )
-
-        // when
-        service.sendApplication(h, serviceWorker, applicationId)
-
-        // then
-        val application = fetchApplicationDetails(h, applicationId)!!
-        assertEquals(true, application.transferApplication)
-        assertEquals(null, application.dueDate)
+        }
+        db.transaction { tx ->
+            // when
+            service.sendApplication(tx, serviceWorker, applicationId)
+        }
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(true, application.transferApplication)
+            assertEquals(null, application.dueDate)
+        }
     }
 
     @Test
@@ -170,7 +187,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, hasAdditionalInfo = false)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -189,7 +206,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, hasAdditionalInfo = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -207,7 +224,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -240,7 +257,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, earlierIndefinite, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -274,7 +291,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, earlierIncome, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -307,7 +324,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, laterIndefiniteIncome, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -340,7 +357,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, earlierIncome, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -374,7 +391,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, laterIncome, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -407,7 +424,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, earlierIndefinite, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true, preferredStartDate = null)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -440,7 +457,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, sameDayIncomeIndefinite, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -473,7 +490,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, sameDayIncome, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -506,7 +523,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, dayBeforeIncomeIndefinite, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -540,7 +557,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, nextDayIncomeIndefinite, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -573,7 +590,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, IncomeDayBefore, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -606,7 +623,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, earlierIncomeEndingOnSameDay, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -639,7 +656,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, earlierIncomeEndingOnNextDay, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -672,7 +689,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
             upsertIncome(tx.handle, mapper, earlierIncomeEndingOnDayBefore, financeUser.id)
             insertDraftApplication(tx.handle, guardian = testAdult_5, maxFeeAccepted = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -695,7 +712,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, appliedType = PlacementType.DAYCARE)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -714,7 +731,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, appliedType = PlacementType.DAYCARE, hasAdditionalInfo = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -733,7 +750,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, hasAdditionalInfo = true)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
@@ -763,7 +780,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -781,7 +798,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
@@ -800,7 +817,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
@@ -819,7 +836,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, appliedType = PlacementType.DAYCARE)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
@@ -873,7 +890,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, appliedType = PlacementType.DAYCARE_PART_TIME)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
@@ -927,7 +944,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, appliedType = PlacementType.PRESCHOOL)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
@@ -997,7 +1014,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, appliedType = PlacementType.PRESCHOOL_DAYCARE)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
@@ -1068,7 +1085,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, appliedType = PlacementType.PRESCHOOL_DAYCARE)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
             service.createPlacementPlan(
                 tx,
@@ -1104,7 +1121,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, appliedType = PlacementType.PRESCHOOL_DAYCARE, child = child)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
             service.createPlacementPlan(
                 tx,
@@ -1230,7 +1247,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         // given
         db.transaction { tx ->
             insertDraftApplication(tx.handle, appliedType = PlacementType.PRESCHOOL, guardian = applier, child = child)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
             service.createPlacementPlan(
                 tx,
@@ -1288,7 +1305,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, appliedType = PlacementType.PRESCHOOL_DAYCARE)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
             service.createPlacementPlan(
                 tx,
@@ -1318,7 +1335,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // given
             insertDraftApplication(tx.handle, appliedType = PlacementType.PRESCHOOL_DAYCARE)
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
             service.createPlacementPlan(
                 tx,
@@ -1355,7 +1372,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 child = testChild_2,
                 guardian = testAdult_1
             )
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
             service.createPlacementPlan(
                 tx,
@@ -1408,7 +1425,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 child = testChild_2,
                 guardian = testAdult_1
             )
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
             service.createPlacementPlan(
                 tx,
@@ -1483,7 +1500,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 child = testChild_2,
                 guardian = testAdult_1
             )
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
             service.createPlacementPlan(
                 tx,
@@ -1512,7 +1529,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 child = testChild_2,
                 guardian = testAdult_1
             )
-            service.sendApplication(tx.handle, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
             service.createPlacementPlan(
                 tx,
@@ -1547,7 +1564,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // when
             service.rejectDecision(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL).id
@@ -1582,14 +1599,14 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // when
             service.acceptDecision(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
             service.rejectDecision(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE).id
@@ -1630,7 +1647,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // when
             val user = AuthenticatedUser(testAdult_5.id, setOf(UserRole.END_USER))
             service.acceptDecision(
-                tx.handle,
+                tx,
                 user,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL).id,
@@ -1638,7 +1655,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 isEnduser = true
             )
             service.rejectDecision(
-                tx.handle,
+                tx,
                 user,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE).id,
@@ -1662,7 +1679,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // when
             assertThrows<Forbidden> {
                 service.acceptDecision(
-                    tx.handle,
+                    tx,
                     user,
                     applicationId,
                     getDecision(tx.handle, DecisionType.PRESCHOOL).id,
@@ -1684,7 +1701,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val user = AuthenticatedUser(testAdult_1.id, setOf(UserRole.END_USER))
             assertThrows<Forbidden> {
                 service.rejectDecision(
-                    tx.handle,
+                    tx,
                     user,
                     applicationId,
                     getDecision(tx.handle, DecisionType.PRESCHOOL).id,
@@ -1703,14 +1720,14 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             // when
             service.acceptDecision(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
             service.acceptDecision(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE).id,
@@ -1755,7 +1772,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // when / then
             assertThrows<BadRequest> {
                 service.acceptDecision(
-                    tx.handle,
+                    tx,
                     serviceWorker,
                     applicationId,
                     getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE).id,
@@ -1771,7 +1788,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             workflowForPreschoolDaycareDecisions(tx)
             service.acceptDecision(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL).id,
@@ -1782,7 +1799,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // when / then
             assertThrows<BadRequest> {
                 service.acceptDecision(
-                    tx.handle,
+                    tx,
                     serviceWorker,
                     applicationId,
                     getDecision(tx.handle, DecisionType.PRESCHOOL).id,
@@ -1798,7 +1815,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             workflowForPreschoolDaycareDecisions(tx)
             service.rejectDecision(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL).id
@@ -1808,7 +1825,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // when / then
             assertThrows<BadRequest> {
                 service.acceptDecision(
-                    tx.handle,
+                    tx,
                     serviceWorker,
                     applicationId,
                     getDecision(tx.handle, DecisionType.PRESCHOOL).id,
@@ -1824,7 +1841,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             workflowForPreschoolDaycareDecisions(tx)
             service.acceptDecision(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL).id,
@@ -1835,7 +1852,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // when / then
             assertThrows<BadRequest> {
                 service.rejectDecision(
-                    tx.handle,
+                    tx,
                     serviceWorker,
                     applicationId,
                     getDecision(tx.handle, DecisionType.PRESCHOOL).id
@@ -1850,7 +1867,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             workflowForPreschoolDaycareDecisions(tx)
             service.rejectDecision(
-                tx.handle,
+                tx,
                 serviceWorker,
                 applicationId,
                 getDecision(tx.handle, DecisionType.PRESCHOOL).id
@@ -1860,7 +1877,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // when / then
             assertThrows<BadRequest> {
                 service.rejectDecision(
-                    tx.handle,
+                    tx,
                     serviceWorker,
                     applicationId,
                     getDecision(tx.handle, DecisionType.PRESCHOOL).id
@@ -1874,7 +1891,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     private fun workflowForPreschoolDaycareDecisions(tx: Database.Transaction) {
         insertDraftApplication(tx.handle, appliedType = PlacementType.PRESCHOOL_DAYCARE)
-        service.sendApplication(tx.handle, serviceWorker, applicationId)
+        service.sendApplication(tx, serviceWorker, applicationId)
         service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
         service.createPlacementPlan(
             tx,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/AbstractIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/AbstractIntegrationTest.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.daycare
 import fi.espoo.evaka.placement.PlacementService
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.config.SharedIntegrationTestConfig
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.utils.DisableSecurity
 import org.jdbi.v3.core.Jdbi
@@ -49,6 +50,8 @@ abstract class AbstractIntegrationTest() {
     @Autowired
     lateinit var jdbi: Jdbi
 
+    lateinit var db: Database
+
     @BeforeAll
     private fun beforeAll() {
         jdbi.handle(::resetDatabase)
@@ -61,5 +64,6 @@ abstract class AbstractIntegrationTest() {
             resetDatabase(h)
             h.execute(legacyDataSql)
         }
+        db = Database(jdbi)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
@@ -73,7 +73,7 @@ class ChildrenControllerIntegrationTest : AbstractIntegrationTest() {
     }
 
     fun getAdditionalInfo(user: AuthenticatedUser) {
-        val response = childController.getAdditionalInfo(user, childId)
+        val response = childController.getAdditionalInfo(db, user, childId)
         val body = response.body!!
 
         assertEquals(HttpStatus.OK, response.statusCode)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
@@ -27,10 +27,11 @@ class DaycareControllerIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `smoke test for groups`() {
         val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
-        val existingGroups = daycareController.getGroups(user, daycareId).body!!
+        val existingGroups = daycareController.getGroups(db, user, daycareId).body!!
         assertEquals(2, existingGroups.size)
 
         val created = daycareController.createGroup(
+            db,
             user,
             daycareId,
             DaycareController.CreateGroupRequest(
@@ -40,7 +41,7 @@ class DaycareControllerIntegrationTest : AbstractIntegrationTest() {
             )
         ).body!!
 
-        val groups = daycareController.getGroups(user, daycareId).body!!
+        val groups = daycareController.getGroups(db, user, daycareId).body!!
         assertEquals(3, groups.size)
 
         val group = groups.find { it.id == created.id }!!
@@ -49,14 +50,14 @@ class DaycareControllerIntegrationTest : AbstractIntegrationTest() {
         assertEquals(groupFounded, group.startDate)
         assertNull(group.endDate)
 
-        val stats = daycareController.getStats(user, daycareId, LocalDate.now(), LocalDate.now().plusDays(50)).body!!
+        val stats = daycareController.getStats(db, user, daycareId, LocalDate.now(), LocalDate.now().plusDays(50)).body!!
         val groupStats = stats.groupCaretakers[group.id]!!
         assertEquals(initialCaretakers, groupStats.minimum)
         assertEquals(initialCaretakers, groupStats.maximum)
 
-        val deleteStatus = daycareController.deleteGroup(user, daycareId, group.id).statusCode
+        val deleteStatus = daycareController.deleteGroup(db, user, daycareId, group.id).statusCode
         assertEquals(HttpStatus.NO_CONTENT, deleteStatus)
-        val groupsAfterDelete = daycareController.getGroups(user, daycareId).body!!
+        val groupsAfterDelete = daycareController.getGroups(db, user, daycareId).body!!
         assertEquals(2, groupsAfterDelete.size)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/LocationControllerIT.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/LocationControllerIT.kt
@@ -29,7 +29,7 @@ class LocationControllerIT : FullApplicationTest() {
 
     @Test
     fun `enduser only sees locations that can be applied to`() {
-        val response = controller.getEnduserUnitsByArea(dbInstance())
+        val response = controller.getEnduserUnitsByArea(db)
 
         with(response.body!!) {
             assertTrue(
@@ -44,7 +44,7 @@ class LocationControllerIT : FullApplicationTest() {
 
     @Test
     fun `clubs are included in results although they do not offer daycare nor preschool`() {
-        val response = controller.getEnduserUnitsByArea(dbInstance())
+        val response = controller.getEnduserUnitsByArea(db)
 
         with(response.body!!) {
             assertTrue(this.any { it.daycares.any { it.type.contains(CareType.CLUB) } })

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/LocationControllerIT.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/LocationControllerIT.kt
@@ -29,7 +29,7 @@ class LocationControllerIT : FullApplicationTest() {
 
     @Test
     fun `enduser only sees locations that can be applied to`() {
-        val response = controller.getEnduserUnitsByArea(db)
+        val response = controller.getEnduserUnitsByArea(dbInstance())
 
         with(response.body!!) {
             assertTrue(
@@ -44,7 +44,7 @@ class LocationControllerIT : FullApplicationTest() {
 
     @Test
     fun `clubs are included in results although they do not offer daycare nor preschool`() {
-        val response = controller.getEnduserUnitsByArea(db)
+        val response = controller.getEnduserUnitsByArea(dbInstance())
 
         with(response.body!!) {
             assertTrue(this.any { it.daycares.any { it.type.contains(CareType.CLUB) } })

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/LocationControllerIT.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/LocationControllerIT.kt
@@ -29,7 +29,7 @@ class LocationControllerIT : FullApplicationTest() {
 
     @Test
     fun `enduser only sees locations that can be applied to`() {
-        val response = controller.getEnduserUnitsByArea()
+        val response = controller.getEnduserUnitsByArea(db)
 
         with(response.body!!) {
             assertTrue(
@@ -44,7 +44,7 @@ class LocationControllerIT : FullApplicationTest() {
 
     @Test
     fun `clubs are included in results although they do not offer daycare nor preschool`() {
-        val response = controller.getEnduserUnitsByArea()
+        val response = controller.getEnduserUnitsByArea(db)
 
         with(response.body!!) {
             assertTrue(this.any { it.daycares.any { it.type.contains(CareType.CLUB) } })

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
@@ -27,7 +27,6 @@ import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.ClosedPeriod
-import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -38,9 +37,6 @@ import java.time.LocalDate
 import java.util.UUID
 
 class AbsenceServiceIntegrationTest : AbstractIntegrationTest() {
-    @Autowired
-    lateinit var db: Jdbi
-
     @Autowired
     lateinit var absenceService: AbsenceService
 
@@ -57,7 +53,7 @@ class AbsenceServiceIntegrationTest : AbstractIntegrationTest() {
     @BeforeEach
     private fun beforeEach() {
         insertDaycareGroup()
-        db.handle {
+        jdbi.handle {
             it.insertTestPerson(DevPerson(id = testUserId))
             it.insertTestEmployee(DevEmployee(id = testUserId))
         }
@@ -254,7 +250,7 @@ class AbsenceServiceIntegrationTest : AbstractIntegrationTest() {
         val result = absenceService.getAbsencesByMonth(groupId, absenceDate.year, absenceDate.monthValue)
         val absence = result.children[0].absences.getValue(absenceDate)[0]
         var modifiedBy = ""
-        db.handle { h ->
+        jdbi.handle { h ->
             modifiedBy = getUserNameById(testUserId, h)
         }
 
@@ -411,7 +407,7 @@ class AbsenceServiceIntegrationTest : AbstractIntegrationTest() {
             it.insertTestPerson(DevPerson(id = childId, dateOfBirth = LocalDate.of(2013, 1, 1)))
             it.insertTestChild(DevChild(childId))
         }
-        db.handle { h ->
+        jdbi.handle { h ->
             insertTestPlacement(
                 h,
                 childId = childId,
@@ -529,6 +525,6 @@ class AbsenceServiceIntegrationTest : AbstractIntegrationTest() {
     }
 
     private fun cleanTestData() {
-        db.handle(::resetDatabase)
+        jdbi.handle(::resetDatabase)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
@@ -54,14 +54,14 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     @Test
     fun `person date of death`() {
         createTestPerson(testPerson.copy(ssn = "010180-999A"))
-        dvvModificationsService.updatePersonsFromDvv(db, listOf("010180-999A"))
+        dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("010180-999A"))
         assertEquals(LocalDate.parse("2019-07-30"), db.read { it.handle.getPersonBySSN("010180-999A") }?.dateOfDeath)
     }
 
     @Test
     fun `person restricted details started`() {
         createTestPerson(testPerson.copy(ssn = "020180-999Y"))
-        dvvModificationsService.updatePersonsFromDvv(db, listOf("020180-999Y"))
+        dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("020180-999Y"))
         val modifiedPerson = db.read { it.handle.getPersonBySSN("020180-999Y") }!!
         assertEquals(true, modifiedPerson.restrictedDetailsEnabled)
         assertEquals("", modifiedPerson.streetAddress)
@@ -72,7 +72,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     @Test
     fun `person restricted details ended and address is set`() {
         createTestPerson(testPerson.copy(ssn = "030180-999L", restrictedDetailsEnabled = true, streetAddress = "", postalCode = "", postOffice = ""))
-        dvvModificationsService.updatePersonsFromDvv(db, listOf("030180-999L"))
+        dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("030180-999L"))
         val modifiedPerson = db.read { it.handle.getPersonBySSN("030180-999L") }!!
         assertEquals(false, modifiedPerson.restrictedDetailsEnabled)
         assertEquals(LocalDate.parse("2030-01-01"), modifiedPerson.restrictedDetailsEndDate)
@@ -84,7 +84,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     @Test
     fun `person address change`() {
         createTestPerson(testPerson.copy(ssn = "040180-9998"))
-        dvvModificationsService.updatePersonsFromDvv(db, listOf("040180-9998"))
+        dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("040180-9998"))
         val modifiedPerson = db.read { it.handle.getPersonBySSN("040180-9998") }!!
         assertEquals("Uusitie 17 A 2", modifiedPerson.streetAddress)
         assertEquals("02940", modifiedPerson.postalCode)
@@ -95,7 +95,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     @Test
     fun `person ssn change`() {
         val testId = createTestPerson(testPerson.copy(ssn = "010181-999K"))
-        dvvModificationsService.updatePersonsFromDvv(db, listOf("010181-999K"))
+        dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("010181-999K"))
         assertEquals(testId, db.read { it.handle.getPersonBySSN("010281-999C") }?.id)
     }
 
@@ -109,7 +109,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createVtjPerson(custodian)
         createVtjPerson(caretaker)
 
-        dvvModificationsService.updatePersonsFromDvv(db, listOf("050118A999W"))
+        dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("050118A999W"))
         val dvvCustodian = db.read { it.handle.getPersonBySSN("050118A999W") }!!
         assertEquals("Harri", dvvCustodian.firstName)
         assertEquals("Huollettava", dvvCustodian.lastName)
@@ -125,7 +125,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createVtjPerson(custodian)
         createVtjPerson(caretaker)
 
-        dvvModificationsService.updatePersonsFromDvv(db, listOf("060118A999J"))
+        dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("060118A999J"))
         val dvvCaretaker = db.read { it.handle.getPersonBySSN("060180-999J") }!!
         assertEquals("Harri", dvvCaretaker.firstName)
         assertEquals("Huoltaja", dvvCaretaker.lastName)
@@ -140,7 +140,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createTestPerson(personWithOldName)
         createVtjPerson(personWithNewName)
 
-        dvvModificationsService.updatePersonsFromDvv(db, listOf(SSN))
+        dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf(SSN))
         val updatedPerson = db.read { it.handle.getPersonBySSN(SSN) }!!
         assertEquals("Urkki", updatedPerson.firstName)
         assertEquals("Uusinimi", updatedPerson.lastName)
@@ -158,7 +158,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         }
         try {
             createTestPerson(testPerson.copy(ssn = "010180-999A"))
-            assertEquals(3, dvvModificationsService.updatePersonsFromDvv(db, listOf("010180-999A")))
+            assertEquals(3, dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("010180-999A")))
             db.read {
                 assertEquals("1", getNextDvvModificationToken(it.handle))
                 assertEquals(LocalDate.parse("2019-07-30"), it.handle.getPersonBySSN("010180-999A")?.dateOfDeath)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -1888,18 +1888,20 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                     endDate = period.end!!
                 )
             }
-
-            absenceService.upsertAbsences(
-                absenceDays.map { (date, type) ->
-                    Absence(
-                        absenceType = type,
-                        childId = child.id,
-                        date = date,
-                        careType = CareType.DAYCARE
-                    )
-                },
-                groupId, testDecisionMaker_1.id
-            )
+            db.transaction { tx ->
+                absenceService.upsertAbsences(
+                    tx,
+                    absenceDays.map { (date, type) ->
+                        Absence(
+                            absenceType = type,
+                            childId = child.id,
+                            date = date,
+                            careType = CareType.DAYCARE
+                        )
+                    },
+                    groupId, testDecisionMaker_1.id
+                )
+            }
         }
 
     private fun insertDecisionsAndPlacements(h: Handle, feeDecisions: List<FeeDecision>) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/AbstractIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/AbstractIntegrationTest.kt
@@ -7,10 +7,11 @@ package fi.espoo.evaka.pis
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.config.SharedIntegrationTestConfig
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.utils.DisableSecurity
 import fi.espoo.evaka.vtjclient.VtjIntegrationTestConfig
 import org.jdbi.v3.core.Jdbi
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
@@ -40,11 +41,20 @@ abstract class AbstractIntegrationTest {
     @Autowired
     lateinit var jdbi: Jdbi
 
-    lateinit var db: Database
+    lateinit var db: Database.Connection
+
+    @BeforeAll
+    protected fun beforeAll() {
+        db = Database(jdbi).connect()
+    }
+
+    @AfterAll
+    protected fun afterAll() {
+        db.close()
+    }
 
     @BeforeEach
-    private fun beforeEach() {
-        jdbi.handle { h -> resetDatabase(h) }
-        db = Database(jdbi)
+    protected fun beforeEach() {
+        db.transaction { it.resetDatabase() }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/AbstractIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/AbstractIntegrationTest.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.pis
 
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.config.SharedIntegrationTestConfig
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.utils.DisableSecurity
 import fi.espoo.evaka.vtjclient.VtjIntegrationTestConfig
@@ -39,8 +40,11 @@ abstract class AbstractIntegrationTest {
     @Autowired
     lateinit var jdbi: Jdbi
 
+    lateinit var db: Database
+
     @BeforeEach
     private fun beforeEach() {
         jdbi.handle { h -> resetDatabase(h) }
+        db = Database(jdbi)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
@@ -25,7 +25,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `no employees return empty list`() {
         val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
-        val response = employeeController.getEmployees(user)
+        val response = employeeController.getEmployees(db, user)
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(emptyList<Employee>(), response.body)
     }
@@ -33,7 +33,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `admin can add employee`() {
         val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
-        val response = employeeController.createEmployee(user, requestFromEmployee(employee1))
+        val response = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(employee1.firstName, response.body!!.firstName)
         assertEquals(employee1.lastName, response.body!!.lastName)
@@ -44,9 +44,9 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `admin gets all employees`() {
         val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
-        assertEquals(HttpStatus.OK, employeeController.createEmployee(user, requestFromEmployee(employee1)).statusCode)
-        assertEquals(HttpStatus.OK, employeeController.createEmployee(user, requestFromEmployee(employee2)).statusCode)
-        val response = employeeController.getEmployees(user)
+        assertEquals(HttpStatus.OK, employeeController.createEmployee(db, user, requestFromEmployee(employee1)).statusCode)
+        assertEquals(HttpStatus.OK, employeeController.createEmployee(db, user, requestFromEmployee(employee2)).statusCode)
+        val response = employeeController.getEmployees(db, user)
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(2, response.body?.size)
         assertEquals(employee1.email, response.body?.get(0)?.email)
@@ -56,26 +56,26 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `admin can first create, then get employee`() {
         val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
-        assertEquals(0, employeeController.getEmployees(user).body?.size)
+        assertEquals(0, employeeController.getEmployees(db, user).body?.size)
 
-        val responseCreate = employeeController.getOrCreateEmployee(requestFromEmployee(employee1))
+        val responseCreate = employeeController.getOrCreateEmployee(db, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, responseCreate.statusCode)
-        assertEquals(1, employeeController.getEmployees(user).body?.size)
+        assertEquals(1, employeeController.getEmployees(db, user).body?.size)
 
-        val responseGet = employeeController.getOrCreateEmployee(requestFromEmployee(employee1))
+        val responseGet = employeeController.getOrCreateEmployee(db, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, responseGet.statusCode)
-        assertEquals(1, employeeController.getEmployees(user).body?.size)
+        assertEquals(1, employeeController.getEmployees(db, user).body?.size)
         assertEquals(responseCreate.body?.id, responseGet.body?.id)
     }
 
     @Test
     fun `admin can delete employee`() {
         val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
-        val createdEmployeeResponse = employeeController.createEmployee(user, requestFromEmployee(employee1))
+        val createdEmployeeResponse = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, createdEmployeeResponse.statusCode)
-        val response = employeeController.deleteEmployee(user, createdEmployeeResponse.body?.id!!)
+        val response = employeeController.deleteEmployee(db, user, createdEmployeeResponse.body?.id!!)
         assertEquals(HttpStatus.OK, response.statusCode)
-        assertEquals(0, employeeController.getEmployees(user).body?.size)
+        assertEquals(0, employeeController.getEmployees(db, user).body?.size)
     }
 
     fun requestFromEmployee(employee: Employee) = NewEmployee(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
@@ -52,7 +52,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val startDate = LocalDate.now()
         val endDate = startDate.plusDays(200)
         val reqBody = ParentshipController.ParentshipRequest(parent.id, child.id, startDate, endDate)
-        val createResponse = controller.createParentship(user, reqBody)
+        val createResponse = controller.createParentship(db, user, reqBody)
         assertEquals(HttpStatus.CREATED, createResponse.statusCode)
         with(createResponse.body!!) {
             assertNotNull(this.id)
@@ -62,7 +62,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
             assertEquals(endDate, this.endDate)
         }
 
-        val getResponse = controller.getParentships(user, headOfChildId = parent.id)
+        val getResponse = controller.getParentships(db, user, headOfChildId = parent.id)
         assertEquals(HttpStatus.OK, getResponse.statusCode)
         assertEquals(1, getResponse.body?.size ?: 0)
         with(getResponse.body!!.first()) {
@@ -73,7 +73,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
             assertEquals(endDate, this.endDate)
         }
 
-        assertEquals(0, controller.getParentships(user, headOfChildId = child.id).body!!.size)
+        assertEquals(0, controller.getParentships(db, user, headOfChildId = child.id).body!!.size)
     }
 
     @Test
@@ -101,7 +101,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val newStartDate = LocalDate.now().plusDays(100)
         val newEndDate = LocalDate.now().plusDays(300)
         val requestBody = ParentshipController.ParentshipUpdateRequest(newStartDate, newEndDate)
-        val updateResponse = controller.updateParentship(user, parentship.id, requestBody)
+        val updateResponse = controller.updateParentship(db, user, parentship.id, requestBody)
         assertEquals(HttpStatus.OK, updateResponse.statusCode)
         with(updateResponse.body!!) {
             assertEquals(parentship.id, this.id)
@@ -110,7 +110,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         }
 
         // child1 should have new dates
-        val fetched1 = controller.getParentship(user, parentship.id).body!!
+        val fetched1 = controller.getParentship(db, user, parentship.id).body!!
         assertEquals(newStartDate, fetched1.startDate)
         assertEquals(newEndDate, fetched1.endDate)
     }
@@ -138,7 +138,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
             h.createParentship(child.id, adult.id, LocalDate.now().plusDays(200), LocalDate.now().plusDays(300))
             assertEquals(2, h.getParentships(headOfChildId = adult.id, childId = null).size)
 
-            val delResponse = controller.deleteParentship(user, parentship.id)
+            val delResponse = controller.deleteParentship(db, user, parentship.id)
             assertEquals(HttpStatus.NO_CONTENT, delResponse.statusCode)
             assertEquals(1, h.getParentships(headOfChildId = adult.id, childId = null).size)
         }
@@ -152,7 +152,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         jdbi.handle { h ->
             h.createParentship(child.id, parent.id, LocalDate.now(), LocalDate.now().plusDays(200))
         }
-        assertThrows<Forbidden> { controller.getParentships(user, headOfChildId = parent.id) }
+        assertThrows<Forbidden> { controller.getParentships(db, user, headOfChildId = parent.id) }
     }
 
     @Test
@@ -165,7 +165,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
             val newStartDate = LocalDate.now().plusDays(100)
             val newEndDate = LocalDate.now().plusDays(300)
             val requestBody = ParentshipController.ParentshipUpdateRequest(newStartDate, newEndDate)
-            assertThrows<Forbidden> { controller.updateParentship(user, parentship.id, requestBody) }
+            assertThrows<Forbidden> { controller.updateParentship(db, user, parentship.id, requestBody) }
         }
     }
 
@@ -176,7 +176,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val child = testPerson2()
         jdbi.handle { h ->
             val parentship = h.createParentship(child.id, parent.id, LocalDate.now(), LocalDate.now().plusDays(200))
-            assertThrows<Forbidden> { controller.deleteParentship(user, parentship.id) }
+            assertThrows<Forbidden> { controller.deleteParentship(db, user, parentship.id) }
         }
     }
 
@@ -189,7 +189,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val startDate = LocalDate.now()
         val endDate = null
         val reqBody = ParentshipController.ParentshipRequest(parent.id, child.id, startDate, endDate)
-        val createResponse = controller.createParentship(user, reqBody)
+        val createResponse = controller.createParentship(db, user, reqBody)
         assertEquals(HttpStatus.CREATED, createResponse.statusCode)
         with(createResponse.body!!) {
             assertNotNull(this.id)
@@ -211,7 +211,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
             val newStartDate = LocalDate.now().plusDays(100)
             val newEndDate = null
             val requestBody = ParentshipController.ParentshipUpdateRequest(newStartDate, newEndDate)
-            val updateResponse = controller.updateParentship(user, parentship.id, requestBody)
+            val updateResponse = controller.updateParentship(db, user, parentship.id, requestBody)
             assertEquals(HttpStatus.OK, updateResponse.statusCode)
             with(updateResponse.body!!) {
                 assertEquals(parentship.id, this.id)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
@@ -53,7 +53,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val startDate = LocalDate.now()
         val endDate = startDate.plusDays(200)
         val reqBody = PartnershipsController.PartnershipRequest(setOf(adult1.id, adult2.id), startDate, endDate)
-        val createResponse = controller.createPartnership(user, reqBody)
+        val createResponse = controller.createPartnership(db, user, reqBody)
         assertEquals(HttpStatus.CREATED, createResponse.statusCode)
         with(createResponse.body!!) {
             assertNotNull(this.id)
@@ -62,7 +62,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
             assertEquals(setOf(adult1, adult2), this.partners)
         }
 
-        val getResponse = controller.getPartnerships(user, adult1.id)
+        val getResponse = controller.getPartnerships(db, user, adult1.id)
         assertEquals(HttpStatus.OK, getResponse.statusCode)
         assertEquals(1, getResponse.body?.size ?: 0)
         with(getResponse.body!!.first()) {
@@ -95,7 +95,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         h.createPartnership(adult1.id, adult2.id, LocalDate.now().plusDays(200), LocalDate.now().plusDays(300))
         assertEquals(2, h.getPartnershipsForPerson(adult1.id).size)
 
-        val delResponse = controller.deletePartnership(user, partnership1.id)
+        val delResponse = controller.deletePartnership(db, user, partnership1.id)
         assertEquals(HttpStatus.NO_CONTENT, delResponse.statusCode)
         assertEquals(1, h.getPartnershipsForPerson(adult1.id).size)
     }
@@ -124,7 +124,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val newStartDate = LocalDate.now().plusDays(100)
         val newEndDate = LocalDate.now().plusDays(300)
         val requestBody = PartnershipsController.PartnershipUpdateRequest(newStartDate, newEndDate)
-        val updateResponse = controller.updatePartnership(user, partnership1.id, requestBody)
+        val updateResponse = controller.updatePartnership(db, user, partnership1.id, requestBody)
         assertEquals(HttpStatus.OK, updateResponse.statusCode)
         with(updateResponse.body!!) {
             assertEquals(partnership1.id, this.id)
@@ -134,7 +134,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         }
 
         // partnership1 should have new dates
-        val fetched1 = controller.getPartnership(user, partnership1.id).body!!
+        val fetched1 = controller.getPartnership(db, user, partnership1.id).body!!
         assertEquals(newStartDate, fetched1.startDate)
         assertEquals(newEndDate, fetched1.endDate)
     }
@@ -151,7 +151,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val newEndDate = LocalDate.now().plusDays(600)
         val requestBody = PartnershipsController.PartnershipUpdateRequest(newStartDate, newEndDate)
         assertThrows<Conflict> {
-            controller.updatePartnership(user, partnership1.id, requestBody)
+            controller.updatePartnership(db, user, partnership1.id, requestBody)
         }
     }
 
@@ -163,7 +163,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         h.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
 
         assertThrows<Forbidden> {
-            controller.getPartnerships(user, adult1.id)
+            controller.getPartnerships(db, user, adult1.id)
         }
     }
 
@@ -177,7 +177,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val reqBody = PartnershipsController.PartnershipRequest(setOf(adult1.id, adult2.id), startDate, endDate)
 
         assertThrows<Forbidden> {
-            controller.createPartnership(user, reqBody)
+            controller.createPartnership(db, user, reqBody)
         }
     }
 
@@ -190,7 +190,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
         val requestBody = PartnershipsController.PartnershipUpdateRequest(LocalDate.now(), LocalDate.now().plusDays(999))
         assertThrows<Forbidden> {
-            controller.updatePartnership(user, partnership.id, requestBody)
+            controller.updatePartnership(db, user, partnership.id, requestBody)
         }
     }
 
@@ -200,7 +200,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val partnership = h.createPartnership(testPerson1().id, testPerson2().id, LocalDate.now(), LocalDate.now().plusDays(200))
 
         assertThrows<Forbidden> {
-            controller.deletePartnership(user, partnership.id)
+            controller.deletePartnership(db, user, partnership.id)
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -57,7 +57,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
     fun `End user cannot end update end user's contact info`() {
         val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.END_USER))
         assertThrows<Forbidden> {
-            controller.updateContactInfo(user, UUID.randomUUID(), contactInfo)
+            controller.updateContactInfo(db, user, UUID.randomUUID(), contactInfo)
         }
     }
 
@@ -67,6 +67,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
+            db,
             user,
             searchTerm = "${person.firstName} ${person.lastName}",
             orderBy = "first_name",
@@ -86,6 +87,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
+            db,
             user,
             searchTerm = "${person.firstName}\t${person.lastName}",
             orderBy = "first_name",
@@ -105,6 +107,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
+            db,
             user,
             searchTerm = "${person.firstName}\u00A0${person.lastName}",
             orderBy = "first_name",
@@ -126,6 +129,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         // IDEOGRAPHIC SPACE, not supported by default in regexes
         // unless Java's Pattern.UNICODE_CHARACTER_CLASS-like functionality is enabled.
         val response = controller.findBySearchTerms(
+            db,
             user,
             searchTerm = "${person.firstName}\u3000${person.lastName}",
             orderBy = "first_name",
@@ -141,7 +145,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     private fun updateContactInfo(user: AuthenticatedUser) {
         val person = createPerson()
-        val actual = controller.updateContactInfo(user, person.id, contactInfo)
+        val actual = controller.updateContactInfo(db, user, person.id, contactInfo)
 
         assertEquals(HttpStatus.OK, actual.statusCode)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -55,8 +55,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         }
         service = VTJBatchRefreshService(
             fridgeFamilyService = fridgeFamilyService,
-            asyncJobRunner = asyncJobRunner,
-            jdbi = jdbi
+            asyncJobRunner = asyncJobRunner
         )
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -90,7 +90,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         )
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_1.id))).thenReturn(dto)
 
-        service.doVTJRefresh(db, VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(dbInstance(), VTJRefresh(testAdult_1.id, user.id))
         verify(parentshipService).createParentship(
             any(),
             eq(testChild_1.id),
@@ -115,7 +115,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
             )
         )
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_1.id))).thenReturn(dto)
-        service.doVTJRefresh(db, VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(dbInstance(), VTJRefresh(testAdult_1.id, user.id))
         verifyZeroInteractions(parentshipService)
     }
 
@@ -151,7 +151,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_1.id))).thenReturn(dto1)
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_2.id))).thenReturn(dto2)
 
-        service.doVTJRefresh(db, VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(dbInstance(), VTJRefresh(testAdult_1.id, user.id))
         verify(parentshipService).createParentship(
             any(),
             eq(testChild_1.id),
@@ -195,7 +195,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_1.id))).thenReturn(dto1)
         whenever(personService.getUpToDatePersonWithChildren(any(), eq(user), eq(testAdult_2.id))).thenReturn(dto2)
 
-        service.doVTJRefresh(db, VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(dbInstance(), VTJRefresh(testAdult_1.id, user.id))
         verifyZeroInteractions(parentshipService)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/VtjClientServiceTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/VtjClientServiceTest.kt
@@ -69,7 +69,8 @@ class VtjClientServiceTest : AbstractIntegrationTest() {
     lateinit var useVtj: String
 
     @BeforeEach
-    fun beforeEach() {
+    override fun beforeEach() {
+        super.beforeEach()
         if (useVtj != "true") {
             mockServer = MockWebServiceServer.createServer(wsTemplate)
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/ClubTerm.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/ClubTerm.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka
 
 import fi.espoo.evaka.shared.domain.ClosedPeriod
-import java.lang.IllegalStateException
 import java.time.LocalDate
 
 // TODO: hard-coding is not a good solution

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerEnduser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerEnduser.kt
@@ -158,7 +158,7 @@ class ApplicationControllerEnduser(
         user: AuthenticatedUser,
         @PathVariable applicationId: UUID
     ): ResponseEntity<Unit> {
-        db.transaction { applicationStateService.sendApplication(it.handle, user, applicationId, isEnduser = true) }
+        db.transaction { applicationStateService.sendApplication(it, user, applicationId, isEnduser = true) }
         return ResponseEntity.noContent().build()
     }
 
@@ -171,7 +171,7 @@ class ApplicationControllerEnduser(
     ): ResponseEntity<Unit> {
         db.transaction {
             applicationStateService.acceptDecision(
-                it.handle,
+                it,
                 user,
                 applicationId,
                 body.decisionId,
@@ -190,7 +190,7 @@ class ApplicationControllerEnduser(
         @RequestBody body: RejectDecisionRequest
     ): ResponseEntity<Unit> {
         db.transaction {
-            applicationStateService.rejectDecision(it.handle, user, applicationId, body.decisionId, isEnduser = true)
+            applicationStateService.rejectDecision(it, user, applicationId, body.decisionId, isEnduser = true)
         }
         return ResponseEntity.noContent().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerEnduser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerEnduser.kt
@@ -12,10 +12,8 @@ import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.NotFound
-import org.jdbi.v3.core.Jdbi
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -32,7 +30,6 @@ import java.util.UUID
 @RestController
 @RequestMapping("/enduser/v2/applications")
 class ApplicationControllerEnduser(
-    private val jdbi: Jdbi,
     private val personService: PersonService,
     private val serializer: ApplicationSerializer,
     private val applicationStateService: ApplicationStateService
@@ -134,21 +131,22 @@ class ApplicationControllerEnduser(
 
     @DeleteMapping("/{applicationId}")
     fun deleteApplication(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable(value = "applicationId") applicationId: UUID
     ): ResponseEntity<Unit> {
         Audit.ApplicationDelete.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.END_USER)
 
-        jdbi.transaction { h ->
-            val application = fetchApplicationDetails(h, applicationId)
+        db.transaction { tx ->
+            val application = fetchApplicationDetails(tx.handle, applicationId)
                 ?.takeIf { it.guardianId == user.id }
                 ?: throw NotFound("Application $applicationId of guardian ${user.id} not found")
 
             if (application.status != ApplicationStatus.CREATED)
                 throw BadRequest("Only drafts can be deleted")
 
-            deleteApplication(h, applicationId)
+            deleteApplication(tx.handle, applicationId)
         }
 
         return ResponseEntity.noContent().build()
@@ -156,22 +154,24 @@ class ApplicationControllerEnduser(
 
     @PostMapping("/{applicationId}/actions/send-application")
     fun sendApplication(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable applicationId: UUID
     ): ResponseEntity<Unit> {
-        jdbi.transaction { applicationStateService.sendApplication(it, user, applicationId, isEnduser = true) }
+        db.transaction { applicationStateService.sendApplication(it.handle, user, applicationId, isEnduser = true) }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/{applicationId}/actions/accept-decision")
     fun acceptDecision(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable applicationId: UUID,
         @RequestBody body: AcceptDecisionRequest
     ): ResponseEntity<Unit> {
-        jdbi.transaction {
+        db.transaction {
             applicationStateService.acceptDecision(
-                it,
+                it.handle,
                 user,
                 applicationId,
                 body.decisionId,
@@ -184,12 +184,13 @@ class ApplicationControllerEnduser(
 
     @PostMapping("/{applicationId}/actions/reject-decision")
     fun rejectDecision(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable applicationId: UUID,
         @RequestBody body: RejectDecisionRequest
     ): ResponseEntity<Unit> {
-        jdbi.transaction {
-            applicationStateService.rejectDecision(it, user, applicationId, body.decisionId, isEnduser = true)
+        db.transaction {
+            applicationStateService.rejectDecision(it.handle, user, applicationId, body.decisionId, isEnduser = true)
         }
         return ResponseEntity.noContent().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerEnduser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerEnduser.kt
@@ -122,7 +122,7 @@ class ApplicationControllerEnduser(
         val formV0 = serializer.deserialize(user, formJson)
         val updatedApplication = db.transaction { tx ->
             applicationStateService
-                .updateOwnApplicationContents(tx.handle, user, applicationId, formV0)
+                .updateOwnApplicationContents(tx, user, applicationId, formV0)
                 .let { serializer.serialize(tx, user, it) }
         }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -275,7 +275,7 @@ class ApplicationControllerV2(
         @PathVariable applicationId: UUID,
         @RequestBody applicationForm: ApplicationForm
     ): ResponseEntity<Unit> {
-        db.transaction { applicationStateService.updateApplicationContents(it.handle, user, applicationId, applicationForm) }
+        db.transaction { applicationStateService.updateApplicationContents(it, user, applicationId, applicationForm) }
         return ResponseEntity.noContent().build()
     }
 
@@ -317,7 +317,7 @@ class ApplicationControllerV2(
             val placementUnitName = getPlacementPlanUnitName(tx.handle, applicationId)
 
             val decisionDrafts = fetchDecisionDrafts(tx.handle, applicationId)
-            val unit = decisionDraftService.getDecisionUnit(tx.handle, decisionDrafts[0].unitId)
+            val unit = decisionDraftService.getDecisionUnit(tx, decisionDrafts[0].unitId)
 
             val applicationGuardian = personService.getUpToDatePerson(tx, user, application.guardianId)
                 ?: throw NotFound("Guardian ${application.guardianId} not found")
@@ -368,7 +368,7 @@ class ApplicationControllerV2(
         Audit.DecisionDraftUpdate.log(targetId = applicationId)
         user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.ADMIN)
 
-        db.transaction { decisionDraftService.updateDecisionDrafts(it.handle, applicationId, body) }
+        db.transaction { decisionDraftService.updateDecisionDrafts(it, applicationId, body) }
         return ResponseEntity.noContent().build()
     }
 
@@ -431,7 +431,7 @@ class ApplicationControllerV2(
     ): ResponseEntity<Unit> {
         db.transaction {
             applicationStateService.respondToPlacementProposal(
-                it.handle,
+                it,
                 user,
                 applicationId,
                 body.status,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -285,7 +285,7 @@ class ApplicationControllerV2(
         user: AuthenticatedUser,
         @PathVariable applicationId: UUID
     ): ResponseEntity<Unit> {
-        db.transaction { applicationStateService.sendApplication(it.handle, user, applicationId) }
+        db.transaction { applicationStateService.sendApplication(it, user, applicationId) }
         return ResponseEntity.noContent().build()
     }
 
@@ -297,7 +297,7 @@ class ApplicationControllerV2(
     ): ResponseEntity<PlacementPlanDraft> {
         Audit.PlacementPlanDraftRead.log(targetId = applicationId)
         user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.ADMIN)
-        return db.read { placementPlanService.getPlacementPlanDraft(it.handle, applicationId) }
+        return db.read { placementPlanService.getPlacementPlanDraft(it, applicationId) }
             .let { ResponseEntity.ok(it) }
     }
 
@@ -450,7 +450,7 @@ class ApplicationControllerV2(
         @RequestBody body: AcceptDecisionRequest
     ): ResponseEntity<Unit> {
         db.transaction {
-            applicationStateService.acceptDecision(it.handle, user, applicationId, body.decisionId, body.requestedStartDate)
+            applicationStateService.acceptDecision(it, user, applicationId, body.decisionId, body.requestedStartDate)
         }
         return ResponseEntity.noContent().build()
     }
@@ -462,7 +462,7 @@ class ApplicationControllerV2(
         @PathVariable applicationId: UUID,
         @RequestBody body: RejectDecisionRequest
     ): ResponseEntity<Unit> {
-        db.transaction { applicationStateService.rejectDecision(it.handle, user, applicationId, body.decisionId) }
+        db.transaction { applicationStateService.rejectDecision(it, user, applicationId, body.decisionId) }
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -27,8 +27,6 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.shared.domain.NotFound

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationDetailsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationDetailsService.kt
@@ -8,13 +8,12 @@ import fi.espoo.evaka.application.persistence.FormType
 import fi.espoo.evaka.placement.Placement
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getPlacementsForChildDuring
-import org.jdbi.v3.core.Handle
+import fi.espoo.evaka.shared.db.Database
 import java.time.LocalDate
 import java.util.UUID
 
-fun applicationFlags(h: Handle, application: ApplicationDetails): ApplicationFlags {
+fun Database.Read.applicationFlags(application: ApplicationDetails): ApplicationFlags {
     return applicationFlags(
-        h = h,
         childId = application.childId,
         formType = when (application.type) {
             ApplicationType.CLUB -> FormType.CLUB
@@ -27,8 +26,7 @@ fun applicationFlags(h: Handle, application: ApplicationDetails): ApplicationFla
     )
 }
 
-fun applicationFlags(
-    h: Handle,
+fun Database.Read.applicationFlags(
     childId: UUID,
     formType: FormType,
     startDate: LocalDate,
@@ -37,15 +35,15 @@ fun applicationFlags(
 ): ApplicationFlags {
     return when (formType) {
         FormType.CLUB -> ApplicationFlags(
-            isTransferApplication = h.getPlacementsForChildDuring(childId, startDate, null)
+            isTransferApplication = handle.getPlacementsForChildDuring(childId, startDate, null)
                 .any { it.type == PlacementType.CLUB }
         )
         FormType.DAYCARE -> ApplicationFlags(
-            isTransferApplication = h.getPlacementsForChildDuring(childId, startDate, null)
+            isTransferApplication = handle.getPlacementsForChildDuring(childId, startDate, null)
                 .any { listOf(PlacementType.DAYCARE, PlacementType.DAYCARE_PART_TIME).contains(it.type) }
         )
         FormType.PRESCHOOL -> {
-            val existingPlacements = h.getPlacementsForChildDuring(childId, startDate, null)
+            val existingPlacements = handle.getPlacementsForChildDuring(childId, startDate, null)
                 .filter {
                     listOf(
                         PlacementType.PRESCHOOL,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -28,7 +28,6 @@ import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.result.RowView
 import org.jdbi.v3.core.statement.StatementContext
 import org.postgresql.util.PGobject
-import java.lang.Error
 import java.sql.ResultSet
 import java.time.LocalDate
 import java.util.UUID

--- a/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
@@ -43,7 +43,7 @@ class DecisionMessageProcessor(
     fun runSendJob(db: Database, msg: SendDecision) = db.transaction { tx ->
         val decisionId = msg.decisionId
 
-        decisionService.deliverDecisionToGuardians(tx.handle, decisionId)
+        decisionService.deliverDecisionToGuardians(tx, decisionId)
         logger.info { "Successfully sent decision(s) pdf for decision (id: $decisionId)." }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
@@ -10,16 +10,13 @@ import fi.espoo.evaka.shared.async.NotifyDecisionCreated
 import fi.espoo.evaka.shared.async.SendDecision
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import mu.KotlinLogging
-import org.jdbi.v3.core.Jdbi
 import org.springframework.stereotype.Component
 
 private val logger = KotlinLogging.logger {}
 
 @Component
 class DecisionMessageProcessor(
-    private val jdbi: Jdbi,
     private val asyncJobRunner: AsyncJobRunner,
     private val decisionService: DecisionService
 ) {
@@ -43,10 +40,10 @@ class DecisionMessageProcessor(
         }
     }
 
-    fun runSendJob(db: Database, msg: SendDecision) = jdbi.transaction { h ->
+    fun runSendJob(db: Database, msg: SendDecision) = db.transaction { tx ->
         val decisionId = msg.decisionId
 
-        decisionService.deliverDecisionToGuardians(h, decisionId)
+        decisionService.deliverDecisionToGuardians(tx.handle, decisionId)
         logger.info { "Successfully sent decision(s) pdf for decision (id: $decisionId)." }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
@@ -33,7 +33,7 @@ import java.util.UUID
 class NoteController(private val acl: AccessControlList) {
     @PostMapping("/search")
     fun getNotes(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody search: NoteSearchDTO
     ): ResponseEntity<List<NoteJSON>> {
@@ -50,7 +50,7 @@ class NoteController(private val acl: AccessControlList) {
 
     @PostMapping("/application/{id}")
     fun createNote(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("id") applicationId: UUID,
         @RequestBody note: NoteRequest
@@ -67,7 +67,7 @@ class NoteController(private val acl: AccessControlList) {
     @PutMapping("/update")
     @Deprecated("use updateNote instead (PUT /note/:id)")
     fun updateNotes(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody notes: List<NoteJSON>
     ): ResponseEntity<NotesWrapperJSON> {
@@ -87,7 +87,7 @@ class NoteController(private val acl: AccessControlList) {
 
     @PutMapping("/{noteId}")
     fun updateNote(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("noteId") noteId: UUID,
         @RequestBody note: NoteRequest
@@ -107,7 +107,7 @@ class NoteController(private val acl: AccessControlList) {
 
     @DeleteMapping("/{noteId}")
     fun deleteNote(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("noteId") noteId: UUID
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
@@ -13,8 +13,6 @@ import fi.espoo.evaka.shared.auth.UserRole.ADMIN
 import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
 import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Forbidden
 import org.jdbi.v3.core.Handle
 import org.springframework.http.ResponseEntity

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -28,7 +28,7 @@ class AssistanceActionController(
 ) {
     @PostMapping("/children/{childId}/assistance-actions")
     fun createAssistanceAction(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: AssistanceActionRequest
@@ -45,7 +45,7 @@ class AssistanceActionController(
 
     @GetMapping("/children/{childId}/assistance-actions")
     fun getAssistanceActions(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<List<AssistanceAction>> {
@@ -56,7 +56,7 @@ class AssistanceActionController(
 
     @PutMapping("/assistance-actions/{id}")
     fun updateAssistanceAction(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable id: UUID,
         @RequestBody body: AssistanceActionRequest
@@ -73,7 +73,7 @@ class AssistanceActionController(
 
     @DeleteMapping("/assistance-actions/{id}")
     fun deleteAssistanceAction(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable id: UUID
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.daycare.controllers.utils.noContent
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -27,6 +28,7 @@ class AssistanceActionController(
 ) {
     @PostMapping("/children/{childId}/assistance-actions")
     fun createAssistanceAction(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: AssistanceActionRequest
@@ -34,6 +36,7 @@ class AssistanceActionController(
         Audit.ChildAssistanceActionCreate.log(targetId = childId)
         user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
         return assistanceActionService.createAssistanceAction(
+            db,
             user = user,
             childId = childId,
             data = body
@@ -42,16 +45,18 @@ class AssistanceActionController(
 
     @GetMapping("/children/{childId}/assistance-actions")
     fun getAssistanceActions(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<List<AssistanceAction>> {
         Audit.ChildAssistanceActionRead.log(targetId = childId)
         user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.FINANCE_ADMIN)
-        return assistanceActionService.getAssistanceActionsByChildId(childId).let(::ok)
+        return assistanceActionService.getAssistanceActionsByChildId(db, childId).let(::ok)
     }
 
     @PutMapping("/assistance-actions/{id}")
     fun updateAssistanceAction(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable id: UUID,
         @RequestBody body: AssistanceActionRequest
@@ -59,6 +64,7 @@ class AssistanceActionController(
         Audit.ChildAssistanceActionUpdate.log(targetId = id)
         user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
         return assistanceActionService.updateAssistanceAction(
+            db,
             user = user,
             id = id,
             data = body
@@ -67,12 +73,13 @@ class AssistanceActionController(
 
     @DeleteMapping("/assistance-actions/{id}")
     fun deleteAssistanceAction(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable id: UUID
     ): ResponseEntity<Unit> {
         Audit.ChildAssistanceActionDelete.log(targetId = id)
         user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
-        assistanceActionService.deleteAssistanceAction(id)
+        assistanceActionService.deleteAssistanceAction(db, id)
         return noContent()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionService.kt
@@ -7,8 +7,6 @@ package fi.espoo.evaka.assistanceaction
 import fi.espoo.evaka.pis.dao.mapPSQLException
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import org.jdbi.v3.core.JdbiException
 import org.springframework.stereotype.Service
 import java.util.UUID

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionService.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 
 @Service
 class AssistanceActionService {
-    fun createAssistanceAction(db: Database, user: AuthenticatedUser, childId: UUID, data: AssistanceActionRequest): AssistanceAction {
+    fun createAssistanceAction(db: Database.Connection, user: AuthenticatedUser, childId: UUID, data: AssistanceActionRequest): AssistanceAction {
         try {
             return db.transaction {
                 shortenOverlappingAssistanceAction(it.handle, user, childId, data.startDate, data.endDate)
@@ -24,11 +24,11 @@ class AssistanceActionService {
         }
     }
 
-    fun getAssistanceActionsByChildId(db: Database, childId: UUID): List<AssistanceAction> {
+    fun getAssistanceActionsByChildId(db: Database.Connection, childId: UUID): List<AssistanceAction> {
         return db.read { getAssistanceActionsByChild(it.handle, childId) }
     }
 
-    fun updateAssistanceAction(db: Database, user: AuthenticatedUser, id: UUID, data: AssistanceActionRequest): AssistanceAction {
+    fun updateAssistanceAction(db: Database.Connection, user: AuthenticatedUser, id: UUID, data: AssistanceActionRequest): AssistanceAction {
         try {
             return db.transaction { updateAssistanceAction(it.handle, user, id, data) }
         } catch (e: JdbiException) {
@@ -36,7 +36,7 @@ class AssistanceActionService {
         }
     }
 
-    fun deleteAssistanceAction(db: Database, id: UUID) {
+    fun deleteAssistanceAction(db: Database.Connection, id: UUID) {
         db.transaction { deleteAssistanceAction(it.handle, id) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionService.kt
@@ -6,39 +6,39 @@ package fi.espoo.evaka.assistanceaction
 
 import fi.espoo.evaka.pis.dao.mapPSQLException
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
-import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.JdbiException
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class AssistanceActionService(private val jdbi: Jdbi) {
-    fun createAssistanceAction(user: AuthenticatedUser, childId: UUID, data: AssistanceActionRequest): AssistanceAction {
+class AssistanceActionService {
+    fun createAssistanceAction(db: Database, user: AuthenticatedUser, childId: UUID, data: AssistanceActionRequest): AssistanceAction {
         try {
-            return jdbi.transaction { h ->
-                shortenOverlappingAssistanceAction(h, user, childId, data.startDate, data.endDate)
-                insertAssistanceAction(h, user, childId, data)
+            return db.transaction {
+                shortenOverlappingAssistanceAction(it.handle, user, childId, data.startDate, data.endDate)
+                insertAssistanceAction(it.handle, user, childId, data)
             }
         } catch (e: JdbiException) {
             throw mapPSQLException(e)
         }
     }
 
-    fun getAssistanceActionsByChildId(childId: UUID): List<AssistanceAction> {
-        return jdbi.handle { h -> getAssistanceActionsByChild(h.setReadOnly(true), childId) }
+    fun getAssistanceActionsByChildId(db: Database, childId: UUID): List<AssistanceAction> {
+        return db.read { getAssistanceActionsByChild(it.handle, childId) }
     }
 
-    fun updateAssistanceAction(user: AuthenticatedUser, id: UUID, data: AssistanceActionRequest): AssistanceAction {
+    fun updateAssistanceAction(db: Database, user: AuthenticatedUser, id: UUID, data: AssistanceActionRequest): AssistanceAction {
         try {
-            return jdbi.transaction { h -> updateAssistanceAction(h, user, id, data) }
+            return db.transaction { updateAssistanceAction(it.handle, user, id, data) }
         } catch (e: JdbiException) {
             throw mapPSQLException(e)
         }
     }
 
-    fun deleteAssistanceAction(id: UUID) {
-        jdbi.transaction { h -> deleteAssistanceAction(h, id) }
+    fun deleteAssistanceAction(db: Database, id: UUID) {
+        db.transaction { deleteAssistanceAction(it.handle, id) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.daycare.controllers.utils.noContent
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -27,6 +28,7 @@ class AssistanceNeedController(
 ) {
     @PostMapping("/children/{childId}/assistance-needs")
     fun createAssistanceNeed(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: AssistanceNeedRequest
@@ -34,6 +36,7 @@ class AssistanceNeedController(
         Audit.ChildAssistanceNeedCreate.log(targetId = childId)
         user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
         return assistanceNeedService.createAssistanceNeed(
+            db,
             user = user,
             childId = childId,
             data = body
@@ -42,16 +45,18 @@ class AssistanceNeedController(
 
     @GetMapping("/children/{childId}/assistance-needs")
     fun getAssistanceNeeds(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<List<AssistanceNeed>> {
         Audit.ChildAssistanceNeedRead.log(targetId = childId)
         user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.FINANCE_ADMIN)
-        return assistanceNeedService.getAssistanceNeedsByChildId(childId).let(::ok)
+        return assistanceNeedService.getAssistanceNeedsByChildId(db, childId).let(::ok)
     }
 
     @PutMapping("/assistance-needs/{id}")
     fun updateAssistanceNeed(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable id: UUID,
         @RequestBody body: AssistanceNeedRequest
@@ -59,6 +64,7 @@ class AssistanceNeedController(
         Audit.ChildAssistanceNeedUpdate.log(targetId = id)
         user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
         return assistanceNeedService.updateAssistanceNeed(
+            db,
             user = user,
             id = id,
             data = body
@@ -67,12 +73,13 @@ class AssistanceNeedController(
 
     @DeleteMapping("/assistance-needs/{id}")
     fun deleteAssistanceNeed(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable id: UUID
     ): ResponseEntity<Unit> {
         Audit.ChildAssistanceNeedDelete.log(targetId = id)
         user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
-        assistanceNeedService.deleteAssistanceNeed(id)
+        assistanceNeedService.deleteAssistanceNeed(db, id)
         return noContent()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -28,7 +28,7 @@ class AssistanceNeedController(
 ) {
     @PostMapping("/children/{childId}/assistance-needs")
     fun createAssistanceNeed(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: AssistanceNeedRequest
@@ -45,7 +45,7 @@ class AssistanceNeedController(
 
     @GetMapping("/children/{childId}/assistance-needs")
     fun getAssistanceNeeds(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<List<AssistanceNeed>> {
@@ -56,7 +56,7 @@ class AssistanceNeedController(
 
     @PutMapping("/assistance-needs/{id}")
     fun updateAssistanceNeed(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable id: UUID,
         @RequestBody body: AssistanceNeedRequest
@@ -73,7 +73,7 @@ class AssistanceNeedController(
 
     @DeleteMapping("/assistance-needs/{id}")
     fun deleteAssistanceNeed(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable id: UUID
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
@@ -6,38 +6,38 @@ package fi.espoo.evaka.assistanceneed
 
 import fi.espoo.evaka.pis.dao.mapPSQLException
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.transaction
-import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.JdbiException
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class AssistanceNeedService(private val jdbi: Jdbi) {
-    fun createAssistanceNeed(user: AuthenticatedUser, childId: UUID, data: AssistanceNeedRequest): AssistanceNeed {
+class AssistanceNeedService {
+    fun createAssistanceNeed(db: Database, user: AuthenticatedUser, childId: UUID, data: AssistanceNeedRequest): AssistanceNeed {
         try {
-            return jdbi.transaction { h ->
-                shortenOverlappingAssistanceNeed(h, user, childId, data.startDate, data.endDate)
-                insertAssistanceNeed(h, user, childId, data)
+            return db.transaction {
+                shortenOverlappingAssistanceNeed(it.handle, user, childId, data.startDate, data.endDate)
+                insertAssistanceNeed(it.handle, user, childId, data)
             }
         } catch (e: JdbiException) {
             throw mapPSQLException(e)
         }
     }
 
-    fun getAssistanceNeedsByChildId(childId: UUID): List<AssistanceNeed> {
-        return jdbi.transaction { h -> getAssistanceNeedsByChild(h.setReadOnly(true), childId) }
+    fun getAssistanceNeedsByChildId(db: Database, childId: UUID): List<AssistanceNeed> {
+        return db.transaction { getAssistanceNeedsByChild(it.handle, childId) }
     }
 
-    fun updateAssistanceNeed(user: AuthenticatedUser, id: UUID, data: AssistanceNeedRequest): AssistanceNeed {
+    fun updateAssistanceNeed(db: Database, user: AuthenticatedUser, id: UUID, data: AssistanceNeedRequest): AssistanceNeed {
         try {
-            return jdbi.transaction { h -> updateAssistanceNeed(h, user, id, data) }
+            return db.transaction { updateAssistanceNeed(it.handle, user, id, data) }
         } catch (e: JdbiException) {
             throw mapPSQLException(e)
         }
     }
 
-    fun deleteAssistanceNeed(id: UUID) {
-        jdbi.transaction { h -> deleteAssistanceNeed(h, id) }
+    fun deleteAssistanceNeed(db: Database, id: UUID) {
+        db.transaction { deleteAssistanceNeed(it.handle, id) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 
 @Service
 class AssistanceNeedService {
-    fun createAssistanceNeed(db: Database, user: AuthenticatedUser, childId: UUID, data: AssistanceNeedRequest): AssistanceNeed {
+    fun createAssistanceNeed(db: Database.Connection, user: AuthenticatedUser, childId: UUID, data: AssistanceNeedRequest): AssistanceNeed {
         try {
             return db.transaction {
                 shortenOverlappingAssistanceNeed(it.handle, user, childId, data.startDate, data.endDate)
@@ -24,11 +24,11 @@ class AssistanceNeedService {
         }
     }
 
-    fun getAssistanceNeedsByChildId(db: Database, childId: UUID): List<AssistanceNeed> {
+    fun getAssistanceNeedsByChildId(db: Database.Connection, childId: UUID): List<AssistanceNeed> {
         return db.transaction { getAssistanceNeedsByChild(it.handle, childId) }
     }
 
-    fun updateAssistanceNeed(db: Database, user: AuthenticatedUser, id: UUID, data: AssistanceNeedRequest): AssistanceNeed {
+    fun updateAssistanceNeed(db: Database.Connection, user: AuthenticatedUser, id: UUID, data: AssistanceNeedRequest): AssistanceNeed {
         try {
             return db.transaction { updateAssistanceNeed(it.handle, user, id, data) }
         } catch (e: JdbiException) {
@@ -36,7 +36,7 @@ class AssistanceNeedService {
         }
     }
 
-    fun deleteAssistanceNeed(db: Database, id: UUID) {
+    fun deleteAssistanceNeed(db: Database.Connection, id: UUID) {
         db.transaction { deleteAssistanceNeed(it.handle, id) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.assistanceneed
 import fi.espoo.evaka.pis.dao.mapPSQLException
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import org.jdbi.v3.core.JdbiException
 import org.springframework.stereotype.Service
 import java.util.UUID

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -10,8 +10,6 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import org.jdbi.v3.core.JdbiException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -30,7 +30,7 @@ class ChildAttendanceController(private val acl: AccessControlList) {
 
     @PostMapping("/arrive")
     fun childArrives(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody body: ArrivalRequest
     ): ResponseEntity<ChildAttendance> {
@@ -52,7 +52,7 @@ class ChildAttendanceController(private val acl: AccessControlList) {
 
     @PostMapping("/depart")
     fun childDeparts(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody body: DepartureRequest
     ): ResponseEntity<Unit> {
@@ -75,7 +75,7 @@ class ChildAttendanceController(private val acl: AccessControlList) {
 
     @GetMapping("/current")
     fun getDaycareAttendances(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam daycareId: UUID
     ): ResponseEntity<List<ChildInGroup>> {
@@ -89,7 +89,7 @@ class ChildAttendanceController(private val acl: AccessControlList) {
 
     @DeleteMapping("/{attendanceId}")
     fun deleteAttendance(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "attendanceId") attendanceId: UUID
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -9,9 +9,9 @@ import fi.espoo.evaka.pis.dao.mapPSQLException
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
-import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.JdbiException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -28,13 +28,11 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/child-attendances")
-class ChildAttendanceController(
-    private val jdbi: Jdbi,
-    private val acl: AccessControlList
-) {
+class ChildAttendanceController(private val acl: AccessControlList) {
 
     @PostMapping("/arrive")
     fun childArrives(
+        db: Database,
         user: AuthenticatedUser,
         @RequestBody body: ArrivalRequest
     ): ResponseEntity<ChildAttendance> {
@@ -43,8 +41,8 @@ class ChildAttendanceController(
             .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF)
 
         try {
-            return jdbi.transaction {
-                it.createAttendance(
+            return db.transaction {
+                it.handle.createAttendance(
                     childId = body.childId,
                     arrived = body.time ?: OffsetDateTime.now()
                 )
@@ -56,6 +54,7 @@ class ChildAttendanceController(
 
     @PostMapping("/depart")
     fun childDeparts(
+        db: Database,
         user: AuthenticatedUser,
         @RequestBody body: DepartureRequest
     ): ResponseEntity<Unit> {
@@ -64,8 +63,8 @@ class ChildAttendanceController(
             .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF)
 
         try {
-            jdbi.transaction {
-                it.updateCurrentAttendanceEnd(
+            db.transaction {
+                it.handle.updateCurrentAttendanceEnd(
                     childId = body.childId,
                     departed = body.time ?: OffsetDateTime.now()
                 )
@@ -78,6 +77,7 @@ class ChildAttendanceController(
 
     @GetMapping("/current")
     fun getDaycareAttendances(
+        db: Database,
         user: AuthenticatedUser,
         @RequestParam daycareId: UUID
     ): ResponseEntity<List<ChildInGroup>> {
@@ -85,16 +85,17 @@ class ChildAttendanceController(
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF)
 
-        return jdbi.handle { it.getDaycareAttendances(daycareId) }
+        return db.read { it.handle.getDaycareAttendances(daycareId) }
             .let { ResponseEntity.ok(it) }
     }
 
     @DeleteMapping("/{attendanceId}")
     fun deleteAttendance(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable(value = "attendanceId") attendanceId: UUID
     ): ResponseEntity<Unit> {
-        jdbi.transaction { it.deleteAttendance(attendanceId) }
+        db.transaction { it.handle.deleteAttendance(attendanceId) }
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -31,7 +31,7 @@ import java.util.UUID
 class BackupCareController(private val acl: AccessControlList) {
     @GetMapping("/children/{childId}/backup-cares")
     fun getForChild(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("childId") childId: UUID
     ): ResponseEntity<ChildBackupCaresResponse> {
@@ -42,7 +42,7 @@ class BackupCareController(private val acl: AccessControlList) {
 
     @PostMapping("/children/{childId}/backup-cares")
     fun createForChild(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("childId") childId: UUID,
         @RequestBody body: NewBackupCare
@@ -58,7 +58,7 @@ class BackupCareController(private val acl: AccessControlList) {
 
     @PostMapping("/backup-cares/{id}")
     fun update(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("id") id: UUID,
         @RequestBody body: BackupCareUpdateRequest
@@ -73,7 +73,7 @@ class BackupCareController(private val acl: AccessControlList) {
     }
 
     @DeleteMapping("/backup-cares/{id}")
-    fun delete(db: Database, user: AuthenticatedUser, @PathVariable("id") id: UUID): ResponseEntity<Unit> {
+    fun delete(db: Database.Connection, user: AuthenticatedUser, @PathVariable("id") id: UUID): ResponseEntity<Unit> {
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR)
         db.transaction { it.handle.deleteBackupCare(id) }
         return ResponseEntity.noContent().build()
@@ -81,7 +81,7 @@ class BackupCareController(private val acl: AccessControlList) {
 
     @GetMapping("/daycares/{daycareId}/backup-cares")
     fun getForDaycare(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -13,8 +13,6 @@ import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
 import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
 import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import org.jdbi.v3.core.JdbiException
 import org.springframework.format.annotation.DateTimeFormat

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
@@ -35,7 +35,7 @@ import java.util.UUID
 class AbsenceController(private val absenceService: AbsenceService, private val acl: AccessControlList) {
     @GetMapping("/{groupId}")
     fun getAbsencesByGroupAndMonth(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam year: Int,
         @RequestParam month: Int,
@@ -50,7 +50,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
 
     @PostMapping("/{groupId}")
     fun upsertAbsences(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody absences: Wrapper<List<Absence>>,
         @PathVariable groupId: UUID
@@ -64,7 +64,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
 
     @GetMapping("/by-child/{childId}")
     fun getAbsencesByChild(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestParam year: Int,
@@ -78,7 +78,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
 
     @PostMapping("/child/{childId}")
     fun upsertAbsence(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody absenceType: AbsenceBody,
         @PathVariable childId: UUID

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
 import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
 import fi.espoo.evaka.shared.auth.UserRole.STAFF
 import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -34,6 +35,7 @@ import java.util.UUID
 class AbsenceController(private val absenceService: AbsenceService, private val acl: AccessControlList) {
     @GetMapping("/{groupId}")
     fun getAbsencesByGroupAndMonth(
+        db: Database,
         user: AuthenticatedUser,
         @RequestParam year: Int,
         @RequestParam month: Int,
@@ -42,12 +44,13 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
         Audit.AbsenceRead.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
             .requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR, STAFF)
-        val absences = absenceService.getAbsencesByMonth(groupId, year, month)
+        val absences = db.read { absenceService.getAbsencesByMonth(it, groupId, year, month) }
         return ResponseEntity.ok(Wrapper(absences))
     }
 
     @PostMapping("/{groupId}")
     fun upsertAbsences(
+        db: Database,
         user: AuthenticatedUser,
         @RequestBody absences: Wrapper<List<Absence>>,
         @PathVariable groupId: UUID
@@ -55,12 +58,13 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
         Audit.AbsenceUpdate.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
             .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR, STAFF)
-        absenceService.upsertAbsences(absences.data, groupId, user.id)
+        db.transaction { absenceService.upsertAbsences(it, absences.data, groupId, user.id) }
         return ResponseEntity.noContent().build()
     }
 
     @GetMapping("/by-child/{childId}")
     fun getAbsencesByChild(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestParam year: Int,
@@ -68,19 +72,20 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
     ): ResponseEntity<Wrapper<AbsenceChildMinimal>> {
         Audit.AbsenceRead.log(targetId = childId)
         user.requireOneOfRoles(ADMIN, UNIT_SUPERVISOR, FINANCE_ADMIN)
-        val absences = absenceService.getAbscencesByChild(childId, year, month)
+        val absences = db.read { absenceService.getAbscencesByChild(it, childId, year, month) }
         return ResponseEntity.ok(Wrapper(absences))
     }
 
     @PostMapping("/child/{childId}")
     fun upsertAbsence(
+        db: Database,
         user: AuthenticatedUser,
         @RequestBody absenceType: AbsenceBody,
         @PathVariable childId: UUID
     ): ResponseEntity<Unit> {
         Audit.ChildAbsenceUpdate.log(targetId = childId)
         user.requireOneOfRoles(ADMIN)
-        absenceService.upsertChildAbsence(childId, absenceType.absenceType, absenceType.careType, user.id)
+        db.transaction { absenceService.upsertChildAbsence(it, childId, absenceType.absenceType, absenceType.careType, user.id) }
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
@@ -30,7 +30,7 @@ import java.util.UUID
 @RestController
 class ChildController(private val acl: AccessControlList) {
     @GetMapping("/children/{childId}/additional-information")
-    fun getAdditionalInfo(db: Database, user: AuthenticatedUser, @PathVariable childId: UUID): ResponseEntity<AdditionalInformation> {
+    fun getAdditionalInfo(db: Database.Connection, user: AuthenticatedUser, @PathVariable childId: UUID): ResponseEntity<AdditionalInformation> {
         Audit.ChildAdditionalInformationRead.log(targetId = childId)
         acl.getRolesForChild(user, childId).requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN, STAFF)
         return db.read { getAdditionalInformation(it.handle, childId) }.let(::ok)
@@ -38,7 +38,7 @@ class ChildController(private val acl: AccessControlList) {
 
     @PutMapping("/children/{childId}/additional-information")
     fun updateAdditionalInfo(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody data: AdditionalInformation

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
@@ -17,8 +17,6 @@ import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
 import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
 import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.mapper.Nested
 import org.springframework.http.ResponseEntity

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -93,7 +93,7 @@ class DaycareController(
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR, STAFF)
 
-        return db.read { daycareService.getDaycareGroups(it.handle, daycareId, startDate, endDate) }.let(::ok)
+        return db.read { daycareService.getDaycareGroups(it, daycareId, startDate, endDate) }.let(::ok)
     }
 
     @PostMapping("/{daycareId}/groups")
@@ -107,7 +107,7 @@ class DaycareController(
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(ADMIN, SERVICE_WORKER, UNIT_SUPERVISOR)
 
-        return db.transaction { daycareService.createGroup(it.handle, daycareId, body.name, body.startDate, body.initialCaretakers) }
+        return db.transaction { daycareService.createGroup(it, daycareId, body.name, body.startDate, body.initialCaretakers) }
             .let { created(it, URI.create("/$daycareId/groups/${it.id}")) }
     }
 
@@ -142,7 +142,7 @@ class DaycareController(
         acl.getRolesForUnitGroup(user, groupId)
             .requireOneOfRoles(ADMIN, SERVICE_WORKER, UNIT_SUPERVISOR)
 
-        db.transaction { daycareService.deleteGroup(it.handle, daycareId, groupId) }
+        db.transaction { daycareService.deleteGroup(it, daycareId, groupId) }
         return noContent()
     }
 
@@ -256,7 +256,7 @@ class DaycareController(
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR, STAFF)
 
-        return db.read { daycareService.getDaycareCapacityStats(it.handle, daycareId, startDate, endDate) }.let(::ok)
+        return db.read { daycareService.getDaycareCapacityStats(it, daycareId, startDate, endDate) }.let(::ok)
     }
 
     @PutMapping("/{daycareId}")

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -161,7 +161,7 @@ class DaycareController(
             val daycareStub = it.handle.getDaycareStub(daycareId)
             ok(
                 CaretakersResponse(
-                    caretakers = caretakerService.getCaretakers(it.handle, groupId),
+                    caretakers = caretakerService.getCaretakers(it, groupId),
                     unitName = daycareStub?.name ?: "",
                     groupName = it.handle.getDaycareGroup(groupId)?.name ?: ""
                 )
@@ -183,7 +183,7 @@ class DaycareController(
 
         db.transaction {
             caretakerService.insert(
-                it.handle,
+                it,
                 groupId = groupId,
                 startDate = body.startDate,
                 endDate = body.endDate,
@@ -208,7 +208,7 @@ class DaycareController(
 
         db.transaction {
             caretakerService.update(
-                it.handle,
+                it,
                 groupId = groupId,
                 id = id,
                 startDate = body.startDate,
@@ -233,7 +233,7 @@ class DaycareController(
 
         db.transaction {
             caretakerService.delete(
-                it.handle,
+                it,
                 groupId = groupId,
                 id = id
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -55,7 +55,7 @@ class DaycareController(
     private val acl: AccessControlList
 ) {
     @GetMapping
-    fun getDaycares(db: Database, user: AuthenticatedUser): ResponseEntity<List<Daycare>> {
+    fun getDaycares(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<Daycare>> {
         Audit.UnitSearch.log()
         user.requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR, STAFF)
         return ResponseEntity.ok(db.read { it.handle.getDaycares(acl.getAuthorizedDaycares(user)) })
@@ -63,7 +63,7 @@ class DaycareController(
 
     @GetMapping("/{daycareId}")
     fun getDaycare(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID
     ): ResponseEntity<DaycareResponse> {
@@ -77,7 +77,7 @@ class DaycareController(
 
     @GetMapping("/{daycareId}/groups")
     fun getGroups(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @RequestParam(
@@ -98,7 +98,7 @@ class DaycareController(
 
     @PostMapping("/{daycareId}/groups")
     fun createGroup(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @RequestBody body: CreateGroupRequest
@@ -116,7 +116,7 @@ class DaycareController(
     )
     @PutMapping("/{daycareId}/groups/{groupId}")
     fun updateGroup(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @PathVariable("groupId") groupId: UUID,
@@ -133,7 +133,7 @@ class DaycareController(
 
     @DeleteMapping("/{daycareId}/groups/{groupId}")
     fun deleteGroup(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @PathVariable("groupId") groupId: UUID
@@ -148,7 +148,7 @@ class DaycareController(
 
     @GetMapping("/{daycareId}/groups/{groupId}/caretakers")
     fun getCaretakers(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @PathVariable("groupId") groupId: UUID
@@ -171,7 +171,7 @@ class DaycareController(
 
     @PostMapping("/{daycareId}/groups/{groupId}/caretakers")
     fun createCaretakers(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @PathVariable("groupId") groupId: UUID,
@@ -195,7 +195,7 @@ class DaycareController(
 
     @PutMapping("/{daycareId}/groups/{groupId}/caretakers/{id}")
     fun updateCaretakers(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @PathVariable("groupId") groupId: UUID,
@@ -221,7 +221,7 @@ class DaycareController(
 
     @DeleteMapping("/{daycareId}/groups/{groupId}/caretakers/{id}")
     fun removeCaretakers(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @PathVariable("groupId") groupId: UUID,
@@ -243,7 +243,7 @@ class DaycareController(
 
     @GetMapping("/{daycareId}/stats")
     fun getStats(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @RequestParam(
@@ -261,7 +261,7 @@ class DaycareController(
 
     @PutMapping("/{daycareId}")
     fun updateDaycare(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
         @RequestBody fields: DaycareFields
@@ -280,7 +280,7 @@ class DaycareController(
 
     @PutMapping("")
     fun createDaycare(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody fields: DaycareFields
     ): ResponseEntity<CreateDaycareResponse> {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -32,8 +32,6 @@ import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
 import fi.espoo.evaka.shared.auth.UserRole.STAFF
 import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -14,12 +14,12 @@ import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.getApplicationUnits
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.Coordinate
 import org.jdbi.v3.core.Handle
-import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
@@ -30,42 +30,41 @@ import java.time.LocalDate
 import java.util.UUID
 
 @RestController
-class LocationController(val jdbi: Jdbi) {
+class LocationController {
     @GetMapping("/public/units")
     fun getApplicationUnits(
+        db: Database,
         user: AuthenticatedUser,
         @RequestParam type: ApplicationUnitType,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): ResponseEntity<List<PublicUnit>> {
-        val units = jdbi.handle { h -> h.getApplicationUnits(type, date, onlyApplicable = user.isEndUser()) }
+        val units = db.read { it.handle.getApplicationUnits(type, date, onlyApplicable = user.isEndUser()) }
         return ResponseEntity.ok(units)
     }
 
     // Units by areas, only including units that can be applied to
     @GetMapping("/enduser/areas")
-    fun getEnduserUnitsByArea(): ResponseEntity<Collection<CareAreaResponseJSON>> {
-        val areas = jdbi.handle { h ->
-            h.getAreas()
-                .map { area: CareArea ->
-                    CareArea(
-                        area.id,
-                        area.name,
-                        area.shortName,
-                        area.locations.filter {
-                            it.type.contains(CareType.CLUB) || it.canApplyDaycare || it.canApplyPreschool
-                        }
-                    )
-                }
-                .toSet()
-        }
+    fun getEnduserUnitsByArea(db: Database): ResponseEntity<Collection<CareAreaResponseJSON>> {
+        val areas = db.read { it.handle.getAreas() }
+            .map { area: CareArea ->
+                CareArea(
+                    area.id,
+                    area.name,
+                    area.shortName,
+                    area.locations.filter {
+                        it.type.contains(CareType.CLUB) || it.canApplyDaycare || it.canApplyPreschool
+                    }
+                )
+            }
+            .toSet()
 
         return ResponseEntity.ok(toCareAreaResponses(areas))
     }
 
     @GetMapping("/areas")
-    fun getAreas(user: AuthenticatedUser): ResponseEntity<Collection<AreaJSON>> {
-        return jdbi
-            .handle {
+    fun getAreas(db: Database, user: AuthenticatedUser): ResponseEntity<Collection<AreaJSON>> {
+        return db
+            .read {
                 it.createQuery("SELECT id, name, short_name FROM care_area")
                     .mapTo<AreaJSON>()
                     .toList()
@@ -74,9 +73,9 @@ class LocationController(val jdbi: Jdbi) {
     }
 
     @GetMapping("/filters/units")
-    fun getUnits(@RequestParam type: UnitTypeFilter, @RequestParam area: String?): ResponseEntity<List<UnitStub>> {
+    fun getUnits(db: Database, @RequestParam type: UnitTypeFilter, @RequestParam area: String?): ResponseEntity<List<UnitStub>> {
         val areas = area?.split(",") ?: listOf()
-        val units = jdbi.handle { h -> h.getUnits(areas, type) }
+        val units = db.read { it.handle.getUnits(areas, type) }
         return ResponseEntity.ok(units)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -16,7 +16,6 @@ import fi.espoo.evaka.daycare.getApplicationUnits
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.Coordinate
 import org.jdbi.v3.core.Handle

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -32,7 +32,7 @@ import java.util.UUID
 class LocationController {
     @GetMapping("/public/units")
     fun getApplicationUnits(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam type: ApplicationUnitType,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
@@ -43,7 +43,7 @@ class LocationController {
 
     // Units by areas, only including units that can be applied to
     @GetMapping("/enduser/areas")
-    fun getEnduserUnitsByArea(db: Database): ResponseEntity<Collection<CareAreaResponseJSON>> {
+    fun getEnduserUnitsByArea(db: Database.Connection): ResponseEntity<Collection<CareAreaResponseJSON>> {
         val areas = db.read { it.handle.getAreas() }
             .map { area: CareArea ->
                 CareArea(
@@ -61,7 +61,7 @@ class LocationController {
     }
 
     @GetMapping("/areas")
-    fun getAreas(db: Database, user: AuthenticatedUser): ResponseEntity<Collection<AreaJSON>> {
+    fun getAreas(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<Collection<AreaJSON>> {
         return db
             .read {
                 it.createQuery("SELECT id, name, short_name FROM care_area")
@@ -72,7 +72,7 @@ class LocationController {
     }
 
     @GetMapping("/filters/units")
-    fun getUnits(db: Database, @RequestParam type: UnitTypeFilter, @RequestParam area: String?): ResponseEntity<List<UnitStub>> {
+    fun getUnits(db: Database.Connection, @RequestParam type: UnitTypeFilter, @RequestParam area: String?): ResponseEntity<List<UnitStub>> {
         val areas = area?.split(",") ?: listOf()
         val units = db.read { it.handle.getUnits(areas, type) }
         return ResponseEntity.ok(units)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
@@ -35,7 +35,7 @@ class StaffAttendanceController(
 ) {
     @GetMapping("/{groupId}")
     fun getAttendancesByGroup(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam year: Int,
         @RequestParam month: Int,
@@ -50,7 +50,7 @@ class StaffAttendanceController(
 
     @PostMapping("/{groupId}")
     fun upsertStaffAttendance(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody staffAttendance: StaffAttendance,
         @PathVariable groupId: UUID

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.shared.auth.UserRole.ADMIN
 import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
 import fi.espoo.evaka.shared.auth.UserRole.STAFF
 import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -34,6 +35,7 @@ class StaffAttendanceController(
 ) {
     @GetMapping("/{groupId}")
     fun getAttendancesByGroup(
+        db: Database,
         user: AuthenticatedUser,
         @RequestParam year: Int,
         @RequestParam month: Int,
@@ -42,12 +44,13 @@ class StaffAttendanceController(
         Audit.StaffAttendanceRead.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
             .requireOneOfRoles(ADMIN, FINANCE_ADMIN, UNIT_SUPERVISOR, STAFF)
-        val result = staffAttendanceService.getAttendancesByMonth(year, month, groupId)
+        val result = staffAttendanceService.getAttendancesByMonth(db, year, month, groupId)
         return ResponseEntity.ok(Wrapper(result))
     }
 
     @PostMapping("/{groupId}")
     fun upsertStaffAttendance(
+        db: Database,
         user: AuthenticatedUser,
         @RequestBody staffAttendance: StaffAttendance,
         @PathVariable groupId: UUID
@@ -59,7 +62,7 @@ class StaffAttendanceController(
             throw BadRequest("Count can't be null")
         }
         staffAttendance.groupId = groupId
-        staffAttendanceService.upsertStaffAttendance(staffAttendance)
+        staffAttendanceService.upsertStaffAttendance(db, staffAttendance)
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 class UnitAclController(private val acl: AccessControlList) {
     @GetMapping("/daycares/{daycareId}/acl")
     fun getAcl(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable daycareId: UUID
     ): ResponseEntity<DaycareAclResponse> {
@@ -40,7 +40,7 @@ class UnitAclController(private val acl: AccessControlList) {
 
     @PutMapping("/daycares/{daycareId}/supervisors/{employeeId}")
     fun insertUnitSupervisor(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable daycareId: UUID,
         @PathVariable employeeId: UUID
@@ -54,7 +54,7 @@ class UnitAclController(private val acl: AccessControlList) {
 
     @DeleteMapping("/daycares/{daycareId}/supervisors/{employeeId}")
     fun deleteUnitSupervisor(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable daycareId: UUID,
         @PathVariable employeeId: UUID
@@ -69,7 +69,7 @@ class UnitAclController(private val acl: AccessControlList) {
 
     @PutMapping("/daycares/{daycareId}/staff/{employeeId}")
     fun insertStaff(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable daycareId: UUID,
         @PathVariable employeeId: UUID
@@ -83,7 +83,7 @@ class UnitAclController(private val acl: AccessControlList) {
 
     @DeleteMapping("/daycares/{daycareId}/staff/{employeeId}")
     fun deleteStaff(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable daycareId: UUID,
         @PathVariable employeeId: UUID

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
@@ -14,9 +14,9 @@ import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
 import fi.espoo.evaka.shared.auth.deleteDaycareAclRow
 import fi.espoo.evaka.shared.auth.getDaycareAclRows
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
-import org.jdbi.v3.core.Jdbi
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,21 +26,23 @@ import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 @RestController
-class UnitAclController(private val acl: AccessControlList, private val jdbi: Jdbi) {
+class UnitAclController(private val acl: AccessControlList) {
     @GetMapping("/daycares/{daycareId}/acl")
     fun getAcl(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable daycareId: UUID
     ): ResponseEntity<DaycareAclResponse> {
         Audit.UnitAclRead.log()
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR)
-        val acls = jdbi.handle { it.getDaycareAclRows(daycareId) }
+        val acls = db.read { it.handle.getDaycareAclRows(daycareId) }
         return ResponseEntity.ok(DaycareAclResponse(acls))
     }
 
     @PutMapping("/daycares/{daycareId}/supervisors/{employeeId}")
     fun insertUnitSupervisor(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable daycareId: UUID,
         @PathVariable employeeId: UUID
@@ -48,12 +50,13 @@ class UnitAclController(private val acl: AccessControlList, private val jdbi: Jd
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(ADMIN)
-        jdbi.transaction { it.insertDaycareAclRow(daycareId, employeeId, UNIT_SUPERVISOR) }
+        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, UNIT_SUPERVISOR) }
         return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/daycares/{daycareId}/supervisors/{employeeId}")
     fun deleteUnitSupervisor(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable daycareId: UUID,
         @PathVariable employeeId: UUID
@@ -62,12 +65,13 @@ class UnitAclController(private val acl: AccessControlList, private val jdbi: Jd
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(ADMIN)
 
-        jdbi.transaction { it.deleteDaycareAclRow(daycareId, employeeId, UNIT_SUPERVISOR) }
+        db.transaction { it.handle.deleteDaycareAclRow(daycareId, employeeId, UNIT_SUPERVISOR) }
         return ResponseEntity.noContent().build()
     }
 
     @PutMapping("/daycares/{daycareId}/staff/{employeeId}")
     fun insertStaff(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable daycareId: UUID,
         @PathVariable employeeId: UUID
@@ -75,12 +79,13 @@ class UnitAclController(private val acl: AccessControlList, private val jdbi: Jd
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR)
-        jdbi.transaction { it.insertDaycareAclRow(daycareId, employeeId, STAFF) }
+        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, STAFF) }
         return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/daycares/{daycareId}/staff/{employeeId}")
     fun deleteStaff(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable daycareId: UUID,
         @PathVariable employeeId: UUID
@@ -89,7 +94,7 @@ class UnitAclController(private val acl: AccessControlList, private val jdbi: Jd
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR)
 
-        jdbi.transaction { it.deleteDaycareAclRow(daycareId, employeeId, STAFF) }
+        db.transaction { it.handle.deleteDaycareAclRow(daycareId, employeeId, STAFF) }
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
@@ -15,8 +15,6 @@ import fi.espoo.evaka.shared.auth.deleteDaycareAclRow
 import fi.espoo.evaka.shared.auth.getDaycareAclRows
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -12,9 +12,9 @@ import fi.espoo.evaka.daycare.getUnitStats
 import fi.espoo.evaka.daycare.initCaretakers
 import fi.espoo.evaka.daycare.isValidDaycareId
 import fi.espoo.evaka.placement.getDaycareGroupPlacements
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.NotFound
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException
 import org.postgresql.util.PSQLException
 import org.postgresql.util.PSQLState
@@ -25,30 +25,30 @@ import java.util.UUID
 @Service
 class DaycareService {
     fun getDaycareCapacityStats(
-        h: Handle,
+        tx: Database.Read,
         daycareId: UUID,
         startDate: LocalDate,
         endDate: LocalDate
     ): DaycareCapacityStats {
-        val unitStats = h.getUnitStats(daycareId, startDate, endDate)
+        val unitStats = tx.handle.getUnitStats(daycareId, startDate, endDate)
         return DaycareCapacityStats(
             unitTotalCaretakers = unitStats,
-            groupCaretakers = h.getGroupStats(daycareId, startDate, endDate)
+            groupCaretakers = tx.handle.getGroupStats(daycareId, startDate, endDate)
         )
     }
 
     fun createGroup(
-        h: Handle,
+        tx: Database.Transaction,
         daycareId: UUID,
         name: String,
         startDate: LocalDate,
         initialCaretakers: Double
-    ): DaycareGroup = h.createDaycareGroup(daycareId, name, startDate).also {
-        h.initCaretakers(it.id, it.startDate, initialCaretakers)
+    ): DaycareGroup = tx.handle.createDaycareGroup(daycareId, name, startDate).also {
+        tx.handle.initCaretakers(it.id, it.startDate, initialCaretakers)
     }
 
-    fun deleteGroup(h: Handle, daycareId: UUID, groupId: UUID) = try {
-        val isEmpty = h.getDaycareGroupPlacements(
+    fun deleteGroup(tx: Database.Transaction, daycareId: UUID, groupId: UUID) = try {
+        val isEmpty = tx.handle.getDaycareGroupPlacements(
             daycareId = daycareId,
             groupId = groupId,
             startDate = null,
@@ -57,17 +57,17 @@ class DaycareService {
 
         if (!isEmpty) throw Conflict("Cannot delete group which has children placed in it")
 
-        h.deleteDaycareGroup(groupId)
+        tx.handle.deleteDaycareGroup(groupId)
     } catch (e: UnableToExecuteStatementException) {
         throw (e.cause as? PSQLException)?.takeIf { it.serverErrorMessage?.sqlState == PSQLState.FOREIGN_KEY_VIOLATION.state }
             ?.let { Conflict("Cannot delete group which is still referred to from other data") }
             ?: e
     }
 
-    fun getDaycareGroups(h: Handle, daycareId: UUID, startDate: LocalDate?, endDate: LocalDate?): List<DaycareGroup> {
-        if (!h.isValidDaycareId(daycareId)) throw NotFound("No daycare found with id $daycareId")
+    fun getDaycareGroups(tx: Database.Read, daycareId: UUID, startDate: LocalDate?, endDate: LocalDate?): List<DaycareGroup> {
+        if (!tx.handle.isValidDaycareId(daycareId)) throw NotFound("No daycare found with id $daycareId")
 
-        return h.getDaycareGroups(daycareId, startDate, endDate)
+        return tx.handle.getDaycareGroups(daycareId, startDate, endDate)
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceService.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 
 @Service
 class StaffAttendanceService {
-    fun getAttendancesByMonth(db: Database, year: Int, month: Int, groupId: UUID): StaffAttendanceGroup {
+    fun getAttendancesByMonth(db: Database.Connection, year: Int, month: Int, groupId: UUID): StaffAttendanceGroup {
         val rangeStart = LocalDate.of(year, month, 1)
         val rangeEnd = rangeStart.with(lastDayOfMonth())
 
@@ -30,7 +30,7 @@ class StaffAttendanceService {
         }
     }
 
-    fun upsertStaffAttendance(db: Database, staffAttendance: StaffAttendance) {
+    fun upsertStaffAttendance(db: Database.Connection, staffAttendance: StaffAttendance) {
         db.transaction { tx ->
             if (!tx.isValidStaffAttendanceDate(staffAttendance)) {
                 throw BadRequest("Error: Upserting staff count failed. Group is not operating in given date")

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceService.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.daycare.service
 import fi.espoo.evaka.daycare.dao.PGConstants.maxDate
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -21,10 +20,10 @@ class StaffAttendanceService {
         val rangeEnd = rangeStart.with(lastDayOfMonth())
 
         return db.read { tx ->
-            val groupInfo = getGroupInfo(groupId, tx.handle) ?: throw BadRequest("Couldn't find group info with id $groupId")
+            val groupInfo = tx.getGroupInfo(groupId) ?: throw BadRequest("Couldn't find group info with id $groupId")
             val endDate = groupInfo.endDate.let { if (it.isBefore(maxDate)) it else null }
 
-            val attendanceList = getStaffAttendanceByRange(rangeStart, rangeEnd, groupId, tx.handle)
+            val attendanceList = tx.getStaffAttendanceByRange(rangeStart, rangeEnd, groupId)
             val attendanceMap = composeAttendanceMap(rangeStart, rangeEnd, groupId, attendanceList)
 
             StaffAttendanceGroup(groupId, groupInfo.groupName, groupInfo.startDate, endDate, attendanceMap)
@@ -33,10 +32,10 @@ class StaffAttendanceService {
 
     fun upsertStaffAttendance(db: Database, staffAttendance: StaffAttendance) {
         db.transaction { tx ->
-            if (!isValidStaffAttendanceDate(staffAttendance, tx.handle)) {
+            if (!tx.isValidStaffAttendanceDate(staffAttendance)) {
                 throw BadRequest("Error: Upserting staff count failed. Group is not operating in given date")
             }
-            upsertStaffAttendance(staffAttendance, tx.handle)
+            tx.upsertStaffAttendance(staffAttendance)
         }
     }
 
@@ -77,7 +76,7 @@ data class GroupInfo(
     val endDate: LocalDate
 )
 
-fun getGroupInfo(groupId: UUID, h: Handle): GroupInfo? {
+fun Database.Read.getGroupInfo(groupId: UUID): GroupInfo? {
     //language=SQL
     val sql =
         """
@@ -86,13 +85,13 @@ fun getGroupInfo(groupId: UUID, h: Handle): GroupInfo? {
             WHERE id = :groupId;
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return createQuery(sql)
         .bind("groupId", groupId)
         .mapTo<GroupInfo>()
         .firstOrNull()
 }
 
-fun isValidStaffAttendanceDate(staffAttendance: StaffAttendance, h: Handle): Boolean {
+fun Database.Read.isValidStaffAttendanceDate(staffAttendance: StaffAttendance): Boolean {
     //language=SQL
     val sql =
         """
@@ -102,13 +101,13 @@ fun isValidStaffAttendanceDate(staffAttendance: StaffAttendance, h: Handle): Boo
             AND :date BETWEEN start_date AND end_date
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return createQuery(sql)
         .bind("id", staffAttendance.groupId)
         .bind("date", staffAttendance.date)
         .mapToMap().list().size > 0
 }
 
-fun upsertStaffAttendance(staffAttendance: StaffAttendance, h: Handle) {
+fun Database.Transaction.upsertStaffAttendance(staffAttendance: StaffAttendance) {
     //language=SQL
     val sql =
         """
@@ -117,14 +116,14 @@ fun upsertStaffAttendance(staffAttendance: StaffAttendance, h: Handle) {
         ON CONFLICT (group_id, date) DO UPDATE SET count = :count
         """.trimIndent()
 
-    h.createUpdate(sql)
+    createUpdate(sql)
         .bind("groupId", staffAttendance.groupId)
         .bind("date", staffAttendance.date)
         .bind("count", staffAttendance.count)
         .execute()
 }
 
-fun getStaffAttendanceByRange(rangeStart: LocalDate, rangeEnd: LocalDate, groupId: UUID, h: Handle): List<StaffAttendance> {
+fun Database.Read.getStaffAttendanceByRange(rangeStart: LocalDate, rangeEnd: LocalDate, groupId: UUID): List<StaffAttendance> {
     //language=SQL
     val sql =
         """
@@ -134,7 +133,7 @@ fun getStaffAttendanceByRange(rangeStart: LocalDate, rangeEnd: LocalDate, groupI
             AND date BETWEEN :rangeStart AND :rangeEnd;
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return createQuery(sql)
         .bind("groupId", groupId)
         .bind("rangeStart", rangeStart)
         .bind("rangeEnd", rangeEnd)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceService.kt
@@ -6,7 +6,6 @@ package fi.espoo.evaka.daycare.service
 
 import fi.espoo.evaka.daycare.dao.PGConstants.maxDate
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
@@ -36,7 +36,7 @@ class DecisionController(
 ) {
     @GetMapping("/by-guardian")
     fun getDecisionsByGuardian(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam("id") guardianId: UUID
     ): ResponseEntity<DecisionListResponse> {
@@ -49,7 +49,7 @@ class DecisionController(
 
     @GetMapping("/by-child")
     fun getDecisionsByChild(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam("id") childId: UUID
     ): ResponseEntity<DecisionListResponse> {
@@ -62,7 +62,7 @@ class DecisionController(
 
     @GetMapping("/by-application")
     fun getDecisionsByApplication(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam("id") applicationId: UUID
     ): ResponseEntity<DecisionListResponse> {
@@ -74,7 +74,7 @@ class DecisionController(
     }
 
     @GetMapping("/units")
-    fun getDecisionUnits(db: Database, user: AuthenticatedUser): ResponseEntity<List<DecisionUnit>> {
+    fun getDecisionUnits(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<DecisionUnit>> {
         Audit.UnitRead.log()
         user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.FINANCE_ADMIN)
         val units = db.read { decisionDraftService.getDecisionUnits(it) }
@@ -83,7 +83,7 @@ class DecisionController(
 
     @GetMapping("/{id}/download", produces = [MediaType.APPLICATION_PDF_VALUE])
     fun downloadDecisionPdf(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("id") decisionId: UUID
     ): ResponseEntity<ByteArray> {

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
@@ -16,8 +16,6 @@ import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
 import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Forbidden
 import org.jdbi.v3.core.Handle
 import org.springframework.http.MediaType

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -49,9 +49,9 @@ class DecisionService(
     private val evakaMessageClient: IEvakaMessageClient,
     private val asyncJobRunner: AsyncJobRunner
 ) {
-    fun finalizeDecisions(h: Handle, user: AuthenticatedUser, applicationId: UUID, sendAsMessage: Boolean): List<UUID> {
-        val decisionIds = finalizeDecisions(h, applicationId)
-        asyncJobRunner.plan(h, decisionIds.map { NotifyDecisionCreated(it, user, sendAsMessage) })
+    fun finalizeDecisions(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID, sendAsMessage: Boolean): List<UUID> {
+        val decisionIds = finalizeDecisions(tx.handle, applicationId)
+        asyncJobRunner.plan(tx, decisionIds.map { NotifyDecisionCreated(it, user, sendAsMessage) })
         return decisionIds
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/EnduserDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/EnduserDecisionController.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 @RestController
 class EnduserDecisionController {
     @GetMapping("/enduser/decisions")
-    fun getDecisions(db: Database, user: AuthenticatedUser): ResponseEntity<EnduserDecisionsResponse> {
+    fun getDecisions(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<EnduserDecisionsResponse> {
         Audit.DecisionRead.log(targetId = user.id)
         user.requireOneOfRoles(Roles.END_USER)
         val decisions = db.read { getDecisionsByGuardian(it.handle, user.id, AclAuthorization.All) }

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/EnduserDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/EnduserDecisionController.kt
@@ -8,8 +8,8 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
-import org.jdbi.v3.core.Jdbi
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
@@ -17,12 +17,12 @@ import java.time.LocalDate
 import java.util.UUID
 
 @RestController
-class EnduserDecisionController(private val jdbi: Jdbi) {
+class EnduserDecisionController {
     @GetMapping("/enduser/decisions")
-    fun getDecisions(user: AuthenticatedUser): ResponseEntity<EnduserDecisionsResponse> {
+    fun getDecisions(db: Database, user: AuthenticatedUser): ResponseEntity<EnduserDecisionsResponse> {
         Audit.DecisionRead.log(targetId = user.id)
         user.requireOneOfRoles(Roles.END_USER)
-        val decisions = jdbi.handle { getDecisionsByGuardian(it, user.id, AclAuthorization.All) }
+        val decisions = db.read { getDecisionsByGuardian(it.handle, user.id, AclAuthorization.All) }
             .map {
                 val unit = when (it.type) {
                     DecisionType.CLUB -> it.unit.name

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/EnduserDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/EnduserDecisionController.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.AsyncJobType
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Service

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -11,8 +11,6 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.transaction
 import mu.KotlinLogging
-import org.jdbi.v3.core.Handle
-import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Service
 import java.time.Instant
@@ -23,7 +21,6 @@ private val logger = KotlinLogging.logger {}
 @Service
 class DvvModificationsBatchRefreshService(
     private val asyncJobRunner: AsyncJobRunner,
-    private val jdbi: Jdbi,
     private val dvvModificationsService: DvvModificationsService
 ) {
     init {
@@ -36,14 +33,14 @@ class DvvModificationsBatchRefreshService(
         logger.info("DvvModificationsRefresh: finished processing $modificationCount DVV person modifications for ${msg.ssns.size} ssns")
     }
 
-    fun scheduleBatch(): Int {
-        val jobCount = jdbi.transaction { h ->
-            deleteOldJobs(h)
+    fun scheduleBatch(db: Database): Int {
+        val jobCount = db.transaction { tx ->
+            tx.deleteOldJobs()
 
-            val ssns = getPersonSsnsToUpdate(h)
+            val ssns = tx.getPersonSsnsToUpdate()
 
             asyncJobRunner.plan(
-                h,
+                tx,
                 payloads = listOf(
                     DvvModificationsRefresh(
                         ssns = ssns,
@@ -61,25 +58,22 @@ class DvvModificationsBatchRefreshService(
 
         return jobCount
     }
+}
 
-    private fun deleteOldJobs(h: Handle) {
-        h.createUpdate("DELETE FROM async_job WHERE type = 'DVV_MODIFICATIONS_REFRESH' AND (claimed_by IS NULL OR completed_at IS NOT NULL)")
-            .execute()
-    }
+private fun Database.Transaction.deleteOldJobs() =
+    createUpdate("DELETE FROM async_job WHERE type = 'DVV_MODIFICATIONS_REFRESH' AND (claimed_by IS NULL OR completed_at IS NOT NULL)")
+        .execute()
 
-    fun getPersonSsnsToUpdate(h: Handle): List<String> {
-        //language=sql
-        return h.createQuery(
-            """
+private fun Database.Read.getPersonSsnsToUpdate(): List<String> = createQuery(
+    //language=sql
+    """
 SELECT DISTINCT(social_security_number) from PERSON p JOIN (
 SELECT head_of_child FROM fridge_child
 WHERE daterange(start_date, end_date, '[]') @> current_date AND conflict = false) hoc ON p.id = hoc.head_of_child
-            """.trimIndent()
-        )
-            .mapTo<String>()
-            .toList()
-    }
-}
+    """.trimIndent()
+)
+    .mapTo<String>()
+    .toList()
 
 data class DvvModificationsRefresh(val ssns: List<String>, val requestingUserId: UUID) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.DVV_MODIFICATIONS_REFRESH

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -32,7 +32,7 @@ class DvvModificationsBatchRefreshService(
         logger.info("DvvModificationsRefresh: finished processing $modificationCount DVV person modifications for ${msg.ssns.size} ssns")
     }
 
-    fun scheduleBatch(db: Database): Int {
+    fun scheduleBatch(db: Database.Connection): Int {
         val jobCount = db.transaction { tx ->
             tx.deleteOldJobs()
 

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
@@ -13,8 +13,6 @@ import fi.espoo.evaka.pis.updatePersonFromVtj
 import fi.espoo.evaka.shared.async.VTJRefresh
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import java.time.LocalDate

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
@@ -34,7 +34,7 @@ import java.util.UUID
 @RequestMapping("/fee-alterations")
 class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner) {
     @GetMapping
-    fun getFeeAlterations(db: Database, user: AuthenticatedUser, @RequestParam personId: String?): ResponseEntity<Wrapper<List<FeeAlteration>>> {
+    fun getFeeAlterations(db: Database.Connection, user: AuthenticatedUser, @RequestParam personId: String?): ResponseEntity<Wrapper<List<FeeAlteration>>> {
         Audit.ChildFeeAlterationsRead.log(targetId = personId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val parsedId = personId?.let { parseUUID(personId) }
@@ -45,7 +45,7 @@ class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner) {
     }
 
     @PostMapping
-    fun createFeeAlteration(db: Database, user: AuthenticatedUser, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
+    fun createFeeAlteration(db: Database.Connection, user: AuthenticatedUser, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
         Audit.ChildFeeAlterationsCreate.log(targetId = feeAlteration.personId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         db.transaction { tx ->
@@ -67,7 +67,7 @@ class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner) {
     }
 
     @PutMapping("/{feeAlterationId}")
-    fun updateFeeAlteration(db: Database, user: AuthenticatedUser, @PathVariable feeAlterationId: String, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
+    fun updateFeeAlteration(db: Database.Connection, user: AuthenticatedUser, @PathVariable feeAlterationId: String, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
         Audit.ChildFeeAlterationsUpdate.log(targetId = feeAlterationId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val parsedId = parseUUID(feeAlterationId)
@@ -90,7 +90,7 @@ class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner) {
     }
 
     @DeleteMapping("/{feeAlterationId}")
-    fun deleteFeeAlteration(db: Database, user: AuthenticatedUser, @PathVariable feeAlterationId: String): ResponseEntity<Unit> {
+    fun deleteFeeAlteration(db: Database.Connection, user: AuthenticatedUser, @PathVariable feeAlterationId: String): ResponseEntity<Unit> {
         Audit.ChildFeeAlterationsDelete.log(targetId = feeAlterationId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val parsedId = parseUUID(feeAlterationId)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
@@ -15,8 +15,6 @@ import fi.espoo.evaka.shared.async.NotifyFeeAlterationUpdated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Period
 import fi.espoo.evaka.shared.domain.maxEndDate

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
@@ -14,12 +14,12 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyFeeAlterationUpdated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Period
 import fi.espoo.evaka.shared.domain.maxEndDate
-import org.jdbi.v3.core.Jdbi
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -34,29 +34,26 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/fee-alterations")
-class FeeAlterationController(
-    private val jdbi: Jdbi,
-    private val asyncJobRunner: AsyncJobRunner
-) {
+class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner) {
     @GetMapping
-    fun getFeeAlterations(user: AuthenticatedUser, @RequestParam personId: String?): ResponseEntity<Wrapper<List<FeeAlteration>>> {
+    fun getFeeAlterations(db: Database, user: AuthenticatedUser, @RequestParam personId: String?): ResponseEntity<Wrapper<List<FeeAlteration>>> {
         Audit.ChildFeeAlterationsRead.log(targetId = personId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val parsedId = personId?.let { parseUUID(personId) }
             ?: throw BadRequest("Query parameter personId is mandatory")
 
-        val feeAlterations = jdbi.handle { h -> getFeeAlterationsForPerson(h, parsedId) }
+        val feeAlterations = db.read { getFeeAlterationsForPerson(it.handle, parsedId) }
         return ResponseEntity.ok(Wrapper(feeAlterations))
     }
 
     @PostMapping
-    fun createFeeAlteration(user: AuthenticatedUser, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
+    fun createFeeAlteration(db: Database, user: AuthenticatedUser, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
         Audit.ChildFeeAlterationsCreate.log(targetId = feeAlteration.personId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        jdbi.transaction { h ->
-            upsertFeeAlteration(h, feeAlteration.copy(id = UUID.randomUUID(), updatedBy = user.id))
+        db.transaction { tx ->
+            upsertFeeAlteration(tx.handle, feeAlteration.copy(id = UUID.randomUUID(), updatedBy = user.id))
             asyncJobRunner.plan(
-                h,
+                tx,
                 listOf(
                     NotifyFeeAlterationUpdated(
                         feeAlteration.personId,
@@ -72,20 +69,20 @@ class FeeAlterationController(
     }
 
     @PutMapping("/{feeAlterationId}")
-    fun updateFeeAlteration(user: AuthenticatedUser, @PathVariable feeAlterationId: String, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
+    fun updateFeeAlteration(db: Database, user: AuthenticatedUser, @PathVariable feeAlterationId: String, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
         Audit.ChildFeeAlterationsUpdate.log(targetId = feeAlterationId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val parsedId = parseUUID(feeAlterationId)
-        jdbi.transaction { h ->
-            val existing = getFeeAlteration(h, parsedId)
-            upsertFeeAlteration(h, feeAlteration.copy(id = parsedId, updatedBy = user.id))
+        db.transaction { tx ->
+            val existing = getFeeAlteration(tx.handle, parsedId)
+            upsertFeeAlteration(tx.handle, feeAlteration.copy(id = parsedId, updatedBy = user.id))
 
             val expandedPeriod = existing?.let {
                 Period(minOf(it.validFrom, feeAlteration.validFrom), maxEndDate(it.validTo, feeAlteration.validTo))
             } ?: Period(feeAlteration.validFrom, feeAlteration.validTo)
 
             asyncJobRunner.plan(
-                h,
+                tx,
                 listOf(NotifyFeeAlterationUpdated(feeAlteration.personId, expandedPeriod.start, expandedPeriod.end))
             )
         }
@@ -95,17 +92,17 @@ class FeeAlterationController(
     }
 
     @DeleteMapping("/{feeAlterationId}")
-    fun deleteFeeAlteration(user: AuthenticatedUser, @PathVariable feeAlterationId: String): ResponseEntity<Unit> {
+    fun deleteFeeAlteration(db: Database, user: AuthenticatedUser, @PathVariable feeAlterationId: String): ResponseEntity<Unit> {
         Audit.ChildFeeAlterationsDelete.log(targetId = feeAlterationId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val parsedId = parseUUID(feeAlterationId)
-        jdbi.transaction { h ->
-            val existing = getFeeAlteration(h, parsedId)
-            deleteFeeAlteration(h, parsedId)
+        db.transaction { tx ->
+            val existing = getFeeAlteration(tx.handle, parsedId)
+            deleteFeeAlteration(tx.handle, parsedId)
 
             existing?.let {
                 asyncJobRunner.plan(
-                    h,
+                    tx,
                     listOf(NotifyFeeAlterationUpdated(existing.personId, existing.validFrom, existing.validTo))
                 )
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -124,7 +124,7 @@ class FeeDecisionController(
         Audit.FeeDecisionConfirm.log(targetId = feeDecisionIds)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         db.transaction { tx ->
-            val confirmedDecisions = service.confirmDrafts(tx.handle, user, feeDecisionIds)
+            val confirmedDecisions = service.confirmDrafts(tx, user, feeDecisionIds)
             asyncJobRunner.plan(tx, confirmedDecisions.map { NotifyFeeDecisionApproved(it) })
         }
         asyncJobRunner.scheduleImmediateRun()
@@ -135,7 +135,7 @@ class FeeDecisionController(
     fun setSent(db: Database, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
         Audit.FeeDecisionMarkSent.log(targetId = feeDecisionIds)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        db.transaction { service.setSent(it.handle, feeDecisionIds) }
+        db.transaction { service.setSent(it, feeDecisionIds) }
         return ResponseEntity.noContent().build()
     }
 
@@ -144,7 +144,7 @@ class FeeDecisionController(
         Audit.FeeDecisionPdfRead.log(targetId = uuid)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val headers = HttpHeaders()
-        val (filename, pdf) = db.read { service.getFeeDecisionPdf(it.handle, uuid) }
+        val (filename, pdf) = db.read { service.getFeeDecisionPdf(it, uuid) }
         headers.add("Content-Disposition", "attachment; filename=\"$filename\"")
         headers.add("Content-Type", "application/pdf")
         return ResponseEntity(pdf, headers, HttpStatus.OK)
@@ -201,7 +201,7 @@ class FeeDecisionController(
     ): ResponseEntity<Unit> {
         Audit.FeeDecisionSetType.log(targetId = uuid)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        db.transaction { service.setType(it.handle, uuid, request.type) }
+        db.transaction { service.setType(it, uuid, request.type) }
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -20,12 +20,12 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyFeeDecisionApproved
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.utils.parseEnum
-import org.jdbi.v3.core.Jdbi
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -70,7 +70,6 @@ data class FeeDecisionSearchResult(
 @RestController
 @RequestMapping(path = ["/fee-decisions", "/decisions"])
 class FeeDecisionController(
-    private val jdbi: Jdbi,
     private val objectMapper: ObjectMapper,
     private val service: FeeDecisionService,
     private val generator: DecisionGenerator,
@@ -78,6 +77,7 @@ class FeeDecisionController(
 ) {
     @GetMapping("/search")
     fun search(
+        db: Database,
         user: AuthenticatedUser,
         @RequestParam(required = true) page: Int,
         @RequestParam(required = true) pageSize: Int,
@@ -98,9 +98,9 @@ class FeeDecisionController(
         if (pageSize > maxPageSize) throw BadRequest("Maximum page size is $maxPageSize")
         if (startDate != null && endDate != null && endDate < startDate)
             throw BadRequest("End date cannot be before start date")
-        val (total, feeDecisions) = jdbi.handle { h ->
+        val (total, feeDecisions) = db.read { tx ->
             searchFeeDecisions(
-                h,
+                tx.handle,
                 page,
                 pageSize,
                 sortBy ?: FeeDecisionSortParam.STATUS,
@@ -122,55 +122,56 @@ class FeeDecisionController(
     }
 
     @PostMapping("/confirm")
-    fun confirmDrafts(user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
+    fun confirmDrafts(db: Database, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
         Audit.FeeDecisionConfirm.log(targetId = feeDecisionIds)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        jdbi.transaction { h ->
-            val confirmedDecisions = service.confirmDrafts(h, user, feeDecisionIds)
-            asyncJobRunner.plan(h, confirmedDecisions.map { NotifyFeeDecisionApproved(it) })
+        db.transaction { tx ->
+            val confirmedDecisions = service.confirmDrafts(tx.handle, user, feeDecisionIds)
+            asyncJobRunner.plan(tx, confirmedDecisions.map { NotifyFeeDecisionApproved(it) })
         }
         asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/mark-sent")
-    fun setSent(user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
+    fun setSent(db: Database, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
         Audit.FeeDecisionMarkSent.log(targetId = feeDecisionIds)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        jdbi.transaction { h -> service.setSent(h, feeDecisionIds) }
+        db.transaction { service.setSent(it.handle, feeDecisionIds) }
         return ResponseEntity.noContent().build()
     }
 
     @GetMapping("/pdf/{uuid}")
-    fun getDecisionPdf(user: AuthenticatedUser, @PathVariable uuid: UUID): ResponseEntity<ByteArray> {
+    fun getDecisionPdf(db: Database, user: AuthenticatedUser, @PathVariable uuid: UUID): ResponseEntity<ByteArray> {
         Audit.FeeDecisionPdfRead.log(targetId = uuid)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val headers = HttpHeaders()
-        val (filename, pdf) = jdbi.handle { h -> service.getFeeDecisionPdf(h, uuid) }
+        val (filename, pdf) = db.read { service.getFeeDecisionPdf(it.handle, uuid) }
         headers.add("Content-Disposition", "attachment; filename=\"$filename\"")
         headers.add("Content-Type", "application/pdf")
         return ResponseEntity(pdf, headers, HttpStatus.OK)
     }
 
     @GetMapping("/{uuid}")
-    fun getDecision(user: AuthenticatedUser, @PathVariable uuid: UUID): ResponseEntity<Wrapper<FeeDecisionDetailed>> {
+    fun getDecision(db: Database, user: AuthenticatedUser, @PathVariable uuid: UUID): ResponseEntity<Wrapper<FeeDecisionDetailed>> {
         Audit.FeeDecisionRead.log(targetId = uuid)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        val res = jdbi.handle { h -> getFeeDecision(h, objectMapper, uuid) }
+        val res = db.read { getFeeDecision(it.handle, objectMapper, uuid) }
             ?: throw NotFound("No fee decision found with given ID ($uuid)")
         return ResponseEntity.ok(Wrapper(res))
     }
 
     @GetMapping("/head-of-family/{uuid}")
     fun getHeadOfFamilyFeeDecisions(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable uuid: UUID
     ): ResponseEntity<Wrapper<List<FeeDecision>>> {
         Audit.FeeDecisionHeadOfFamilyRead.log(targetId = uuid)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        val res = jdbi.handle { h ->
+        val res = db.read {
             findFeeDecisionsForHeadOfFamily(
-                h,
+                it.handle,
                 objectMapper,
                 uuid,
                 null,
@@ -182,25 +183,27 @@ class FeeDecisionController(
 
     @PostMapping("/head-of-family/{id}/create-retroactive")
     fun generateRetroactiveDecisions(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable id: UUID,
         @RequestBody body: CreateRetroactiveFeeDecisionsBody
     ): ResponseEntity<Unit> {
         Audit.FeeDecisionHeadOfFamilyCreateRetroactive.log(targetId = id)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        jdbi.transaction { h -> generator.createRetroactive(h, id, body.from) }
+        db.transaction { generator.createRetroactive(it.handle, id, body.from) }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/set-type/{uuid}")
     fun setType(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable uuid: UUID,
         @RequestBody request: FeeDecisionTypeRequest
     ): ResponseEntity<Unit> {
         Audit.FeeDecisionSetType.log(targetId = uuid)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        jdbi.transaction { h -> service.setType(h, uuid, request.type) }
+        db.transaction { service.setType(it.handle, uuid, request.type) }
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -75,7 +75,7 @@ class FeeDecisionController(
 ) {
     @GetMapping("/search")
     fun search(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam(required = true) page: Int,
         @RequestParam(required = true) pageSize: Int,
@@ -120,7 +120,7 @@ class FeeDecisionController(
     }
 
     @PostMapping("/confirm")
-    fun confirmDrafts(db: Database, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
+    fun confirmDrafts(db: Database.Connection, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
         Audit.FeeDecisionConfirm.log(targetId = feeDecisionIds)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         db.transaction { tx ->
@@ -132,7 +132,7 @@ class FeeDecisionController(
     }
 
     @PostMapping("/mark-sent")
-    fun setSent(db: Database, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
+    fun setSent(db: Database.Connection, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
         Audit.FeeDecisionMarkSent.log(targetId = feeDecisionIds)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         db.transaction { service.setSent(it, feeDecisionIds) }
@@ -140,7 +140,7 @@ class FeeDecisionController(
     }
 
     @GetMapping("/pdf/{uuid}")
-    fun getDecisionPdf(db: Database, user: AuthenticatedUser, @PathVariable uuid: UUID): ResponseEntity<ByteArray> {
+    fun getDecisionPdf(db: Database.Connection, user: AuthenticatedUser, @PathVariable uuid: UUID): ResponseEntity<ByteArray> {
         Audit.FeeDecisionPdfRead.log(targetId = uuid)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val headers = HttpHeaders()
@@ -151,7 +151,7 @@ class FeeDecisionController(
     }
 
     @GetMapping("/{uuid}")
-    fun getDecision(db: Database, user: AuthenticatedUser, @PathVariable uuid: UUID): ResponseEntity<Wrapper<FeeDecisionDetailed>> {
+    fun getDecision(db: Database.Connection, user: AuthenticatedUser, @PathVariable uuid: UUID): ResponseEntity<Wrapper<FeeDecisionDetailed>> {
         Audit.FeeDecisionRead.log(targetId = uuid)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val res = db.read { getFeeDecision(it.handle, objectMapper, uuid) }
@@ -161,7 +161,7 @@ class FeeDecisionController(
 
     @GetMapping("/head-of-family/{uuid}")
     fun getHeadOfFamilyFeeDecisions(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable uuid: UUID
     ): ResponseEntity<Wrapper<List<FeeDecision>>> {
@@ -181,7 +181,7 @@ class FeeDecisionController(
 
     @PostMapping("/head-of-family/{id}/create-retroactive")
     fun generateRetroactiveDecisions(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable id: UUID,
         @RequestBody body: CreateRetroactiveFeeDecisionsBody
@@ -194,7 +194,7 @@ class FeeDecisionController(
 
     @PostMapping("/set-type/{uuid}")
     fun setType(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable uuid: UUID,
         @RequestBody request: FeeDecisionTypeRequest

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -21,8 +21,6 @@ import fi.espoo.evaka.shared.async.NotifyFeeDecisionApproved
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.utils.parseEnum

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
@@ -29,7 +29,7 @@ data class GenerateDecisionsBody(
 @RequestMapping("/fee-decision-generator")
 class FeeDecisionGeneratorController(private val asyncJobRunner: AsyncJobRunner) {
     @PostMapping("/generate")
-    fun generateDecisions(db: Database, user: AuthenticatedUser, @RequestBody data: GenerateDecisionsBody): ResponseEntity<Unit> {
+    fun generateDecisions(db: Database.Connection, user: AuthenticatedUser, @RequestBody data: GenerateDecisionsBody): ResponseEntity<Unit> {
         Audit.FeeDecisionGenerate.log(targetId = data.targetHeads)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         generateAllStartingFrom(
@@ -40,7 +40,7 @@ class FeeDecisionGeneratorController(private val asyncJobRunner: AsyncJobRunner)
         return ResponseEntity.noContent().build()
     }
 
-    private fun generateAllStartingFrom(db: Database, starting: LocalDate, targetHeads: List<UUID>) {
+    private fun generateAllStartingFrom(db: Database.Connection, starting: LocalDate, targetHeads: List<UUID>) {
         db.transaction { tx ->
             val heads = if (targetHeads.isEmpty()) {
                 tx.createQuery("SELECT head_of_child FROM fridge_child WHERE COALESCE(end_date, '9999-01-01') >= :from AND conflict = false")

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
@@ -9,8 +9,8 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyFamilyUpdated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.transaction
-import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -28,25 +28,23 @@ data class GenerateDecisionsBody(
 
 @RestController
 @RequestMapping("/fee-decision-generator")
-class FeeDecisionGeneratorController(
-    private val asyncJobRunner: AsyncJobRunner,
-    private val jdbi: Jdbi
-) {
+class FeeDecisionGeneratorController(private val asyncJobRunner: AsyncJobRunner) {
     @PostMapping("/generate")
-    fun generateDecisions(user: AuthenticatedUser, @RequestBody data: GenerateDecisionsBody): ResponseEntity<Unit> {
+    fun generateDecisions(db: Database, user: AuthenticatedUser, @RequestBody data: GenerateDecisionsBody): ResponseEntity<Unit> {
         Audit.FeeDecisionGenerate.log(targetId = data.targetHeads)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         generateAllStartingFrom(
+            db,
             LocalDate.parse(data.starting, DateTimeFormatter.ISO_DATE),
             data.targetHeads.filterNotNull().distinct()
         )
         return ResponseEntity.noContent().build()
     }
 
-    private fun generateAllStartingFrom(starting: LocalDate, targetHeads: List<UUID>) {
-        jdbi.transaction { h ->
+    private fun generateAllStartingFrom(db: Database, starting: LocalDate, targetHeads: List<UUID>) {
+        db.transaction { tx ->
             val heads = if (targetHeads.isEmpty()) {
-                h.createQuery("SELECT head_of_child FROM fridge_child WHERE COALESCE(end_date, '9999-01-01') >= :from AND conflict = false")
+                tx.createQuery("SELECT head_of_child FROM fridge_child WHERE COALESCE(end_date, '9999-01-01') >= :from AND conflict = false")
                     .bind("from", starting)
                     .mapTo<UUID>()
                     .list()
@@ -56,7 +54,7 @@ class FeeDecisionGeneratorController(
                 NotifyFamilyUpdated(headId, starting, null)
             }
 
-            asyncJobRunner.plan(h, jobs)
+            asyncJobRunner.plan(tx, jobs)
         }
         asyncJobRunner.scheduleImmediateRun()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.shared.async.NotifyFamilyUpdated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -19,12 +19,12 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyIncomeUpdated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Period
 import fi.espoo.evaka.shared.domain.maxEndDate
-import org.jdbi.v3.core.Jdbi
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -40,23 +40,22 @@ import java.util.UUID
 @RestController
 @RequestMapping("/incomes")
 class IncomeController(
-    private val jdbi: Jdbi,
     private val mapper: ObjectMapper,
     private val asyncJobRunner: AsyncJobRunner
 ) {
     @GetMapping
-    fun getIncome(user: AuthenticatedUser, @RequestParam personId: String?): ResponseEntity<Wrapper<List<Income>>> {
+    fun getIncome(db: Database, user: AuthenticatedUser, @RequestParam personId: String?): ResponseEntity<Wrapper<List<Income>>> {
         Audit.PersonIncomeRead.log(targetId = personId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val parsedId = personId?.let { parseUUID(personId) }
             ?: throw BadRequest("Query parameter personId is mandatory")
 
-        val incomes = jdbi.handle { h -> getIncomesForPerson(h, mapper, parsedId) }
+        val incomes = db.read { getIncomesForPerson(it.handle, mapper, parsedId) }
         return ResponseEntity.ok(Wrapper(incomes))
     }
 
     @PostMapping
-    fun createIncome(user: AuthenticatedUser, @RequestBody income: Income): ResponseEntity<UUID> {
+    fun createIncome(db: Database, user: AuthenticatedUser, @RequestBody income: Income): ResponseEntity<UUID> {
         Audit.PersonIncomeCreate.log(targetId = income.personId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val period = try {
@@ -67,12 +66,12 @@ class IncomeController(
             }
         }
 
-        val id = jdbi.transaction { h ->
+        val id = db.transaction { tx ->
             val id = UUID.randomUUID()
             val validIncome = income.copy(id = id).let(::validateIncome)
-            splitEarlierIncome(h, validIncome.personId, period)
-            upsertIncome(h, mapper, validIncome, user.id)
-            asyncJobRunner.plan(h, listOf(NotifyIncomeUpdated(validIncome.personId, period.start, period.end)))
+            splitEarlierIncome(tx.handle, validIncome.personId, period)
+            upsertIncome(tx.handle, mapper, validIncome, user.id)
+            asyncJobRunner.plan(tx, listOf(NotifyIncomeUpdated(validIncome.personId, period.start, period.end)))
             id
         }
 
@@ -82,6 +81,7 @@ class IncomeController(
 
     @PutMapping("/{incomeId}")
     fun updateIncome(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable incomeId: String,
         @RequestBody income: Income
@@ -89,17 +89,17 @@ class IncomeController(
         Audit.PersonIncomeUpdate.log(targetId = incomeId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
 
-        jdbi.transaction { h ->
-            val existing = getIncome(h, mapper, parseUUID(incomeId))
+        db.transaction { tx ->
+            val existing = getIncome(tx.handle, mapper, parseUUID(incomeId))
             val validIncome = income.copy(id = parseUUID(incomeId)).let(::validateIncome)
-            upsertIncome(h, mapper, validIncome, user.id)
+            upsertIncome(tx.handle, mapper, validIncome, user.id)
 
             val expandedPeriod = existing?.let {
                 Period(minOf(it.validFrom, income.validFrom), maxEndDate(it.validTo, income.validTo))
             } ?: Period(income.validFrom, income.validTo)
 
             asyncJobRunner.plan(
-                h,
+                tx,
                 listOf(NotifyIncomeUpdated(validIncome.personId, expandedPeriod.start, expandedPeriod.end))
             )
         }
@@ -109,18 +109,18 @@ class IncomeController(
     }
 
     @DeleteMapping("/{incomeId}")
-    fun deleteIncome(user: AuthenticatedUser, @PathVariable incomeId: String): ResponseEntity<Unit> {
+    fun deleteIncome(db: Database, user: AuthenticatedUser, @PathVariable incomeId: String): ResponseEntity<Unit> {
         Audit.PersonIncomeDelete.log(targetId = incomeId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
 
-        jdbi.transaction { h ->
-            val existing = getIncome(h, mapper, parseUUID(incomeId))
+        db.transaction { tx ->
+            val existing = getIncome(tx.handle, mapper, parseUUID(incomeId))
                 ?: throw BadRequest("Income not found")
             val period = Period(existing.validFrom, existing.validTo)
 
-            deleteIncome(h, parseUUID(incomeId))
+            deleteIncome(tx.handle, parseUUID(incomeId))
 
-            asyncJobRunner.plan(h, listOf(NotifyIncomeUpdated(existing.personId, period.start, period.end)))
+            asyncJobRunner.plan(tx, listOf(NotifyIncomeUpdated(existing.personId, period.start, period.end)))
         }
 
         asyncJobRunner.scheduleImmediateRun()

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -42,7 +42,7 @@ class IncomeController(
     private val asyncJobRunner: AsyncJobRunner
 ) {
     @GetMapping
-    fun getIncome(db: Database, user: AuthenticatedUser, @RequestParam personId: String?): ResponseEntity<Wrapper<List<Income>>> {
+    fun getIncome(db: Database.Connection, user: AuthenticatedUser, @RequestParam personId: String?): ResponseEntity<Wrapper<List<Income>>> {
         Audit.PersonIncomeRead.log(targetId = personId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val parsedId = personId?.let { parseUUID(personId) }
@@ -53,7 +53,7 @@ class IncomeController(
     }
 
     @PostMapping
-    fun createIncome(db: Database, user: AuthenticatedUser, @RequestBody income: Income): ResponseEntity<UUID> {
+    fun createIncome(db: Database.Connection, user: AuthenticatedUser, @RequestBody income: Income): ResponseEntity<UUID> {
         Audit.PersonIncomeCreate.log(targetId = income.personId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val period = try {
@@ -79,7 +79,7 @@ class IncomeController(
 
     @PutMapping("/{incomeId}")
     fun updateIncome(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable incomeId: String,
         @RequestBody income: Income
@@ -107,7 +107,7 @@ class IncomeController(
     }
 
     @DeleteMapping("/{incomeId}")
-    fun deleteIncome(db: Database, user: AuthenticatedUser, @PathVariable incomeId: String): ResponseEntity<Unit> {
+    fun deleteIncome(db: Database.Connection, user: AuthenticatedUser, @PathVariable incomeId: String): ResponseEntity<Unit> {
         Audit.PersonIncomeDelete.log(targetId = incomeId)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -20,8 +20,6 @@ import fi.espoo.evaka.shared.async.NotifyIncomeUpdated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Period
 import fi.espoo.evaka.shared.domain.maxEndDate

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
@@ -22,8 +22,6 @@ import fi.espoo.evaka.invoicing.service.markManuallySent
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.utils.parseEnum

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
@@ -66,7 +66,7 @@ class InvoiceController(
 ) {
     @GetMapping("/search")
     fun searchInvoices(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam(required = true) page: Int,
         @RequestParam(required = true) pageSize: Int,
@@ -107,7 +107,7 @@ class InvoiceController(
     }
 
     @PostMapping("/create-drafts")
-    fun createDraftInvoices(db: Database, user: AuthenticatedUser): ResponseEntity<Unit> {
+    fun createDraftInvoices(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<Unit> {
         Audit.InvoicesCreate.log()
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         db.transaction { createAllDraftInvoices(it.handle, objectMapper) }
@@ -115,7 +115,7 @@ class InvoiceController(
     }
 
     @PostMapping("/delete-drafts")
-    fun deleteDraftInvoices(db: Database, user: AuthenticatedUser, @RequestBody invoiceIds: List<UUID>): ResponseEntity<Unit> {
+    fun deleteDraftInvoices(db: Database.Connection, user: AuthenticatedUser, @RequestBody invoiceIds: List<UUID>): ResponseEntity<Unit> {
         Audit.InvoicesDeleteDrafts.log(targetId = invoiceIds)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         db.transaction { deleteDraftInvoices(it.handle, invoiceIds) }
@@ -124,7 +124,7 @@ class InvoiceController(
 
     @PostMapping("/send")
     fun sendInvoices(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         @RequestParam(required = false) invoiceDate: LocalDate?,
@@ -142,7 +142,7 @@ class InvoiceController(
 
     @PostMapping("/send/by-date")
     fun sendInvoicesByDate(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody payload: InvoicePayload
     ): ResponseEntity<Unit> {
@@ -156,7 +156,7 @@ class InvoiceController(
     }
 
     @PostMapping("/mark-sent")
-    fun markInvoicesSent(db: Database, user: AuthenticatedUser, @RequestBody invoiceIds: List<UUID>): ResponseEntity<Unit> {
+    fun markInvoicesSent(db: Database.Connection, user: AuthenticatedUser, @RequestBody invoiceIds: List<UUID>): ResponseEntity<Unit> {
         Audit.InvoicesMarkSent.log(targetId = invoiceIds)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         db.transaction { it.markManuallySent(user, invoiceIds) }
@@ -164,7 +164,7 @@ class InvoiceController(
     }
 
     @GetMapping("/{uuid}")
-    fun getInvoice(db: Database, user: AuthenticatedUser, @PathVariable uuid: String): ResponseEntity<Wrapper<InvoiceDetailed>> {
+    fun getInvoice(db: Database.Connection, user: AuthenticatedUser, @PathVariable uuid: String): ResponseEntity<Wrapper<InvoiceDetailed>> {
         Audit.InvoicesRead.log(targetId = uuid)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val parsedUuid = parseUUID(uuid)
@@ -175,7 +175,7 @@ class InvoiceController(
 
     @GetMapping("/head-of-family/{uuid}")
     fun getHeadOfFamilyInvoices(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable uuid: String
     ): ResponseEntity<Wrapper<List<Invoice>>> {
@@ -188,7 +188,7 @@ class InvoiceController(
 
     @PutMapping("/{uuid}")
     fun putInvoice(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable uuid: String,
         @RequestBody invoice: Invoice
@@ -201,7 +201,7 @@ class InvoiceController(
     }
 
     @GetMapping("/codes")
-    fun getInvoiceCodes(db: Database, user: AuthenticatedUser): ResponseEntity<Wrapper<InvoiceCodes>> {
+    fun getInvoiceCodes(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<Wrapper<InvoiceCodes>> {
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val codes = db.read { it.getInvoiceCodes() }
         return ResponseEntity.ok(Wrapper(codes))

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -25,8 +25,6 @@ import fi.espoo.evaka.shared.async.NotifyVoucherValueDecisionApproved
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.domain.Period

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -51,7 +51,7 @@ class VoucherValueDecisionController(
 ) {
     @GetMapping("/search")
     fun search(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam(required = true) page: Int,
         @RequestParam(required = true) pageSize: Int,
@@ -87,7 +87,7 @@ class VoucherValueDecisionController(
 
     @GetMapping("/{id}")
     fun getDecision(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable id: UUID
     ): ResponseEntity<Wrapper<VoucherValueDecisionDetailed>> {
@@ -99,7 +99,7 @@ class VoucherValueDecisionController(
     }
 
     @PostMapping("/send")
-    fun sendDrafts(db: Database, user: AuthenticatedUser, @RequestBody decisionIds: List<UUID>): ResponseEntity<Unit> {
+    fun sendDrafts(db: Database.Connection, user: AuthenticatedUser, @RequestBody decisionIds: List<UUID>): ResponseEntity<Unit> {
         Audit.VoucherValueDecisionSend.log(targetId = decisionIds)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         db.transaction { sendVoucherValueDecisions(it, user, decisionIds) }
@@ -108,7 +108,7 @@ class VoucherValueDecisionController(
     }
 
     @GetMapping("/pdf/{id}")
-    fun getDecisionPdf(db: Database, user: AuthenticatedUser, @PathVariable id: UUID): ResponseEntity<ByteArray> {
+    fun getDecisionPdf(db: Database.Connection, user: AuthenticatedUser, @PathVariable id: UUID): ResponseEntity<ByteArray> {
         Audit.FeeDecisionPdfRead.log(targetId = id)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val (filename, pdf) = db.read { valueDecisionService.getDecisionPdf(it, id) }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -111,7 +111,7 @@ class VoucherValueDecisionController(
     fun getDecisionPdf(db: Database, user: AuthenticatedUser, @PathVariable id: UUID): ResponseEntity<ByteArray> {
         Audit.FeeDecisionPdfRead.log(targetId = id)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        val (filename, pdf) = db.read { valueDecisionService.getDecisionPdf(it.handle, id) }
+        val (filename, pdf) = db.read { valueDecisionService.getDecisionPdf(it, id) }
         val headers = HttpHeaders().apply {
             add("Content-Disposition", "attachment; filename=\"$filename\"")
             add("Content-Type", "application/pdf")

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.shared.async.NotifyIncomeUpdated
 import fi.espoo.evaka.shared.async.NotifyPlacementPlanApplied
 import fi.espoo.evaka.shared.async.NotifyServiceNeedUpdated
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Period
 import mu.KotlinLogging
 import org.springframework.stereotype.Component

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
@@ -15,7 +15,6 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Period
 import mu.KotlinLogging
-import org.jdbi.v3.core.Jdbi
 import org.springframework.stereotype.Component
 
 private val logger = KotlinLogging.logger {}
@@ -23,7 +22,6 @@ private val logger = KotlinLogging.logger {}
 @Component
 class FeeDecisionGenerationJobProcessor(
     private val generator: DecisionGenerator,
-    private val jdbi: Jdbi,
     asyncJobRunner: AsyncJobRunner
 ) {
     init {
@@ -34,28 +32,28 @@ class FeeDecisionGenerationJobProcessor(
         asyncJobRunner.notifyServiceNeedUpdated = ::runJob
     }
 
-    fun runJob(db: Database, msg: NotifyFamilyUpdated) = jdbi.transaction { h ->
+    fun runJob(db: Database, msg: NotifyFamilyUpdated) = db.transaction { tx ->
         logger.info { "Handling family updated event for person (id: ${msg.adultId})" }
-        generator.handleFamilyUpdate(h, msg.adultId, Period(msg.startDate, msg.endDate))
+        generator.handleFamilyUpdate(tx.handle, msg.adultId, Period(msg.startDate, msg.endDate))
     }
 
-    fun runJob(db: Database, msg: NotifyFeeAlterationUpdated) = jdbi.transaction { h ->
+    fun runJob(db: Database, msg: NotifyFeeAlterationUpdated) = db.transaction { tx ->
         logger.info { "Handling fee alteration updated event ($msg)" }
-        generator.handleFeeAlterationChange(h, msg.personId, Period(msg.startDate, msg.endDate))
+        generator.handleFeeAlterationChange(tx.handle, msg.personId, Period(msg.startDate, msg.endDate))
     }
 
-    fun runJob(db: Database, msg: NotifyIncomeUpdated) = jdbi.transaction { h ->
+    fun runJob(db: Database, msg: NotifyIncomeUpdated) = db.transaction { tx ->
         logger.info { "Handling income updated event ($msg)" }
-        generator.handleIncomeChange(h, msg.personId, Period(msg.startDate, msg.endDate))
+        generator.handleIncomeChange(tx.handle, msg.personId, Period(msg.startDate, msg.endDate))
     }
 
-    fun runJob(db: Database, msg: NotifyPlacementPlanApplied) = jdbi.transaction { h ->
+    fun runJob(db: Database, msg: NotifyPlacementPlanApplied) = db.transaction { tx ->
         logger.info { "Handling placement plan accepted event ($msg)" }
-        generator.handlePlacement(h, msg.childId, Period(msg.startDate, msg.endDate))
+        generator.handlePlacement(tx.handle, msg.childId, Period(msg.startDate, msg.endDate))
     }
 
-    fun runJob(db: Database, msg: NotifyServiceNeedUpdated) = jdbi.transaction { h ->
+    fun runJob(db: Database, msg: NotifyServiceNeedUpdated) = db.transaction { tx ->
         logger.info { "Handling service need updated event for child (id: ${msg.childId})" }
-        generator.handleServiceNeed(h, msg.childId, Period(msg.startDate, msg.endDate))
+        generator.handleServiceNeed(tx.handle, msg.childId, Period(msg.startDate, msg.endDate))
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.shared.async.NotifyFeeDecisionPdfGenerated
 import fi.espoo.evaka.shared.async.NotifyVoucherValueDecisionApproved
 import fi.espoo.evaka.shared.async.NotifyVoucherValueDecisionPdfGenerated
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
@@ -32,27 +32,27 @@ class InvoicingAsyncJobs(
 
     fun runCreateFeeDecisionPdf(db: Database, msg: NotifyFeeDecisionApproved) = db.transaction { tx ->
         val decisionId = msg.decisionId
-        feeService.createFeeDecisionPdf(tx.handle, decisionId)
+        feeService.createFeeDecisionPdf(tx, decisionId)
         logger.info { "Successfully created fee decision pdf (id: $decisionId)." }
         asyncJobRunner.plan(tx, listOf(NotifyFeeDecisionPdfGenerated(decisionId)))
     }
 
     fun runSendFeeDecisionPdf(db: Database, msg: NotifyFeeDecisionPdfGenerated) = db.transaction { tx ->
         val decisionId = msg.decisionId
-        feeService.sendDecision(tx.handle, decisionId)
+        feeService.sendDecision(tx, decisionId)
         logger.info { "Successfully sent fee decision msg to suomi.fi (id: $decisionId)." }
     }
 
     fun runCreateVoucherValueDecisionPdf(db: Database, msg: NotifyVoucherValueDecisionApproved) = db.transaction { tx ->
         val decisionId = msg.decisionId
-        valueDecisionService.createDecisionPdf(tx.handle, decisionId)
+        valueDecisionService.createDecisionPdf(tx, decisionId)
         logger.info { "Successfully created voucher value decision pdf (id: $decisionId)." }
         asyncJobRunner.plan(tx, listOf(NotifyVoucherValueDecisionPdfGenerated(decisionId)))
     }
 
     fun runSendVoucherValueDecisionPdf(db: Database, msg: NotifyVoucherValueDecisionPdfGenerated) = db.transaction { tx ->
         val decisionId = msg.decisionId
-        valueDecisionService.sendDecision(tx.handle, decisionId)
+        valueDecisionService.sendDecision(tx, decisionId)
         logger.info { "Successfully sent fee decision msg to suomi.fi (id: $decisionId)." }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
@@ -27,7 +27,7 @@ class KoskiUpdateService(
     private val asyncJobRunner: AsyncJobRunner
 ) {
     fun update(
-        db: Database,
+        db: Database.Connection,
         personIds: String?,
         daycareIds: String?
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
@@ -30,7 +30,7 @@ import java.util.UUID
 class OccupancyController(private val acl: AccessControlList) {
     @GetMapping("/by-unit/{unitId}")
     fun getOccupancyPeriods(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable unitId: UUID,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
@@ -53,7 +53,7 @@ class OccupancyController(private val acl: AccessControlList) {
 
     @GetMapping("/by-unit/{unitId}/groups")
     fun getOccupancyPeriodsOnGroups(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable unitId: UUID,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
@@ -31,14 +31,14 @@ import java.util.UUID
 class EmployeeController {
 
     @GetMapping()
-    fun getEmployees(db: Database, user: AuthenticatedUser): ResponseEntity<List<Employee>> {
+    fun getEmployees(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<Employee>> {
         Audit.EmployeesRead.log()
         user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
         return ResponseEntity.ok(db.read { it.handle.getEmployees() }.sortedBy { it.email })
     }
 
     @GetMapping("/{id}")
-    fun getEmployee(db: Database, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Employee> {
+    fun getEmployee(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Employee> {
         Audit.EmployeeRead.log(targetId = id)
         if (user.id != id) {
             user.requireOneOfRoles(
@@ -55,14 +55,14 @@ class EmployeeController {
     }
 
     @PostMapping("")
-    fun createEmployee(db: Database, user: AuthenticatedUser, @RequestBody employee: NewEmployee): ResponseEntity<Employee> {
+    fun createEmployee(db: Database.Connection, user: AuthenticatedUser, @RequestBody employee: NewEmployee): ResponseEntity<Employee> {
         Audit.EmployeeCreate.log(targetId = employee.aad)
         user.requireOneOfRoles(Roles.ADMIN)
         return ResponseEntity.ok().body(db.transaction { it.handle.createEmployee(employee) })
     }
 
     @PostMapping("/identity")
-    fun getOrCreateEmployee(db: Database, @RequestBody employee: NewEmployee): ResponseEntity<AuthenticatedUser> {
+    fun getOrCreateEmployee(db: Database.Connection, @RequestBody employee: NewEmployee): ResponseEntity<AuthenticatedUser> {
         Audit.EmployeeGetOrCreate.log(targetId = employee.aad)
         if (employee.aad == null) {
             throw BadRequest("Cannot create or fetch employee without aad")
@@ -76,7 +76,7 @@ class EmployeeController {
     }
 
     @DeleteMapping("/{id}")
-    fun deleteEmployee(db: Database, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Unit> {
+    fun deleteEmployee(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Unit> {
         Audit.EmployeeDelete.log(targetId = id)
         user.requireOneOfRoles(Roles.ADMIN)
         db.transaction { it.handle.deleteEmployee(id) }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
@@ -27,7 +27,7 @@ class FamilyController(
     private val acl: AccessControlList
 ) {
     @GetMapping("/by-adult/{id}")
-    fun getFamilyByPerson(db: Database, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<FamilyOverview> {
+    fun getFamilyByPerson(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<FamilyOverview> {
         Audit.PisFamilyRead.log(targetId = id)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
         val result = db.read { familyOverviewService.getFamilyByAdult(it, id) }
@@ -37,7 +37,7 @@ class FamilyController(
 
     @GetMapping("/contacts")
     fun getFamilyContactSummary(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam(value = "childId", required = true) childId: UUID
     ): ResponseEntity<List<FamilyContact>> {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
@@ -11,9 +11,7 @@ import fi.espoo.evaka.pis.service.FamilyOverviewService
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
-import fi.espoo.evaka.shared.db.handle
-import org.jdbi.v3.core.Handle
-import org.jdbi.v3.core.Jdbi
+import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -26,32 +24,32 @@ import java.util.UUID
 @RequestMapping("/family")
 class FamilyController(
     private val familyOverviewService: FamilyOverviewService,
-    private val acl: AccessControlList,
-    private val jdbi: Jdbi
+    private val acl: AccessControlList
 ) {
     @GetMapping("/by-adult/{id}")
-    fun getFamilyByPerson(user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<FamilyOverview> {
+    fun getFamilyByPerson(db: Database, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<FamilyOverview> {
         Audit.PisFamilyRead.log(targetId = id)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        val result = jdbi.handle { familyOverviewService.getFamilyByAdult(it, id) }
+        val result = db.read { familyOverviewService.getFamilyByAdult(it.handle, id) }
             ?: return ResponseEntity.notFound().build()
         return ResponseEntity.ok(result)
     }
 
     @GetMapping("/contacts")
     fun getFamilyContactSummary(
+        db: Database,
         user: AuthenticatedUser,
         @RequestParam(value = "childId", required = true) childId: UUID
     ): ResponseEntity<List<FamilyContact>> {
         Audit.FamilyContactsRead.log(targetId = childId)
         acl.getRolesForChild(user, childId).requireOneOfRoles(Roles.ADMIN, Roles.STAFF)
-        return jdbi
-            .handle { h -> fetchFamilyContacts(h, childId) }
+        return db
+            .read { it.fetchFamilyContacts(childId) }
             .let { ResponseEntity.ok(it) }
     }
 }
 
-fun fetchFamilyContacts(h: Handle, childId: UUID): List<FamilyContact> {
+private fun Database.Read.fetchFamilyContacts(childId: UUID): List<FamilyContact> {
     // language=sql
     val sql =
         """
@@ -110,8 +108,7 @@ fun fetchFamilyContacts(h: Handle, childId: UUID): List<FamilyContact> {
             )
     """
 
-    return h
-        .createQuery(sql)
+    return createQuery(sql)
         .bind("id", childId)
         .mapTo(FamilyContact::class.java)
         .list()

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
@@ -30,7 +30,7 @@ class FamilyController(
     fun getFamilyByPerson(db: Database, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<FamilyOverview> {
         Audit.PisFamilyRead.log(targetId = id)
         user.requireOneOfRoles(Roles.FINANCE_ADMIN)
-        val result = db.read { familyOverviewService.getFamilyByAdult(it.handle, id) }
+        val result = db.read { familyOverviewService.getFamilyByAdult(it, id) }
             ?: return ResponseEntity.notFound().build()
         return ResponseEntity.ok(result)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -17,8 +17,6 @@ import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
 import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
 import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -39,7 +39,7 @@ class ParentshipController(
 ) {
     @PostMapping
     fun createParentship(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody body: ParentshipRequest
     ): ResponseEntity<Parentship> {
@@ -57,7 +57,7 @@ class ParentshipController(
 
     @GetMapping
     fun getParentships(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam(value = "headOfChildId", required = false) headOfChildId: VolttiIdentifier? = null,
         @RequestParam(value = "childId", required = false) childId: VolttiIdentifier? = null
@@ -76,7 +76,7 @@ class ParentshipController(
     }
 
     @GetMapping("/{id}")
-    fun getParentship(db: Database, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Parentship> {
+    fun getParentship(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Parentship> {
         Audit.ParentShipsRead.log(targetId = id)
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
 
@@ -89,7 +89,7 @@ class ParentshipController(
 
     @PutMapping("/{id}")
     fun updateParentship(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") id: UUID,
         @RequestBody body: ParentshipUpdateRequest
@@ -106,7 +106,7 @@ class ParentshipController(
 
     @PutMapping("/{id}/retry")
     fun retryPartnership(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") parentshipId: UUID
     ): ResponseEntity<Unit> {
@@ -119,7 +119,7 @@ class ParentshipController(
     }
 
     @DeleteMapping("/{id}")
-    fun deleteParentship(db: Database, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Unit> {
+    fun deleteParentship(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Unit> {
         Audit.ParentShipsDelete.log(targetId = id)
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -48,7 +48,7 @@ class ParentshipController(
 
         with(body) {
             return db.transaction {
-                parentshipService.createParentship(it.handle, childId, headOfChildId, startDate, endDate)
+                parentshipService.createParentship(it, childId, headOfChildId, startDate, endDate)
             }
                 .also { asyncJobRunner.scheduleImmediateRun() }
                 .let { ResponseEntity.created(URI.create("/parentships/${it.id}")).body(it) }
@@ -71,8 +71,8 @@ class ParentshipController(
                 childId = childId,
                 includeConflicts = true
             )
-                .let { ResponseEntity.ok().body(it) }
         }
+            .let { ResponseEntity.ok().body(it) }
     }
 
     @GetMapping("/{id}")
@@ -82,9 +82,9 @@ class ParentshipController(
 
         return db.read {
             it.handle.getParentship(id)
-                ?.let { ResponseEntity.ok().body(it) }
-                ?: ResponseEntity.notFound().build()
         }
+            ?.let { ResponseEntity.ok().body(it) }
+            ?: ResponseEntity.notFound().build()
     }
 
     @PutMapping("/{id}")
@@ -98,7 +98,7 @@ class ParentshipController(
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
 
         return db.transaction {
-            parentshipService.updateParentshipDuration(it.handle, id, body.startDate, body.endDate)
+            parentshipService.updateParentshipDuration(it, id, body.startDate, body.endDate)
         }
             .also { asyncJobRunner.scheduleImmediateRun() }
             .let { ResponseEntity.ok().body(it) }
@@ -113,7 +113,7 @@ class ParentshipController(
         Audit.ParentShipsRetry.log(targetId = parentshipId)
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
 
-        db.transaction { parentshipService.retryParentship(it.handle, parentshipId) }
+        db.transaction { parentshipService.retryParentship(it, parentshipId) }
         asyncJobRunner.scheduleImmediateRun()
         return noContent()
     }
@@ -123,7 +123,7 @@ class ParentshipController(
         Audit.ParentShipsDelete.log(targetId = id)
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
 
-        db.transaction { parentshipService.deleteParentship(it.handle, id) }
+        db.transaction { parentshipService.deleteParentship(it, id) }
         asyncJobRunner.scheduleImmediateRun()
 
         return ResponseEntity.noContent().build()

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
@@ -18,8 +18,6 @@ import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
 import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
 import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
@@ -38,7 +38,7 @@ import java.util.UUID
 class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private val partnershipService: PartnershipService) {
     @PostMapping
     fun createPartnership(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody body: PartnershipRequest
     ): ResponseEntity<Partnership> {
@@ -61,7 +61,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
 
     @GetMapping
     fun getPartnerships(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam(name = "personId", required = true) personId: VolttiIdentifier
     ): ResponseEntity<List<Partnership>> {
@@ -74,7 +74,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
 
     @GetMapping("/{id}")
     fun getPartnership(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") partnershipId: UUID
     ): ResponseEntity<Partnership> {
@@ -88,7 +88,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
 
     @PutMapping("/{id}")
     fun updatePartnership(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") partnershipId: UUID,
         @RequestBody body: PartnershipUpdateRequest
@@ -111,7 +111,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
 
     @PutMapping("/{id}/retry")
     fun retryPartnership(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") partnershipId: UUID
     ): ResponseEntity<Unit> {
@@ -129,7 +129,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
 
     @DeleteMapping("/{id}")
     fun deletePartnership(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") partnershipId: UUID
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -54,7 +54,7 @@ class PersonController(
     private val asyncJobRunner: AsyncJobRunner
 ) {
     @PostMapping("/identity")
-    fun postPersonIdentity(db: Database, @RequestBody person: PersonIdentityJSON): ResponseEntity<AuthenticatedUser> {
+    fun postPersonIdentity(db: Database.Connection, @RequestBody person: PersonIdentityJSON): ResponseEntity<AuthenticatedUser> {
         Audit.PersonCreate.log()
         return db.transaction { tx ->
             tx.handle.getPersonBySSN(person.socialSecurityNumber) ?: tx.handle.createPerson(
@@ -71,7 +71,7 @@ class PersonController(
     }
 
     @PostMapping
-    fun createEmpty(db: Database, user: AuthenticatedUser): ResponseEntity<PersonIdentityResponseJSON> {
+    fun createEmpty(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<PersonIdentityResponseJSON> {
         Audit.PersonCreate.log()
         user.requireOneOfRoles(SERVICE_WORKER, FINANCE_ADMIN, ADMIN)
         return db.transaction { it.handle.createEmptyPerson() }
@@ -80,7 +80,7 @@ class PersonController(
 
     @GetMapping(value = ["/details/{personId}", "/identity/{personId}"])
     fun getPerson(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: VolttiIdentifier
     ): ResponseEntity<PersonJSON> {
@@ -94,7 +94,7 @@ class PersonController(
 
     @GetMapping("/dependants/{personId}")
     fun getPersonDependants(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: VolttiIdentifier
     ): ResponseEntity<List<PersonWithChildrenDTO>> {
@@ -107,7 +107,7 @@ class PersonController(
 
     @GetMapping("/guardians/{personId}")
     fun getPersonGuardians(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: VolttiIdentifier
     ): ResponseEntity<List<PersonJSON>> {
@@ -120,7 +120,7 @@ class PersonController(
 
     @GetMapping("/search")
     fun findBySearchTerms(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam(
             value = "searchTerm",
@@ -151,7 +151,7 @@ class PersonController(
 
     @PutMapping(value = ["/{personId}/contact-info"])
     fun updateContactInfo(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: VolttiIdentifier,
         @RequestBody contactInfo: ContactInfo
@@ -167,7 +167,7 @@ class PersonController(
 
     @PatchMapping("/{personId}")
     fun updatePersonDetails(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: VolttiIdentifier,
         @RequestBody data: PersonPatch
@@ -180,7 +180,7 @@ class PersonController(
 
     @DeleteMapping("/{personId}")
     fun safeDeletePerson(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: VolttiIdentifier
     ): ResponseEntity<Unit> {
@@ -192,7 +192,7 @@ class PersonController(
 
     @PutMapping("/{personId}/ssn")
     fun addSsn(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: VolttiIdentifier,
         @RequestBody body: AddSsnRequest
@@ -212,7 +212,7 @@ class PersonController(
 
     @GetMapping("/details/ssn/{ssn}")
     fun getOrCreatePersonBySsn(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("ssn") ssn: String,
         @RequestParam("readonly", required = false) readonly: Boolean = false
@@ -241,7 +241,7 @@ class PersonController(
 
     @GetMapping("/get-deceased/")
     fun getDeceased(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam("sinceDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) sinceDate: LocalDate
     ): ResponseEntity<List<PersonJSON>> {
@@ -256,7 +256,7 @@ class PersonController(
 
     @PostMapping("/merge")
     fun mergePeople(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody body: MergeRequest
     ): ResponseEntity<Unit> {
@@ -271,7 +271,7 @@ class PersonController(
 
     @PostMapping("/create")
     fun createPerson(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody body: CreatePersonBody
     ): ResponseEntity<UUID> {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -30,8 +30,6 @@ import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
 import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
 import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka.pis.controllers
 
 import fi.espoo.evaka.Audit
-import fi.espoo.evaka.dvv.DvvModificationsBatchRefreshService
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.identity.VolttiIdentifier
 import fi.espoo.evaka.identity.isValidSSN
@@ -22,7 +21,6 @@ import fi.espoo.evaka.pis.service.PersonJSON
 import fi.espoo.evaka.pis.service.PersonPatch
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.pis.service.PersonWithChildrenDTO
-import fi.espoo.evaka.pis.service.VTJBatchRefreshService
 import fi.espoo.evaka.pis.updatePersonContactInfo
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -35,7 +33,6 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
-import org.jdbi.v3.core.Jdbi
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -55,17 +52,14 @@ import java.util.UUID
 @RequestMapping("/person")
 class PersonController(
     private val personService: PersonService,
-    private val vtjBatchRefreshService: VTJBatchRefreshService,
-    private val dvvModificationsBatchRefreshService: DvvModificationsBatchRefreshService,
     private val mergeService: MergeService,
-    private val jdbi: Jdbi,
     private val asyncJobRunner: AsyncJobRunner
 ) {
     @PostMapping("/identity")
-    fun postPersonIdentity(@RequestBody person: PersonIdentityJSON): ResponseEntity<AuthenticatedUser> {
+    fun postPersonIdentity(db: Database, @RequestBody person: PersonIdentityJSON): ResponseEntity<AuthenticatedUser> {
         Audit.PersonCreate.log()
-        return jdbi.transaction { h ->
-            h.getPersonBySSN(person.socialSecurityNumber) ?: h.createPerson(
+        return db.transaction { tx ->
+            tx.handle.getPersonBySSN(person.socialSecurityNumber) ?: tx.handle.createPerson(
                 PersonIdentityRequest(
                     identity = person.toIdentifier(),
                     firstName = person.firstName,
@@ -79,10 +73,10 @@ class PersonController(
     }
 
     @PostMapping
-    fun createEmpty(user: AuthenticatedUser): ResponseEntity<PersonIdentityResponseJSON> {
+    fun createEmpty(db: Database, user: AuthenticatedUser): ResponseEntity<PersonIdentityResponseJSON> {
         Audit.PersonCreate.log()
         user.requireOneOfRoles(SERVICE_WORKER, FINANCE_ADMIN, ADMIN)
-        return jdbi.transaction { it.createEmptyPerson() }
+        return db.transaction { it.handle.createEmptyPerson() }
             .let { ResponseEntity.ok().body(PersonIdentityResponseJSON.from(it)) }
     }
 
@@ -128,6 +122,7 @@ class PersonController(
 
     @GetMapping("/search")
     fun findBySearchTerms(
+        db: Database,
         user: AuthenticatedUser,
         @RequestParam(
             value = "searchTerm",
@@ -146,8 +141,8 @@ class PersonController(
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
         return ResponseEntity.ok()
             .body(
-                jdbi.handle {
-                    it.searchPeople(
+                db.read {
+                    it.handle.searchPeople(
                         searchTerm,
                         orderBy,
                         sortDirection
@@ -158,13 +153,14 @@ class PersonController(
 
     @PutMapping(value = ["/{personId}/contact-info"])
     fun updateContactInfo(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: VolttiIdentifier,
         @RequestBody contactInfo: ContactInfo
     ): ResponseEntity<ContactInfo> {
         Audit.PersonContactInfoUpdate.log(targetId = personId)
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
-        return if (jdbi.transaction { it.updatePersonContactInfo(personId, contactInfo) }) {
+        return if (db.transaction { it.handle.updatePersonContactInfo(personId, contactInfo) }) {
             ResponseEntity.ok().body(contactInfo)
         } else {
             ResponseEntity.notFound().build()
@@ -247,6 +243,7 @@ class PersonController(
 
     @GetMapping("/get-deceased/")
     fun getDeceased(
+        db: Database,
         user: AuthenticatedUser,
         @RequestParam("sinceDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) sinceDate: LocalDate
     ): ResponseEntity<List<PersonJSON>> {
@@ -255,7 +252,7 @@ class PersonController(
 
         return ResponseEntity.ok()
             .body(
-                jdbi.handle { it.getDeceasedPeople(sinceDate) }.map { personDTO -> PersonJSON.from(personDTO) }
+                db.read { it.handle.getDeceasedPeople(sinceDate) }.map { personDTO -> PersonJSON.from(personDTO) }
             )
     }
 
@@ -276,12 +273,13 @@ class PersonController(
 
     @PostMapping("/create")
     fun createPerson(
+        db: Database,
         user: AuthenticatedUser,
         @RequestBody body: CreatePersonBody
     ): ResponseEntity<UUID> {
         Audit.PersonCreate.log()
         user.requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN)
-        return jdbi.transaction { it.createPerson(body) }
+        return db.transaction { it.handle.createPerson(body) }
             .let { ResponseEntity.ok(it) }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyOverviewService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyOverviewService.kt
@@ -11,7 +11,7 @@ import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.invoicing.domain.getTotalIncome
 import fi.espoo.evaka.invoicing.domain.getTotalIncomeEffect
 import fi.espoo.evaka.invoicing.domain.incomeTotal
-import org.jdbi.v3.core.Handle
+import fi.espoo.evaka.shared.db.Database
 import org.springframework.stereotype.Service
 import java.sql.ResultSet
 import java.time.LocalDate
@@ -19,7 +19,7 @@ import java.util.UUID
 
 @Service
 class FamilyOverviewService(private val objectMapper: ObjectMapper) {
-    fun getFamilyByAdult(h: Handle, adultId: UUID): FamilyOverview? {
+    fun getFamilyByAdult(tx: Database.Read, adultId: UUID): FamilyOverview? {
         val sql =
             """
 WITH adult_ids AS
@@ -71,7 +71,7 @@ AND fc.conflict = FALSE
 ORDER BY date_of_birth ASC
 """
         val familyMembersNow =
-            h.createQuery(sql).bind("id", adultId).map { rs, _ -> toFamilyOverviewPerson(rs, objectMapper) }
+            tx.createQuery(sql).bind("id", adultId).map { rs, _ -> toFamilyOverviewPerson(rs, objectMapper) }
 
         val (adults, children) = familyMembersNow.partition { it.headOfChild == null }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
@@ -69,7 +69,7 @@ class FridgeFamilyService(
                 try {
                     db.transaction { tx ->
                         parentshipService.createParentship(
-                            tx.handle,
+                            tx,
                             childId = child.id,
                             headOfChildId = msg.personId,
                             startDate = LocalDate.now(),

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
@@ -12,7 +12,6 @@ import mu.KotlinLogging
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Service
-import java.lang.Exception
 import java.time.LocalDate
 import java.util.UUID
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
@@ -7,22 +7,12 @@ package fi.espoo.evaka.pis.service
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.VTJRefresh
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
-import mu.KotlinLogging
-import org.jdbi.v3.core.Handle
-import org.jdbi.v3.core.Jdbi
-import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Service
-import java.time.Instant
-import java.util.UUID
-
-private val logger = KotlinLogging.logger {}
 
 @Service
 class VTJBatchRefreshService(
     private val fridgeFamilyService: FridgeFamilyService,
-    private val asyncJobRunner: AsyncJobRunner,
-    private val jdbi: Jdbi
+    asyncJobRunner: AsyncJobRunner
 ) {
 
     init {
@@ -31,48 +21,5 @@ class VTJBatchRefreshService(
 
     fun doVTJRefresh(db: Database, msg: VTJRefresh) {
         fridgeFamilyService.doVTJRefresh(db, msg)
-    }
-
-    fun scheduleBatch(): Int {
-        val jobCount = jdbi.transaction { h ->
-            deleteOldJobs(h)
-
-            val requestingUserId = UUID.fromString("00000000-0000-0000-0000-000000000000")
-            val personIds = getPersonIdsToRefresh(h)
-            personIds.forEachIndexed { i, personId ->
-                asyncJobRunner.plan(
-                    h,
-                    payloads = listOf(
-                        VTJRefresh(
-                            personId = personId,
-                            requestingUserId = requestingUserId
-                        )
-                    ),
-                    runAt = Instant.now().plusSeconds(i.toLong())
-                )
-            }
-
-            personIds.size
-        }
-
-        asyncJobRunner.scheduleImmediateRun()
-
-        return jobCount
-    }
-
-    private fun deleteOldJobs(h: Handle) {
-        h.createUpdate("DELETE FROM async_job WHERE type = 'VTJ_REFRESH' AND (claimed_by IS NULL OR completed_at IS NOT NULL)").execute()
-    }
-
-    private fun getPersonIdsToRefresh(h: Handle): Set<UUID> {
-        // language=sql
-        val sql =
-            """
-            SELECT head_of_child FROM fridge_child 
-            WHERE daterange(start_date, end_date, '[]') @> current_date AND conflict = false
-            """.trimIndent()
-
-        return h.createQuery(sql).mapTo<UUID>()
-            .toHashSet()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -47,7 +47,7 @@ class PlacementController(
 ) {
     @GetMapping
     fun getPlacements(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam(value = "daycareId", required = false) daycareId: UUID? = null,
         @RequestParam(value = "childId", required = false) childId: UUID? = null,
@@ -82,7 +82,7 @@ class PlacementController(
 
     @GetMapping("/plans")
     fun getPlacementPlans(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam(value = "daycareId", required = true) daycareId: UUID,
         @RequestParam(
@@ -100,7 +100,7 @@ class PlacementController(
 
     @PostMapping
     fun createPlacement(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody body: PlacementCreateRequestBody
     ): ResponseEntity<Placement> {
@@ -138,7 +138,7 @@ class PlacementController(
 
     @PutMapping("/{placementId}")
     fun updatePlacementById(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("placementId") placementId: UUID,
         @RequestBody body: PlacementUpdateRequestBody
@@ -168,7 +168,7 @@ class PlacementController(
 
     @DeleteMapping("/{placementId}")
     fun deletePlacement(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("placementId") placementId: UUID
     ): ResponseEntity<Unit> {
@@ -187,7 +187,7 @@ class PlacementController(
 
     @PostMapping("/{placementId}/group-placements")
     fun createGroupPlacement(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("placementId") placementId: UUID,
         @RequestBody body: GroupPlacementRequestBody
@@ -210,7 +210,7 @@ class PlacementController(
 
     @DeleteMapping("/{daycarePlacementId}/group-placements/{groupPlacementId}")
     fun deleteGroupPlacement(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycarePlacementId") daycarePlacementId: UUID,
         @PathVariable("groupPlacementId") groupPlacementId: UUID
@@ -226,7 +226,7 @@ class PlacementController(
 
     @PostMapping("/{daycarePlacementId}/group-placements/{groupPlacementId}/transfer")
     fun transferGroupPlacement(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycarePlacementId") daycarePlacementId: UUID,
         @PathVariable("groupPlacementId") groupPlacementId: UUID,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -21,8 +21,6 @@ import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
 import fi.espoo.evaka.shared.config.Roles.STAFF
 import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -112,7 +112,7 @@ class PlacementPlanService(
             if (allowPreschool) {
                 val period = requestedStartDate?.let { plan.period.copy(start = it) } ?: plan.period
                 placementService.createPlacement(
-                    h = tx.handle,
+                    tx,
                     type = if (plan.type == PlacementType.PRESCHOOL_DAYCARE) PlacementType.PRESCHOOL else PlacementType.PREPARATORY,
                     childId = childId,
                     unitId = plan.unitId,
@@ -132,7 +132,7 @@ class PlacementPlanService(
                 // placement is used because invoices are handled differently
                 if (period.end.isAfter(term.end)) {
                     placementService.createPlacement(
-                        h = tx.handle,
+                        tx,
                         type = plan.type,
                         childId = childId,
                         unitId = plan.unitId,
@@ -140,7 +140,7 @@ class PlacementPlanService(
                         endDate = term.end
                     )
                     placementService.createPlacement(
-                        h = tx.handle,
+                        tx,
                         type = PlacementType.DAYCARE,
                         childId = childId,
                         unitId = plan.unitId,
@@ -149,7 +149,7 @@ class PlacementPlanService(
                     )
                 } else {
                     placementService.createPlacement(
-                        h = tx.handle,
+                        tx,
                         type = plan.type,
                         childId = childId,
                         unitId = plan.unitId,
@@ -167,7 +167,7 @@ class PlacementPlanService(
         } else {
             val period = requestedStartDate?.let { plan.period.copy(start = it) } ?: plan.period
             placementService.createPlacement(
-                h = tx.handle,
+                tx,
                 type = plan.type,
                 childId = childId,
                 unitId = plan.unitId,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -14,8 +14,6 @@ import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.NotFound
 import org.jdbi.v3.core.Handle
 import org.springframework.stereotype.Service
-import java.lang.Error
-import java.lang.IllegalArgumentException
 import java.time.LocalDate
 import java.util.UUID
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedReport.kt
@@ -12,10 +12,8 @@ import fi.espoo.evaka.shared.config.Roles.ADMIN
 import fi.espoo.evaka.shared.config.Roles.DIRECTOR
 import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
 import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
-import fi.espoo.evaka.shared.db.handle
-import org.jdbi.v3.core.Handle
-import org.jdbi.v3.core.Jdbi
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -25,23 +23,21 @@ import java.time.LocalDate
 import java.util.UUID
 
 @RestController
-class AssistanceNeedsReportController(
-    private val jdbi: Jdbi,
-    private val acl: AccessControlList
-) {
+class AssistanceNeedsReportController(private val acl: AccessControlList) {
     @GetMapping("/reports/assistance-needs")
     fun getAssistanceNeedReport(
+        db: Database,
         user: AuthenticatedUser,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): ResponseEntity<List<AssistanceNeedReportRow>> {
         Audit.AssistanceNeedsReportRead.log()
         user.requireOneOfRoles(SERVICE_WORKER, ADMIN, DIRECTOR, UNIT_SUPERVISOR)
         val units = acl.getAuthorizedUnits(user)
-        return jdbi.handle { h -> getAssistanceNeedReportRows(h, date, units.ids).let(::ok) }
+        return db.read { it.getAssistanceNeedReportRows(date, units.ids).let(::ok) }
     }
 }
 
-fun getAssistanceNeedReportRows(h: Handle, date: LocalDate, units: Collection<UUID>? = null): List<AssistanceNeedReportRow> {
+fun Database.Read.getAssistanceNeedReportRows(date: LocalDate, units: Collection<UUID>? = null): List<AssistanceNeedReportRow> {
     // language=sql
     val sql =
         """
@@ -78,7 +74,7 @@ fun getAssistanceNeedReportRows(h: Handle, date: LocalDate, units: Collection<UU
         """.trimIndent()
 
     @Suppress("UNCHECKED_CAST")
-    return h.createQuery(sql)
+    return createQuery(sql)
         .bind("target_date", date)
         .bind("units", units?.toTypedArray())
         .map { rs, _ ->

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.invoicing.domain.addressUsable
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.Period
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
@@ -12,9 +12,9 @@ import fi.espoo.evaka.invoicing.domain.InvoiceStatus
 import fi.espoo.evaka.invoicing.domain.addressUsable
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.Period
-import org.jdbi.v3.core.Jdbi
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -30,46 +30,47 @@ internal fun getMonthPeriod(date: LocalDate): Period {
 }
 
 @RestController
-class InvoiceReportController(private val jdbi: Jdbi) {
+class InvoiceReportController {
     @GetMapping("/reports/invoices")
     fun getInvoiceReport(
+        db: Database,
         user: AuthenticatedUser,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): ResponseEntity<InvoiceReport> {
         Audit.InvoicesReportRead.log()
         user.requireOneOfRoles(Roles.FINANCE_ADMIN, Roles.DIRECTOR, Roles.ADMIN)
-        return getInvoiceReportWithRows(
-            getMonthPeriod(date)
-        ).let(::ok)
-    }
-
-    fun getInvoiceReportWithRows(period: Period): InvoiceReport {
-        val rows = jdbi.handle { h ->
-            val invoices = searchInvoices(
-                h,
-                statuses = listOf(InvoiceStatus.SENT),
-                sentAt = period
+        return db.read {
+            it.getInvoiceReportWithRows(
+                getMonthPeriod(date)
             )
-
-            invoices.groupBy { it.agreementType }
-                .map { (agreementType, invoices) ->
-                    InvoiceReportRow(
-                        areaCode = agreementType,
-                        amountOfInvoices = invoices.size,
-                        totalSumCents = invoices.sumBy { it.totalPrice() },
-                        amountWithoutSSN = invoices.count { it.headOfFamily.ssn.isNullOrBlank() },
-                        amountWithoutAddress = invoices.count { withoutAddress(it) },
-                        amountWithZeroPrice = invoices.count { it.totalPrice() == 0 }
-                    )
-                }
-                .sortedBy { it.areaCode }
-        }
-
-        return InvoiceReport(reportRows = rows)
+        }.let(::ok)
     }
 }
 
-fun withoutAddress(invoice: InvoiceDetailed): Boolean = !addressUsable(
+private fun Database.Read.getInvoiceReportWithRows(period: Period): InvoiceReport {
+    val invoices = searchInvoices(
+        handle,
+        statuses = listOf(InvoiceStatus.SENT),
+        sentAt = period
+    )
+
+    val rows = invoices.groupBy { it.agreementType }
+        .map { (agreementType, invoices) ->
+            InvoiceReportRow(
+                areaCode = agreementType,
+                amountOfInvoices = invoices.size,
+                totalSumCents = invoices.sumBy { it.totalPrice() },
+                amountWithoutSSN = invoices.count { it.headOfFamily.ssn.isNullOrBlank() },
+                amountWithoutAddress = invoices.count { withoutAddress(it) },
+                amountWithZeroPrice = invoices.count { it.totalPrice() == 0 }
+            )
+        }
+        .sortedBy { it.areaCode }
+
+    return InvoiceReport(reportRows = rows)
+}
+
+private fun withoutAddress(invoice: InvoiceDetailed): Boolean = !addressUsable(
     invoice.headOfFamily.streetAddress,
     invoice.headOfFamily.postalCode,
     invoice.headOfFamily.postOffice

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.auth.UserRole.STAFF
 import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
 import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
 import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -32,6 +33,7 @@ class ServiceNeedController(
 ) {
     @PostMapping("/children/{childId}/service-needs")
     fun createServiceNeed(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: ServiceNeedRequest
@@ -39,6 +41,7 @@ class ServiceNeedController(
         Audit.ChildServiceNeedCreate.log(targetId = childId)
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR)
         return serviceNeedService.createServiceNeed(
+            db,
             user = user,
             childId = childId,
             data = body
@@ -47,16 +50,18 @@ class ServiceNeedController(
 
     @GetMapping("/children/{childId}/service-needs")
     fun getServiceNeeds(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<List<ServiceNeed>> {
         Audit.ChildServiceNeedRead.log(targetId = childId)
         acl.getRolesForChild(user, childId).requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN, STAFF)
-        return serviceNeedService.getServiceNeedsByChildId(childId).let(::ok)
+        return serviceNeedService.getServiceNeedsByChildId(db, childId).let(::ok)
     }
 
     @PutMapping("/service-needs/{id}")
     fun updateServiceNeed(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable id: UUID,
         @RequestBody body: ServiceNeedRequest
@@ -64,6 +69,7 @@ class ServiceNeedController(
         Audit.ChildServiceNeedUpdate.log(targetId = id)
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR)
         return serviceNeedService.updateServiceNeed(
+            db,
             user = user,
             id = id,
             data = body
@@ -72,12 +78,13 @@ class ServiceNeedController(
 
     @DeleteMapping("/service-needs/{id}")
     fun deleteServiceNeed(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable id: UUID
     ): ResponseEntity<Unit> {
         Audit.ChildServiceNeedDelete.log(targetId = id)
         user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR)
-        serviceNeedService.deleteServiceNeed(id)
+        serviceNeedService.deleteServiceNeed(db, id)
         return noContent()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -33,7 +33,7 @@ class ServiceNeedController(
 ) {
     @PostMapping("/children/{childId}/service-needs")
     fun createServiceNeed(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: ServiceNeedRequest
@@ -50,7 +50,7 @@ class ServiceNeedController(
 
     @GetMapping("/children/{childId}/service-needs")
     fun getServiceNeeds(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<List<ServiceNeed>> {
@@ -61,7 +61,7 @@ class ServiceNeedController(
 
     @PutMapping("/service-needs/{id}")
     fun updateServiceNeed(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable id: UUID,
         @RequestBody body: ServiceNeedRequest
@@ -78,7 +78,7 @@ class ServiceNeedController(
 
     @DeleteMapping("/service-needs/{id}")
     fun deleteServiceNeed(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable id: UUID
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedService.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 
 @Service
 class ServiceNeedService(private val asyncJobRunner: AsyncJobRunner) {
-    fun createServiceNeed(db: Database, user: AuthenticatedUser, childId: UUID, data: ServiceNeedRequest): ServiceNeed {
+    fun createServiceNeed(db: Database.Connection, user: AuthenticatedUser, childId: UUID, data: ServiceNeedRequest): ServiceNeed {
         try {
             return db.transaction { tx ->
                 shortenOverlappingServiceNeed(tx.handle, user, childId, data.startDate, data.endDate)
@@ -30,11 +30,11 @@ class ServiceNeedService(private val asyncJobRunner: AsyncJobRunner) {
         }
     }
 
-    fun getServiceNeedsByChildId(db: Database, childId: UUID): List<ServiceNeed> {
+    fun getServiceNeedsByChildId(db: Database.Connection, childId: UUID): List<ServiceNeed> {
         return db.read { tx -> getServiceNeedsByChild(tx.handle, childId) }
     }
 
-    fun updateServiceNeed(db: Database, user: AuthenticatedUser, id: UUID, data: ServiceNeedRequest): ServiceNeed {
+    fun updateServiceNeed(db: Database.Connection, user: AuthenticatedUser, id: UUID, data: ServiceNeedRequest): ServiceNeed {
         try {
             return db.transaction { tx ->
                 updateServiceNeed(tx.handle, user, id, data).also {
@@ -48,7 +48,7 @@ class ServiceNeedService(private val asyncJobRunner: AsyncJobRunner) {
         }
     }
 
-    fun deleteServiceNeed(db: Database, id: UUID) {
+    fun deleteServiceNeed(db: Database.Connection, id: UUID) {
         db.transaction { tx ->
             deleteServiceNeed(tx.handle, id).also {
                 tx.notifyServiceNeedUpdated(it)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.voltti.logging.MdcKey
 import mu.KotlinLogging
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.Jdbi
 import java.lang.reflect.UndeclaredThrowableException
 import java.time.Duration
@@ -84,14 +83,6 @@ class AsyncJobRunner(
 
     @Volatile
     var sendApplicationEmail: (db: Database, msg: SendApplicationEmail) -> Unit = noHandler
-
-    fun plan(
-        h: Handle,
-        payloads: Iterable<AsyncJobPayload>,
-        retryCount: Int = defaultRetryCount,
-        retryInterval: Duration = defaultRetryInterval,
-        runAt: Instant = Instant.now()
-    ) = h.transaction { plan(Database.Transaction.wrap(it), payloads, retryCount, retryInterval, runAt) }
 
     fun plan(
         tx: Database.Transaction,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.shared.async
 import fi.espoo.evaka.application.utils.exhaust
 import fi.espoo.evaka.dvv.DvvModificationsRefresh
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.voltti.logging.MdcKey
 import mu.KotlinLogging
 import org.jdbi.v3.core.Jdbi

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
@@ -25,14 +25,14 @@ class ScheduledOperationController(
 ) {
 
     @PostMapping("/dvv/update")
-    fun dvvUpdate(db: Database): ResponseEntity<Int> {
+    fun dvvUpdate(db: Database.Connection): ResponseEntity<Int> {
         Audit.VtjBatchSchedule.log()
         return ResponseEntity.ok(dvvModificationsBatchRefreshService.scheduleBatch(db))
     }
 
     @PostMapping("/koski/update")
     fun koskiUpdate(
-        db: Database,
+        db: Database.Connection,
         @RequestParam(required = false) personIds: String?,
         @RequestParam(required = false) daycareIds: String?
     ): ResponseEntity<Unit> {
@@ -53,7 +53,7 @@ class ScheduledOperationController(
     }
 
     @PostMapping("/application/clear-old-drafts")
-    fun removeOldDraftApplications(db: Database): ResponseEntity<Unit> {
+    fun removeOldDraftApplications(db: Database.Connection): ResponseEntity<Unit> {
         Audit.ApplicationsDeleteDrafts.log()
         db.transaction { removeOldDrafts(it.handle) }
         return ResponseEntity.noContent().build()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
@@ -9,9 +9,7 @@ import fi.espoo.evaka.application.removeOldDrafts
 import fi.espoo.evaka.dvv.DvvModificationsBatchRefreshService
 import fi.espoo.evaka.koski.KoskiUpdateService
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.varda.VardaUpdateService
-import org.jdbi.v3.core.Jdbi
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -21,16 +19,15 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/scheduled")
 class ScheduledOperationController(
-    private val jdbi: Jdbi,
     private val vardaUpdateService: VardaUpdateService,
     private val koskiUpdateService: KoskiUpdateService,
     private val dvvModificationsBatchRefreshService: DvvModificationsBatchRefreshService
 ) {
 
     @PostMapping("/dvv/update")
-    fun dvvUpdate(): ResponseEntity<Int> {
+    fun dvvUpdate(db: Database): ResponseEntity<Int> {
         Audit.VtjBatchSchedule.log()
-        return ResponseEntity.ok(dvvModificationsBatchRefreshService.scheduleBatch())
+        return ResponseEntity.ok(dvvModificationsBatchRefreshService.scheduleBatch(db))
     }
 
     @PostMapping("/koski/update")
@@ -56,9 +53,9 @@ class ScheduledOperationController(
     }
 
     @PostMapping("/application/clear-old-drafts")
-    fun removeOldDraftApplications(): ResponseEntity<Unit> {
+    fun removeOldDraftApplications(db: Database): ResponseEntity<Unit> {
         Audit.ApplicationsDeleteDrafts.log()
-        jdbi.transaction { removeOldDrafts(it) }
+        db.transaction { removeOldDrafts(it.handle) }
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/DatabaseSpringSupport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/DatabaseSpringSupport.kt
@@ -7,15 +7,55 @@ package fi.espoo.evaka.shared.db
 import org.jdbi.v3.core.Jdbi
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.MethodParameter
+import org.springframework.ui.ModelMap
 import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.context.request.WebRequestInterceptor
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
+/**
+ * Automatically manages and injects a per-thread Database / Database.Connection into controllers
+ * which have one of those as an argument in the method signature.
+ */
 @Configuration
 class DatabaseSpringSupport(private val jdbi: Jdbi) : WebMvcConfigurer {
+    private val database: ThreadLocal<Database> = ThreadLocal.withInitial { Database(jdbi) }
+    private val connection: ThreadLocal<Database.Connection?> = ThreadLocal()
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addWebRequestInterceptor(object : WebRequestInterceptor {
+            override fun preHandle(request: WebRequest) {}
+            override fun postHandle(request: WebRequest, model: ModelMap?) {}
+            override fun afterCompletion(request: WebRequest, ex: Exception?) = database.remove()
+        })
+        registry.addWebRequestInterceptor(object : WebRequestInterceptor {
+            override fun preHandle(request: WebRequest) {}
+            override fun postHandle(request: WebRequest, model: ModelMap?) {}
+            override fun afterCompletion(request: WebRequest, ex: Exception?) {
+                val c = connection.get()
+                connection.remove()
+                c?.close()
+            }
+        })
+        super.addInterceptors(registry)
+    }
+
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(object : HandlerMethodArgumentResolver {
+            override fun supportsParameter(parameter: MethodParameter): Boolean =
+                Database.Connection::class.java.isAssignableFrom(parameter.parameterType)
+
+            override fun resolveArgument(
+                parameter: MethodParameter,
+                mavContainer: ModelAndViewContainer?,
+                webRequest: NativeWebRequest,
+                binderFactory: WebDataBinderFactory?
+            ) = connection.get() ?: database.get().connect().also(connection::set)
+        })
         resolvers.add(object : HandlerMethodArgumentResolver {
             override fun supportsParameter(parameter: MethodParameter): Boolean =
                 Database::class.java.isAssignableFrom(parameter.parameterType)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -52,8 +52,6 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.shared.domain.Coordinate
@@ -63,7 +61,6 @@ import fi.espoo.evaka.shared.message.SuomiFiMessage
 import fi.espoo.evaka.vtjclient.dto.VtjPerson
 import fi.espoo.evaka.vtjclient.service.persondetails.MockPersonDetailsService
 import org.jdbi.v3.core.Handle
-import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.context.annotation.Configuration
@@ -112,7 +109,6 @@ private val fakeAdmin = AuthenticatedUser(
 @RestController
 @RequestMapping("/dev-api")
 class DevApi(
-    private val jdbi: Jdbi,
     private val objectMapper: ObjectMapper,
     private val personService: PersonService,
     private val asyncJobRunner: AsyncJobRunner,
@@ -120,8 +116,8 @@ class DevApi(
     private val applicationStateService: ApplicationStateService
 ) {
     @PostMapping("/clean-up")
-    fun cleanUpDatabase(): ResponseEntity<Unit> {
-        jdbi.transaction { it.clearDatabase() }
+    fun cleanUpDatabase(db: Database): ResponseEntity<Unit> {
+        db.transaction { it.handle.clearDatabase() }
         return ResponseEntity.noContent().build()
     }
 
@@ -133,66 +129,67 @@ class DevApi(
     }
 
     @DeleteMapping("/applications/{id}")
-    fun deleteApplicationByApplicationId(@PathVariable id: UUID): ResponseEntity<Unit> {
-        jdbi.transaction { it.deleteApplication(id) }
+    fun deleteApplicationByApplicationId(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+        db.transaction { it.handle.deleteApplication(id) }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/care-areas")
-    fun createCareAreas(@RequestBody careAreas: List<DevCareArea>): ResponseEntity<Unit> {
-        jdbi.transaction { careAreas.forEach { careArea -> it.insertTestCareArea(careArea) } }
+    fun createCareAreas(db: Database, @RequestBody careAreas: List<DevCareArea>): ResponseEntity<Unit> {
+        db.transaction { careAreas.forEach { careArea -> it.handle.insertTestCareArea(careArea) } }
         return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/care-areas/{id}")
-    fun deleteArea(@PathVariable id: UUID): ResponseEntity<Unit> {
-        jdbi.transaction { it.deleteCareArea(id) }
+    fun deleteArea(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+        db.transaction { it.handle.deleteCareArea(id) }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/daycares")
-    fun createDaycares(@RequestBody daycares: List<DevDaycare>): ResponseEntity<Unit> {
-        jdbi.transaction { daycares.forEach { daycare -> it.insertTestDaycare(daycare) } }
+    fun createDaycares(db: Database, @RequestBody daycares: List<DevDaycare>): ResponseEntity<Unit> {
+        db.transaction { daycares.forEach { daycare -> it.handle.insertTestDaycare(daycare) } }
         return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/daycares/{id}")
-    fun deleteDaycare(@PathVariable id: UUID): ResponseEntity<Unit> {
-        jdbi.transaction { it.deleteDaycare(id) }
+    fun deleteDaycare(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+        db.transaction { it.handle.deleteDaycare(id) }
         return ResponseEntity.noContent().build()
     }
 
     @PutMapping("/daycares/{daycareId}/acl")
     fun allowSupervisorToAccessDaycare(
+        db: Database,
         @PathVariable daycareId: UUID,
         @RequestBody body: DaycareAclInsert
     ): ResponseEntity<Unit> {
-        jdbi.transaction { h ->
-            updateDaycareAcl(h, daycareId, body.personAad, UserRole.UNIT_SUPERVISOR)
+        db.transaction { tx ->
+            updateDaycareAcl(tx.handle, daycareId, body.personAad, UserRole.UNIT_SUPERVISOR)
         }
         return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/daycares/{daycareId}/acl/{userAad}")
-    fun removeUserAccessToDaycare(@PathVariable daycareId: UUID, @PathVariable userAad: UUID): ResponseEntity<Unit> {
-        jdbi.transaction { h ->
-            removeDaycareAcl(h, daycareId, userAad)
+    fun removeUserAccessToDaycare(db: Database, @PathVariable daycareId: UUID, @PathVariable userAad: UUID): ResponseEntity<Unit> {
+        db.transaction { tx ->
+            removeDaycareAcl(tx.handle, daycareId, userAad)
         }
         return ResponseEntity.ok().build()
     }
 
     @PostMapping("/daycare-groups")
-    fun createDaycareGroups(@RequestBody groups: List<DevDaycareGroup>): ResponseEntity<Unit> {
-        jdbi.transaction {
-            groups.forEach { group -> it.insertTestDaycareGroup(group) }
+    fun createDaycareGroups(db: Database, @RequestBody groups: List<DevDaycareGroup>): ResponseEntity<Unit> {
+        db.transaction {
+            groups.forEach { group -> it.handle.insertTestDaycareGroup(group) }
         }
         return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/daycare-groups/{id}")
-    fun removeDaycareGroup(@PathVariable id: UUID): ResponseEntity<Unit> {
-        jdbi.transaction { h ->
-            h.deleteDaycareGroup(id)
+    fun removeDaycareGroup(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+        db.transaction { tx ->
+            tx.handle.deleteDaycareGroup(id)
         }
         return ResponseEntity.ok().build()
     }
@@ -205,11 +202,11 @@ class DevApi(
     )
 
     @PostMapping("/daycare-caretakers")
-    fun createDaycareCaretakers(@RequestBody caretakers: List<Caretaker>): ResponseEntity<Unit> {
-        jdbi.transaction { h ->
+    fun createDaycareCaretakers(db: Database, @RequestBody caretakers: List<Caretaker>): ResponseEntity<Unit> {
+        db.transaction { tx ->
             caretakers.forEach { caretaker ->
                 insertTestCaretakers(
-                    h,
+                    tx.handle,
                     caretaker.groupId,
                     amount = caretaker.amount,
                     startDate = caretaker.startDate,
@@ -221,21 +218,21 @@ class DevApi(
     }
 
     @PostMapping("/children")
-    fun createChildren(@RequestBody children: List<DevChild>): ResponseEntity<Unit> {
-        jdbi.transaction { children.forEach { child -> it.insertTestChild(child) } }
+    fun createChildren(db: Database, @RequestBody children: List<DevChild>): ResponseEntity<Unit> {
+        db.transaction { children.forEach { child -> it.handle.insertTestChild(child) } }
         return ResponseEntity.noContent().build()
     }
 
     // also cascades delete to daycare_placement and group_placement
     @DeleteMapping("/children/{id}")
-    fun deleteChild(@PathVariable id: UUID): ResponseEntity<Unit> {
-        jdbi.transaction { it.deleteChild(id) }
+    fun deleteChild(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+        db.transaction { it.handle.deleteChild(id) }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/daycare-placements")
-    fun createDaycarePlacements(@RequestBody placements: List<DevPlacement>): ResponseEntity<Unit> {
-        jdbi.transaction { placements.forEach { placement -> it.insertTestPlacement(placement) } }
+    fun createDaycarePlacements(db: Database, @RequestBody placements: List<DevPlacement>): ResponseEntity<Unit> {
+        db.transaction { placements.forEach { placement -> it.handle.insertTestPlacement(placement) } }
         return ResponseEntity.noContent().build()
     }
 
@@ -250,11 +247,11 @@ class DevApi(
     )
 
     @PostMapping("/decisions")
-    fun createDecisions(@RequestBody decisions: List<DecisionRequest>): ResponseEntity<Unit> {
-        decisions.forEach { decision ->
-            jdbi.handle { h ->
+    fun createDecisions(db: Database, @RequestBody decisions: List<DecisionRequest>): ResponseEntity<Unit> {
+        db.transaction { tx ->
+            decisions.forEach { decision ->
                 insertDecision(
-                    h,
+                    tx.handle,
                     decision.id,
                     decision.employeeId,
                     LocalDate.now(ZoneId.of("Europe/Helsinki")),
@@ -270,25 +267,25 @@ class DevApi(
     }
 
     @PostMapping("/fee-decisions")
-    fun createFeeDecisions(@RequestBody decisions: List<FeeDecision>): ResponseEntity<Unit> {
-        jdbi.transaction { h -> upsertFeeDecisions(h, objectMapper, decisions) }
+    fun createFeeDecisions(db: Database, @RequestBody decisions: List<FeeDecision>): ResponseEntity<Unit> {
+        db.transaction { tx -> upsertFeeDecisions(tx.handle, objectMapper, decisions) }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/value-decisions")
-    fun createVoucherValueDecisions(@RequestBody decisions: List<VoucherValueDecision>): ResponseEntity<Unit> {
-        jdbi.transaction { h -> h.upsertValueDecisions(objectMapper, decisions) }
+    fun createVoucherValueDecisions(db: Database, @RequestBody decisions: List<VoucherValueDecision>): ResponseEntity<Unit> {
+        db.transaction { tx -> tx.handle.upsertValueDecisions(objectMapper, decisions) }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/invoices")
-    fun createInvoices(@RequestBody invoices: List<Invoice>): ResponseEntity<Unit> {
-        jdbi.handle(insertInvoices(invoices))
+    fun createInvoices(db: Database, @RequestBody invoices: List<Invoice>): ResponseEntity<Unit> {
+        db.transaction { tx -> insertInvoices(invoices)(tx.handle) }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/pricing")
-    fun createPricing(@RequestBody pricing: DevPricing): ResponseEntity<UUID> = jdbi.transaction {
+    fun createPricing(db: Database, @RequestBody pricing: DevPricing): ResponseEntity<UUID> = db.transaction {
         ResponseEntity.ok(
             it.createUpdate(
                 """
@@ -301,53 +298,53 @@ RETURNING id
     }
 
     @PostMapping("/pricing/clean-up")
-    fun clearPricing(): ResponseEntity<Unit> {
-        jdbi.handle { it.createUpdate("DELETE FROM pricing").execute() }
+    fun clearPricing(db: Database): ResponseEntity<Unit> {
+        db.transaction { it.execute("DELETE FROM pricing") }
         return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/pricing/{id}")
-    fun deletePricing(@PathVariable id: UUID): ResponseEntity<Unit> {
-        jdbi.transaction { it.deletePricing(id) }
+    fun deletePricing(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+        db.transaction { it.handle.deletePricing(id) }
         return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/incomes/person/{id}")
-    fun deleteIncomesByPerson(@PathVariable id: UUID): ResponseEntity<Unit> {
-        jdbi.transaction { it.deleteIncome(id) }
+    fun deleteIncomesByPerson(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+        db.transaction { it.handle.deleteIncome(id) }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/person")
-    fun upsertPerson(@RequestBody body: DevPerson): ResponseEntity<PersonDTO> {
+    fun upsertPerson(db: Database, @RequestBody body: DevPerson): ResponseEntity<PersonDTO> {
         if (body.ssn == null) throw BadRequest("SSN is required for using this endpoint")
-        return jdbi.transaction { h ->
-            val person = h.getPersonBySSN(body.ssn)
+        return db.transaction { tx ->
+            val person = tx.handle.getPersonBySSN(body.ssn)
             val personDTO = body.toPersonDTO()
 
             if (person != null) {
-                h.updatePersonFromVtj(personDTO).let { ResponseEntity.ok(it) }
+                tx.handle.updatePersonFromVtj(personDTO).let { ResponseEntity.ok(it) }
             } else {
-                h.createPersonFromVtj(personDTO).let { ResponseEntity.ok(it) }
+                tx.handle.createPersonFromVtj(personDTO).let { ResponseEntity.ok(it) }
             }
         }
     }
 
     @PostMapping("/person/create")
-    fun createPerson(@RequestBody body: DevPerson): ResponseEntity<UUID> {
-        return jdbi.transaction { h ->
-            val personId = h.insertTestPerson(body)
+    fun createPerson(db: Database, @RequestBody body: DevPerson): ResponseEntity<UUID> {
+        return db.transaction { tx ->
+            val personId = tx.handle.insertTestPerson(body)
             val dto = body.copy(id = personId).toPersonDTO()
             if (dto.identity is ExternalIdentifier.SSN) {
-                h.updatePersonFromVtj(dto)
+                tx.handle.updatePersonFromVtj(dto)
             }
             ResponseEntity.ok(personId)
         }
     }
 
     @DeleteMapping("/person/{id}")
-    fun deletePerson(@PathVariable id: UUID): ResponseEntity<Unit> {
-        jdbi.transaction {
+    fun deletePerson(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+        db.transaction {
             it.execute(
                 """
 WITH applications AS (DELETE FROM application WHERE child_id = ? OR guardian_id = ? RETURNING id)
@@ -373,41 +370,39 @@ DELETE FROM application_form USING applications WHERE application_id = applicati
     }
 
     @DeleteMapping("/person/ssn/{ssn}")
-    fun deletePersonBySsn(@PathVariable ssn: String): ResponseEntity<Unit> {
-        jdbi.handle { h ->
+    fun deletePersonBySsn(db: Database, @PathVariable ssn: String): ResponseEntity<Unit> {
+        db.read { h ->
             h.createQuery("SELECT id FROM person WHERE social_security_number = :ssn")
                 .bind("ssn", ssn)
                 .mapTo<UUID>()
                 .firstOrNull()
-        }?.let { uuid ->
-            deletePerson(uuid)
-        }
+        }?.let { uuid -> deletePerson(db, uuid) }
         return ResponseEntity.ok().build()
     }
 
     @PostMapping("/parentship")
-    fun createParentships(@RequestBody parentships: List<DevParentship>): ResponseEntity<List<DevParentship>> {
-        return jdbi.handle { h -> parentships.map { h.insertTestParentship(it) } }.let { ResponseEntity.ok(it) }
+    fun createParentships(db: Database, @RequestBody parentships: List<DevParentship>): ResponseEntity<List<DevParentship>> {
+        return db.transaction { tx -> parentships.map { tx.handle.insertTestParentship(it) } }.let { ResponseEntity.ok(it) }
     }
 
     @GetMapping("/employee")
-    fun getEmployees(): ResponseEntity<List<Employee>> {
-        return ResponseEntity.ok(jdbi.transaction { it.getEmployees() })
+    fun getEmployees(db: Database): ResponseEntity<List<Employee>> {
+        return ResponseEntity.ok(db.read { it.handle.getEmployees() })
     }
 
     @PostMapping("/employee")
-    fun createEmployee(@RequestBody body: DevEmployee): ResponseEntity<UUID> {
-        return ResponseEntity.ok(jdbi.transaction { it.insertTestEmployee(body) })
+    fun createEmployee(db: Database, @RequestBody body: DevEmployee): ResponseEntity<UUID> {
+        return ResponseEntity.ok(db.transaction { it.handle.insertTestEmployee(body) })
     }
 
     @DeleteMapping("/employee/{aad}")
-    fun deleteEmployee(@PathVariable aad: UUID): ResponseEntity<Unit> {
-        jdbi.transaction { it.deleteEmployeeByAad(aad) }
+    fun deleteEmployee(db: Database, @PathVariable aad: UUID): ResponseEntity<Unit> {
+        db.transaction { it.handle.deleteEmployeeByAad(aad) }
         return ResponseEntity.ok().build()
     }
 
     @PostMapping("/employee/aad/{aad}")
-    fun upsertEmployeeByAad(@PathVariable aad: UUID, @RequestBody employee: DevEmployee): ResponseEntity<UUID> = jdbi.transaction {
+    fun upsertEmployeeByAad(db: Database, @PathVariable aad: UUID, @RequestBody employee: DevEmployee): ResponseEntity<UUID> = db.transaction {
         ResponseEntity.ok(
             it.createUpdate(
                 """
@@ -425,14 +420,14 @@ RETURNING id
     }
 
     @DeleteMapping("/employee/roles/aad/{aad}")
-    fun deleteEmployeeRolesByAad(@PathVariable aad: UUID): ResponseEntity<Unit> {
-        jdbi.transaction { it.deleteEmployeeRolesByAad(aad) }
+    fun deleteEmployeeRolesByAad(db: Database, @PathVariable aad: UUID): ResponseEntity<Unit> {
+        db.transaction { it.handle.deleteEmployeeRolesByAad(aad) }
         return ResponseEntity.ok().build()
     }
 
     @PostMapping("/child")
-    fun insertChild(@RequestBody body: DevPerson): ResponseEntity<UUID> = jdbi.transaction {
-        val id = it.insertTestPerson(
+    fun insertChild(db: Database, @RequestBody body: DevPerson): ResponseEntity<UUID> = db.transaction {
+        val id = it.handle.insertTestPerson(
             DevPerson(
                 id = body.id,
                 dateOfBirth = body.dateOfBirth,
@@ -445,25 +440,25 @@ RETURNING id
                 restrictedDetailsEnabled = body.restrictedDetailsEnabled
             )
         )
-        it.insertTestChild(DevChild(id = id))
+        it.handle.insertTestChild(DevChild(id = id))
         ResponseEntity.ok(id)
     }
 
     @PostMapping("/backup-cares")
-    fun createBackupCares(@RequestBody backupCares: List<DevBackupCare>): ResponseEntity<Unit> {
-        jdbi.transaction { h -> backupCares.forEach { insertTestBackupCare(h, it) } }
+    fun createBackupCares(db: Database, @RequestBody backupCares: List<DevBackupCare>): ResponseEntity<Unit> {
+        db.transaction { tx -> backupCares.forEach { insertTestBackupCare(tx.handle, it) } }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/applications")
-    fun createApplications(@RequestBody applications: List<ApplicationWithForm>): ResponseEntity<List<UUID>> {
+    fun createApplications(db: Database, @RequestBody applications: List<ApplicationWithForm>): ResponseEntity<List<UUID>> {
         val uuids =
-            jdbi.transaction { h ->
+            db.transaction { tx ->
                 applications.map { application ->
-                    val id = insertApplication(h, application)
+                    val id = insertApplication(tx.handle, application)
                     application.form?.let { applicationFormString ->
                         insertApplicationForm(
-                            h,
+                            tx.handle,
                             ApplicationForm(
                                 applicationId = id,
                                 revision = 1,
@@ -479,18 +474,19 @@ RETURNING id
 
     @PostMapping("/placement-plan/{application-id}")
     fun createPlacementPlan(
+        db: Database,
         @PathVariable("application-id") applicationId: UUID,
         @RequestBody placementPlan: PlacementPlan
     ): ResponseEntity<Unit> {
-        jdbi.transaction { h ->
-            val application = fetchApplicationDetails(h, applicationId)
+        db.transaction { tx ->
+            val application = fetchApplicationDetails(tx.handle, applicationId)
                 ?: throw NotFound("application $applicationId not found")
             val preschoolDaycarePeriod = if (placementPlan.preschoolDaycarePeriodStart != null) ClosedPeriod(
                 placementPlan.preschoolDaycarePeriodStart, placementPlan.preschoolDaycarePeriodEnd!!
             ) else null
 
             placementPlanService.createPlacementPlan(
-                h,
+                tx.handle,
                 application,
                 DaycarePlacementPlan(
                     placementPlan.unitId,
@@ -504,12 +500,12 @@ RETURNING id
     }
 
     @GetMapping("/messages")
-    fun getMessages(): ResponseEntity<List<SuomiFiMessage>> {
+    fun getMessages(db: Database): ResponseEntity<List<SuomiFiMessage>> {
         return ResponseEntity.ok(MockEvakaMessageClient.getMessages())
     }
 
     @PostMapping("/messages/clean-up")
-    fun cleanUpMessages(): ResponseEntity<Unit> {
+    fun cleanUpMessages(db: Database): ResponseEntity<Unit> {
         MockEvakaMessageClient.clearMessages()
         return ResponseEntity.noContent().build()
     }
@@ -533,13 +529,13 @@ RETURNING id
     }
 
     @GetMapping("/vtj-persons/{ssn}")
-    fun getVtjPerson(@PathVariable ssn: String): ResponseEntity<VtjPerson> {
+    fun getVtjPerson(db: Database, @PathVariable ssn: String): ResponseEntity<VtjPerson> {
         return MockPersonDetailsService.getPerson(ssn)?.let { person -> ResponseEntity.ok(person) }
             ?: throw NotFound("vtj person $ssn was not found")
     }
 
     @DeleteMapping("/vtj-persons/{ssn}")
-    fun deleteVtjPerson(@PathVariable ssn: String): ResponseEntity<Unit> {
+    fun deleteVtjPerson(db: Database, @PathVariable ssn: String): ResponseEntity<Unit> {
         MockPersonDetailsService.deletePerson(ssn)
         return ResponseEntity.noContent().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -486,7 +486,7 @@ RETURNING id
             ) else null
 
             placementPlanService.createPlacementPlan(
-                tx.handle,
+                tx,
                 application,
                 DaycarePlacementPlan(
                     placementPlan.unitId,
@@ -596,7 +596,7 @@ RETURNING id
     ): ResponseEntity<Unit> {
         db.transaction { tx ->
             ensureFakeAdminExists(tx.handle)
-            placementPlanService.getPlacementPlanDraft(tx.handle, applicationId)
+            placementPlanService.getPlacementPlanDraft(tx, applicationId)
                 .let {
                     DaycarePlacementPlan(
                         unitId = it.preferredUnits.first().id,

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -34,10 +34,8 @@ import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
 import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
 import fi.espoo.evaka.shared.auth.UserRole.STAFF
 import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
-import fi.espoo.evaka.shared.db.handle
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.ClosedPeriod
-import org.jdbi.v3.core.Handle
-import org.jdbi.v3.core.Jdbi
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
@@ -53,12 +51,10 @@ val detailedDataRoles = arrayOf(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPER
 
 @Controller
 @RequestMapping("/views/units")
-class UnitsView(
-    private val jdbi: Jdbi,
-    private val acl: AccessControlList
-) {
+class UnitsView(private val acl: AccessControlList) {
     @GetMapping("/{unitId}")
     fun getUnitViewData(
+        db: Database,
         user: AuthenticatedUser,
         @PathVariable unitId: UUID,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
@@ -72,14 +68,14 @@ class UnitsView(
         currentUserRoles.requireOneOfRoles(*basicDataRoles)
 
         val period = ClosedPeriod(from, to)
-        val unitData = jdbi.handle {
-            val groups = it.getDaycareGroups(unitId, from, to)
-            val placements = getDaycarePlacements(it, unitId, null, from, to).toList()
-            val backupCares = it.getBackupCaresForDaycare(unitId, period)
-            val missingGroupPlacements = it.getMissingGroupPlacements(unitId)
+        val unitData = db.read {
+            val groups = it.handle.getDaycareGroups(unitId, from, to)
+            val placements = getDaycarePlacements(it.handle, unitId, null, from, to).toList()
+            val backupCares = it.handle.getBackupCaresForDaycare(unitId, period)
+            val missingGroupPlacements = it.handle.getMissingGroupPlacements(unitId)
             val caretakers = Caretakers(
-                unitCaretakers = it.getUnitStats(unitId, from, to),
-                groupCaretakers = it.getGroupStats(unitId, from, to)
+                unitCaretakers = it.handle.getUnitStats(unitId, from, to),
+                groupCaretakers = it.handle.getGroupStats(unitId, from, to)
             )
 
             val basicData = UnitDataResponse(
@@ -93,9 +89,9 @@ class UnitsView(
             if (currentUserRoles.hasOneOfRoles(*detailedDataRoles)) {
                 val unitOccupancies = getUnitOccupancies(it, unitId, period)
                 val groupOccupancies = getGroupOccupancies(it, unitId, period)
-                val placementProposals = getPlacementPlans(it, unitId, null, null, listOf(ApplicationStatus.WAITING_UNIT_CONFIRMATION))
-                val placementPlans = getPlacementPlans(it, unitId, null, null, listOf(ApplicationStatus.WAITING_CONFIRMATION, ApplicationStatus.WAITING_MAILING))
-                val applications = it.getApplicationUnitSummaries(unitId)
+                val placementProposals = getPlacementPlans(it.handle, unitId, null, null, listOf(ApplicationStatus.WAITING_UNIT_CONFIRMATION))
+                val placementPlans = getPlacementPlans(it.handle, unitId, null, null, listOf(ApplicationStatus.WAITING_CONFIRMATION, ApplicationStatus.WAITING_MAILING))
+                val applications = it.handle.getApplicationUnitSummaries(unitId)
 
                 basicData.copy(
                     unitOccupancies = unitOccupancies,
@@ -136,19 +132,19 @@ data class UnitOccupancies(
     val realized: OccupancyResponse
 )
 
-fun getUnitOccupancies(
-    h: Handle,
+private fun getUnitOccupancies(
+    tx: Database.Read,
     unitId: UUID,
     period: ClosedPeriod
 ): UnitOccupancies {
     return UnitOccupancies(
-        planned = getOccupancyResponse(calculateOccupancyPeriods(unitId, period, OccupancyType.PLANNED)(h)),
-        confirmed = getOccupancyResponse(calculateOccupancyPeriods(unitId, period, OccupancyType.CONFIRMED)(h)),
-        realized = getOccupancyResponse(calculateOccupancyPeriods(unitId, period, OccupancyType.REALIZED)(h))
+        planned = getOccupancyResponse(tx.calculateOccupancyPeriods(unitId, period, OccupancyType.PLANNED)),
+        confirmed = getOccupancyResponse(tx.calculateOccupancyPeriods(unitId, period, OccupancyType.CONFIRMED)),
+        realized = getOccupancyResponse(tx.calculateOccupancyPeriods(unitId, period, OccupancyType.REALIZED))
     )
 }
 
-fun getOccupancyResponse(occupancies: List<OccupancyPeriod>): OccupancyResponse {
+private fun getOccupancyResponse(occupancies: List<OccupancyPeriod>): OccupancyResponse {
     return OccupancyResponse(
         occupancies = occupancies,
         max = occupancies.filter { it.percentage != null }.maxBy { it.percentage!! },
@@ -161,30 +157,30 @@ data class GroupOccupancies(
     val realized: Map<UUID, OccupancyResponse>
 )
 
-fun getGroupOccupancies(
-    h: Handle,
+private fun getGroupOccupancies(
+    tx: Database.Read,
     unitId: UUID,
     period: ClosedPeriod
 ): GroupOccupancies {
     return GroupOccupancies(
         confirmed = getGroupOccupancyResponses(
-            calculateOccupancyPeriodsGroupLevel(
+            tx.calculateOccupancyPeriodsGroupLevel(
                 unitId,
                 period,
                 OccupancyType.CONFIRMED
-            )(h)
+            )
         ),
         realized = getGroupOccupancyResponses(
-            calculateOccupancyPeriodsGroupLevel(
+            tx.calculateOccupancyPeriodsGroupLevel(
                 unitId,
                 period,
                 OccupancyType.REALIZED
-            )(h)
+            )
         )
     )
 }
 
-fun getGroupOccupancyResponses(occupancies: List<OccupancyPeriodGroupLevel>): Map<UUID, OccupancyResponse> {
+private fun getGroupOccupancyResponses(occupancies: List<OccupancyPeriodGroupLevel>): Map<UUID, OccupancyResponse> {
     return occupancies
         .groupBy { it.groupId }
         .mapValues { (_, value) ->

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -70,7 +70,7 @@ class UnitsView(private val acl: AccessControlList) {
         val period = ClosedPeriod(from, to)
         val unitData = db.read {
             val groups = it.handle.getDaycareGroups(unitId, from, to)
-            val placements = getDaycarePlacements(it.handle, unitId, null, from, to).toList()
+            val placements = it.getDaycarePlacements(unitId, null, from, to).toList()
             val backupCares = it.handle.getBackupCaresForDaycare(unitId, period)
             val missingGroupPlacements = it.handle.getMissingGroupPlacements(unitId)
             val caretakers = Caretakers(

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.varda
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.varda.integration.VardaClient
 import fi.espoo.evaka.varda.integration.VardaTokenProvider
 import mu.KotlinLogging

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -33,11 +33,11 @@ class VardaUpdateService(
     fun updateAll() {
         val client = VardaClient(tokenProvider, env, mapper)
         if (forceSync) {
-            updateAll(jdbi, client, mapper, personService, organizer)
+            updateAll(Database(jdbi), client, mapper, personService, organizer)
         } else {
             thread {
                 try {
-                    updateAll(jdbi, client, mapper, personService, organizer)
+                    updateAll(Database(jdbi), client, mapper, personService, organizer)
                 } catch (e: Throwable) {
                     val exception = (e as? UndeclaredThrowableException)?.cause ?: e
                     logger.error(exception) { "Failed to run Varda update" }
@@ -51,23 +51,19 @@ class VardaUpdateService(
 }
 
 fun updateAll(
-    jdbi: Jdbi,
+    db: Database,
     client: VardaClient,
     mapper: ObjectMapper,
     personService: PersonService,
     organizer: String
 ) {
-    jdbi.handle { h ->
-        removeMarkedFeeDataFromVarda(h, client)
-        removeMarkedPlacementsFromVarda(h, client)
-        removeMarkedDecisionsFromVarda(h, client)
-        updateOrganizer(h, client, organizer)
-        updateUnits(h, client, organizer)
-        updateChildren(h, client, organizer)
-        updateDecisions(h, client)
-        updatePlacements(h, client)
-    }
-    Database(jdbi).transaction { tx ->
-        updateFeeData(tx, client, mapper, personService)
-    }
+    db.transaction { removeMarkedFeeDataFromVarda(it.handle, client) }
+    db.transaction { removeMarkedPlacementsFromVarda(it.handle, client) }
+    db.transaction { removeMarkedDecisionsFromVarda(it.handle, client) }
+    db.transaction { updateOrganizer(it.handle, client, organizer) }
+    db.transaction { updateUnits(it.handle, client, organizer) }
+    db.transaction { updateChildren(it.handle, client, organizer) }
+    db.transaction { updateDecisions(it.handle, client) }
+    db.transaction { updatePlacements(it.handle, client) }
+    db.transaction { updateFeeData(it, client, mapper, personService) }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -44,7 +44,7 @@ class VtjController(
 ) {
     @GetMapping("/uuid/{personId}")
     fun getDetails(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: UUID
     ): ResponseEntity<VtjPersonDTO> {
@@ -59,7 +59,7 @@ class VtjController(
     }
 
     private fun getPersonDataWithChildren(
-        db: Database,
+        db: Database.Connection,
         user: AuthenticatedUser,
         personId: VolttiIdentifier
     ): PersonResult {
@@ -77,7 +77,7 @@ class VtjController(
         }
     }
 
-    private fun personResult(db: Database, user: AuthenticatedUser, personId: VolttiIdentifier): PersonResult {
+    private fun personResult(db: Database.Connection, user: AuthenticatedUser, personId: VolttiIdentifier): PersonResult {
         val guardianResult = db.read { it.handle.getPersonById(personId) }
             ?.let { person ->
                 when (person.identity) {

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getEnum
 import fi.espoo.evaka.shared.db.getUUID
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.vtjclient.dto.NativeLanguage
 import fi.espoo.evaka.vtjclient.dto.PersonDataSource
@@ -23,7 +22,6 @@ import fi.espoo.evaka.vtjclient.dto.VtjPersonDTO
 import fi.espoo.evaka.vtjclient.service.persondetails.PersonStorageService
 import fi.espoo.evaka.vtjclient.usecases.dto.PersonResult
 import mu.KotlinLogging
-import org.jdbi.v3.core.Jdbi
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.AccessDeniedException
@@ -42,8 +40,7 @@ class UseCaseDeniedException : AccessDeniedException("Use case not allowed for c
 @RequestMapping("/persondetails")
 class VtjController(
     private val personStorageService: PersonStorageService,
-    private val personService: PersonService,
-    private val jdbi: Jdbi
+    private val personService: PersonService
 ) {
     @GetMapping("/uuid/{personId}")
     fun getDetails(
@@ -57,7 +54,7 @@ class VtjController(
         return when (vtjData) {
             is PersonResult.Error -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
             is PersonResult.NotFound -> ResponseEntity.notFound().build()
-            is PersonResult.Result -> ResponseEntity.ok(withChildPlacements(vtjData.vtjPersonDTO))
+            is PersonResult.Result -> ResponseEntity.ok(db.read { withChildPlacements(it, vtjData.vtjPersonDTO) })
         }
     }
 
@@ -94,11 +91,11 @@ class VtjController(
             ?: PersonResult.NotFound()
     }
 
-    private fun withChildPlacements(guardian: VtjPersonDTO): VtjPersonDTO = jdbi.handle { h ->
+    private fun withChildPlacements(tx: Database.Read, guardian: VtjPersonDTO): VtjPersonDTO {
         val sql =
             "SELECT child_id, start_date, end_date, type FROM placement WHERE child_id = ANY(:children) AND end_date > current_date"
 
-        val placements = h.createQuery(sql)
+        val placements = tx.createQuery(sql)
             .bind("children", guardian.children.map { it.id }.toTypedArray())
             .map { rs, _ ->
                 rs.getUUID("child_id") to Placement(
@@ -110,7 +107,7 @@ class VtjController(
                 )
             }
 
-        guardian.copy(
+        return guardian.copy(
             children = guardian.children.map { child ->
                 val childPlacements = placements
                     .filter { (id, _) -> id == child.id }

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/mapper/VTJResponseMapper.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/mapper/VTJResponseMapper.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.vtjclient.soap.ObjectFactory
 import fi.espoo.evaka.vtjclient.soap.VTJHenkiloVastaussanoma
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
-import java.lang.RuntimeException
 import javax.xml.bind.JAXBElement
 
 private val logger = KotlinLogging.logger {}


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

* use new Database API in controllers, services, and async jobs. Most database queries still use old Handle API
* pass Database.Connection to tests and controllers. This was the original idea, but previously I wasn't sure if connection cleanup was possible to implement with simple Spring MVC integration