### PR TITLE
[EVAKA-4008] message-service: log errors once, don't abuse audit logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -738,6 +738,8 @@ jobs:
           command: ./gradlew test
       - store_test_results:
           path: /home/circleci/repo/service/build/test-results/test/
+      - store_test_results:
+          path: /home/circleci/repo/service-lib/build/test-results/test/
       - login_docker_hub
       - run:
           working_directory: *workspace_service
@@ -788,6 +790,8 @@ jobs:
           command: ./gradlew test
       - store_test_results:
           path: /home/circleci/repo/message-service/build/test-results/test/
+      - store_test_results:
+          path: /home/circleci/repo/service-lib/build/test-results/test/
       - login_docker_hub
       - run:
           working_directory: *workspace_message_service
@@ -796,6 +800,8 @@ jobs:
           path: /home/circleci/repo/message-service/build/test-results/integrationTest/
       - store_artifacts:
           path: /home/circleci/repo/message-service/build/reports/
+      - store_artifacts:
+          path: /home/circleci/repo/service-lib/build/reports/
       - notify_slack
 
   message_service_build_and_push_image:

--- a/message-service/README.md
+++ b/message-service/README.md
@@ -60,6 +60,9 @@ If you want to set ktlint formatter rules as your IDEA kotlin formatting rules, 
 
 ### Local testing against SFI
 
+**NOTE:** These instructions are only relevant for Voltti developers as they require
+an existing connection and configuration for Suomi.fi Viestit.
+
 Use the `SfiApiTest` class to run the test, remember to remove the `@Ignore` from the class.
 
 Add the following to your application-test.properties:
@@ -115,7 +118,7 @@ The `LocalForward` target IP is for QAT, if you need to send to prod SFI, check 
 from the VIA excel.
 
 SSH to the instance you just specified above with `ssh sfi-tunnel-test` and run your test. If the test succeeds, you should be
-able to read the message from the SFI test enviroment. The address and passwords are on the  [wiki](https://voltti.atlassian.net/wiki/spaces/EVAKA/pages/852328491/Suomi.fi+Viestit+k+ytt+notto)
+able to read the message from the SFI test environment. The address and passwords are on the  [wiki](https://voltti.atlassian.net/wiki/spaces/EVAKA/pages/852328491/Suomi.fi+Viestit+k+ytt+notto)
 page.
 
 You can see the content of the replies and responses in the log because the trace logging is enabled in `application-test.properties`:

--- a/message-service/src/main/kotlin/fi/espoo/evaka/msg/config/SfiSoapClientConfig.kt
+++ b/message-service/src/main/kotlin/fi/espoo/evaka/msg/config/SfiSoapClientConfig.kt
@@ -73,18 +73,8 @@ class SfiSoapClientConfig {
 
         override fun resolveFault(message: WebServiceMessage) {
             when (message) {
-                is FaultAwareWebServiceMessage -> {
-                    logger.error(
-                        "Fault while doing SFI Message request: {message.faultCode}. " +
-                            "Reason: ${message.faultReason}",
-                        message
-                    )
-                    throw WebServiceFaultException(message)
-                }
-                else -> {
-                    logger.error("Unknown error while doing SFI Message request: \"$message\".", message)
-                    throw WebServiceFaultException("Message has unknown fault: $message")
-                }
+                is FaultAwareWebServiceMessage -> throw WebServiceFaultException(message)
+                else -> throw WebServiceFaultException("Message has unknown fault: $message")
             }
         }
     }

--- a/message-service/src/main/kotlin/fi/espoo/evaka/msg/service/sfi/SfiClientService.kt
+++ b/message-service/src/main/kotlin/fi/espoo/evaka/msg/service/sfi/SfiClientService.kt
@@ -5,15 +5,9 @@
 package fi.espoo.evaka.msg.service.sfi
 
 import fi.espoo.evaka.msg.mapper.ISfiMapper
-import fi.espoo.evaka.msg.service.sfi.ISfiClientService.MessageDetails
 import fi.espoo.evaka.msg.service.sfi.ISfiClientService.MessageMetadata
-import fi.espoo.evaka.msg.service.sfi.SfiClientService.SfiRequestStatus.CREATING_REQUEST
-import fi.espoo.evaka.msg.service.sfi.SfiClientService.SfiRequestStatus.ERROR_DURING_REQUEST
-import fi.espoo.evaka.msg.service.sfi.SfiClientService.SfiRequestStatus.RECEIVED_ERROR_RESPONSE
-import fi.espoo.evaka.msg.service.sfi.SfiClientService.SfiRequestStatus.RECEIVED_OK_RESPONSE
 import fi.espoo.evaka.msg.sficlient.soap.LahetaViestiResponse
 import fi.espoo.evaka.msg.sficlient.soap.ObjectFactory
-import fi.espoo.voltti.logging.loggers.audit
 import mu.KotlinLogging
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
@@ -37,17 +31,9 @@ class SfiClientService(
         val caseId = metadata.message.uniqueCaseIdentifier
 
         logger.info { "Sending SFI message about $caseId with messageId: $uniqueSfiMessageId" }
-        logger.audit(
-            toLogParamsMap(
-                messageDetails = metadata.message,
-                requestId = uniqueSfiMessageId.toString(),
-                status = CREATING_REQUEST
-            )
-        ) { "Sending SFI message about $caseId with messageId: $uniqueSfiMessageId" }
 
         val request = sfiObjectFactory.createLahetaViesti()
             .apply {
-
                 viranomainen = sfiAccountDetailsService.getAuthorityDetails(uniqueSfiMessageId)
                 kysely = sfiAccountDetailsService.createQueryWithPrintingDetails()
                 kysely.kohteet = sfiMapper.mapToSoapTargets(metadata)
@@ -56,18 +42,7 @@ class SfiClientService(
         val soapResponse: LahetaViestiResponse = try {
             wsTemplate.marshalSendAndReceiveAsType(request)
         } catch (e: Exception) {
-            logger.error("Error while sending SFI request $uniqueSfiMessageId", e)
-            logger.audit(
-                toLogParamsMap(
-                    messageDetails = metadata.message,
-                    requestId = uniqueSfiMessageId.toString(),
-                    status = ERROR_DURING_REQUEST
-                )
-            ) {
-                "Error while sending SFI request about $caseId with messageId: " +
-                    "$uniqueSfiMessageId"
-            }
-            throw e
+            throw Exception("Error while sending SFI request about $caseId with messageId: $uniqueSfiMessageId", e)
         }
 
         return soapResponse.let(SfiResponse.Mapper::from)
@@ -77,50 +52,11 @@ class SfiClientService(
                         "Successfully sent SFI message about $caseId with messageId: $uniqueSfiMessageId " +
                             "response: ${it.text}"
                     }
-                    logger.audit(
-                        toLogParamsMap(
-                            messageDetails = metadata.message,
-                            requestId = uniqueSfiMessageId.toString(),
-                            status = RECEIVED_OK_RESPONSE
-                        )
-                    ) {
-                        "Successfully sent SFI message about $caseId " +
-                            "with messageId: $uniqueSfiMessageId"
-                    }
                 } else {
-                    logger.error {
-                        "SFI responded with error to message about $caseId with messageId: " +
-                            "$uniqueSfiMessageId. Response ${it.code} : ${it.text}"
-                    }
-                    logger.audit(
-                        toLogParamsMap(
-                            messageDetails = metadata.message,
-                            requestId = uniqueSfiMessageId.toString(),
-                            status = RECEIVED_ERROR_RESPONSE
-                        )
-                    ) {
-                        "SFI responded with error to message about $caseId with " +
-                            "messageId: $uniqueSfiMessageId. Response: ${it.code}"
-                    }
                     sfiErrorResponseHandler.handleError(it)
                 }
                 it
             }
-    }
-
-    private fun toLogParamsMap(messageDetails: MessageDetails, requestId: String, status: SfiRequestStatus) = mapOf(
-        "meta" to mapOf(
-            "status" to status.value
-        ),
-        "targetId" to requestId,
-        "objectId" to messageDetails.uniqueCaseIdentifier
-    )
-
-    enum class SfiRequestStatus(val value: String) {
-        CREATING_REQUEST("creating request"),
-        RECEIVED_OK_RESPONSE("ok response received"),
-        RECEIVED_ERROR_RESPONSE("error response received"),
-        ERROR_DURING_REQUEST("error during request")
     }
 
     private inline fun <reified T> WebServiceTemplate.marshalSendAndReceiveAsType(request: Any): T =

--- a/message-service/src/test/kotlin/fi/espoo/evaka/msg/service/sfi/SfiClientServiceTest.kt
+++ b/message-service/src/test/kotlin/fi/espoo/evaka/msg/service/sfi/SfiClientServiceTest.kt
@@ -111,7 +111,7 @@ class SfiClientServiceTest {
             service.sendMessage(metadata)
             fail<Nothing>("Expecting an exception")
         } catch (e: Exception) {
-            assertThat(e).hasMessage(message)
+            assertThat(e).hasCause(RuntimeException(message))
         }
     }
 

--- a/service-lib/src/main/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggers.kt
+++ b/service-lib/src/main/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggers.kt
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.voltti.logging.loggers
+
+import mu.KLogger
+import net.logstash.logback.argument.StructuredArguments
+
+/**
+ * Extensions to allow adding meta-fields (and technically any other) to app-misc logs
+ * without requiring StructuredArguments wrapper and a dependency to net.logstash.logback.
+ */
+
+fun KLogger.trace(args: Map<String, Any?>, m: () -> Any?) {
+    if (isTraceEnabled) trace(m.toStringSafe(), StructuredArguments.entries(args))
+}
+
+fun KLogger.debug(args: Map<String, Any?>, m: () -> Any?) {
+    if (isDebugEnabled) debug(m.toStringSafe(), StructuredArguments.entries(args))
+}
+
+fun KLogger.info(args: Map<String, Any?>, m: () -> Any?) {
+    if (isInfoEnabled) info(m.toStringSafe(), StructuredArguments.entries(args))
+}
+
+fun KLogger.warn(args: Map<String, Any?>, m: () -> Any?) {
+    if (isWarnEnabled) warn(m.toStringSafe(), StructuredArguments.entries(args))
+}
+
+fun KLogger.error(args: Map<String, Any?>, m: () -> Any?) {
+    if (isErrorEnabled) error(m.toStringSafe(), StructuredArguments.entries(args))
+}

--- a/service-lib/src/test/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggersTest.kt
+++ b/service-lib/src/test/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggersTest.kt
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.voltti.logging.loggers
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import fi.espoo.voltti.logging.utils.clearTestMessages
+import fi.espoo.voltti.logging.utils.getTestAppender
+import fi.espoo.voltti.logging.utils.getTestMessages
+import fi.espoo.voltti.logging.utils.setupTestAppender
+import mu.KLogger
+import mu.KotlinLogging
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.test.context.junit4.SpringRunner
+
+private val logger = KotlinLogging.logger {}.also(KLogger::setupTestAppender)
+private const val message = "test message"
+private val initialLogLevel = (logger.underlyingLogger as Logger).level
+
+@RunWith(SpringRunner::class)
+class AppMiscLoggersTest {
+    @Before
+    fun before() {
+        // To avoid noise in other tests, just raise the log level for these tests that require TRACE
+        (logger.underlyingLogger as Logger).level = Level.TRACE
+    }
+
+    @After
+    fun clear() {
+        logger.clearTestMessages()
+        (logger.underlyingLogger as Logger).level = initialLogLevel
+    }
+
+    @Test
+    fun `trace log message logged`() {
+        logger.trace(mapOf("argKey" to "argVal")) { message }
+        assertEquals(message, logger.getTestMessages().first())
+    }
+
+    @Test
+    fun `arguments added to trace log entry`() {
+        val args = mapOf("argKey" to "argVal", "meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        logger.trace(args) { message }
+
+        val event = logger.getTestAppender().getEvents().first()
+        compareArgs(args, event)
+    }
+
+    @Test
+    fun `debug log message logged`() {
+        logger.debug(mapOf("argKey" to "argVal")) { message }
+        assertEquals(message, logger.getTestMessages().first())
+    }
+
+    @Test
+    fun `arguments added to debug log entry`() {
+        val args = mapOf("argKey" to "argVal", "meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        logger.debug(args) { message }
+
+        val event = logger.getTestAppender().getEvents().first()
+        compareArgs(args, event)
+    }
+
+    @Test
+    fun `info log message logged`() {
+        logger.info(mapOf("argKey" to "argVal")) { message }
+        assertEquals(message, logger.getTestMessages().first())
+    }
+
+    @Test
+    fun `arguments added to info log entry`() {
+        val args = mapOf("argKey" to "argVal", "meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        logger.info(args) { message }
+
+        val event = logger.getTestAppender().getEvents().first()
+        compareArgs(args, event)
+    }
+
+    @Test
+    fun `warn log message logged`() {
+        logger.warn(mapOf("argKey" to "argVal")) { message }
+        assertEquals(message, logger.getTestMessages().first())
+    }
+
+    @Test
+    fun `arguments added to warn log entry`() {
+        val args = mapOf("argKey" to "argVal", "meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        logger.warn(args) { message }
+
+        val event = logger.getTestAppender().getEvents().first()
+        compareArgs(args, event)
+    }
+
+    @Test
+    fun `error log message logged`() {
+        logger.error(mapOf("argKey" to "argVal")) { message }
+        assertEquals(message, logger.getTestMessages().first())
+    }
+
+    @Test
+    fun `arguments added to error log entry`() {
+        val args = mapOf("argKey" to "argVal", "meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        logger.error(args) { message }
+
+        val event = logger.getTestAppender().getEvents().first()
+        compareArgs(args, event)
+    }
+
+    private fun compareArgs(expectedArgs: Map<String, Any>, event: ILoggingEvent) {
+        assertEquals(expectedArgs.toString(), event.argumentArray.first().toString())
+    }
+}


### PR DESCRIPTION
#### Summary
- message-service: only log SFI errors once, don't abuse audit logs
   - All message sending errors are handled and _logged_ by the async job handler, no need to double or even triple log them
   - Don't log errors as audit logs -- errors are only interesting and required as audit events when relating to authentication & authorization (e.g. failed attack attempts)
   - Don't log errors while handling them in the SOAP client, they will be logged by the client's users
   - Include all relevant data in log messages where possible
      - I don't love losing the metadata from single messages but as we now have tracing IDs I find this an acceptable compromise to avoid noise
- service-lib/logging: add support for meta-field in misc logs
   - Extend all other `Klogger` methods to allow setting the meta-field to app-misc type logs without adding a dependency to `net.logstash.logback:logstash-logback-encoder` just to get `StructuredArguments`
- CI: store service-lib test results, reports
   - service-lib build & tests are ran in both `service_test` and `message_service_test` jobs -> gather build reports & test results in both

#### Dependencies
None

#### Testing instructions
The SFI client logs are rather difficult to verify (without executing against the staging env).

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] The code is consistent with the existing code base
- [x] Tests have been written for the change (e2e, integration tests)
- [x] The change has been tested locally
- [x] The change conforms to the UX specifications
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```