### PR TITLE
EVAKA-3831: Block placement to a ghost unit: Disable submit button and warn user

### DIFF
--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -674,7 +674,7 @@ export const fi = {
       },
       warning: {
         overlap: 'Ajalle on jo sijoitus',
-        ghostUnit: 'Yksikkö on merkattu haamuyksiköksi.'
+        ghostUnit: 'Yksikkö on merkitty haamuyksiköksi.'
       }
     },
     fridgeParents: {
@@ -1696,7 +1696,8 @@ export const fi = {
     date: 'Sijoituspäivämäärä',
     dateError: 'Päällekkäinen sijoitus ajanjaksolle.',
     preparatoryPeriod: 'Valmistava opetus',
-    dateOfBirth: 'Syntymäaika'
+    dateOfBirth: 'Syntymäaika',
+    selectedUnit: 'Valittu yksikkö'
   },
   decisionDraft: {
     title: 'Päätöksen teko ja lähetys',

--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -673,7 +673,8 @@ export const fi = {
         }
       },
       warning: {
-        overlap: 'Ajalle on jo sijoitus'
+        overlap: 'Ajalle on jo sijoitus',
+        ghostUnit: 'Yksikkö on merkattu haamuyksiköksi.'
       }
     },
     fridgeParents: {

--- a/frontend/packages/employee-frontend/src/components/common/FormModal.tsx
+++ b/frontend/packages/employee-frontend/src/components/common/FormModal.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components'
 import FocusLock from 'react-focus-lock'
 
 import Title from '~components/shared/atoms/Title'
-import Button from '~components/shared/atoms/buttons/Button'
+import Button, { InfoStatus } from '~components/shared/atoms/buttons/Button'
 import Colors from '~components/shared/Colors'
 import { DefaultMargins, Gap } from 'components/shared/layout/white-space'
 import { useTranslation } from '~state/i18n'
@@ -149,6 +149,10 @@ interface Props {
   'data-qa'?: string
   children: React.ReactNode
   iconColour?: IconColour
+  resolveInfo?: {
+    text: string
+    status?: InfoStatus
+  }
 }
 
 const handleClick = (click: () => void) => () => click()
@@ -166,7 +170,8 @@ function FormModal({
   size = 'md',
   resolveDisabled = false,
   children,
-  iconColour = 'blue'
+  iconColour = 'blue',
+  resolveInfo
 }: Props) {
   const { i18n } = useTranslation()
   return (
@@ -221,6 +226,7 @@ function FormModal({
                   )}
                   <Button
                     primary
+                    info={resolveInfo}
                     dataQa="modal-okBtn"
                     onClick={handleClick(resolve)}
                     disabled={resolveDisabled}

--- a/frontend/packages/employee-frontend/src/components/common/FormModal.tsx
+++ b/frontend/packages/employee-frontend/src/components/common/FormModal.tsx
@@ -9,11 +9,12 @@ import styled from 'styled-components'
 import FocusLock from 'react-focus-lock'
 
 import Title from '~components/shared/atoms/Title'
-import Button, { InfoStatus } from '~components/shared/atoms/buttons/Button'
+import Button from '~components/shared/atoms/buttons/Button'
 import Colors from '~components/shared/Colors'
 import { DefaultMargins, Gap } from 'components/shared/layout/white-space'
 import { useTranslation } from '~state/i18n'
 import { modalZIndex } from '~components/shared/layout/z-helpers'
+import { InfoStatus } from 'components/shared/UnderRowStatusIcon'
 
 export const DimmedModal = styled.div``
 

--- a/frontend/packages/employee-frontend/src/components/placement-draft/PlacementDraft.tsx
+++ b/frontend/packages/employee-frontend/src/components/placement-draft/PlacementDraft.tsx
@@ -117,6 +117,20 @@ function PlacementDraft({ match }: RouteComponentProps<{ id: UUID }>) {
   const { setTitle, formatTitleName } = useContext<TitleState>(TitleContext)
 
   const [additionalUnits, setAdditionalUnits] = useState<Unit[]>([])
+  const [selectedUnitIsGhostUnit, setSelectedUnitIsGhostUnit] = useState<
+    boolean
+  >(false)
+
+  useEffect(() => {
+    isSuccess(units) &&
+      placement.unitId &&
+      setSelectedUnitIsGhostUnit(
+        units.data
+          .filter((unit) => unit.id === placement.unitId)
+          .map((unit) => unit.ghostUnit)
+          .includes(true)
+      )
+  }, [placement])
 
   function hasOverlap(
     placement: PlacementDraftPlacement,
@@ -351,11 +365,14 @@ function PlacementDraft({ match }: RouteComponentProps<{ id: UUID }>) {
               placement={placement}
               setPlacement={setPlacement}
               placementDraft={placementDraft.data}
+              selectedUnitIsGhostUnit={selectedUnitIsGhostUnit}
             />
             <SendButtonContainer>
               <Button
                 primary
-                disabled={placement.unitId === undefined}
+                disabled={
+                  placement.unitId === undefined || selectedUnitIsGhostUnit
+                }
                 dataQa="send-placement-button"
                 onClick={() => {
                   void createPlacementPlan(id, placement).then(() =>

--- a/frontend/packages/employee-frontend/src/components/placement-draft/PlacementDraft.tsx
+++ b/frontend/packages/employee-frontend/src/components/placement-draft/PlacementDraft.tsx
@@ -304,7 +304,7 @@ function PlacementDraft({ match }: RouteComponentProps<{ id: UUID }>) {
         {isSuccess(placementDraft) && placement.period && (
           <Fragment>
             <PlacementDraftInfo>
-              <Title size={2}>{i18n.placementDraft.createPlacementDraft}</Title>
+              <Title size={1}>{i18n.placementDraft.createPlacementDraft}</Title>
               <ChildName>
                 <Title size={3}>
                   {formatName(
@@ -379,7 +379,7 @@ function PlacementDraft({ match }: RouteComponentProps<{ id: UUID }>) {
                     redirectToMainPage()
                   )
                 }}
-                text={i18n.common.send}
+                text={i18n.placementDraft.createPlacementDraft}
               />
             </SendButtonContainer>
           </Fragment>

--- a/frontend/packages/employee-frontend/src/components/placement-draft/UnitCard.tsx
+++ b/frontend/packages/employee-frontend/src/components/placement-draft/UnitCard.tsx
@@ -117,6 +117,7 @@ interface Props {
   setAdditionalUnits: Dispatch<SetStateAction<Unit[]>>
   setPlacement: Dispatch<SetStateAction<DaycarePlacementPlan>>
   isSelectedUnit: boolean
+  displayGhostUnitWarning: boolean
 }
 
 const MemoizedCard = memo(function UnitCard({
@@ -127,7 +128,8 @@ const MemoizedCard = memo(function UnitCard({
   additionalUnits,
   setAdditionalUnits,
   setPlacement,
-  isSelectedUnit
+  isSelectedUnit,
+  displayGhostUnitWarning
 }: Props) {
   const { i18n } = useTranslation()
 
@@ -214,6 +216,14 @@ const MemoizedCard = memo(function UnitCard({
           onClick={() => selectUnit(unitId)}
           icon={(isSelectedUnit && faCheck) || undefined}
           text={isSelectedUnit ? 'Valittu yksikkö' : 'Valitse'}
+          info={
+            displayGhostUnitWarning
+              ? {
+                  text: i18n.childInformation.placements.warning.ghostUnit,
+                  status: 'warning'
+                }
+              : undefined
+          }
         />
       </MarginBox>
     </Card>

--- a/frontend/packages/employee-frontend/src/components/placement-draft/UnitCard.tsx
+++ b/frontend/packages/employee-frontend/src/components/placement-draft/UnitCard.tsx
@@ -215,7 +215,11 @@ const MemoizedCard = memo(function UnitCard({
           dataQa="select-placement-unit"
           onClick={() => selectUnit(unitId)}
           icon={(isSelectedUnit && faCheck) || undefined}
-          text={isSelectedUnit ? 'Valittu yksikkö' : 'Valitse'}
+          text={
+            isSelectedUnit
+              ? i18n.placementDraft.selectedUnit
+              : i18n.common.select
+          }
           info={
             displayGhostUnitWarning
               ? {

--- a/frontend/packages/employee-frontend/src/components/placement-draft/UnitCards.tsx
+++ b/frontend/packages/employee-frontend/src/components/placement-draft/UnitCards.tsx
@@ -42,7 +42,7 @@ const MemoizedCards = memo(function UnitCards({
   return (
     <FlexContainer data-qa="placement-list">
       {placementDraft.preferredUnits.concat(additionalUnits).map((unit) => {
-        const isSelectedUnit = placement.unitId == unit.id
+        const isSelectedUnit = placement.unitId === unit.id
         return (
           <MemoizedCard
             unitId={unit.id}

--- a/frontend/packages/employee-frontend/src/components/placement-draft/UnitCards.tsx
+++ b/frontend/packages/employee-frontend/src/components/placement-draft/UnitCards.tsx
@@ -21,6 +21,7 @@ interface Props {
   placement: DaycarePlacementPlan
   setPlacement: Dispatch<SetStateAction<DaycarePlacementPlan>>
   placementDraft: PlacementDraft
+  selectedUnitIsGhostUnit: boolean
 }
 
 const MemoizedCards = memo(function UnitCards({
@@ -28,7 +29,8 @@ const MemoizedCards = memo(function UnitCards({
   setAdditionalUnits,
   placement,
   setPlacement,
-  placementDraft
+  placementDraft,
+  selectedUnitIsGhostUnit
 }: Props) {
   if (!placement.period) return null
 
@@ -39,19 +41,23 @@ const MemoizedCards = memo(function UnitCards({
 
   return (
     <FlexContainer data-qa="placement-list">
-      {placementDraft.preferredUnits.concat(additionalUnits).map((unit) => (
-        <MemoizedCard
-          unitId={unit.id}
-          unitName={unit.name}
-          key={unit.id}
-          startDate={startDate}
-          endDate={endDate}
-          additionalUnits={additionalUnits}
-          setAdditionalUnits={setAdditionalUnits}
-          setPlacement={setPlacement}
-          isSelectedUnit={placement.unitId === unit.id}
-        />
-      ))}
+      {placementDraft.preferredUnits.concat(additionalUnits).map((unit) => {
+        const isSelectedUnit = placement.unitId == unit.id
+        return (
+          <MemoizedCard
+            unitId={unit.id}
+            unitName={unit.name}
+            key={unit.id}
+            startDate={startDate}
+            endDate={endDate}
+            additionalUnits={additionalUnits}
+            setAdditionalUnits={setAdditionalUnits}
+            setPlacement={setPlacement}
+            isSelectedUnit={isSelectedUnit}
+            displayGhostUnitWarning={isSelectedUnit && selectedUnitIsGhostUnit}
+          />
+        )
+      })}
     </FlexContainer>
   )
 })

--- a/frontend/packages/employee-frontend/src/components/shared/UnderRowStatusIcon.tsx
+++ b/frontend/packages/employee-frontend/src/components/shared/UnderRowStatusIcon.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { DefaultMargins } from 'components/shared/layout/white-space'
+import styled from 'styled-components'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { fasCheckCircle, fasExclamationTriangle } from 'icon-set'
+import { BaseProps } from 'components/shared/utils'
+import Colors from 'components/shared/Colors'
+
+export const StatusIcon = styled.div`
+  font-size: 15px;
+  margin-left: ${DefaultMargins.xs};
+`
+
+export type InfoStatus = 'warning' | 'success'
+
+interface UnderRowStatusIconProps extends BaseProps {
+  status?: InfoStatus
+}
+
+function UnderRowStatusIcon({ status }: UnderRowStatusIconProps) {
+  return (
+    <StatusIcon>
+      {status === 'warning' && (
+        <FontAwesomeIcon
+          icon={fasExclamationTriangle}
+          color={Colors.accents.orange}
+        />
+      )}
+      {status === 'success' && (
+        <FontAwesomeIcon icon={fasCheckCircle} color={Colors.accents.green} />
+      )}
+    </StatusIcon>
+  )
+}
+
+export default UnderRowStatusIcon

--- a/frontend/packages/employee-frontend/src/components/shared/atoms/buttons/Button.tsx
+++ b/frontend/packages/employee-frontend/src/components/shared/atoms/buttons/Button.tsx
@@ -10,8 +10,9 @@ import classNames from 'classnames'
 import { defaultButtonTextStyle } from 'components/shared/atoms/buttons/button-commons'
 import { BaseProps } from 'components/shared/utils'
 import { DefaultMargins } from 'components/shared/layout/white-space'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { fasCheckCircle, fasExclamationTriangle } from 'icon-set'
+import UnderRowStatusIcon, {
+  InfoStatus
+} from 'components/shared/UnderRowStatusIcon'
 
 const Wrapper = styled.div`
   min-width: 0; // needed for correct overflow behavior
@@ -76,7 +77,7 @@ export const StyledButton = styled.button`
   ${defaultButtonTextStyle}
 `
 
-const UnderRow = styled.div`
+const ButtonUnderRow = styled.div`
   padding: 0 12px;
   margin-top: ${DefaultMargins.xxs};
   margin-bottom: -20px;
@@ -102,13 +103,6 @@ const UnderRow = styled.div`
     color: ${Colors.accents.orangeDark};
   }
 `
-
-const StatusIcon = styled.div`
-  font-size: 15px;
-  margin-left: ${DefaultMargins.xs};
-`
-
-export type InfoStatus = 'warning' | 'success'
 
 interface ButtonProps extends BaseProps {
   onClick?: (e: React.MouseEvent) => unknown
@@ -161,23 +155,10 @@ function Button({
       >
         {text}
       </StyledButton>
-      <UnderRow className={classNames(info?.status)}>
+      <ButtonUnderRow className={classNames(info?.status)}>
         <span>{info?.text}</span>
-        <StatusIcon>
-          {info?.status === 'warning' && (
-            <FontAwesomeIcon
-              icon={fasExclamationTriangle}
-              color={Colors.accents.orange}
-            />
-          )}
-          {info?.status === 'success' && (
-            <FontAwesomeIcon
-              icon={fasCheckCircle}
-              color={Colors.accents.green}
-            />
-          )}
-        </StatusIcon>
-      </UnderRow>
+        <UnderRowStatusIcon status={info?.status} />
+      </ButtonUnderRow>
     </Wrapper>
   )
 }

--- a/frontend/packages/employee-frontend/src/components/shared/atoms/buttons/Button.tsx
+++ b/frontend/packages/employee-frontend/src/components/shared/atoms/buttons/Button.tsx
@@ -9,6 +9,13 @@ import Colors, { Greyscale } from 'components/shared/Colors'
 import classNames from 'classnames'
 import { defaultButtonTextStyle } from 'components/shared/atoms/buttons/button-commons'
 import { BaseProps } from 'components/shared/utils'
+import { DefaultMargins } from 'components/shared/layout/white-space'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { fasCheckCircle, fasExclamationTriangle } from 'icon-set'
+
+const Wrapper = styled.div`
+  min-width: 0; // needed for correct overflow behavior
+`
 
 export const StyledButton = styled.button`
   min-height: 45px;
@@ -69,6 +76,40 @@ export const StyledButton = styled.button`
   ${defaultButtonTextStyle}
 `
 
+const UnderRow = styled.div`
+  padding: 0 12px;
+  margin-top: ${DefaultMargins.xxs};
+  margin-bottom: -20px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  position: absolute;
+
+  font-size: 12px;
+  text-overflow: ellipsis;
+
+  word-wrap:break-word;
+  width: 120px;
+  white-space: normal
+
+  color: ${Colors.greyscale.dark};
+
+  &.success {
+    color: ${Colors.accents.greenDark};
+  }
+
+  &.warning {
+    color: ${Colors.accents.orangeDark};
+  }
+`
+
+const StatusIcon = styled.div`
+  font-size: 15px;
+  margin-left: ${DefaultMargins.xs};
+`
+
+export type InfoStatus = 'warning' | 'success'
+
 interface ButtonProps extends BaseProps {
   onClick?: (e: React.MouseEvent) => unknown
   text: string
@@ -76,6 +117,10 @@ interface ButtonProps extends BaseProps {
   disabled?: boolean
   type?: 'submit' | 'button'
   'data-qa'?: string
+  info?: {
+    text: string
+    status?: InfoStatus
+  }
 }
 
 function Button({
@@ -86,7 +131,8 @@ function Button({
   text,
   primary = false,
   disabled = false,
-  type = 'button'
+  type = 'button',
+  info
 }: ButtonProps) {
   const [ignoreClick, setIgnoreClick] = React.useState(false)
   const [, , startUnignoreClickTimer] = useTimeoutFn(() => {
@@ -105,15 +151,34 @@ function Button({
     }
   }
   return (
-    <StyledButton
-      className={classNames(className, { primary, disabled })}
-      data-qa={dataQa2 ?? dataQa}
-      onClick={handleOnClick}
-      disabled={disabled}
-      type={type}
-    >
-      {text}
-    </StyledButton>
+    <Wrapper>
+      <StyledButton
+        className={classNames(className, { primary, disabled })}
+        data-qa={dataQa2 ?? dataQa}
+        onClick={handleOnClick}
+        disabled={disabled}
+        type={type}
+      >
+        {text}
+      </StyledButton>
+      <UnderRow className={classNames(info?.status)}>
+        <span>{info?.text}</span>
+        <StatusIcon>
+          {info?.status === 'warning' && (
+            <FontAwesomeIcon
+              icon={fasExclamationTriangle}
+              color={Colors.accents.orange}
+            />
+          )}
+          {info?.status === 'success' && (
+            <FontAwesomeIcon
+              icon={fasCheckCircle}
+              color={Colors.accents.green}
+            />
+          )}
+        </StatusIcon>
+      </UnderRow>
+    </Wrapper>
   )
 }
 

--- a/frontend/packages/employee-frontend/src/components/shared/atoms/buttons/InlineButton.tsx
+++ b/frontend/packages/employee-frontend/src/components/shared/atoms/buttons/InlineButton.tsx
@@ -11,7 +11,9 @@ import classNames from 'classnames'
 import { defaultButtonTextStyle } from 'components/shared/atoms/buttons/button-commons'
 import { BaseProps } from 'components/shared/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { fasCheckCircle, fasExclamationTriangle } from 'icon-set'
+import UnderRowStatusIcon, {
+  InfoStatus
+} from 'components/shared/UnderRowStatusIcon'
 
 const Wrapper = styled.div`
   min-width: 0; // needed for correct overflow behavior
@@ -50,7 +52,7 @@ const StyledButton = styled.button`
   ${defaultButtonTextStyle}
 `
 
-const UnderRow = styled.div`
+const InlineButtonUnderRow = styled.div`
   height: 16px;
   padding: 0 12px;
   margin-top: ${DefaultMargins.xxs};
@@ -77,17 +79,10 @@ const UnderRow = styled.div`
   }
 `
 
-const StatusIcon = styled.div`
-  font-size: 15px;
-  margin-left: ${DefaultMargins.xs};
-`
-
 const UnderRowWrapper = styled.div`
   position: absolute;
   left: 50%;
 `
-
-type InfoStatus = 'warning' | 'success'
 
 interface InlineButtonProps extends BaseProps {
   onClick: () => unknown
@@ -123,23 +118,10 @@ function InlineButton({
       </StyledButton>
       {info && (
         <UnderRowWrapper>
-          <UnderRow className={classNames(info.status)}>
+          <InlineButtonUnderRow className={classNames(info.status)}>
             <span>{info.text}</span>
-            <StatusIcon>
-              {info.status === 'warning' && (
-                <FontAwesomeIcon
-                  icon={fasExclamationTriangle}
-                  color={Colors.accents.orange}
-                />
-              )}
-              {info.status === 'success' && (
-                <FontAwesomeIcon
-                  icon={fasCheckCircle}
-                  color={Colors.accents.green}
-                />
-              )}
-            </StatusIcon>
-          </UnderRow>
+            <UnderRowStatusIcon status={info?.status} />
+          </InlineButtonUnderRow>
         </UnderRowWrapper>
       )}
     </Wrapper>

--- a/frontend/packages/employee-frontend/src/components/shared/atoms/buttons/InlineButton.tsx
+++ b/frontend/packages/employee-frontend/src/components/shared/atoms/buttons/InlineButton.tsx
@@ -5,12 +5,17 @@
 import React from 'react'
 import styled from 'styled-components'
 import Colors, { Greyscale } from 'components/shared/Colors'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { DefaultMargins } from 'components/shared/layout/white-space'
 import classNames from 'classnames'
 import { defaultButtonTextStyle } from 'components/shared/atoms/buttons/button-commons'
 import { BaseProps } from 'components/shared/utils'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { fasCheckCircle, fasExclamationTriangle } from 'icon-set'
+
+const Wrapper = styled.div`
+  min-width: 0; // needed for correct overflow behavior
+`
 
 const StyledButton = styled.button`
   width: fit-content;
@@ -45,12 +50,55 @@ const StyledButton = styled.button`
   ${defaultButtonTextStyle}
 `
 
+const UnderRow = styled.div`
+  height: 16px;
+  padding: 0 12px;
+  margin-top: ${DefaultMargins.xxs};
+  margin-bottom: -20px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  left: -50%;
+
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  color: ${Colors.greyscale.dark};
+
+  &.success {
+    color: ${Colors.accents.greenDark};
+  }
+
+  &.warning {
+    color: ${Colors.accents.orangeDark};
+  }
+`
+
+const StatusIcon = styled.div`
+  font-size: 15px;
+  margin-left: ${DefaultMargins.xs};
+`
+
+const UnderRowWrapper = styled.div`
+  position: absolute;
+  left: 50%;
+`
+
+type InfoStatus = 'warning' | 'success'
+
 interface InlineButtonProps extends BaseProps {
   onClick: () => unknown
   text: string
 
   icon?: IconDefinition
   disabled?: boolean
+  info?: {
+    text: string
+    status?: InfoStatus
+  }
 }
 
 function InlineButton({
@@ -59,18 +107,42 @@ function InlineButton({
   onClick,
   text,
   icon,
-  disabled = false
+  disabled = false,
+  info = undefined
 }: InlineButtonProps) {
   return (
-    <StyledButton
-      className={classNames(className, { disabled })}
-      data-qa={dataQa}
-      onClick={onClick}
-      disabled={disabled}
-    >
-      {icon && <FontAwesomeIcon icon={icon} />}
-      <span>{text}</span>
-    </StyledButton>
+    <Wrapper>
+      <StyledButton
+        className={classNames(className, { disabled })}
+        data-qa={dataQa}
+        onClick={onClick}
+        disabled={disabled}
+      >
+        {icon && <FontAwesomeIcon icon={icon} />}
+        <span>{text}</span>
+      </StyledButton>
+      {info && (
+        <UnderRowWrapper>
+          <UnderRow className={classNames(info.status)}>
+            <span>{info.text}</span>
+            <StatusIcon>
+              {info.status === 'warning' && (
+                <FontAwesomeIcon
+                  icon={fasExclamationTriangle}
+                  color={Colors.accents.orange}
+                />
+              )}
+              {info.status === 'success' && (
+                <FontAwesomeIcon
+                  icon={fasCheckCircle}
+                  color={Colors.accents.green}
+                />
+              )}
+            </StatusIcon>
+          </UnderRow>
+        </UnderRowWrapper>
+      )}
+    </Wrapper>
   )
 }
 

--- a/frontend/packages/employee-frontend/src/components/shared/atoms/form/InputField.tsx
+++ b/frontend/packages/employee-frontend/src/components/shared/atoms/form/InputField.tsx
@@ -8,10 +8,13 @@ import styled from 'styled-components'
 import Colors from 'components/shared/Colors'
 import classNames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { fasCheckCircle, fasExclamationTriangle, faTimes } from 'icon-set'
+import { faTimes } from 'icon-set'
 import { DefaultMargins } from 'components/shared/layout/white-space'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 import TextareaAutosize from 'react-autosize-textarea'
+import UnderRowStatusIcon, {
+  InfoStatus
+} from 'components/shared/UnderRowStatusIcon'
 
 const Wrapper = styled.div`
   min-width: 0; // needed for correct overflow behavior
@@ -108,7 +111,7 @@ const InputIcon = styled.div`
   }
 `
 
-const UnderRow = styled.div`
+const InputFieldUnderRow = styled.div`
   height: 16px;
   padding: 0 12px;
   margin-top: ${DefaultMargins.xxs};
@@ -132,13 +135,6 @@ const UnderRow = styled.div`
     color: ${Colors.accents.orangeDark};
   }
 `
-
-const StatusIcon = styled.div`
-  font-size: 15px;
-  margin-left: ${DefaultMargins.xs};
-`
-
-type InfoStatus = 'warning' | 'success'
 
 interface TextInputProps extends BaseProps {
   value: string
@@ -222,23 +218,10 @@ function InputField({
         )}
       </InputRow>
       {info && (
-        <UnderRow className={classNames(info.status)}>
+        <InputFieldUnderRow className={classNames(info.status)}>
           <span>{info.text}</span>
-          <StatusIcon>
-            {info.status === 'warning' && (
-              <FontAwesomeIcon
-                icon={fasExclamationTriangle}
-                color={Colors.accents.orange}
-              />
-            )}
-            {info.status === 'success' && (
-              <FontAwesomeIcon
-                icon={fasCheckCircle}
-                color={Colors.accents.green}
-              />
-            )}
-          </StatusIcon>
-        </UnderRow>
+          <UnderRowStatusIcon status={info?.status} />
+        </InputFieldUnderRow>
       )}
     </Wrapper>
   )

--- a/frontend/packages/employee-frontend/src/state/placementdraft.tsx
+++ b/frontend/packages/employee-frontend/src/state/placementdraft.tsx
@@ -9,6 +9,7 @@ import { PlacementDraft } from '~types/placementdraft'
 export interface Unit {
   id: string
   name: string
+  ghostUnit?: boolean
 }
 
 export interface PlacementDraftState {

--- a/frontend/packages/employee-frontend/src/types/application.ts
+++ b/frontend/packages/employee-frontend/src/types/application.ts
@@ -60,6 +60,7 @@ interface ServiceNeed {
 export interface PreferredUnit {
   id: UUID
   name: string
+  ghostUnit?: boolean
 }
 
 interface Preferences {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
@@ -214,7 +214,8 @@ SELECT
     can_apply_daycare,
     can_apply_preschool,
     opening_date,
-    closing_date
+    closing_date,
+    ghost_unit
 FROM daycare
 WHERE daterange(opening_date, closing_date, '[]') @> :date AND (
     (:club AND type && '{CLUB}'::care_types[] AND (NOT :onlyApplicable OR can_apply_club))

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -127,7 +127,8 @@ data class PublicUnit(
     val phone: String?,
     val email: String?,
     val url: String?,
-    val location: Coordinate?
+    val location: Coordinate?,
+    val ghostUnit: Boolean?
 )
 
 data class CareAreaResponseJSON(


### PR DESCRIPTION
#### Summary

A child should never be placed into a ghost unit.

* Frontend logic updates: In the relevant forms, disable submit button and display a warning when a ghost unit is selected.
* UI updates: Add `UnderRow` to `Button` and `InlineButton` in order to display warnings under buttons.
* Backend update: Add the `ghostUnit` flag to the return data of `/api/internal/public/units`.

Attached some images for a quick reference.

![image](https://user-images.githubusercontent.com/18037297/99534099-8f973880-29af-11eb-8870-73ad17f32476.png)
![image](https://user-images.githubusercontent.com/18037297/99534166-ac337080-29af-11eb-9403-9b020db511a0.png)