### PR TITLE
EVAKA-3464 show attachments on application preview

### DIFF
--- a/apigw/src/enduser/routes.ts
+++ b/apigw/src/enduser/routes.ts
@@ -32,6 +32,8 @@ router.post(
   proxy
 )
 
+router.get('/attachments/:applicationId/download', proxy) 
+
 const multipartProxy = createProxy({ multipart: true })
 router.post('/attachments/enduser/applications/:applicationId', multipartProxy)
 

--- a/apigw/src/enduser/routes.ts
+++ b/apigw/src/enduser/routes.ts
@@ -32,7 +32,7 @@ router.post(
   proxy
 )
 
-router.get('/attachments/:applicationId/download', proxy) 
+router.get('/attachments/:applicationId/download', proxy)
 
 const multipartProxy = createProxy({ multipart: true })
 router.post('/attachments/enduser/applications/:applicationId', multipartProxy)

--- a/frontend/packages/enduser-frontend/src/localization/app/fi.json
+++ b/frontend/packages/enduser-frontend/src/localization/app/fi.json
@@ -458,6 +458,8 @@
       "service": {
         "title": "Palvelun tarve",
         "section-title": "Varhaiskasvatuksen alkaminen",
+        "attachments-label": "Tarvittavat liitteet",
+        "no-attachments": "Ei liitetty, lähetetään postilla",
         "expedited": {
           "label": "Hakemus on kiireellinen",
           "message": {

--- a/frontend/packages/enduser-frontend/src/localization/app/fi.json
+++ b/frontend/packages/enduser-frontend/src/localization/app/fi.json
@@ -462,7 +462,7 @@
           "label": "Hakemus on kiireellinen",
           "message": {
             "title": "Hakemus on kiireellinen",
-            "text": "Mikäli varhaiskasvatuspaikan tarve johtuu äkillisestä työllistymisestä tai opiskelusta, tulee paikkaa hakea viimeistään kaksi viikkoa ennen kuin tarve alkaa. Kahden viikon käsittelyaika alkaa siitä, kun työ- tai opiskelutodistukset on toimitettu palveluohjaukseen (varhaiskasvatuksen.palveluohjaus@espoo.fi)."
+            "text": "Mikäli varhaiskasvatuspaikan tarve johtuu äkillisestä työllistymisestä tai opiskelusta, tulee paikkaa hakea viimeistään kaksi viikkoa ennen kuin tarve alkaa. Hakemuksen liitteenä tulee olla työ- tai opiskelutodistus molemmilta samassa taloudessa asuvilta huoltajilta. Suosittelemme toimittamaan liitteen sähköisesti tässä, sillä kahden viikon käsittelyaika alkaa siitä, kun olemme vastaanottaneet hakemuksen tarvittavine liitteineen. Jos et voi lisätä liitteitä hakemukselle sähköisesti, lähetä ne postilla osoitteeseen Varhaiskasvatuksen palveluohjaus, PL 3125, 02070 Espoon kaupunki."
           }
         },
         "startDate": {
@@ -871,6 +871,11 @@
       "daycare-check-title": "Varhaiskasvatushakemuksen tarkistaminen",
       "preschool-check-title": "Esiopetushakemuksen tarkistaminen",
       "send-information": "<strong>Hakemusta ei ole vielä lähetetty.</strong> Tarkista antamasi tiedot ja lähetä sivun lopussa olevalla Lähetä hakemus-painikkeella.",
+      "attachments-info": {
+        "headline": "<strong>Huom!</strong> Jos lisäät liitteet seuraaviin kohtiin sähköisesti, hakemuksesi käsitellään nopeammin, sillä käsittelyaika alkaa liitteiden saapumisesta.",
+        "go-back-1": "Palaa takaisin hakemusnäkymään",
+        "go-back-2": "lisätäksesi liitteet hakemukseen."
+      },
       "general-title": "Hakemuksen yhteenveto",
       "term": "Haku toimintakaudelle",
       "general-info": "Cras erat lacus, facilisis sed orci non, lacinia condimentum libero. Aliquam lectus mi, convallis bibendum vestibulum at, gravida vitae elit. Ut at risus a sapien maximus cursus eget vitae dui. Suspendisse tempor, ligula vitae sollicitudin fringilla, neque ante ultrices erat, ut lacinia nisi velit in tellus.",

--- a/frontend/packages/enduser-frontend/src/views/applications/daycare-application/daycare-application.vue
+++ b/frontend/packages/enduser-frontend/src/views/applications/daycare-application/daycare-application.vue
@@ -995,6 +995,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
           :summaryChecked="summaryChecked"
           :form="model"
           @summaryCheckedChanged="summaryCheckedChanged"
+          @closeSummary="closeSummary"
         />
         <section class="columns is-centered has-text-centered">
           <div class="column is-narrow">
@@ -1002,7 +1003,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
               size="wide"
               :primary="true"
               :outlined="true"
-              @click="showSummary = false"
+              @click="closeSummary"
               >{{ $t('form.back-to-form') | uppercase }}</c-button
             >
           </div>
@@ -1445,6 +1446,9 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       },
       summaryCheckedChanged(value) {
         this.summaryChecked = value
+      },
+      closeSummary() {
+        this.showSummary = false
       },
       withAsterisk
     },

--- a/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-daycare-summary.vue
+++ b/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-daycare-summary.vue
@@ -23,6 +23,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
           v-if="!isPreschool"
         />
 
+        <!-- Liitteet -->
         <div class="attachment-list-wrapper" v-show="applicationForm.urgent">
           <p class="strong">{{$t('form.daycare-application.service.attachments-label')}}</p>
           <p v-if="applicationFiles.length === 0">{{$t('form.daycare-application.service.no-attachments')}}</p>
@@ -33,7 +34,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
                   :icon="['fal', 'file']"
                 ></font-awesome-icon>
               </span>
-              <a :href="`/enduser/applications/attachments/${file.id}`">{{ file.file.name }}</a>
+              <a :href="`/api/application/attachments/${file.id}/download`"
+                target="_blank"
+                rel="noreferrer"
+              >{{ file.file.name }}</a>
             </li>
           </ul>
         </div>

--- a/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-daycare-summary.vue
+++ b/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-daycare-summary.vue
@@ -23,6 +23,21 @@ SPDX-License-Identifier: LGPL-2.1-or-later
           v-if="!isPreschool"
         />
 
+        <div class="attachment-list-wrapper" v-show="applicationForm.urgent">
+          <p class="strong">{{$t('form.daycare-application.service.attachments-label')}}</p>
+          <p v-if="applicationFiles.length === 0">{{$t('form.daycare-application.service.no-attachments')}}</p>
+          <ul v-else>
+            <li v-for="file in applicationFiles" v-bind:key="file.id">
+              <span class="attachment-icon">
+                <font-awesome-icon
+                  :icon="['fal', 'file']"
+                ></font-awesome-icon>
+              </span>
+              <a :href="`/enduser/applications/attachments/${file.id}`">{{ file.file.name }}</a>
+            </li>
+          </ul>
+        </div>
+
         <div class="columns is-gapless">
           <div class="column">
             <div class="strong">{{ $t(`form.${type}-application.service.startDate.label`) }}</div>
@@ -476,7 +491,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['countries', 'languages']),
+    ...mapGetters(['countries', 'languages', 'applicationFiles']),
     type() {
       return this.applicationForm.type.value
     },
@@ -582,6 +597,15 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
+.attachment-list-wrapper {
+  margin-bottom: 1rem;
+
+  & .attachment-icon {
+    margin-right: 1rem;
+  }
+}
+
 .club-summary-title {
   margin-top: 1.5rem;
 }

--- a/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-daycare-summary.vue
+++ b/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-daycare-summary.vue
@@ -24,7 +24,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         />
 
         <!-- Liitteet -->
-        <div class="attachment-list-wrapper" v-show="applicationForm.urgent">
+        <div class="attachment-list-wrapper" v-if="attachmentsEnabled" v-show="applicationForm.urgent">
           <p class="strong">{{$t('form.daycare-application.service.attachments-label')}}</p>
           <p v-if="applicationFiles.length === 0">{{$t('form.daycare-application.service.no-attachments')}}</p>
           <ul v-else>
@@ -480,6 +480,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 <script>
 import { mapGetters } from 'vuex'
+import { config } from '@evaka/enduser-frontend/src/config'
 import _ from 'lodash'
 import { formatDate } from '@/utils/date-utils'
 import { APPLICATION_TYPE, LANGUAGES } from '@/constants.ts'
@@ -498,6 +499,9 @@ export default {
     ...mapGetters(['countries', 'languages', 'applicationFiles']),
     type() {
       return this.applicationForm.type.value
+    },
+    attachmentsEnabled() {
+      return config.feature.attachments
     },
     currentLocaleIsSwedish() {
       return this.$i18n.locale.toLowerCase() === LANGUAGES.SV

--- a/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-summary.vue
+++ b/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-summary.vue
@@ -14,8 +14,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       v-html="$t('form.summary.send-information')"
     ></p>
 
-    <!-- Huomautus liitteistä -->
-    <div class="application-attachments-info" v-show="form.urgent && applicationFiles.length === 0">
+    <div class="application-attachments-info" v-if="attachmentsEnabled" v-show="form.urgent && applicationFiles.length === 0">
       <span class="float-left">
         <font-awesome-icon
           :icon="['fas', 'info-circle']"
@@ -76,6 +75,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 <script>
   import { mapGetters } from 'vuex'
+  import { config } from '@evaka/enduser-frontend/src/config'
   import DaycareSummary from '@/views/applications/daycare-application/form-components/summary/application-daycare-summary'
 
   export default {
@@ -90,6 +90,9 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       ...mapGetters(['applicationFiles']),
       type() {
         return this.form.type.value
+      },
+      attachmentsEnabled() {
+        return config.feature.attachments
       }
     },
     methods: {

--- a/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-summary.vue
+++ b/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-summary.vue
@@ -14,6 +14,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       v-html="$t('form.summary.send-information')"
     ></p>
 
+    <!-- Huomautus liitteistä -->
     <div class="application-attachments-info" v-show="form.urgent && applicationFiles.length === 0">
       <span class="float-left">
         <font-awesome-icon
@@ -27,7 +28,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
           <li>{{ $t('form.daycare-application.service.expedited.label') }}</li>
           <li>{{ $t('form.daycare-application.service.extended.label') }}</li>
         </ul>
-        <a @click="goBack">{{ $t('form.summary.attachments-info.go-back-1') }}</a> <span>{{ $t('form.summary.attachments-info.go-back-2') }}</span>
+        <a @click="closeSummary">{{ $t('form.summary.attachments-info.go-back-1') }}</a> <span>{{ $t('form.summary.attachments-info.go-back-2') }}</span>
       </div>
     </div>
 
@@ -99,8 +100,8 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       summaryCheckedChanged(event) {
         this.$emit('summaryCheckedChanged', event.target.checked)
       },
-      goBack() {
-        return history.go(-1)
+      closeSummary() {
+        this.$emit('closeSummary')
       }
     }
   }

--- a/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-summary.vue
+++ b/frontend/packages/enduser-frontend/src/views/applications/daycare-application/form-components/summary/application-summary.vue
@@ -13,6 +13,24 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       class="check-application-information"
       v-html="$t('form.summary.send-information')"
     ></p>
+
+    <div class="application-attachments-info" v-show="form.urgent && applicationFiles.length === 0">
+      <span class="float-left">
+        <font-awesome-icon
+          :icon="['fas', 'info-circle']"
+          size="1x"
+        ></font-awesome-icon>
+      </span>
+      <div class="application-attachments-info-content" >
+        <p v-html="$t('form.summary.attachments-info.headline')"></p>
+        <ul>
+          <li>{{ $t('form.daycare-application.service.expedited.label') }}</li>
+          <li>{{ $t('form.daycare-application.service.extended.label') }}</li>
+        </ul>
+        <a @click="goBack">{{ $t('form.summary.attachments-info.go-back-1') }}</a> <span>{{ $t('form.summary.attachments-info.go-back-2') }}</span>
+      </div>
+    </div>
+
     <div class="application-date-details">
       <span class="application-created">
         <span class="strong"
@@ -56,6 +74,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 </template>
 
 <script>
+  import { mapGetters } from 'vuex'
   import DaycareSummary from '@/views/applications/daycare-application/form-components/summary/application-daycare-summary'
 
   export default {
@@ -67,6 +86,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       DaycareSummary
     },
     computed: {
+      ...mapGetters(['applicationFiles']),
       type() {
         return this.form.type.value
       }
@@ -78,6 +98,9 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       },
       summaryCheckedChanged(event) {
         this.$emit('summaryCheckedChanged', event.target.checked)
+      },
+      goBack() {
+        return history.go(-1)
       }
     }
   }
@@ -195,5 +218,28 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         border-color: rgba(gray, 0.8);
       }
     }
+  }
+
+  .application-attachments-info {
+    border: 1px solid $soft-blue;
+    padding: 1rem;
+    margin: 1rem 0;
+
+    & ul {
+      list-style-type: circle;
+      list-style-position: inside;
+    }
+
+    & li {
+      margin-left: 1rem;
+    }
+  }
+
+  .application-attachments-info-content {
+    padding: 0 2rem;
+  }
+
+  .float-left {
+    float: left;
   }
 </style>

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -123,12 +123,3 @@ fun isOwnApplication(r: Database.Read, applicationId: UUID, user: AuthenticatedU
         .toList()
         .isNotEmpty()
 }
-
-fun isOwnAttachment(r: Database.Read, attachmentId: UUID, user: AuthenticatedUser): Boolean {
-    return r.createQuery("SELECT 1 FROM attachment at JOIN application ap ON at.application_id = ap.id WHERE at.id = :id AND ap.guardian_id = :userId")
-        .bind("id", attachmentId)
-        .bind("userId", user.id)
-        .mapTo<Int>()
-        .toList()
-        .isNotEmpty()
-}


### PR DESCRIPTION
#### Summary
Application preview should list uploaded attachments and (in some cases) an info box about the benefits of doing so.

<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
![Screenshot_2020-11-18 Varhaiskasvatuksen haku(2)](https://user-images.githubusercontent.com/3275771/99567572-f5e38180-29d6-11eb-9b98-2c7df240b10b.png)
![Screenshot_2020-11-18 Varhaiskasvatuksen haku(1)](https://user-images.githubusercontent.com/3275771/99567575-f714ae80-29d6-11eb-9111-8618aa683275.png)
![Screenshot_2020-11-18 Varhaiskasvatuksen haku](https://user-images.githubusercontent.com/3275771/99567576-f7ad4500-29d6-11eb-94d1-167605503cc9.png)
