### PR TITLE
Use FuelManager for varda token fetch

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
@@ -65,7 +65,7 @@ abstract class FullApplicationTest {
         db.transaction { it.resetDatabase() }
         feeDecisionMinDate = LocalDate.parse(env.getRequiredProperty("fee_decision_min_date"))
         val vardaBaseUrl = "http://localhost:$httpPort/mock-integration/varda/api"
-        vardaTokenProvider = VardaTempTokenProvider(env, objectMapper, vardaBaseUrl)
+        vardaTokenProvider = VardaTempTokenProvider(http, env, objectMapper, vardaBaseUrl)
         vardaClient = VardaClient(vardaTokenProvider, http, env, objectMapper, vardaBaseUrl)
         vardaOrganizerName = env.getProperty("fi.espoo.varda.organizer", "Espoo")
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -57,6 +57,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         koskiTester = KoskiTester(
             jdbi,
             KoskiClient(
+                fuel = http,
                 env = env,
                 baseUrl = "http://localhost:${koskiServer.port}",
                 asyncJobRunner = null

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
@@ -33,6 +33,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
         koskiTester = KoskiTester(
             jdbi,
             KoskiClient(
+                fuel = http,
                 env = env,
                 baseUrl = "http://localhost:${koskiServer.port}",
                 asyncJobRunner = null

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaClientIntegrationMockHttpsServer.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaClientIntegrationMockHttpsServer.kt
@@ -16,8 +16,8 @@ class VardaClientIntegrationMockHttpsServer(httpsPort: Int) : AutoCloseable {
         config.server {
             val server = Server()
             val sslConnector = ServerConnector(server, getSslContextFactory())
-            sslConnector.setPort(httpsPort)
-            server.setConnectors(arrayOf<Connector>(sslConnector))
+            sslConnector.port = httpsPort
+            server.connectors = arrayOf<Connector>(sslConnector)
             server
         }
     }.start()
@@ -39,7 +39,8 @@ class VardaClientIntegrationMockHttpsServer(httpsPort: Int) : AutoCloseable {
     }
 
     fun getSslContextFactory(): SslContextFactory {
-        val sslContextFactory = SslContextFactory(this.javaClass.getResource("/test-certificate/localhost.keystore").toExternalForm())
+        val sslContextFactory = SslContextFactory.Server()
+        sslContextFactory.setKeyStorePath(this.javaClass.getResource("/test-certificate/localhost.keystore").toExternalForm())
         sslContextFactory.setKeyStorePassword("password")
         return sslContextFactory
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -12,8 +12,8 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
-import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.Headers
 import com.github.kittinunf.fuel.core.Method
 import com.github.kittinunf.fuel.core.extensions.authentication
@@ -30,6 +30,7 @@ private val logger = KotlinLogging.logger { }
 
 @Component
 class KoskiClient(
+    private val fuel: FuelManager,
     private val env: Environment,
     private val baseUrl: String = env.getRequiredProperty("fi.espoo.integration.koski.url"),
     private val sourceSystem: String = env.getRequiredProperty("fi.espoo.integration.koski.source_system"),
@@ -62,7 +63,7 @@ class KoskiClient(
         if (!tx.isPayloadChanged(msg.key, payload)) {
             logger.info { "Koski upload ${msg.key} ${data.operation}: no change in payload -> skipping" }
         } else {
-            val (_, _, result) = Fuel.request(
+            val (_, _, result) = fuel.request(
                 method = if (data.operation == KoskiOperation.CREATE) Method.POST else Method.PUT,
                 path = "$baseUrl/oppija"
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaTokenProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaTokenProvider.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.varda.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.Headers
 import fi.espoo.evaka.shared.utils.responseStringWithRetries
 import kotlinx.coroutines.runBlocking
@@ -33,6 +33,7 @@ interface VardaTokenProvider {
  */
 @Service
 class VardaTempTokenProvider(
+    private val fuel: FuelManager,
     env: Environment,
     private val objectMapper: ObjectMapper,
     baseUrl: String = env.getRequiredProperty("fi.espoo.integration.varda.url")
@@ -59,7 +60,7 @@ class VardaTempTokenProvider(
             }
         }
 
-    private fun fetchToken(): VardaApiToken = Fuel.get(apiTokenUrl)
+    private fun fetchToken(): VardaApiToken = fuel.get(apiTokenUrl)
         .header(Headers.AUTHORIZATION, basicAuth)
         .header(Headers.ACCEPT, "application/json")
         .header(Headers.CONTENT_TYPE, "application/json")


### PR DESCRIPTION
#### Summary

Use common FuelManager for Koski calls and Varda token fetching.

#### Dependencies

Requires certificates installed on environments before update.

#### Testing instructions

Varda and Koski should work as before.

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] The code is consistent with the existing code base
- [x] Tests have been written for the change (e2e, integration tests)
- [x] The change has been tested locally
- [x] The change conforms to the UX specifications
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```
