### PR TITLE
Work around generic parameter type erasure in mapJsonColumn

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DbTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DbTest.kt
@@ -1,0 +1,43 @@
+package fi.espoo.evaka.shared.db
+
+import fi.espoo.evaka.PureJdbiTest
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DbTest : PureJdbiTest() {
+    private data class Foo(val value: String)
+
+    private fun Database.Read.fooJsonQuery() =
+        createQuery("SELECT jsonb_agg(jsonb_build_object('value', 'foo')) AS json")
+
+    @Test
+    fun `mapJsonColumn can map a jsonb array to a kotlin array`() {
+        val result = db.read { tx ->
+            tx.fooJsonQuery().map { row ->
+                row.mapJsonColumn<Array<Foo>>("json")
+            }.single()
+        }
+        assertArrayEquals(arrayOf(Foo("foo")), result)
+    }
+
+    @Test
+    fun `mapJsonColumn can map a jsonb array to a kotlin list`() {
+        val result = db.read { tx ->
+            tx.fooJsonQuery().map { row ->
+                row.mapJsonColumn<List<Foo>>("json")
+            }.single()
+        }
+        assertEquals(listOf(Foo("foo")), result)
+    }
+
+    @Test
+    fun `mapJsonColumn can map a jsonb array to a kotlin set`() {
+        val result = db.read { tx ->
+            tx.fooJsonQuery().map { row ->
+                row.mapJsonColumn<Set<Foo>>("json")
+            }.single()
+        }
+        assertEquals(setOf(Foo("foo")), result)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.Period
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.generic.GenericType
 import org.jdbi.v3.core.kotlin.KotlinPlugin
 import org.jdbi.v3.core.qualifier.QualifiedType
 import org.jdbi.v3.core.result.RowView
@@ -131,4 +132,4 @@ inline fun <reified T> RowView.mapColumn(name: String, type: QualifiedType<T> = 
  * Maps a row json column to a value.
  */
 inline fun <reified T : Any> RowView.mapJsonColumn(name: String): T =
-    mapColumn(name, QualifiedType.of(T::class.java).with(Json::class.java))
+    mapColumn(name, QualifiedType.of(object : GenericType<T>() {}).with(Json::class.java))


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

For example, if T is List<Foo>, T::class.java simply returns generic List<Object> due to type erasure. Using a local GenericType object class and instance retains reified type information of any generic type parameters of T.

This also means every call site will have an anonymous dummy class, but it shouldn't cause problems.