### PR TITLE
EVAKA-4012: improve and unify planned occupancy logic

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/PlannedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/PlannedOccupancyTest.kt
@@ -8,14 +8,25 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.reports.OccupancyReportRowGroupedValues
+import fi.espoo.evaka.reports.OccupancyUnitReportResultRow
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
+import fi.espoo.evaka.shared.dev.DevChild
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestApplication
+import fi.espoo.evaka.shared.dev.insertTestChild
+import fi.espoo.evaka.shared.dev.insertTestDaycare
+import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacementPlan
 import fi.espoo.evaka.shared.domain.ClosedPeriod
+import fi.espoo.evaka.testAreaId
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1
 import org.junit.jupiter.api.AfterEach
@@ -37,7 +48,9 @@ class PlannedOccupancyTest : FullApplicationTest() {
         jdbi.handle(::resetDatabase)
     }
 
-    private val defaultPeriod = ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
+    private val defaultPeriod = ClosedPeriod(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 1, 31))
+    val period1 = ClosedPeriod(defaultPeriod.start, LocalDate.of(2019, 1, 15))
+    val period2 = ClosedPeriod(LocalDate.of(2019, 1, 16), defaultPeriod.end)
 
     @Test
     fun `planned occupancy calculation does not break when there are no children placed into a unit`() {
@@ -47,6 +60,13 @@ class PlannedOccupancyTest : FullApplicationTest() {
             listOf(OccupancyPeriod(defaultPeriod, 0.0, 0)),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(0.0, reportResult1?.sum)
+        assertEquals(0, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(0.0, reportResult2?.sum)
+        assertEquals(0, reportResult2?.headcount)
     }
 
     @Test
@@ -66,6 +86,13 @@ class PlannedOccupancyTest : FullApplicationTest() {
             listOf(OccupancyPeriod(defaultPeriod, 1.0, 1)),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(1.0, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(1.0, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
@@ -85,6 +112,13 @@ class PlannedOccupancyTest : FullApplicationTest() {
             listOf(OccupancyPeriod(defaultPeriod, 1.75, 1)),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(1.75, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(1.75, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
@@ -104,6 +138,13 @@ class PlannedOccupancyTest : FullApplicationTest() {
             listOf(OccupancyPeriod(defaultPeriod, 0.54, 1)),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(0.54, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(0.54, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
@@ -123,6 +164,13 @@ class PlannedOccupancyTest : FullApplicationTest() {
             listOf(OccupancyPeriod(defaultPeriod, 0.5, 1)),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(0.5, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(0.5, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
@@ -142,6 +190,13 @@ class PlannedOccupancyTest : FullApplicationTest() {
             listOf(OccupancyPeriod(defaultPeriod, 1.75, 1)),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(1.75, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(1.75, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
@@ -162,6 +217,13 @@ class PlannedOccupancyTest : FullApplicationTest() {
             listOf(OccupancyPeriod(defaultPeriod, 3.0, 1)),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(3.0, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(3.0, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
@@ -182,6 +244,13 @@ class PlannedOccupancyTest : FullApplicationTest() {
             listOf(OccupancyPeriod(defaultPeriod, 5.25, 1)),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(5.25, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(5.25, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
@@ -191,7 +260,7 @@ class PlannedOccupancyTest : FullApplicationTest() {
                 testDaycare.id,
                 defaultPeriod,
                 LocalDate.of(2015, 1, 1),
-                defaultPeriod.copy(start = defaultPeriod.start.plusMonths(1))
+                period2
             )
         )
 
@@ -199,11 +268,18 @@ class PlannedOccupancyTest : FullApplicationTest() {
 
         assertEquals(
             listOf(
-                OccupancyPeriod(defaultPeriod.copy(end = defaultPeriod.start.plusMonths(1).minusDays(1)), 0.5, 1),
-                OccupancyPeriod(defaultPeriod.copy(start = defaultPeriod.start.plusMonths(1)), 1.0, 1)
+                OccupancyPeriod(period1, 0.5, 1),
+                OccupancyPeriod(period2, 1.0, 1)
             ),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, period1.end)
+        assertEquals(0.5, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, period2.start)
+        assertEquals(1.0, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
@@ -223,8 +299,8 @@ class PlannedOccupancyTest : FullApplicationTest() {
                 applicationId = applicationId,
                 unitId = testDaycare.id,
                 type = PlacementType.DAYCARE,
-                startDate = defaultPeriod.start.plusMonths(6),
-                endDate = defaultPeriod.end
+                startDate = period2.start,
+                endDate = period2.end
             )
         }
 
@@ -232,11 +308,18 @@ class PlannedOccupancyTest : FullApplicationTest() {
 
         assertEquals(
             listOf(
-                OccupancyPeriod(defaultPeriod.copy(end = defaultPeriod.start.plusMonths(6).minusDays(1)), 0.54, 1),
-                OccupancyPeriod(defaultPeriod.copy(start = defaultPeriod.start.plusMonths(6)), 1.0, 1)
+                OccupancyPeriod(period1, 0.54, 1),
+                OccupancyPeriod(period2, 1.0, 1)
             ),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, period1.end)
+        assertEquals(0.54, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, period2.start)
+        assertEquals(1.0, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
@@ -256,8 +339,8 @@ class PlannedOccupancyTest : FullApplicationTest() {
                 applicationId = applicationId,
                 unitId = testDaycare.id,
                 type = PlacementType.DAYCARE_PART_TIME,
-                startDate = defaultPeriod.start.plusMonths(6),
-                endDate = defaultPeriod.end
+                startDate = period2.start,
+                endDate = period2.end
             )
         }
 
@@ -265,15 +348,21 @@ class PlannedOccupancyTest : FullApplicationTest() {
 
         assertEquals(
             listOf(
-                OccupancyPeriod(defaultPeriod.copy(end = defaultPeriod.start.plusMonths(6).minusDays(1)), 1.0, 1),
-                OccupancyPeriod(defaultPeriod.copy(start = defaultPeriod.start.plusMonths(6)), 0.54, 1)
+                OccupancyPeriod(defaultPeriod, 1.0, 1)
             ),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(1.0, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(1.0, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
-    fun `occupancy calculation picks latest placement plant when two placement plans are valid during same period`() {
+    fun `occupancy calculation picks latest placement plan when two placement plans are valid during same period`() {
         val childId = UUID.randomUUID()
         jdbi.handle { h ->
             createPlanOccupancyTestFixture(
@@ -289,8 +378,8 @@ class PlannedOccupancyTest : FullApplicationTest() {
                 applicationId = applicationId,
                 unitId = testDaycare.id,
                 type = PlacementType.DAYCARE_PART_TIME,
-                startDate = defaultPeriod.start.plusMonths(1),
-                endDate = defaultPeriod.end,
+                startDate = period2.start,
+                endDate = period2.end,
                 updated = Instant.now().plusMillis(10000)
             )
         }
@@ -301,6 +390,13 @@ class PlannedOccupancyTest : FullApplicationTest() {
             listOf(OccupancyPeriod(defaultPeriod, 1.0, 1)),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(1.0, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(1.0, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     @Test
@@ -326,6 +422,83 @@ class PlannedOccupancyTest : FullApplicationTest() {
             listOf(OccupancyPeriod(defaultPeriod, 0.0, 0)),
             result
         )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(0.0, reportResult1?.sum)
+        assertEquals(0, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(0.0, reportResult2?.sum)
+        assertEquals(0, reportResult2?.headcount)
+    }
+
+    @Test
+    fun `when child is planned to transfer to another unit the child is counted into both units`() {
+        val childId = UUID.randomUUID()
+        val daycareId1 = testDaycare.id
+        val daycareId2 = UUID.randomUUID()
+
+        db.transaction { tx ->
+            tx.handle.insertTestPerson(DevPerson(id = childId, dateOfBirth = LocalDate.of(2015, 1, 1)))
+            tx.handle.insertTestChild(DevChild(id = childId))
+            tx.handle.insertTestDaycare(DevDaycare(id = daycareId2, areaId = testDaycare.areaId, name = "foo"))
+
+            tx.handle.insertTestPlacement(DevPlacement(type = PlacementType.DAYCARE, childId = childId, unitId = daycareId1, startDate = defaultPeriod.start, endDate = defaultPeriod.end))
+
+            val applicationId = insertTestApplication(tx.handle, childId = childId)
+            insertTestPlacementPlan(h = tx.handle, applicationId = applicationId, unitId = daycareId2, type = PlacementType.DAYCARE_PART_TIME, startDate = period2.start, endDate = period2.end)
+        }
+
+        val result1 = fetchAndParseOccupancy(daycareId1, defaultPeriod)
+        assertEquals(
+            listOf(OccupancyPeriod(defaultPeriod, 1.0, 1)),
+            result1
+        )
+
+        val result2 = fetchAndParseOccupancy(daycareId2, defaultPeriod)
+        assertEquals(
+            listOf(
+                OccupancyPeriod(period1, 0.0, 0),
+                OccupancyPeriod(period2, 0.54, 1)
+            ),
+            result2
+        )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, daycareId1, period2.start)
+        assertEquals(1.0, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, daycareId2, period2.start)
+        assertEquals(0.54, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
+    }
+
+    @Test
+    fun `when child is planned to transfer to same unit the higher capacity wins`() {
+        val childId = UUID.randomUUID()
+        val daycareId1 = testDaycare.id
+
+        db.transaction { tx ->
+            tx.handle.insertTestPerson(DevPerson(id = childId, dateOfBirth = LocalDate.of(2015, 1, 1)))
+            tx.handle.insertTestChild(DevChild(id = childId))
+
+            tx.handle.insertTestPlacement(DevPlacement(type = PlacementType.DAYCARE, childId = childId, unitId = daycareId1, startDate = defaultPeriod.start, endDate = defaultPeriod.end))
+
+            val applicationId = insertTestApplication(tx.handle, childId = childId)
+            insertTestPlacementPlan(h = tx.handle, applicationId = applicationId, unitId = daycareId1, type = PlacementType.DAYCARE_PART_TIME, startDate = period2.start, endDate = period2.end)
+        }
+
+        val result = fetchAndParseOccupancy(daycareId1, defaultPeriod)
+        assertEquals(
+            listOf(OccupancyPeriod(defaultPeriod, 1.0, 1)),
+            result
+        )
+
+        val reportResult1 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.start)
+        assertEquals(1.0, reportResult1?.sum)
+        assertEquals(1, reportResult1?.headcount)
+        val reportResult2 = fetchAndParsePlannedOccupancyReportForUnitDay(testAreaId, testDaycare.id, defaultPeriod.end)
+        assertEquals(1.0, reportResult2?.sum)
+        assertEquals(1, reportResult2?.headcount)
     }
 
     private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
@@ -337,5 +510,19 @@ class PlannedOccupancyTest : FullApplicationTest() {
         assertEquals(200, response.statusCode)
 
         return objectMapper.readValue<OccupancyResponse>(result.get()).occupancies
+    }
+
+    private fun fetchAndParsePlannedOccupancyReportForUnitDay(careAreaId: UUID, unitId: UUID, date: LocalDate): OccupancyReportRowGroupedValues? {
+        val (_, response, result) = http.get(
+            "/reports/occupancy-by-unit",
+            listOf("type" to "PLANNED", "careAreaId" to careAreaId, "year" to date.year, "month" to date.month.value)
+        )
+            .asUser(testUser)
+            .responseString()
+        assertEquals(200, response.statusCode)
+
+        return objectMapper.readValue<List<OccupancyUnitReportResultRow>>(result.get())
+            .first { it.unitId == unitId }
+            .occupancies[date]
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
@@ -225,13 +225,17 @@ private val plannedMaxCoefficients =
     """.trimIndent()
 
 private fun finalCoefficients(planned: Boolean) = if (planned) """
-    SELECT
-        coalesce(p.unit_id, c.unit_id) AS unit_id,
-        coalesce(p.day, c.day) AS day,
-        coalesce(p.child_id, c.child_id) AS child_id,
-        coalesce(p.coefficient, c.coefficient) AS coefficient
-    FROM coefficients c
-    FULL JOIN planned_max_coefficients p ON c.day = p.day AND c.child_id = p.child_id
+    SELECT unit_id, day, child_id, max(coefficient) AS coefficient
+    FROM (
+        SELECT unit_id, day, child_id, coefficient
+        FROM planned_max_coefficients
+
+        UNION ALL
+
+        SELECT unit_id, day, child_id, coefficient
+        FROM coefficients c
+    ) AS all_coefficients
+    GROUP BY unit_id, day, child_id
 """.trimIndent() else """
     SELECT * FROM coefficients
 """.trimIndent()


### PR DESCRIPTION
#### Summary
Changed planned occupancy logic (now uses 'prepare for the worst case scenario' principle) and unified it between unit view and report:

- If child has overlapping placement and placement_plan to different units, child counts into both units
- If child has overlapping placement and placement_plan to same unit, the one with higher capacity need wins

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```
