### PR TITLE
[EVAKA-4014] enduser: don't load applications & decisions upon auth

### DIFF
--- a/frontend/e2e-test/README.md
+++ b/frontend/e2e-test/README.md
@@ -117,16 +117,13 @@ test('Application main page is visible', async (t) => {
 })
 ```
 
-## TODO
+## Known issues
 
-- [x] Build docker container for tests (docker-compose can be used as an example)
-  - Use `evaka-compose`
-- [x] Trigger test workflow when pushing commits to master branch (frontend and backend?)
-  - Triggered by this repository, will attempt to find matching branch name for backend Docker images
-- [ ] Testrunner to launch test tasks in certain order
-- [ ] Refactoring to replace id selectors by data-qa attribute in frontend repos
-- [ ] Replace for loops by selector's visibilitycheck option
-- [ ] Re-introduce Browserstack for E2E testing
+- Some selectors still use IDs/classes instead of data-qa attributes
+- Should replace for loops by selector's visibilitycheck option
+- Tests aren't run against multiple different browsers
+- Test data isn't cleared from local DB on test failure when running with `--stop-on-first-fail`
+  - Testcafe issue: `Fixture.after` isn't called when using the option (unlike `.afterEach`)
 
 ## More information
 

--- a/frontend/packages/enduser-frontend/src/store/index.ts
+++ b/frontend/packages/enduser-frontend/src/store/index.ts
@@ -47,11 +47,11 @@ export default new Vuex.Store<RootState>({
       commit(types.INIT_FILTERS)
       commit(types.INIT_ADDRESSES)
     },
-    async loadApplicationsAndDecisions({ dispatch }, userId) {
+    async loadApplicationsAndDecisions({ dispatch }) {
       await Promise.all([
         dispatch('loader/add', 'loader.initializing'),
-        dispatch('loadApplications', userId),
-        dispatch('loadDecisions', userId)
+        dispatch('loadApplications'),
+        dispatch('loadDecisions')
       ])
       dispatch('loader/clear')
     }

--- a/frontend/packages/enduser-frontend/src/store/modules/auth.ts
+++ b/frontend/packages/enduser-frontend/src/store/modules/auth.ts
@@ -34,7 +34,6 @@ const actions = {
     commit(LOG_IN, loggedIn)
     if (loggedIn) {
       commit(SET_USER, user)
-      dispatch('loadApplicationsAndDecisions', user.id)
     } else {
       commit(SET_USER, EMPTY_USER)
     }

--- a/frontend/packages/enduser-frontend/src/views/applications/application-list.vue
+++ b/frontend/packages/enduser-frontend/src/views/applications/application-list.vue
@@ -105,7 +105,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       }
     },
     created() {
-      this.$store.dispatch('loadApplications')
+      this.$store.dispatch('loadApplicationsAndDecisions')
     },
     methods: {
       async newApplication(payload) {


### PR DESCRIPTION
#### Summary

- Both will be loaded by their respective views when rendered
  - Applications page actually has to load both to link to decisions from applications but at least it's one request less
- E2E: docs for known cleanup issue
  - For some reason, Testcafe doesn't actually run Fixture.after when running with --stop-on-first-fail / stopOnFirstFail -> test data created with dev-API isn't actually cleared when a test fails, requiring a full reset of the local database (or manually going through everything)

#### Dependencies

None

#### Testing instructions

Before PR:

1. Don't authenticate
1. Navigate directly to `/applications` in enduser-frontend
1. See **two** requests to `/api/application/enduser/v2/applications` after authentication

From PR branch:

1. Don't authenticate
1. Navigate directly to `/applications` in enduser-frontend
1. See **only one** request to `/api/application/enduser/v2/applications` after authentication

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [x] The change has been tested locally
- [x] The change conforms to the UX specifications
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```