### PR TITLE
EVAKA-HOTFIX Changed a-tags to <Link> elements to fix whole page reloads

### DIFF
--- a/frontend/packages/employee-frontend/src/components/attendances/AttendanceGroupSelectorPage.tsx
+++ b/frontend/packages/employee-frontend/src/components/attendances/AttendanceGroupSelectorPage.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { Fragment, useContext, useEffect } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import styled from 'styled-components'
 import MetaTags from 'react-meta-tags'
 
@@ -60,13 +60,13 @@ export default React.memo(function AttendanceGroupSelectorPage() {
                 {i18n.attendances.chooseGroup}
               </AllCapsTitle>
               <Flex>
-                <a href={`attendance/all/coming`}>
+                <Link to={`attendance/all/coming`}>
                   <CustomButton primary text={i18n.common.all} />
-                </a>
+                </Link>
                 {attendanceResponse.data.unit.groups.map((group: Group) => (
-                  <a key={group.id} href={`attendance/${group.id}/coming`}>
+                  <Link key={group.id} to={`attendance/${group.id}/coming`}>
                     <CustomButton primary key={group.id} text={group.name} />
-                  </a>
+                  </Link>
                 ))}
               </Flex>
             </ContentArea>

--- a/frontend/packages/employee-frontend/src/components/attendances/AttendanceList.tsx
+++ b/frontend/packages/employee-frontend/src/components/attendances/AttendanceList.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 
 import { FixedSpaceColumn } from '~components/shared/layout/flex-helpers'
 import ChildListItem from './ChildListItem'
@@ -34,15 +34,15 @@ export default React.memo(function AttendanceList({
       <UnorderedList spacing={'xs'}>
         {attendanceChildren.map((ac) => (
           <li key={ac.id}>
-            <a
-              href={`/employee/units/${unitId}/groups/${groupIdOrAll}/childattendance/${ac.id}`}
+            <Link
+              to={`/units/${unitId}/groups/${groupIdOrAll}/childattendance/${ac.id}`}
             >
               <ChildListItem
                 type={ac.status}
                 key={ac.id}
                 attendanceChild={ac}
               />
-            </a>
+            </Link>
           </li>
         ))}
       </UnorderedList>

--- a/frontend/packages/employee-frontend/src/components/attendances/AttendancePageWrapper.tsx
+++ b/frontend/packages/employee-frontend/src/components/attendances/AttendancePageWrapper.tsx
@@ -5,6 +5,7 @@
 import React, { Fragment, useContext, useEffect, useState } from 'react'
 
 import {
+  Link,
   Redirect,
   Route,
   Switch,
@@ -232,7 +233,7 @@ export default React.memo(function AttendancePageWrapper() {
             paddingVertical={'s'}
             paddingHorozontal={'s'}
           >
-            <a href={`/employee/units/${unitId}/groupselector`}>
+            <Link to={`/employee/units/${unitId}/groupselector`}>
               <WideButton
                 primary
                 text={
@@ -243,7 +244,7 @@ export default React.memo(function AttendancePageWrapper() {
                     : i18n.attendances.groupSelectError
                 }
               />
-            </a>
+            </Link>
             <Switch>
               <Route
                 exact


### PR DESCRIPTION
#### Summary
Changed `<a>`-tags to react routers `<Link>` elements to fix whole page reloads in the mobile attendances.