### PR TITLE
Do CSRF checks after authentication checks

### DIFF
--- a/apigw/src/enduser/app.ts
+++ b/apigw/src/enduser/app.ts
@@ -44,9 +44,9 @@ setupLoggingMiddleware(app)
 
 app.use('/api/application/', publicRoutes)
 app.use('/api/application/', createAuthEndpoints('enduser'))
-app.use(csrf)
 app.use('/api/application/', userDetails('enduser'))
 app.all('*', authenticate)
+app.use(csrf)
 app.use('/api/application/', routes)
 app.use(errorHandler(false))
 

--- a/apigw/src/enduser/routes/auth-status.ts
+++ b/apigw/src/enduser/routes/auth-status.ts
@@ -5,13 +5,14 @@
 import { NextFunction, Request, Response, Router } from 'express'
 import { getUserDetails } from '../services/pis'
 import { SessionType } from '../../shared/session'
-import { csrfCookie } from '../../shared/middleware/csrf'
+import { csrf, csrfCookie } from '../../shared/middleware/csrf'
 
 export default function authStatus(sessionType: SessionType) {
   const router = Router()
 
   router.get(
     '/auth/status',
+    csrf,
     csrfCookie(sessionType),
     (req: Request, res: Response, next: NextFunction) => {
       if (req.user) {

--- a/apigw/src/internal/app.ts
+++ b/apigw/src/internal/app.ts
@@ -64,9 +64,9 @@ function internalApiRouter() {
     )
   }
 
-  router.use(csrf)
   router.use(userDetails('employee'))
   router.use(authenticate)
+  router.use(csrf)
   router.post('/attachments', createProxy({ multipart: true }))
   router.use(createProxy())
   router.use(errorHandler(true))

--- a/apigw/src/shared/routes/auth/status.ts
+++ b/apigw/src/shared/routes/auth/status.ts
@@ -4,7 +4,7 @@
 
 import { NextFunction, Request, Response, Router } from 'express'
 import { getEmployeeDetails } from '../../service/pis'
-import { csrfCookie } from '../../middleware/csrf'
+import { csrf, csrfCookie } from '../../middleware/csrf'
 import { SessionType } from '../../session'
 
 export default function authStatus(sessionType: SessionType) {
@@ -12,6 +12,7 @@ export default function authStatus(sessionType: SessionType) {
 
   router.get(
     '/auth/status',
+    csrf,
     csrfCookie(sessionType),
     (req: Request, res: Response, next: NextFunction) => {
       const user = req.user


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

If a request has a CSRF header but no session is active, we want 401
from the authentication check instead of 403 from the CSRF token check.

/auth/status endpoint is a special case that needs the csrf middleware,
because it generates a CSRF token into the session if there isn't any.