### PR TITLE
Evaka fix prevent making start date earlier

### DIFF
--- a/frontend/packages/enduser-frontend/src/store/modules/forms.ts
+++ b/frontend/packages/enduser-frontend/src/store/modules/forms.ts
@@ -114,7 +114,8 @@ const currentState = {
   files: {
     urgent: [],
     extendedCare: []
-  }
+  },
+  originalPreferredStartDate: ''
 }
 
 const defaultChild = {
@@ -239,7 +240,8 @@ const module: Module<any, RootState> = {
     urgentFiles: (state) => state.files.urgent,
     uploadedUrgentFiles: (state) => state.files.urgent.filter((file) => file.id),
     extendedCareFiles: (state) => state.files.extendedCare,
-    uploadedExtendedCareFiles: (state) => state.files.extendedCare.filter((file) => file.id)
+    uploadedExtendedCareFiles: (state) => state.files.extendedCare.filter((file) => file.id),
+    originalPreferredStartDate: (state) => state.originalPreferredStartDate
   },
   actions: {
     updateForm({ commit }, payload) {
@@ -334,6 +336,7 @@ const module: Module<any, RootState> = {
         key: attachment.id
       }))
       .filter(({type}) => type ===  ATTACHMENT_TYPE.EXTENDED_CARE)
+      state.originalPreferredStartDate = application.preferredStartDate
     },
     [types.REVERT_APPLICATION_FORM](state) {
       state.application = _.cloneDeep(state.loadedApplication)

--- a/frontend/packages/enduser-frontend/src/views/applications/daycare-application/daycare-application.vue
+++ b/frontend/packages/enduser-frontend/src/views/applications/daycare-application/daycare-application.vue
@@ -169,7 +169,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
                           )
                         "
                       ></div>
-                      <div v-else  
+                      <div v-else
                         v-html="
                           $t(
                             `form.${type}-application.service.expedited.message.text`
@@ -1134,7 +1134,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       }
     },
     computed: {
-      ...mapGetters(['daycareForm', 'applicationUnits', 'urgentFiles', 'extendedCareFiles']),
+      ...mapGetters(['daycareForm', 'applicationUnits', 'urgentFiles', 'extendedCareFiles', 'originalPreferredStartDate']),
       id(): string {
         return this.$route.params.id
       },
@@ -1162,7 +1162,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
           : ''
       },
       minimumStartdate(): null | string {
-        return this.isPreschool
+        // If application is already sent, the preferred start date can only be moved forward
+        return (this.model.status.value !== 'CREATED' && this.originalPreferredStartDate) ?
+          this.originalPreferredStartDate
+        : this.isPreschool
           ? datepickerTodayFormat()
           : minimumDaycareStartdate()
       },

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -442,6 +442,15 @@ class ApplicationStateService(
 
         val form = ApplicationForm.fromV0(formV0, original.childRestricted, original.guardianRestricted)
 
+        if (listOf(SENT).contains(original.status)) {
+            original.form.preferences.preferredStartDate?.let { previousStartDate ->
+                form.preferences.preferredStartDate?.let { newStartDate ->
+                    if (previousStartDate.isAfter(newStartDate))
+                        throw BadRequest("Moving start date $previousStartDate earlier to $newStartDate is not allowed")
+                }
+            }
+        }
+
         tx.updateApplicationContents(original, form)
         return getApplication(tx, applicationId)
     }


### PR DESCRIPTION
#### Summary
Once an application is sent, the preferred start date can only be moved forward. Prevent it from both backend and in the UI

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```
