### PR TITLE
Refactor roles imports

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -35,7 +35,6 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -81,7 +80,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     @Autowired
     lateinit var mapper: ObjectMapper
 
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     private val applicationId = UUID.randomUUID()
     val address = Address(
@@ -245,7 +244,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - existing overlapping indefinite income will be handled`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIndefinite = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -279,7 +278,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - existing overlapping income will be handled by not adding a new income for user`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -312,7 +311,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - later indefinite income will be handled by not adding a new income`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val laterIndefiniteIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -345,7 +344,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - earlier income does not affect creating a new income`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -379,7 +378,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - later income will be handled by not adding a new income`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val laterIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -412,7 +411,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - if application does not have a preferred start date income will not be created`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIndefinite = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -445,7 +444,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists indefinite income for the same day `() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val sameDayIncomeIndefinite = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -478,7 +477,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists income for the same day `() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val sameDayIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -511,7 +510,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - new income will be created if there exists indefinite income for the same day - 1 `() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val dayBeforeIncomeIndefinite = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -545,7 +544,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists indefinite income for the same day + 1 `() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val nextDayIncomeIndefinite = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -578,7 +577,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists income for the same day - 1 `() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val IncomeDayBefore = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -611,7 +610,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists income that ends on the same day`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncomeEndingOnSameDay = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -644,7 +643,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists income that ends on the same day + 1`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncomeEndingOnNextDay = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -677,7 +676,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists income that ends on the same day - 1`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncomeEndingOnDayBefore = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
@@ -8,8 +8,8 @@ import com.github.kittinunf.fuel.core.extensions.jsonBody
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 class ApplicationUpdateIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @Test
     fun `when application update sets urgent to false, the new due date is calculated from sent date`() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/EmailResponseIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/EmailResponseIntegrationTest.kt
@@ -15,8 +15,8 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -46,8 +46,8 @@ class EmailResponseIntegrationTest : FullApplicationTest() {
     private val validDaycareForm = DaycareFormV0.fromApplication2(validDaycareApplication)
     private val validClubForm = ClubFormV0.fromForm2(validClubApplication.form, false, false)
 
-    private val serviceWorker = AuthenticatedUser(testAdult_1.id, setOf(Roles.SERVICE_WORKER))
-    private val endUser = AuthenticatedUser(testAdult_1.id, setOf(Roles.END_USER))
+    private val serviceWorker = AuthenticatedUser(testAdult_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val endUser = AuthenticatedUser(testAdult_1.id, setOf(UserRole.END_USER))
     private val guardian = testAdult_1.copy(email = "john.doe@espootest.com")
     private val guardianAsDaycareAdult = Adult(
         firstName = guardian.firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -10,8 +10,8 @@ import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -32,7 +32,7 @@ import java.time.Instant
 import java.util.UUID
 
 class GetApplicationIntegrationTests : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     private val validDaycareForm = DaycareFormV0.fromApplication2(validDaycareApplication)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
@@ -10,8 +10,8 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevAssistanceAction
 import fi.espoo.evaka.shared.dev.insertTestAssistanceAction
@@ -26,7 +26,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class AssistanceActionIntegrationTest : FullApplicationTest() {
-    private val assistanceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val assistanceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
@@ -10,8 +10,8 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevAssistanceNeed
 import fi.espoo.evaka.shared.dev.insertTestAssistanceNeed
@@ -26,7 +26,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class AssistanceNeedIntegrationTest : FullApplicationTest() {
-    private val assistanceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val assistanceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
@@ -11,8 +11,8 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
@@ -32,7 +32,7 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class BackupCareIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
@@ -14,8 +14,8 @@ import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -34,7 +34,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class DaycareEditIntegrationTest : FullApplicationTest() {
-    private val admin = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.ADMIN))
+    private val admin = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.ADMIN))
     private val fields = DaycareFields(
         name = "Uusi päiväkoti",
         openingDate = LocalDate.of(2020, 1, 1),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareGroupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareGroupIntegrationTest.kt
@@ -12,8 +12,8 @@ import fi.espoo.evaka.daycare.controllers.DaycareController
 import fi.espoo.evaka.daycare.service.DaycareGroup
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevBackupCare
 import fi.espoo.evaka.shared.dev.DevCareArea
@@ -42,7 +42,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class DaycareGroupIntegrationTest : FullApplicationTest() {
-    private val admin = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.ADMIN))
+    private val admin = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.ADMIN))
 
     @BeforeEach
     protected fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.daycare.controllers
 
 import fi.espoo.evaka.daycare.AbstractIntegrationTest
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -26,7 +26,7 @@ class DaycareControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `smoke test for groups`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
         val existingGroups = daycareController.getGroups(db, user, daycareId).body!!
         assertEquals(2, existingGroups.size)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.shared.auth.DaycareAclRow
 import fi.espoo.evaka.shared.auth.DaycareAclRowEmployee
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -43,7 +42,7 @@ class UnitAclControllerIntegrationTest : FullApplicationTest() {
     protected fun beforeEach() {
         jdbi.handle { h ->
             resetDatabase(h)
-            admin = AuthenticatedUser(h.insertTestEmployee(DevEmployee(roles = setOf(Roles.ADMIN))), roles = setOf(Roles.ADMIN))
+            admin = AuthenticatedUser(h.insertTestEmployee(DevEmployee(roles = setOf(UserRole.ADMIN))), roles = setOf(UserRole.ADMIN))
             h.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
             h.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
             employee.also {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -24,8 +24,8 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -54,7 +54,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class DecisionCreationIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @Autowired
     private lateinit var asyncJobRunner: AsyncJobRunner
@@ -406,9 +406,9 @@ WHERE id = :unitId
             )
         }
         val invalidRoleLists = listOf(
-            setOf(Roles.UNIT_SUPERVISOR),
-            setOf(Roles.FINANCE_ADMIN),
-            setOf(Roles.END_USER),
+            setOf(UserRole.UNIT_SUPERVISOR),
+            setOf(UserRole.FINANCE_ADMIN),
+            setOf(UserRole.END_USER),
             setOf()
         )
         invalidRoleLists.forEach { roles ->

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
@@ -20,8 +20,8 @@ import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -58,8 +58,8 @@ import java.util.stream.Stream
 data class DecisionResolutionTestCase(val isServiceWorker: Boolean, val isAccept: Boolean)
 
 class DecisionResolutionIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
-    private val endUser = AuthenticatedUser(testAdult_1.id, setOf(Roles.END_USER))
+    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val endUser = AuthenticatedUser(testAdult_1.id, setOf(UserRole.END_USER))
     private val applicationId = UUID.randomUUID()
 
     @BeforeEach
@@ -334,7 +334,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
     }
 
     private fun acceptDecisionAndAssert(h: Handle, user: AuthenticatedUser, applicationId: UUID, decisionId: UUID, requestedStartDate: LocalDate) {
-        val path = "${if (user.roles.contains(Roles.END_USER)) "/enduser" else ""}/v2/applications/$applicationId/actions/accept-decision"
+        val path = "${if (user.roles.contains(UserRole.END_USER)) "/enduser" else ""}/v2/applications/$applicationId/actions/accept-decision"
 
         val (_, res, _) = http.post(path)
             .jsonBody(objectMapper.writeValueAsString(AcceptDecisionRequest(decisionId, requestedStartDate)))
@@ -351,7 +351,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
     }
 
     private fun rejectDecisionAndAssert(h: Handle, user: AuthenticatedUser, applicationId: UUID, decisionId: UUID) {
-        val path = "${if (user.roles.contains(Roles.END_USER)) "/enduser" else ""}/v2/applications/$applicationId/actions/reject-decision"
+        val path = "${if (user.roles.contains(UserRole.END_USER)) "/enduser" else ""}/v2/applications/$applicationId/actions/reject-decision"
 
         val (_, res, _) = http.post(path)
             .jsonBody(objectMapper.writeValueAsString(RejectDecisionRequest(decisionId)))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeAlterationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeAlterationIntegrationTest.kt
@@ -13,8 +13,8 @@ import fi.espoo.evaka.invoicing.data.upsertFeeAlteration
 import fi.espoo.evaka.invoicing.domain.FeeAlteration
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.testDecisionMaker_1
 import org.junit.jupiter.api.AfterEach
@@ -46,7 +46,7 @@ class FeeAlterationIntegrationTest : FullApplicationTest() {
         jdbi.handle(::resetDatabase)
     }
 
-    private val user = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.FINANCE_ADMIN))
+    private val user = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
     private val personId = UUID.randomUUID()
 
     private val testFeeAlteration = FeeAlteration(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -22,8 +22,8 @@ import fi.espoo.evaka.invoicing.domain.ServiceNeed
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.Period
 import fi.espoo.evaka.testAdult_1
@@ -49,7 +49,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
     @Autowired
     lateinit var asyncJobRunner: AsyncJobRunner
 
-    private val user = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.FINANCE_ADMIN))
+    private val user = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
 
     private val testDecisions = listOf(
         createFeeDecisionFixture(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/IncomeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/IncomeIntegrationTest.kt
@@ -19,8 +19,8 @@ import fi.espoo.evaka.invoicing.domain.IncomeType
 import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testDecisionMaker_1
@@ -66,7 +66,7 @@ class IncomeIntegrationTest : FullApplicationTest() {
         notes = ""
     )
 
-    private val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(Roles.FINANCE_ADMIN))
+    private val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
 
     @Test
     fun `getIncome works with no data in DB`() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -32,8 +32,8 @@ import fi.espoo.evaka.invoicing.integration.fallbackPostalCode
 import fi.espoo.evaka.invoicing.integration.fallbackStreetAddress
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -152,7 +152,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         )
     )
 
-    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.FINANCE_ADMIN))
+    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
 
     @BeforeEach()
     fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/ConfirmedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/ConfirmedOccupancyTest.kt
@@ -12,8 +12,8 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -586,7 +586,7 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
         )
     }
 
-    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     private fun fetchAndParseOccupancy(unitId: UUID, period: ClosedPeriod): List<OccupancyPeriod> {
         val (_, response, result) = http

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/PlannedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/PlannedOccupancyTest.kt
@@ -12,8 +12,8 @@ import fi.espoo.evaka.reports.OccupancyReportRowGroupedValues
 import fi.espoo.evaka.reports.OccupancyUnitReportResultRow
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevPlacement
@@ -471,7 +471,7 @@ class PlannedOccupancyTest : FullApplicationTest() {
         assertEquals(0, reportResult2?.headcount)
     }
 
-    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     private fun fetchAndParseOccupancy(unitId: UUID, period: ClosedPeriod): List<OccupancyPeriod> {
         val (_, response, result) = http.get("/occupancy/by-unit/$unitId?from=${period.start}&to=${period.end}&type=PLANNED")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealizedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealizedOccupancyTest.kt
@@ -12,8 +12,8 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestAbsence
@@ -227,7 +227,7 @@ class RealizedOccupancyTest : FullApplicationTest() {
         )
     }
 
-    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     private fun fetchAndParseOccupancy(unitId: UUID, period: ClosedPeriod): List<OccupancyPeriod> {
         val (_, response, result) = http

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
@@ -9,7 +9,7 @@ import fi.espoo.evaka.pis.Employee
 import fi.espoo.evaka.pis.NewEmployee
 import fi.espoo.evaka.pis.controllers.EmployeeController
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -24,7 +24,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `no employees return empty list`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
         val response = employeeController.getEmployees(db, user)
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(emptyList<Employee>(), response.body)
@@ -32,7 +32,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `admin can add employee`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
         val response = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(employee1.firstName, response.body!!.firstName)
@@ -43,7 +43,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `admin gets all employees`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
         assertEquals(HttpStatus.OK, employeeController.createEmployee(db, user, requestFromEmployee(employee1)).statusCode)
         assertEquals(HttpStatus.OK, employeeController.createEmployee(db, user, requestFromEmployee(employee2)).statusCode)
         val response = employeeController.getEmployees(db, user)
@@ -55,7 +55,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `admin can first create, then get employee`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
         assertEquals(0, employeeController.getEmployees(db, user).body?.size)
 
         val responseCreate = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
@@ -70,7 +70,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `admin can delete employee`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
         val createdEmployeeResponse = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, createdEmployeeResponse.statusCode)
         val response = employeeController.deleteEmployee(db, user, createdEmployeeResponse.body?.id!!)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
@@ -12,8 +12,8 @@ import fi.espoo.evaka.pis.createPartnership
 import fi.espoo.evaka.pis.service.FamilyOverview
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
@@ -109,7 +109,7 @@ class FamilyOverviewTest : FullApplicationTest() {
         )
     }
 
-    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.FINANCE_ADMIN))
+    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
 
     private fun fetchAndParseFamilyDetails(personId: UUID): FamilyOverview {
         val (_, response, result) = http.get("/family/by-adult/$personId")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.pis.getParentships
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.pis.service.PersonJSON
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Forbidden
@@ -32,17 +32,17 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can create and fetch parentships`() {
-        `can create and fetch parentships`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER)))
+        `can create and fetch parentships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can create and fetch parentships`() {
-        `can create and fetch parentships`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.UNIT_SUPERVISOR)))
+        `can create and fetch parentships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can create and fetch parentships`() {
-        `can create and fetch parentships`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.FINANCE_ADMIN)))
+        `can create and fetch parentships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can create and fetch parentships`(user: AuthenticatedUser) {
@@ -78,17 +78,17 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can update parentships`() {
-        `can update parentship duration`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER)))
+        `can update parentship duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can update parentships`() {
-        `can update parentship duration`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.UNIT_SUPERVISOR)))
+        `can update parentship duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can update parentships`() {
-        `can update parentship duration`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.FINANCE_ADMIN)))
+        `can update parentship duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can update parentship duration`(user: AuthenticatedUser) {
@@ -117,17 +117,17 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can delete parentships`() {
-        `can delete parentship`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER)))
+        `can delete parentship`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can delete parentships`() {
-        `can delete parentship`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.UNIT_SUPERVISOR)))
+        `can delete parentship`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can delete parentships`() {
-        `can delete parentship`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.FINANCE_ADMIN)))
+        `can delete parentship`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can delete parentship`(user: AuthenticatedUser) {
@@ -146,7 +146,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to get parentships`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.END_USER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
         val parent = testPerson1()
         val child = testPerson2()
         jdbi.handle { h ->
@@ -157,7 +157,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to update parentship`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.END_USER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
         val parent = testPerson1()
         val child = testPerson2()
         jdbi.handle { h ->
@@ -171,7 +171,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to delete parentship`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.END_USER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
         val parent = testPerson1()
         val child = testPerson2()
         jdbi.handle { h ->
@@ -182,7 +182,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can create a parentship without an end date`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val parent = testPerson1()
         val child = testPerson2()
 
@@ -202,7 +202,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can update a parentship without an end date`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val adult = testPerson1()
         val child = testPerson2()
         jdbi.handle { h ->

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.pis.getPartnershipsForPerson
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.pis.service.PersonJSON
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Conflict
@@ -33,17 +33,17 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can create and fetch partnerships`() {
-        `can create and fetch partnerships`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER)))
+        `can create and fetch partnerships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can create and fetch partnerships`() {
-        `can create and fetch partnerships`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.UNIT_SUPERVISOR)))
+        `can create and fetch partnerships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can create and fetch partnerships`() {
-        `can create and fetch partnerships`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.FINANCE_ADMIN)))
+        `can create and fetch partnerships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can create and fetch partnerships`(user: AuthenticatedUser) {
@@ -75,17 +75,17 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can delete partnerships`() {
-        `can delete partnership`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER)))
+        `can delete partnership`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can delete partnerships`() {
-        `can delete partnership`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.UNIT_SUPERVISOR)))
+        `can delete partnership`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can delete partnerships`() {
-        `can delete partnership`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.FINANCE_ADMIN)))
+        `can delete partnership`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can delete partnership`(user: AuthenticatedUser) = jdbi.handle { h ->
@@ -102,17 +102,17 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can update partnerships`() {
-        `can update partnership duration`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER)))
+        `can update partnership duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can update partnerships`() {
-        `can update partnership duration`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.UNIT_SUPERVISOR)))
+        `can update partnership duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can update partnerships`() {
-        `can update partnership duration`(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.FINANCE_ADMIN)))
+        `can update partnership duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can update partnership duration`(user: AuthenticatedUser) = jdbi.handle { h ->
@@ -141,7 +141,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `can updating partnership duration to overlap throws conflict`() = jdbi.handle { h ->
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val partnership1 = h.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
@@ -157,7 +157,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to get partnerships`() = jdbi.handle { h ->
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.END_USER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         h.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
@@ -169,7 +169,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to create a partnership`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.END_USER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val startDate = LocalDate.now()
@@ -183,7 +183,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to update partnerships`() = jdbi.handle { h ->
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.END_USER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val partnership = h.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
@@ -196,7 +196,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to delete a partnership`() = jdbi.handle { h ->
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.END_USER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
         val partnership = h.createPartnership(testPerson1().id, testPerson2().id, LocalDate.now(), LocalDate.now().plusDays(200))
 
         assertThrows<Forbidden> {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.pis.service.ContactInfo
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Forbidden
@@ -40,22 +40,22 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `Finance admin can update end user's contact info`() {
-        updateContactInfo(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.FINANCE_ADMIN)))
+        updateContactInfo(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     @Test
     fun `Service worker can update end user's contact info`() {
-        updateContactInfo(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER)))
+        updateContactInfo(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `Unit supervisor can update end user's contact info`() {
-        updateContactInfo(AuthenticatedUser(UUID.randomUUID(), setOf(Roles.UNIT_SUPERVISOR)))
+        updateContactInfo(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `End user cannot end update end user's contact info`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.END_USER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
         assertThrows<Forbidden> {
             controller.updateContactInfo(db, user, UUID.randomUUID(), contactInfo)
         }
@@ -63,7 +63,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `Search finds person by first and last name`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
@@ -83,7 +83,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `Search treats tabs as spaces in search terms`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
@@ -103,7 +103,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `Search treats non-breaking spaces as spaces in search terms`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
@@ -123,7 +123,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `Search treats obscrube unicode spaces as spaces in search terms`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER))
+        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val person = createPerson()
 
         // IDEOGRAPHIC SPACE, not supported by default in regexes

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
@@ -11,8 +11,8 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
@@ -41,7 +41,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
 
     private val unitSupervisor = AuthenticatedUser(testDecisionMaker_1.id, emptySet())
     private val staff = AuthenticatedUser(testDecisionMaker_2.id, emptySet())
-    private val serviceWorker = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     fun setUp() {
@@ -57,7 +57,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
             )
             h.insertTestDaycareGroup(testDaycareGroup)
             testPlacement = h.getDaycarePlacements(daycareId, null, null, null).first()
-            updateDaycareAclWithEmployee(h, daycareId, unitSupervisor.id, Roles.UNIT_SUPERVISOR)
+            updateDaycareAclWithEmployee(h, daycareId, unitSupervisor.id, UserRole.UNIT_SUPERVISOR)
         }
     }
 
@@ -485,7 +485,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
                 startDate = newEnd,
                 endDate = newEnd.plusMonths(2)
             )
-            updateDaycareAclWithEmployee(h, testDaycare2.id, unitSupervisor.id, Roles.UNIT_SUPERVISOR)
+            updateDaycareAclWithEmployee(h, testDaycare2.id, unitSupervisor.id, UserRole.UNIT_SUPERVISOR)
             val body = PlacementUpdateRequestBody(
                 startDate = placementStart,
                 endDate = newEnd
@@ -510,7 +510,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
     @Test
     fun `staff can't modify placements`() {
         jdbi.handle { h ->
-            updateDaycareAclWithEmployee(h, daycareId, staff.id, Roles.STAFF)
+            updateDaycareAclWithEmployee(h, daycareId, staff.id, UserRole.STAFF)
             val newStart = placementStart.plusDays(1)
             val newEnd = placementEnd.minusDays(2)
             val body = PlacementUpdateRequestBody(startDate = newStart, endDate = newEnd)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
@@ -19,8 +19,8 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
@@ -43,7 +43,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class PlacementPlanIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {
@@ -203,9 +203,9 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
             )
         }
         val invalidRoleLists = listOf(
-            setOf(Roles.UNIT_SUPERVISOR),
-            setOf(Roles.FINANCE_ADMIN),
-            setOf(Roles.END_USER),
+            setOf(UserRole.UNIT_SUPERVISOR),
+            setOf(UserRole.FINANCE_ADMIN),
+            setOf(UserRole.END_USER),
             setOf()
         )
         invalidRoleLists.forEach { roles ->

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReportTest.kt
@@ -8,8 +8,8 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -25,7 +25,7 @@ class DuplicatePeopleReportTest : FullApplicationTest() {
         db.transaction { it.resetDatabase() }
     }
 
-    private val adminUser = AuthenticatedUser(id = UUID.randomUUID(), roles = setOf(Roles.ADMIN))
+    private val adminUser = AuthenticatedUser(id = UUID.randomUUID(), roles = setOf(UserRole.ADMIN))
 
     @Test
     fun `two people with identical names and dates of birth are matched`() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
@@ -13,8 +13,8 @@ import fi.espoo.evaka.invoicing.data.upsertInvoices
 import fi.espoo.evaka.invoicing.domain.InvoiceStatus
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
@@ -71,7 +71,7 @@ class InvoicingReportTest : FullApplicationTest() {
         )
     }
 
-    private val testUser = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.DIRECTOR))
+    private val testUser = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.DIRECTOR))
 
     private fun getAndAssert(date: LocalDate, expected: InvoiceReport) {
         val (_, response, result) = http.get(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
@@ -9,8 +9,8 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.testAreaId
 import fi.espoo.evaka.testDaycare
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class ReportSmokeTests : FullApplicationTest() {
-    private val testUser = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.ADMIN))
+    private val testUser = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
 
     @BeforeAll
     fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
@@ -10,8 +10,8 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.testChild_1
@@ -107,7 +107,7 @@ class StartingPlacementsReportTest : FullApplicationTest() {
         getAndAssert(date, listOf(toReportRow(testChild_1, placementStart)))
     }
 
-    private val testUser = AuthenticatedUser(UUID.randomUUID(), setOf(Roles.DIRECTOR))
+    private val testUser = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.DIRECTOR))
 
     private fun getAndAssert(date: LocalDate, expected: List<StartingPlacementsRow>) {
         val (_, response, result) = http.get(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
@@ -10,8 +10,8 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
 import fi.espoo.evaka.testChild_1
@@ -26,7 +26,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class ServiceNeedIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(Roles.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -54,7 +54,6 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -89,7 +88,7 @@ class ApplicationStateService(
                 throw Forbidden("User does not own this application")
             }
         } else {
-            user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+            user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
         }
 
         verifyStatus(application, CREATED)
@@ -126,7 +125,7 @@ class ApplicationStateService(
 
     fun moveToWaitingPlacement(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.ApplicationVerify.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, SENT)
@@ -155,7 +154,7 @@ class ApplicationStateService(
 
     fun returnToSent(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.ApplicationReturnToSent.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_PLACEMENT)
@@ -164,7 +163,7 @@ class ApplicationStateService(
 
     fun cancelApplication(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.ApplicationCancel.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, setOf(SENT, WAITING_PLACEMENT))
@@ -173,7 +172,7 @@ class ApplicationStateService(
 
     fun setVerified(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.ApplicationAdminDetailsUpdate.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_PLACEMENT)
@@ -182,7 +181,7 @@ class ApplicationStateService(
 
     fun setUnverified(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.ApplicationAdminDetailsUpdate.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_PLACEMENT)
@@ -210,7 +209,7 @@ class ApplicationStateService(
 
     fun cancelPlacementPlan(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.ApplicationReturnToWaitingPlacement.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_DECISION)
@@ -221,7 +220,7 @@ class ApplicationStateService(
 
     fun confirmPlacementWithoutDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.PlacementCreate.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, setOf(WAITING_DECISION, WAITING_UNIT_CONFIRMATION))
@@ -241,7 +240,7 @@ class ApplicationStateService(
 
     fun sendDecisionsWithoutProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.DecisionCreate.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_DECISION)
@@ -250,7 +249,7 @@ class ApplicationStateService(
 
     fun sendPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.PlacementProposalCreate.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_DECISION)
@@ -259,7 +258,7 @@ class ApplicationStateService(
 
     fun withdrawPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.ApplicationReturnToWaitingDecision.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_UNIT_CONFIRMATION)
@@ -325,7 +324,7 @@ class ApplicationStateService(
 
     fun confirmDecisionMailed(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
         Audit.DecisionConfirmMailed.log(targetId = applicationId)
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_MAILING)
@@ -340,7 +339,7 @@ class ApplicationStateService(
                 throw Forbidden("User does not own this application")
             }
         } else {
-            acl.getRolesForApplication(user, applicationId).requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
+            acl.getRolesForApplication(user, applicationId).requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         }
 
         verifyStatus(application, setOf(WAITING_CONFIRMATION, ACTIVE))
@@ -396,7 +395,7 @@ class ApplicationStateService(
                 throw Forbidden("User does not own this application")
             }
         } else {
-            acl.getRolesForApplication(user, applicationId).requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
+            acl.getRolesForApplication(user, applicationId).requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         }
 
         verifyStatus(application, setOf(WAITING_CONFIRMATION, ACTIVE, REJECTED))

--- a/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
@@ -8,7 +8,7 @@ import fi.espoo.evaka.decision.DecisionService
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyDecisionCreated
 import fi.espoo.evaka.shared.async.SendDecision
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
@@ -29,7 +29,7 @@ class DecisionMessageProcessor(
         val user = msg.user
         val decisionId = msg.decisionId
 
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
 
         decisionService.createDecisionPdfs(tx, user, decisionId)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -9,7 +9,7 @@ import fi.espoo.evaka.daycare.controllers.utils.created
 import fi.espoo.evaka.daycare.controllers.utils.noContent
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -34,7 +34,7 @@ class AssistanceActionController(
         @RequestBody body: AssistanceActionRequest
     ): ResponseEntity<AssistanceAction> {
         Audit.ChildAssistanceActionCreate.log(targetId = childId)
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         return assistanceActionService.createAssistanceAction(
             db,
             user = user,
@@ -50,7 +50,7 @@ class AssistanceActionController(
         @PathVariable childId: UUID
     ): ResponseEntity<List<AssistanceAction>> {
         Audit.ChildAssistanceActionRead.log(targetId = childId)
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.FINANCE_ADMIN, Roles.SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN, UserRole.SPECIAL_EDUCATION_TEACHER)
         return assistanceActionService.getAssistanceActionsByChildId(db, childId).let(::ok)
     }
 
@@ -62,7 +62,7 @@ class AssistanceActionController(
         @RequestBody body: AssistanceActionRequest
     ): ResponseEntity<AssistanceAction> {
         Audit.ChildAssistanceActionUpdate.log(targetId = id)
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         return assistanceActionService.updateAssistanceAction(
             db,
             user = user,
@@ -78,7 +78,7 @@ class AssistanceActionController(
         @PathVariable id: UUID
     ): ResponseEntity<Unit> {
         Audit.ChildAssistanceActionDelete.log(targetId = id)
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         assistanceActionService.deleteAssistanceAction(db, id)
         return noContent()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -9,7 +9,7 @@ import fi.espoo.evaka.daycare.controllers.utils.created
 import fi.espoo.evaka.daycare.controllers.utils.noContent
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -34,7 +34,7 @@ class AssistanceNeedController(
         @RequestBody body: AssistanceNeedRequest
     ): ResponseEntity<AssistanceNeed> {
         Audit.ChildAssistanceNeedCreate.log(targetId = childId)
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         return assistanceNeedService.createAssistanceNeed(
             db,
             user = user,
@@ -50,7 +50,7 @@ class AssistanceNeedController(
         @PathVariable childId: UUID
     ): ResponseEntity<List<AssistanceNeed>> {
         Audit.ChildAssistanceNeedRead.log(targetId = childId)
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.FINANCE_ADMIN, Roles.SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN, UserRole.SPECIAL_EDUCATION_TEACHER)
         return assistanceNeedService.getAssistanceNeedsByChildId(db, childId).let(::ok)
     }
 
@@ -62,7 +62,7 @@ class AssistanceNeedController(
         @RequestBody body: AssistanceNeedRequest
     ): ResponseEntity<AssistanceNeed> {
         Audit.ChildAssistanceNeedUpdate.log(targetId = id)
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         return assistanceNeedService.updateAssistanceNeed(
             db,
             user = user,
@@ -78,7 +78,7 @@ class AssistanceNeedController(
         @PathVariable id: UUID
     ): ResponseEntity<Unit> {
         Audit.ChildAssistanceNeedDelete.log(targetId = id)
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR, Roles.SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         assistanceNeedService.deleteAssistanceNeed(db, id)
         return noContent()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -6,12 +6,7 @@ package fi.espoo.evaka.backupcare
 
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.STAFF
-import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
-import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
-import fi.espoo.evaka.shared.config.Roles.SPECIAL_EDUCATION_TEACHER
-import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
 import fi.espoo.evaka.shared.domain.ClosedPeriod
@@ -36,7 +31,7 @@ class BackupCareController(private val acl: AccessControlList) {
         user: AuthenticatedUser,
         @PathVariable("childId") childId: UUID
     ): ResponseEntity<ChildBackupCaresResponse> {
-        acl.getRolesForChild(user, childId).requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN, STAFF, SPECIAL_EDUCATION_TEACHER)
+        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
         val backupCares = db.read { it.handle.getBackupCaresForChild(childId) }
         return ResponseEntity.ok(ChildBackupCaresResponse(backupCares))
     }
@@ -48,7 +43,7 @@ class BackupCareController(private val acl: AccessControlList) {
         @PathVariable("childId") childId: UUID,
         @RequestBody body: NewBackupCare
     ): ResponseEntity<BackupCareCreateResponse> {
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         try {
             val id = db.transaction { it.handle.createBackupCare(childId, body) }
             return ResponseEntity.ok(BackupCareCreateResponse(id))
@@ -64,7 +59,7 @@ class BackupCareController(private val acl: AccessControlList) {
         @PathVariable("id") id: UUID,
         @RequestBody body: BackupCareUpdateRequest
     ): ResponseEntity<Unit> {
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         try {
             db.transaction { it.handle.updateBackupCare(id, body.period, body.groupId) }
             return ResponseEntity.noContent().build()
@@ -75,7 +70,7 @@ class BackupCareController(private val acl: AccessControlList) {
 
     @DeleteMapping("/backup-cares/{id}")
     fun delete(db: Database.Connection, user: AuthenticatedUser, @PathVariable("id") id: UUID): ResponseEntity<Unit> {
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         db.transaction { it.handle.deleteBackupCare(id) }
         return ResponseEntity.noContent().build()
     }
@@ -89,7 +84,7 @@ class BackupCareController(private val acl: AccessControlList) {
         @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
     ): ResponseEntity<UnitBackupCaresResponse> {
         acl.getRolesForUnit(user, daycareId)
-            .requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR, STAFF)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF)
         val backupCares = db.read { it.handle.getBackupCaresForDaycare(daycareId, ClosedPeriod(startDate, endDate)) }
         return ResponseEntity.ok(UnitBackupCaresResponse(backupCares))
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
@@ -14,11 +14,7 @@ import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
-import fi.espoo.evaka.shared.auth.UserRole.STAFF
-import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -43,7 +39,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
     ): ResponseEntity<Wrapper<AbsenceGroup>> {
         Audit.AbsenceRead.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
-            .requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR, STAFF)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF)
         val absences = db.read { absenceService.getAbsencesByMonth(it, groupId, year, month) }
         return ResponseEntity.ok(Wrapper(absences))
     }
@@ -57,7 +53,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
     ): ResponseEntity<Unit> {
         Audit.AbsenceUpdate.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
-            .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR, STAFF)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF)
         db.transaction { absenceService.upsertAbsences(it, absences.data, groupId, user.id) }
         return ResponseEntity.noContent().build()
     }
@@ -71,7 +67,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
         @RequestParam month: Int
     ): ResponseEntity<Wrapper<AbsenceChildMinimal>> {
         Audit.AbsenceRead.log(targetId = childId)
-        user.requireOneOfRoles(ADMIN, UNIT_SUPERVISOR, FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
         val absences = db.read { absenceService.getAbscencesByChild(it, childId, year, month) }
         return ResponseEntity.ok(Wrapper(absences))
     }
@@ -84,7 +80,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
         @PathVariable childId: UUID
     ): ResponseEntity<Unit> {
         Audit.ChildAbsenceUpdate.log(targetId = childId)
-        user.requireOneOfRoles(ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN)
         db.transaction { absenceService.upsertChildAbsence(it, childId, absenceType.absenceType, absenceType.careType, user.id) }
         return ResponseEntity.noContent().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
@@ -12,11 +12,7 @@ import fi.espoo.evaka.daycare.getChild
 import fi.espoo.evaka.daycare.updateChild
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.STAFF
-import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
-import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
-import fi.espoo.evaka.shared.config.Roles.SPECIAL_EDUCATION_TEACHER
-import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.mapper.Nested
@@ -33,7 +29,7 @@ class ChildController(private val acl: AccessControlList) {
     @GetMapping("/children/{childId}/additional-information")
     fun getAdditionalInfo(db: Database.Connection, user: AuthenticatedUser, @PathVariable childId: UUID): ResponseEntity<AdditionalInformation> {
         Audit.ChildAdditionalInformationRead.log(targetId = childId)
-        acl.getRolesForChild(user, childId).requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN, STAFF, SPECIAL_EDUCATION_TEACHER)
+        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
         return db.read { getAdditionalInformation(it.handle, childId) }.let(::ok)
     }
 
@@ -45,7 +41,7 @@ class ChildController(private val acl: AccessControlList) {
         @RequestBody data: AdditionalInformation
     ): ResponseEntity<Unit> {
         Audit.ChildAdditionalInformationUpdate.log(targetId = childId)
-        acl.getRolesForChild(user, childId).requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
+        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
         db.transaction { upsertAdditionalInformation(it.handle, childId, data) }
         return noContent()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
@@ -11,10 +11,7 @@ import fi.espoo.evaka.daycare.service.StaffAttendanceGroup
 import fi.espoo.evaka.daycare.service.StaffAttendanceService
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.STAFF
-import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.springframework.http.ResponseEntity
@@ -43,7 +40,7 @@ class StaffAttendanceController(
     ): ResponseEntity<Wrapper<StaffAttendanceGroup>> {
         Audit.StaffAttendanceRead.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
-            .requireOneOfRoles(ADMIN, FINANCE_ADMIN, UNIT_SUPERVISOR, STAFF)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF)
         val result = staffAttendanceService.getAttendancesByMonth(db, year, month, groupId)
         return ResponseEntity.ok(Wrapper(result))
     }
@@ -57,7 +54,7 @@ class StaffAttendanceController(
     ): ResponseEntity<Unit> {
         Audit.StaffAttendanceUpdate.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
-            .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR, STAFF)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF)
         if (staffAttendance.count == null) {
             throw BadRequest("Count can't be null")
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
@@ -8,9 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.DaycareAclRow
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.STAFF
-import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.deleteDaycareAclRow
 import fi.espoo.evaka.shared.auth.getDaycareAclRows
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
@@ -33,7 +31,7 @@ class UnitAclController(private val acl: AccessControlList) {
     ): ResponseEntity<DaycareAclResponse> {
         Audit.UnitAclRead.log()
         acl.getRolesForUnit(user, daycareId)
-            .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
         val acls = db.read { it.handle.getDaycareAclRows(daycareId) }
         return ResponseEntity.ok(DaycareAclResponse(acls))
     }
@@ -47,8 +45,8 @@ class UnitAclController(private val acl: AccessControlList) {
     ): ResponseEntity<Unit> {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
-            .requireOneOfRoles(ADMIN)
-        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, UNIT_SUPERVISOR) }
+            .requireOneOfRoles(UserRole.ADMIN)
+        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, UserRole.UNIT_SUPERVISOR) }
         return ResponseEntity.noContent().build()
     }
 
@@ -61,9 +59,9 @@ class UnitAclController(private val acl: AccessControlList) {
     ): ResponseEntity<Unit> {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
-            .requireOneOfRoles(ADMIN)
+            .requireOneOfRoles(UserRole.ADMIN)
 
-        db.transaction { it.handle.deleteDaycareAclRow(daycareId, employeeId, UNIT_SUPERVISOR) }
+        db.transaction { it.handle.deleteDaycareAclRow(daycareId, employeeId, UserRole.UNIT_SUPERVISOR) }
         return ResponseEntity.noContent().build()
     }
 
@@ -76,8 +74,8 @@ class UnitAclController(private val acl: AccessControlList) {
     ): ResponseEntity<Unit> {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
-            .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR)
-        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, STAFF) }
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
+        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, UserRole.STAFF) }
         return ResponseEntity.noContent().build()
     }
 
@@ -90,9 +88,9 @@ class UnitAclController(private val acl: AccessControlList) {
     ): ResponseEntity<Unit> {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
-            .requireOneOfRoles(ADMIN, UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
-        db.transaction { it.handle.deleteDaycareAclRow(daycareId, employeeId, STAFF) }
+        db.transaction { it.handle.deleteDaycareAclRow(daycareId, employeeId, UserRole.STAFF) }
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/EnduserDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/EnduserDecisionController.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.decision
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -20,7 +20,7 @@ class EnduserDecisionController {
     @GetMapping("/enduser/decisions")
     fun getDecisions(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<EnduserDecisionsResponse> {
         Audit.DecisionRead.log(targetId = user.id)
-        user.requireOneOfRoles(Roles.END_USER)
+        user.requireOneOfRoles(UserRole.END_USER)
         val decisions = db.read { getDecisionsByGuardian(it.handle, user.id, AclAuthorization.All) }
             .map {
                 val unit = when (it.type) {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
@@ -8,7 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyFamilyUpdated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.http.ResponseEntity
@@ -31,7 +31,7 @@ class FeeDecisionGeneratorController(private val asyncJobRunner: AsyncJobRunner)
     @PostMapping("/generate")
     fun generateDecisions(db: Database.Connection, user: AuthenticatedUser, @RequestBody data: GenerateDecisionsBody): ResponseEntity<Unit> {
         Audit.FeeDecisionGenerate.log(targetId = data.targetHeads)
-        user.requireOneOfRoles(Roles.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         generateAllStartingFrom(
             db,
             LocalDate.parse(data.starting, DateTimeFormatter.ISO_DATE),

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -18,7 +18,7 @@ import fi.espoo.evaka.invoicing.domain.IncomeType
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyIncomeUpdated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Period
@@ -44,7 +44,7 @@ class IncomeController(
     @GetMapping
     fun getIncome(db: Database.Connection, user: AuthenticatedUser, @RequestParam personId: String?): ResponseEntity<Wrapper<List<Income>>> {
         Audit.PersonIncomeRead.log(targetId = personId)
-        user.requireOneOfRoles(Roles.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         val parsedId = personId?.let { parseUUID(personId) }
             ?: throw BadRequest("Query parameter personId is mandatory")
 
@@ -55,7 +55,7 @@ class IncomeController(
     @PostMapping
     fun createIncome(db: Database.Connection, user: AuthenticatedUser, @RequestBody income: Income): ResponseEntity<UUID> {
         Audit.PersonIncomeCreate.log(targetId = income.personId)
-        user.requireOneOfRoles(Roles.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         val period = try {
             Period(income.validFrom, income.validTo)
         } catch (e: Exception) {
@@ -85,7 +85,7 @@ class IncomeController(
         @RequestBody income: Income
     ): ResponseEntity<Unit> {
         Audit.PersonIncomeUpdate.log(targetId = incomeId)
-        user.requireOneOfRoles(Roles.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
 
         db.transaction { tx ->
             val existing = getIncome(tx.handle, mapper, parseUUID(incomeId))
@@ -109,7 +109,7 @@ class IncomeController(
     @DeleteMapping("/{incomeId}")
     fun deleteIncome(db: Database.Connection, user: AuthenticatedUser, @PathVariable incomeId: String): ResponseEntity<Unit> {
         Audit.PersonIncomeDelete.log(targetId = incomeId)
-        user.requireOneOfRoles(Roles.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
 
         db.transaction { tx ->
             val existing = getIncome(tx.handle, mapper, parseUUID(incomeId))

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
@@ -7,10 +7,7 @@ package fi.espoo.evaka.occupancy
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
-import fi.espoo.evaka.shared.config.Roles.ADMIN
-import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
-import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -39,7 +36,7 @@ class OccupancyController(private val acl: AccessControlList) {
     ): ResponseEntity<OccupancyResponse> {
         Audit.OccupancyRead.log(targetId = unitId)
         acl.getRolesForUnit(user, unitId)
-            .requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, Roles.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
 
         val occupancies = db.read { it.calculateOccupancyPeriods(unitId, ClosedPeriod(from, to), type) }
 
@@ -62,7 +59,7 @@ class OccupancyController(private val acl: AccessControlList) {
     ): ResponseEntity<List<OccupancyResponseGroupLevel>> {
         Audit.OccupancyRead.log(targetId = unitId)
         acl.getRolesForUnit(user, unitId)
-            .requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, Roles.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
 
         val occupancies = db.read { it.calculateOccupancyPeriodsGroupLevel(unitId, ClosedPeriod(from, to), type) }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.pis
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -36,7 +36,7 @@ class SystemIdentityController {
                 )
             )
         }
-            .let { ResponseEntity.ok().body(AuthenticatedUser(it.id, setOf(Roles.END_USER))) }
+            .let { ResponseEntity.ok().body(AuthenticatedUser(it.id, setOf(UserRole.END_USER))) }
     }
 
     @PostMapping("/system/employee-identity")

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
@@ -12,7 +12,7 @@ import fi.espoo.evaka.pis.deleteEmployee
 import fi.espoo.evaka.pis.getEmployee
 import fi.espoo.evaka.pis.getEmployees
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -31,7 +31,7 @@ class EmployeeController {
     @GetMapping()
     fun getEmployees(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<Employee>> {
         Audit.EmployeesRead.log()
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER, Roles.UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         return ResponseEntity.ok(db.read { it.handle.getEmployees() }.sortedBy { it.email })
     }
 
@@ -40,12 +40,12 @@ class EmployeeController {
         Audit.EmployeeRead.log(targetId = id)
         if (user.id != id) {
             user.requireOneOfRoles(
-                Roles.ADMIN,
-                Roles.SERVICE_WORKER,
-                Roles.FINANCE_ADMIN,
-                Roles.UNIT_SUPERVISOR,
-                Roles.STAFF,
-                Roles.DIRECTOR
+                UserRole.ADMIN,
+                UserRole.SERVICE_WORKER,
+                UserRole.FINANCE_ADMIN,
+                UserRole.UNIT_SUPERVISOR,
+                UserRole.STAFF,
+                UserRole.DIRECTOR
             )
         }
         return db.read { it.handle.getEmployee(id) }?.let { ResponseEntity.ok().body(it) }
@@ -55,14 +55,14 @@ class EmployeeController {
     @PostMapping("")
     fun createEmployee(db: Database.Connection, user: AuthenticatedUser, @RequestBody employee: NewEmployee): ResponseEntity<Employee> {
         Audit.EmployeeCreate.log(targetId = employee.aad)
-        user.requireOneOfRoles(Roles.ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN)
         return ResponseEntity.ok().body(db.transaction { it.handle.createEmployee(employee) })
     }
 
     @DeleteMapping("/{id}")
     fun deleteEmployee(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Unit> {
         Audit.EmployeeDelete.log(targetId = id)
-        user.requireOneOfRoles(Roles.ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN)
         db.transaction { it.handle.deleteEmployee(id) }
         return ResponseEntity.ok().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
@@ -10,7 +10,7 @@ import fi.espoo.evaka.pis.service.FamilyOverview
 import fi.espoo.evaka.pis.service.FamilyOverviewService
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -29,7 +29,7 @@ class FamilyController(
     @GetMapping("/by-adult/{id}")
     fun getFamilyByPerson(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<FamilyOverview> {
         Audit.PisFamilyRead.log(targetId = id)
-        user.requireOneOfRoles(Roles.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         val result = db.read { familyOverviewService.getFamilyByAdult(it, id) }
             ?: return ResponseEntity.notFound().build()
         return ResponseEntity.ok(result)
@@ -42,7 +42,7 @@ class FamilyController(
         @RequestParam(value = "childId", required = true) childId: UUID
     ): ResponseEntity<List<FamilyContact>> {
         Audit.FamilyContactsRead.log(targetId = childId)
-        acl.getRolesForChild(user, childId).requireOneOfRoles(Roles.ADMIN, Roles.STAFF, Roles.SPECIAL_EDUCATION_TEACHER)
+        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.ADMIN, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
         return db
             .read { it.fetchFamilyContacts(childId) }
             .let { ResponseEntity.ok(it) }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
@@ -14,9 +14,7 @@ import fi.espoo.evaka.pis.service.PartnershipService
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyFamilyUpdated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
-import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
-import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.springframework.http.ResponseEntity
@@ -43,7 +41,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
         @RequestBody body: PartnershipRequest
     ): ResponseEntity<Partnership> {
         Audit.PartnerShipsCreate.log(targetId = body.personIds)
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
         with(body) {
             if (personIds.size != 2) throw BadRequest("Must have exactly two partners")
@@ -66,7 +64,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
         @RequestParam(name = "personId", required = true) personId: VolttiIdentifier
     ): ResponseEntity<List<Partnership>> {
         Audit.PartnerShipsRead.log(targetId = personId)
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
         return db.read { it.handle.getPartnershipsForPerson(personId, includeConflicts = true) }
             .let { ResponseEntity.ok().body(it) }
@@ -79,7 +77,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
         @PathVariable(value = "id") partnershipId: UUID
     ): ResponseEntity<Partnership> {
         Audit.PartnerShipsRead.log(targetId = partnershipId)
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
         return db.read { it.handle.getPartnership(partnershipId) }
             ?.let { ResponseEntity.ok().body(it) }
@@ -94,7 +92,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
         @RequestBody body: PartnershipUpdateRequest
     ): ResponseEntity<Partnership> {
         Audit.PartnerShipsUpdate.log(targetId = partnershipId)
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
         return db
             .transaction { tx ->
@@ -116,7 +114,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
         @PathVariable(value = "id") partnershipId: UUID
     ): ResponseEntity<Unit> {
         Audit.PartnerShipsRetry.log(targetId = partnershipId)
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
         db.transaction { tx ->
             partnershipService.retryPartnership(tx, partnershipId)?.let {
@@ -134,7 +132,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
         @PathVariable(value = "id") partnershipId: UUID
     ): ResponseEntity<Unit> {
         Audit.PartnerShipsDelete.log(targetId = partnershipId)
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
         db.transaction { tx ->
             partnershipService.deletePartnership(tx, partnershipId)?.also { partnership ->

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -29,7 +29,7 @@ class ApplicationsReportController {
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): ResponseEntity<List<ApplicationsReportRow>> {
         Audit.ApplicationsReportRead.log()
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.DIRECTOR, Roles.ADMIN)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.DIRECTOR, UserRole.ADMIN)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
 
         return db.read { it.getApplicationsRows(from, to) }.let(::ok)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceActionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceActionsReport.kt
@@ -8,11 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles.ADMIN
-import fi.espoo.evaka.shared.config.Roles.DIRECTOR
-import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
-import fi.espoo.evaka.shared.config.Roles.SPECIAL_EDUCATION_TEACHER
-import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import org.springframework.format.annotation.DateTimeFormat
@@ -32,7 +28,7 @@ class AssistanceActionsReportController(private val acl: AccessControlList) {
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): ResponseEntity<List<AssistanceActionReportRow>> {
         Audit.AssistanceActionsReportRead.log()
-        user.requireOneOfRoles(SERVICE_WORKER, ADMIN, DIRECTOR, UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.DIRECTOR, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         val units = acl.getAuthorizedUnits(user)
         return db.read { it.getAssistanceActionsReportRows(date, units.ids).let(::ok) }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedReport.kt
@@ -8,11 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles.ADMIN
-import fi.espoo.evaka.shared.config.Roles.DIRECTOR
-import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
-import fi.espoo.evaka.shared.config.Roles.SPECIAL_EDUCATION_TEACHER
-import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import org.springframework.format.annotation.DateTimeFormat
@@ -32,7 +28,7 @@ class AssistanceNeedsReportController(private val acl: AccessControlList) {
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): ResponseEntity<List<AssistanceNeedReportRow>> {
         Audit.AssistanceNeedsReportRead.log()
-        user.requireOneOfRoles(SERVICE_WORKER, ADMIN, DIRECTOR, UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.DIRECTOR, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         val units = acl.getAuthorizedUnits(user)
         return db.read { it.getAssistanceNeedReportRows(date, units.ids).let(::ok) }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
@@ -9,11 +9,7 @@ import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles.ADMIN
-import fi.espoo.evaka.shared.config.Roles.DIRECTOR
-import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
-import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
-import fi.espoo.evaka.shared.config.Roles.SPECIAL_EDUCATION_TEACHER
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import org.springframework.format.annotation.DateTimeFormat
@@ -33,7 +29,7 @@ class ChildAgeLanguageReportController(private val acl: AccessControlList) {
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): ResponseEntity<List<ChildAgeLanguageReportRow>> {
         Audit.ChildAgeLanguageReportRead.log()
-        user.requireOneOfRoles(SERVICE_WORKER, FINANCE_ADMIN, ADMIN, DIRECTOR, SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.ADMIN, UserRole.DIRECTOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         return db.read { it.getChildAgeLanguageRows(date, acl.getAuthorizedDaycares(user)) }.let(::ok)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
@@ -8,10 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
-import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.getUUID
@@ -25,7 +22,7 @@ class ChildrenInDifferentAddressReportController(private val acl: AccessControlL
     @GetMapping("/reports/children-in-different-address")
     fun getChildrenInDifferentAddressReport(db: Database, user: AuthenticatedUser): ResponseEntity<List<ChildrenInDifferentAddressReportRow>> {
         Audit.ChildrenInDifferentAddressReportRead.log()
-        user.requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
         val authorizedUnits = acl.getAuthorizedUnits(user)
         val rows = db.read { it.getChildrenInDifferentAddressRows(authorizedUnits) }
         return ResponseEntity.ok(rows)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import org.springframework.http.ResponseEntity
@@ -21,7 +21,7 @@ class DuplicatePeopleReportController {
     @GetMapping("/reports/duplicate-people")
     fun getDuplicatePeopleReport(db: Database, user: AuthenticatedUser): ResponseEntity<List<DuplicatePeopleReportRow>> {
         Audit.DuplicatePeopleReportRead.log()
-        user.requireOneOfRoles(Roles.ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN)
         return db.read { it.getDuplicatePeople() }.let(::ok)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import org.springframework.http.ResponseEntity
@@ -29,7 +29,7 @@ class EndedPlacementsReportController {
         Audit.EndedPlacementsReportRead.log()
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
-        user.requireOneOfRoles(Roles.DIRECTOR, Roles.ADMIN, Roles.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.DIRECTOR, UserRole.ADMIN, UserRole.FINANCE_ADMIN)
 
         return db.read { it.getEndedPlacementsRows(from, to) }.let(::ok)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
@@ -7,12 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.DIRECTOR
-import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
-import fi.espoo.evaka.shared.auth.UserRole.SPECIAL_EDUCATION_TEACHER
-import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.db.mapNullableColumn
@@ -31,7 +26,7 @@ class FamilyContactReportController(private val acl: AccessControlList) {
         @RequestParam unitId: UUID
     ): ResponseEntity<List<FamilyContactReportRow>> {
         Audit.FamilyContactReportRead.log()
-        acl.getRolesForUnit(user, unitId).requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, DIRECTOR, UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
+        acl.getRolesForUnit(user, unitId).requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.DIRECTOR, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         return db.read { it.getFamilyContacts(unitId) }.let { ResponseEntity.ok(it) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
@@ -7,10 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
-import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.getUUID
@@ -24,7 +21,7 @@ class FamilyConflictReportController(private val acl: AccessControlList) {
     @GetMapping("/reports/family-conflicts")
     fun getFamilyConflictsReport(db: Database, user: AuthenticatedUser): ResponseEntity<List<FamilyConflictReportRow>> {
         Audit.FamilyConflictReportRead.log()
-        user.requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
         val authorizedUnits = acl.getAuthorizedUnits(user)
         return db.read { it.getFamilyConflicts(authorizedUnits.ids) }
             .let { ResponseEntity.ok(it) }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
@@ -11,7 +11,7 @@ import fi.espoo.evaka.invoicing.domain.InvoiceDetailed
 import fi.espoo.evaka.invoicing.domain.InvoiceStatus
 import fi.espoo.evaka.invoicing.domain.addressUsable
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Period
 import org.springframework.format.annotation.DateTimeFormat
@@ -37,7 +37,7 @@ class InvoiceReportController {
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): ResponseEntity<InvoiceReport> {
         Audit.InvoicesReportRead.log()
-        user.requireOneOfRoles(Roles.FINANCE_ADMIN, Roles.DIRECTOR, Roles.ADMIN)
+        user.requireOneOfRoles(UserRole.FINANCE_ADMIN, UserRole.DIRECTOR, UserRole.ADMIN)
         return db.read {
             it.getInvoiceReportWithRows(
                 getMonthPeriod(date)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
@@ -7,10 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
-import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import org.springframework.format.annotation.DateTimeFormat
@@ -31,7 +28,7 @@ class MissingHeadOfFamilyReportController(private val acl: AccessControlList) {
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?
     ): ResponseEntity<List<MissingHeadOfFamilyReportRow>> {
         Audit.MissingHeadOfFamilyReportRead.log()
-        user.requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
         val authorizedUnits = acl.getAuthorizedUnits(user)
         return db.read { ResponseEntity.ok(it.getMissingHeadOfFamilyRows(from, to, authorizedUnits.ids)) }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
@@ -7,10 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
-import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -32,7 +29,7 @@ class MissingServiceNeedReportController(private val acl: AccessControlList) {
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?
     ): ResponseEntity<List<MissingServiceNeedReportRow>> {
         Audit.MissingServiceNeedReportRead.log()
-        user.requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
         if (to != null && to.isBefore(from)) throw BadRequest("Invalid time range")
 
         val authorizedUnits = acl.getAuthorizedUnits(user)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -8,7 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.occupancy.OccupancyType
 import fi.espoo.evaka.occupancy.getSql
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -32,7 +32,7 @@ class OccupancyReportController {
         @RequestParam month: Int
     ): ResponseEntity<List<OccupancyUnitReportResultRow>> {
         Audit.OccupancyReportRead.log(targetId = careAreaId)
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.ADMIN, Roles.FINANCE_ADMIN, Roles.DIRECTOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.FINANCE_ADMIN, UserRole.DIRECTOR)
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 
@@ -89,7 +89,7 @@ class OccupancyReportController {
         @RequestParam month: Int
     ): ResponseEntity<List<OccupancyGroupReportResultRow>> {
         Audit.OccupancyReportRead.log(targetId = careAreaId)
-        user.requireOneOfRoles(Roles.SERVICE_WORKER, Roles.ADMIN, Roles.FINANCE_ADMIN, Roles.DIRECTOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.FINANCE_ADMIN, UserRole.DIRECTOR)
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
@@ -7,10 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
-import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.getUUID
@@ -24,7 +21,7 @@ class PartnersInDifferentAddressReportController(private val acl: AccessControlL
     @GetMapping("/reports/partners-in-different-address")
     fun getPartnersInDifferentAddressReport(db: Database, user: AuthenticatedUser): ResponseEntity<List<PartnersInDifferentAddressReportRow>> {
         Audit.PartnersInDifferentAddressReportRead.log()
-        user.requireOneOfRoles(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
         val authorizedUnits = acl.getAuthorizedUnits(user)
         return db.read { it.getPartnersInDifferentAddressRows(authorizedUnits.ids) }
             .let { ResponseEntity.ok(it) }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.springframework.format.annotation.DateTimeFormat
@@ -30,7 +30,7 @@ class PresenceReportController {
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): ResponseEntity<List<PresenceReportRow>> {
         Audit.PresenceReportRead.log()
-        user.requireOneOfRoles(Roles.DIRECTOR, Roles.ADMIN)
+        user.requireOneOfRoles(UserRole.DIRECTOR, UserRole.ADMIN)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
         if (to.isAfter(from.plusDays(MAX_NUMBER_OF_DAYS.toLong()))) throw BadRequest("Period is too long. Use maximum of $MAX_NUMBER_OF_DAYS days")
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -9,7 +9,7 @@ import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getEnum
 import fi.espoo.evaka.shared.db.getNullableUUID
@@ -33,7 +33,7 @@ class RawReportController {
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): ResponseEntity<List<RawReportRow>> {
         Audit.RawReportRead.log()
-        user.requireOneOfRoles(Roles.DIRECTOR, Roles.ADMIN)
+        user.requireOneOfRoles(UserRole.DIRECTOR, UserRole.ADMIN)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
         if (to.isAfter(from.plusDays(7))) throw BadRequest("Time range too long")
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
@@ -8,10 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles.ADMIN
-import fi.espoo.evaka.shared.config.Roles.DIRECTOR
-import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
-import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
@@ -30,7 +27,7 @@ class ServiceNeedReport(private val acl: AccessControlList) {
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): ResponseEntity<List<ServiceNeedReportRow>> {
         Audit.ServiceNeedReportRead.log()
-        user.requireOneOfRoles(SERVICE_WORKER, ADMIN, DIRECTOR, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.DIRECTOR, UserRole.UNIT_SUPERVISOR)
         val authorizedUnits = acl.getAuthorizedUnits(user)
         return db.read {
             it.getServiceNeedRows(date, authorizedUnits.ids?.toList())

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.ClosedPeriod
@@ -29,7 +29,7 @@ class StartingPlacementsReportController {
         @RequestParam("month") month: Int
     ): ResponseEntity<List<StartingPlacementsRow>> {
         Audit.StartingPlacementsReportRead.log()
-        user.requireOneOfRoles(Roles.ADMIN, Roles.SERVICE_WORKER, Roles.FINANCE_ADMIN, Roles.DIRECTOR)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.DIRECTOR)
         val rows = db.read { it.getStartingPlacementsRows(year, month) }
         return ResponseEntity.ok(rows)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -10,11 +10,7 @@ import fi.espoo.evaka.daycare.controllers.utils.noContent
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.STAFF
-import fi.espoo.evaka.shared.config.Roles.FINANCE_ADMIN
-import fi.espoo.evaka.shared.config.Roles.SERVICE_WORKER
-import fi.espoo.evaka.shared.config.Roles.SPECIAL_EDUCATION_TEACHER
-import fi.espoo.evaka.shared.config.Roles.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -40,7 +36,7 @@ class ServiceNeedController(
         @RequestBody body: ServiceNeedRequest
     ): ResponseEntity<ServiceNeed> {
         Audit.ChildServiceNeedCreate.log(targetId = childId)
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         return serviceNeedService.createServiceNeed(
             db,
             user = user,
@@ -56,7 +52,7 @@ class ServiceNeedController(
         @PathVariable childId: UUID
     ): ResponseEntity<List<ServiceNeed>> {
         Audit.ChildServiceNeedRead.log(targetId = childId)
-        acl.getRolesForChild(user, childId).requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN, STAFF, SPECIAL_EDUCATION_TEACHER)
+        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
         return serviceNeedService.getServiceNeedsByChildId(db, childId).let(::ok)
     }
 
@@ -68,7 +64,7 @@ class ServiceNeedController(
         @RequestBody body: ServiceNeedRequest
     ): ResponseEntity<ServiceNeed> {
         Audit.ChildServiceNeedUpdate.log(targetId = id)
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         return serviceNeedService.updateServiceNeed(
             db,
             user = user,
@@ -84,7 +80,7 @@ class ServiceNeedController(
         @PathVariable id: UUID
     ): ResponseEntity<Unit> {
         Audit.ChildServiceNeedDelete.log(targetId = id)
-        user.requireOneOfRoles(SERVICE_WORKER, UNIT_SUPERVISOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         serviceNeedService.deleteServiceNeed(db, id)
         return noContent()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
@@ -6,17 +6,16 @@ package fi.espoo.evaka.shared.auth
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.domain.Forbidden
 import java.util.UUID
 
 @JsonSerialize(using = AuthenticatedUserJsonSerializer::class)
 data class AuthenticatedUser(@JsonInclude val id: UUID, @JsonInclude override val roles: Set<UserRole>) : RoleContainer {
-    fun isEndUser() = roles.contains(Roles.END_USER)
-    fun isServiceWorker() = roles.contains(Roles.SERVICE_WORKER)
-    fun isUnitSupervisor() = roles.contains(Roles.UNIT_SUPERVISOR)
-    fun isFinanceAdmin() = roles.contains(Roles.FINANCE_ADMIN)
-    fun isAdmin() = roles.contains(Roles.ADMIN)
+    fun isEndUser() = roles.contains(UserRole.END_USER)
+    fun isServiceWorker() = roles.contains(UserRole.SERVICE_WORKER)
+    fun isUnitSupervisor() = roles.contains(UserRole.UNIT_SUPERVISOR)
+    fun isFinanceAdmin() = roles.contains(UserRole.FINANCE_ADMIN)
+    fun isAdmin() = roles.contains(UserRole.ADMIN)
 
     fun assertMachineUser() {
         if (this != machineUser) throw Forbidden("Only accessible to the machine user")

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/SecurityConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/SecurityConfig.kt
@@ -8,7 +8,6 @@ import com.auth0.jwt.algorithms.Algorithm
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUserSpringSupport
 import fi.espoo.evaka.shared.auth.JwtKeys
-import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.loadPrivateKey
 import fi.espoo.evaka.shared.auth.loadPublicKeys
 import org.jdbi.v3.core.Jdbi
@@ -24,17 +23,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import java.net.URI
 import java.nio.file.Paths
-
-object Roles {
-    val SERVICE_WORKER = UserRole.SERVICE_WORKER
-    val END_USER = UserRole.END_USER
-    val UNIT_SUPERVISOR = UserRole.UNIT_SUPERVISOR
-    val FINANCE_ADMIN = UserRole.FINANCE_ADMIN
-    val ADMIN = UserRole.ADMIN
-    val DIRECTOR = UserRole.DIRECTOR
-    val STAFF = UserRole.STAFF
-    val SPECIAL_EDUCATION_TEACHER = UserRole.SPECIAL_EDUCATION_TEACHER
-}
 
 @Configuration
 @Import(AuthenticatedUserSpringSupport::class)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -50,7 +50,6 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.config.Roles
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.ClosedPeriod
@@ -522,7 +521,7 @@ RETURNING id
 
             uuid?.let {
                 // Refresh Pis data by forcing refresh from VTJ
-                val dummyUser = AuthenticatedUser(it, setOf(Roles.SERVICE_WORKER))
+                val dummyUser = AuthenticatedUser(it, setOf(UserRole.SERVICE_WORKER))
                 personService.getUpToDatePerson(tx, dummyUser, it)
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -29,12 +29,7 @@ import fi.espoo.evaka.placement.getMissingGroupPlacements
 import fi.espoo.evaka.placement.getPlacementPlans
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole.ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
-import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
-import fi.espoo.evaka.shared.auth.UserRole.SPECIAL_EDUCATION_TEACHER
-import fi.espoo.evaka.shared.auth.UserRole.STAFF
-import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import org.springframework.format.annotation.DateTimeFormat
@@ -47,8 +42,8 @@ import org.springframework.web.bind.annotation.RequestParam
 import java.time.LocalDate
 import java.util.UUID
 
-val basicDataRoles = arrayOf(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR, STAFF, SPECIAL_EDUCATION_TEACHER)
-val detailedDataRoles = arrayOf(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR)
+val basicDataRoles = arrayOf(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
+val detailedDataRoles = arrayOf(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
 
 @Controller
 @RequestMapping("/views/units")

--- a/service/src/test/kotlin/fi/espoo/evaka/application/enduser/club/ClubApplicationSerializerTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/application/enduser/club/ClubApplicationSerializerTest.kt
@@ -26,7 +26,7 @@ import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -64,21 +64,21 @@ class ClubApplicationSerializerTest {
 
     @Test
     fun toClubFormFromEnduserJSON() {
-        val user = AuthenticatedUser(requestingUserId, setOf(Roles.END_USER))
+        val user = AuthenticatedUser(requestingUserId, setOf(UserRole.END_USER))
         val clubForm = serializer.deserialize(user, ENDUSER_CLUBFORM_JSON)
         assertTrue(clubForm is ClubFormV0)
     }
 
     @Test
     fun toEnduserJSONFromClubApplication() {
-        val user = AuthenticatedUser(requestingUserId, setOf(Roles.END_USER))
+        val user = AuthenticatedUser(requestingUserId, setOf(UserRole.END_USER))
         val clubJSON = serializer.serialize(tx, user, mockEnduserClubApplication())
         assertTrue(clubJSON.form is EnduserClubFormJSON)
     }
 
     @Test
     fun `enduser deserialized json matches expected`() {
-        val user = AuthenticatedUser(requestingUserId, setOf(Roles.END_USER))
+        val user = AuthenticatedUser(requestingUserId, setOf(UserRole.END_USER))
         val form = (serializer.deserialize(user, ENDUSER_CLUBFORM_JSON) as ClubFormV0)
         val expectedApplication = mockEnduserClubApplication()
         val expectedForm = ClubFormV0.fromForm2(expectedApplication.form, expectedApplication.childRestricted, expectedApplication.guardianRestricted)
@@ -87,7 +87,7 @@ class ClubApplicationSerializerTest {
 
     @Test
     fun `enduser serialized json matches expected`() {
-        val user = AuthenticatedUser(requestingUserId, setOf(Roles.END_USER))
+        val user = AuthenticatedUser(requestingUserId, setOf(UserRole.END_USER))
         val expectedApplication = mockEnduserClubApplication()
         val applicationJson = serializer.serialize(tx, user, expectedApplication)
         assertTrue(ReflectionEquals(mockEnduserClubFormJson(expectedApplication)).matches(applicationJson.form))

--- a/service/src/test/kotlin/fi/espoo/evaka/application/enduser/daycare/DaycareApplicationSerializerTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/application/enduser/daycare/DaycareApplicationSerializerTest.kt
@@ -27,7 +27,7 @@ import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.Roles
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -65,7 +65,7 @@ class DaycareApplicationSerializerTest {
 
     @Test
     fun `enduser deserialized daycare json matches expected`() {
-        val user = AuthenticatedUser(requestingUserId, setOf(Roles.END_USER))
+        val user = AuthenticatedUser(requestingUserId, setOf(UserRole.END_USER))
         val daycareForm = serializer.deserialize(user, DAYCARE_JSON)
         assertTrue(daycareForm is DaycareFormV0)
         val expectedForm = DaycareFormV0.fromForm2(
@@ -79,7 +79,7 @@ class DaycareApplicationSerializerTest {
 
     @Test
     fun `enduser serialized daycare json matches expected`() {
-        val user = AuthenticatedUser(requestingUserId, setOf(Roles.END_USER))
+        val user = AuthenticatedUser(requestingUserId, setOf(UserRole.END_USER))
         val json = serializer.serialize(tx, user, expectedEnduserDaycareApplication)
         assertTrue(json.form is EnduserDaycareFormJSON)
         assertEquals(expectedEnduserDaycareFormJSON, json.form)

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserExt.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserExt.kt
@@ -4,7 +4,6 @@
 
 package fi.espoo.evaka.shared.auth
 
-import fi.espoo.evaka.shared.config.Roles
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
@@ -15,16 +14,16 @@ import java.util.UUID
 private val employeeId = UUID.fromString("00000000-0000-0000-0000-000000000000")
 
 fun AuthenticatedUser.Companion.serviceWorker(id: UUID = employeeId) =
-    AuthenticatedUser(id, setOf(Roles.SERVICE_WORKER))
+    AuthenticatedUser(id, setOf(UserRole.SERVICE_WORKER))
 
 fun AuthenticatedUser.Companion.unitSupervisor(id: UUID = employeeId) =
-    AuthenticatedUser(id, setOf(Roles.UNIT_SUPERVISOR))
+    AuthenticatedUser(id, setOf(UserRole.UNIT_SUPERVISOR))
 
 fun AuthenticatedUser.Companion.financeAdmin(id: UUID = employeeId) =
-    AuthenticatedUser(id, setOf(Roles.FINANCE_ADMIN))
+    AuthenticatedUser(id, setOf(UserRole.FINANCE_ADMIN))
 
 fun AuthenticatedUser.Companion.endUser(id: UUID = UUID.randomUUID()) =
-    AuthenticatedUser(id, setOf(Roles.END_USER))
+    AuthenticatedUser(id, setOf(UserRole.END_USER))
 
 fun AuthenticatedUser.mockMvcAuthentication(): RequestPostProcessor =
     SecurityMockMvcRequestPostProcessors.authentication(object : Authentication {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2017-2020 City of Espoo

SPDX-License-Identifier: LGPL-2.1-or-later
-->

#### Summary

* Replace `config.Roles` by `auth.UserRole` throughout.
* Remove the `config.Roles` enum.
* Instead of importing a role directly (e.g. `ADMIN`), import `auth.UserRole` and refer to e.g. `UserRole.ADMIN` in code throughout.