### PR TITLE
Make Espoo AD email optional again

### DIFF
--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -57,7 +57,7 @@ export interface EmployeeIdentityRequest {
   aad: string
   firstName: string
   lastName: string
-  email: string
+  email?: string
 }
 
 export interface EmployeeResponse {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
@@ -70,7 +70,7 @@ class SystemIdentityController {
         val aad: UUID,
         val firstName: String,
         val lastName: String,
-        val email: String
+        val email: String?
     )
 
     data class PersonIdentityRequest(


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

If an Espoo AD profile had no e-mail, `/system/employee-identity` returned status 400 even though e-mail is not really mandatory in the underlying data model.