### PR TITLE
EVAKA-3464 proxy max body size

### DIFF
--- a/compose/proxy/nginx.conf
+++ b/compose/proxy/nginx.conf
@@ -92,6 +92,11 @@ server {
     proxy_no_cache 1;
 
     proxy_pass  $enduserUrl;
+
+    location /api/application/attachments {
+      client_max_body_size 100m;
+      proxy_pass  $enduserUrl;
+    }
   }
 
   location /api/internal {
@@ -107,6 +112,11 @@ server {
     proxy_no_cache 1;
 
     proxy_pass  $internalUrl;
+
+    location /api/internal/attachments {
+      client_max_body_size 100m;
+      proxy_pass  $internalUrl;
+    }
   }
 
   # Direct all CPS report to internal endpoint /api/csp/csp-report

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -228,11 +228,21 @@ server {
   location /api/application {
     include     proxy_params;
     proxy_pass  $enduserUrl;
+
+    location /api/application/attachments {
+      client_max_body_size 100m;
+      proxy_pass  $enduserUrl;
+    }
   }
 
   location /api/internal {
     include     proxy_params;
     proxy_pass  $internalUrl;
+
+    location /api/internal/attachments {
+      client_max_body_size 100m;
+      proxy_pass  $internalUrl;
+    }
   }
 
   # Direct all CPS reports to internal endpoint /api/csp/csp-report


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
Unset `client_max_body_size` in proxy for `*/attachments` paths.
