### PR TITLE
Evaka: fix deselect last unit in application unit filter

### DIFF
--- a/frontend/e2e-test/test/e2e/pages/employee/applications/application-list-view.ts
+++ b/frontend/e2e-test/test/e2e/pages/employee/applications/application-list-view.ts
@@ -36,7 +36,10 @@ const specialFilterItems = {
   duplicate: Selector('[data-for="application-basis-DUPLICATE_APPLICATION"]')
 }
 
-const application = (id: string) => Selector(`[data-application-id="${id}"]`)
+const unitFilter = Selector('[data-qa="unit-selector"] input')
+
+const application = (id: string) =>
+  Selector(`[data-application-id="${id}"]`, { timeout: 3000 })
 
 const applications = Selector('[data-qa="table-of-applications"]').find(
   '[data-qa="table-application-row"]'
@@ -51,5 +54,6 @@ export default {
   specialFilterItems,
   application,
   applications,
-  areaFilterItems
+  areaFilterItems,
+  unitFilter
 }

--- a/frontend/e2e-test/test/e2e/specs/5_employee/unit-editor.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/5_employee/unit-editor.spec.ts
@@ -34,7 +34,7 @@ fixture('Unit - unit details')
     await cleanUp()
   })
 
-test('Admin creates a new unit', async (t) => {
+test('Admin creates a new unit', async () => {
   await unitDetailsPage.openNewUnitEditor()
   await unitDetailsPage.fillUnitName('Uusi Kerho')
   await unitDetailsPage.chooseArea('Matinkylä-Olari')

--- a/frontend/packages/employee-frontend/src/components/applications/ApplicationsFilters.tsx
+++ b/frontend/packages/employee-frontend/src/components/applications/ApplicationsFilters.tsx
@@ -201,6 +201,7 @@ function ApplicationFilters() {
             units={isSuccess(allUnits) ? allUnits.data : []}
             selectedUnits={units}
             onChange={changeUnits}
+            dataQa={'unit-selector'}
           />
           <Gap size="m" />
           <ApplicationBasisFilter toggled={basis} toggle={toggleBasis} />

--- a/frontend/packages/employee-frontend/src/components/common/Filters.tsx
+++ b/frontend/packages/employee-frontend/src/components/common/Filters.tsx
@@ -991,16 +991,18 @@ interface MultiUnitsProps {
   units: { id: string; name: string }[]
   selectedUnits: string[]
   onChange: (v: string[]) => void
+  dataQa?: string
 }
 
 export function MultiSelectUnitFilter({
   units,
   selectedUnits,
-  onChange
+  onChange,
+  dataQa
 }: MultiUnitsProps) {
   const { i18n } = useTranslation()
   return (
-    <Fragment>
+    <div data-qa={dataQa}>
       <Label>
         <LabelText>{i18n.filters.unit}</LabelText>
       </Label>
@@ -1017,7 +1019,7 @@ export function MultiSelectUnitFilter({
         getOptionValue={(option) => option.id}
         getOptionLabel={(option) => option.name}
       />
-    </Fragment>
+    </div>
   )
 }
 

--- a/frontend/packages/employee-frontend/src/components/common/Filters.tsx
+++ b/frontend/packages/employee-frontend/src/components/common/Filters.tsx
@@ -1010,9 +1010,9 @@ export function MultiSelectUnitFilter({
         value={units.filter((unit) => selectedUnits.includes(unit.id))}
         options={units}
         onChange={(selected) => {
-          selected &&
-            'length' in selected &&
-            onChange(selected.map(({ id }) => id))
+          selected && 'length' in selected
+            ? onChange(selected.map(({ id }) => id))
+            : onChange([])
         }}
         getOptionValue={(option) => option.id}
         getOptionLabel={(option) => option.name}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2017-2020 City of Espoo

SPDX-License-Identifier: LGPL-2.1-or-later
-->

#### Summary
Fixes: application search unit filter last unit cannot be deselected

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```
