### PR TITLE
EVAKA-3985: Preserve filtered area in application report

### DIFF
--- a/frontend/e2e-test/test/e2e/pages/reports.ts
+++ b/frontend/e2e-test/test/e2e/pages/reports.ts
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import config from '../config'
 import { ClientFunction, Selector, t } from 'testcafe'
+import config from '../config'
+import { format } from 'date-fns'
 
 export default class ReportsPage {
   readonly url = config.employeeUrl
@@ -15,6 +16,10 @@ export default class ReportsPage {
 
   async selectVoucherServiceProvidersReport() {
     await t.click(Selector('[data-qa="report-voucher-service-providers"]'))
+  }
+
+  async selectApplicationsReport() {
+    await t.click(Selector('[data-qa="report-applications"]'))
   }
 
   async selectMonth(month: 'Tammikuu') {
@@ -38,6 +43,15 @@ export default class ReportsPage {
     await t.pressKey('enter')
   }
 
+  async selectDateRangePickerDates(from: Date, to: Date) {
+    const fromInput = Selector('[data-qa="datepicker-from"] input')
+    const toInput = Selector('[data-qa="datepicker-to"] input')
+    await t.selectText(fromInput).pressKey('delete')
+    await t.typeText(fromInput, format(from, 'dd.MM.yyyy'))
+    await t.selectText(toInput).pressKey('delete')
+    await t.typeText(toInput, format(to, 'dd.MM.yyyy'))
+  }
+
   async assertVoucherServiceProviderRowCount(expectedChildCount: number) {
     await t.expect(Selector('.reportRow').count).eql(expectedChildCount)
   }
@@ -55,6 +69,14 @@ export default class ReportsPage {
     await t
       .expect(unitRowSelector.find('[data-qa="child-sum"]').innerText)
       .eql(expectedMonthlySum)
+  }
+
+  async assertApplicationsReportContainsArea(area: string) {
+    const applicationTableSelector = Selector(
+      `[data-qa="report-application-table"]`
+    )
+    await t.expect(applicationTableSelector.exists).ok()
+    await t.expect(applicationTableSelector.find('td').innerText).eql(area)
   }
 
   async getCsvReport(): Promise<string> {

--- a/frontend/e2e-test/test/e2e/specs/5_employee/application-report.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/5_employee/application-report.spec.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import ReportsPage from '../../pages/reports'
+import { seppoAdminRole } from '../../config/users'
+
+fixture('Reporting - applications').meta({
+  type: 'regression',
+  subType: 'reports'
+})
+
+const reports = new ReportsPage()
+
+test('application report is generated correctly, respecting care area filter', async (t) => {
+  await t.useRole(seppoAdminRole)
+  await reports.selectReportsTab()
+  await reports.selectApplicationsReport()
+
+  await reports.assertApplicationsReportContainsArea(
+    'Espoon keskus (eteläinen)'
+  )
+  await reports.selectArea('Espoonlahti')
+  await reports.selectDateRangePickerDates(new Date(), new Date())
+  await reports.assertApplicationsReportContainsArea('Espoonlahti')
+})

--- a/frontend/packages/employee-frontend/src/components/Reports.tsx
+++ b/frontend/packages/employee-frontend/src/components/Reports.tsx
@@ -213,7 +213,10 @@ function Reports() {
                   color={EspooColours.bluePrimary}
                   content={faFileAlt}
                 />
-                <LinkTitle to="/reports/applications">
+                <LinkTitle
+                  data-qa={'report-applications'}
+                  to="/reports/applications"
+                >
                   {i18n.reports.applications.title}
                 </LinkTitle>
               </TitleRow>

--- a/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
@@ -60,7 +60,6 @@ function Applications() {
 
   useEffect(() => {
     setRows(Loading())
-    setDisplayFilters(emptyDisplayFilters)
     void getApplicationsReport(filters).then(setRows)
   }, [filters])
 
@@ -100,9 +99,9 @@ function Applications() {
             <ReactSelect
               options={[
                 ...(isSuccess(rows)
-                  ? distinct(
-                      rows.data.map((row) => row.careAreaName)
-                    ).map((s) => ({ value: s, label: s }))
+                  ? distinct(rows.data.map((row) => row.careAreaName))
+                      .map((s) => ({ value: s, label: s }))
+                      .concat([{ label: i18n.common.all, value: '' }])
                   : [])
               ]}
               onChange={(option) =>

--- a/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/Applications.tsx
@@ -83,19 +83,21 @@ function Applications() {
               date={filters.from}
               onChange={(from) => setFilters({ ...filters, from })}
               type="half-width"
+              dataQa="datepicker-from"
             />
             <span>{' - '}</span>
             <DatePicker
               date={filters.to}
               onChange={(to) => setFilters({ ...filters, to })}
               type="half-width"
+              dataQa="datepicker-to"
             />
           </FlexRow>
         </FilterRow>
 
         <FilterRow>
           <FilterLabel>{i18n.reports.common.careAreaName}</FilterLabel>
-          <Wrapper>
+          <Wrapper data-qa="select-area">
             <ReactSelect
               options={[
                 ...(isSuccess(rows)
@@ -172,7 +174,7 @@ function Applications() {
                 i18n.reports.applications.title
               } ${filters.from.formatIso()}-${filters.to.formatIso()}.csv`}
             />
-            <TableScrollable>
+            <TableScrollable data-qa="report-application-table">
               <Thead>
                 <Tr>
                   <Th>{i18n.reports.common.careAreaName}</Th>

--- a/frontend/packages/employee-frontend/src/components/reports/common.tsx
+++ b/frontend/packages/employee-frontend/src/components/reports/common.tsx
@@ -25,10 +25,18 @@ export const TableScrollableWrapper = styled.div`
   }
 `
 
-export function TableScrollable({ children }: { children: React.ReactNode }) {
+interface TableScrollableProps {
+  children: React.ReactNode
+  'data-qa'?: string
+}
+
+export function TableScrollable({
+  children,
+  'data-qa': dataQa
+}: TableScrollableProps) {
   return (
     <TableScrollableWrapper>
-      <Table>{children}</Table>
+      <Table data-qa={dataQa}>{children}</Table>
     </TableScrollableWrapper>
   )
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2017-2020 City of Espoo

SPDX-License-Identifier: LGPL-2.1-or-later
-->

#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
- Preserve selected care area when adjusting dates
- Add E2E tests for application report


#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->
None

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->
Go to Reports section and select application report. Select area (e.g. Espoonlahti) and 
adjust from and to dates in datepicker. The area you selected should remain selected.

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] The code is consistent with the existing code base
- [x] Tests have been written for the change (e2e, integration tests)
- [x] The change has been tested locally
- [x] The change conforms to the UX specifications
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All changes in all changed files have been reviewed
- [ ] The code is consistent with the existing code base
- [ ] Tests have been written for the change (e2e, integration tests)
- [ ] The change has been tested locally
- [ ] The change conforms to the UX specifications
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```
