### PR TITLE
[EVAKA-4006] Use a separate token in long term mobile cookie

### DIFF
--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -121,11 +121,16 @@ export interface ValidatePairingRequest {
   responseKey: string
 }
 
+export interface MobileDeviceIdentity {
+  id: UUID
+  longTermToken: UUID
+}
+
 export async function validatePairing(
   req: express.Request,
   id: UUID,
   request: ValidatePairingRequest
-): Promise<UUID> {
+): Promise<MobileDeviceIdentity> {
   const { data } = await client.post(
     `/system/pairings/${encodeURIComponent(id)}/validation`,
     request,
@@ -133,17 +138,26 @@ export async function validatePairing(
       headers: createServiceRequestHeaders(req, machineUser)
     }
   )
-  const mobileDeviceId = data.mobileDeviceId
-  if (!mobileDeviceId || typeof mobileDeviceId !== 'string') {
-    throw new Error(`No mobile device ID in pairing`)
-  }
-  return mobileDeviceId
+  return data
 }
 
 export interface MobileDevice {
   id: UUID
   name: string
   unitId: UUID
+}
+
+export async function identifyMobileDevice(
+  req: express.Request,
+  token: UUID
+): Promise<MobileDeviceIdentity> {
+  const { data } = await client.get(
+    `/system/mobile-identity/${encodeURIComponent(token)}`,
+    {
+      headers: createServiceRequestHeaders(req, machineUser)
+    }
+  )
+  return data
 }
 
 export async function getMobileDevice(

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDeviceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDeviceQueries.kt
@@ -15,6 +15,10 @@ fun Database.Read.getDevice(id: UUID): MobileDevice {
         .firstOrNull() ?: throw NotFound("Device $id not found")
 }
 
+fun Database.Read.getDeviceByToken(token: UUID): MobileDeviceIdentity = createQuery(
+    "SELECT id, long_term_token FROM mobile_device WHERE long_term_token = : token AND deleted = false"
+).mapTo<MobileDeviceIdentity>().singleOrNull() ?: throw NotFound("Device not found with token $token")
+
 fun Database.Read.listDevices(unitId: UUID): List<MobileDevice> {
     // language=sql
     val sql = "SELECT * FROM mobile_device WHERE unit_id = :unitId AND deleted = false"

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/Pairing.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/Pairing.kt
@@ -26,3 +26,5 @@ data class MobileDevice(
     val name: String,
     val unitId: UUID
 )
+
+data class MobileDeviceIdentity(val id: UUID, val longTermToken: UUID)

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
@@ -99,7 +99,7 @@ WITH target_pairing AS (
     WHERE id = :id AND challenge_key = :challenge AND response_key = :response AND status = 'READY' AND expires > :now AND attempts <= :maxAttempts
     RETURNING mobile_device_id
 )
-UPDATE mobile_device SET long_term_token = ext.uuid_generate_v1mc()
+UPDATE mobile_device SET long_term_token = :longTermToken
 WHERE id = (SELECT mobile_device_id FROM target_pairing)
 RETURNING id, long_term_token
         """
@@ -110,6 +110,7 @@ RETURNING id, long_term_token
         .bind("response", responseKey)
         .bind("now", ZonedDateTime.now(zoneId).toInstant())
         .bind("maxAttempts", maxAttempts)
+        .bind("longTermToken", UUID.randomUUID())
         .mapTo<MobileDeviceIdentity>()
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
@@ -68,7 +68,7 @@ fun Database.Transaction.respondPairingChallengeCreateDevice(id: UUID, challenge
                 FROM target_pairing
                 RETURNING employee.id
             ), new_device AS (
-                INSERT INTO mobile_device (id, unit_id, name) 
+                INSERT INTO mobile_device (id, unit_id, name)
                 SELECT new_employee.id, target_pairing.unit_id, :name
                 FROM new_employee, target_pairing
                 RETURNING mobile_device.id
@@ -90,14 +90,19 @@ fun Database.Transaction.respondPairingChallengeCreateDevice(id: UUID, challenge
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
 }
 
-fun Database.Transaction.validatePairing(id: UUID, challengeKey: String, responseKey: String): Pairing {
+fun Database.Transaction.validatePairing(id: UUID, challengeKey: String, responseKey: String): MobileDeviceIdentity {
     // language=sql
     val sql =
         """
-            UPDATE pairing SET status = 'PAIRED'
-            WHERE id = :id AND challenge_key = :challenge AND response_key = :response AND status = 'READY' AND expires > :now AND attempts <= :maxAttempts
-            RETURNING *
-        """.trimIndent()
+WITH target_pairing AS (
+    UPDATE pairing SET status = 'PAIRED'
+    WHERE id = :id AND challenge_key = :challenge AND response_key = :response AND status = 'READY' AND expires > :now AND attempts <= :maxAttempts
+    RETURNING mobile_device_id
+)
+UPDATE mobile_device SET long_term_token = ext.uuid_generate_v1mc()
+WHERE id = (SELECT mobile_device_id FROM target_pairing)
+RETURNING id, long_term_token
+        """
 
     return createQuery(sql)
         .bind("id", id)
@@ -105,7 +110,7 @@ fun Database.Transaction.validatePairing(id: UUID, challengeKey: String, respons
         .bind("response", responseKey)
         .bind("now", ZonedDateTime.now(zoneId).toInstant())
         .bind("maxAttempts", maxAttempts)
-        .mapTo<Pairing>()
+        .mapTo<MobileDeviceIdentity>()
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -134,7 +134,7 @@ class PairingsController(
         db: Database.Connection,
         @PathVariable id: UUID,
         @RequestBody body: PostPairingValidationReq
-    ): ResponseEntity<Pairing> {
+    ): ResponseEntity<MobileDeviceIdentity> {
         Audit.PairingValidation.log(targetId = id)
         db.transaction { it.incrementAttempts(id, body.challengeKey) }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
@@ -6,6 +6,8 @@ package fi.espoo.evaka.pis
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.identity.ExternalIdentifier
+import fi.espoo.evaka.pairing.MobileDeviceIdentity
+import fi.espoo.evaka.pairing.getDeviceByToken
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -64,6 +66,17 @@ class SystemIdentityController {
                     )
             }
         )
+    }
+
+    @PostMapping("/system/mobile-identity/{token}")
+    fun mobileIdentity(
+        db: Database.Connection,
+        user: AuthenticatedUser,
+        token: UUID
+    ): ResponseEntity<MobileDeviceIdentity> {
+        Audit.MobileDevicesRead.log(targetId = token)
+        user.assertMachineUser()
+        return ResponseEntity.ok(db.read { it.getDeviceByToken(token) })
     }
 
     data class EmployeeIdentityRequest(

--- a/service/src/main/resources/db/migration/V25__mobile_device_token.sql
+++ b/service/src/main/resources/db/migration/V25__mobile_device_token.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mobile_device ADD COLUMN long_term_token uuid;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -22,3 +22,4 @@ V21__add_special_education_teacher_role.sql
 V22__alter_valid_acl_role_constraint.sql
 V23__mobile_device.sql
 V24__mobile_user_role.sql
+V25__mobile_device_token.sql


### PR DESCRIPTION
#### Summary

Instead of directly using the mobile device id in the cookie, use a separate token that can be rotated without having to remove+add actual rows in the mobile_device table.
