### PR TITLE
Use smaller transactions in Varda integration

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -82,7 +82,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
     fun `PAOS decision is sent when it has all required data`() {
         jdbi.handle { h ->
             val decisionId = insertPlacementWithDecision(h, testChild_1, testPurchasedDaycare.id, ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))).first
-            updateChildren(h)
+            updateChildren()
 
             val children = getUploadedChildren(h)
             assertEquals(1, children.size)
@@ -105,7 +105,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             val firstPeriod = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             val municipalDecisionId = insertPlacementWithDecision(h, testChild_1, testDaycare.id, firstPeriod).first
             val paosDecisionId = insertPlacementWithDecision(h, testChild_1, testPurchasedDaycare.id, ClosedPeriod(firstPeriod.end.plusDays(1), firstPeriod.end.plusDays(300))).first
-            updateChildren(h)
+            updateChildren()
 
             updateDecisions(h, vardaClient)
 
@@ -835,7 +835,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
 
             insertPlacementWithDecision(h, child = testChild_1, unitId = testDaycare.id, period = period)
-            updateChildren(h)
+            updateChildren()
             updateDecisions(h, vardaClient)
 
             assertEquals(1, getVardaDecisions(h).size)
@@ -846,7 +846,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
                 .bind("id", testDaycare.id)
                 .execute()
 
-            updateChildren(h)
+            updateChildren()
             updateDecisions(h, vardaClient)
             assertEquals(2, getVardaDecisions(h).size)
         }
@@ -858,7 +858,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
 
             insertPlacementWithDecision(h, child = testChild_1, unitId = testDaycare.id, period = period)
-            updateChildren(h)
+            updateChildren()
             updateDecisions(h, vardaClient)
 
             assertEquals(1, getVardaDecisions(h).size)
@@ -895,8 +895,8 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             .execute()
     }
 
-    private fun updateChildren(h: Handle) {
-        updateChildren(h, vardaClient, vardaOrganizerName)
+    private fun updateChildren() {
+        updateChildren(db, vardaClient, vardaOrganizerName)
     }
 }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -18,7 +18,7 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.updatePlacementStartAndEndDate
 import fi.espoo.evaka.resetDatabase
-import fi.espoo.evaka.shared.db.handle
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
@@ -34,7 +34,6 @@ import fi.espoo.evaka.testPurchasedDaycare
 import fi.espoo.evaka.toDaycareFormAdult
 import fi.espoo.evaka.toDaycareFormChild
 import fi.espoo.evaka.varda.integration.MockVardaIntegrationEndpoint
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -53,831 +52,754 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        jdbi.handle(::insertGeneralTestFixtures)
+        db.transaction { insertGeneralTestFixtures(it.handle) }
     }
 
     @AfterEach
     fun afterEach() {
-        jdbi.handle(::resetDatabase)
+        db.transaction { it.resetDatabase() }
         mockEndpoint.decisions.clear()
     }
 
     @Test
     fun `municipal daycare decision is sent when it has all required data`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val decisionId = insertDecisionWithApplication(db, testChild_1, period)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(1, result.size)
-            assertEquals(decisionId, result.first().evakaDecisionId)
-        }
+        val result = getVardaDecisions()
+        assertEquals(1, result.size)
+        assertEquals(decisionId, result.first().evakaDecisionId)
     }
 
     @Test
     fun `PAOS decision is sent when it has all required data`() {
-        jdbi.handle { h ->
-            val decisionId = insertPlacementWithDecision(h, testChild_1, testPurchasedDaycare.id, ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))).first
-            updateChildren()
+        val decisionId = insertPlacementWithDecision(db, testChild_1, testPurchasedDaycare.id, ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))).first
+        updateChildren()
 
-            val children = getUploadedChildren(db)
-            assertEquals(1, children.size)
+        val children = getUploadedChildren(db)
+        assertEquals(1, children.size)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val vardaDecisions = mockEndpoint.decisions
-            assertEquals(1, vardaDecisions.size)
-            assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, vardaDecisions[0].providerTypeCode)
+        val vardaDecisions = mockEndpoint.decisions
+        assertEquals(1, vardaDecisions.size)
+        assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, vardaDecisions[0].providerTypeCode)
 
-            val decisionRows = getVardaDecisions()
-            assertEquals(1, decisionRows.size)
-            assertEquals(decisionId, decisionRows.first().evakaDecisionId)
-        }
+        val decisionRows = getVardaDecisions()
+        assertEquals(1, decisionRows.size)
+        assertEquals(decisionId, decisionRows.first().evakaDecisionId)
     }
 
     @Test
     fun `child with municipal and PAOS decisions is handled correctly`() {
-        jdbi.handle { h ->
-            val firstPeriod = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            val municipalDecisionId = insertPlacementWithDecision(h, testChild_1, testDaycare.id, firstPeriod).first
-            val paosDecisionId = insertPlacementWithDecision(h, testChild_1, testPurchasedDaycare.id, ClosedPeriod(firstPeriod.end.plusDays(1), firstPeriod.end.plusDays(300))).first
-            updateChildren()
+        val firstPeriod = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val municipalDecisionId = insertPlacementWithDecision(db, testChild_1, testDaycare.id, firstPeriod).first
+        val paosDecisionId = insertPlacementWithDecision(db, testChild_1, testPurchasedDaycare.id, ClosedPeriod(firstPeriod.end.plusDays(1), firstPeriod.end.plusDays(300))).first
+        updateChildren()
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val decisionRows = getVardaDecisions()
-            assertEquals(2, decisionRows.size)
-            assertNotNull(decisionRows.find { it.evakaDecisionId == municipalDecisionId })
-            assertNotNull(decisionRows.find { it.evakaDecisionId == paosDecisionId })
+        val decisionRows = getVardaDecisions()
+        assertEquals(2, decisionRows.size)
+        assertNotNull(decisionRows.find { it.evakaDecisionId == municipalDecisionId })
+        assertNotNull(decisionRows.find { it.evakaDecisionId == paosDecisionId })
 
-            val children = getUploadedChildren(db)
-            val decisions = mockEndpoint.decisions
-            assertEquals(2, children.size)
-            assertEquals(2, decisions.size)
+        val children = getUploadedChildren(db)
+        val decisions = mockEndpoint.decisions
+        assertEquals(2, children.size)
+        assertEquals(2, decisions.size)
 
-            val paosChild = children.firstOrNull { it.ophOrganizerOid == defaultPurchasedOrganizerOid }
-            assertNotNull(paosChild)
+        val paosChild = children.firstOrNull { it.ophOrganizerOid == defaultPurchasedOrganizerOid }
+        assertNotNull(paosChild)
 
-            val paosDecision = decisions.firstOrNull { it.childUrl.contains(paosChild!!.vardaChildId.toString()) }
-            assertNotNull(paosDecision)
+        val paosDecision = decisions.firstOrNull { it.childUrl.contains(paosChild!!.vardaChildId.toString()) }
+        assertNotNull(paosDecision)
 
-            val municipalChild = children.firstOrNull { it.ophOrganizerOid == defaultMunicipalOrganizerOid }
-            assertNotNull(municipalChild)
+        val municipalChild = children.firstOrNull { it.ophOrganizerOid == defaultMunicipalOrganizerOid }
+        assertNotNull(municipalChild)
 
-            val municipalDecision = decisions.firstOrNull { it.childUrl.contains(municipalChild!!.vardaChildId.toString()) }
-            assertNotNull(municipalDecision)
+        val municipalDecision = decisions.firstOrNull { it.childUrl.contains(municipalChild!!.vardaChildId.toString()) }
+        assertNotNull(municipalDecision)
 
-            assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, paosDecision!!.providerTypeCode)
-            assertEquals(VardaUnitProviderType.MUNICIPAL.vardaCode, municipalDecision!!.providerTypeCode)
-        }
+        assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, paosDecision!!.providerTypeCode)
+        assertEquals(VardaUnitProviderType.MUNICIPAL.vardaCode, municipalDecision!!.providerTypeCode)
     }
 
     @Test
     fun `a daycare decision is not sent when there is no existing service need`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(0, result.size)
-        }
+        val result = getVardaDecisions()
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `a daycare decision is not sent when service need does not overlap with decision`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertServiceNeed(h, testChild_1.id, ClosedPeriod(period.start.minusYears(1), period.end.minusYears(1)))
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertServiceNeed(db, testChild_1.id, ClosedPeriod(period.start.minusYears(1), period.end.minusYears(1)))
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(0, result.size)
-        }
+        val result = getVardaDecisions()
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `daycare decision is not sent when hours per week is zero`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertServiceNeed(h, testChild_1.id, period, 0.0)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertServiceNeed(db, testChild_1.id, period, 0.0)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(0, result.size)
-        }
+        val result = getVardaDecisions()
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `a daycare decision is not sent when the child has not been imported to varda yet`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertServiceNeed(h, testChild_1.id, period)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertServiceNeed(db, testChild_1.id, period)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(0, result.size)
-        }
+        val result = getVardaDecisions()
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `preschool decisions are not sent`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period, decisionType = DecisionType.PRESCHOOL)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(0, result.size)
-        }
+        val result = getVardaDecisions()
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `a preschool daycare decision is sent`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            val decisionId =
-                insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val decisionId =
+            insertDecisionWithApplication(db, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(1, result.size)
-            assertEquals(decisionId, result.first().evakaDecisionId)
-        }
+        val result = getVardaDecisions()
+        assertEquals(1, result.size)
+        assertEquals(decisionId, result.first().evakaDecisionId)
     }
 
     @Test
     fun `a daycare decision is updated when a new service need is created for the period`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            val serviceNeedEndDate = period.start.plusMonths(1)
-            insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
-            insertServiceNeed(h, testChild_1.id, period.copy(end = serviceNeedEndDate))
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val serviceNeedEndDate = period.start.plusMonths(1)
+        insertDecisionWithApplication(db, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
+        insertServiceNeed(db, testChild_1.id, period.copy(end = serviceNeedEndDate))
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val originalUploadedAt = getVardaDecisions().first().uploadedAt
+        updateDecisions(db, vardaClient)
+        val originalUploadedAt = getVardaDecisions().first().uploadedAt
 
-            insertServiceNeed(h, testChild_1.id, period.copy(start = serviceNeedEndDate.plusDays(1)))
-            updateDecisions(db, vardaClient)
+        insertServiceNeed(db, testChild_1.id, period.copy(start = serviceNeedEndDate.plusDays(1)))
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(1, result.size)
-            assertTrue(originalUploadedAt < result.first().uploadedAt)
-        }
+        val result = getVardaDecisions()
+        assertEquals(1, result.size)
+        assertTrue(originalUploadedAt < result.first().uploadedAt)
     }
 
     @Test
     fun `a daycare decision is updated when service need is updated`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
-            val serviceNeedId = insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
+        val serviceNeedId = insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val originalUploadedAt = getVardaDecisions().first().uploadedAt
+        updateDecisions(db, vardaClient)
+        val originalUploadedAt = getVardaDecisions().first().uploadedAt
 
-            updateServiceNeed(serviceNeedId, originalUploadedAt.plusSeconds(1))
-            updateDecisions(db, vardaClient)
+        updateServiceNeed(serviceNeedId, originalUploadedAt.plusSeconds(1))
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(1, result.size)
-            assertTrue(originalUploadedAt < result.first().uploadedAt)
-        }
+        val result = getVardaDecisions()
+        assertEquals(1, result.size)
+        assertTrue(originalUploadedAt < result.first().uploadedAt)
     }
 
     @Test
     fun `a daycare decision is updated when a new overlapping decision is made`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val originalUploadedAt = getVardaDecisions().first().uploadedAt
+        updateDecisions(db, vardaClient)
+        val originalUploadedAt = getVardaDecisions().first().uploadedAt
 
-            insertDecisionWithApplication(h, testChild_1, period.copy(start = period.start.plusMonths(1)))
-            updateDecisions(db, vardaClient)
+        insertDecisionWithApplication(db, testChild_1, period.copy(start = period.start.plusMonths(1)))
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(2, result.size)
-            assertTrue(result.all { originalUploadedAt < it.uploadedAt })
-        }
+        val result = getVardaDecisions()
+        assertEquals(2, result.size)
+        assertTrue(result.all { originalUploadedAt < it.uploadedAt })
     }
 
     @Test
     fun `a daycare decision is deleted when a new decision that completely replaced the old one is made`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            val firstDecisionId =
-                insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val firstDecisionId =
+            insertDecisionWithApplication(db, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val originalDecisionId = getVardaDecisions().first().evakaDecisionId
-            assertEquals(firstDecisionId, originalDecisionId)
+        updateDecisions(db, vardaClient)
+        val originalDecisionId = getVardaDecisions().first().evakaDecisionId
+        assertEquals(firstDecisionId, originalDecisionId)
 
-            val secondDecisionId = insertDecisionWithApplication(h, testChild_1, period)
-            updateDecisions(db, vardaClient)
+        val secondDecisionId = insertDecisionWithApplication(db, testChild_1, period)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(1, result.size)
-            assertNotEquals(originalDecisionId, result.first().evakaDecisionId)
-            assertEquals(secondDecisionId, result.first().evakaDecisionId)
-        }
+        val result = getVardaDecisions()
+        assertEquals(1, result.size)
+        assertNotEquals(originalDecisionId, result.first().evakaDecisionId)
+        assertEquals(secondDecisionId, result.first().evakaDecisionId)
     }
 
     @Test
     fun `a derived daycare decision is sent when there is a placement without a decision`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            val placementId = insertPlacement(h, testChild_1.id, period)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val placementId = insertPlacement(db, testChild_1.id, period)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(1, result.size)
-            assertEquals(placementId, result.first().evakaPlacementId)
-        }
+        val result = getVardaDecisions()
+        assertEquals(1, result.size)
+        assertEquals(placementId, result.first().evakaPlacementId)
     }
 
     @Test
     fun `multiple decisions are created from multiple derived daycare decisions`() {
-        jdbi.handle { h ->
-            insertVardaChild(h, testChild_1.id)
-            val firstSemester = ClosedPeriod(LocalDate.of(2018, 1, 8), LocalDate.of(2019, 5, 31))
-            val firstSummer = ClosedPeriod(LocalDate.of(2019, 6, 1), LocalDate.of(2019, 7, 31))
-            insertPlacement(h, testChild_1.id, firstSemester, PlacementType.PRESCHOOL_DAYCARE)
-            insertPlacement(h, testChild_1.id, firstSummer, PlacementType.DAYCARE)
-            insertServiceNeed(h, testChild_1.id, firstSemester)
-            insertServiceNeed(h, testChild_1.id, firstSummer)
+        insertVardaChild(db, testChild_1.id)
+        val firstSemester = ClosedPeriod(LocalDate.of(2018, 1, 8), LocalDate.of(2019, 5, 31))
+        val firstSummer = ClosedPeriod(LocalDate.of(2019, 6, 1), LocalDate.of(2019, 7, 31))
+        insertPlacement(db, testChild_1.id, firstSemester, PlacementType.PRESCHOOL_DAYCARE)
+        insertPlacement(db, testChild_1.id, firstSummer, PlacementType.DAYCARE)
+        insertServiceNeed(db, testChild_1.id, firstSemester)
+        insertServiceNeed(db, testChild_1.id, firstSummer)
 
-            val secondSemester = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 5, 31))
-            val secondSummer = ClosedPeriod(LocalDate.of(2020, 6, 1), LocalDate.of(2020, 7, 31))
-            insertPlacement(h, testChild_1.id, secondSemester, PlacementType.PRESCHOOL_DAYCARE)
-            insertPlacement(h, testChild_1.id, secondSummer, PlacementType.DAYCARE)
-            insertServiceNeed(h, testChild_1.id, secondSemester)
-            insertServiceNeed(h, testChild_1.id, secondSummer)
+        val secondSemester = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 5, 31))
+        val secondSummer = ClosedPeriod(LocalDate.of(2020, 6, 1), LocalDate.of(2020, 7, 31))
+        insertPlacement(db, testChild_1.id, secondSemester, PlacementType.PRESCHOOL_DAYCARE)
+        insertPlacement(db, testChild_1.id, secondSummer, PlacementType.DAYCARE)
+        insertServiceNeed(db, testChild_1.id, secondSemester)
+        insertServiceNeed(db, testChild_1.id, secondSummer)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(4, result.size)
-        }
+        val result = getVardaDecisions()
+        assertEquals(4, result.size)
     }
 
     @Test
     fun `a derived daycare decision is updated when the placement is updated`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            val placementId = insertPlacement(h, testChild_1.id, period)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val placementId = insertPlacement(db, testChild_1.id, period)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val originalUploadedAt = getVardaDecisions().first().uploadedAt
+        updateDecisions(db, vardaClient)
+        val originalUploadedAt = getVardaDecisions().first().uploadedAt
 
-            updatePlacement(h, placementId, originalUploadedAt.plusSeconds(1))
-            updateDecisions(db, vardaClient)
+        updatePlacement(db, placementId, originalUploadedAt.plusSeconds(1))
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(1, result.size)
-            assertTrue(originalUploadedAt < result.first().uploadedAt)
-        }
+        val result = getVardaDecisions()
+        assertEquals(1, result.size)
+        assertTrue(originalUploadedAt < result.first().uploadedAt)
     }
 
     @Test
     fun `a derived daycare decision is updated when service need is updated`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertPlacement(h, testChild_1.id, period)
-            val serviceNeedId = insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertPlacement(db, testChild_1.id, period)
+        val serviceNeedId = insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val originalUploadedAt = getVardaDecisions().first().uploadedAt
+        updateDecisions(db, vardaClient)
+        val originalUploadedAt = getVardaDecisions().first().uploadedAt
 
-            updateServiceNeed(serviceNeedId, originalUploadedAt.plusSeconds(1))
-            updateDecisions(db, vardaClient)
+        updateServiceNeed(serviceNeedId, originalUploadedAt.plusSeconds(1))
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(1, result.size)
-            assertTrue(originalUploadedAt < result.first().uploadedAt)
-        }
+        val result = getVardaDecisions()
+        assertEquals(1, result.size)
+        assertTrue(originalUploadedAt < result.first().uploadedAt)
     }
 
     @Test
     fun `a derived daycare decision is deleted when the placement is removed`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            val placementId = insertPlacement(h, testChild_1.id, period)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val placementId = insertPlacement(db, testChild_1.id, period)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val beforeDelete = getVardaDecisions()
-            assertEquals(1, beforeDelete.size)
+        updateDecisions(db, vardaClient)
+        val beforeDelete = getVardaDecisions()
+        assertEquals(1, beforeDelete.size)
 
-            deletePlacement(h, placementId)
-            updateDecisions(db, vardaClient)
-            val result = getVardaDecisions()
-            assertEquals(0, result.size)
-        }
+        deletePlacement(db, placementId)
+        updateDecisions(db, vardaClient)
+        val result = getVardaDecisions()
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `a derived decision is sent when child has a rejected decision`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertPlacement(h, testChild_1.id, period)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
-            insertDecisionWithApplication(
-                h = h,
-                child = testChild_1,
-                period = period,
-                decisionStatus = DecisionStatus.REJECTED
-            )
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertPlacement(db, testChild_1.id, period)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
+        insertDecisionWithApplication(
+            db,
+            child = testChild_1,
+            period = period,
+            decisionStatus = DecisionStatus.REJECTED
+        )
 
-            updateDecisions(db, vardaClient)
-            val result = getVardaDecisions()
-            assertEquals(1, result.size)
-        }
+        updateDecisions(db, vardaClient)
+        val result = getVardaDecisions()
+        assertEquals(1, result.size)
     }
 
     @Test
     fun `a derived decision is sent when child has a pending decision`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertPlacement(h, testChild_1.id, period)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
-            insertDecisionWithApplication(
-                h = h,
-                child = testChild_1,
-                period = period,
-                decisionStatus = DecisionStatus.PENDING
-            )
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertPlacement(db, testChild_1.id, period)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
+        insertDecisionWithApplication(
+            db,
+            child = testChild_1,
+            period = period,
+            decisionStatus = DecisionStatus.PENDING
+        )
 
-            updateDecisions(db, vardaClient)
-            val result = getVardaDecisions()
-            assertEquals(1, result.size)
-        }
+        updateDecisions(db, vardaClient)
+        val result = getVardaDecisions()
+        assertEquals(1, result.size)
     }
 
     @Test
     fun `daycare decision is sent with correct data`() {
-        jdbi.handle { h ->
-            val sentDate = LocalDate.of(2019, 6, 1)
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period, sentDate = sentDate)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val sentDate = LocalDate.of(2019, 6, 1)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period, sentDate = sentDate)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val decisions = mockEndpoint.decisions
-            assertEquals(1, decisions.size)
+        val decisions = mockEndpoint.decisions
+        assertEquals(1, decisions.size)
 
-            val decision = decisions[0]
-            assertEquals(period.start, decision.startDate)
-            assertEquals(period.end, decision.endDate)
-            assertEquals(40.0, decision.hoursPerWeek)
-            assertEquals(true, decision.daily)
-            assertEquals(true, decision.fullDay)
-            assertEquals(false, decision.shiftCare)
-            assertEquals(VardaUnitProviderType.MUNICIPAL.vardaCode, decision.providerTypeCode)
-            assertEquals(false, decision.urgent)
-            assertEquals(sentDate, decision.applicationDate)
-        }
+        val decision = decisions[0]
+        assertEquals(period.start, decision.startDate)
+        assertEquals(period.end, decision.endDate)
+        assertEquals(40.0, decision.hoursPerWeek)
+        assertEquals(true, decision.daily)
+        assertEquals(true, decision.fullDay)
+        assertEquals(false, decision.shiftCare)
+        assertEquals(VardaUnitProviderType.MUNICIPAL.vardaCode, decision.providerTypeCode)
+        assertEquals(false, decision.urgent)
+        assertEquals(sentDate, decision.applicationDate)
     }
 
     @Test
     fun `application date is never after decision start date`() {
-        jdbi.handle { h ->
-            val sentDate = LocalDate.of(2019, 6, 1)
-            val period = ClosedPeriod(sentDate.minusMonths(1), sentDate.plusMonths(1))
-            insertDecisionWithApplication(h, testChild_1, period, sentDate = sentDate)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val sentDate = LocalDate.of(2019, 6, 1)
+        val period = ClosedPeriod(sentDate.minusMonths(1), sentDate.plusMonths(1))
+        insertDecisionWithApplication(db, testChild_1, period, sentDate = sentDate)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val decision = mockEndpoint.decisions[0]
-            assertNotEquals(sentDate, decision.applicationDate)
-            assertEquals(period.start, decision.applicationDate)
-        }
+        val decision = mockEndpoint.decisions[0]
+        assertNotEquals(sentDate, decision.applicationDate)
+        assertEquals(period.start, decision.applicationDate)
     }
 
     @Test
     fun `PAOS daycare decision is sent with correct data`() {
-        jdbi.handle { h ->
-            val sentDate = LocalDate.of(2019, 6, 1)
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period, sentDate = sentDate, unitId = testPurchasedDaycare.id)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id, ophOrganizationOid = defaultPurchasedOrganizerOid)
+        val sentDate = LocalDate.of(2019, 6, 1)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period, sentDate = sentDate, unitId = testPurchasedDaycare.id)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id, ophOrganizationOid = defaultPurchasedOrganizerOid)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val decisions = mockEndpoint.decisions
-            assertEquals(1, decisions.size)
+        val decisions = mockEndpoint.decisions
+        assertEquals(1, decisions.size)
 
-            val decision = decisions[0]
-            assertEquals(period.start, decision.startDate)
-            assertEquals(period.end, decision.endDate)
-            assertEquals(40.0, decision.hoursPerWeek)
-            assertEquals(true, decision.daily)
-            assertEquals(true, decision.fullDay)
-            assertEquals(false, decision.shiftCare)
-            assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, decision.providerTypeCode)
-            assertEquals(false, decision.urgent)
-            assertEquals(sentDate, decision.applicationDate)
-        }
+        val decision = decisions[0]
+        assertEquals(period.start, decision.startDate)
+        assertEquals(period.end, decision.endDate)
+        assertEquals(40.0, decision.hoursPerWeek)
+        assertEquals(true, decision.daily)
+        assertEquals(true, decision.fullDay)
+        assertEquals(false, decision.shiftCare)
+        assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, decision.providerTypeCode)
+        assertEquals(false, decision.urgent)
+        assertEquals(sentDate, decision.applicationDate)
     }
 
     @Test
     fun `a preschool daycare decision without preparatory is sent with correct hours per week`() {
-        jdbi.handle { h ->
-            val weeklyHours = 50.0
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
-            insertServiceNeed(h, testChild_1.id, period, weeklyHours)
-            insertVardaChild(h, testChild_1.id)
-            insertPlacement(h, testChild_1.id, period, type = PlacementType.PRESCHOOL_DAYCARE)
-            updateDecisions(db, vardaClient)
+        val weeklyHours = 50.0
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
+        insertServiceNeed(db, testChild_1.id, period, weeklyHours)
+        insertVardaChild(db, testChild_1.id)
+        insertPlacement(db, testChild_1.id, period, type = PlacementType.PRESCHOOL_DAYCARE)
+        updateDecisions(db, vardaClient)
 
-            val decisions = mockEndpoint.decisions
-            assertEquals(1, decisions.size)
-            assertEquals(weeklyHours - 20, decisions[0].hoursPerWeek)
-        }
+        val decisions = mockEndpoint.decisions
+        assertEquals(1, decisions.size)
+        assertEquals(weeklyHours - 20, decisions[0].hoursPerWeek)
     }
 
     @Test
     fun `a preschool daycare decision with preparatory is sent with correct hours per week`() {
-        jdbi.handle { h ->
-            val weeklyHours = 50.0
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
-            insertServiceNeed(h, testChild_1.id, period, weeklyHours)
-            insertVardaChild(h, testChild_1.id)
-            insertPlacement(h, testChild_1.id, period, type = PlacementType.PREPARATORY_DAYCARE)
-            updateDecisions(db, vardaClient)
+        val weeklyHours = 50.0
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
+        insertServiceNeed(db, testChild_1.id, period, weeklyHours)
+        insertVardaChild(db, testChild_1.id)
+        insertPlacement(db, testChild_1.id, period, type = PlacementType.PREPARATORY_DAYCARE)
+        updateDecisions(db, vardaClient)
 
-            val decisions = mockEndpoint.decisions
-            assertEquals(1, decisions.size)
-            assertEquals(weeklyHours - 25, decisions[0].hoursPerWeek)
-        }
+        val decisions = mockEndpoint.decisions
+        assertEquals(1, decisions.size)
+        assertEquals(weeklyHours - 25, decisions[0].hoursPerWeek)
     }
 
     @Test
     fun `a decision has a correct end date when another decision replaces it midway`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertDecisionWithApplication(h, testChild_1, period.copy(start = period.start.plusMonths(1)))
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertDecisionWithApplication(db, testChild_1, period.copy(start = period.start.plusMonths(1)))
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val result = mockEndpoint.decisions.toList().sortedBy { it.startDate }
-            assertEquals(2, result.size)
-            assertEquals(period.start, result[0].startDate)
-            assertEquals(period.start.plusMonths(1).minusDays(1), result[0].endDate)
-            assertEquals(period.start.plusMonths(1), result[1].startDate)
-            assertEquals(period.end, result[1].endDate)
-        }
+        updateDecisions(db, vardaClient)
+        val result = mockEndpoint.decisions.toList().sortedBy { it.startDate }
+        assertEquals(2, result.size)
+        assertEquals(period.start, result[0].startDate)
+        assertEquals(period.start.plusMonths(1).minusDays(1), result[0].endDate)
+        assertEquals(period.start.plusMonths(1), result[1].startDate)
+        assertEquals(period.end, result[1].endDate)
     }
 
     @Test
     fun `a decision is not affected by a new decision that does not overlap with it`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertDecisionWithApplication(
-                h,
-                testChild_1,
-                ClosedPeriod(period.end.plusDays(1), period.end.plusMonths(1))
-            )
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertDecisionWithApplication(
+            db,
+            testChild_1,
+            ClosedPeriod(period.end.plusDays(1), period.end.plusMonths(1))
+        )
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val result = mockEndpoint.decisions[0]
-            assertEquals(period.start, result.startDate)
-            assertEquals(period.end, result.endDate)
-        }
+        updateDecisions(db, vardaClient)
+        val result = mockEndpoint.decisions[0]
+        assertEquals(period.start, result.startDate)
+        assertEquals(period.end, result.endDate)
     }
 
     @Test
     fun `a decision is not full day with 24 hours`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertServiceNeed(h, testChild_1.id, period, hours = 24.0)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertServiceNeed(db, testChild_1.id, period, hours = 24.0)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val result = mockEndpoint.decisions[0]
-            assertEquals(false, result.fullDay)
-        }
+        updateDecisions(db, vardaClient)
+        val result = mockEndpoint.decisions[0]
+        assertEquals(false, result.fullDay)
     }
 
     @Test
     fun `a decision is full day with 25 hours`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertServiceNeed(h, testChild_1.id, period, hours = 25.0)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertServiceNeed(db, testChild_1.id, period, hours = 25.0)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val result = mockEndpoint.decisions[0]
-            assertEquals(true, result.fullDay)
-        }
+        updateDecisions(db, vardaClient)
+        val result = mockEndpoint.decisions[0]
+        assertEquals(true, result.fullDay)
     }
 
     @Test
     fun `a decision is full day with more than 25 hours`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertServiceNeed(h, testChild_1.id, period, hours = 25.5)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertServiceNeed(db, testChild_1.id, period, hours = 25.5)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
-            val result = mockEndpoint.decisions[0]
-            assertEquals(true, result.fullDay)
-        }
+        updateDecisions(db, vardaClient)
+        val result = mockEndpoint.decisions[0]
+        assertEquals(true, result.fullDay)
     }
 
     @Test
     fun `decision in the future is not sent to Varda`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusMonths(2))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusMonths(2))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(0, result.size)
-        }
+        val result = getVardaDecisions()
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `derived decision in the future is not sent to Varda`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusMonths(2))
-            insertPlacement(h, testChild_1.id, period)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusMonths(2))
+        insertPlacement(db, testChild_1.id, period)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions()
-            assertEquals(0, result.size)
-        }
+        val result = getVardaDecisions()
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `only one decision is sent to Varda when it has multiple placements inside it`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertVardaUnit(h)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
-            val newMiddleStart = period.start.plusMonths(1)
-            val newMiddleEnd = period.end.minusMonths(1)
-            insertPlacement(h, testChild_1.id, ClosedPeriod(period.start, newMiddleStart.minusDays(1)))
-            insertPlacement(h, testChild_1.id, ClosedPeriod(newMiddleStart, newMiddleEnd))
-            insertPlacement(h, testChild_1.id, ClosedPeriod(newMiddleEnd.plusDays(1), period.end))
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertVardaUnit(db)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
+        val newMiddleStart = period.start.plusMonths(1)
+        val newMiddleEnd = period.end.minusMonths(1)
+        insertPlacement(db, testChild_1.id, ClosedPeriod(period.start, newMiddleStart.minusDays(1)))
+        insertPlacement(db, testChild_1.id, ClosedPeriod(newMiddleStart, newMiddleEnd))
+        insertPlacement(db, testChild_1.id, ClosedPeriod(newMiddleEnd.plusDays(1), period.end))
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions().size)
-            val decisions = mockEndpoint.decisions
-            assertEquals(1, decisions.size)
+        assertEquals(1, getVardaDecisions().size)
+        val decisions = mockEndpoint.decisions
+        assertEquals(1, decisions.size)
 
-            val decision = decisions[0]
-            assertEquals(period.start, decision.startDate)
-            assertEquals(period.end, decision.endDate)
-        }
+        val decision = decisions[0]
+        assertEquals(period.start, decision.startDate)
+        assertEquals(period.end, decision.endDate)
     }
 
     @Test
     fun `a decision dates are prolonged when its placement is prolonged`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertVardaUnit(h)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
-            updateDecisions(db, vardaClient)
-            val decisions = getVardaDecisions()
-            assertEquals(1, decisions.size)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertVardaUnit(db)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
+        updateDecisions(db, vardaClient)
+        val decisions = getVardaDecisions()
+        assertEquals(1, decisions.size)
 
-            val placementId = insertPlacement(h, testChild_1.id, period)
-            updatePlacements(h, vardaClient)
-            val placements = getVardaPlacements(h)
-            assertEquals(1, placements.size)
-            assertEquals(placementId, placements.first().evakaPlacementId)
-            assertEquals(decisions.first().id, placements.first().decisionId)
+        val placementId = insertPlacement(db, testChild_1.id, period)
+        updatePlacements(db, vardaClient)
+        val placements = getVardaPlacements(db)
+        assertEquals(1, placements.size)
+        assertEquals(placementId, placements.first().evakaPlacementId)
+        assertEquals(decisions.first().id, placements.first().decisionId)
 
-            val newStart = period.start.minusMonths(1)
-            val newEnd = period.end.plusMonths(1)
-            h.updatePlacementStartAndEndDate(placementId, newStart, newEnd)
-            updateDecisions(db, vardaClient)
+        val newStart = period.start.minusMonths(1)
+        val newEnd = period.end.plusMonths(1)
+        db.transaction { it.handle.updatePlacementStartAndEndDate(placementId, newStart, newEnd) }
+        updateDecisions(db, vardaClient)
 
-            val vardaDecisions = mockEndpoint.decisions
-            assertEquals(1, vardaDecisions.size)
-            assertEquals(newStart, vardaDecisions.first().startDate)
-            assertEquals(newEnd, vardaDecisions.first().endDate)
-        }
+        val vardaDecisions = mockEndpoint.decisions
+        assertEquals(1, vardaDecisions.size)
+        assertEquals(newStart, vardaDecisions.first().startDate)
+        assertEquals(newEnd, vardaDecisions.first().endDate)
     }
 
     @Test
     fun `a decisions placements are deleted first when it's updated`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertVardaUnit(h)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
-            updateDecisions(db, vardaClient)
-            val decisions = getVardaDecisions()
-            assertEquals(1, decisions.size)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertVardaUnit(db)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
+        updateDecisions(db, vardaClient)
+        val decisions = getVardaDecisions()
+        assertEquals(1, decisions.size)
 
-            val placementId = insertPlacement(h, testChild_1.id, period)
-            updatePlacements(h, vardaClient)
-            val placements = getVardaPlacements(h)
-            assertEquals(1, placements.size)
+        val placementId = insertPlacement(db, testChild_1.id, period)
+        updatePlacements(db, vardaClient)
+        val placements = getVardaPlacements(db)
+        assertEquals(1, placements.size)
 
-            h.updatePlacementStartAndEndDate(placementId, period.start.plusMonths(1), period.end.minusMonths(1))
-            updateDecisions(db, vardaClient)
-            assertEquals(0, getVardaPlacements(h).size)
-
-            updatePlacements(h, vardaClient)
-            assertEquals(1, getVardaPlacements(h).size)
+        db.transaction {
+            it.handle.updatePlacementStartAndEndDate(placementId, period.start.plusMonths(1), period.end.minusMonths(1))
         }
+        updateDecisions(db, vardaClient)
+        assertEquals(0, getVardaPlacements(db).size)
+
+        updatePlacements(db, vardaClient)
+        assertEquals(1, getVardaPlacements(db).size)
     }
 
     @Test
     fun `decision has correct dates when multiple placements that prolong it are added`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertVardaUnit(h)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertVardaUnit(db)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions().size)
-            assertEquals(1, mockEndpoint.decisions.size)
-            val initialDecision = mockEndpoint.decisions[0]
-            assertEquals(period.start, initialDecision.startDate)
-            assertEquals(period.end, initialDecision.endDate)
+        assertEquals(1, getVardaDecisions().size)
+        assertEquals(1, mockEndpoint.decisions.size)
+        val initialDecision = mockEndpoint.decisions[0]
+        assertEquals(period.start, initialDecision.startDate)
+        assertEquals(period.end, initialDecision.endDate)
 
-            val newStart = period.start.minusMonths(1)
-            val newEnd = period.end.plusMonths(1)
-            val newMiddleStart = period.start.plusMonths(1)
-            val newMiddleEnd = period.end.minusMonths(1)
-            insertPlacement(h, testChild_1.id, ClosedPeriod(newStart, newMiddleStart.minusDays(1)))
-            insertPlacement(h, testChild_1.id, ClosedPeriod(newMiddleStart, newMiddleEnd))
-            insertPlacement(h, testChild_1.id, ClosedPeriod(newMiddleEnd.plusDays(1), newEnd))
+        val newStart = period.start.minusMonths(1)
+        val newEnd = period.end.plusMonths(1)
+        val newMiddleStart = period.start.plusMonths(1)
+        val newMiddleEnd = period.end.minusMonths(1)
+        insertPlacement(db, testChild_1.id, ClosedPeriod(newStart, newMiddleStart.minusDays(1)))
+        insertPlacement(db, testChild_1.id, ClosedPeriod(newMiddleStart, newMiddleEnd))
+        insertPlacement(db, testChild_1.id, ClosedPeriod(newMiddleEnd.plusDays(1), newEnd))
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions().size)
-            assertEquals(1, mockEndpoint.decisions.size)
-            val finalDecision = mockEndpoint.decisions[0]
-            assertEquals(newStart, finalDecision.startDate)
-            assertEquals(newEnd, finalDecision.endDate)
-        }
+        assertEquals(1, getVardaDecisions().size)
+        assertEquals(1, mockEndpoint.decisions.size)
+        val finalDecision = mockEndpoint.decisions[0]
+        assertEquals(newStart, finalDecision.startDate)
+        assertEquals(newEnd, finalDecision.endDate)
     }
 
     @Test
     fun `decision is soft deleted if it is flagged with should_be_deleted`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertVardaUnit(h)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertVardaUnit(db)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions().size)
-            assertEquals(0, getSoftDeletedVardaDecisions().size)
+        assertEquals(1, getVardaDecisions().size)
+        assertEquals(0, getSoftDeletedVardaDecisions().size)
 
-            h.createUpdate("UPDATE varda_decision SET should_be_deleted = true").execute()
+        db.transaction { it.createUpdate("UPDATE varda_decision SET should_be_deleted = true").execute() }
 
-            removeMarkedDecisionsFromVarda(db, vardaClient)
-            updateDecisions(db, vardaClient)
+        removeMarkedDecisionsFromVarda(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            assertEquals(1, getSoftDeletedVardaDecisions().size)
-        }
+        assertEquals(1, getSoftDeletedVardaDecisions().size)
     }
 
     @Test
     fun `decision is not updated if upload flag is turned off`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertVardaUnit(h, unitId = testDaycare.id)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertVardaUnit(db, unitId = testDaycare.id)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
 
-            updateDecisions(db, vardaClient)
+        updateDecisions(db, vardaClient)
 
-            h.createUpdate("UPDATE daycare SET upload_to_varda = false WHERE id = :id").bind("id", testDaycare.id).execute()
+        db.transaction { it.createUpdate("UPDATE daycare SET upload_to_varda = false WHERE id = :id").bind("id", testDaycare.id).execute() }
 
-            val newStart = period.start.minusMonths(1)
-            insertPlacement(h, testChild_1.id, ClosedPeriod(newStart, period.end))
-            updateDecisions(db, vardaClient)
+        val newStart = period.start.minusMonths(1)
+        insertPlacement(db, testChild_1.id, ClosedPeriod(newStart, period.end))
+        updateDecisions(db, vardaClient)
 
-            val decision = mockEndpoint.decisions[0]
-            assertEquals(period.start, decision.startDate)
-        }
+        val decision = mockEndpoint.decisions[0]
+        assertEquals(period.start, decision.startDate)
     }
 
     @Test
     fun `updating daycare organizer oid yields new varda decision if old is soft deleted`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
 
-            insertPlacementWithDecision(h, child = testChild_1, unitId = testDaycare.id, period = period)
-            updateChildren()
-            updateDecisions(db, vardaClient)
+        insertPlacementWithDecision(db, child = testChild_1, unitId = testDaycare.id, period = period)
+        updateChildren()
+        updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions().size)
+        assertEquals(1, getVardaDecisions().size)
 
-            h.createUpdate("update varda_decision set deleted_at = NOW()").execute()
-
-            h.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id")
+        db.transaction {
+            it.createUpdate("update varda_decision set deleted_at = NOW()").execute()
+            it.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id")
                 .bind("id", testDaycare.id)
                 .execute()
-
-            updateChildren()
-            updateDecisions(db, vardaClient)
-            assertEquals(2, getVardaDecisions().size)
         }
+
+        updateChildren()
+        updateDecisions(db, vardaClient)
+        assertEquals(2, getVardaDecisions().size)
     }
 
     @Test
     fun `soft deleted decisions are not sent`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
+        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
 
-            insertPlacementWithDecision(h, child = testChild_1, unitId = testDaycare.id, period = period)
-            updateChildren()
-            updateDecisions(db, vardaClient)
+        insertPlacementWithDecision(db, child = testChild_1, unitId = testDaycare.id, period = period)
+        updateChildren()
+        updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions().size)
-            assertEquals(1, mockEndpoint.decisions.size)
+        assertEquals(1, getVardaDecisions().size)
+        assertEquals(1, mockEndpoint.decisions.size)
 
-            h.createUpdate("update varda_decision set deleted_at = NOW()").execute()
+        db.transaction { it.createUpdate("update varda_decision set deleted_at = NOW()").execute() }
 
-            removeMarkedDecisionsFromVarda(db, vardaClient)
+        removeMarkedDecisionsFromVarda(db, vardaClient)
 
-            mockEndpoint.decisions.clear()
+        mockEndpoint.decisions.clear()
 
-            updateDecisions(db, vardaClient)
-            assertEquals(2, getVardaDecisions().size)
-            assertEquals(1, mockEndpoint.decisions.size)
+        updateDecisions(db, vardaClient)
+        assertEquals(2, getVardaDecisions().size)
+        assertEquals(1, mockEndpoint.decisions.size)
 
-            updateDecisions(db, vardaClient)
-            assertEquals(2, getVardaDecisions().size)
-            assertEquals(1, mockEndpoint.decisions.size)
-        }
+        updateDecisions(db, vardaClient)
+        assertEquals(2, getVardaDecisions().size)
+        assertEquals(1, mockEndpoint.decisions.size)
     }
 
     private fun getVardaDecisions() = db.read {
@@ -905,23 +827,25 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 }
 
 internal fun insertServiceNeed(
-    h: Handle,
+    db: Database.Connection,
     childId: UUID,
     period: ClosedPeriod,
     hours: Double = 40.0
 ): UUID {
-    return insertTestServiceNeed(
-        h,
-        childId,
-        testDecisionMaker_1.id,
-        startDate = period.start,
-        endDate = period.end,
-        hoursPerWeek = hours
-    )
+    return db.transaction {
+        insertTestServiceNeed(
+            it.handle,
+            childId,
+            testDecisionMaker_1.id,
+            startDate = period.start,
+            endDate = period.end,
+            hoursPerWeek = hours
+        )
+    }
 }
 
-internal fun insertVardaChild(h: Handle, childId: UUID, createdAt: Instant = Instant.now(), ophOrganizationOid: String = defaultMunicipalOrganizerOid) {
-    h.createUpdate(
+internal fun insertVardaChild(db: Database.Connection, childId: UUID, createdAt: Instant = Instant.now(), ophOrganizationOid: String = defaultMunicipalOrganizerOid) = db.transaction {
+    it.createUpdate(
         """
 INSERT INTO varda_child
     (id, person_id, varda_person_id, varda_person_oid, varda_child_id, created_at, modified_at, uploaded_at, oph_organizer_oid)
@@ -942,17 +866,17 @@ VALUES
 }
 
 fun insertDecisionWithApplication(
-    h: Handle,
+    db: Database.Connection,
     child: PersonData.Detailed,
     period: ClosedPeriod,
     unitId: UUID = testDaycare.id,
     decisionType: DecisionType = DecisionType.DAYCARE,
     sentDate: LocalDate = LocalDate.of(2019, 1, 1),
     decisionStatus: DecisionStatus = DecisionStatus.ACCEPTED
-): UUID {
-    val applicationId = insertTestApplication(h, childId = child.id, sentDate = sentDate)
+): UUID = db.transaction {
+    val applicationId = insertTestApplication(it.handle, childId = child.id, sentDate = sentDate)
     insertTestApplicationForm(
-        h, applicationId,
+        it.handle, applicationId,
         DaycareFormV0(
             type = FormType.DAYCARE,
             partTime = false,
@@ -978,24 +902,26 @@ fun insertDecisionWithApplication(
         resolvedBy = testDecisionMaker_1.id,
         resolved = Instant.now()
     )
-    return h.insertTestDecision(acceptedDecision)
+    it.handle.insertTestDecision(acceptedDecision)
 }
 
-fun insertPlacementWithDecision(h: Handle, child: PersonData.Detailed, unitId: UUID, period: ClosedPeriod): Pair<UUID, UUID> {
-    val decisionId = insertDecisionWithApplication(h = h, child = child, period = period, unitId = unitId)
-    insertServiceNeed(h, child.id, period)
-    val placementId = insertTestPlacement(
-        h = h,
-        childId = child.id,
-        unitId = unitId,
-        startDate = period.start,
-        endDate = period.end
-    )
-    return Pair(decisionId, placementId)
+fun insertPlacementWithDecision(db: Database.Connection, child: PersonData.Detailed, unitId: UUID, period: ClosedPeriod): Pair<UUID, UUID> {
+    val decisionId = insertDecisionWithApplication(db, child = child, period = period, unitId = unitId)
+    insertServiceNeed(db, child.id, period)
+    return db.transaction {
+        val placementId = insertTestPlacement(
+            h = it.handle,
+            childId = child.id,
+            unitId = unitId,
+            startDate = period.start,
+            endDate = period.end
+        )
+        Pair(decisionId, placementId)
+    }
 }
 
-private fun deletePlacement(h: Handle, id: UUID) {
-    h.createUpdate("DELETE FROM placement WHERE id = :id")
+private fun deletePlacement(db: Database.Connection, id: UUID) = db.transaction {
+    it.createUpdate("DELETE FROM placement WHERE id = :id")
         .bind("id", id)
         .execute()
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -70,9 +70,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(1, result.size)
             assertEquals(decisionId, result.first().evakaDecisionId)
         }
@@ -84,16 +84,16 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             val decisionId = insertPlacementWithDecision(h, testChild_1, testPurchasedDaycare.id, ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))).first
             updateChildren()
 
-            val children = getUploadedChildren(h)
+            val children = getUploadedChildren(db)
             assertEquals(1, children.size)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
             val vardaDecisions = mockEndpoint.decisions
             assertEquals(1, vardaDecisions.size)
             assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, vardaDecisions[0].providerTypeCode)
 
-            val decisionRows = getVardaDecisions(h)
+            val decisionRows = getVardaDecisions()
             assertEquals(1, decisionRows.size)
             assertEquals(decisionId, decisionRows.first().evakaDecisionId)
         }
@@ -107,14 +107,14 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             val paosDecisionId = insertPlacementWithDecision(h, testChild_1, testPurchasedDaycare.id, ClosedPeriod(firstPeriod.end.plusDays(1), firstPeriod.end.plusDays(300))).first
             updateChildren()
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val decisionRows = getVardaDecisions(h)
+            val decisionRows = getVardaDecisions()
             assertEquals(2, decisionRows.size)
             assertNotNull(decisionRows.find { it.evakaDecisionId == municipalDecisionId })
             assertNotNull(decisionRows.find { it.evakaDecisionId == paosDecisionId })
 
-            val children = getUploadedChildren(h)
+            val children = getUploadedChildren(db)
             val decisions = mockEndpoint.decisions
             assertEquals(2, children.size)
             assertEquals(2, decisions.size)
@@ -143,9 +143,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertDecisionWithApplication(h, testChild_1, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(0, result.size)
         }
     }
@@ -158,9 +158,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, ClosedPeriod(period.start.minusYears(1), period.end.minusYears(1)))
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(0, result.size)
         }
     }
@@ -173,9 +173,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period, 0.0)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(0, result.size)
         }
     }
@@ -187,9 +187,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertDecisionWithApplication(h, testChild_1, period)
             insertServiceNeed(h, testChild_1.id, period)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(0, result.size)
         }
     }
@@ -202,9 +202,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(0, result.size)
         }
     }
@@ -218,9 +218,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(1, result.size)
             assertEquals(decisionId, result.first().evakaDecisionId)
         }
@@ -235,13 +235,13 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period.copy(end = serviceNeedEndDate))
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
-            val originalUploadedAt = getVardaDecisions(h).first().uploadedAt
+            updateDecisions(db, vardaClient)
+            val originalUploadedAt = getVardaDecisions().first().uploadedAt
 
             insertServiceNeed(h, testChild_1.id, period.copy(start = serviceNeedEndDate.plusDays(1)))
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(1, result.size)
             assertTrue(originalUploadedAt < result.first().uploadedAt)
         }
@@ -255,13 +255,13 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             val serviceNeedId = insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
-            val originalUploadedAt = getVardaDecisions(h).first().uploadedAt
+            updateDecisions(db, vardaClient)
+            val originalUploadedAt = getVardaDecisions().first().uploadedAt
 
-            updateServiceNeed(h, serviceNeedId, originalUploadedAt.plusSeconds(1))
-            updateDecisions(h, vardaClient)
+            updateServiceNeed(serviceNeedId, originalUploadedAt.plusSeconds(1))
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(1, result.size)
             assertTrue(originalUploadedAt < result.first().uploadedAt)
         }
@@ -275,13 +275,13 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
-            val originalUploadedAt = getVardaDecisions(h).first().uploadedAt
+            updateDecisions(db, vardaClient)
+            val originalUploadedAt = getVardaDecisions().first().uploadedAt
 
             insertDecisionWithApplication(h, testChild_1, period.copy(start = period.start.plusMonths(1)))
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(2, result.size)
             assertTrue(result.all { originalUploadedAt < it.uploadedAt })
         }
@@ -296,14 +296,14 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
-            val originalDecisionId = getVardaDecisions(h).first().evakaDecisionId
+            updateDecisions(db, vardaClient)
+            val originalDecisionId = getVardaDecisions().first().evakaDecisionId
             assertEquals(firstDecisionId, originalDecisionId)
 
             val secondDecisionId = insertDecisionWithApplication(h, testChild_1, period)
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(1, result.size)
             assertNotEquals(originalDecisionId, result.first().evakaDecisionId)
             assertEquals(secondDecisionId, result.first().evakaDecisionId)
@@ -318,9 +318,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(1, result.size)
             assertEquals(placementId, result.first().evakaPlacementId)
         }
@@ -344,9 +344,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, secondSemester)
             insertServiceNeed(h, testChild_1.id, secondSummer)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(4, result.size)
         }
     }
@@ -359,13 +359,13 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
-            val originalUploadedAt = getVardaDecisions(h).first().uploadedAt
+            updateDecisions(db, vardaClient)
+            val originalUploadedAt = getVardaDecisions().first().uploadedAt
 
             updatePlacement(h, placementId, originalUploadedAt.plusSeconds(1))
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(1, result.size)
             assertTrue(originalUploadedAt < result.first().uploadedAt)
         }
@@ -379,13 +379,13 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             val serviceNeedId = insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
-            val originalUploadedAt = getVardaDecisions(h).first().uploadedAt
+            updateDecisions(db, vardaClient)
+            val originalUploadedAt = getVardaDecisions().first().uploadedAt
 
-            updateServiceNeed(h, serviceNeedId, originalUploadedAt.plusSeconds(1))
-            updateDecisions(h, vardaClient)
+            updateServiceNeed(serviceNeedId, originalUploadedAt.plusSeconds(1))
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(1, result.size)
             assertTrue(originalUploadedAt < result.first().uploadedAt)
         }
@@ -399,13 +399,13 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
-            val beforeDelete = getVardaDecisions(h)
+            updateDecisions(db, vardaClient)
+            val beforeDelete = getVardaDecisions()
             assertEquals(1, beforeDelete.size)
 
             deletePlacement(h, placementId)
-            updateDecisions(h, vardaClient)
-            val result = getVardaDecisions(h)
+            updateDecisions(db, vardaClient)
+            val result = getVardaDecisions()
             assertEquals(0, result.size)
         }
     }
@@ -424,8 +424,8 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
                 decisionStatus = DecisionStatus.REJECTED
             )
 
-            updateDecisions(h, vardaClient)
-            val result = getVardaDecisions(h)
+            updateDecisions(db, vardaClient)
+            val result = getVardaDecisions()
             assertEquals(1, result.size)
         }
     }
@@ -444,8 +444,8 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
                 decisionStatus = DecisionStatus.PENDING
             )
 
-            updateDecisions(h, vardaClient)
-            val result = getVardaDecisions(h)
+            updateDecisions(db, vardaClient)
+            val result = getVardaDecisions()
             assertEquals(1, result.size)
         }
     }
@@ -459,7 +459,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
             val decisions = mockEndpoint.decisions
             assertEquals(1, decisions.size)
@@ -486,7 +486,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
             val decision = mockEndpoint.decisions[0]
             assertNotEquals(sentDate, decision.applicationDate)
@@ -503,7 +503,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id, ophOrganizationOid = defaultPurchasedOrganizerOid)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
             val decisions = mockEndpoint.decisions
             assertEquals(1, decisions.size)
@@ -530,7 +530,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period, weeklyHours)
             insertVardaChild(h, testChild_1.id)
             insertPlacement(h, testChild_1.id, period, type = PlacementType.PRESCHOOL_DAYCARE)
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
             val decisions = mockEndpoint.decisions
             assertEquals(1, decisions.size)
@@ -547,7 +547,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period, weeklyHours)
             insertVardaChild(h, testChild_1.id)
             insertPlacement(h, testChild_1.id, period, type = PlacementType.PREPARATORY_DAYCARE)
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
             val decisions = mockEndpoint.decisions
             assertEquals(1, decisions.size)
@@ -564,7 +564,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             val result = mockEndpoint.decisions.toList().sortedBy { it.startDate }
             assertEquals(2, result.size)
             assertEquals(period.start, result[0].startDate)
@@ -587,7 +587,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             val result = mockEndpoint.decisions[0]
             assertEquals(period.start, result.startDate)
             assertEquals(period.end, result.endDate)
@@ -602,7 +602,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period, hours = 24.0)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             val result = mockEndpoint.decisions[0]
             assertEquals(false, result.fullDay)
         }
@@ -616,7 +616,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period, hours = 25.0)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             val result = mockEndpoint.decisions[0]
             assertEquals(true, result.fullDay)
         }
@@ -630,7 +630,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period, hours = 25.5)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             val result = mockEndpoint.decisions[0]
             assertEquals(true, result.fullDay)
         }
@@ -644,9 +644,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(0, result.size)
         }
     }
@@ -659,9 +659,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            val result = getVardaDecisions(h)
+            val result = getVardaDecisions()
             assertEquals(0, result.size)
         }
     }
@@ -680,9 +680,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertPlacement(h, testChild_1.id, ClosedPeriod(newMiddleStart, newMiddleEnd))
             insertPlacement(h, testChild_1.id, ClosedPeriod(newMiddleEnd.plusDays(1), period.end))
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions(h).size)
+            assertEquals(1, getVardaDecisions().size)
             val decisions = mockEndpoint.decisions
             assertEquals(1, decisions.size)
 
@@ -700,8 +700,8 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertVardaUnit(h)
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
-            updateDecisions(h, vardaClient)
-            val decisions = getVardaDecisions(h)
+            updateDecisions(db, vardaClient)
+            val decisions = getVardaDecisions()
             assertEquals(1, decisions.size)
 
             val placementId = insertPlacement(h, testChild_1.id, period)
@@ -714,7 +714,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             val newStart = period.start.minusMonths(1)
             val newEnd = period.end.plusMonths(1)
             h.updatePlacementStartAndEndDate(placementId, newStart, newEnd)
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
             val vardaDecisions = mockEndpoint.decisions
             assertEquals(1, vardaDecisions.size)
@@ -731,8 +731,8 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertVardaUnit(h)
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
-            updateDecisions(h, vardaClient)
-            val decisions = getVardaDecisions(h)
+            updateDecisions(db, vardaClient)
+            val decisions = getVardaDecisions()
             assertEquals(1, decisions.size)
 
             val placementId = insertPlacement(h, testChild_1.id, period)
@@ -741,7 +741,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             assertEquals(1, placements.size)
 
             h.updatePlacementStartAndEndDate(placementId, period.start.plusMonths(1), period.end.minusMonths(1))
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             assertEquals(0, getVardaPlacements(h).size)
 
             updatePlacements(h, vardaClient)
@@ -758,9 +758,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions(h).size)
+            assertEquals(1, getVardaDecisions().size)
             assertEquals(1, mockEndpoint.decisions.size)
             val initialDecision = mockEndpoint.decisions[0]
             assertEquals(period.start, initialDecision.startDate)
@@ -774,9 +774,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertPlacement(h, testChild_1.id, ClosedPeriod(newMiddleStart, newMiddleEnd))
             insertPlacement(h, testChild_1.id, ClosedPeriod(newMiddleEnd.plusDays(1), newEnd))
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions(h).size)
+            assertEquals(1, getVardaDecisions().size)
             assertEquals(1, mockEndpoint.decisions.size)
             val finalDecision = mockEndpoint.decisions[0]
             assertEquals(newStart, finalDecision.startDate)
@@ -793,17 +793,17 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions(h).size)
-            assertEquals(0, getSoftDeletedVardaDecisions(h).size)
+            assertEquals(1, getVardaDecisions().size)
+            assertEquals(0, getSoftDeletedVardaDecisions().size)
 
             h.createUpdate("UPDATE varda_decision SET should_be_deleted = true").execute()
 
             removeMarkedDecisionsFromVarda(db, vardaClient)
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            assertEquals(1, getSoftDeletedVardaDecisions(h).size)
+            assertEquals(1, getSoftDeletedVardaDecisions().size)
         }
     }
 
@@ -816,13 +816,13 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, period)
             insertVardaChild(h, testChild_1.id)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
             h.createUpdate("UPDATE daycare SET upload_to_varda = false WHERE id = :id").bind("id", testDaycare.id).execute()
 
             val newStart = period.start.minusMonths(1)
             insertPlacement(h, testChild_1.id, ClosedPeriod(newStart, period.end))
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
             val decision = mockEndpoint.decisions[0]
             assertEquals(period.start, decision.startDate)
@@ -836,9 +836,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
             insertPlacementWithDecision(h, child = testChild_1, unitId = testDaycare.id, period = period)
             updateChildren()
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions(h).size)
+            assertEquals(1, getVardaDecisions().size)
 
             h.createUpdate("update varda_decision set deleted_at = NOW()").execute()
 
@@ -847,8 +847,8 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
                 .execute()
 
             updateChildren()
-            updateDecisions(h, vardaClient)
-            assertEquals(2, getVardaDecisions(h).size)
+            updateDecisions(db, vardaClient)
+            assertEquals(2, getVardaDecisions().size)
         }
     }
 
@@ -859,9 +859,9 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
             insertPlacementWithDecision(h, child = testChild_1, unitId = testDaycare.id, period = period)
             updateChildren()
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
 
-            assertEquals(1, getVardaDecisions(h).size)
+            assertEquals(1, getVardaDecisions().size)
             assertEquals(1, mockEndpoint.decisions.size)
 
             h.createUpdate("update varda_decision set deleted_at = NOW()").execute()
@@ -870,26 +870,30 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
             mockEndpoint.decisions.clear()
 
-            updateDecisions(h, vardaClient)
-            assertEquals(2, getVardaDecisions(h).size)
+            updateDecisions(db, vardaClient)
+            assertEquals(2, getVardaDecisions().size)
             assertEquals(1, mockEndpoint.decisions.size)
 
-            updateDecisions(h, vardaClient)
-            assertEquals(2, getVardaDecisions(h).size)
+            updateDecisions(db, vardaClient)
+            assertEquals(2, getVardaDecisions().size)
             assertEquals(1, mockEndpoint.decisions.size)
         }
     }
 
-    private fun getVardaDecisions(h: Handle) = h.createQuery("SELECT * FROM varda_decision")
-        .map(toVardaDecisionRow)
-        .toList()
+    private fun getVardaDecisions() = db.read {
+        it.createQuery("SELECT * FROM varda_decision")
+            .map(toVardaDecisionRow)
+            .toList()
+    }
 
-    private fun getSoftDeletedVardaDecisions(h: Handle) = h.createQuery("SELECT * FROM varda_decision WHERE deleted_at IS NOT NULL")
-        .map(toVardaDecisionRow)
-        .toList()
+    private fun getSoftDeletedVardaDecisions() = db.read {
+        it.createQuery("SELECT * FROM varda_decision WHERE deleted_at IS NOT NULL")
+            .map(toVardaDecisionRow)
+            .toList()
+    }
 
-    private fun updateServiceNeed(h: Handle, id: UUID, updatedAt: Instant) {
-        h.createUpdate("UPDATE service_need SET updated = :updatedAt WHERE id = :id")
+    private fun updateServiceNeed(id: UUID, updatedAt: Instant) = db.transaction {
+        it.createUpdate("UPDATE service_need SET updated = :updatedAt WHERE id = :id")
             .bind("id", id)
             .bind("updatedAt", updatedAt)
             .execute()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -800,7 +800,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
             h.createUpdate("UPDATE varda_decision SET should_be_deleted = true").execute()
 
-            removeMarkedDecisionsFromVarda(h, vardaClient)
+            removeMarkedDecisionsFromVarda(db, vardaClient)
             updateDecisions(h, vardaClient)
 
             assertEquals(1, getSoftDeletedVardaDecisions(h).size)
@@ -866,7 +866,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
             h.createUpdate("update varda_decision set deleted_at = NOW()").execute()
 
-            removeMarkedDecisionsFromVarda(h, vardaClient)
+            removeMarkedDecisionsFromVarda(db, vardaClient)
 
             mockEndpoint.decisions.clear()
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -18,8 +18,6 @@ import fi.espoo.evaka.invoicing.domain.PlacementType
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestChild
@@ -34,7 +32,6 @@ import fi.espoo.evaka.testChild_3
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testPurchasedDaycare
 import fi.espoo.evaka.varda.integration.MockVardaIntegrationEndpoint
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -57,298 +54,278 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        jdbi.handle { h ->
-            insertGeneralTestFixtures(h)
-            insertVardaUnit(h)
-            assertEquals(0, getVardaFeeDataRows(h).size)
-            mockEndpoint.feeData.clear()
-        }
+        db.transaction { insertGeneralTestFixtures(it.handle) }
+        insertVardaUnit(db)
+        assertEquals(0, getVardaFeeDataRows(db).size)
+        mockEndpoint.feeData.clear()
     }
 
     @AfterEach
     fun afterEach() {
-        jdbi.handle(::resetDatabase)
+        db.transaction { it.resetDatabase() }
     }
 
     @Test
     fun `fee data is sent when placement is sent to Varda`() {
-        jdbi.handle { h ->
-            createDecisionsAndPlacements(h = h, child = testChild_1)
-            insertFeeDecision(h, FeeDecisionStatus.SENT, listOf(testChild_1), objectMapper)
+        createDecisionsAndPlacements(child = testChild_1)
+        insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(testChild_1), objectMapper)
 
-            updateFeeData(h)
+        updateFeeData()
 
-            assertEquals(1, getVardaFeeDataRows(h).size)
-        }
+        assertEquals(1, getVardaFeeDataRows(db).size)
     }
 
     @Test
     fun `fee data is saved to database correctly after upload`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertServiceNeed(h, testChild_1.id, period)
-            insertVardaChild(h, testChild_1.id)
-            val placementId = insertTestPlacement(
-                h = h,
+        val period = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
+        val placementId = db.transaction {
+            insertTestPlacement(
+                it.handle,
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 startDate = period.start,
                 endDate = period.end
             )
-            updateDecisions(db, vardaClient)
-            updatePlacements(h, vardaClient)
-
-            val feeDecision = insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period.start, period.end)
-            )
-
-            updateFeeData(h)
-            val feeDataRows = getVardaFeeDataRows(h)
-            assertEquals(1, feeDataRows.size)
-            assertEquals(feeDecision.id, feeDataRows[0].evakaFeeDecisionId)
-            assertEquals(placementId, feeDataRows[0].evakaPlacementId)
-            assertNotNull(feeDataRows[0].vardaFeeDataId)
-            assertNotNull(feeDataRows[0].createdAt)
-            assertNotNull(feeDataRows[0].uploadedAt)
         }
+        updateDecisions(db, vardaClient)
+        updatePlacements(db, vardaClient)
+
+        val feeDecision = insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period.start, period.end)
+        )
+
+        updateFeeData()
+        val feeDataRows = getVardaFeeDataRows(db)
+        assertEquals(1, feeDataRows.size)
+        assertEquals(feeDecision.id, feeDataRows[0].evakaFeeDecisionId)
+        assertEquals(placementId, feeDataRows[0].evakaPlacementId)
+        assertNotNull(feeDataRows[0].vardaFeeDataId)
+        assertNotNull(feeDataRows[0].createdAt)
+        assertNotNull(feeDataRows[0].uploadedAt)
     }
 
     @Test
     fun `fee data is mapped correctly`() {
-        jdbi.handle { h ->
-            createDecisionsAndPlacements(h = h, child = testChild_1)
-            val feeDecision = insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                placementType = PlacementType.DAYCARE
-            )
+        createDecisionsAndPlacements(child = testChild_1)
+        val feeDecision = insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            placementType = PlacementType.DAYCARE
+        )
 
-            updateFeeData(h)
+        updateFeeData()
 
-            val results = mockEndpoint.feeData
-            assertEquals(1, results.size)
+        val results = mockEndpoint.feeData
+        assertEquals(1, results.size)
 
-            val result = results[0]
-            assertEquals("MP03", result.feeCode)
-            assertEquals(0.0, result.voucherAmount)
-            assertEquals(feeDecision.familySize, result.familySize)
-            assertEquals(289.0, result.feeAmount)
-            assertEquals(feeDecision.validFrom, result.startDate)
-            assertEquals(feeDecision.validTo, result.endDate)
-        }
+        val result = results[0]
+        assertEquals("MP03", result.feeCode)
+        assertEquals(0.0, result.voucherAmount)
+        assertEquals(feeDecision.familySize, result.familySize)
+        assertEquals(289.0, result.feeAmount)
+        assertEquals(feeDecision.validFrom, result.startDate)
+        assertEquals(feeDecision.validTo, result.endDate)
     }
 
     @Test
     fun `five year old daycare is mapped correctly`() {
-        jdbi.handle { h ->
-            createDecisionsAndPlacements(h = h, child = testChild_1)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                placementType = PlacementType.FIVE_YEARS_OLD_DAYCARE
-            )
+        createDecisionsAndPlacements(child = testChild_1)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            placementType = PlacementType.FIVE_YEARS_OLD_DAYCARE
+        )
 
-            updateFeeData(h)
+        updateFeeData()
 
-            val results = mockEndpoint.feeData
-            assertEquals(1, results.size)
+        val results = mockEndpoint.feeData
+        assertEquals(1, results.size)
 
-            assertEquals("MP02", results[0].feeCode)
-        }
+        assertEquals("MP02", results[0].feeCode)
     }
 
     @Test
     fun `fee decision with two children generates two fee data entries`() {
-        jdbi.handle { h ->
-            createDecisionsAndPlacements(h, testChild_1)
-            createDecisionsAndPlacements(h, testChild_2)
-            insertFeeDecision(h, FeeDecisionStatus.SENT, listOf(testChild_1, testChild_2), objectMapper)
+        createDecisionsAndPlacements(testChild_1)
+        createDecisionsAndPlacements(testChild_2)
+        insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(testChild_1, testChild_2), objectMapper)
 
-            updateFeeData(h)
+        updateFeeData()
 
-            assertEquals(2, getVardaFeeDataRows(h).size)
-        }
+        assertEquals(2, getVardaFeeDataRows(db).size)
     }
 
     @Test
     fun `fee data is not sent when there is no placement sent to Varda`() {
-        jdbi.handle { h ->
-            createDecisionsAndPlacements(h, testChild_1)
-            insertFeeDecision(h, FeeDecisionStatus.SENT, listOf(testChild_1), objectMapper)
-            clearVardaPlacements(h)
+        createDecisionsAndPlacements(testChild_1)
+        insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(testChild_1), objectMapper)
+        clearVardaPlacements(db)
 
-            updateFeeData(h)
+        updateFeeData()
 
-            assertEquals(0, getVardaFeeDataRows(h).size)
-        }
+        assertEquals(0, getVardaFeeDataRows(db).size)
     }
 
     @Test
     fun `fee data is not sent when the fee decision is annulled`() {
-        jdbi.handle { h ->
-            createDecisionsAndPlacements(h, testChild_1)
-            insertFeeDecision(h, FeeDecisionStatus.ANNULLED, listOf(testChild_1), objectMapper)
+        createDecisionsAndPlacements(testChild_1)
+        insertFeeDecision(db, FeeDecisionStatus.ANNULLED, listOf(testChild_1), objectMapper)
 
-            updateFeeData(h)
+        updateFeeData()
 
-            assertEquals(0, getVardaFeeDataRows(h).size)
-        }
+        assertEquals(0, getVardaFeeDataRows(db).size)
     }
 
     @Test
     fun `fee data is not sent when the fee decision is draft`() {
-        jdbi.handle { h ->
-            createDecisionsAndPlacements(h, testChild_1)
-            val sentFeeDecision = insertFeeDecision(h, FeeDecisionStatus.SENT, listOf(testChild_1), objectMapper)
+        createDecisionsAndPlacements(testChild_1)
+        val sentFeeDecision = insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(testChild_1), objectMapper)
 
-            updateFeeData(h)
+        updateFeeData()
 
-            insertFeeDecision(h, FeeDecisionStatus.DRAFT, listOf(testChild_1), objectMapper)
-            h.createUpdate("UPDATE placement SET updated = now() + interval '30 second' WHERE 1 = 1").execute()
-
-            updateFeeData(h)
-
-            val feeDataRows = getVardaFeeDataRows(h)
-            assertEquals(1, feeDataRows.size)
-            assertEquals(sentFeeDecision.id, feeDataRows[0].evakaFeeDecisionId)
+        insertFeeDecision(db, FeeDecisionStatus.DRAFT, listOf(testChild_1), objectMapper)
+        db.transaction {
+            it.createUpdate("UPDATE placement SET updated = now() + interval '30 second' WHERE 1 = 1").execute()
         }
+
+        updateFeeData()
+
+        val feeDataRows = getVardaFeeDataRows(db)
+        assertEquals(1, feeDataRows.size)
+        assertEquals(sentFeeDecision.id, feeDataRows[0].evakaFeeDecisionId)
     }
 
     @Test
     fun `child with no guardians is not sent to Varda`() {
-        jdbi.handle { h ->
-            // testChild_3 doesn't have guardians in mock VTJ data
-            createDecisionsAndPlacements(h = h, child = testChild_3)
-            insertFeeDecision(h, FeeDecisionStatus.SENT, listOf(testChild_3), objectMapper)
+        // testChild_3 doesn't have guardians in mock VTJ data
+        createDecisionsAndPlacements(child = testChild_3)
+        insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(testChild_3), objectMapper)
 
-            updateFeeData(h)
+        updateFeeData()
 
-            assertEquals(0, getVardaFeeDataRows(h).size)
-        }
+        assertEquals(0, getVardaFeeDataRows(db).size)
     }
 
     @Test
     fun `fee data is sent and updated to database only once`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
-            createDecisionsAndPlacements(h = h, child = testChild_1, period = period)
+        val period = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
+        createDecisionsAndPlacements(child = testChild_1, period = period)
 
-            updateDecisions(db, vardaClient)
-            updatePlacements(h, vardaClient)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period.start, period.end)
-            )
+        updateDecisions(db, vardaClient)
+        updatePlacements(db, vardaClient)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period.start, period.end)
+        )
 
-            updateFeeData(h)
-            val originalEntry = getVardaFeeDataRows(h)[0]
+        updateFeeData()
+        val originalEntry = getVardaFeeDataRows(db)[0]
 
-            updateFeeData(h)
-            updateFeeData(h)
-            updateFeeData(h)
-            updateFeeData(h)
+        updateFeeData()
+        updateFeeData()
+        updateFeeData()
+        updateFeeData()
 
-            val finalEntry = getVardaFeeDataRows(h)[0]
-            assertEquals(1, mockEndpoint.feeData.size)
-            assertEquals(1, getVardaFeeDataRows(h).size)
-            assertEquals(originalEntry, finalEntry)
-        }
+        val finalEntry = getVardaFeeDataRows(db)[0]
+        assertEquals(1, mockEndpoint.feeData.size)
+        assertEquals(1, getVardaFeeDataRows(db).size)
+        assertEquals(originalEntry, finalEntry)
     }
 
     @Test
     fun `child with various decisions in Varda is handled correctly`() {
-        jdbi.handle { h ->
-            val period1 = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
-            val period2 = ClosedPeriod(period1.end.plusMonths(1), LocalDate.now().plusMonths(6))
-            val child = testChild_1
-            createDecisionsAndPlacements(h = h, child = child, period = period1)
+        val period1 = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
+        val period2 = ClosedPeriod(period1.end.plusMonths(1), LocalDate.now().plusMonths(6))
+        val child = testChild_1
+        createDecisionsAndPlacements(child = child, period = period1)
 
-            updateDecisions(db, vardaClient)
-            updatePlacements(h, vardaClient)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period1.start, period1.end)
-            )
+        updateDecisions(db, vardaClient)
+        updatePlacements(db, vardaClient)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period1.start, period1.end)
+        )
 
-            updateFeeData(h)
-            assertEquals(1, getVardaFeeDataRows(h).size)
+        updateFeeData()
+        assertEquals(1, getVardaFeeDataRows(db).size)
 
+        db.transaction {
             insertTestPlacement(
-                h = h,
+                it.handle,
                 childId = child.id,
                 unitId = testDaycare.id,
                 startDate = period2.start,
                 endDate = period2.end
             )
-            insertServiceNeed(h, child.id, period2)
-            updateDecisions(db, vardaClient)
-            updatePlacements(h, vardaClient)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period2.start, period2.end)
-            )
-
-            updateFeeData(h)
-            assertEquals(2, getVardaFeeDataRows(h).size)
         }
+        insertServiceNeed(db, child.id, period2)
+        updateDecisions(db, vardaClient)
+        updatePlacements(db, vardaClient)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period2.start, period2.end)
+        )
+
+        updateFeeData()
+        assertEquals(2, getVardaFeeDataRows(db).size)
     }
 
     @Test
     fun `child with decision to municipal and purchased units is handled correctly`() {
-        jdbi.handle { h ->
-            val period1 = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
-            val period2 = ClosedPeriod(period1.end.plusMonths(1), LocalDate.now().plusMonths(6))
+        val period1 = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
+        val period2 = ClosedPeriod(period1.end.plusMonths(1), LocalDate.now().plusMonths(6))
 
-            val child = testChild_1
+        val child = testChild_1
 
-            val paosDaycareId = testPurchasedDaycare.id
+        val paosDaycareId = testPurchasedDaycare.id
 
-            updateUnits(db, vardaClient, vardaOrganizerName)
+        updateUnits(db, vardaClient, vardaOrganizerName)
 
-            createDecisionsAndPlacements(h = h, child = child, period = period1, daycareId = paosDaycareId)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(child),
-                objectMapper = objectMapper,
-                period = Period(period1.start, period1.end),
-                daycareId = paosDaycareId
-            )
-            updateFeeData(h)
-            assertEquals(1, getVardaFeeDataRows(h).size)
+        createDecisionsAndPlacements(child = child, period = period1, daycareId = paosDaycareId)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(child),
+            objectMapper = objectMapper,
+            period = Period(period1.start, period1.end),
+            daycareId = paosDaycareId
+        )
+        updateFeeData()
+        assertEquals(1, getVardaFeeDataRows(db).size)
 
-            val daycareId = testDaycare.id
-            createDecisionsAndPlacements(h = h, child = child, period = period2, daycareId = daycareId)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(child),
-                objectMapper = objectMapper,
-                period = Period(period2.start, period2.end),
-                daycareId = daycareId
-            )
-            updateFeeData(h)
+        val daycareId = testDaycare.id
+        createDecisionsAndPlacements(child = child, period = period2, daycareId = daycareId)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(child),
+            objectMapper = objectMapper,
+            period = Period(period2.start, period2.end),
+            daycareId = daycareId
+        )
+        updateFeeData()
 
-            assertEquals(2, getVardaFeeDataRows(h).size)
-        }
+        assertEquals(2, getVardaFeeDataRows(db).size)
     }
 
     @Test
@@ -358,35 +335,35 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             Placement       |-------|  |--|
             Fee data        |-------|  |--|
         */
-        jdbi.handle { h ->
-            val decisionPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6))
-            val firstPlacementPeriod = ClosedPeriod(decisionPeriod.start.plusMonths(1), decisionPeriod.start.plusMonths(2))
-            val secondPlacementPeriod = ClosedPeriod(firstPlacementPeriod.end.plusMonths(1), decisionPeriod.end.minusMonths(1))
-            insertDecisionWithApplication(h, testChild_1, decisionPeriod)
-            insertServiceNeed(h, testChild_1.id, decisionPeriod)
-            insertVardaChild(h, testChild_1.id, Instant.now().minusSeconds(60 * 60 * 24))
-            insertTestPlacement(h = h, childId = testChild_1.id, unitId = testDaycare.id, startDate = firstPlacementPeriod.start, endDate = firstPlacementPeriod.end)
-            insertTestPlacement(h = h, childId = testChild_1.id, unitId = testDaycare.id, startDate = secondPlacementPeriod.start, endDate = secondPlacementPeriod.end)
-            updateDecisions(db, vardaClient)
-            updatePlacements(h, vardaClient)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(decisionPeriod.start, decisionPeriod.end)
-            )
-            updateFeeData(h)
-
-            assertEquals(2, getVardaFeeDataRows(h).size)
-            assertEquals(2, getVardaPlacements(h).size)
-
-            val uploadedFeeData: List<VardaFeeData> = mockEndpoint.feeData.sortedBy { data -> data.startDate }
-            assertEquals(firstPlacementPeriod.start, uploadedFeeData[0].startDate)
-            assertEquals(firstPlacementPeriod.end, uploadedFeeData[0].endDate)
-            assertEquals(secondPlacementPeriod.start, uploadedFeeData[1].startDate)
-            assertEquals(secondPlacementPeriod.end, uploadedFeeData[1].endDate)
+        val decisionPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6))
+        val firstPlacementPeriod = ClosedPeriod(decisionPeriod.start.plusMonths(1), decisionPeriod.start.plusMonths(2))
+        val secondPlacementPeriod = ClosedPeriod(firstPlacementPeriod.end.plusMonths(1), decisionPeriod.end.minusMonths(1))
+        insertDecisionWithApplication(db, testChild_1, decisionPeriod)
+        insertServiceNeed(db, testChild_1.id, decisionPeriod)
+        insertVardaChild(db, testChild_1.id, Instant.now().minusSeconds(60 * 60 * 24))
+        db.transaction {
+            insertTestPlacement(it.handle, childId = testChild_1.id, unitId = testDaycare.id, startDate = firstPlacementPeriod.start, endDate = firstPlacementPeriod.end)
+            insertTestPlacement(it.handle, childId = testChild_1.id, unitId = testDaycare.id, startDate = secondPlacementPeriod.start, endDate = secondPlacementPeriod.end)
         }
+        updateDecisions(db, vardaClient)
+        updatePlacements(db, vardaClient)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(decisionPeriod.start, decisionPeriod.end)
+        )
+        updateFeeData()
+
+        assertEquals(2, getVardaFeeDataRows(db).size)
+        assertEquals(2, getVardaPlacements(db).size)
+
+        val uploadedFeeData: List<VardaFeeData> = mockEndpoint.feeData.sortedBy { data -> data.startDate }
+        assertEquals(firstPlacementPeriod.start, uploadedFeeData[0].startDate)
+        assertEquals(firstPlacementPeriod.end, uploadedFeeData[0].endDate)
+        assertEquals(secondPlacementPeriod.start, uploadedFeeData[1].startDate)
+        assertEquals(secondPlacementPeriod.end, uploadedFeeData[1].endDate)
     }
 
     @Test
@@ -396,383 +373,364 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             Placement       |----------------|
             Fee data        |--------||------|
         */
-        jdbi.handle { h ->
-            val decisionPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6))
-            val feeDecisionsPeriod1 = ClosedPeriod(decisionPeriod.start, decisionPeriod.start.plusMonths(2))
-            val feeDecisionPeriod2 = ClosedPeriod(feeDecisionsPeriod1.end.plusMonths(1), decisionPeriod.end)
-            val placementPeriod = ClosedPeriod(feeDecisionsPeriod1.start.plusMonths(1), feeDecisionPeriod2.end.minusMonths(1))
+        val decisionPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6))
+        val feeDecisionsPeriod1 = ClosedPeriod(decisionPeriod.start, decisionPeriod.start.plusMonths(2))
+        val feeDecisionPeriod2 = ClosedPeriod(feeDecisionsPeriod1.end.plusMonths(1), decisionPeriod.end)
+        val placementPeriod = ClosedPeriod(feeDecisionsPeriod1.start.plusMonths(1), feeDecisionPeriod2.end.minusMonths(1))
 
-            insertDecisionWithApplication(h, testChild_1, decisionPeriod)
-            insertServiceNeed(h, testChild_1.id, decisionPeriod)
-            insertVardaChild(h, testChild_1.id)
-            insertTestPlacement(h = h, childId = testChild_1.id, unitId = testDaycare.id, startDate = placementPeriod.start, endDate = placementPeriod.end)
-            updateDecisions(db, vardaClient)
-            updatePlacements(h, vardaClient)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(feeDecisionsPeriod1.start, feeDecisionsPeriod1.end)
-            )
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1, testChild_2),
-                objectMapper = objectMapper,
-                period = Period(feeDecisionPeriod2.start, feeDecisionPeriod2.end)
-            )
-
-            updateFeeData(h)
-            assertEquals(2, getVardaFeeDataRows(h).size)
-            assertEquals(1, getVardaPlacements(h).size)
-
-            val uploadedFeeData: List<VardaFeeData> = mockEndpoint.feeData.sortedBy { data -> data.startDate }
-            assertEquals(placementPeriod.start, uploadedFeeData[0].startDate)
-            assertEquals(feeDecisionsPeriod1.end, uploadedFeeData[0].endDate)
-            assertEquals(2, uploadedFeeData[0].familySize)
-
-            assertEquals(feeDecisionPeriod2.start, uploadedFeeData[1].startDate)
-            assertEquals(placementPeriod.end, uploadedFeeData[1].endDate)
-            assertEquals(3, uploadedFeeData[1].familySize)
+        insertDecisionWithApplication(db, testChild_1, decisionPeriod)
+        insertServiceNeed(db, testChild_1.id, decisionPeriod)
+        insertVardaChild(db, testChild_1.id)
+        db.transaction {
+            insertTestPlacement(it.handle, childId = testChild_1.id, unitId = testDaycare.id, startDate = placementPeriod.start, endDate = placementPeriod.end)
         }
+        updateDecisions(db, vardaClient)
+        updatePlacements(db, vardaClient)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(feeDecisionsPeriod1.start, feeDecisionsPeriod1.end)
+        )
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1, testChild_2),
+            objectMapper = objectMapper,
+            period = Period(feeDecisionPeriod2.start, feeDecisionPeriod2.end)
+        )
+
+        updateFeeData()
+        assertEquals(2, getVardaFeeDataRows(db).size)
+        assertEquals(1, getVardaPlacements(db).size)
+
+        val uploadedFeeData: List<VardaFeeData> = mockEndpoint.feeData.sortedBy { data -> data.startDate }
+        assertEquals(placementPeriod.start, uploadedFeeData[0].startDate)
+        assertEquals(feeDecisionsPeriod1.end, uploadedFeeData[0].endDate)
+        assertEquals(2, uploadedFeeData[0].familySize)
+
+        assertEquals(feeDecisionPeriod2.start, uploadedFeeData[1].startDate)
+        assertEquals(placementPeriod.end, uploadedFeeData[1].endDate)
+        assertEquals(3, uploadedFeeData[1].familySize)
     }
 
     @Test
     fun `delete fee data entry if its placement is removed`() {
-        jdbi.handle { h ->
-            createDecisionsAndPlacements(h)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-            )
-            updateFeeData(h)
+        createDecisionsAndPlacements()
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
+        )
+        updateFeeData()
 
-            assertEquals(1, getVardaPlacements(h).size)
-            assertEquals(1, getVardaFeeDataRows(h).size)
+        assertEquals(1, getVardaPlacements(db).size)
+        assertEquals(1, getVardaFeeDataRows(db).size)
 
-            clearPlacements(h)
-            updatePlacements(h, vardaClient)
-            updateFeeData(h)
+        clearPlacements(db)
+        updatePlacements(db, vardaClient)
+        updateFeeData()
 
-            assertEquals(0, getVardaPlacements(h).size)
-            assertEquals(0, getVardaFeeDataRows(h).size)
-        }
+        assertEquals(0, getVardaPlacements(db).size)
+        assertEquals(0, getVardaFeeDataRows(db).size)
     }
 
     @Test
     fun `delete all fee data entries of annulled fee decisions`() {
-        jdbi.handle { h ->
-            val decisionPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6))
-            val firstPlacementPeriod = ClosedPeriod(decisionPeriod.start.plusMonths(1), decisionPeriod.start.plusMonths(2))
-            val secondPlacementPeriod = ClosedPeriod(firstPlacementPeriod.end.plusMonths(1), decisionPeriod.end.minusMonths(1))
-            insertDecisionWithApplication(h, testChild_1, decisionPeriod)
-            insertServiceNeed(h, testChild_1.id, decisionPeriod)
-            insertVardaChild(h, testChild_1.id, Instant.now().minusSeconds(60 * 60 * 24))
-            insertTestPlacement(h = h, childId = testChild_1.id, unitId = testDaycare.id, startDate = firstPlacementPeriod.start, endDate = firstPlacementPeriod.end)
-            insertTestPlacement(h = h, childId = testChild_1.id, unitId = testDaycare.id, startDate = secondPlacementPeriod.start, endDate = secondPlacementPeriod.end)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(decisionPeriod.start, decisionPeriod.end)
-            )
-            updateDecisions(db, vardaClient)
-            updatePlacements(h, vardaClient)
-            updateFeeData(h)
-
-            assertEquals(2, getVardaFeeDataRows(h).size)
-
-            setFeeDecisionsAnnulled(h)
-            updateFeeData(h)
-
-            assertEquals(0, getVardaFeeDataRows(h).size)
+        val decisionPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6))
+        val firstPlacementPeriod = ClosedPeriod(decisionPeriod.start.plusMonths(1), decisionPeriod.start.plusMonths(2))
+        val secondPlacementPeriod = ClosedPeriod(firstPlacementPeriod.end.plusMonths(1), decisionPeriod.end.minusMonths(1))
+        insertDecisionWithApplication(db, testChild_1, decisionPeriod)
+        insertServiceNeed(db, testChild_1.id, decisionPeriod)
+        insertVardaChild(db, testChild_1.id, Instant.now().minusSeconds(60 * 60 * 24))
+        db.transaction {
+            insertTestPlacement(it.handle, childId = testChild_1.id, unitId = testDaycare.id, startDate = secondPlacementPeriod.start, endDate = secondPlacementPeriod.end)
+            insertTestPlacement(it.handle, childId = testChild_1.id, unitId = testDaycare.id, startDate = firstPlacementPeriod.start, endDate = firstPlacementPeriod.end)
         }
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(decisionPeriod.start, decisionPeriod.end)
+        )
+        updateDecisions(db, vardaClient)
+        updatePlacements(db, vardaClient)
+        updateFeeData()
+
+        assertEquals(2, getVardaFeeDataRows(db).size)
+
+        setFeeDecisionsAnnulled(db)
+        updateFeeData()
+
+        assertEquals(0, getVardaFeeDataRows(db).size)
     }
 
     @Test
     fun `deleting legacy fee data works`() {
-        jdbi.handle { h ->
-            val feeDecision = insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-            )
-            // language=SQL
-            val sql =
+        val feeDecision = insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
+        )
+        db.transaction {
+            it.createUpdate(
                 """
-                    INSERT INTO varda_fee_data (evaka_fee_decision_id, varda_fee_data_id, evaka_placement_id) 
-                    VALUES (:feeDecisionId, 12333, NULL)
-                """.trimIndent()
-
-            h.createUpdate(sql)
+                INSERT INTO varda_fee_data (evaka_fee_decision_id, varda_fee_data_id, evaka_placement_id)
+                VALUES (:feeDecisionId, 12333, NULL)
+                """
+            )
                 .bind("feeDecisionId", feeDecision.id)
                 .execute()
-
-            assertEquals(1, getVardaFeeDataRows(h).size)
-            updateFeeData(h)
-            assertEquals(0, getVardaFeeDataRows(h).size)
         }
+
+        assertEquals(1, getVardaFeeDataRows(db).size)
+        updateFeeData()
+        assertEquals(0, getVardaFeeDataRows(db).size)
     }
 
     @Test
     fun `modify fee data entry when placement is modified`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-            createDecisionsAndPlacements(h, period = period)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period.start, period.end)
-            )
-            updateFeeData(h)
+        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
+        createDecisionsAndPlacements(period = period)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period.start, period.end)
+        )
+        updateFeeData()
 
-            assertEquals(1, getVardaFeeDataRows(h).size)
-            val originalFeeData = mockEndpoint.feeData[0]
-            assertEquals(period.start, originalFeeData.startDate)
-            assertEquals(period.end, originalFeeData.endDate)
+        assertEquals(1, getVardaFeeDataRows(db).size)
+        val originalFeeData = mockEndpoint.feeData[0]
+        assertEquals(period.start, originalFeeData.startDate)
+        assertEquals(period.end, originalFeeData.endDate)
 
-            val newStart = period.start.plusDays(1)
-            val newEnd = period.end.minusDays(1)
-            // language=SQL
-            val sql =
-                """
-                    UPDATE placement SET start_date = :newStart, end_date = :newEnd WHERE 1 = 1
-                """.trimIndent()
-
-            h.createUpdate(sql)
+        val newStart = period.start.plusDays(1)
+        val newEnd = period.end.minusDays(1)
+        db.transaction {
+            it.createUpdate("UPDATE placement SET start_date = :newStart, end_date = :newEnd WHERE 1 = 1")
                 .bind("newStart", newStart)
                 .bind("newEnd", newEnd)
                 .execute()
-
-            updateFeeData(h)
-
-            val newFeeData = mockEndpoint.feeData[0]
-            assertNotEquals(originalFeeData.startDate, newFeeData.startDate)
-            assertNotEquals(originalFeeData.endDate, newFeeData.endDate)
-            assertEquals(newStart, newFeeData.startDate)
-            assertEquals(newEnd, newFeeData.endDate)
         }
+
+        updateFeeData()
+
+        val newFeeData = mockEndpoint.feeData[0]
+        assertNotEquals(originalFeeData.startDate, newFeeData.startDate)
+        assertNotEquals(originalFeeData.endDate, newFeeData.endDate)
+        assertEquals(newStart, newFeeData.startDate)
+        assertEquals(newEnd, newFeeData.endDate)
     }
 
     @Test
     fun `modifying fee data updates the timestamp`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-            createDecisionsAndPlacements(h, period = period)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period.start, period.end)
-            )
-            updateFeeData(h)
+        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
+        createDecisionsAndPlacements(period = period)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period.start, period.end)
+        )
+        updateFeeData()
 
-            assertEquals(1, getVardaFeeDataRows(h).size)
-            val originalEntry = getVardaFeeDataRows(h)[0]
+        assertEquals(1, getVardaFeeDataRows(db).size)
+        val originalEntry = getVardaFeeDataRows(db)[0]
 
-            val newStart = period.start.plusDays(1)
-            // language=SQL
-            val sql =
-                """
-                    UPDATE placement SET start_date = :newStart WHERE 1 = 1
-                """.trimIndent()
-
-            h.createUpdate(sql)
+        val newStart = period.start.plusDays(1)
+        db.transaction {
+            it.createUpdate("UPDATE placement SET start_date = :newStart WHERE 1 = 1")
                 .bind("newStart", newStart)
                 .execute()
-
-            updateFeeData(h)
-
-            val finalEntry = getVardaFeeDataRows(h)[0]
-            assertNotEquals(originalEntry, finalEntry)
-            assertTrue(originalEntry.uploadedAt < finalEntry.uploadedAt)
         }
+
+        updateFeeData()
+
+        val finalEntry = getVardaFeeDataRows(db)[0]
+        assertNotEquals(originalEntry, finalEntry)
+        assertTrue(originalEntry.uploadedAt < finalEntry.uploadedAt)
     }
 
     @Test
     fun `fee data is soft deleted if it is flagged with should_be_deleted`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-            createDecisionsAndPlacements(h, period = period)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period.start, period.end)
-            )
-            updateFeeData(h)
+        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
+        createDecisionsAndPlacements(period = period)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period.start, period.end)
+        )
+        updateFeeData()
 
-            assertEquals(1, getVardaFeeDataRows(h).size)
-            assertEquals(0, getSoftDeletedVardaFeeData(h).size)
+        assertEquals(1, getVardaFeeDataRows(db).size)
+        assertEquals(0, getSoftDeletedVardaFeeData(db).size)
 
-            h.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute()
+        db.transaction { it.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute() }
 
-            removeMarkedFeeDataFromVarda(db, vardaClient)
-            assertEquals(1, getSoftDeletedVardaFeeData(h).size)
-        }
+        removeMarkedFeeDataFromVarda(db, vardaClient)
+        assertEquals(1, getSoftDeletedVardaFeeData(db).size)
     }
 
     @Test
     fun `fee_data is not updated if upload flag is turned off`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
 
-            createDecisionsAndPlacements(h, period = period)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period.start, period.end)
-            )
+        createDecisionsAndPlacements(period = period)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period.start, period.end)
+        )
 
-            updateAll(h)
+        updateAll()
 
-            assertEquals(1, mockEndpoint.feeData.size)
+        assertEquals(1, mockEndpoint.feeData.size)
 
-            h.createUpdate("UPDATE daycare SET upload_to_varda = false WHERE id = :id").bind("id", testDaycare.id).execute()
-
-            h.createUpdate("UPDATE placement SET start_date = :newStart")
+        db.transaction {
+            it.createUpdate("UPDATE daycare SET upload_to_varda = false WHERE id = :id").bind("id", testDaycare.id).execute()
+            it.createUpdate("UPDATE placement SET start_date = :newStart")
                 .bind("newStart", period.start.minusMonths(1))
                 .execute()
-
-            updateAll(h)
-
-            val feeData = mockEndpoint.feeData
-            assertEquals(1, feeData.size)
-            assertEquals(period.start, feeData[0].startDate)
         }
+
+        updateAll()
+
+        val feeData = mockEndpoint.feeData
+        assertEquals(1, feeData.size)
+        assertEquals(period.start, feeData[0].startDate)
     }
 
     @Test
     fun `updating daycare organizer oid yields new varda fee data row if old is soft deleted`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
 
-            createDecisionsAndPlacements(h, period = period)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period.start, period.end)
-            )
+        createDecisionsAndPlacements(period = period)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period.start, period.end)
+        )
 
-            updateAll(h)
+        updateAll()
 
-            assertEquals(1, getVardaFeeDataRows(h).size)
+        assertEquals(1, getVardaFeeDataRows(db).size)
 
-            h.createUpdate("update varda_fee_data set should_be_deleted = true, deleted_at = NOW()").execute()
-            h.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id")
+        db.transaction {
+            it.createUpdate("update varda_fee_data set should_be_deleted = true, deleted_at = NOW()").execute()
+            it.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id")
                 .bind("id", testDaycare.id)
                 .execute()
-
-            updateAll(h)
-
-            assertEquals(2, getVardaFeeDataRows(h).size)
         }
+
+        updateAll()
+
+        assertEquals(2, getVardaFeeDataRows(db).size)
     }
 
     @Test
     fun `fee data is sent once if it's soft deleted`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-            createDecisionsAndPlacements(h, period = period)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period.start, period.end)
-            )
-            updateAll(h)
+        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
+        createDecisionsAndPlacements(period = period)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period.start, period.end)
+        )
+        updateAll()
 
-            assertEquals(1, getVardaFeeDataRows(h).size)
-            assertEquals(0, getSoftDeletedVardaFeeData(h).size)
+        assertEquals(1, getVardaFeeDataRows(db).size)
+        assertEquals(0, getSoftDeletedVardaFeeData(db).size)
 
-            h.createUpdate("UPDATE varda_placement SET should_be_deleted = true").execute()
-            h.createUpdate("UPDATE varda_decision SET should_be_deleted = true").execute()
-            h.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute()
-            h.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id").bind("id", testDaycare.id).execute()
-
-            removeMarkedPlacementsFromVarda(db, vardaClient)
-            removeMarkedDecisionsFromVarda(db, vardaClient)
-            removeMarkedFeeDataFromVarda(db, vardaClient)
-            mockEndpoint.feeData.clear()
-
-            updateAll(h)
-            assertEquals(2, getVardaFeeDataRows(h).size)
-            assertEquals(1, getSoftDeletedVardaFeeData(h).size)
-            assertEquals(1, mockEndpoint.feeData.size)
-
-            updateAll(h)
-            assertEquals(2, getVardaFeeDataRows(h).size)
-            assertEquals(1, mockEndpoint.feeData.size)
+        db.transaction {
+            it.createUpdate("UPDATE varda_placement SET should_be_deleted = true").execute()
+            it.createUpdate("UPDATE varda_decision SET should_be_deleted = true").execute()
+            it.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute()
+            it.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id").bind("id", testDaycare.id).execute()
         }
+
+        removeMarkedPlacementsFromVarda(db, vardaClient)
+        removeMarkedDecisionsFromVarda(db, vardaClient)
+        removeMarkedFeeDataFromVarda(db, vardaClient)
+        mockEndpoint.feeData.clear()
+
+        updateAll()
+        assertEquals(2, getVardaFeeDataRows(db).size)
+        assertEquals(1, getSoftDeletedVardaFeeData(db).size)
+        assertEquals(1, mockEndpoint.feeData.size)
+
+        updateAll()
+        assertEquals(2, getVardaFeeDataRows(db).size)
+        assertEquals(1, mockEndpoint.feeData.size)
     }
 
     @Test
     fun `fee data is not sent multiple times for multiple fee decisions`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-            val period2 = ClosedPeriod(period.start.minusMonths(6), period.start.minusMonths(1))
-            createDecisionsAndPlacements(h, period = period)
-            createDecisionsAndPlacements(h, period = period2)
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period.start, period.end)
-            )
-            insertFeeDecision(
-                h = h,
-                status = FeeDecisionStatus.SENT,
-                children = listOf(testChild_1),
-                objectMapper = objectMapper,
-                period = Period(period2.start, period2.end)
-            )
-            updateAll(h)
+        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
+        val period2 = ClosedPeriod(period.start.minusMonths(6), period.start.minusMonths(1))
+        createDecisionsAndPlacements(period = period)
+        createDecisionsAndPlacements(period = period2)
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period.start, period.end)
+        )
+        insertFeeDecision(
+            db,
+            status = FeeDecisionStatus.SENT,
+            children = listOf(testChild_1),
+            objectMapper = objectMapper,
+            period = Period(period2.start, period2.end)
+        )
+        updateAll()
 
-            assertEquals(2, getVardaFeeDataRows(h).size)
-            assertEquals(0, getSoftDeletedVardaFeeData(h).size)
+        assertEquals(2, getVardaFeeDataRows(db).size)
+        assertEquals(0, getSoftDeletedVardaFeeData(db).size)
 
-            h.createUpdate("UPDATE varda_placement SET should_be_deleted = true").execute()
-            h.createUpdate("UPDATE varda_decision SET should_be_deleted = true").execute()
-            h.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute()
-            h.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id").bind("id", testDaycare.id).execute()
-
-            removeMarkedPlacementsFromVarda(db, vardaClient)
-            removeMarkedDecisionsFromVarda(db, vardaClient)
-            removeMarkedFeeDataFromVarda(db, vardaClient)
-            mockEndpoint.feeData.clear()
-
-            updateAll(h)
-            assertEquals(4, getVardaFeeDataRows(h).size)
-            assertEquals(2, getSoftDeletedVardaFeeData(h).size)
-            assertEquals(2, mockEndpoint.feeData.size)
-
-            updateAll(h)
-            assertEquals(4, getVardaFeeDataRows(h).size)
-            assertEquals(2, mockEndpoint.feeData.size)
+        db.transaction {
+            it.createUpdate("UPDATE varda_placement SET should_be_deleted = true").execute()
+            it.createUpdate("UPDATE varda_decision SET should_be_deleted = true").execute()
+            it.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute()
+            it.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id").bind("id", testDaycare.id).execute()
         }
+
+        removeMarkedPlacementsFromVarda(db, vardaClient)
+        removeMarkedDecisionsFromVarda(db, vardaClient)
+        removeMarkedFeeDataFromVarda(db, vardaClient)
+        mockEndpoint.feeData.clear()
+
+        updateAll()
+        assertEquals(4, getVardaFeeDataRows(db).size)
+        assertEquals(2, getSoftDeletedVardaFeeData(db).size)
+        assertEquals(2, mockEndpoint.feeData.size)
+
+        updateAll()
+        assertEquals(4, getVardaFeeDataRows(db).size)
+        assertEquals(2, mockEndpoint.feeData.size)
     }
 
     @Test
     fun `child whose guardians has no name is not sent to Varda`() {
-        jdbi.handle { h ->
-            h.insertTestPerson(
+        db.transaction {
+            it.handle.insertTestPerson(
                 DevPerson(
                     id = childWithNamelessParent.id,
                     dateOfBirth = childWithNamelessParent.dateOfBirth,
@@ -784,80 +742,81 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
                     postOffice = childWithNamelessParent.postOffice!!
                 )
             )
-            h.insertTestChild(DevChild(id = childWithNamelessParent.id))
-
-            // Niilo Nimettömänpoika's guardian doesn't have a name in mock VTJ data
-            createDecisionsAndPlacements(h = h, child = childWithNamelessParent)
-            insertFeeDecision(h, FeeDecisionStatus.SENT, listOf(childWithNamelessParent), objectMapper)
-
-            updateFeeData(h)
-
-            assertEquals(0, getVardaFeeDataRows(h).size)
+            it.handle.insertTestChild(DevChild(id = childWithNamelessParent.id))
         }
+
+        // Niilo Nimettömänpoika's guardian doesn't have a name in mock VTJ data
+        createDecisionsAndPlacements(child = childWithNamelessParent)
+        insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(childWithNamelessParent), objectMapper)
+
+        updateFeeData()
+
+        assertEquals(0, getVardaFeeDataRows(db).size)
     }
 
-    private fun updateAll(h: Handle) {
+    private fun updateAll() {
         updateChildren(db, vardaClient, vardaOrganizerName)
         updateDecisions(db, vardaClient)
-        updatePlacements(h, vardaClient)
-        updateFeeData(h)
+        updatePlacements(db, vardaClient)
+        updateFeeData()
     }
 
-    private fun updateFeeData(h: Handle) {
-        h.transaction {
-            updateFeeData(Database.Transaction.wrap(it), vardaClient, objectMapper, personService)
-        }
+    private fun updateFeeData() {
+        updateFeeData(db, vardaClient, objectMapper, personService)
     }
 
     private fun createDecisionsAndPlacements(
-        h: Handle,
         child: PersonData.Detailed = testChild_1,
         period: ClosedPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6)),
         daycareId: UUID = testDaycare.id
     ) {
-        insertDecisionWithApplication(h, child, period, unitId = daycareId)
-        insertServiceNeed(h, child.id, period)
-        insertTestPlacement(
-            h = h,
-            childId = child.id,
-            unitId = daycareId,
-            startDate = period.start,
-            endDate = period.end
-        )
+        insertDecisionWithApplication(db, child, period, unitId = daycareId)
+        insertServiceNeed(db, child.id, period)
+        db.transaction {
+            insertTestPlacement(
+                h = it.handle,
+                childId = child.id,
+                unitId = daycareId,
+                startDate = period.start,
+                endDate = period.end
+            )
+        }
         updateChildren(db, vardaClient, organizerName = vardaOrganizerName)
         updateDecisions(db, vardaClient)
-        updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
     }
 }
 
-private fun getSoftDeletedVardaFeeData(h: Handle): List<VardaFeeDataRow> =
-    h.createQuery("SELECT * FROM varda_fee_data WHERE deleted_at IS NOT NULL")
+private fun getSoftDeletedVardaFeeData(db: Database.Connection): List<VardaFeeDataRow> = db.read {
+    it.createQuery("SELECT * FROM varda_fee_data WHERE deleted_at IS NOT NULL")
         .mapTo<VardaFeeDataRow>().list() ?: emptyList()
+}
 
-private fun clearVardaPlacements(h: Handle) {
-    h.createUpdate("TRUNCATE varda_placement")
+private fun clearVardaPlacements(db: Database.Connection) = db.transaction {
+    it.createUpdate("TRUNCATE varda_placement")
         .execute()
 }
 
-private fun setFeeDecisionsAnnulled(h: Handle) {
-    h.createUpdate("UPDATE fee_decision SET status = :annulledStatus")
+private fun setFeeDecisionsAnnulled(db: Database.Connection) = db.transaction {
+    it.createUpdate("UPDATE fee_decision SET status = :annulledStatus")
         .bind("annulledStatus", FeeDecisionStatus.ANNULLED)
         .execute()
 }
 
-private fun getVardaFeeDataRows(h: Handle): List<VardaFeeDataRow> =
-    h.createQuery("SELECT * FROM varda_fee_data")
+private fun getVardaFeeDataRows(db: Database.Connection): List<VardaFeeDataRow> = db.read {
+    it.createQuery("SELECT * FROM varda_fee_data")
         .mapTo<VardaFeeDataRow>().list() ?: emptyList()
+}
 
 private fun insertFeeDecision(
-    h: Handle,
+    db: Database.Connection,
     status: FeeDecisionStatus,
     children: List<PersonData.Detailed>,
     objectMapper: ObjectMapper,
     period: Period = Period(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6)),
     placementType: PlacementType = PlacementType.DAYCARE,
     daycareId: UUID = testDaycare.id
-): FeeDecision {
+): FeeDecision = db.transaction {
     val feeDecision = createFeeDecisionFixture(
         status = status,
         decisionType = FeeDecisionType.NORMAL,
@@ -872,12 +831,12 @@ private fun insertFeeDecision(
             )
         }
     )
-    upsertFeeDecisions(h, objectMapper, listOf(feeDecision))
-    return feeDecision
+    upsertFeeDecisions(it.handle, objectMapper, listOf(feeDecision))
+    feeDecision
 }
 
-private fun clearPlacements(h: Handle) {
-    h.createUpdate("DELETE FROM placement WHERE 1 = 1")
+private fun clearPlacements(db: Database.Connection) = db.transaction {
+    it.createUpdate("DELETE FROM placement WHERE 1 = 1")
         .execute()
 }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -618,7 +618,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
             h.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute()
 
-            removeMarkedFeeDataFromVarda(h, vardaClient)
+            removeMarkedFeeDataFromVarda(db, vardaClient)
             assertEquals(1, getSoftDeletedVardaFeeData(h).size)
         }
     }
@@ -706,9 +706,9 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             h.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute()
             h.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id").bind("id", testDaycare.id).execute()
 
-            removeMarkedPlacementsFromVarda(h, vardaClient)
-            removeMarkedDecisionsFromVarda(h, vardaClient)
-            removeMarkedFeeDataFromVarda(h, vardaClient)
+            removeMarkedPlacementsFromVarda(db, vardaClient)
+            removeMarkedDecisionsFromVarda(db, vardaClient)
+            removeMarkedFeeDataFromVarda(db, vardaClient)
             mockEndpoint.feeData.clear()
 
             updateAll(h)
@@ -753,9 +753,9 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             h.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute()
             h.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id").bind("id", testDaycare.id).execute()
 
-            removeMarkedPlacementsFromVarda(h, vardaClient)
-            removeMarkedDecisionsFromVarda(h, vardaClient)
-            removeMarkedFeeDataFromVarda(h, vardaClient)
+            removeMarkedPlacementsFromVarda(db, vardaClient)
+            removeMarkedDecisionsFromVarda(db, vardaClient)
+            removeMarkedFeeDataFromVarda(db, vardaClient)
             mockEndpoint.feeData.clear()
 
             updateAll(h)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -797,7 +797,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
     }
 
     private fun updateAll(h: Handle) {
-        updateChildren(h, vardaClient, vardaOrganizerName)
+        updateChildren(db, vardaClient, vardaOrganizerName)
         updateDecisions(h, vardaClient)
         updatePlacements(h, vardaClient)
         updateFeeData(h)
@@ -824,7 +824,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             startDate = period.start,
             endDate = period.end
         )
-        updateChildren(h, vardaClient, organizerName = vardaOrganizerName)
+        updateChildren(db, vardaClient, organizerName = vardaOrganizerName)
         updateDecisions(h, vardaClient)
         updatePlacements(h, vardaClient)
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -321,7 +321,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
             val paosDaycareId = testPurchasedDaycare.id
 
-            updateUnits(h, vardaClient, vardaOrganizerName)
+            updateUnits(db, vardaClient, vardaOrganizerName)
 
             createDecisionsAndPlacements(h = h, child = child, period = period1, daycareId = paosDaycareId)
             insertFeeDecision(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -96,7 +96,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
                 startDate = period.start,
                 endDate = period.end
             )
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             updatePlacements(h, vardaClient)
 
             val feeDecision = insertFeeDecision(
@@ -242,7 +242,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
             createDecisionsAndPlacements(h = h, child = testChild_1, period = period)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             updatePlacements(h, vardaClient)
             insertFeeDecision(
                 h = h,
@@ -275,7 +275,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             val child = testChild_1
             createDecisionsAndPlacements(h = h, child = child, period = period1)
 
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             updatePlacements(h, vardaClient)
             insertFeeDecision(
                 h = h,
@@ -296,7 +296,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
                 endDate = period2.end
             )
             insertServiceNeed(h, child.id, period2)
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             updatePlacements(h, vardaClient)
             insertFeeDecision(
                 h = h,
@@ -367,7 +367,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             insertVardaChild(h, testChild_1.id, Instant.now().minusSeconds(60 * 60 * 24))
             insertTestPlacement(h = h, childId = testChild_1.id, unitId = testDaycare.id, startDate = firstPlacementPeriod.start, endDate = firstPlacementPeriod.end)
             insertTestPlacement(h = h, childId = testChild_1.id, unitId = testDaycare.id, startDate = secondPlacementPeriod.start, endDate = secondPlacementPeriod.end)
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             updatePlacements(h, vardaClient)
             insertFeeDecision(
                 h = h,
@@ -406,7 +406,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             insertServiceNeed(h, testChild_1.id, decisionPeriod)
             insertVardaChild(h, testChild_1.id)
             insertTestPlacement(h = h, childId = testChild_1.id, unitId = testDaycare.id, startDate = placementPeriod.start, endDate = placementPeriod.end)
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             updatePlacements(h, vardaClient)
             insertFeeDecision(
                 h = h,
@@ -481,7 +481,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
                 objectMapper = objectMapper,
                 period = Period(decisionPeriod.start, decisionPeriod.end)
             )
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             updatePlacements(h, vardaClient)
             updateFeeData(h)
 
@@ -798,7 +798,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
     private fun updateAll(h: Handle) {
         updateChildren(db, vardaClient, vardaOrganizerName)
-        updateDecisions(h, vardaClient)
+        updateDecisions(db, vardaClient)
         updatePlacements(h, vardaClient)
         updateFeeData(h)
     }
@@ -825,7 +825,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             endDate = period.end
         )
         updateChildren(db, vardaClient, organizerName = vardaOrganizerName)
-        updateDecisions(h, vardaClient)
+        updateDecisions(db, vardaClient)
         updatePlacements(h, vardaClient)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.PlacementType.DAYCARE
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.dev.insertTestPlacement
@@ -44,7 +45,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             insertVardaUnit(h)
             val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            val vardaDecisionId = insertTestVardaDecision(h, decisionId = decisionId)
+            val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
             val placementId = insertPlacement(h, testChild_1.id, period)
 
             updatePlacements(h, vardaClient)
@@ -81,10 +82,10 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             val decisionId = insertDecisionWithApplication(h, testChild_1, period, unitId = daycareId)
 
-            val vardaUnits = getVardaUnits(h)
+            val vardaUnits = getVardaUnits(db)
             assertNull(vardaUnits.find { it.evakaDaycareId == daycareId })
 
-            insertTestVardaDecision(h, decisionId = decisionId)
+            insertTestVardaDecision(db, decisionId = decisionId)
             insertPlacement(h, testChild_1.id, period, unitId = daycareId)
 
             updatePlacements(h, vardaClient)
@@ -100,7 +101,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.now().plusMonths(1), LocalDate.now().plusYears(1))
             insertVardaUnit(h)
             val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            insertTestVardaDecision(h, decisionId = decisionId)
+            insertTestVardaDecision(db, decisionId = decisionId)
             insertPlacement(h, testChild_1.id, period)
 
             updatePlacements(h, vardaClient)
@@ -117,7 +118,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             insertVardaUnit(h)
             val decisionId =
                 insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
-            insertTestVardaDecision(h, decisionId = decisionId)
+            insertTestVardaDecision(db, decisionId = decisionId)
             insertPlacement(h, testChild_1.id, period, type = PlacementType.PRESCHOOL)
 
             updatePlacements(h, vardaClient)
@@ -134,7 +135,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             insertVardaUnit(h)
             val decisionId =
                 insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
-            val vardaDecisionId = insertTestVardaDecision(h, decisionId = decisionId)
+            val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
             val placementId = insertPlacement(h, testChild_1.id, period, type = PlacementType.PRESCHOOL_DAYCARE)
 
             updatePlacements(h, vardaClient)
@@ -152,7 +153,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             insertVardaUnit(h)
             val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            val vardaDecisionId = insertTestVardaDecision(h, decisionId = decisionId)
+            val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
             val placementId1 = insertPlacement(h, testChild_1.id, period.copy(end = period.start.plusDays(5)))
             val placementId2 = insertPlacement(
                 h,
@@ -178,7 +179,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             insertVardaUnit(h)
             val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            insertTestVardaDecision(h, decisionId = decisionId)
+            insertTestVardaDecision(db, decisionId = decisionId)
             insertPlacement(h, testChild_1.id, period)
 
             updatePlacements(h, vardaClient)
@@ -200,7 +201,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             insertVardaUnit(h)
             val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            insertTestVardaDecision(h, decisionId = decisionId)
+            insertTestVardaDecision(db, decisionId = decisionId)
             val placementId = insertPlacement(h, testChild_1.id, period.copy(end = period.start.plusDays(5)))
             insertPlacement(
                 h,
@@ -229,7 +230,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             insertVardaUnit(h)
             val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            insertTestVardaDecision(h, decisionId = decisionId)
+            insertTestVardaDecision(db, decisionId = decisionId)
             val placementId = insertPlacement(h, testChild_1.id, period)
 
             updatePlacements(h, vardaClient)
@@ -250,7 +251,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             insertVardaUnit(h)
             val placementId = insertPlacement(h, testChild_1.id, period)
-            insertTestVardaDecision(h, placementId = placementId)
+            insertTestVardaDecision(db, placementId = placementId)
 
             updatePlacements(h, vardaClient)
 
@@ -266,7 +267,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             insertVardaUnit(h = h, unitOid = null)
             val placementId = insertPlacement(h, testChild_1.id, period)
-            insertTestVardaDecision(h, placementId = placementId)
+            insertTestVardaDecision(db, placementId = placementId)
 
             updatePlacements(h, vardaClient)
 
@@ -281,7 +282,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             insertVardaUnit(h)
             val placementId = insertPlacement(h, testChild_1.id, period)
-            insertTestVardaDecision(h, placementId = placementId)
+            insertTestVardaDecision(db, placementId = placementId)
 
             updatePlacements(h, vardaClient)
 
@@ -304,7 +305,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
             insertVardaUnit(h, unitId = unitId)
             val placementId = insertPlacement(h, testChild_1.id, unitId = unitId, period = period)
-            insertTestVardaDecision(h, placementId = placementId)
+            insertTestVardaDecision(db, placementId = placementId)
 
             updatePlacements(h, vardaClient)
 
@@ -328,7 +329,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
             insertPlacementWithDecision(h, child = testChild_1, unitId = testDaycare.id, period = period)
 
             updateChildren(db, vardaClient, vardaOrganizerName)
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             updatePlacements(h, vardaClient)
 
             assertEquals(1, getVardaPlacements(h).size)
@@ -341,7 +342,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
                 .execute()
 
             updateChildren(db, vardaClient, vardaOrganizerName)
-            updateDecisions(h, vardaClient)
+            updateDecisions(db, vardaClient)
             updatePlacements(h, vardaClient)
 
             assertEquals(2, getVardaPlacements(h).size)
@@ -380,19 +381,21 @@ VALUES (:evakaDaycareId, :vardaUnitId,  :createdAt, :uploadedAt)
     }
 }
 
-internal fun insertTestVardaDecision(h: Handle, decisionId: UUID? = null, placementId: UUID? = null): UUID {
+internal fun insertTestVardaDecision(db: Database.Connection, decisionId: UUID? = null, placementId: UUID? = null): UUID {
     val id = UUID.randomUUID()
-    insertVardaDecision(
-        h,
-        VardaDecisionTableRow(
-            id = id,
-            vardaDecisionId = 123L,
-            evakaDecisionId = decisionId,
-            evakaPlacementId = placementId,
-            createdAt = Instant.now(),
-            uploadedAt = Instant.now()
+    db.transaction {
+        insertVardaDecision(
+            it,
+            VardaDecisionTableRow(
+                id = id,
+                vardaDecisionId = 123L,
+                evakaDecisionId = decisionId,
+                evakaPlacementId = placementId,
+                createdAt = Instant.now(),
+                uploadedAt = Instant.now()
+            )
         )
-    )
+    }
     return id
 }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -290,7 +290,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
 
             h.createUpdate("UPDATE varda_placement SET should_be_deleted = true").execute()
 
-            removeMarkedPlacementsFromVarda(h, vardaClient)
+            removeMarkedPlacementsFromVarda(db, vardaClient)
             updatePlacements(h, vardaClient)
 
             assertEquals(1, getSoftDeletedVardaPlacements(h).size)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -12,12 +12,10 @@ import fi.espoo.evaka.placement.PlacementType.DAYCARE
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -41,326 +39,303 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `a daycare placement is sent when the corresponding decision has been sent`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h)
-            val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
-            val placementId = insertPlacement(h, testChild_1.id, period)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        val decisionId = insertDecisionWithApplication(db, testChild_1, period)
+        val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
+        val placementId = insertPlacement(db, testChild_1.id, period)
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(1, result.size)
-            assertEquals(placementId, result.first().evakaPlacementId)
-            assertEquals(vardaDecisionId, result.first().decisionId)
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(1, result.size)
+        assertEquals(placementId, result.first().evakaPlacementId)
+        assertEquals(vardaDecisionId, result.first().decisionId)
     }
 
     @Test
     fun `a daycare placement is not sent when the corresponding varda decision is missing`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h)
-            insertDecisionWithApplication(h, testChild_1, period)
-            insertPlacement(h, testChild_1.id, period)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        insertDecisionWithApplication(db, testChild_1, period)
+        insertPlacement(db, testChild_1.id, period)
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(0, result.size)
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `a daycare placement is sent if upload_to_varda flag is true even if the corresponding varda unit is missing`() {
-        jdbi.handle { h ->
-            val daycareId = testDaycare.id
-            h.createUpdate("update daycare set upload_to_varda = true where id = :id")
+        val daycareId = testDaycare.id
+        db.transaction {
+            it.createUpdate("update daycare set upload_to_varda = true where id = :id")
                 .bind("id", daycareId)
                 .execute()
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            val decisionId = insertDecisionWithApplication(h, testChild_1, period, unitId = daycareId)
-
-            val vardaUnits = getVardaUnits(db)
-            assertNull(vardaUnits.find { it.evakaDaycareId == daycareId })
-
-            insertTestVardaDecision(db, decisionId = decisionId)
-            insertPlacement(h, testChild_1.id, period, unitId = daycareId)
-
-            updatePlacements(h, vardaClient)
-
-            val result = getVardaPlacements(h)
-            assertEquals(1, result.size)
         }
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val decisionId = insertDecisionWithApplication(db, testChild_1, period, unitId = daycareId)
+
+        val vardaUnits = getVardaUnits(db)
+        assertNull(vardaUnits.find { it.evakaDaycareId == daycareId })
+
+        insertTestVardaDecision(db, decisionId = decisionId)
+        insertPlacement(db, testChild_1.id, period, unitId = daycareId)
+
+        updatePlacements(db, vardaClient)
+
+        val result = getVardaPlacements(db)
+        assertEquals(1, result.size)
     }
 
     @Test
     fun `a daycare placement is not sent when starts in the future`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.now().plusMonths(1), LocalDate.now().plusYears(1))
-            insertVardaUnit(h)
-            val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            insertTestVardaDecision(db, decisionId = decisionId)
-            insertPlacement(h, testChild_1.id, period)
+        val period = ClosedPeriod(LocalDate.now().plusMonths(1), LocalDate.now().plusYears(1))
+        insertVardaUnit(db)
+        val decisionId = insertDecisionWithApplication(db, testChild_1, period)
+        insertTestVardaDecision(db, decisionId = decisionId)
+        insertPlacement(db, testChild_1.id, period)
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(0, result.size)
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `a preschool placement is not sent`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h)
-            val decisionId =
-                insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
-            insertTestVardaDecision(db, decisionId = decisionId)
-            insertPlacement(h, testChild_1.id, period, type = PlacementType.PRESCHOOL)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        val decisionId =
+            insertDecisionWithApplication(db, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
+        insertTestVardaDecision(db, decisionId = decisionId)
+        insertPlacement(db, testChild_1.id, period, type = PlacementType.PRESCHOOL)
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(0, result.size)
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `a preschool daycare placement is not sent`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h)
-            val decisionId =
-                insertDecisionWithApplication(h, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
-            val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
-            val placementId = insertPlacement(h, testChild_1.id, period, type = PlacementType.PRESCHOOL_DAYCARE)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        val decisionId =
+            insertDecisionWithApplication(db, testChild_1, period, decisionType = DecisionType.PRESCHOOL_DAYCARE)
+        val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
+        val placementId = insertPlacement(db, testChild_1.id, period, type = PlacementType.PRESCHOOL_DAYCARE)
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(1, result.size)
-            assertEquals(placementId, result.first().evakaPlacementId)
-            assertEquals(vardaDecisionId, result.first().decisionId)
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(1, result.size)
+        assertEquals(placementId, result.first().evakaPlacementId)
+        assertEquals(vardaDecisionId, result.first().decisionId)
     }
 
     @Test
     fun `multiple daycare placements are all sent`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h)
-            val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
-            val placementId1 = insertPlacement(h, testChild_1.id, period.copy(end = period.start.plusDays(5)))
-            val placementId2 = insertPlacement(
-                h,
-                testChild_1.id,
-                period.copy(start = period.start.plusDays(6), end = period.start.plusDays(10))
-            )
-            val placementId3 = insertPlacement(h, testChild_1.id, period.copy(start = period.start.plusDays(11)))
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        val decisionId = insertDecisionWithApplication(db, testChild_1, period)
+        val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
+        val placementId1 = insertPlacement(db, testChild_1.id, period.copy(end = period.start.plusDays(5)))
+        val placementId2 = insertPlacement(
+            db,
+            testChild_1.id,
+            period.copy(start = period.start.plusDays(6), end = period.start.plusDays(10))
+        )
+        val placementId3 = insertPlacement(db, testChild_1.id, period.copy(start = period.start.plusDays(11)))
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(3, result.size)
-            assertTrue(result.any { p -> p.evakaPlacementId == placementId1 })
-            assertTrue(result.any { p -> p.evakaPlacementId == placementId2 })
-            assertTrue(result.any { p -> p.evakaPlacementId == placementId3 })
-            assertTrue(result.all { p -> p.decisionId == vardaDecisionId })
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(3, result.size)
+        assertTrue(result.any { p -> p.evakaPlacementId == placementId1 })
+        assertTrue(result.any { p -> p.evakaPlacementId == placementId2 })
+        assertTrue(result.any { p -> p.evakaPlacementId == placementId3 })
+        assertTrue(result.all { p -> p.decisionId == vardaDecisionId })
     }
 
     @Test
     fun `varda placement is deleted when the original placement is deleted`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h)
-            val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            insertTestVardaDecision(db, decisionId = decisionId)
-            insertPlacement(h, testChild_1.id, period)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        val decisionId = insertDecisionWithApplication(db, testChild_1, period)
+        insertTestVardaDecision(db, decisionId = decisionId)
+        insertPlacement(db, testChild_1.id, period)
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            val beforeDelete = getVardaPlacements(h)
-            assertEquals(1, beforeDelete.size)
+        val beforeDelete = getVardaPlacements(db)
+        assertEquals(1, beforeDelete.size)
 
-            h.createUpdate("DELETE FROM placement").execute()
-            updatePlacements(h, vardaClient)
+        db.transaction { it.createUpdate("DELETE FROM placement").execute() }
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(0, result.size)
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `varda placement is deleted when the original placement is deleted with multiple placements`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h)
-            val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            insertTestVardaDecision(db, decisionId = decisionId)
-            val placementId = insertPlacement(h, testChild_1.id, period.copy(end = period.start.plusDays(5)))
-            insertPlacement(
-                h,
-                testChild_1.id,
-                period.copy(start = period.start.plusDays(6), end = period.start.plusDays(10))
-            )
-            insertPlacement(h, testChild_1.id, period.copy(start = period.start.plusDays(11)))
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        val decisionId = insertDecisionWithApplication(db, testChild_1, period)
+        insertTestVardaDecision(db, decisionId = decisionId)
+        val placementId = insertPlacement(db, testChild_1.id, period.copy(end = period.start.plusDays(5)))
+        insertPlacement(
+            db,
+            testChild_1.id,
+            period.copy(start = period.start.plusDays(6), end = period.start.plusDays(10))
+        )
+        insertPlacement(db, testChild_1.id, period.copy(start = period.start.plusDays(11)))
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            val beforeDelete = getVardaPlacements(h)
-            assertEquals(3, beforeDelete.size)
+        val beforeDelete = getVardaPlacements(db)
+        assertEquals(3, beforeDelete.size)
 
-            h.createUpdate("DELETE FROM placement WHERE id = :id").bind("id", placementId).execute()
-            updatePlacements(h, vardaClient)
+        db.transaction { it.createUpdate("DELETE FROM placement WHERE id = :id").bind("id", placementId).execute() }
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(2, result.size)
-            assertTrue(result.none { it.evakaPlacementId == placementId })
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(2, result.size)
+        assertTrue(result.none { it.evakaPlacementId == placementId })
     }
 
     @Test
     fun `varda placement is updated when a placement is updated`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h)
-            val decisionId = insertDecisionWithApplication(h, testChild_1, period)
-            insertTestVardaDecision(db, decisionId = decisionId)
-            val placementId = insertPlacement(h, testChild_1.id, period)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        val decisionId = insertDecisionWithApplication(db, testChild_1, period)
+        insertTestVardaDecision(db, decisionId = decisionId)
+        val placementId = insertPlacement(db, testChild_1.id, period)
 
-            updatePlacements(h, vardaClient)
-            val originalUploadedAt = getVardaPlacements(h).first().uploadedAt
+        updatePlacements(db, vardaClient)
+        val originalUploadedAt = getVardaPlacements(db).first().uploadedAt
 
-            updatePlacement(h, placementId, originalUploadedAt.plusSeconds(1))
-            updatePlacements(h, vardaClient)
+        updatePlacement(db, placementId, originalUploadedAt.plusSeconds(1))
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(1, result.size)
-            assertTrue(originalUploadedAt < result.first().uploadedAt)
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(1, result.size)
+        assertTrue(originalUploadedAt < result.first().uploadedAt)
     }
 
     @Test
     fun `a daycare placement is sent when a varda decision has been derived from it`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h)
-            val placementId = insertPlacement(h, testChild_1.id, period)
-            insertTestVardaDecision(db, placementId = placementId)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        val placementId = insertPlacement(db, testChild_1.id, period)
+        insertTestVardaDecision(db, placementId = placementId)
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(1, result.size)
-            assertEquals(placementId, result.first().evakaPlacementId)
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(1, result.size)
+        assertEquals(placementId, result.first().evakaPlacementId)
     }
 
     @Test
     fun `a daycare placement is not sent when varda_unit has no OID`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h = h, unitOid = null)
-            val placementId = insertPlacement(h, testChild_1.id, period)
-            insertTestVardaDecision(db, placementId = placementId)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db, unitOid = null)
+        val placementId = insertPlacement(db, testChild_1.id, period)
+        insertTestVardaDecision(db, placementId = placementId)
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(0, result.size)
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(0, result.size)
     }
 
     @Test
     fun `placement is soft deleted if it is flagged with should_be_deleted`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h)
-            val placementId = insertPlacement(h, testChild_1.id, period)
-            insertTestVardaDecision(db, placementId = placementId)
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        val placementId = insertPlacement(db, testChild_1.id, period)
+        insertTestVardaDecision(db, placementId = placementId)
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            assertEquals(1, getVardaPlacements(h).size)
-            assertEquals(0, getSoftDeletedVardaPlacements(h).size)
+        assertEquals(1, getVardaPlacements(db).size)
+        assertEquals(0, getSoftDeletedVardaPlacements(db).size)
 
-            h.createUpdate("UPDATE varda_placement SET should_be_deleted = true").execute()
+        db.transaction { it.createUpdate("UPDATE varda_placement SET should_be_deleted = true").execute() }
 
-            removeMarkedPlacementsFromVarda(db, vardaClient)
-            updatePlacements(h, vardaClient)
+        removeMarkedPlacementsFromVarda(db, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            assertEquals(1, getSoftDeletedVardaPlacements(h).size)
-        }
+        assertEquals(1, getSoftDeletedVardaPlacements(db).size)
     }
 
     @Test
     fun `placement is not updated if upload flag is turned off`() {
-        jdbi.handle { h ->
-            val unitId = testDaycare.id
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-            insertVardaUnit(h, unitId = unitId)
-            val placementId = insertPlacement(h, testChild_1.id, unitId = unitId, period = period)
-            insertTestVardaDecision(db, placementId = placementId)
+        val unitId = testDaycare.id
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db, unitId = unitId)
+        val placementId = insertPlacement(db, testChild_1.id, unitId = unitId, period = period)
+        insertTestVardaDecision(db, placementId = placementId)
 
-            updatePlacements(h, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            h.createUpdate("UPDATE daycare SET upload_to_varda = false WHERE id = :id").bind("id", testDaycare.id).execute()
+        db.transaction { it.createUpdate("UPDATE daycare SET upload_to_varda = false WHERE id = :id").bind("id", testDaycare.id).execute() }
 
-            val originalUploadedAt = getVardaPlacements(h).first().uploadedAt
+        val originalUploadedAt = getVardaPlacements(db).first().uploadedAt
 
-            updatePlacement(h, placementId, originalUploadedAt.plusSeconds(1))
-            updatePlacements(h, vardaClient)
+        updatePlacement(db, placementId, originalUploadedAt.plusSeconds(1))
+        updatePlacements(db, vardaClient)
 
-            val result = getVardaPlacements(h)
-            assertEquals(originalUploadedAt, result.first().uploadedAt)
-        }
+        val result = getVardaPlacements(db)
+        assertEquals(originalUploadedAt, result.first().uploadedAt)
     }
 
     @Test
     fun `updating daycare organizer oid yields new varda placement if old is soft deleted`() {
-        jdbi.handle { h ->
-            val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
 
-            insertPlacementWithDecision(h, child = testChild_1, unitId = testDaycare.id, period = period)
+        insertPlacementWithDecision(db, child = testChild_1, unitId = testDaycare.id, period = period)
 
-            updateChildren(db, vardaClient, vardaOrganizerName)
-            updateDecisions(db, vardaClient)
-            updatePlacements(h, vardaClient)
+        updateChildren(db, vardaClient, vardaOrganizerName)
+        updateDecisions(db, vardaClient)
+        updatePlacements(db, vardaClient)
 
-            assertEquals(1, getVardaPlacements(h).size)
+        assertEquals(1, getVardaPlacements(db).size)
 
-            h.createUpdate("update varda_decision set deleted_at = NOW()").execute()
-            h.createUpdate("update varda_placement set deleted_at = NOW()").execute()
-
-            h.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id")
+        db.transaction {
+            it.createUpdate("update varda_decision set deleted_at = NOW()").execute()
+            it.createUpdate("update varda_placement set deleted_at = NOW()").execute()
+            it.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id")
                 .bind("id", testDaycare.id)
                 .execute()
-
-            updateChildren(db, vardaClient, vardaOrganizerName)
-            updateDecisions(db, vardaClient)
-            updatePlacements(h, vardaClient)
-
-            assertEquals(2, getVardaPlacements(h).size)
         }
+
+        updateChildren(db, vardaClient, vardaOrganizerName)
+        updateDecisions(db, vardaClient)
+        updatePlacements(db, vardaClient)
+
+        assertEquals(2, getVardaPlacements(db).size)
     }
 }
 
-private fun getSoftDeletedVardaPlacements(h: Handle) = h.createQuery("SELECT * FROM varda_placement WHERE deleted_at IS NOT NULL")
-    .map(toVardaPlacementRow)
-    .toList()
+private fun getSoftDeletedVardaPlacements(db: Database.Connection) = db.read {
+    it.createQuery("SELECT * FROM varda_placement WHERE deleted_at IS NOT NULL")
+        .map(toVardaPlacementRow)
+        .toList()
+}
 
-internal fun getVardaPlacements(h: Handle) = h.createQuery("SELECT * FROM varda_placement")
-    .map(toVardaPlacementRow)
-    .toList()
+internal fun getVardaPlacements(db: Database.Connection) = db.read {
+    it.createQuery("SELECT * FROM varda_placement")
+        .map(toVardaPlacementRow)
+        .toList()
+}
 
-internal fun insertVardaUnit(h: Handle, unitId: UUID = testDaycare.id, unitOid: String? = "1.2.3") {
-    h.transaction { t ->
-        t
+internal fun insertVardaUnit(db: Database.Connection, unitId: UUID = testDaycare.id, unitOid: String? = "1.2.3") {
+    db.transaction {
+        it
             .createUpdate(
                 """
 INSERT INTO varda_unit (evaka_daycare_id, varda_unit_id, created_at, uploaded_at)
@@ -374,7 +349,7 @@ VALUES (:evakaDaycareId, :vardaUnitId,  :createdAt, :uploadedAt)
             .bind("uploadedAt", Instant.now())
             .execute()
 
-        t.createUpdate("UPDATE daycare SET oph_unit_oid = :unitOid WHERE daycare.id = :unitId")
+        it.createUpdate("UPDATE daycare SET oph_unit_oid = :unitOid WHERE daycare.id = :unitId")
             .bind("unitId", unitId)
             .bind("unitOid", unitOid)
             .execute()
@@ -400,25 +375,29 @@ internal fun insertTestVardaDecision(db: Database.Connection, decisionId: UUID? 
 }
 
 internal fun insertPlacement(
-    h: Handle,
+    db: Database.Connection,
     childId: UUID,
     period: ClosedPeriod,
     type: PlacementType = DAYCARE,
     unitId: UUID = testDaycare.id
 ): UUID {
-    return insertTestPlacement(
-        h,
-        childId = childId,
-        type = type,
-        startDate = period.start,
-        endDate = period.end,
-        unitId = unitId
-    )
+    return db.transaction {
+        insertTestPlacement(
+            it.handle,
+            childId = childId,
+            type = type,
+            startDate = period.start,
+            endDate = period.end,
+            unitId = unitId
+        )
+    }
 }
 
-internal fun updatePlacement(h: Handle, id: UUID, updatedAt: Instant) {
-    h.createUpdate("UPDATE placement SET updated = :updatedAt WHERE id = :id")
-        .bind("id", id)
-        .bind("updatedAt", updatedAt)
-        .execute()
+internal fun updatePlacement(db: Database.Connection, id: UUID, updatedAt: Instant) {
+    db.transaction {
+        it.createUpdate("UPDATE placement SET updated = :updatedAt WHERE id = :id")
+            .bind("id", id)
+            .bind("updatedAt", updatedAt)
+            .execute()
+    }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -327,7 +327,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
 
             insertPlacementWithDecision(h, child = testChild_1, unitId = testDaycare.id, period = period)
 
-            updateChildren(h, vardaClient, vardaOrganizerName)
+            updateChildren(db, vardaClient, vardaOrganizerName)
             updateDecisions(h, vardaClient)
             updatePlacements(h, vardaClient)
 
@@ -340,7 +340,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
                 .bind("id", testDaycare.id)
                 .execute()
 
-            updateChildren(h, vardaClient, vardaOrganizerName)
+            updateChildren(db, vardaClient, vardaOrganizerName)
             updateDecisions(h, vardaClient)
             updatePlacements(h, vardaClient)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
@@ -41,14 +41,14 @@ class ScheduledOperationController(
     }
 
     @PostMapping("/varda/update")
-    fun vardaUpdate(): ResponseEntity<Unit> {
-        vardaUpdateService.updateAll()
+    fun vardaUpdate(db: Database.Connection): ResponseEntity<Unit> {
+        vardaUpdateService.updateAll(db)
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/varda/units/update")
-    fun vardaUpdateUnits(): ResponseEntity<Unit> {
-        vardaUpdateService.updateUnits()
+    fun vardaUpdateUnits(db: Database.Connection): ResponseEntity<Unit> {
+        vardaUpdateService.updateUnits(db)
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDecisions.kt
@@ -15,7 +15,6 @@ import fi.espoo.evaka.shared.db.getEnum
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.varda.integration.VardaClient
 import mu.KotlinLogging
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.statement.StatementContext
 import java.sql.ResultSet
@@ -25,10 +24,10 @@ import java.util.UUID
 
 private val logger = KotlinLogging.logger { }
 
-fun updateDecisions(h: Handle, client: VardaClient) {
-    removeDeletedDecisions(h, client)
-    sendNewDecisions(h, client)
-    sendUpdatedDecisions(h, client)
+fun updateDecisions(db: Database.Connection, client: VardaClient) {
+    removeDeletedDecisions(db, client)
+    sendNewDecisions(db, client)
+    sendUpdatedDecisions(db, client)
 }
 
 fun removeMarkedDecisionsFromVarda(db: Database.Connection, client: VardaClient) {
@@ -40,73 +39,82 @@ fun removeMarkedDecisionsFromVarda(db: Database.Connection, client: VardaClient)
     }
 }
 
-fun sendNewDecisions(h: Handle, client: VardaClient) {
-    val newDecisions = getNewDecisions(h, client.getChildUrl)
-    val newDerivedDecisions = getNewDerivedDecisions(h, client.getChildUrl)
-
+fun sendNewDecisions(db: Database.Connection, client: VardaClient) {
+    val newDecisions = db.read { getNewDecisions(it, client.getChildUrl) }
     newDecisions.forEach { (decisionId, newDecision) ->
         if (validateDecision(decisionId, newDecision)) {
             client.createDecision(newDecision)?.let { (vardaDecisionId) ->
-                insertVardaDecision(
-                    h,
-                    VardaDecisionTableRow(
-                        id = UUID.randomUUID(),
-                        vardaDecisionId = vardaDecisionId,
-                        evakaDecisionId = decisionId,
-                        evakaPlacementId = null,
-                        createdAt = Instant.now(),
-                        uploadedAt = Instant.now()
+                db.transaction {
+                    insertVardaDecision(
+                        it,
+                        VardaDecisionTableRow(
+                            id = UUID.randomUUID(),
+                            vardaDecisionId = vardaDecisionId,
+                            evakaDecisionId = decisionId,
+                            evakaPlacementId = null,
+                            createdAt = Instant.now(),
+                            uploadedAt = Instant.now()
+                        )
                     )
-                )
+                }
             }
         }
     }
 
+    val newDerivedDecisions = db.read { getNewDerivedDecisions(it, client.getChildUrl) }
     newDerivedDecisions.forEach { (placementId, newDecision) ->
         if (validateDecision(placementId, newDecision)) {
             client.createDecision(newDecision)?.let { (vardaDecisionId) ->
-                insertVardaDecision(
-                    h,
-                    VardaDecisionTableRow(
-                        id = UUID.randomUUID(),
-                        vardaDecisionId = vardaDecisionId,
-                        evakaDecisionId = null,
-                        evakaPlacementId = placementId,
-                        createdAt = Instant.now(),
-                        uploadedAt = Instant.now()
+                db.transaction {
+                    insertVardaDecision(
+                        it,
+                        VardaDecisionTableRow(
+                            id = UUID.randomUUID(),
+                            vardaDecisionId = vardaDecisionId,
+                            evakaDecisionId = null,
+                            evakaPlacementId = placementId,
+                            createdAt = Instant.now(),
+                            uploadedAt = Instant.now()
+                        )
                     )
-                )
+                }
             }
         }
     }
 }
 
-fun sendUpdatedDecisions(h: Handle, client: VardaClient) {
-    val updatedDecisions = getUpdatedDecisions(h, client.getChildUrl)
-    val updatedDerivedDecisions = getUpdatedDerivedDecisions(h, client.getChildUrl)
-    val decisionPlacementIds = h.createQuery("SELECT varda_placement_id FROM varda_placement WHERE decision_id = ANY(:decisionIds)")
-        .bind("decisionIds", (updatedDecisions.map { it.first } + updatedDerivedDecisions.map { it.first }).toTypedArray())
-        .mapTo<Long>()
-        .toList()
-    decisionPlacementIds.forEach { id ->
-        if (client.deletePlacement(id)) {
-            deletePlacement(h, id)
-        }
-    }
+fun sendUpdatedDecisions(db: Database.Connection, client: VardaClient) {
+    val updatedDecisions = db.read { getUpdatedDecisions(it, client.getChildUrl) }
+    val updatedDerivedDecisions = db.read { getUpdatedDerivedDecisions(it, client.getChildUrl) }
+    deleteDecisionPlacements(db, client, updatedDecisions.map { it.first } + updatedDerivedDecisions.map { it.first })
     (updatedDecisions + updatedDerivedDecisions).forEach { (id, vardaDecisionId, updatedDecision) ->
         if (validateDecision(id, updatedDecision)) {
             client.updateDecision(vardaDecisionId, updatedDecision)?.let {
-                updateDecisionUploadTimestamp(h, id)
+                db.transaction { updateDecisionUploadTimestamp(it, id) }
             }
         }
     }
 }
 
-fun removeDeletedDecisions(h: Handle, client: VardaClient) {
-    val removedDecisions = getRemovedDecisions(h)
+fun deleteDecisionPlacements(db: Database.Connection, client: VardaClient, decisionIds: List<UUID>) {
+    val decisionPlacementIds = db.read {
+        it.createQuery("SELECT varda_placement_id FROM varda_placement WHERE decision_id = ANY(:decisionIds)")
+            .bind("decisionIds", decisionIds.toTypedArray())
+            .mapTo<Long>()
+            .toList()
+    }
+    decisionPlacementIds.forEach { id ->
+        if (client.deletePlacement(id)) {
+            db.transaction { deletePlacement(it.handle, id) }
+        }
+    }
+}
+
+fun removeDeletedDecisions(db: Database.Connection, client: VardaClient) {
+    val removedDecisions = db.read { getRemovedDecisions(it) }
     removedDecisions.forEach { vardaDecisionId ->
         client.deleteDecision(vardaDecisionId).let { success ->
-            if (success) deleteDecision(h, vardaDecisionId)
+            if (success) db.transaction { deleteDecision(it, vardaDecisionId) }
         }
     }
 }
@@ -196,19 +204,19 @@ JOIN LATERAL (
 ) latest_sn ON TRUE
     """.trimIndent()
 
-private fun getNewDecisions(h: Handle, getChildUrl: (Long) -> String): List<Pair<UUID, VardaDecision>> {
+private fun getNewDecisions(tx: Database.Read, getChildUrl: (Long) -> String): List<Pair<UUID, VardaDecision>> {
     val sql =
         """
 $decisionQueryBase
 WHERE vd.id IS NULL
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return tx.createQuery(sql)
         .map(toVardaDecisionWithDecisionId(getChildUrl))
         .toList()
 }
 
-fun insertVardaDecision(h: Handle, decision: VardaDecisionTableRow) {
+fun insertVardaDecision(tx: Database.Transaction, decision: VardaDecisionTableRow) {
     val sql =
         """
 INSERT INTO varda_decision (
@@ -228,7 +236,7 @@ INSERT INTO varda_decision (
 )
         """.trimIndent()
 
-    h.createUpdate(sql)
+    tx.createUpdate(sql)
         .bind("id", decision.id)
         .bind("vardaDecisionId", decision.vardaDecisionId)
         .bind("evakaDecisionId", decision.evakaDecisionId)
@@ -238,21 +246,21 @@ INSERT INTO varda_decision (
         .execute()
 }
 
-private fun getUpdatedDecisions(h: Handle, getChildUrl: (Long) -> String): List<Triple<UUID, Long, VardaDecision>> {
+private fun getUpdatedDecisions(tx: Database.Read, getChildUrl: (Long) -> String): List<Triple<UUID, Long, VardaDecision>> {
     val sql =
         """
 $decisionQueryBase
 WHERE vd.uploaded_at < greatest(latest_sn.updated, d.updated, first_placement.updated, last_placement.updated)
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return tx.createQuery(sql)
         .map(toVardaDecisionWithIdAndVardaId(getChildUrl))
         .toList()
 }
 
-private fun updateDecisionUploadTimestamp(h: Handle, id: UUID, uploadedAt: Instant = Instant.now()) {
+private fun updateDecisionUploadTimestamp(tx: Database.Transaction, id: UUID, uploadedAt: Instant = Instant.now()) {
     val sql = "UPDATE varda_decision SET uploaded_at = :uploadedAt WHERE id = :id"
-    h.createUpdate(sql)
+    tx.createUpdate(sql)
         .bind("id", id)
         .bind("uploadedAt", uploadedAt)
         .execute()
@@ -300,21 +308,21 @@ JOIN LATERAL (
 ) latest_sn ON true
     """.trimIndent()
 
-private fun getNewDerivedDecisions(h: Handle, getChildUrl: (Long) -> String): List<Pair<UUID, VardaDecision>> {
+private fun getNewDerivedDecisions(tx: Database.Read, getChildUrl: (Long) -> String): List<Pair<UUID, VardaDecision>> {
     val sql =
         """
 $derivedDecisionQueryBase
 WHERE vd.id IS NULL
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return tx.createQuery(sql)
         .bind("types", daycarePlacementTypes)
         .map(toVardaDecisionWithDecisionId(getChildUrl))
         .toList()
 }
 
 private fun getUpdatedDerivedDecisions(
-    h: Handle,
+    tx: Database.Read,
     getChildUrl: (Long) -> String
 ): List<Triple<UUID, Long, VardaDecision>> {
     val sql =
@@ -323,13 +331,13 @@ $derivedDecisionQueryBase
 WHERE vd.uploaded_at < greatest(latest_sn.updated, p.updated)
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return tx.createQuery(sql)
         .bind("types", daycarePlacementTypes)
         .map(toVardaDecisionWithIdAndVardaId(getChildUrl))
         .toList()
 }
 
-private fun getRemovedDecisions(h: Handle): List<Long> {
+private fun getRemovedDecisions(tx: Database.Read): List<Long> {
     val sql =
         """
 WITH accepted_daycare_decision AS (
@@ -341,13 +349,13 @@ WHERE vd.evaka_placement_id IS NULL
 AND d.id IS NULL
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return tx.createQuery(sql)
         .mapTo(Long::class.java)
         .toList()
 }
 
-private fun deleteDecision(h: Handle, vardaDecisionId: Long) {
-    h.createUpdate("DELETE FROM varda_decision WHERE varda_decision_id = :id")
+private fun deleteDecision(tx: Database.Transaction, vardaDecisionId: Long) {
+    tx.createUpdate("DELETE FROM varda_decision WHERE varda_decision_id = :id")
         .bind("id", vardaDecisionId)
         .execute()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDecisions.kt
@@ -105,7 +105,7 @@ fun deleteDecisionPlacements(db: Database.Connection, client: VardaClient, decis
     }
     decisionPlacementIds.forEach { id ->
         if (client.deletePlacement(id)) {
-            db.transaction { deletePlacement(it.handle, id) }
+            db.transaction { deletePlacement(it, id) }
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaFeeData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaFeeData.kt
@@ -17,7 +17,6 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.varda.integration.VardaClient
 import mu.KotlinLogging
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import java.sql.ResultSet
 import java.time.Instant
@@ -27,15 +26,15 @@ import java.util.UUID
 private val logger = KotlinLogging.logger {}
 
 fun updateFeeData(
-    tx: Database.Transaction,
+    db: Database.Connection,
     client: VardaClient,
     mapper: ObjectMapper,
     personService: PersonService
 ) {
-    deleteEntriesFromAnnulledFeeDecision(tx.handle, client)
-    deleteEntriesFromDeletedPlacements(tx.handle, client)
-    updateEntriesFromModifiedPlacements(tx, client, mapper, personService)
-    uploadNewFeeData(tx, client, mapper, personService)
+    deleteEntriesFromAnnulledFeeDecision(db, client)
+    deleteEntriesFromDeletedPlacements(db, client)
+    updateEntriesFromModifiedPlacements(db, client, mapper, personService)
+    uploadNewFeeData(db, client, mapper, personService)
 }
 
 fun removeMarkedFeeDataFromVarda(db: Database.Connection, client: VardaClient) {
@@ -47,51 +46,55 @@ fun removeMarkedFeeDataFromVarda(db: Database.Connection, client: VardaClient) {
     }
 }
 
-fun deleteEntriesFromAnnulledFeeDecision(h: Handle, client: VardaClient) {
-    getAnnulledFeeDecisions(h)
+fun deleteEntriesFromAnnulledFeeDecision(db: Database.Connection, client: VardaClient) {
+    getAnnulledFeeDecisions(db)
         .forEach { vardaId ->
             if (client.deleteFeeData(vardaId)) {
-                deleteVardaFeeDecision(vardaId, h)
+                deleteVardaFeeDecision(db, vardaId)
             }
         }
 }
 
-fun deleteEntriesFromDeletedPlacements(h: Handle, client: VardaClient) {
+fun deleteEntriesFromDeletedPlacements(db: Database.Connection, client: VardaClient) {
     // also removes legacy fee data entries since their placementId is null
-    getDeletedPlacements(h)
+    getDeletedPlacements(db)
         .forEach { vardaId ->
             if (client.deleteFeeData(vardaId)) {
-                deleteVardaFeeDecision(vardaId, h)
+                deleteVardaFeeDecision(db, vardaId)
             }
         }
 }
 
-fun updateEntriesFromModifiedPlacements(tx: Database.Transaction, client: VardaClient, mapper: ObjectMapper, personService: PersonService) {
-    getModifiedFeeData(tx.handle, mapper)
+fun updateEntriesFromModifiedPlacements(db: Database.Connection, client: VardaClient, mapper: ObjectMapper, personService: PersonService) {
+    getModifiedFeeData(db, mapper)
         .forEach { (vardaId, feeDataBase) ->
-            val feeData = baseToFeeData(tx, feeDataBase, personService, client)
-            if (feeData != null && client.updateFeeData(vardaId, feeData)) {
-                insertFeeDataUpload(tx.handle, feeDataBase, vardaId)
+            db.transaction {
+                val feeData = baseToFeeData(it, feeDataBase, personService, client)
+                if (feeData != null && client.updateFeeData(vardaId, feeData)) {
+                    insertFeeDataUpload(it, feeDataBase, vardaId)
+                }
             }
         }
 }
 
 fun uploadNewFeeData(
-    tx: Database.Transaction,
+    db: Database.Connection,
     client: VardaClient,
     mapper: ObjectMapper,
     personService: PersonService
 ) {
-    val feeData = getStaleFeeData(tx.handle, mapper)
+    val feeData = getStaleFeeData(db, mapper)
     feeData.forEach { feeDataBase ->
-        val newFeeData = baseToFeeData(tx, feeDataBase, personService, client)
-        if (newFeeData != null) {
-            val response = client.createFeeData(newFeeData)
-            if (response != null) {
-                insertFeeDataUpload(tx.handle, feeDataBase, response.vardaId)
+        db.transaction {
+            val newFeeData = baseToFeeData(it, feeDataBase, personService, client)
+            if (newFeeData != null) {
+                val response = client.createFeeData(newFeeData)
+                if (response != null) {
+                    insertFeeDataUpload(it, feeDataBase, response.vardaId)
+                }
+            } else {
+                logger.info { "Not sending Varda fee data because child has no guardians in VTJ (child: ${feeDataBase.evakaChildId})" }
             }
-        } else {
-            logger.info { "Not sending Varda fee data because child has no guardians in VTJ (child: ${feeDataBase.evakaChildId})" }
         }
     }
 }
@@ -117,7 +120,7 @@ fun softDeleteFeeData(tx: Database.Transaction, vardaFeeDataId: Int) {
 }
 
 private fun getStaleFeeData(
-    h: Handle,
+    db: Database.Connection,
     mapper: ObjectMapper
 ): List<VardaFeeDataBase> {
     val placementTypes = listOf(PlacementType.DAYCARE, PlacementType.FIVE_YEARS_OLD_DAYCARE, PlacementType.PRESCHOOL_WITH_DAYCARE, PlacementType.PREPARATORY_WITH_DAYCARE).toTypedArray()
@@ -129,15 +132,17 @@ private fun getStaleFeeData(
             AND fdp.placement_type = ANY(:placementTypes)
         """.trimIndent()
 
-    return h
-        .createQuery(sql)
-        .bind("sentStatus", FeeDecisionStatus.SENT)
-        .bind("placementTypes", placementTypes)
-        .map { rs, _ -> toVardaFeeDataBase(rs, mapper) }
-        .toList()
+    return db.read {
+        it
+            .createQuery(sql)
+            .bind("sentStatus", FeeDecisionStatus.SENT)
+            .bind("placementTypes", placementTypes)
+            .map { rs, _ -> toVardaFeeDataBase(rs, mapper) }
+            .toList()
+    }
 }
 
-private fun insertFeeDataUpload(h: Handle, feeDataBase: VardaFeeDataBase, vardaId: Long) {
+private fun insertFeeDataUpload(tx: Database.Transaction, feeDataBase: VardaFeeDataBase, vardaId: Long) {
     // language=SQL
     val sql =
         """
@@ -147,7 +152,7 @@ private fun insertFeeDataUpload(h: Handle, feeDataBase: VardaFeeDataBase, vardaI
         DO UPDATE SET uploaded_at = :checkTimestamp
         """.trimIndent()
 
-    h.createUpdate(sql)
+    tx.handle.createUpdate(sql)
         .bind("decisionId", feeDataBase.evakaFeeDecisionId)
         .bind("placementId", feeDataBase.placementId)
         .bind("vardaId", vardaId)
@@ -155,7 +160,7 @@ private fun insertFeeDataUpload(h: Handle, feeDataBase: VardaFeeDataBase, vardaI
         .execute()
 }
 
-private fun getAnnulledFeeDecisions(h: Handle): List<Int> {
+private fun getAnnulledFeeDecisions(db: Database.Connection): List<Int> {
     // language=SQL
     val sql =
         """
@@ -166,13 +171,14 @@ private fun getAnnulledFeeDecisions(h: Handle): List<Int> {
             AND varda_fee_data.id IS NOT NULL;
         """.trimIndent()
 
-    return h
-        .createQuery(sql)
-        .bind("annulledStatus", FeeDecisionStatus.ANNULLED)
-        .mapTo<Int>().list()
+    return db.read {
+        it.createQuery(sql)
+            .bind("annulledStatus", FeeDecisionStatus.ANNULLED)
+            .mapTo<Int>().list()
+    }
 }
 
-private fun deleteVardaFeeDecision(vardaId: Int, h: Handle) {
+private fun deleteVardaFeeDecision(db: Database.Connection, vardaId: Int) {
     // language=SQL
     val sql =
         """
@@ -180,12 +186,14 @@ private fun deleteVardaFeeDecision(vardaId: Int, h: Handle) {
         WHERE varda_fee_data_id = :vardaId
         """.trimIndent()
 
-    h.createUpdate(sql)
-        .bind("vardaId", vardaId)
-        .execute()
+    db.transaction {
+        it.createUpdate(sql)
+            .bind("vardaId", vardaId)
+            .execute()
+    }
 }
 
-private fun getDeletedPlacements(h: Handle): List<Int> {
+private fun getDeletedPlacements(db: Database.Connection): List<Int> {
     // language=SQL
     val sql =
         """
@@ -194,12 +202,14 @@ private fun getDeletedPlacements(h: Handle): List<Int> {
             WHERE evaka_placement_id IS NULL
         """.trimIndent()
 
-    return h.createQuery(sql)
-        .mapTo<Int>()
-        .list()
+    return db.read {
+        it.createQuery(sql)
+            .mapTo<Int>()
+            .list()
+    }
 }
 
-private fun getModifiedFeeData(h: Handle, mapper: ObjectMapper): List<Pair<Long, VardaFeeDataBase>> {
+private fun getModifiedFeeData(db: Database.Connection, mapper: ObjectMapper): List<Pair<Long, VardaFeeDataBase>> {
     // language=SQL
     val sql =
         """
@@ -208,11 +218,12 @@ private fun getModifiedFeeData(h: Handle, mapper: ObjectMapper): List<Pair<Long,
         AND vfd.uploaded_at < p.updated
         """.trimIndent()
 
-    return h
-        .createQuery(sql)
-        .bind("sentStatus", FeeDecisionStatus.SENT)
-        .map { rs, _ -> toVardaFeeDataBaseWithVardaId(rs, mapper) }
-        .toList()
+    return db.read {
+        it.createQuery(sql)
+            .bind("sentStatus", FeeDecisionStatus.SENT)
+            .map { rs, _ -> toVardaFeeDataBaseWithVardaId(rs, mapper) }
+            .toList()
+    }
 }
 
 private val feeDataQueryBase =

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaPlacements.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaPlacements.kt
@@ -11,17 +11,16 @@ import fi.espoo.evaka.placement.PlacementType.PRESCHOOL_DAYCARE
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.varda.integration.VardaClient
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.statement.StatementContext
 import java.sql.ResultSet
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-fun updatePlacements(h: Handle, client: VardaClient) {
-    removeDeletedPlacements(h, client)
-    sendNewPlacements(h, client)
-    sendUpdatedPlacements(h, client)
+fun updatePlacements(db: Database.Connection, client: VardaClient) {
+    removeDeletedPlacements(db, client)
+    sendNewPlacements(db, client)
+    sendUpdatedPlacements(db, client)
 }
 
 fun removeMarkedPlacementsFromVarda(db: Database.Connection, client: VardaClient) {
@@ -33,39 +32,41 @@ fun removeMarkedPlacementsFromVarda(db: Database.Connection, client: VardaClient
     }
 }
 
-fun sendNewPlacements(h: Handle, client: VardaClient) {
-    val newPlacements = getNewPlacements(h, client.getDecisionUrl)
+fun sendNewPlacements(db: Database.Connection, client: VardaClient) {
+    val newPlacements = db.read { getNewPlacements(it, client.getDecisionUrl) }
     newPlacements.forEach { (decisionId, placementId, newPlacement) ->
         client.createPlacement(newPlacement)?.let { (vardaPlacementId) ->
-            insertVardaPlacement(
-                h,
-                VardaPlacementTableRow(
-                    id = UUID.randomUUID(),
-                    vardaPlacementId = vardaPlacementId,
-                    evakaPlacementId = placementId,
-                    decisionId = decisionId,
-                    createdAt = Instant.now(),
-                    uploadedAt = Instant.now()
+            db.transaction {
+                insertVardaPlacement(
+                    it,
+                    VardaPlacementTableRow(
+                        id = UUID.randomUUID(),
+                        vardaPlacementId = vardaPlacementId,
+                        evakaPlacementId = placementId,
+                        decisionId = decisionId,
+                        createdAt = Instant.now(),
+                        uploadedAt = Instant.now()
+                    )
                 )
-            )
+            }
         }
     }
 }
 
-fun sendUpdatedPlacements(h: Handle, client: VardaClient) {
-    val updatedPlacements = getUpdatedPlacements(h, client.getDecisionUrl)
+fun sendUpdatedPlacements(db: Database.Connection, client: VardaClient) {
+    val updatedPlacements = db.read { getUpdatedPlacements(it, client.getDecisionUrl) }
     updatedPlacements.forEach { (id, vardaPlacementId, updatedPlacement) ->
         client.updatePlacement(vardaPlacementId, updatedPlacement)?.let {
-            updatePlacementUploadTimestamp(h, id)
+            db.transaction { updatePlacementUploadTimestamp(it, id) }
         }
     }
 }
 
-fun removeDeletedPlacements(h: Handle, client: VardaClient) {
-    val removedPlacements = getRemovedPlacements(h)
+fun removeDeletedPlacements(db: Database.Connection, client: VardaClient) {
+    val removedPlacements = db.read { getRemovedPlacements(it) }
     removedPlacements.forEach { vardaPlacementId ->
         client.deletePlacement(vardaPlacementId).let { success ->
-            if (success) deletePlacement(h, vardaPlacementId)
+            if (success) db.transaction { deletePlacement(it, vardaPlacementId) }
         }
     }
 }
@@ -112,23 +113,20 @@ JOIN sent_decision d
     AND daterange(p.start_date, p.end_date, '[]') && daterange(d.start_date, d.end_date, '[]')
     """.trimIndent()
 
-fun getNewPlacements(
-    h: Handle,
-    getDecisionUrl: (Long) -> String
-): List<Triple<UUID, UUID, VardaPlacement>> {
+fun getNewPlacements(tx: Database.Read, getDecisionUrl: (Long) -> String): List<Triple<UUID, UUID, VardaPlacement>> {
     val sql =
         """
 $placementBaseQuery
 WHERE vp.id IS NULL
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return tx.createQuery(sql)
         .bind("types", daycarePlacementTypes)
         .map(toVardaPlacementWithDecisionAndPlacementId(getDecisionUrl))
         .toList()
 }
 
-fun insertVardaPlacement(h: Handle, placement: VardaPlacementTableRow) {
+fun insertVardaPlacement(tx: Database.Transaction, placement: VardaPlacementTableRow) {
     val sql =
         """
 INSERT INTO varda_placement (
@@ -148,7 +146,7 @@ INSERT INTO varda_placement (
 )
         """.trimIndent()
 
-    h.createUpdate(sql)
+    tx.createUpdate(sql)
         .bind("id", placement.id)
         .bind("vardaPlacementId", placement.vardaPlacementId)
         .bind("evakaPlacementId", placement.evakaPlacementId)
@@ -159,7 +157,7 @@ INSERT INTO varda_placement (
 }
 
 private fun getUpdatedPlacements(
-    h: Handle,
+    tx: Database.Read,
     getDecisionUrl: (Long) -> String
 ): List<Triple<UUID, Long, VardaPlacement>> {
     val sql =
@@ -168,28 +166,28 @@ $placementBaseQuery
 WHERE vp.uploaded_at < p.updated
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return tx.createQuery(sql)
         .bind("types", daycarePlacementTypes)
         .map(toVardaPlacementWithIdAndVardaId(getDecisionUrl))
         .toList()
 }
 
-private fun updatePlacementUploadTimestamp(h: Handle, id: UUID, uploadedAt: Instant = Instant.now()) {
+private fun updatePlacementUploadTimestamp(tx: Database.Transaction, id: UUID, uploadedAt: Instant = Instant.now()) {
     val sql = "UPDATE varda_placement SET uploaded_at = :uploadedAt WHERE id = :id"
-    h.createUpdate(sql)
+    tx.createUpdate(sql)
         .bind("id", id)
         .bind("uploadedAt", uploadedAt)
         .execute()
 }
 
-fun getRemovedPlacements(h: Handle): List<Long> {
-    return h.createQuery("SELECT varda_placement_id FROM varda_placement WHERE evaka_placement_id IS NULL")
+fun getRemovedPlacements(tx: Database.Read): List<Long> {
+    return tx.createQuery("SELECT varda_placement_id FROM varda_placement WHERE evaka_placement_id IS NULL")
         .mapTo(Long::class.java)
         .toList()
 }
 
-fun deletePlacement(h: Handle, vardaPlacementId: Long) {
-    h.createUpdate("DELETE FROM varda_placement WHERE varda_placement_id = :id")
+fun deletePlacement(tx: Database.Transaction, vardaPlacementId: Long) {
+    tx.createUpdate("DELETE FROM varda_placement WHERE varda_placement_id = :id")
         .bind("id", vardaPlacementId)
         .execute()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -60,7 +60,7 @@ fun updateAll(
     removeMarkedPlacementsFromVarda(db, client)
     removeMarkedDecisionsFromVarda(db, client)
     updateOrganizer(db, client, organizer)
-    db.transaction { updateUnits(it.handle, client, organizer) }
+    updateUnits(db, client, organizer)
     db.transaction { updateChildren(it.handle, client, organizer) }
     db.transaction { updateDecisions(it.handle, client) }
     db.transaction { updatePlacements(it.handle, client) }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -61,7 +61,7 @@ fun updateAll(
     removeMarkedDecisionsFromVarda(db, client)
     updateOrganizer(db, client, organizer)
     updateUnits(db, client, organizer)
-    db.transaction { updateChildren(it.handle, client, organizer) }
+    updateChildren(db, client, organizer)
     db.transaction { updateDecisions(it.handle, client) }
     db.transaction { updatePlacements(it.handle, client) }
     db.transaction { updateFeeData(it, client, mapper, personService) }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -64,5 +64,5 @@ fun updateAll(
     updateChildren(db, client, organizer)
     updateDecisions(db, client)
     db.transaction { updatePlacements(it.handle, client) }
-    db.transaction { updateFeeData(it, client, mapper, personService) }
+    updateFeeData(db, client, mapper, personService)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -62,7 +62,7 @@ fun updateAll(
     updateOrganizer(db, client, organizer)
     updateUnits(db, client, organizer)
     updateChildren(db, client, organizer)
-    db.transaction { updateDecisions(it.handle, client) }
+    updateDecisions(db, client)
     db.transaction { updatePlacements(it.handle, client) }
     db.transaction { updateFeeData(it, client, mapper, personService) }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -63,6 +63,6 @@ fun updateAll(
     updateUnits(db, client, organizer)
     updateChildren(db, client, organizer)
     updateDecisions(db, client)
-    db.transaction { updatePlacements(it.handle, client) }
+    updatePlacements(db, client)
     updateFeeData(db, client, mapper, personService)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.varda.integration.VardaClient
 import fi.espoo.evaka.varda.integration.VardaTokenProvider
 import mu.KotlinLogging
-import org.jdbi.v3.core.Jdbi
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import java.lang.reflect.UndeclaredThrowableException
@@ -60,7 +59,7 @@ fun updateAll(
     removeMarkedFeeDataFromVarda(db, client)
     removeMarkedPlacementsFromVarda(db, client)
     removeMarkedDecisionsFromVarda(db, client)
-    db.transaction { updateOrganizer(it.handle, client, organizer) }
+    updateOrganizer(db, client, organizer)
     db.transaction { updateUnits(it.handle, client, organizer) }
     db.transaction { updateChildren(it.handle, client, organizer) }
     db.transaction { updateDecisions(it.handle, client) }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Instead of doing Varda integration in large transactions that are open during http calls, open small ones for specific updates so that there's a greater chance of consistency between Varda and our database.

