### PR TITLE
Run varda update in an async job

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -29,7 +29,8 @@ enum class AsyncJobType {
     DVV_MODIFICATIONS_REFRESH,
     UPLOAD_TO_KOSKI,
     SEND_APPLICATION_EMAIL,
-    GARBAGE_COLLECT_PAIRING
+    GARBAGE_COLLECT_PAIRING,
+    VARDA_UPDATE
 }
 
 interface AsyncJobPayload {
@@ -126,6 +127,11 @@ data class InitializeFamilyFromApplication(val applicationId: UUID, override val
 
 data class VTJRefresh(val personId: UUID, val requestingUserId: UUID) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.VTJ_REFRESH
+    override val user: AuthenticatedUser? = null
+}
+
+class VardaUpdate : AsyncJobPayload {
+    override val asyncJobType = AsyncJobType.VARDA_UPDATE
     override val user: AuthenticatedUser? = null
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -86,6 +86,9 @@ class AsyncJobRunner(
     @Volatile
     var garbageCollectPairing: (db: Database, msg: GarbageCollectPairing) -> Unit = noHandler
 
+    @Volatile
+    var vardaUpdate: (db: Database, msg: VardaUpdate) -> Unit = noHandler
+
     fun plan(
         tx: Database.Transaction,
         payloads: Iterable<AsyncJobPayload>,
@@ -193,6 +196,7 @@ class AsyncJobRunner(
                     AsyncJobType.UPLOAD_TO_KOSKI -> it.runJob(job, this.uploadToKoski)
                     AsyncJobType.SEND_APPLICATION_EMAIL -> it.runJob(job, this.sendApplicationEmail)
                     AsyncJobType.GARBAGE_COLLECT_PAIRING -> it.runJob(job, this.garbageCollectPairing)
+                    AsyncJobType.VARDA_UPDATE -> it.runJob(job, this.vardaUpdate)
                 }.exhaust()
             }
             if (completed) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
@@ -42,13 +42,7 @@ class ScheduledOperationController(
 
     @PostMapping("/varda/update")
     fun vardaUpdate(db: Database.Connection): ResponseEntity<Unit> {
-        vardaUpdateService.updateAll(db)
-        return ResponseEntity.noContent().build()
-    }
-
-    @PostMapping("/varda/units/update")
-    fun vardaUpdateUnits(db: Database.Connection): ResponseEntity<Unit> {
-        vardaUpdateService.updateUnits(db)
+        vardaUpdateService.scheduleVardaUpdate(db)
         return ResponseEntity.noContent().build()
     }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Previously the connection would immediately close after the new varda update thread is created.
