### PR TITLE
Varda derived decisions changes

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -428,6 +428,19 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
     }
 
     @Test
+    fun `a derived daycare decision is not sent when its service need is temporary`() {
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        val placementId = insertPlacement(db, testChild_1.id, period)
+        insertServiceNeed(db, testChild_1.id, period, temporary = true)
+        insertVardaChild(db, testChild_1.id)
+
+        updateDecisions(db, vardaClient)
+
+        val result = getVardaDecisions()
+        assertEquals(0, result.size)
+    }
+
+    @Test
     fun `daycare decision is sent with correct data`() {
         val sentDate = LocalDate.of(2019, 6, 1)
         val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
@@ -848,7 +861,8 @@ internal fun insertServiceNeed(
     db: Database.Connection,
     childId: UUID,
     period: ClosedPeriod,
-    hours: Double = 40.0
+    hours: Double = 40.0,
+    temporary: Boolean = false
 ): UUID {
     return db.transaction {
         insertTestServiceNeed(
@@ -857,7 +871,8 @@ internal fun insertServiceNeed(
             testDecisionMaker_1.id,
             startDate = period.start,
             endDate = period.end,
-            hoursPerWeek = hours
+            hoursPerWeek = hours,
+            temporary = temporary
         )
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.updatePlacementStartAndEndDate
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.serviceneed.deleteServiceNeed
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -368,6 +369,23 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         assertEquals(1, beforeDelete.size)
 
         deletePlacement(db, placementId)
+        updateDecisions(db, vardaClient)
+        val result = getVardaDecisions()
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `a derived daycare decision is deleted when its service need is removed`() {
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertPlacement(db, testChild_1.id, period)
+        val serviceNeedId = insertServiceNeed(db, testChild_1.id, period)
+        insertVardaChild(db, testChild_1.id)
+
+        updateDecisions(db, vardaClient)
+        val beforeDelete = getVardaDecisions()
+        assertEquals(1, beforeDelete.size)
+
+        db.transaction { deleteServiceNeed(it.handle, serviceNeedId) }
         updateDecisions(db, vardaClient)
         val result = getVardaDecisions()
         assertEquals(0, result.size)

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDecisions.kt
@@ -199,6 +199,7 @@ JOIN LATERAL (
     SELECT * FROM service_need sn
     WHERE sn.child_id = d.child_id
     AND daterange(sn.start_date, sn.end_date, '[]') && daterange(d.start_date, d.end_date, '[]')
+    AND NOT temporary
     ORDER BY sn.start_date DESC
     LIMIT 1
 ) latest_sn ON TRUE
@@ -303,6 +304,7 @@ JOIN LATERAL (
     SELECT * FROM service_need sn
     WHERE sn.child_id = p.child_id
     AND daterange(sn.start_date, sn.end_date, '[]') && daterange(p.start_date, p.end_date, '[]')
+    AND NOT temporary
     ORDER BY sn.start_date DESC
     LIMIT 1
 ) latest_sn ON true


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Delete derived decisions from Varda if the data is incomplete. The reasoning is that if there's a placement without a corresponding service need it's unlikely that the data is very reliable anyway. Some of these cases have been placements that span only one day months after the child has actually been in daycare.

Also, do not include decisions that only have a temporary service need for the duration. Temporary daycare should be handled separately.

