### PR TITLE
EVAKA-HOTFIX Removed the period after the mobile pairing url

### DIFF
--- a/frontend/packages/employee-frontend/src/components/unit/MobilePairingModal.tsx
+++ b/frontend/packages/employee-frontend/src/components/unit/MobilePairingModal.tsx
@@ -113,7 +113,7 @@ export default React.memo(function MobilePairingModal({
             <Fragment>
               {i18n.unit.accessControl.mobileDevices.modalText1}
               <br />
-              <Bold>{`${window.location.hostname}/employee/mobile`}.</Bold>
+              <Bold>{`${window.location.hostname}/employee/mobile`}</Bold>
               <br />
               {i18n.unit.accessControl.mobileDevices.modalText2}
             </Fragment>


### PR DESCRIPTION
#### Summary
Removed the period after the mobile pairing url. This came up when doing the pairing with the users.
