### PR TITLE
Replace AAD with namespaced external ID

### DIFF
--- a/apigw/src/shared/auth/espoo-ad-saml.ts
+++ b/apigw/src/shared/auth/espoo-ad-saml.ts
@@ -46,8 +46,10 @@ interface EspooAdProfile {
 }
 
 async function verifyProfile(profile: EspooAdProfile): Promise<SamlUser> {
+  const aad = profile[ESPOO_AD_USER_ID_KEY]
+  if (!aad) throw Error('No user ID in SAML data')
   const person = await getOrCreateEmployee({
-    aad: profile[ESPOO_AD_USER_ID_KEY],
+    externalId: `espoo-ad:${aad}`,
     firstName: profile[ESPOO_AD_GIVEN_NAME_KEY],
     lastName: profile[ESPOO_AD_FAMILY_NAME_KEY],
     email: profile[ESPOO_AD_EMAIL_KEY]
@@ -88,7 +90,7 @@ export default function createEspooAdStrategy():
         firstName,
         lastName,
         email,
-        aad: userId,
+        externalId: `espoo-ad:${userId}`,
         roles: roles as UserRole[]
       })
       return verifyProfile({

--- a/apigw/src/shared/dev-api.ts
+++ b/apigw/src/shared/dev-api.ts
@@ -8,13 +8,13 @@ interface DevEmployee {
   firstName: string
   lastName: string
   email: string
-  aad: UUID
+  externalId: string
   roles: UserRole[]
 }
 
 export async function upsertEmployee(employee: DevEmployee): Promise<UUID> {
   const { data } = await client.post(
-    `/dev-api/employee/aad/${employee.aad}`,
+    `/dev-api/employee/external-id/${employee.externalId}`,
     employee
   )
   return data

--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -55,7 +55,7 @@ export interface AuthenticatedUser {
 }
 
 export interface EmployeeIdentityRequest {
-  aad: string
+  externalId: string
   firstName: string
   lastName: string
   email?: string
@@ -63,7 +63,7 @@ export interface EmployeeIdentityRequest {
 
 export interface EmployeeResponse {
   id: string
-  aad: string | null
+  externalId: string | null
   firstName: string
   lastName: string
   email: string

--- a/frontend/e2e-test/test/e2e/config/index.ts
+++ b/frontend/e2e-test/test/e2e/config/index.ts
@@ -2,16 +2,23 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { UUID } from '../dev-api/types'
+
 interface Config {
   env: string | undefined
   adminUrl: string
   employeeUrl: string
   devApiGwUrl: string
   enduserUrl: string
-  supervisorAad: string
-  adminAad: string
+  supervisorAad: UUID
+  supervisorExternalId: string
+  adminAad: UUID
+  adminExternalId: string
   mobileUrl: string
 }
+
+const supervisorAad = '123dc92c-278b-4cea-9e54-2cc7e41555f3'
+const adminAad = 'c50be1c1-304d-4d5a-86a0-1fad225c76cb'
 
 const config: Config = {
   env: process.env.TEST_ENV,
@@ -23,8 +30,10 @@ const config: Config = {
     process.env.BASE_URL || 'http://localhost:3020'
   }/api/internal/dev-api`,
   enduserUrl: process.env.BASE_URL || 'http://localhost:9091',
-  supervisorAad: '123dc92c-278b-4cea-9e54-2cc7e41555f3',
-  adminAad: 'c50be1c1-304d-4d5a-86a0-1fad225c76cb',
+  supervisorAad,
+  supervisorExternalId: `espoo-ad:${supervisorAad}`,
+  adminAad,
+  adminExternalId: `espoo-ad:${adminAad}`,
   mobileUrl: `${
     process.env.BASE_URL || 'http://localhost:9093'
   }/employee/mobile`

--- a/frontend/e2e-test/test/e2e/dev-api/fixtures.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/fixtures.ts
@@ -41,7 +41,7 @@ import {
 
 export const supervisor: EmployeeDetail = {
   id: '552e5bde-92fb-4807-a388-40016f85f593',
-  aad: config.supervisorAad,
+  externalId: config.supervisorExternalId,
   firstName: 'Eva',
   lastName: 'Esihenkilo',
   email: 'eva.esihenkilo@espoo.fi',

--- a/frontend/e2e-test/test/e2e/dev-api/index.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/index.ts
@@ -259,9 +259,9 @@ export async function insertBackupCareFixtures(
   }
 }
 
-export async function deleteEmployeeFixture(aad: UUID): Promise<void> {
+export async function deleteEmployeeFixture(externalId: string): Promise<void> {
   try {
-    await devClient.delete(`/employee/${aad}`)
+    await devClient.delete(`/employee/${externalId}`)
   } catch (e) {
     throw new DevApiError(e)
   }
@@ -299,22 +299,22 @@ export async function insertParentshipFixtures(
 }
 
 export async function setAclForDaycares(
-  personAad: UUID,
+  externalId: string,
   daycareId: UUID
 ): Promise<void> {
   try {
-    await devClient.put(`/daycares/${daycareId}/acl`, { personAad })
+    await devClient.put(`/daycares/${daycareId}/acl`, { externalId })
   } catch (e) {
     throw new DevApiError(e)
   }
 }
 
 export async function deleteAclForDaycare(
-  supervisorId: UUID,
+  externalId: string,
   daycareId: UUID
 ): Promise<void> {
   try {
-    await devClient.delete(`/daycares/${daycareId}/acl/${supervisorId}`)
+    await devClient.delete(`/daycares/${daycareId}/acl/${externalId}`)
   } catch (e) {
     throw new DevApiError(e)
   }

--- a/frontend/e2e-test/test/e2e/dev-api/index.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/index.ts
@@ -261,7 +261,15 @@ export async function insertBackupCareFixtures(
 
 export async function deleteEmployeeFixture(externalId: string): Promise<void> {
   try {
-    await devClient.delete(`/employee/${externalId}`)
+    await devClient.delete(`/employee/external-id/${externalId}`)
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}
+
+export async function deleteEmployeeById(id: UUID): Promise<void> {
+  try {
+    await devClient.delete(`/employee/${id}`)
   } catch (e) {
     throw new DevApiError(e)
   }

--- a/frontend/e2e-test/test/e2e/dev-api/types.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/types.ts
@@ -262,7 +262,7 @@ export interface EmployeeDetail {
   id?: string
   firstName: string
   lastName: string
-  aad?: string
+  externalId?: string
   email?: string
   roles: UserRole[]
 }

--- a/frontend/e2e-test/test/e2e/specs/1_application/club-application.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/1_application/club-application.spec.ts
@@ -36,7 +36,7 @@ const applicationWorkbench = new ApplicationWorkbenchPage()
 const applicationReadView = new ApplicationReadView()
 const supervisor: EmployeeDetail = {
   id: '552e5bde-92fb-4807-a388-40016f85f593',
-  aad: config.supervisorAad,
+  externalId: config.supervisorExternalId,
   firstName: 'Eeva',
   lastName: 'Esimies',
   email: 'eeva.esimies@espoo.fi',
@@ -55,14 +55,17 @@ fixture('New club application')
       email: `${Math.random().toString(36).substring(7)}@espoo.fi`
     }
     await insertEmployeeFixture(uniqueSupervisor)
-    await setAclForDaycare(config.supervisorAad, fixtures.clubFixture.id)
+    await setAclForDaycare(config.supervisorExternalId, fixtures.clubFixture.id)
     await cleanUpMessages()
   })
   .afterEach(logConsoleMessages)
   .after(async () => {
     applicationId ? await deleteApplication(applicationId) : false
-    await deleteAclForDaycare(config.supervisorAad, fixtures.clubFixture.id)
-    await deleteEmployeeFixture(config.supervisorAad)
+    await deleteAclForDaycare(
+      config.supervisorExternalId,
+      fixtures.clubFixture.id
+    )
+    await deleteEmployeeFixture(config.supervisorExternalId)
     await cleanUpMessages()
     await cleanUp()
   })

--- a/frontend/e2e-test/test/e2e/specs/1_application/daycare-application.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/1_application/daycare-application.spec.ts
@@ -36,7 +36,7 @@ const applicationWorkbench = new ApplicationWorkbenchPage()
 const applicationReadView = new ApplicationReadView()
 const supervisor: EmployeeDetail = {
   id: '552e5bde-92fb-4807-a388-40016f85f593',
-  aad: config.supervisorAad,
+  externalId: config.supervisorExternalId,
   firstName: 'Eeva',
   lastName: 'Esimies',
   email: 'eeva.esimies@espoo.fi',
@@ -55,14 +55,20 @@ fixture('New daycare application')
       email: `${Math.random().toString(36).substring(7)}@espoo.fi`
     }
     await insertEmployeeFixture(uniqueSupervisor)
-    await setAclForDaycare(config.supervisorAad, fixtures.daycareFixture.id)
+    await setAclForDaycare(
+      config.supervisorExternalId,
+      fixtures.daycareFixture.id
+    )
     await cleanUpMessages()
   })
   .afterEach(logConsoleMessages)
   .after(async () => {
     applicationId ? await deleteApplication(applicationId) : false
-    await deleteAclForDaycare(config.supervisorAad, fixtures.daycareFixture.id)
-    await deleteEmployeeFixture(config.supervisorAad)
+    await deleteAclForDaycare(
+      config.supervisorExternalId,
+      fixtures.daycareFixture.id
+    )
+    await deleteEmployeeFixture(config.supervisorExternalId)
     await cleanUpMessages()
     await cleanUp()
   })

--- a/frontend/e2e-test/test/e2e/specs/2_employee-2/application-transitions.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/2_employee-2/application-transitions.spec.ts
@@ -32,7 +32,7 @@ const unitPage = new UnitPage()
 
 const supervisor: EmployeeDetail = {
   id: '552e5bde-92fb-4807-a388-40016f85f593',
-  aad: config.supervisorAad,
+  externalId: config.supervisorExternalId,
   firstName: 'Eeva',
   lastName: 'Esimies',
   email: 'eeva.esimies@espoo.fi',
@@ -53,7 +53,10 @@ fixture('Application-transitions')
       email: `${Math.random().toString(36).substring(7)}@espoo.fi`
     }
     await insertEmployeeFixture(uniqueSupervisor)
-    await setAclForDaycare(config.supervisorAad, fixtures.daycareFixture.id)
+    await setAclForDaycare(
+      config.supervisorExternalId,
+      fixtures.daycareFixture.id
+    )
     await cleanUpMessages()
   })
   .afterEach(async (t) => {
@@ -69,9 +72,12 @@ fixture('Application-transitions')
     await cleanUpMessages()
   })
   .after(async () => {
-    await deleteAclForDaycare(config.supervisorAad, fixtures.daycareFixture.id)
+    await deleteAclForDaycare(
+      config.supervisorExternalId,
+      fixtures.daycareFixture.id
+    )
     await cleanUp()
-    await deleteEmployeeFixture(config.supervisorAad)
+    await deleteEmployeeFixture(config.supervisorExternalId)
   })
 
 test('Supervisor accepts decision on behalf of the enduser', async (t) => {

--- a/frontend/e2e-test/test/e2e/specs/2_employee-2/guardian-information-page.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/2_employee-2/guardian-information-page.spec.ts
@@ -83,7 +83,7 @@ fixture('Employee - Guardian Information')
   .after(async () => {
     applicationId && (await deleteApplication(applicationId))
     await cleanUp()
-    await deleteEmployeeFixture(config.supervisorAad)
+    await deleteEmployeeFixture(config.supervisorExternalId)
   })
 
 test('guardian information is shown', async () => {

--- a/frontend/e2e-test/test/e2e/specs/2_employee-2/paper-application.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/2_employee-2/paper-application.spec.ts
@@ -55,9 +55,12 @@ fixture('Employee - paper application')
 const formatPersonName = (person: ApplicationPersonDetail) =>
   `${person.lastName} ${person.firstName}`
 
-// eslint-disable-next-line
-const formatPersonAddress = (person: ApplicationPersonDetail) =>
-  `${person.streetAddress}, ${person.postalCode} ${person.postOffice}`
+const formatPersonAddress = ({
+  streetAddress,
+  postalCode,
+  postOffice
+}: ApplicationPersonDetail) =>
+  `${streetAddress ?? ''}, ${postalCode ?? ''} ${postOffice ?? ''}`
 
 test('Paper application can be created for guardian and child with ssn', async () => {
   await childInforationPage.openCreateApplicationModal()

--- a/frontend/e2e-test/test/e2e/specs/2_employee-2/paper-application.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/2_employee-2/paper-application.spec.ts
@@ -13,6 +13,7 @@ import { daycareGroupFixture } from '../../dev-api/fixtures'
 import { logConsoleMessages } from '../../utils/fixture'
 import { t } from 'testcafe'
 import {
+  deleteEmployeeById,
   deleteEmployeeFixture,
   insertDaycareGroupFixtures,
   insertEmployeeFixture
@@ -48,14 +49,15 @@ fixture('Employee - paper application')
   .after(async () => {
     await cleanUp()
     await deleteEmployeeFixture(config.supervisorExternalId)
-    await deleteEmployeeFixture(supervisorId)
+    await deleteEmployeeById(supervisorId)
   })
 
 const formatPersonName = (person: ApplicationPersonDetail) =>
   `${person.lastName} ${person.firstName}`
 
 // eslint-disable-next-line
-const formatPersonAddress = (person: ApplicationPersonDetail) => `${person.streetAddress}, ${person.postalCode} ${person.postOffice}`
+const formatPersonAddress = (person: ApplicationPersonDetail) =>
+  `${person.streetAddress}, ${person.postalCode} ${person.postOffice}`
 
 test('Paper application can be created for guardian and child with ssn', async () => {
   await childInforationPage.openCreateApplicationModal()

--- a/frontend/e2e-test/test/e2e/specs/2_employee-2/paper-application.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/2_employee-2/paper-application.spec.ts
@@ -47,7 +47,7 @@ fixture('Employee - paper application')
   .afterEach(logConsoleMessages)
   .after(async () => {
     await cleanUp()
-    await deleteEmployeeFixture(config.supervisorAad)
+    await deleteEmployeeFixture(config.supervisorExternalId)
     await deleteEmployeeFixture(supervisorId)
   })
 

--- a/frontend/e2e-test/test/e2e/specs/5_employee/absence.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/5_employee/absence.spec.ts
@@ -45,12 +45,15 @@ fixture('Employee - Absences')
     ;[fixtures, cleanUp] = await initializeAreaAndPersonData()
     await insertDaycareGroupFixtures([daycareGroupFixture])
     await insertEmployeeFixture({
-      aad: config.supervisorAad,
+      externalId: config.supervisorExternalId,
       firstName: 'Seppo',
       lastName: 'Sorsa',
       roles: []
     })
-    await setAclForDaycares(config.supervisorAad, fixtures.daycareFixture.id)
+    await setAclForDaycares(
+      config.supervisorExternalId,
+      fixtures.daycareFixture.id
+    )
 
     daycarePlacementFixture = createDaycarePlacementFixture(
       fixtures.enduserChildFixtureJari.id,
@@ -65,7 +68,7 @@ fixture('Employee - Absences')
   .afterEach(logConsoleMessages)
   .after(async () => {
     await cleanUp()
-    await deleteEmployeeFixture(config.supervisorAad)
+    await deleteEmployeeFixture(config.supervisorExternalId)
   })
 
 test('User can place a child into a group and remove the child from the group', async (t) => {

--- a/frontend/e2e-test/test/e2e/specs/5_employee/unit-acl.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/5_employee/unit-acl.spec.ts
@@ -24,9 +24,9 @@ import { Role, t } from 'testcafe'
 const home = new EmployeeHome()
 const unitPage = new UnitPage()
 
-const employeeAads = [
-  'df979243-f081-4241-bc4f-e93a019bddfa',
-  '7e7daa1e-2e92-4c36-9e90-63cea3cd8f3f'
+const employeeExternalIds = [
+  'espoo-ad:df979243-f081-4241-bc4f-e93a019bddfa',
+  'espoo-ad:7e7daa1e-2e92-4c36-9e90-63cea3cd8f3f'
 ] as const
 let employeeUuids: UUID[] = []
 
@@ -47,25 +47,28 @@ fixture('Employee - Unit ACL')
   .page(config.adminUrl)
   .before(async () => {
     ;[fixtures, cleanUp] = await initializeAreaAndPersonData()
-    await deleteEmployeeFixture(config.supervisorAad)
+    await deleteEmployeeFixture(config.supervisorExternalId)
     await insertEmployeeFixture({
-      aad: config.supervisorAad,
+      externalId: config.supervisorExternalId,
       firstName: 'Seppo',
       lastName: 'Sorsa',
       email: 'seppo.sorsa@espoo.fi',
       roles: []
     })
-    await setAclForDaycares(config.supervisorAad, fixtures.daycareFixture.id)
+    await setAclForDaycares(
+      config.supervisorExternalId,
+      fixtures.daycareFixture.id
+    )
     employeeUuids = await Promise.all([
       insertEmployeeFixture({
-        aad: employeeAads[0],
+        externalId: employeeExternalIds[0],
         firstName: 'Pete',
         lastName: 'Päiväkoti',
         email: 'pete@example.com',
         roles: []
       }),
       insertEmployeeFixture({
-        aad: employeeAads[1],
+        externalId: employeeExternalIds[1],
         firstName: 'Yrjö',
         lastName: 'Yksikkö',
         email: 'yy@example.com',
@@ -87,8 +90,8 @@ fixture('Employee - Unit ACL')
       deviceId = null
     }
     await cleanUp()
-    await Promise.all(employeeAads.map(deleteEmployeeFixture))
-    await deleteEmployeeFixture(config.supervisorAad)
+    await Promise.all(employeeExternalIds.map(deleteEmployeeFixture))
+    await deleteEmployeeFixture(config.supervisorExternalId)
   })
 
 test('User can add and delete unit supervisors', async (t) => {

--- a/frontend/e2e-test/test/e2e/specs/6_mobile/pairing.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/6_mobile/pairing.spec.ts
@@ -24,9 +24,9 @@ import { t } from 'testcafe'
 
 const pairingFlow = new PairingFlow()
 
-const employeeAads = [
-  'df979243-f081-4241-bc4f-e93a019bddfa',
-  '7e7daa1e-2e92-4c36-9e90-63cea3cd8f3f'
+const employeeExternalIds = [
+  'espoo-ad:df979243-f081-4241-bc4f-e93a019bddfa',
+  'espoo-ad:7e7daa1e-2e92-4c36-9e90-63cea3cd8f3f'
 ] as const
 
 let pairingId: UUID | undefined = undefined
@@ -40,25 +40,28 @@ fixture('Mobile pairing')
   .page(config.adminUrl)
   .before(async () => {
     ;[fixtures, cleanUp] = await initializeAreaAndPersonData()
-    await deleteEmployeeFixture(config.supervisorAad)
+    await deleteEmployeeFixture(config.supervisorExternalId)
     await insertEmployeeFixture({
-      aad: config.supervisorAad,
+      externalId: config.supervisorExternalId,
       firstName: 'Seppo',
       lastName: 'Sorsa',
       email: 'seppo.sorsa@espoo.fi',
       roles: []
     })
-    await setAclForDaycares(config.supervisorAad, fixtures.daycareFixture.id)
+    await setAclForDaycares(
+      config.supervisorExternalId,
+      fixtures.daycareFixture.id
+    )
     await Promise.all([
       insertEmployeeFixture({
-        aad: employeeAads[0],
+        externalId: employeeExternalIds[0],
         firstName: 'Pete',
         lastName: 'Päiväkoti',
         email: 'pete@example.com',
         roles: []
       }),
       insertEmployeeFixture({
-        aad: employeeAads[1],
+        externalId: employeeExternalIds[1],
         firstName: 'Yrjö',
         lastName: 'Yksikkö',
         email: 'yy@example.com',
@@ -80,8 +83,8 @@ fixture('Mobile pairing')
       deviceId = null
     }
     await cleanUp()
-    await Promise.all(employeeAads.map(deleteEmployeeFixture))
-    await deleteEmployeeFixture(config.supervisorAad)
+    await Promise.all(employeeExternalIds.map(deleteEmployeeFixture))
+    await deleteEmployeeFixture(config.supervisorExternalId)
   })
 
 test('User can add a mobile device mobile side', async (t) => {

--- a/frontend/packages/employee-frontend/src/types/employee.ts
+++ b/frontend/packages/employee-frontend/src/types/employee.ts
@@ -6,7 +6,7 @@ import { UUID } from '~/types'
 
 export interface Employee {
   id: UUID
-  aad: UUID | null
+  externalId: string | null
   firstName: string | null
   lastName: string | null
   email: string

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.pis.controller
 
+import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.pis.AbstractIntegrationTest
 import fi.espoo.evaka.pis.Employee
 import fi.espoo.evaka.pis.NewEmployee
@@ -38,7 +39,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
         assertEquals(employee1.firstName, response.body!!.firstName)
         assertEquals(employee1.lastName, response.body!!.lastName)
         assertEquals(employee1.email, response.body!!.email)
-        assertEquals(employee1.aad, response.body!!.aad)
+        assertEquals(employee1.externalId, response.body!!.externalId)
     }
 
     @Test
@@ -82,14 +83,14 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
         email = employee.email,
         firstName = employee.firstName,
         lastName = employee.lastName,
-        aad = employee.aad
+        externalId = employee.externalId
     )
 
     val employee1 = Employee(
         email = "employee1@espoo.fi",
         firstName = "etunimi1",
         lastName = "sukunimi1",
-        aad = UUID.randomUUID(),
+        externalId = ExternalId.of(namespace = "espoo-ad", value = UUID.randomUUID().toString()),
         created = Instant.now(),
         updated = Instant.now(),
         id = UUID.randomUUID()
@@ -99,7 +100,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
         email = "employee2@espoo.fi",
         firstName = "etunimi2",
         lastName = "sukunimi2",
-        aad = UUID.randomUUID(),
+        externalId = ExternalId.of(namespace = "espoo-ad", value = UUID.randomUUID().toString()),
         created = Instant.now(),
         updated = Instant.now(),
         id = UUID.randomUUID()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/VtjClientServiceTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/VtjClientServiceTest.kt
@@ -170,7 +170,7 @@ class VtjClientServiceTest : AbstractIntegrationTest() {
         firstName = "Integration",
         lastName = "Test",
         email = "integration-test@example.org",
-        aad = null,
+        externalId = null,
         created = Instant.now(),
         updated = null
     )

--- a/service/src/integrationTest/resources/legacy_db_data.sql
+++ b/service/src/integrationTest/resources/legacy_db_data.sql
@@ -83,5 +83,5 @@ VALUES ('ff4fbaad-d02f-4f7a-9f7f-4c4e0f2a2b21',
 INSERT INTO varda_organizer (organizer, email, phone, iban)
 VALUES ('Espoo', 'test@espoo.fi', '+358981624', 'FI1680001370795552');
 
-INSERT INTO employee(id, first_name, last_name, aad_object_id, email)
-VALUES('00000000-0000-0000-0000-000000000000', 'Ally', 'Aardvark', '2014e23e-17c2-482f-ba4d-f8b9edc9d5c9', 'ally.aardvark@espoo.fi');
+INSERT INTO employee(id, first_name, last_name, external_id, email)
+VALUES('00000000-0000-0000-0000-000000000000', 'Ally', 'Aardvark', 'espoo-ad:2014e23e-17c2-482f-ba4d-f8b9edc9d5c9', 'ally.aardvark@espoo.fi');

--- a/service/src/main/kotlin/fi/espoo/evaka/identity/ExternalId.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/identity/ExternalId.kt
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.identity
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.util.StdConverter
+
+/**
+ * An identifier originating from an external system.
+ *
+ * eVaka doesn't internally understand the meaning of the value, so it can be anything.
+ */
+@JsonSerialize(converter = ExternalId.ToJson::class)
+@JsonDeserialize(converter = ExternalId.FromJson::class)
+data class ExternalId private constructor(val namespace: String, val value: String) {
+    override fun toString(): String = "$namespace:$value"
+
+    companion object {
+        fun of(namespace: String, value: String): ExternalId {
+            if (namespace.contains(':')) throw IllegalArgumentException("Invalid external id namespace $namespace")
+            return ExternalId(namespace, value)
+        }
+
+        fun parse(text: String): ExternalId {
+            val idx = text.indexOf(':')
+            if (idx == -1) throw IllegalArgumentException("Invalid external id $text")
+            return ExternalId(namespace = text.substring(0, idx), value = text.substring(idx + 1))
+        }
+    }
+
+    class FromJson : StdConverter<String, ExternalId>() {
+        override fun convert(value: String): ExternalId = parse(value)
+    }
+
+    class ToJson : StdConverter<ExternalId, String>() {
+        override fun convert(value: ExternalId): String = value.toString()
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/identity/ExternalIdSpringSupport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/identity/ExternalIdSpringSupport.kt
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.identity
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.convert.converter.Converter
+import org.springframework.format.FormatterRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class ExternalIdSpringSupport : WebMvcConfigurer {
+    override fun addFormatters(registry: FormatterRegistry) {
+        registry.addConverter(ExternalIdParser())
+    }
+
+    class ExternalIdParser : Converter<String, ExternalId> {
+        override fun convert(source: String): ExternalId = ExternalId.parse(source)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
@@ -63,7 +63,7 @@ fun Database.Transaction.respondPairingChallengeCreateDevice(id: UUID, challenge
                 WHERE p.id = :id AND p.challenge_key = :challenge AND p.response_key = :response 
                     AND p.status = 'WAITING_RESPONSE' AND p.expires > :now AND p.attempts <= :maxAttempts
             ), new_employee AS (
-                INSERT INTO employee (first_name, last_name, email, aad_object_id)
+                INSERT INTO employee (first_name, last_name, email, external_id)
                 SELECT :name, unit_name, null, null
                 FROM target_pairing
                 RETURNING employee.id

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/Employee.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/Employee.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.pis
 
+import fi.espoo.evaka.identity.ExternalId
 import java.time.Instant
 import java.util.UUID
 
@@ -12,7 +13,7 @@ data class Employee(
     val firstName: String,
     val lastName: String,
     val email: String?,
-    val aad: UUID?,
+    val externalId: ExternalId?,
     val created: Instant,
     val updated: Instant?
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.pis
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.pairing.MobileDeviceIdentity
 import fi.espoo.evaka.pairing.getDeviceByToken
@@ -47,15 +48,15 @@ class SystemIdentityController {
         user: AuthenticatedUser,
         @RequestBody employee: EmployeeIdentityRequest
     ): ResponseEntity<AuthenticatedUser> {
-        Audit.EmployeeGetOrCreate.log(targetId = employee.aad)
+        Audit.EmployeeGetOrCreate.log(targetId = employee.externalId)
         user.assertMachineUser()
         return ResponseEntity.ok(
             db.transaction {
-                it.handle.getEmployeeAuthenticatedUser(employee.aad)
+                it.handle.getEmployeeAuthenticatedUser(employee.externalId)
                     ?: AuthenticatedUser(
                         it.handle.createEmployee(
                             NewEmployee(
-                                aad = employee.aad,
+                                externalId = employee.externalId,
                                 firstName = employee.firstName,
                                 lastName = employee.lastName,
                                 email = employee.email,
@@ -80,7 +81,7 @@ class SystemIdentityController {
     }
 
     data class EmployeeIdentityRequest(
-        val aad: UUID,
+        val externalId: ExternalId,
         val firstName: String,
         val lastName: String,
         val email: String?

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
@@ -54,7 +54,7 @@ class EmployeeController {
 
     @PostMapping("")
     fun createEmployee(db: Database.Connection, user: AuthenticatedUser, @RequestBody employee: NewEmployee): ResponseEntity<Employee> {
-        Audit.EmployeeCreate.log(targetId = employee.aad)
+        Audit.EmployeeCreate.log(targetId = employee.externalId)
         user.requireOneOfRoles(UserRole.ADMIN)
         return ResponseEntity.ok().body(db.transaction { it.handle.createEmployee(employee) })
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
+import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.Period
@@ -75,9 +76,11 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
     jdbi.registerArgument(periodArgumentFactory)
     jdbi.registerArgument(coordinateArgumentFactory)
     jdbi.registerArgument(identityArgumentFactory)
+    jdbi.registerArgument(externalIdArgumentFactory)
     jdbi.registerColumnMapper(ClosedPeriod::class.java, closedPeriodColumnMapper)
     jdbi.registerColumnMapper(Period::class.java, periodColumnMapper)
     jdbi.registerColumnMapper(Coordinate::class.java, coordinateColumnMapper)
+    jdbi.registerColumnMapper(ExternalId::class.java, externalIdColumnMapper)
     jdbi.registerArrayType(UUID::class.java, "uuid")
     return jdbi
 }
@@ -92,7 +95,10 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
 inline fun <reified T : Any, This : SqlStatement<This>> SqlStatement<This>.bindNullable(name: String, value: T?): This =
     this.bindByType(name, value, QualifiedType.of(T::class.java))
 
-inline fun <reified T : Any, This : SqlStatement<This>> SqlStatement<This>.bindNullable(name: String, value: Collection<T>?): This =
+inline fun <reified T : Any, This : SqlStatement<This>> SqlStatement<This>.bindNullable(
+    name: String,
+    value: Collection<T>?
+): This =
     this.bindNullable(name, value?.toTypedArray())
 
 /**

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.decision.DecisionStatus
 import fi.espoo.evaka.decision.DecisionType
+import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.invoicing.domain.FeeAlteration
 import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.invoicing.domain.IncomeType
@@ -85,11 +86,11 @@ RETURNING id
 """
 )
 
-fun updateDaycareAcl(h: Handle, daycareId: UUID, personAad: UUID, role: UserRole) {
+fun updateDaycareAcl(h: Handle, daycareId: UUID, externalId: ExternalId, role: UserRole) {
     h
-        .createUpdate("INSERT INTO daycare_acl (employee_id, daycare_id, role) VALUES ((SELECT id from employee where aad_object_id = :aad_object_id), :daycare_id, :role)")
+        .createUpdate("INSERT INTO daycare_acl (employee_id, daycare_id, role) VALUES ((SELECT id from employee where external_id = :external_id), :daycare_id, :role)")
         .bind("daycare_id", daycareId)
-        .bind("aad_object_id", personAad)
+        .bind("external_id", externalId)
         .bind("role", role)
         .execute()
 }
@@ -107,7 +108,7 @@ fun Database.Transaction.createMobileDeviceToUnit(id: UUID, unitId: UUID, name: 
     // language=sql
     val sql =
         """
-        INSERT INTO employee (id, first_name, last_name, email, aad_object_id)
+        INSERT INTO employee (id, first_name, last_name, email, external_id)
         VALUES (:id, :name, 'Yksikkö', null, null);
         
         INSERT INTO mobile_device (id, unit_id, name) VALUES (:id, :unitId, :name);
@@ -120,19 +121,19 @@ fun Database.Transaction.createMobileDeviceToUnit(id: UUID, unitId: UUID, name: 
         .execute()
 }
 
-fun removeDaycareAcl(h: Handle, daycareId: UUID, personAad: UUID) {
+fun removeDaycareAcl(h: Handle, daycareId: UUID, externalId: ExternalId) {
     h
-        .createUpdate("DELETE FROM daycare_acl WHERE daycare_id=:daycare_id AND employee_id=(SELECT id from employee where aad_object_id = :aad_object_id)")
+        .createUpdate("DELETE FROM daycare_acl WHERE daycare_id=:daycare_id AND employee_id=(SELECT id from employee where external_id = :external_id)")
         .bind("daycare_id", daycareId)
-        .bind("aad_object_id", personAad)
+        .bind("external_id", externalId)
         .execute()
 }
 
 fun Handle.insertTestEmployee(employee: DevEmployee) = insertTestDataRow(
     employee,
     """
-INSERT INTO employee (id, first_name, last_name, email, aad_object_id, roles)
-VALUES (:id, :firstName, :lastName, :email, :aad, :roles::user_role[])
+INSERT INTO employee (id, first_name, last_name, email, external_id, roles)
+VALUES (:id, :firstName, :lastName, :email, :externalId, :roles::user_role[])
 RETURNING id
 """
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -45,6 +45,7 @@ import fi.espoo.evaka.pairing.initPairing
 import fi.espoo.evaka.pairing.respondPairingChallengeCreateDevice
 import fi.espoo.evaka.pis.Employee
 import fi.espoo.evaka.pis.createPersonFromVtj
+import fi.espoo.evaka.pis.deleteEmployee
 import fi.espoo.evaka.pis.deleteEmployeeByExternalId
 import fi.espoo.evaka.pis.deleteEmployeeRolesByExternalId
 import fi.espoo.evaka.pis.getEmployees
@@ -381,8 +382,14 @@ DELETE FROM attachment USING ApplicationsDeleted WHERE application_id = Applicat
         return ResponseEntity.ok(db.transaction { it.handle.insertTestEmployee(body) })
     }
 
-    @DeleteMapping("/employee/{externalId}")
-    fun deleteEmployee(db: Database, @PathVariable externalId: ExternalId): ResponseEntity<Unit> {
+    @DeleteMapping("/employee/{id}")
+    fun deleteEmployee(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+        db.transaction { it.handle.deleteEmployee(id) }
+        return ResponseEntity.ok().build()
+    }
+
+    @DeleteMapping("/employee/external-id/{externalId}")
+    fun deleteEmployeeByExternalId(db: Database, @PathVariable externalId: ExternalId): ResponseEntity<Unit> {
         db.transaction { it.handle.deleteEmployeeByExternalId(externalId) }
         return ResponseEntity.ok().build()
     }

--- a/service/src/main/resources/db/migration/V26__aad_to_external_id.sql
+++ b/service/src/main/resources/db/migration/V26__aad_to_external_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE employee ADD COLUMN external_id text CONSTRAINT uniq$employee_external_id UNIQUE;
+UPDATE employee SET external_id = 'espoo-ad:' || aad_object_id::text WHERE aad_object_id IS NOT NULL;
+ALTER TABLE employee DROP COLUMN aad_object_id;

--- a/service/src/main/resources/dev-data/employees.sql
+++ b/service/src/main/resources/dev-data/employees.sql
@@ -2,15 +2,15 @@
 --
 -- SPDX-License-Identifier: LGPL-2.1-or-later
 
-INSERT INTO employee (id, first_name, last_name, email, aad_object_id, roles) VALUES ('00000000-0000-0000-0000-000000000000', 'Päivi', 'Pääkäyttäjä', 'paivi.paakayttaja@espoo.fi', '00000000-0000-0000-0000-000000000000', '{ADMIN, SERVICE_WORKER, FINANCE_ADMIN}'::user_role[]);
-INSERT INTO employee (id, first_name, last_name, email, aad_object_id, roles) VALUES ('00000000-0000-0000-0001-000000000000', 'Paula', 'Palveluohjaaja', 'paula.palveluohjaaja@espoo.fi', '00000000-0000-0000-0001-000000000000', '{SERVICE_WORKER}'::user_role[]);
-INSERT INTO employee (id, first_name, last_name, email, aad_object_id, roles) VALUES ('00000000-0000-0000-0002-000000000000', 'Lasse', 'Laskuttaja', 'lasse.laskuttaja@espoo.fi', '00000000-0000-0000-0002-000000000000', '{FINANCE_ADMIN}'::user_role[]);
-INSERT INTO employee (id, first_name, last_name, email, aad_object_id, roles) VALUES ('00000000-0000-0000-0003-000000000000', 'Raisa', 'Raportoija', 'raisa.raportoija@espoo.fi', '00000000-0000-0000-0003-000000000000', '{DIRECTOR}'::user_role[]);
-INSERT INTO employee (id, first_name, last_name, email, aad_object_id) VALUES ('00000000-0000-0000-0004-000000000000', 'Essi', 'Esimies', 'essi.esimies@espoo.fi', '00000000-0000-0000-0004-000000000000');
-INSERT INTO employee (id, first_name, last_name, email, aad_object_id) VALUES ('00000000-0000-0000-0004-000000000001', 'Eemeli', 'Esimies', 'eemeli.esimies@espoo.fi', '00000000-0000-0000-0004-000000000001');
-INSERT INTO employee (id, first_name, last_name, email, aad_object_id) VALUES ('00000000-0000-0000-0005-000000000000', 'Kaisa', 'Kasvattaja', 'kaisa.kasvattaja@espoo.fi', '00000000-0000-0000-0005-000000000000');
-INSERT INTO employee (id, first_name, last_name, email, aad_object_id) VALUES ('00000000-0000-0000-0005-000000000001', 'Kalle', 'Kasvattaja', 'kalle.kasvattaja@espoo.fi', '00000000-0000-0000-0005-000000000001');
-INSERT INTO employee (id, first_name, last_name, email, aad_object_id) VALUES ('00000000-0000-0000-0006-000000000000', 'Erkki', 'Erityisopettaja', 'erkki.erityisopettaja@espoo.fi', '00000000-0000-0000-0006-000000000000');
+INSERT INTO employee (id, first_name, last_name, email, external_id, roles) VALUES ('00000000-0000-0000-0000-000000000000', 'Päivi', 'Pääkäyttäjä', 'paivi.paakayttaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0000-000000000000', '{ADMIN, SERVICE_WORKER, FINANCE_ADMIN}'::user_role[]);
+INSERT INTO employee (id, first_name, last_name, email, external_id, roles) VALUES ('00000000-0000-0000-0001-000000000000', 'Paula', 'Palveluohjaaja', 'paula.palveluohjaaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0001-000000000000', '{SERVICE_WORKER}'::user_role[]);
+INSERT INTO employee (id, first_name, last_name, email, external_id, roles) VALUES ('00000000-0000-0000-0002-000000000000', 'Lasse', 'Laskuttaja', 'lasse.laskuttaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0002-000000000000', '{FINANCE_ADMIN}'::user_role[]);
+INSERT INTO employee (id, first_name, last_name, email, external_id, roles) VALUES ('00000000-0000-0000-0003-000000000000', 'Raisa', 'Raportoija', 'raisa.raportoija@espoo.fi', 'espoo-ad:00000000-0000-0000-0003-000000000000', '{DIRECTOR}'::user_role[]);
+INSERT INTO employee (id, first_name, last_name, email, external_id) VALUES ('00000000-0000-0000-0004-000000000000', 'Essi', 'Esimies', 'essi.esimies@espoo.fi', 'espoo-ad:00000000-0000-0000-0004-000000000000');
+INSERT INTO employee (id, first_name, last_name, email, external_id) VALUES ('00000000-0000-0000-0004-000000000001', 'Eemeli', 'Esimies', 'eemeli.esimies@espoo.fi', 'espoo-ad:00000000-0000-0000-0004-000000000001');
+INSERT INTO employee (id, first_name, last_name, email, external_id) VALUES ('00000000-0000-0000-0005-000000000000', 'Kaisa', 'Kasvattaja', 'kaisa.kasvattaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0005-000000000000');
+INSERT INTO employee (id, first_name, last_name, email, external_id) VALUES ('00000000-0000-0000-0005-000000000001', 'Kalle', 'Kasvattaja', 'kalle.kasvattaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0005-000000000001');
+INSERT INTO employee (id, first_name, last_name, email, external_id) VALUES ('00000000-0000-0000-0006-000000000000', 'Erkki', 'Erityisopettaja', 'erkki.erityisopettaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0006-000000000000');
 
 INSERT INTO daycare_acl (daycare_id, employee_id, role) VALUES ('2dd6e5f6-788e-11e9-bd72-9f1cfe2d8405', '00000000-0000-0000-0004-000000000000', 'UNIT_SUPERVISOR');
 INSERT INTO daycare_acl (daycare_id, employee_id, role) VALUES ('2dda790a-788e-11e9-bdab-27ae0339236a', '00000000-0000-0000-0004-000000000000', 'UNIT_SUPERVISOR');

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -23,3 +23,4 @@ V22__alter_valid_acl_role_constraint.sql
 V23__mobile_device.sql
 V24__mobile_user_role.sql
 V25__mobile_device_token.sql
+V26__aad_to_external_id.sql

--- a/service/src/test/kotlin/fi/espoo/evaka/identity/ExternalIdTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/identity/ExternalIdTest.kt
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.identity
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import fi.espoo.evaka.shared.config.defaultObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ExternalIdTest {
+    private val objectMapper = defaultObjectMapper()
+
+    @Test
+    fun `external ids can serialized to and from json`() {
+        val id = ExternalId.of("espoo-ad", "123456")
+        val json = objectMapper.writeValueAsString(id)
+        assertEquals("\"espoo-ad:123456\"", json)
+        assertEquals(id, objectMapper.readValue<ExternalId>(json))
+    }
+
+    @Test
+    fun `external ids have a string representation and can be parsed from it`() {
+        val id = ExternalId.of("espoo-ad", "123456")
+        val text = id.toString()
+        assertEquals("espoo-ad:123456", text)
+        assertEquals(id, ExternalId.parse(text))
+    }
+}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

* migrate AADs like `some-uuid` -> external IDs like `espoo-ad:some-uuid`
* model external IDs using `ExternalId` type, which guarantees we have a namespace and a value