### PR TITLE
Improve Varda fee data reliability

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -285,9 +285,21 @@ val testChild_7 = PersonData.Detailed(
     restrictedDetailsEnabled = false
 )
 
+val testChildWithNamelessGuardian = PersonData.Detailed(
+    id = UUID.randomUUID(),
+    dateOfBirth = LocalDate.of(2018, 12, 31),
+    ssn = "311218A999J",
+    firstName = "Niilo",
+    lastName = "Nimettömänpoika",
+    streetAddress = "Kankkulankaivo 1",
+    postalCode = "00340",
+    postOffice = "Espoo",
+    restrictedDetailsEnabled = false
+)
+
 val allWorkers = setOf(testDecisionMaker_1)
 val allAdults = setOf(testAdult_1, testAdult_2, testAdult_3, testAdult_4, testAdult_5, testAdult_6)
-val allChildren = setOf(testChild_1, testChild_2, testChild_3, testChild_4, testChild_5, testChild_6, testChild_7)
+val allChildren = setOf(testChild_1, testChild_2, testChild_3, testChild_4, testChild_5, testChild_6, testChild_7, testChildWithNamelessGuardian)
 val allBasicChildren = allChildren.map { PersonData.Basic(it.id, it.dateOfBirth, it.firstName, it.lastName, it.ssn) }
 val allDaycares = setOf(testDaycare, testDaycare2)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaChildrenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaChildrenIntegrationTest.kt
@@ -46,6 +46,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
             assertEquals(0, getUploadedChildren(db).size)
             mockEndpoint.children.clear()
         }
+        mockEndpoint.cleanUp()
     }
 
     @Test
@@ -97,7 +98,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
                 .execute()
 
             uploadChildren()
-            val payload = mockEndpoint.children[0]
+            val payload = mockEndpoint.children.values.first()
             assertEquals(1, getUploadedChildren(db).size)
             assertEquals(defaultMunicipalOrganizerOid, payload.organizerOid)
             assertNull(payload.ownOrganizationOid)
@@ -125,7 +126,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
                 .execute()
 
             uploadChildren()
-            val payload = mockEndpoint.children[0]
+            val payload = mockEndpoint.children.values.first()
             assertEquals(1, getUploadedChildren(db).size)
             assertNull(payload.organizerOid)
             assertEquals(defaultMunicipalOrganizerOid, payload.ownOrganizationOid)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -59,7 +59,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
     @AfterEach
     fun afterEach() {
         db.transaction { it.resetDatabase() }
-        mockEndpoint.decisions.clear()
+        mockEndpoint.cleanUp()
     }
 
     @Test
@@ -88,7 +88,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
         val vardaDecisions = mockEndpoint.decisions
         assertEquals(1, vardaDecisions.size)
-        assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, vardaDecisions[0].providerTypeCode)
+        assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, vardaDecisions.values.first().providerTypeCode)
 
         val decisionRows = getVardaDecisions()
         assertEquals(1, decisionRows.size)
@@ -117,13 +117,13 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         val paosChild = children.firstOrNull { it.ophOrganizerOid == defaultPurchasedOrganizerOid }
         assertNotNull(paosChild)
 
-        val paosDecision = decisions.firstOrNull { it.childUrl.contains(paosChild!!.vardaChildId.toString()) }
+        val paosDecision = decisions.values.firstOrNull { it.childUrl.contains("/lapset/${paosChild!!.vardaChildId}") }
         assertNotNull(paosDecision)
 
         val municipalChild = children.firstOrNull { it.ophOrganizerOid == defaultMunicipalOrganizerOid }
         assertNotNull(municipalChild)
 
-        val municipalDecision = decisions.firstOrNull { it.childUrl.contains(municipalChild!!.vardaChildId.toString()) }
+        val municipalDecision = decisions.values.firstOrNull { it.childUrl.contains("/lapset/${municipalChild!!.vardaChildId}/") }
         assertNotNull(municipalDecision)
 
         assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, paosDecision!!.providerTypeCode)
@@ -430,7 +430,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
     @Test
     fun `a derived daycare decision is not sent when its service need is temporary`() {
         val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-        val placementId = insertPlacement(db, testChild_1.id, period)
+        insertPlacement(db, testChild_1.id, period)
         insertServiceNeed(db, testChild_1.id, period, temporary = true)
         insertVardaChild(db, testChild_1.id)
 
@@ -453,7 +453,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         val decisions = mockEndpoint.decisions
         assertEquals(1, decisions.size)
 
-        val decision = decisions[0]
+        val decision = decisions.values.first()
         assertEquals(period.start, decision.startDate)
         assertEquals(period.end, decision.endDate)
         assertEquals(40.0, decision.hoursPerWeek)
@@ -475,7 +475,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
         updateDecisions(db, vardaClient)
 
-        val decision = mockEndpoint.decisions[0]
+        val decision = mockEndpoint.decisions.values.first()
         assertNotEquals(sentDate, decision.applicationDate)
         assertEquals(period.start, decision.applicationDate)
     }
@@ -493,7 +493,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         val decisions = mockEndpoint.decisions
         assertEquals(1, decisions.size)
 
-        val decision = decisions[0]
+        val decision = decisions.values.first()
         assertEquals(period.start, decision.startDate)
         assertEquals(period.end, decision.endDate)
         assertEquals(40.0, decision.hoursPerWeek)
@@ -517,7 +517,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
         val decisions = mockEndpoint.decisions
         assertEquals(1, decisions.size)
-        assertEquals(weeklyHours - 20, decisions[0].hoursPerWeek)
+        assertEquals(weeklyHours - 20, decisions.values.first().hoursPerWeek)
     }
 
     @Test
@@ -532,7 +532,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
         val decisions = mockEndpoint.decisions
         assertEquals(1, decisions.size)
-        assertEquals(weeklyHours - 25, decisions[0].hoursPerWeek)
+        assertEquals(weeklyHours - 25, decisions.values.first().hoursPerWeek)
     }
 
     @Test
@@ -544,7 +544,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         insertVardaChild(db, testChild_1.id)
 
         updateDecisions(db, vardaClient)
-        val result = mockEndpoint.decisions.toList().sortedBy { it.startDate }
+        val result = mockEndpoint.decisions.values.sortedBy { it.startDate }
         assertEquals(2, result.size)
         assertEquals(period.start, result[0].startDate)
         assertEquals(period.start.plusMonths(1).minusDays(1), result[0].endDate)
@@ -565,7 +565,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         insertVardaChild(db, testChild_1.id)
 
         updateDecisions(db, vardaClient)
-        val result = mockEndpoint.decisions[0]
+        val result = mockEndpoint.decisions.values.first()
         assertEquals(period.start, result.startDate)
         assertEquals(period.end, result.endDate)
     }
@@ -578,7 +578,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         insertVardaChild(db, testChild_1.id)
 
         updateDecisions(db, vardaClient)
-        val result = mockEndpoint.decisions[0]
+        val result = mockEndpoint.decisions.values.first()
         assertEquals(false, result.fullDay)
     }
 
@@ -590,7 +590,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         insertVardaChild(db, testChild_1.id)
 
         updateDecisions(db, vardaClient)
-        val result = mockEndpoint.decisions[0]
+        val result = mockEndpoint.decisions.values.first()
         assertEquals(true, result.fullDay)
     }
 
@@ -602,7 +602,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         insertVardaChild(db, testChild_1.id)
 
         updateDecisions(db, vardaClient)
-        val result = mockEndpoint.decisions[0]
+        val result = mockEndpoint.decisions.values.first()
         assertEquals(true, result.fullDay)
     }
 
@@ -651,7 +651,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         val decisions = mockEndpoint.decisions
         assertEquals(1, decisions.size)
 
-        val decision = decisions[0]
+        val decision = decisions.values.first()
         assertEquals(period.start, decision.startDate)
         assertEquals(period.end, decision.endDate)
     }
@@ -681,8 +681,8 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
         val vardaDecisions = mockEndpoint.decisions
         assertEquals(1, vardaDecisions.size)
-        assertEquals(newStart, vardaDecisions.first().startDate)
-        assertEquals(newEnd, vardaDecisions.first().endDate)
+        assertEquals(newStart, vardaDecisions.values.first().startDate)
+        assertEquals(newEnd, vardaDecisions.values.first().endDate)
     }
 
     @Test
@@ -723,7 +723,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
         assertEquals(1, getVardaDecisions().size)
         assertEquals(1, mockEndpoint.decisions.size)
-        val initialDecision = mockEndpoint.decisions[0]
+        val initialDecision = mockEndpoint.decisions.values.first()
         assertEquals(period.start, initialDecision.startDate)
         assertEquals(period.end, initialDecision.endDate)
 
@@ -739,7 +739,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
         assertEquals(1, getVardaDecisions().size)
         assertEquals(1, mockEndpoint.decisions.size)
-        val finalDecision = mockEndpoint.decisions[0]
+        val finalDecision = mockEndpoint.decisions.values.first()
         assertEquals(newStart, finalDecision.startDate)
         assertEquals(newEnd, finalDecision.endDate)
     }
@@ -781,7 +781,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         insertPlacement(db, testChild_1.id, ClosedPeriod(newStart, period.end))
         updateDecisions(db, vardaClient)
 
-        val decision = mockEndpoint.decisions[0]
+        val decision = mockEndpoint.decisions.values.first()
         assertEquals(period.start, decision.startDate)
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -4,11 +4,12 @@
 
 package fi.espoo.evaka.varda
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.kittinunf.fuel.core.extensions.jsonBody
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.createFeeDecisionFixture
 import fi.espoo.evaka.invoicing.createFeeDecisionPartFixture
+import fi.espoo.evaka.invoicing.data.getFeeDecisionsByIds
 import fi.espoo.evaka.invoicing.data.upsertFeeDecisions
 import fi.espoo.evaka.invoicing.domain.FeeDecision
 import fi.espoo.evaka.invoicing.domain.FeeDecisionStatus
@@ -17,27 +18,28 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.PlacementType
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.dev.DevChild
-import fi.espoo.evaka.shared.dev.DevPerson
-import fi.espoo.evaka.shared.dev.insertTestChild
-import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.shared.domain.Period
 import fi.espoo.evaka.testAdult_1
+import fi.espoo.evaka.testAdult_2
+import fi.espoo.evaka.testChildWithNamelessGuardian
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
 import fi.espoo.evaka.testChild_3
 import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.testDecisionMaker_1
 import fi.espoo.evaka.testPurchasedDaycare
 import fi.espoo.evaka.varda.integration.MockVardaIntegrationEndpoint
 import org.jdbi.v3.core.kotlin.mapTo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -52,722 +54,490 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
     @Autowired
     lateinit var mockEndpoint: MockVardaIntegrationEndpoint
 
+    @Autowired
+    lateinit var asyncJobRunner: AsyncJobRunner
+
     @BeforeEach
     fun beforeEach() {
         db.transaction { insertGeneralTestFixtures(it.handle) }
         insertVardaUnit(db)
-        assertEquals(0, getVardaFeeDataRows(db).size)
         mockEndpoint.cleanUp()
     }
 
     @AfterEach
     fun afterEach() {
         db.transaction { it.resetDatabase() }
+        mockEndpoint.cleanUp()
     }
 
+    private val testPeriod = ClosedPeriod(start = LocalDate.now().minusMonths(1), end = LocalDate.now())
+
+    private val guardiansTestChild1 = listOf(testAdult_1, testAdult_2)
+        .map { VardaGuardian(it.ssn!!, it.firstName, it.lastName) }
+
     @Test
-    fun `fee data is sent when placement is sent to Varda`() {
-        createDecisionsAndPlacements(child = testChild_1)
-        insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(testChild_1), objectMapper)
+    fun `fee data is sent when a decision is sent to varda`() {
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        val feeDecision = insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
 
-        updateFeeData()
+        updateAll()
 
-        assertEquals(1, getVardaFeeDataRows(db).size)
+        assertEquals(1, mockEndpoint.feeData.size)
+        mockEndpoint.feeData.values.first().let {
+            assertEquals(guardiansTestChild1, it.huoltajat)
+            assertEquals(FeeBasisCode.DAYCARE.code, it.maksun_peruste_koodi)
+            assertEquals(0, it.palveluseteli_arvo)
+            assertEquals(feeDecision.parts.first().finalFee(), it.asiakasmaksu)
+            assertEquals(feeDecision.familySize, it.perheen_koko)
+            assertEquals(testPeriod.start, it.alkamis_pvm)
+            assertEquals(testPeriod.end, it.paattymis_pvm)
+        }
     }
 
     @Test
     fun `fee data is saved to database correctly after upload`() {
-        val period = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
-        insertDecisionWithApplication(db, testChild_1, period)
-        insertServiceNeed(db, testChild_1.id, period)
-        insertVardaChild(db, testChild_1.id)
-        val placementId = db.transaction {
-            insertTestPlacement(
-                it.handle,
-                childId = testChild_1.id,
-                unitId = testDaycare.id,
-                startDate = period.start,
-                endDate = period.end
-            )
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        val feeDecision = insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
+
+        updateAll()
+
+        assertEquals(1, mockEndpoint.feeData.size)
+        val vardaFeeDataRows = getVardaFeeDataRows(db)
+        assertEquals(1, vardaFeeDataRows.size)
+        vardaFeeDataRows.first().let { row ->
+            assertEquals(feeDecision.id, row.evakaFeeDecisionId)
+            assertEquals(mockEndpoint.feeData.keys.first(), row.vardaId)
+            db.read {
+                val decisionId = it.createQuery("SELECT id FROM varda_decision LIMIT 1").mapTo<UUID>().first()
+                assertEquals(decisionId, row.vardaDecisionId)
+                val childId = it.createQuery("SELECT id FROM varda_child LIMIT 1").mapTo<UUID>().first()
+                assertEquals(childId, row.vardaChildId)
+            }
         }
-        updateDecisions(db, vardaClient)
-        updatePlacements(db, vardaClient)
-
-        val feeDecision = insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period.start, period.end)
-        )
-
-        updateFeeData()
-        val feeDataRows = getVardaFeeDataRows(db)
-        assertEquals(1, feeDataRows.size)
-        assertEquals(feeDecision.id, feeDataRows[0].evakaFeeDecisionId)
-        assertEquals(placementId, feeDataRows[0].evakaPlacementId)
-        assertNotNull(feeDataRows[0].vardaFeeDataId)
-        assertNotNull(feeDataRows[0].createdAt)
-        assertNotNull(feeDataRows[0].uploadedAt)
     }
 
     @Test
-    fun `fee data is mapped correctly`() {
-        createDecisionsAndPlacements(child = testChild_1)
-        val feeDecision = insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            placementType = PlacementType.DAYCARE
-        )
-
-        updateFeeData()
-
-        val results = mockEndpoint.feeData.values
-        assertEquals(1, results.size)
-
-        val result = results.first()
-        assertEquals("MP03", result.feeCode)
-        assertEquals(0.0, result.voucherAmount)
-        assertEquals(feeDecision.familySize, result.familySize)
-        assertEquals(289.0, result.feeAmount)
-        assertEquals(feeDecision.validFrom, result.startDate)
-        assertEquals(feeDecision.validTo, result.endDate)
-    }
-
-    @Test
-    fun `five year old daycare is mapped correctly`() {
-        createDecisionsAndPlacements(child = testChild_1)
+    fun `five year old daycare has correct fee basis code`() {
+        createDecisionsAndPlacements(testPeriod, testChild_1)
         insertFeeDecision(
             db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
+            listOf(testChild_1),
+            testPeriod,
             placementType = PlacementType.FIVE_YEARS_OLD_DAYCARE
-        )
+        ).send()
 
-        updateFeeData()
+        updateAll()
 
-        val results = mockEndpoint.feeData.values
-        assertEquals(1, results.size)
-
-        assertEquals("MP02", results.first().feeCode)
-    }
-
-    @Test
-    fun `fee decision with two children generates two fee data entries`() {
-        createDecisionsAndPlacements(testChild_1)
-        createDecisionsAndPlacements(testChild_2)
-        insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(testChild_1, testChild_2), objectMapper)
-
-        updateFeeData()
-
-        assertEquals(2, getVardaFeeDataRows(db).size)
-    }
-
-    @Test
-    fun `fee data is not sent when there is no placement sent to Varda`() {
-        createDecisionsAndPlacements(testChild_1)
-        insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(testChild_1), objectMapper)
-        clearVardaPlacements(db)
-
-        updateFeeData()
-
-        assertEquals(0, getVardaFeeDataRows(db).size)
-    }
-
-    @Test
-    fun `fee data is not sent when the fee decision is annulled`() {
-        createDecisionsAndPlacements(testChild_1)
-        insertFeeDecision(db, FeeDecisionStatus.ANNULLED, listOf(testChild_1), objectMapper)
-
-        updateFeeData()
-
-        assertEquals(0, getVardaFeeDataRows(db).size)
-    }
-
-    @Test
-    fun `fee data is not sent when the fee decision is draft`() {
-        createDecisionsAndPlacements(testChild_1)
-        val sentFeeDecision = insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(testChild_1), objectMapper)
-
-        updateFeeData()
-
-        insertFeeDecision(db, FeeDecisionStatus.DRAFT, listOf(testChild_1), objectMapper)
-        db.transaction {
-            it.createUpdate("UPDATE placement SET updated = now() + interval '30 second' WHERE 1 = 1").execute()
+        assertEquals(1, mockEndpoint.feeData.size)
+        mockEndpoint.feeData.values.first().let {
+            assertEquals(FeeBasisCode.FIVE_YEAR_OLDS_DAYCARE.code, it.maksun_peruste_koodi)
         }
+    }
 
-        updateFeeData()
+    @Test
+    fun `fee decision with two children results in two fee data entries`() {
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        createDecisionsAndPlacements(testPeriod, testChild_2)
+        insertFeeDecision(db, listOf(testChild_1, testChild_2), testPeriod).send()
 
-        val feeDataRows = getVardaFeeDataRows(db)
-        assertEquals(1, feeDataRows.size)
-        assertEquals(sentFeeDecision.id, feeDataRows[0].evakaFeeDecisionId)
+        updateAll()
+
+        assertEquals(2, mockEndpoint.feeData.size)
+    }
+
+    @Test
+    fun `fee data is not sent when there is no decision sent to Varda`() {
+        insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
+
+        updateAll()
+
+        assertEquals(0, mockEndpoint.feeData.size)
+    }
+
+    @Test
+    fun `fee data is not sent when the fee decision is still a draft`() {
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        insertFeeDecision(db, listOf(testChild_1), testPeriod)
+
+        updateAll()
+
+        assertEquals(0, mockEndpoint.feeData.size)
     }
 
     @Test
     fun `child with no guardians is not sent to Varda`() {
         // testChild_3 doesn't have guardians in mock VTJ data
-        createDecisionsAndPlacements(child = testChild_3)
-        insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(testChild_3), objectMapper)
+        createDecisionsAndPlacements(testPeriod, testChild_3)
+        insertFeeDecision(db, listOf(testChild_3), testPeriod).send()
 
-        updateFeeData()
+        updateAll()
 
-        assertEquals(0, getVardaFeeDataRows(db).size)
+        assertEquals(0, mockEndpoint.feeData.size)
     }
 
     @Test
-    fun `fee data is sent and updated to database only once`() {
-        val period = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
-        createDecisionsAndPlacements(child = testChild_1, period = period)
+    fun `child with a nameless guardian is not sent to Varda`() {
+        createDecisionsAndPlacements(testPeriod, testChildWithNamelessGuardian)
+        insertFeeDecision(db, listOf(testChildWithNamelessGuardian), testPeriod).send()
 
-        updateDecisions(db, vardaClient)
-        updatePlacements(db, vardaClient)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period.start, period.end)
-        )
+        updateAll()
 
-        updateFeeData()
-        val originalEntry = getVardaFeeDataRows(db)[0]
-
-        updateFeeData()
-        updateFeeData()
-        updateFeeData()
-        updateFeeData()
-
-        val finalEntry = getVardaFeeDataRows(db)[0]
-        assertEquals(1, mockEndpoint.feeData.size)
-        assertEquals(1, getVardaFeeDataRows(db).size)
-        assertEquals(originalEntry, finalEntry)
+        assertEquals(0, mockEndpoint.feeData.size)
     }
 
     @Test
-    fun `child with various decisions in Varda is handled correctly`() {
-        val period1 = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
-        val period2 = ClosedPeriod(period1.end.plusMonths(1), LocalDate.now().plusMonths(6))
-        val child = testChild_1
-        createDecisionsAndPlacements(child = child, period = period1)
+    fun `fee data is not updated when fee decision has not been updated`() {
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
 
-        updateDecisions(db, vardaClient)
-        updatePlacements(db, vardaClient)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period1.start, period1.end)
-        )
+        updateAll()
 
-        updateFeeData()
-        assertEquals(1, getVardaFeeDataRows(db).size)
+        val originalSentData = mockEndpoint.feeData.toMap()
+        assertEquals(1, originalSentData.size)
+        val originalRows = getVardaFeeDataRows(db)
+        assertEquals(1, originalRows.size)
 
-        db.transaction {
-            insertTestPlacement(
-                it.handle,
-                childId = child.id,
-                unitId = testDaycare.id,
-                startDate = period2.start,
-                endDate = period2.end
-            )
+        updateAll()
+
+        val newSentData = mockEndpoint.feeData.toMap()
+        assertEquals(1, newSentData.size)
+        assertEquals(originalSentData, newSentData)
+        val newRows = getVardaFeeDataRows(db)
+        assertEquals(1, newRows.size)
+        assertEquals(originalRows, newRows)
+    }
+
+    @Test
+    fun `fee data is sent for both decision periods when one fee decision covers two decisions`() {
+        val periodFirstHalf = testPeriod.copy(end = testPeriod.start.plusDays(7))
+        val periodSecondHalf = testPeriod.copy(start = testPeriod.start.plusDays(8))
+        createDecisionsAndPlacements(periodFirstHalf, testChild_1)
+        createDecisionsAndPlacements(periodSecondHalf, testChild_1)
+        val feeDecision = insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
+
+        updateAll()
+
+        val sortedSentData = mockEndpoint.feeData.values.sortedBy { it.alkamis_pvm }
+        assertEquals(2, mockEndpoint.feeData.size)
+        sortedSentData.first().let {
+            assertEquals(guardiansTestChild1, it.huoltajat)
+            assertEquals(FeeBasisCode.DAYCARE.code, it.maksun_peruste_koodi)
+            assertEquals(0, it.palveluseteli_arvo)
+            assertEquals(feeDecision.parts.first().finalFee(), it.asiakasmaksu)
+            assertEquals(feeDecision.familySize, it.perheen_koko)
+            assertEquals(periodFirstHalf.start, it.alkamis_pvm)
+            assertEquals(periodFirstHalf.end, it.paattymis_pvm)
         }
-        insertServiceNeed(db, child.id, period2)
-        updateDecisions(db, vardaClient)
-        updatePlacements(db, vardaClient)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period2.start, period2.end)
-        )
+        sortedSentData.last().let {
+            assertEquals(guardiansTestChild1, it.huoltajat)
+            assertEquals(FeeBasisCode.DAYCARE.code, it.maksun_peruste_koodi)
+            assertEquals(0, it.palveluseteli_arvo)
+            assertEquals(feeDecision.parts.first().finalFee(), it.asiakasmaksu)
+            assertEquals(feeDecision.familySize, it.perheen_koko)
+            assertEquals(periodSecondHalf.start, it.alkamis_pvm)
+            assertEquals(periodSecondHalf.end, it.paattymis_pvm)
+        }
+    }
 
-        updateFeeData()
-        assertEquals(2, getVardaFeeDataRows(db).size)
+    @Test
+    fun `fee data is sent for both decision periods when two fee decisions cover one decision`() {
+        val periodFirstHalf = testPeriod.copy(end = testPeriod.start.plusDays(7))
+        val periodSecondHalf = testPeriod.copy(start = testPeriod.start.plusDays(8))
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        val firstFeeDecision = insertFeeDecision(db, listOf(testChild_1), periodFirstHalf).send()
+        val secondFeeDecision = insertFeeDecision(
+            db,
+            listOf(testChild_1, testChild_2),
+            periodSecondHalf
+        ).send()
+
+        updateAll()
+
+        val sortedSentData = mockEndpoint.feeData.values.sortedBy { it.alkamis_pvm }
+        assertEquals(2, mockEndpoint.feeData.size)
+        sortedSentData.first().let {
+            assertEquals(guardiansTestChild1, it.huoltajat)
+            assertEquals(FeeBasisCode.DAYCARE.code, it.maksun_peruste_koodi)
+            assertEquals(0, it.palveluseteli_arvo)
+            assertEquals(firstFeeDecision.parts.first().finalFee(), it.asiakasmaksu)
+            assertEquals(firstFeeDecision.familySize, it.perheen_koko)
+            assertEquals(periodFirstHalf.start, it.alkamis_pvm)
+            assertEquals(periodFirstHalf.end, it.paattymis_pvm)
+        }
+        sortedSentData.last().let {
+            assertEquals(guardiansTestChild1, it.huoltajat)
+            assertEquals(FeeBasisCode.DAYCARE.code, it.maksun_peruste_koodi)
+            assertEquals(0, it.palveluseteli_arvo)
+            assertEquals(secondFeeDecision.parts.first().finalFee(), it.asiakasmaksu)
+            assertEquals(secondFeeDecision.familySize, it.perheen_koko)
+            assertEquals(periodSecondHalf.start, it.alkamis_pvm)
+            assertEquals(periodSecondHalf.end, it.paattymis_pvm)
+        }
     }
 
     @Test
     fun `child with decision to municipal and purchased units is handled correctly`() {
-        val period1 = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().minusMonths(5))
-        val period2 = ClosedPeriod(period1.end.plusMonths(1), LocalDate.now().plusMonths(6))
-
-        val child = testChild_1
-
-        val paosDaycareId = testPurchasedDaycare.id
-
-        updateUnits(db, vardaClient, vardaOrganizerName)
-
-        createDecisionsAndPlacements(child = child, period = period1, daycareId = paosDaycareId)
-        insertFeeDecision(
+        val periodFirstHalf = testPeriod.copy(end = testPeriod.start.plusDays(7))
+        val periodSecondHalf = testPeriod.copy(start = testPeriod.start.plusDays(8))
+        createDecisionsAndPlacements(periodFirstHalf, testChild_1, testDaycare.id)
+        createDecisionsAndPlacements(periodSecondHalf, testChild_1, testPurchasedDaycare.id)
+        val firstFeeDecision = insertFeeDecision(
             db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(child),
-            objectMapper = objectMapper,
-            period = Period(period1.start, period1.end),
-            daycareId = paosDaycareId
-        )
-        updateFeeData()
-        assertEquals(1, getVardaFeeDataRows(db).size)
-
-        val daycareId = testDaycare.id
-        createDecisionsAndPlacements(child = child, period = period2, daycareId = daycareId)
-        insertFeeDecision(
+            listOf(testChild_1),
+            periodFirstHalf,
+            daycareId = testDaycare.id
+        ).send()
+        val secondFeeDecision = insertFeeDecision(
             db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(child),
-            objectMapper = objectMapper,
-            period = Period(period2.start, period2.end),
-            daycareId = daycareId
-        )
-        updateFeeData()
+            listOf(testChild_1, testChild_2),
+            periodSecondHalf,
+            daycareId = testPurchasedDaycare.id
+        ).send()
 
-        assertEquals(2, getVardaFeeDataRows(db).size)
-    }
+        updateAll()
 
-    @Test
-    fun `two fee data entries is sent with two placements inside one fee decision`() {
-        /*
-            Fee decision |--------------------|
-            Placement       |-------|  |--|
-            Fee data        |-------|  |--|
-        */
-        val decisionPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6))
-        val firstPlacementPeriod = ClosedPeriod(decisionPeriod.start.plusMonths(1), decisionPeriod.start.plusMonths(2))
-        val secondPlacementPeriod = ClosedPeriod(firstPlacementPeriod.end.plusMonths(1), decisionPeriod.end.minusMonths(1))
-        insertDecisionWithApplication(db, testChild_1, decisionPeriod)
-        insertServiceNeed(db, testChild_1.id, decisionPeriod)
-        insertVardaChild(db, testChild_1.id, Instant.now().minusSeconds(60 * 60 * 24))
-        db.transaction {
-            insertTestPlacement(it.handle, childId = testChild_1.id, unitId = testDaycare.id, startDate = firstPlacementPeriod.start, endDate = firstPlacementPeriod.end)
-            insertTestPlacement(it.handle, childId = testChild_1.id, unitId = testDaycare.id, startDate = secondPlacementPeriod.start, endDate = secondPlacementPeriod.end)
+        val sortedSentData = mockEndpoint.feeData.values.sortedBy { it.alkamis_pvm }
+        assertEquals(2, mockEndpoint.feeData.size)
+        sortedSentData.first().let {
+            assertEquals(guardiansTestChild1, it.huoltajat)
+            assertEquals(FeeBasisCode.DAYCARE.code, it.maksun_peruste_koodi)
+            assertEquals(0, it.palveluseteli_arvo)
+            assertEquals(firstFeeDecision.parts.first().finalFee(), it.asiakasmaksu)
+            assertEquals(firstFeeDecision.familySize, it.perheen_koko)
+            assertEquals(periodFirstHalf.start, it.alkamis_pvm)
+            assertEquals(periodFirstHalf.end, it.paattymis_pvm)
         }
-        updateDecisions(db, vardaClient)
-        updatePlacements(db, vardaClient)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(decisionPeriod.start, decisionPeriod.end)
-        )
-        updateFeeData()
-
-        assertEquals(2, getVardaFeeDataRows(db).size)
-        assertEquals(2, getVardaPlacements(db).size)
-
-        val uploadedFeeData: List<VardaFeeData> = mockEndpoint.feeData.values.sortedBy { data -> data.startDate }
-        assertEquals(firstPlacementPeriod.start, uploadedFeeData[0].startDate)
-        assertEquals(firstPlacementPeriod.end, uploadedFeeData[0].endDate)
-        assertEquals(secondPlacementPeriod.start, uploadedFeeData[1].startDate)
-        assertEquals(secondPlacementPeriod.end, uploadedFeeData[1].endDate)
-    }
-
-    @Test
-    fun `two different fee data entries are sent when placement has two fee decisions`() {
-        /*
-            Fee decision |-----------||-----------|
-            Placement       |----------------|
-            Fee data        |--------||------|
-        */
-        val decisionPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6))
-        val feeDecisionsPeriod1 = ClosedPeriod(decisionPeriod.start, decisionPeriod.start.plusMonths(2))
-        val feeDecisionPeriod2 = ClosedPeriod(feeDecisionsPeriod1.end.plusMonths(1), decisionPeriod.end)
-        val placementPeriod = ClosedPeriod(feeDecisionsPeriod1.start.plusMonths(1), feeDecisionPeriod2.end.minusMonths(1))
-
-        insertDecisionWithApplication(db, testChild_1, decisionPeriod)
-        insertServiceNeed(db, testChild_1.id, decisionPeriod)
-        insertVardaChild(db, testChild_1.id)
-        db.transaction {
-            insertTestPlacement(it.handle, childId = testChild_1.id, unitId = testDaycare.id, startDate = placementPeriod.start, endDate = placementPeriod.end)
+        sortedSentData.last().let {
+            assertEquals(guardiansTestChild1, it.huoltajat)
+            assertEquals(FeeBasisCode.DAYCARE.code, it.maksun_peruste_koodi)
+            assertEquals(0, it.palveluseteli_arvo)
+            assertEquals(secondFeeDecision.parts.first().finalFee(), it.asiakasmaksu)
+            assertEquals(secondFeeDecision.familySize, it.perheen_koko)
+            assertEquals(periodSecondHalf.start, it.alkamis_pvm)
+            assertEquals(periodSecondHalf.end, it.paattymis_pvm)
         }
-        updateDecisions(db, vardaClient)
-        updatePlacements(db, vardaClient)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(feeDecisionsPeriod1.start, feeDecisionsPeriod1.end)
-        )
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1, testChild_2),
-            objectMapper = objectMapper,
-            period = Period(feeDecisionPeriod2.start, feeDecisionPeriod2.end)
-        )
-
-        updateFeeData()
-        assertEquals(2, getVardaFeeDataRows(db).size)
-        assertEquals(1, getVardaPlacements(db).size)
-
-        val uploadedFeeData: List<VardaFeeData> = mockEndpoint.feeData.values.sortedBy { data -> data.startDate }
-        assertEquals(placementPeriod.start, uploadedFeeData[0].startDate)
-        assertEquals(feeDecisionsPeriod1.end, uploadedFeeData[0].endDate)
-        assertEquals(2, uploadedFeeData[0].familySize)
-
-        assertEquals(feeDecisionPeriod2.start, uploadedFeeData[1].startDate)
-        assertEquals(placementPeriod.end, uploadedFeeData[1].endDate)
-        assertEquals(3, uploadedFeeData[1].familySize)
     }
 
     @Test
-    fun `delete fee data entry if its placement is removed`() {
-        createDecisionsAndPlacements()
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-        )
-        updateFeeData()
+    fun `fee data is deleted when corresponding decision is deleted`() {
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
 
-        assertEquals(1, getVardaPlacements(db).size)
-        assertEquals(1, getVardaFeeDataRows(db).size)
+        updateAll()
 
-        clearPlacements(db)
-        updatePlacements(db, vardaClient)
-        updateFeeData()
+        val originalSentData = mockEndpoint.feeData.toMap()
+        assertEquals(1, originalSentData.size)
+        val originalRows = getVardaFeeDataRows(db)
+        assertEquals(1, originalRows.size)
 
-        assertEquals(0, getVardaPlacements(db).size)
-        assertEquals(0, getVardaFeeDataRows(db).size)
-    }
-
-    @Test
-    fun `delete all fee data entries of annulled fee decisions`() {
-        val decisionPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6))
-        val firstPlacementPeriod = ClosedPeriod(decisionPeriod.start.plusMonths(1), decisionPeriod.start.plusMonths(2))
-        val secondPlacementPeriod = ClosedPeriod(firstPlacementPeriod.end.plusMonths(1), decisionPeriod.end.minusMonths(1))
-        insertDecisionWithApplication(db, testChild_1, decisionPeriod)
-        insertServiceNeed(db, testChild_1.id, decisionPeriod)
-        insertVardaChild(db, testChild_1.id, Instant.now().minusSeconds(60 * 60 * 24))
         db.transaction {
-            insertTestPlacement(it.handle, childId = testChild_1.id, unitId = testDaycare.id, startDate = secondPlacementPeriod.start, endDate = secondPlacementPeriod.end)
-            insertTestPlacement(it.handle, childId = testChild_1.id, unitId = testDaycare.id, startDate = firstPlacementPeriod.start, endDate = firstPlacementPeriod.end)
+            it.execute("DELETE FROM decision")
+            it.execute("DELETE FROM placement")
         }
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(decisionPeriod.start, decisionPeriod.end)
-        )
-        updateDecisions(db, vardaClient)
-        updatePlacements(db, vardaClient)
-        updateFeeData()
+        updateAll()
 
-        assertEquals(2, getVardaFeeDataRows(db).size)
-
-        setFeeDecisionsAnnulled(db)
-        updateFeeData()
-
-        assertEquals(0, getVardaFeeDataRows(db).size)
+        val newSentData = mockEndpoint.feeData.toMap()
+        assertEquals(0, newSentData.size)
+        val newRows = getVardaFeeDataRows(db)
+        assertEquals(0, newRows.size)
     }
 
     @Test
-    fun `deleting legacy fee data works`() {
-        val feeDecision = insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-        )
+    fun `fee data is deleted when corresponding fee decision is annulled`() {
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        val feeDecision = insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
+
+        updateAll()
+
+        val originalSentData = mockEndpoint.feeData.toMap()
+        assertEquals(1, originalSentData.size)
+        val originalRows = getVardaFeeDataRows(db)
+        assertEquals(1, originalRows.size)
+
         db.transaction {
-            it.createUpdate(
-                """
-                INSERT INTO varda_fee_data (evaka_fee_decision_id, varda_fee_data_id, evaka_placement_id)
-                VALUES (:feeDecisionId, 12333, NULL)
-                """
+            it.execute(
+                "UPDATE fee_decision SET status = ? WHERE id = ?",
+                FeeDecisionStatus.ANNULLED,
+                feeDecision.id
             )
-                .bind("feeDecisionId", feeDecision.id)
-                .execute()
         }
+        updateAll()
 
-        assertEquals(1, getVardaFeeDataRows(db).size)
-        updateFeeData()
-        assertEquals(0, getVardaFeeDataRows(db).size)
+        val newSentData = mockEndpoint.feeData.toMap()
+        assertEquals(0, newSentData.size)
+        val newRows = getVardaFeeDataRows(db)
+        assertEquals(0, newRows.size)
     }
 
     @Test
-    fun `modify fee data entry when placement is modified`() {
-        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-        createDecisionsAndPlacements(period = period)
-        insertFeeDecision(
+    fun `fee data is replaced when corresponding fee decision is replaced by a new one`() {
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        val originalFeeDecision = insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
+
+        updateAll()
+
+        val originalSentData = mockEndpoint.feeData.toMap()
+        assertEquals(1, originalSentData.size)
+        originalSentData.values.first().let { data ->
+            assertEquals(originalFeeDecision.familySize, data.perheen_koko)
+        }
+        val originalRows = getVardaFeeDataRows(db)
+        assertEquals(1, originalRows.size)
+
+        val newFeeDecision = insertFeeDecision(db, listOf(testChild_1, testChild_2), testPeriod).send()
+        updateAll()
+
+        val newSentData = mockEndpoint.feeData.toMap()
+        assertEquals(1, newSentData.size)
+        newSentData.values.first().let { data ->
+            assertEquals(newFeeDecision.familySize, data.perheen_koko)
+        }
+        val newRows = getVardaFeeDataRows(db)
+        assertEquals(1, newRows.size)
+    }
+
+    @Test
+    fun `fee data is updated and a new one is created when corresponding fee decision is partially replaced by a new one`() {
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        val originalFeeDecision = insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
+
+        updateAll()
+
+        val originalSentData = mockEndpoint.feeData.toMap()
+        assertEquals(1, originalSentData.size)
+        originalSentData.values.first().let { data ->
+            assertEquals(originalFeeDecision.familySize, data.perheen_koko)
+            assertEquals(testPeriod.start, data.alkamis_pvm)
+            assertEquals(testPeriod.end, data.paattymis_pvm)
+        }
+        val originalRows = getVardaFeeDataRows(db)
+        assertEquals(1, originalRows.size)
+
+        val periodEndHalf = testPeriod.copy(start = testPeriod.start.plusDays(8))
+        val newFeeDecision = insertFeeDecision(
             db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period.start, period.end)
-        )
-        updateFeeData()
+            listOf(testChild_1, testChild_2),
+            periodEndHalf
+        ).send()
+        updateAll()
 
-        assertEquals(1, getVardaFeeDataRows(db).size)
-        val originalFeeData = mockEndpoint.feeData.values.first()
-        assertEquals(period.start, originalFeeData.startDate)
-        assertEquals(period.end, originalFeeData.endDate)
+        val newSentData = mockEndpoint.feeData.toMap()
+        assertEquals(2, newSentData.size)
+        val originalData = newSentData[originalSentData.keys.first()]
+        assertNotNull(originalData)
+        originalData!!.let { data ->
+            assertEquals(originalFeeDecision.familySize, data.perheen_koko)
+            assertEquals(testPeriod.start, data.alkamis_pvm)
+            assertEquals(periodEndHalf.start.minusDays(1), data.paattymis_pvm)
+        }
+        newSentData.values.last().let { data ->
+            assertEquals(newFeeDecision.familySize, data.perheen_koko)
+            assertEquals(periodEndHalf.start, data.alkamis_pvm)
+            assertEquals(periodEndHalf.end, data.paattymis_pvm)
+        }
+        val newRows = getVardaFeeDataRows(db)
+        assertEquals(2, newRows.size)
+    }
 
-        val newStart = period.start.plusDays(1)
-        val newEnd = period.end.minusDays(1)
+    @Test
+    fun `fee data is updated and a new one is created when a new decision is created and fee data is updated after a new fee decision is created`() {
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        val originalFeeDecision = insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
+
+        updateAll()
+
+        val originalSentData = mockEndpoint.feeData.toMap()
+        assertEquals(1, originalSentData.size)
+        originalSentData.values.first().let { data ->
+            assertEquals(originalFeeDecision.familySize, data.perheen_koko)
+            assertEquals(testPeriod.start, data.alkamis_pvm)
+            assertEquals(testPeriod.end, data.paattymis_pvm)
+        }
+        val originalRows = getVardaFeeDataRows(db)
+        assertEquals(1, originalRows.size)
+
+        val newPeriod = testPeriod.copy(start = testPeriod.start.plusDays(8))
         db.transaction {
-            it.createUpdate("UPDATE placement SET start_date = :newStart, end_date = :newEnd WHERE 1 = 1")
-                .bind("newStart", newStart)
-                .bind("newEnd", newEnd)
-                .execute()
+            it.execute("UPDATE placement SET end_date = ?", newPeriod.start.minusDays(1))
+            it.execute("UPDATE service_need SET end_date = ?", newPeriod.start.minusDays(1))
         }
+        createDecisionsAndPlacements(newPeriod, testChild_1)
+        updateAll()
 
-        updateFeeData()
+        val newSentData = mockEndpoint.feeData.toMap()
+        assertEquals(2, newSentData.size)
+        newSentData.values.first().let { data ->
+            assertEquals(originalFeeDecision.familySize, data.perheen_koko)
+            assertEquals(testPeriod.start, data.alkamis_pvm)
+            assertEquals(newPeriod.start.minusDays(1), data.paattymis_pvm)
+        }
+        newSentData.values.last().let { data ->
+            assertEquals(originalFeeDecision.familySize, data.perheen_koko)
+            assertEquals(newPeriod.start, data.alkamis_pvm)
+            assertEquals(newPeriod.end, data.paattymis_pvm)
+        }
+        val newRows = getVardaFeeDataRows(db)
+        assertEquals(2, newRows.size)
 
-        val newFeeData = mockEndpoint.feeData.values.first()
-        assertNotEquals(originalFeeData.startDate, newFeeData.startDate)
-        assertNotEquals(originalFeeData.endDate, newFeeData.endDate)
-        assertEquals(newStart, newFeeData.startDate)
-        assertEquals(newEnd, newFeeData.endDate)
+        val newFeeDecision = insertFeeDecision(
+            db,
+            listOf(testChild_1, testChild_2),
+            newPeriod
+        ).send()
+        updateAll()
+
+        val updatedSentData = mockEndpoint.feeData.toMap()
+        assertEquals(2, updatedSentData.size)
+        updatedSentData.values.last().let { data ->
+            assertEquals(newFeeDecision.familySize, data.perheen_koko)
+            assertEquals(newPeriod.start, data.alkamis_pvm)
+            assertEquals(newPeriod.end, data.paattymis_pvm)
+        }
+        val updatedRows = getVardaFeeDataRows(db)
+        assertEquals(2, updatedRows.size)
     }
 
     @Test
-    fun `modifying fee data updates the timestamp`() {
-        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-        createDecisionsAndPlacements(period = period)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period.start, period.end)
-        )
-        updateFeeData()
-
-        assertEquals(1, getVardaFeeDataRows(db).size)
-        val originalEntry = getVardaFeeDataRows(db)[0]
-
-        val newStart = period.start.plusDays(1)
-        db.transaction {
-            it.createUpdate("UPDATE placement SET start_date = :newStart WHERE 1 = 1")
-                .bind("newStart", newStart)
-                .execute()
-        }
-
-        updateFeeData()
-
-        val finalEntry = getVardaFeeDataRows(db)[0]
-        assertNotEquals(originalEntry, finalEntry)
-        assertTrue(originalEntry.uploadedAt < finalEntry.uploadedAt)
-    }
-
-    @Test
-    fun `fee data is soft deleted if it is flagged with should_be_deleted`() {
-        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-        createDecisionsAndPlacements(period = period)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period.start, period.end)
-        )
-        updateFeeData()
-
-        assertEquals(1, getVardaFeeDataRows(db).size)
-        assertEquals(0, getSoftDeletedVardaFeeData(db).size)
-
-        db.transaction { it.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute() }
-
-        removeMarkedFeeDataFromVarda(db, vardaClient)
-        assertEquals(1, getSoftDeletedVardaFeeData(db).size)
-    }
-
-    @Test
-    fun `fee_data is not updated if upload flag is turned off`() {
-        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-
-        createDecisionsAndPlacements(period = period)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period.start, period.end)
-        )
+    fun `fee data is sent in an expected way when a child's both guardians have a fee decision`() {
+        // Although this shouldn't usually happen, it's not prevented at the database level
+        // so we have take this case into account
+        createDecisionsAndPlacements(testPeriod, testChild_1)
+        insertFeeDecision(db, listOf(testChild_1), testPeriod).send()
+        insertFeeDecision(db, listOf(testChild_1), testPeriod, guardian = testAdult_2.id).send()
 
         updateAll()
-
-        assertEquals(1, mockEndpoint.feeData.size)
-
-        db.transaction {
-            it.createUpdate("UPDATE daycare SET upload_to_varda = false WHERE id = :id").bind("id", testDaycare.id).execute()
-            it.createUpdate("UPDATE placement SET start_date = :newStart")
-                .bind("newStart", period.start.minusMonths(1))
-                .execute()
-        }
-
-        updateAll()
-
-        val feeData = mockEndpoint.feeData
-        assertEquals(1, feeData.size)
-        assertEquals(period.start, feeData.values.first().startDate)
-    }
-
-    @Test
-    fun `updating daycare organizer oid yields new varda fee data row if old is soft deleted`() {
-        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
-
-        createDecisionsAndPlacements(period = period)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period.start, period.end)
-        )
-
-        updateAll()
-
-        assertEquals(1, getVardaFeeDataRows(db).size)
-
-        db.transaction {
-            it.createUpdate("update varda_fee_data set should_be_deleted = true, deleted_at = NOW()").execute()
-            it.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id")
-                .bind("id", testDaycare.id)
-                .execute()
-        }
-
-        updateAll()
-
-        assertEquals(2, getVardaFeeDataRows(db).size)
-    }
-
-    @Test
-    fun `fee data is sent once if it's soft deleted`() {
-        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-        createDecisionsAndPlacements(period = period)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period.start, period.end)
-        )
-        updateAll()
-
-        assertEquals(1, getVardaFeeDataRows(db).size)
-        assertEquals(0, getSoftDeletedVardaFeeData(db).size)
-
-        db.transaction {
-            it.createUpdate("UPDATE varda_placement SET should_be_deleted = true").execute()
-            it.createUpdate("UPDATE varda_decision SET should_be_deleted = true").execute()
-            it.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute()
-            it.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id").bind("id", testDaycare.id).execute()
-        }
-
-        removeMarkedPlacementsFromVarda(db, vardaClient)
-        removeMarkedDecisionsFromVarda(db, vardaClient)
-        removeMarkedFeeDataFromVarda(db, vardaClient)
-        mockEndpoint.feeData.clear()
-
-        updateAll()
-        assertEquals(2, getVardaFeeDataRows(db).size)
-        assertEquals(1, getSoftDeletedVardaFeeData(db).size)
-        assertEquals(1, mockEndpoint.feeData.size)
-
-        updateAll()
-        assertEquals(2, getVardaFeeDataRows(db).size)
-        assertEquals(1, mockEndpoint.feeData.size)
-    }
-
-    @Test
-    fun `fee data is not sent multiple times for multiple fee decisions`() {
-        val period = ClosedPeriod(LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(1))
-        val period2 = ClosedPeriod(period.start.minusMonths(6), period.start.minusMonths(1))
-        createDecisionsAndPlacements(period = period)
-        createDecisionsAndPlacements(period = period2)
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period.start, period.end)
-        )
-        insertFeeDecision(
-            db,
-            status = FeeDecisionStatus.SENT,
-            children = listOf(testChild_1),
-            objectMapper = objectMapper,
-            period = Period(period2.start, period2.end)
-        )
-        updateAll()
-
-        assertEquals(2, getVardaFeeDataRows(db).size)
-        assertEquals(0, getSoftDeletedVardaFeeData(db).size)
-
-        db.transaction {
-            it.createUpdate("UPDATE varda_placement SET should_be_deleted = true").execute()
-            it.createUpdate("UPDATE varda_decision SET should_be_deleted = true").execute()
-            it.createUpdate("UPDATE varda_fee_data SET should_be_deleted = true").execute()
-            it.createUpdate("UPDATE daycare SET oph_organizer_oid = '1.22.333.4444.1' where id = :id").bind("id", testDaycare.id).execute()
-        }
-
-        removeMarkedPlacementsFromVarda(db, vardaClient)
-        removeMarkedDecisionsFromVarda(db, vardaClient)
-        removeMarkedFeeDataFromVarda(db, vardaClient)
-        mockEndpoint.feeData.clear()
-
-        updateAll()
-        assertEquals(4, getVardaFeeDataRows(db).size)
-        assertEquals(2, getSoftDeletedVardaFeeData(db).size)
         assertEquals(2, mockEndpoint.feeData.size)
 
         updateAll()
-        assertEquals(4, getVardaFeeDataRows(db).size)
         assertEquals(2, mockEndpoint.feeData.size)
-    }
 
-    @Test
-    fun `child whose guardians has no name is not sent to Varda`() {
+        val newPeriod = testPeriod.copy(start = testPeriod.start.plusDays(8))
         db.transaction {
-            it.handle.insertTestPerson(
-                DevPerson(
-                    id = childWithNamelessParent.id,
-                    dateOfBirth = childWithNamelessParent.dateOfBirth,
-                    ssn = childWithNamelessParent.ssn,
-                    firstName = childWithNamelessParent.firstName,
-                    lastName = childWithNamelessParent.lastName,
-                    streetAddress = childWithNamelessParent.streetAddress!!,
-                    postalCode = childWithNamelessParent.postalCode!!,
-                    postOffice = childWithNamelessParent.postOffice!!
-                )
-            )
-            it.handle.insertTestChild(DevChild(id = childWithNamelessParent.id))
+            it.execute("UPDATE placement SET end_date = ?", newPeriod.start.minusDays(1))
+            it.execute("UPDATE service_need SET end_date = ?", newPeriod.start.minusDays(1))
         }
+        createDecisionsAndPlacements(newPeriod, testChild_1)
 
-        // Niilo Nimettömänpoika's guardian doesn't have a name in mock VTJ data
-        createDecisionsAndPlacements(child = childWithNamelessParent)
-        insertFeeDecision(db, FeeDecisionStatus.SENT, listOf(childWithNamelessParent), objectMapper)
+        updateAll()
+        assertEquals(4, mockEndpoint.feeData.size)
 
-        updateFeeData()
+        insertFeeDecision(db, listOf(testChild_1), newPeriod).send()
+        insertFeeDecision(db, listOf(testChild_1), newPeriod, guardian = testAdult_2.id).send()
 
-        assertEquals(0, getVardaFeeDataRows(db).size)
+        updateAll()
+        assertEquals(4, mockEndpoint.feeData.size)
     }
 
     private fun updateAll() {
         updateChildren(db, vardaClient, vardaOrganizerName)
         updateDecisions(db, vardaClient)
         updatePlacements(db, vardaClient)
-        updateFeeData()
-    }
-
-    private fun updateFeeData() {
-        updateFeeData(db, vardaClient, objectMapper, personService)
+        updateFeeData(db, vardaClient, personService)
     }
 
     private fun createDecisionsAndPlacements(
+        period: ClosedPeriod,
         child: PersonData.Detailed = testChild_1,
-        period: ClosedPeriod = ClosedPeriod(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6)),
         daycareId: UUID = testDaycare.id
     ) {
         insertDecisionWithApplication(db, child, period, unitId = daycareId)
@@ -781,73 +551,57 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
                 endDate = period.end
             )
         }
-        updateChildren(db, vardaClient, organizerName = vardaOrganizerName)
-        updateDecisions(db, vardaClient)
-        updatePlacements(db, vardaClient)
+    }
+
+    data class VardaFeeDataRow(
+        val id: UUID,
+        val evakaFeeDecisionId: UUID,
+        val vardaId: Long?,
+        val vardaDecisionId: UUID?,
+        val vardaChildId: UUID?,
+        val createdAt: Instant,
+        val uploadedAt: Instant
+    )
+
+    private fun getVardaFeeDataRows(db: Database.Connection): List<VardaFeeDataRow> = db.read {
+        it.createQuery("SELECT * FROM varda_fee_data")
+            .mapTo<VardaFeeDataRow>()
+            .toList()
+    }
+
+    private fun insertFeeDecision(
+        db: Database.Connection,
+        children: List<PersonData.Detailed>,
+        period: ClosedPeriod,
+        placementType: PlacementType = PlacementType.DAYCARE,
+        daycareId: UUID = testDaycare.id,
+        guardian: UUID = testAdult_1.id
+    ): FeeDecision = db.transaction {
+        val feeDecision = createFeeDecisionFixture(
+            status = FeeDecisionStatus.DRAFT,
+            decisionType = FeeDecisionType.NORMAL,
+            headOfFamilyId = guardian,
+            period = Period(period.start, period.end),
+            parts = children.map { child ->
+                createFeeDecisionPartFixture(
+                    childId = child.id,
+                    dateOfBirth = testChild_1.dateOfBirth,
+                    daycareId = daycareId,
+                    placementType = placementType
+                )
+            }
+        )
+        upsertFeeDecisions(it.handle, objectMapper, listOf(feeDecision))
+        feeDecision
+    }
+
+    private fun FeeDecision.send(): FeeDecision {
+        val (_, response, _) = http.post("/fee-decisions/confirm")
+            .asUser(AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)))
+            .jsonBody(objectMapper.writeValueAsString(listOf(this.id)))
+            .response()
+        assertEquals(204, response.statusCode)
+        asyncJobRunner.runPendingJobsSync()
+        return db.read { getFeeDecisionsByIds(it.handle, objectMapper, listOf(this.id)) }.first()
     }
 }
-
-private fun getSoftDeletedVardaFeeData(db: Database.Connection): List<VardaFeeDataRow> = db.read {
-    it.createQuery("SELECT * FROM varda_fee_data WHERE deleted_at IS NOT NULL")
-        .mapTo<VardaFeeDataRow>().list() ?: emptyList()
-}
-
-private fun clearVardaPlacements(db: Database.Connection) = db.transaction {
-    it.createUpdate("TRUNCATE varda_placement")
-        .execute()
-}
-
-private fun setFeeDecisionsAnnulled(db: Database.Connection) = db.transaction {
-    it.createUpdate("UPDATE fee_decision SET status = :annulledStatus")
-        .bind("annulledStatus", FeeDecisionStatus.ANNULLED)
-        .execute()
-}
-
-private fun getVardaFeeDataRows(db: Database.Connection): List<VardaFeeDataRow> = db.read {
-    it.createQuery("SELECT * FROM varda_fee_data")
-        .mapTo<VardaFeeDataRow>().list() ?: emptyList()
-}
-
-private fun insertFeeDecision(
-    db: Database.Connection,
-    status: FeeDecisionStatus,
-    children: List<PersonData.Detailed>,
-    objectMapper: ObjectMapper,
-    period: Period = Period(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6)),
-    placementType: PlacementType = PlacementType.DAYCARE,
-    daycareId: UUID = testDaycare.id
-): FeeDecision = db.transaction {
-    val feeDecision = createFeeDecisionFixture(
-        status = status,
-        decisionType = FeeDecisionType.NORMAL,
-        headOfFamilyId = testAdult_1.id,
-        period = period,
-        parts = children.map { child ->
-            createFeeDecisionPartFixture(
-                childId = child.id,
-                dateOfBirth = testChild_1.dateOfBirth,
-                daycareId = daycareId,
-                placementType = placementType
-            )
-        }
-    )
-    upsertFeeDecisions(it.handle, objectMapper, listOf(feeDecision))
-    feeDecision
-}
-
-private fun clearPlacements(db: Database.Connection) = db.transaction {
-    it.createUpdate("DELETE FROM placement WHERE 1 = 1")
-        .execute()
-}
-
-val childWithNamelessParent = PersonData.Detailed(
-    id = UUID.randomUUID(),
-    dateOfBirth = LocalDate.of(2018, 12, 31),
-    ssn = "311218A999J",
-    firstName = "Niilo",
-    lastName = "Nimettömänpoika",
-    streetAddress = "Kankkulankaivo 1",
-    postalCode = "00340",
-    postOffice = "Espoo",
-    restrictedDetailsEnabled = false
-)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -57,7 +57,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
         db.transaction { insertGeneralTestFixtures(it.handle) }
         insertVardaUnit(db)
         assertEquals(0, getVardaFeeDataRows(db).size)
-        mockEndpoint.feeData.clear()
+        mockEndpoint.cleanUp()
     }
 
     @AfterEach
@@ -124,10 +124,10 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
         updateFeeData()
 
-        val results = mockEndpoint.feeData
+        val results = mockEndpoint.feeData.values
         assertEquals(1, results.size)
 
-        val result = results[0]
+        val result = results.first()
         assertEquals("MP03", result.feeCode)
         assertEquals(0.0, result.voucherAmount)
         assertEquals(feeDecision.familySize, result.familySize)
@@ -149,10 +149,10 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
         updateFeeData()
 
-        val results = mockEndpoint.feeData
+        val results = mockEndpoint.feeData.values
         assertEquals(1, results.size)
 
-        assertEquals("MP02", results[0].feeCode)
+        assertEquals("MP02", results.first().feeCode)
     }
 
     @Test
@@ -359,7 +359,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
         assertEquals(2, getVardaFeeDataRows(db).size)
         assertEquals(2, getVardaPlacements(db).size)
 
-        val uploadedFeeData: List<VardaFeeData> = mockEndpoint.feeData.sortedBy { data -> data.startDate }
+        val uploadedFeeData: List<VardaFeeData> = mockEndpoint.feeData.values.sortedBy { data -> data.startDate }
         assertEquals(firstPlacementPeriod.start, uploadedFeeData[0].startDate)
         assertEquals(firstPlacementPeriod.end, uploadedFeeData[0].endDate)
         assertEquals(secondPlacementPeriod.start, uploadedFeeData[1].startDate)
@@ -405,7 +405,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
         assertEquals(2, getVardaFeeDataRows(db).size)
         assertEquals(1, getVardaPlacements(db).size)
 
-        val uploadedFeeData: List<VardaFeeData> = mockEndpoint.feeData.sortedBy { data -> data.startDate }
+        val uploadedFeeData: List<VardaFeeData> = mockEndpoint.feeData.values.sortedBy { data -> data.startDate }
         assertEquals(placementPeriod.start, uploadedFeeData[0].startDate)
         assertEquals(feeDecisionsPeriod1.end, uploadedFeeData[0].endDate)
         assertEquals(2, uploadedFeeData[0].familySize)
@@ -508,7 +508,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
         updateFeeData()
 
         assertEquals(1, getVardaFeeDataRows(db).size)
-        val originalFeeData = mockEndpoint.feeData[0]
+        val originalFeeData = mockEndpoint.feeData.values.first()
         assertEquals(period.start, originalFeeData.startDate)
         assertEquals(period.end, originalFeeData.endDate)
 
@@ -523,7 +523,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
         updateFeeData()
 
-        val newFeeData = mockEndpoint.feeData[0]
+        val newFeeData = mockEndpoint.feeData.values.first()
         assertNotEquals(originalFeeData.startDate, newFeeData.startDate)
         assertNotEquals(originalFeeData.endDate, newFeeData.endDate)
         assertEquals(newStart, newFeeData.startDate)
@@ -610,7 +610,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
         val feeData = mockEndpoint.feeData
         assertEquals(1, feeData.size)
-        assertEquals(period.start, feeData[0].startDate)
+        assertEquals(period.start, feeData.values.first().startDate)
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaOrganizerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaOrganizerIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.varda.integration.MockVardaIntegrationEndpoint
 import org.jdbi.v3.core.kotlin.mapTo
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -18,6 +19,9 @@ import org.springframework.beans.factory.annotation.Autowired
 
 class VardaOrganizerIntegrationTest : FullApplicationTest() {
     @Autowired
+    lateinit var mockEndpoint: MockVardaIntegrationEndpoint
+
+    @Autowired
     lateinit var personService: PersonService
 
     @BeforeEach
@@ -26,6 +30,7 @@ class VardaOrganizerIntegrationTest : FullApplicationTest() {
             tx.resetDatabase()
             insertGeneralTestFixtures(tx.handle)
         }
+        mockEndpoint.cleanUp()
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -16,17 +16,22 @@ import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.varda.integration.MockVardaIntegrationEndpoint
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
 class VardaPlacementsIntegrationTest : FullApplicationTest() {
+    @Autowired
+    lateinit var mockEndpoint: MockVardaIntegrationEndpoint
+
     @BeforeEach
     fun beforeEach() {
         jdbi.handle(::insertGeneralTestFixtures)
@@ -35,6 +40,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
     @AfterEach
     fun afterEach() {
         jdbi.handle(::resetDatabase)
+        mockEndpoint.cleanUp()
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaFeeData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaFeeData.kt
@@ -5,358 +5,304 @@
 package fi.espoo.evaka.varda
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
-import fi.espoo.evaka.invoicing.domain.FeeAlterationWithEffect
 import fi.espoo.evaka.invoicing.domain.FeeDecisionStatus
 import fi.espoo.evaka.invoicing.domain.PlacementType
+import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
+import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.varda.integration.VardaClient
-import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
-import java.sql.ResultSet
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-private val logger = KotlinLogging.logger {}
-
 fun updateFeeData(
     db: Database.Connection,
     client: VardaClient,
-    mapper: ObjectMapper,
     personService: PersonService
 ) {
-    deleteEntriesFromAnnulledFeeDecision(db, client)
-    deleteEntriesFromDeletedPlacements(db, client)
-    updateEntriesFromModifiedPlacements(db, client, mapper, personService)
-    uploadNewFeeData(db, client, mapper, personService)
+    deleteAnnulledFeeData(db, client)
+    createAndUpdateFeeData(db, client, personService)
 }
 
 fun removeMarkedFeeDataFromVarda(db: Database.Connection, client: VardaClient) {
-    val feeDataIds: List<Int> = db.read { getFeeDataToDelete(it) }
-    feeDataIds.forEach { id ->
+    db.read { getMarkedFeeData(it) }.forEach { id ->
         if (client.deleteFeeData(id)) {
             db.transaction { softDeleteFeeData(it, id) }
         }
     }
 }
 
-fun deleteEntriesFromAnnulledFeeDecision(db: Database.Connection, client: VardaClient) {
-    getAnnulledFeeDecisions(db)
-        .forEach { vardaId ->
-            if (client.deleteFeeData(vardaId)) {
-                deleteVardaFeeDecision(db, vardaId)
-            }
-        }
+fun deleteAnnulledFeeData(db: Database.Connection, client: VardaClient) {
+    val vardaIds = db.read { getAnnulledFeeDecisions(it) }
+    deleteFeeData(db, client, vardaIds)
 }
 
-fun deleteEntriesFromDeletedPlacements(db: Database.Connection, client: VardaClient) {
-    // also removes legacy fee data entries since their placementId is null
-    getDeletedPlacements(db)
-        .forEach { vardaId ->
-            if (client.deleteFeeData(vardaId)) {
-                deleteVardaFeeDecision(db, vardaId)
-            }
+fun deleteFeeData(db: Database.Connection, client: VardaClient, vardaIds: List<Long>) {
+    vardaIds.forEach { vardaId ->
+        if (client.deleteFeeData(vardaId)) {
+            db.transaction { deleteVardaFeeData(it, vardaId) }
         }
+    }
 }
 
-fun updateEntriesFromModifiedPlacements(db: Database.Connection, client: VardaClient, mapper: ObjectMapper, personService: PersonService) {
-    getModifiedFeeData(db, mapper)
-        .forEach { (vardaId, feeDataBase) ->
-            db.transaction {
-                val feeData = baseToFeeData(it, feeDataBase, personService, client)
-                if (feeData != null && client.updateFeeData(vardaId, feeData)) {
-                    insertFeeDataUpload(it, feeDataBase, vardaId)
+fun createAndUpdateFeeData(db: Database.Connection, client: VardaClient, personService: PersonService) {
+    val children = db.read { getChildrenWithOutdatedFeeData(it) }
+    children.forEach { (childId, childVardaId) ->
+        val vardaDecisionPeriods = client.getChildDecisions(childVardaId)
+
+        val outdatedFeeData = vardaDecisionPeriods.flatMap { decisionPeriod ->
+            db.read { getOutdatedFeeData(it, decisionPeriod) }
+        }
+        deleteFeeData(db, client, outdatedFeeData)
+
+        val guardians = db.transaction { personService.getGuardians(it, AuthenticatedUser.machineUser, childId) }
+            .filter { (it.firstName + it.lastName).isNotBlank() }
+        if (guardians.isEmpty()) return@forEach
+
+        val feeData = vardaDecisionPeriods.flatMap { decisionPeriod ->
+            db.read {
+                getDecisionFeeData(it, childVardaId, decisionPeriod)
+                    .map { data -> decisionPeriod.id to data }
+            }
+        }
+
+        feeData.forEach { (vardaDecisionId, data) ->
+            val richData = baseToFeeData(data, guardians, client.getChildUrl(data.vardaChildId))
+            when (data.vardaId) {
+                is Long -> {
+                    client.updateFeeData(data.vardaId, richData).let { success ->
+                        if (success) db.transaction { updateFeeDataUploadedAt(it, data.vardaId, Instant.now()) }
+                    }
                 }
-            }
-        }
-}
-
-fun uploadNewFeeData(
-    db: Database.Connection,
-    client: VardaClient,
-    mapper: ObjectMapper,
-    personService: PersonService
-) {
-    val feeData = getStaleFeeData(db, mapper)
-    feeData.forEach { feeDataBase ->
-        db.transaction {
-            val newFeeData = baseToFeeData(it, feeDataBase, personService, client)
-            if (newFeeData != null) {
-                val response = client.createFeeData(newFeeData)
-                if (response != null) {
-                    insertFeeDataUpload(it, feeDataBase, response.vardaId)
+                else -> {
+                    client.createFeeData(richData)?.let { (vardaId) ->
+                        db.transaction {
+                            insertFeeDataUpload(it, vardaId, data.feeDecisionId, vardaDecisionId, childVardaId)
+                        }
+                    }
                 }
-            } else {
-                logger.info { "Not sending Varda fee data because child has no guardians in VTJ (child: ${feeDataBase.evakaChildId})" }
             }
         }
     }
 }
 
-fun getFeeDataToDelete(tx: Database.Read): List<Int> {
-    return tx.createQuery(
-        // language=SQL
-        """
-SELECT varda_fee_data_id 
-FROM varda_fee_data
-WHERE should_be_deleted = true
-AND deleted_at IS NULL
-"""
-    )
-        .mapTo(Int::class.java)
+fun getMarkedFeeData(tx: Database.Read): List<Long> {
+    return tx
+        .createQuery("SELECT varda_id FROM varda_fee_data WHERE should_be_deleted = true AND deleted_at IS NULL")
+        .mapTo<Long>()
         .toList()
 }
 
-fun softDeleteFeeData(tx: Database.Transaction, vardaFeeDataId: Int) {
-    tx.createUpdate("UPDATE varda_fee_data SET deleted_at = NOW() WHERE varda_fee_data_id = :vardaFeeDataId")
-        .bind("vardaFeeDataId", vardaFeeDataId)
-        .execute()
-}
-
-private fun getStaleFeeData(
-    db: Database.Connection,
-    mapper: ObjectMapper
-): List<VardaFeeDataBase> {
-    val placementTypes = listOf(PlacementType.DAYCARE, PlacementType.FIVE_YEARS_OLD_DAYCARE, PlacementType.PRESCHOOL_WITH_DAYCARE, PlacementType.PREPARATORY_WITH_DAYCARE).toTypedArray()
-    // language=SQL
-    val sql =
-        """    
-        $feeDataQueryBase
-        WHERE vfd.id IS NULL
-            AND fdp.placement_type = ANY(:placementTypes)
-        """.trimIndent()
-
-    return db.read {
-        it
-            .createQuery(sql)
-            .bind("sentStatus", FeeDecisionStatus.SENT)
-            .bind("placementTypes", placementTypes)
-            .map { rs, _ -> toVardaFeeDataBase(rs, mapper) }
-            .toList()
-    }
-}
-
-private fun insertFeeDataUpload(tx: Database.Transaction, feeDataBase: VardaFeeDataBase, vardaId: Long) {
-    // language=SQL
-    val sql =
-        """
-        INSERT INTO varda_fee_data (evaka_fee_decision_id, evaka_placement_id, varda_fee_data_id, uploaded_at)
-        VALUES (:decisionId, :placementId, :vardaId, :checkTimestamp)
-        ON CONFLICT ON CONSTRAINT varda_fee_data_evaka_fee_decision_id_evaka_placement_id_key
-        DO UPDATE SET uploaded_at = :checkTimestamp
-        """.trimIndent()
-
-    tx.handle.createUpdate(sql)
-        .bind("decisionId", feeDataBase.evakaFeeDecisionId)
-        .bind("placementId", feeDataBase.placementId)
+fun softDeleteFeeData(tx: Database.Transaction, vardaId: Long) {
+    tx.createUpdate("UPDATE varda_fee_data SET deleted_at = :deletedAt WHERE varda_id = :vardaId")
         .bind("vardaId", vardaId)
-        .bind("checkTimestamp", feeDataBase.checkTimestamp)
+        .bind("deletedAt", Instant.now())
         .execute()
 }
 
-private fun getAnnulledFeeDecisions(db: Database.Connection): List<Int> {
-    // language=SQL
-    val sql =
+private fun insertFeeDataUpload(
+    tx: Database.Transaction,
+    vardaId: Long,
+    feeDecisionId: UUID,
+    vardaDecisionId: Long,
+    vardaChildId: Long
+) {
+    tx.createUpdate(
         """
-        SELECT varda_fee_data_id
-        FROM varda_fee_data
-            LEFT JOIN fee_decision ON fee_decision.id = varda_fee_data.evaka_fee_decision_id
-        WHERE status = :annulledStatus
-            AND varda_fee_data.id IS NOT NULL;
-        """.trimIndent()
-
-    return db.read {
-        it.createQuery(sql)
-            .bind("annulledStatus", FeeDecisionStatus.ANNULLED)
-            .mapTo<Int>().list()
-    }
+INSERT INTO varda_fee_data (varda_id, evaka_fee_decision_id, varda_decision_id, varda_child_id, uploaded_at)
+VALUES (
+    :vardaId,
+    :feeDecisionId,
+    (SELECT id FROM varda_decision WHERE varda_decision_id = :vardaDecisionId),
+    (SELECT id FROM varda_child WHERE varda_child_id = :vardaChildId),
+    :uploadedAt
+)
+"""
+    )
+        .bind("vardaId", vardaId)
+        .bind("feeDecisionId", feeDecisionId)
+        .bind("vardaDecisionId", vardaDecisionId)
+        .bind("vardaChildId", vardaChildId)
+        .bind("uploadedAt", Instant.now())
+        .execute()
 }
 
-private fun deleteVardaFeeDecision(db: Database.Connection, vardaId: Int) {
-    // language=SQL
-    val sql =
-        """
-        DELETE FROM varda_fee_data
-        WHERE varda_fee_data_id = :vardaId
-        """.trimIndent()
-
-    db.transaction {
-        it.createUpdate(sql)
-            .bind("vardaId", vardaId)
-            .execute()
-    }
+private fun updateFeeDataUploadedAt(tx: Database.Transaction, vardaId: Long, timestamp: Instant) {
+    tx.createUpdate("UPDATE varda_fee_data SET uploaded_at = :timestamp WHERE varda_id = :vardaId")
+        .bind("vardaId", vardaId)
+        .bind("timestamp", timestamp)
+        .execute()
 }
 
-private fun getDeletedPlacements(db: Database.Connection): List<Int> {
-    // language=SQL
-    val sql =
-        """
-            SELECT varda_fee_data_id 
-            FROM varda_fee_data
-            WHERE evaka_placement_id IS NULL
-        """.trimIndent()
-
-    return db.read {
-        it.createQuery(sql)
-            .mapTo<Int>()
-            .list()
-    }
+private fun getAnnulledFeeDecisions(tx: Database.Read): List<Long> {
+    return tx
+        .createQuery(
+            """
+SELECT varda_id
+FROM varda_fee_data
+JOIN fee_decision ON fee_decision.id = varda_fee_data.evaka_fee_decision_id AND fee_decision.status = :annulled
+"""
+        )
+        .bind("annulled", FeeDecisionStatus.ANNULLED)
+        .mapTo<Long>()
+        .toList()
 }
 
-private fun getModifiedFeeData(db: Database.Connection, mapper: ObjectMapper): List<Pair<Long, VardaFeeDataBase>> {
-    // language=SQL
-    val sql =
+private fun getChildrenWithOutdatedFeeData(tx: Database.Read): List<Pair<UUID, Long>> {
+    return tx.createQuery(
         """
-         $feeDataQueryBase
-        WHERE vfd.varda_fee_data_id IS NOT NULL 
-        AND vfd.uploaded_at < p.updated
-        """.trimIndent()
-
-    return db.read {
-        it.createQuery(sql)
-            .bind("sentStatus", FeeDecisionStatus.SENT)
-            .map { rs, _ -> toVardaFeeDataBaseWithVardaId(rs, mapper) }
-            .toList()
-    }
+SELECT varda_child.person_id, varda_child.varda_child_id
+FROM varda_child
+JOIN LATERAL (
+    SELECT MAX(fd.sent_at) sent_at
+    FROM fee_decision fd
+    JOIN fee_decision_part p ON fd.id = p.fee_decision_id AND p.child = varda_child.person_id
+    WHERE fd.status = :sent
+) latest_fee_decision ON true
+JOIN LATERAL (
+    SELECT MAX(uploaded_at) uploaded_at
+    FROM varda_fee_data
+    WHERE varda_child_id = varda_child.id
+) latest_fee_data ON true
+WHERE COALESCE(latest_fee_data.uploaded_at <= COALESCE(latest_fee_decision.sent_at, '-infinity'), true)
+"""
+    )
+        .bind("sent", FeeDecisionStatus.SENT)
+        .map { rs, _ -> rs.getUUID("person_id") to rs.getLong("varda_child_id") }
+        .toList()
 }
 
-private val feeDataQueryBase =
-    // language=SQL
-    """
-        SELECT fd.id                              AS fee_decision_id,
-            vfd.varda_fee_data_id                 AS varda_id,
-            p.id                                  AS placement_id,
-            p.child_id                            AS evaka_child_id,
-            vc.varda_child_id                     AS varda_child_id,
-            GREATEST(fd.valid_from, p.start_date) AS start_date,
-            LEAST(fd.valid_to, p.end_date)        AS end_date,
-            fdp.fee,
-            family_size,
-            fdp.fee_alterations,
-            fdp.placement_type,
-            now()                               AS check_timestamp
-        FROM varda_placement vp
-            JOIN placement p ON vp.evaka_placement_id = p.id AND vp.deleted_at IS NULL
-            LEFT JOIN varda_fee_data vfd ON p.id = vfd.evaka_placement_id AND vfd.deleted_at IS NULL
-            JOIN fee_decision_part fdp ON fdp.child = p.child_id
-            JOIN fee_decision fd ON (fdp.fee_decision_id = fd.id AND daterange(p.start_date, p.end_date, '[]') && daterange(fd.valid_from, fd.valid_to, '[]') AND fd.status = :sentStatus)
-            JOIN daycare u ON p.unit_id = u.id
-            JOIN varda_child vc ON p.child_id = vc.person_id AND vc.oph_organizer_oid = u.oph_organizer_oid
-    """.trimIndent()
+fun getOutdatedFeeData(tx: Database.Read, decisionPeriod: VardaClient.DecisionPeriod): List<Long> {
+    return tx
+        .createQuery(
+            """
+SELECT vfd.varda_id
+FROM varda_decision vd
+JOIN varda_fee_data vfd ON vd.id = vfd.varda_decision_id
+JOIN fee_decision d ON vfd.evaka_fee_decision_id = d.id AND NOT daterange(d.valid_from, d.valid_to, '[]') && :decisionPeriod
+WHERE vd.varda_decision_id = :decisionId
+"""
+        )
+        .bind("decisionId", decisionPeriod.id)
+        .bind("decisionPeriod", ClosedPeriod(decisionPeriod.alkamis_pvm, decisionPeriod.paattymis_pvm))
+        .mapTo<Long>()
+        .toList()
+}
 
-private fun baseToFeeData(tx: Database.Transaction, feeDataBase: VardaFeeDataBase, personService: PersonService, client: VardaClient): VardaFeeData? {
-    val guardians = personService
-        .getGuardians(tx, AuthenticatedUser.machineUser, feeDataBase.evakaChildId)
-        .filter {
-            if ((it.firstName + it.lastName).isNotBlank()) {
-                true
-            } else {
-                logger.warn("Skipped Varda guardian because name was blank: ${it.id}")
-                false
-            }
-        }
+fun getDecisionFeeData(tx: Database.Read, childVardaId: Long, decisionPeriod: VardaClient.DecisionPeriod): List<VardaFeeDataBase> {
+    return tx
+        .createQuery(
+            """
+SELECT
+    d.id AS fee_decision_id,
+    vc.varda_child_id AS varda_child_id,
+    vfd.varda_id AS varda_id,
+    GREATEST(d.valid_from, :decisionStartDate) AS start_date,
+    LEAST(d.valid_to, :decisionEndDate) AS end_date,
+    p.fee + COALESCE(alterations.sum, 0) AS fee,
+    d.family_size AS family_size,
+    p.placement_type AS placement_type
+FROM varda_child vc
+JOIN fee_decision_part p ON vc.person_id = p.child
+JOIN fee_decision d ON p.fee_decision_id = d.id AND daterange(d.valid_from, d.valid_to, '[]') && :decisionPeriod AND d.status = :sent
+LEFT JOIN (
+    SELECT fee_decision_part.id, SUM(effects.effect) sum
+    FROM fee_decision_part
+    JOIN (
+        SELECT id, (jsonb_array_elements(fee_alterations)->>'effect')::integer effect
+        FROM fee_decision_part
+    ) effects ON fee_decision_part.id = effects.id
+    GROUP BY fee_decision_part.id
+) alterations ON p.id = alterations.id
+JOIN varda_decision vd ON vd.varda_decision_id = :decisionId
+LEFT JOIN varda_fee_data vfd ON d.id = vfd.evaka_fee_decision_id AND vd.id = vfd.varda_decision_id AND vc.id = vfd.varda_child_id
+WHERE vc.varda_child_id = :childVardaId
+"""
+        )
+        .bind("childVardaId", childVardaId)
+        .bind("decisionId", decisionPeriod.id)
+        .bind("decisionStartDate", decisionPeriod.alkamis_pvm)
+        .bind("decisionEndDate", decisionPeriod.paattymis_pvm)
+        .bind("decisionPeriod", ClosedPeriod(decisionPeriod.alkamis_pvm, decisionPeriod.paattymis_pvm))
+        .bind("sent", FeeDecisionStatus.SENT)
+        .mapTo<VardaFeeDataBase>()
+        .toList()
+}
+
+fun deleteVardaFeeData(tx: Database.Transaction, vardaId: Long) {
+    tx.createUpdate("DELETE FROM varda_fee_data WHERE varda_id = :vardaId")
+        .bind("vardaId", vardaId)
+        .execute()
+}
+
+private fun baseToFeeData(
+    feeDataBase: VardaFeeDataBase,
+    guardians: List<PersonDTO>,
+    childUrl: String
+): VardaFeeData {
+    val vardaGuardians = guardians
         .map { guardian ->
             VardaGuardian(
-                ssn = guardian.identity.toString(),
-                firstName = guardian.firstName!!,
-                lastName = guardian.lastName!!
+                henkilotunnus = guardian.identity.toString(),
+                etunimet = guardian.firstName!!,
+                sukunimi = guardian.lastName!!
             )
         }
 
-    return when (guardians.isNotEmpty()) {
-        true -> VardaFeeData(
-            guardians = guardians,
-            childUrl = client.getChildUrl(feeDataBase.vardaChildId),
-            voucherAmount = 0.0,
-            feeCode = if (feeDataBase.placementType == PlacementType.FIVE_YEARS_OLD_DAYCARE) "MP02" else "MP03",
-            feeAmount = feeDataBase.finalFee(),
-            familySize = feeDataBase.familySize,
-            startDate = feeDataBase.startDate,
-            endDate = feeDataBase.endDate
-        )
-        false -> null
-    }
+    return VardaFeeData(
+        huoltajat = vardaGuardians,
+        lapsi = childUrl,
+        palveluseteli_arvo = 0,
+        maksun_peruste_koodi =
+            if (feeDataBase.placementType == PlacementType.FIVE_YEARS_OLD_DAYCARE)
+                FeeBasisCode.FIVE_YEAR_OLDS_DAYCARE.code
+            else
+                FeeBasisCode.DAYCARE.code,
+        asiakasmaksu = feeDataBase.fee,
+        perheen_koko = feeDataBase.familySize,
+        alkamis_pvm = feeDataBase.startDate,
+        paattymis_pvm = feeDataBase.endDate
+    )
 }
 
-private fun toVardaFeeDataBase(rs: ResultSet, mapper: ObjectMapper) = VardaFeeDataBase(
-    evakaFeeDecisionId = rs.getUUID("fee_decision_id"),
-    placementId = rs.getUUID("placement_id"),
-    evakaChildId = rs.getUUID("evaka_child_id"),
-    vardaChildId = rs.getLong("varda_child_id"),
-    startDate = rs.getDate("start_date").toLocalDate(),
-    endDate = rs.getDate("end_date").toLocalDate(),
-    fee = rs.getInt("fee"),
-    familySize = rs.getInt("family_size"),
-    feeAlterations = mapper.readValue(rs.getString("fee_alterations")),
-    placementType = PlacementType.valueOf(rs.getString("placement_type")),
-    checkTimestamp = rs.getTimestamp("check_timestamp").toInstant()
-)
-
-private fun toVardaFeeDataBaseWithVardaId(rs: ResultSet, mapper: ObjectMapper): Pair<Long, VardaFeeDataBase> =
-    rs.getLong("varda_id") to toVardaFeeDataBase(rs, mapper)
+enum class FeeBasisCode(val code: String) {
+    FIVE_YEAR_OLDS_DAYCARE("MP02"),
+    DAYCARE("MP03")
+}
 
 data class VardaGuardian(
-    @JsonProperty("henkilotunnus")
-    val ssn: String,
-    @JsonProperty("etunimet")
-    val firstName: String,
-    @JsonProperty("sukunimi")
-    val lastName: String
+    val henkilotunnus: String,
+    val etunimet: String,
+    val sukunimi: String
 )
 
 data class VardaFeeDataBase(
-    val evakaFeeDecisionId: UUID,
-    val placementId: UUID,
-    val evakaChildId: UUID,
+    val feeDecisionId: UUID,
     val vardaChildId: Long,
+    val vardaId: Long?,
     val startDate: LocalDate,
     val endDate: LocalDate?,
     val fee: Int,
     val familySize: Int,
-    val feeAlterations: List<FeeAlterationWithEffect> = listOf(),
-    val placementType: PlacementType,
-    val checkTimestamp: Instant
-) {
-    fun finalFee(): Double = (fee + feeAlterations.sumBy { it.effect }) / 100.0
-}
+    val placementType: PlacementType
+)
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class VardaFeeData(
-    @JsonProperty("huoltajat")
-    val guardians: List<VardaGuardian>,
-    @JsonProperty("lapsi")
-    val childUrl: String,
-    @JsonProperty("maksun_peruste_koodi")
-    val feeCode: String,
-    @JsonProperty("palveluseteli_arvo")
-    val voucherAmount: Double,
-    @JsonProperty("asiakasmaksu")
-    val feeAmount: Double,
-    @JsonProperty("perheen_koko")
-    val familySize: Int,
-    @JsonProperty("alkamis_pvm")
-    val startDate: LocalDate,
-    @JsonProperty("paattymis_pvm")
-    val endDate: LocalDate?
+    val huoltajat: List<VardaGuardian>,
+    val lapsi: String,
+    val maksun_peruste_koodi: String,
+    val palveluseteli_arvo: Int,
+    val asiakasmaksu: Int,
+    val perheen_koko: Int,
+    val alkamis_pvm: LocalDate,
+    val paattymis_pvm: LocalDate?
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class VardaFeeDataResponse(
-    @JsonProperty("id")
-    val vardaId: Long
-)
-
-data class VardaFeeDataRow(
-    val id: UUID,
-    val evakaFeeDecisionId: UUID,
-    val evakaPlacementId: UUID?,
-    val vardaFeeDataId: Long?,
-    val createdAt: Instant,
-    val uploadedAt: Instant
+    val id: Long
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -34,7 +34,7 @@ class VardaUpdateService(
     fun scheduleVardaUpdate(db: Database.Connection) {
         if (forceSync) {
             val client = VardaClient(tokenProvider, fuel, env, mapper)
-            updateAll(db, client, mapper, personService, organizer)
+            updateAll(db, client, personService, organizer)
         } else {
             db.transaction { asyncJobRunner.plan(it, listOf(VardaUpdate()), retryCount = 1) }
         }
@@ -42,14 +42,13 @@ class VardaUpdateService(
 
     fun updateAll(db: Database, msg: VardaUpdate) {
         val client = VardaClient(tokenProvider, fuel, env, mapper)
-        db.connect { updateAll(it, client, mapper, personService, organizer) }
+        db.connect { updateAll(it, client, personService, organizer) }
     }
 }
 
 fun updateAll(
     db: Database.Connection,
     client: VardaClient,
-    mapper: ObjectMapper,
     personService: PersonService,
     organizer: String
 ) {
@@ -61,5 +60,5 @@ fun updateAll(
     updateChildren(db, client, organizer)
     updateDecisions(db, client)
     updatePlacements(db, client)
-    updateFeeData(db, client, mapper, personService)
+    updateFeeData(db, client, personService)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/MockVardaIntegrationEndpoint.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/MockVardaIntegrationEndpoint.kt
@@ -5,11 +5,12 @@
 package fi.espoo.evaka.varda.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import fi.espoo.evaka.varda.VardaChildRequest
 import fi.espoo.evaka.varda.VardaDecision
 import fi.espoo.evaka.varda.VardaFeeData
 import fi.espoo.evaka.varda.VardaPersonRequest
+import fi.espoo.evaka.varda.VardaPlacement
+import fi.espoo.evaka.varda.VardaUpdateOrganizer
 import mu.KotlinLogging
 import org.springframework.context.annotation.Profile
 import org.springframework.http.ResponseEntity
@@ -24,7 +25,9 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.util.concurrent.locks.ReentrantLock
 import javax.servlet.http.HttpServletRequest
+import kotlin.concurrent.withLock
 
 private val logger = KotlinLogging.logger {}
 
@@ -32,23 +35,52 @@ private val logger = KotlinLogging.logger {}
 @RestController
 @RequestMapping("/mock-integration/varda/api")
 class MockVardaIntegrationEndpoint(private val mapper: ObjectMapper) {
-    val decisions = mutableListOf<VardaDecision>()
-    val feeData = mutableListOf<VardaFeeData>()
-    val children = mutableListOf<VardaChildRequest>()
+    private val lock = ReentrantLock()
+
+    var organizerId = 0L
+    var unitId = 0L
+    var personId = 0L
+    val people = mutableMapOf<Long, VardaPersonRequest>()
+    var decisionId = 0L
+    val decisions = mutableMapOf<Long, VardaDecision>()
+    var placementId = 0L
+    val placements = mutableMapOf<Long, VardaPlacement>()
+    var feeDataId = 0L
+    val feeData = mutableMapOf<Long, VardaFeeData>()
+    var childId = 0L
+    val children = mutableMapOf<Long, VardaChildRequest>()
+
+    fun cleanUp() {
+        lock.withLock {
+            organizerId = 0L
+            unitId = 0L
+            personId = 0L
+            people.clear()
+            decisionId = 0L
+            decisions.clear()
+            placementId = 0L
+            placements.clear()
+            feeDataId = 0L
+            feeData.clear()
+            childId = 0L
+            children.clear()
+        }
+    }
 
     @GetMapping("/user/apikey/")
-    fun getApiKey(): ResponseEntity<String> {
+    fun getApiKey(): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint GET /users/apiKey called" }
-        return ResponseEntity.ok("{\"token\": \"49921df1b823e6fbaeb14dc23fd42325213187ad\"}")
+        ResponseEntity.ok("{\"token\": \"49921df1b823e6fbaeb14dc23fd42325213187ad\"}")
     }
 
     @PostMapping("/v1/toimipaikat/")
     fun createUnit(
         @RequestBody body: String,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint POST /toimipaikat received body: $body" }
-        return ResponseEntity.ok(getMockUnitResponse())
+        unitId = unitId.inc()
+        ResponseEntity.ok(getMockUnitResponse(unitId))
     }
 
     @PutMapping("/v1/toimipaikat/{vardaId}/")
@@ -56,151 +88,167 @@ class MockVardaIntegrationEndpoint(private val mapper: ObjectMapper) {
         @PathVariable("vardaId") vardaId: Long?,
         @RequestBody body: String,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint PUT /toimipaikat/$vardaId recieved body: $body" }
-        return ResponseEntity.ok(getMockUnitResponse(vardaId))
+        val id = if (vardaId == null) {
+            unitId = unitId.inc()
+            unitId
+        } else {
+            vardaId
+        }
+        ResponseEntity.ok(getMockUnitResponse(id))
     }
 
     @PutMapping("/v1/vakajarjestajat/{vardaId}")
     fun updateOrganizer(
         @PathVariable("vardaId") vardaId: Long?,
-        @RequestBody body: String,
+        @RequestBody body: VardaUpdateOrganizer,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint PUT /vakajarjestaja/$vardaId recieved body: $body" }
-        return ResponseEntity.ok(getMockOrganizerResponse(vardaId))
+        val id = if (vardaId == null) {
+            organizerId = organizerId.inc()
+            organizerId
+        } else {
+            vardaId
+        }
+        ResponseEntity.ok(getMockOrganizerResponse(id))
     }
 
     @PostMapping("/v1/henkilot/")
     fun createPerson(
         @RequestBody body: VardaPersonRequest,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint POST /henkilot received body: $body" }
-        return ResponseEntity.ok(getMockPersonResponse())
+        personId = personId.inc()
+        people.put(personId, body)
+        ResponseEntity.ok(getMockPersonResponse(personId))
     }
 
     @PostMapping("/v1/lapset/")
     fun createChild(
-        @RequestBody body: String,
+        @RequestBody body: VardaChildRequest,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint POST /lapset received body: $body" }
-        this.children.add(mapper.readValue(body))
-        return ResponseEntity.ok(getMockChildResponse())
+        childId = childId.inc()
+        this.children.put(childId, body)
+        ResponseEntity.ok(getMockChildResponse(childId))
     }
 
     @PostMapping("/v1/varhaiskasvatuspaatokset/")
     fun postDecision(
-        @RequestBody body: String,
+        @RequestBody body: VardaDecision,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint POST /varhaiskasvatuspaatokset received body: $body" }
-        decisions.add(mapper.readValue(body))
-        return ResponseEntity.ok(getMockDecisionResponse())
+        decisionId = decisionId.inc()
+        decisions.put(decisionId, body)
+        ResponseEntity.ok(getMockDecisionResponse(decisionId))
     }
 
     @PutMapping("/v1/varhaiskasvatuspaatokset/{vardaId}/")
     fun updateDecision(
         @PathVariable vardaId: Long,
-        @RequestBody body: String,
+        @RequestBody body: VardaDecision,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint PUT /varhaiskasvatuspaatokset/$vardaId/ received body: $body" }
-        val newDecision: VardaDecision = mapper.readValue(body)
-        // applicationDate is not perfect identifier but it's the best we have for VardaDecision
-        decisions.removeAt(decisions.indexOfFirst { decision -> decision.applicationDate == newDecision.applicationDate })
-        decisions.add(newDecision)
-        return ResponseEntity.ok(getMockDecisionResponse(vardaId))
+        decisions.replace(vardaId, body)
+        ResponseEntity.ok(getMockDecisionResponse(vardaId))
     }
 
     @DeleteMapping("/v1/varhaiskasvatuspaatokset/{vardaId}/")
     fun deleteDecision(
         @PathVariable vardaId: Long,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<Unit> {
+    ): ResponseEntity<Unit> = lock.withLock {
         logger.info { "Mock varda integration endpoint DELETE /varhaiskasvatuspaatokset/$vardaId/ called" }
-        return ResponseEntity.noContent().build()
+        decisions.remove(vardaId)
+        ResponseEntity.noContent().build()
     }
 
     @GetMapping("v1/lapset/{childId}/varhaiskasvatuspaatokset/")
     fun getDecisions(
         @PathVariable childId: Long,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         val result =
             """{
             "results": 
             ${mapper.writeValueAsString(
-                decisions.filter {
-                    it.childUrl.contains(childId.toString())
+                decisions.filter { (_, decision) ->
+                    decision.childUrl.contains(childId.toString())
                 }
             )}
             }
             """.trimIndent()
-        return ResponseEntity.ok(result)
+        ResponseEntity.ok(result)
     }
 
     @PostMapping("/v1/varhaiskasvatussuhteet/")
     fun createPlacement(
-        @RequestBody body: String,
+        @RequestBody body: VardaPlacement,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint POST /varhaiskasvatussuhteet received body: $body" }
-        return ResponseEntity.ok(getMockPlacementResponse())
+        placementId = placementId.inc()
+        placements.put(placementId, body)
+        ResponseEntity.ok(getMockPlacementResponse(placementId))
     }
 
     @PutMapping("/v1/varhaiskasvatussuhteet/{vardaId}/")
     fun updatePlacement(
         @PathVariable vardaId: Long,
-        @RequestBody body: String,
+        @RequestBody body: VardaPlacement,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint PUT /varhaiskasvatussuhteet/$vardaId/ received body: $body" }
-        return ResponseEntity.ok(getMockPlacementResponse(vardaId))
+        placements.replace(vardaId, body)
+        ResponseEntity.ok(getMockPlacementResponse(vardaId))
     }
 
     @DeleteMapping("/v1/varhaiskasvatussuhteet/{vardaId}/")
     fun deletePlacement(
         @PathVariable vardaId: Long,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<Unit> {
+    ): ResponseEntity<Unit> = lock.withLock {
         logger.info { "Mock varda integration endpoint DELETE /varhaiskasvatussuhteet/$vardaId/ called" }
-        return ResponseEntity.noContent().build()
+        placements.remove(vardaId)
+        ResponseEntity.noContent().build()
     }
 
     @PostMapping("/v1/maksutiedot/")
     fun createFeeData(
-        @RequestBody body: String,
+        @RequestBody body: VardaFeeData,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
-        val feeData = mapper.readValue<VardaFeeData>(body)
-        this.feeData.add(feeData)
+    ): ResponseEntity<String> = lock.withLock {
+        this.feeDataId = feeDataId.inc()
+        this.feeData.put(feeDataId, body)
         logger.info { "Mock varda integration endpoint POST /maksutiedot received body: $body" }
-        return ResponseEntity.ok(getMockFeeDataResponse(null, feeData))
+        ResponseEntity.ok(getMockFeeDataResponse(feeDataId, body))
     }
 
     @PutMapping("/v1/maksutiedot/{vardaId}")
     fun updateFeeData(
         @PathVariable vardaId: Long,
-        @RequestBody body: String,
+        @RequestBody body: VardaFeeData,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint PUT /maksutiedot/$vardaId received body: $body" }
-        val newFeeDataEntry = mapper.readValue<VardaFeeData>(body)
-        // childUrl is not a perfect identifier but it's the best we have for VardaFeeData
-        this.feeData.removeAt(feeData.indexOfFirst { data -> data.childUrl == newFeeDataEntry.childUrl })
-        this.feeData.add(newFeeDataEntry)
-        return ResponseEntity.ok(getMockFeeDataResponse(vardaId, newFeeDataEntry))
+        this.feeData.replace(vardaId, body)
+        ResponseEntity.ok(getMockFeeDataResponse(vardaId, body))
     }
 
     @DeleteMapping("/v1/maksutiedot/{vardaId}/")
     fun deleteFeeData(
         @PathVariable vardaId: Long,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> {
+    ): ResponseEntity<String> = lock.withLock {
         logger.info { "Mock varda integration endpoint DELETE /maksutiedot received id: $vardaId" }
-        return ResponseEntity.noContent().build()
+        this.feeData.remove(vardaId)
+        ResponseEntity.noContent().build()
     }
 
     // Avoid creating a whole spring security setup for just this mock controller but still simulate Varda endpoints
@@ -219,12 +267,11 @@ class MockVardaIntegrationEndpoint(private val mapper: ObjectMapper) {
         }
     }
 
-    private fun getMockUnitResponse(id: Long? = null): String {
-        val responseId = id ?: (100000..999999).random().toLong()
+    private fun getMockUnitResponse(id: Long): String {
         return """
             {
-            "url": "https://varda.api/v1/toimipaikat/$responseId/",
-            "id": $responseId,
+            "url": "https://varda.api/v1/toimipaikat/$id/",
+            "id": $id,
             "vakajarjestaja": "https://varda.api/v1/vakajarjestajat/298/",
             "organisaatio_oid": "1.2.246.562.10.47181946360",
             "kayntiosoite": "kayntiosoite",
@@ -256,11 +303,11 @@ class MockVardaIntegrationEndpoint(private val mapper: ObjectMapper) {
         """.trimIndent()
     }
 
-    private fun getMockOrganizerResponse(id: Long? = null): String {
+    private fun getMockOrganizerResponse(id: Long): String {
         return """
             {
-              "url": "http://localhost:8888/mock-integration/varda/api/v1/vakajarjestajat/298/",
-              "id": ${id ?: (100000..999999).random().toLong()},
+              "url": "http://localhost:8888/mock-integration/varda/api/v1/vakajarjestajat/$id/",
+              "id": $id,
               "nimi": "Espoon kaupunki",
               "y_tunnus": "0101263-6",
               "yritysmuoto": "KUNTA",
@@ -286,12 +333,11 @@ class MockVardaIntegrationEndpoint(private val mapper: ObjectMapper) {
         """.trimIndent()
     }
 
-    private fun getMockChildResponse(id: Long? = null): String {
-        val responseId = id ?: (100000..999999).random().toLong()
+    private fun getMockChildResponse(id: Long): String {
         return """
             {
-              "url": "https://backend-qa.varda-db.csc.fi/api/v1/lapset/$responseId/",
-              "id": $responseId,
+              "url": "https://backend-qa.varda-db.csc.fi/api/v1/lapset/$id/",
+              "id": $id,
               "henkilo": "https://backend-qa.varda-db.csc.fi/api/v1/henkilot/687426/",
               "vakatoimija": "https://backend-qa.varda-db.csc.fi/api/v1/vakajarjestajat/299/",
               "oma_organisaatio": null,
@@ -305,28 +351,26 @@ class MockVardaIntegrationEndpoint(private val mapper: ObjectMapper) {
         """.trimIndent()
     }
 
-    private fun getMockPersonResponse(id: Long? = null): String {
-        val responseId = id ?: (100000..999999).random().toLong()
+    private fun getMockPersonResponse(id: Long): String {
         return """
             {
-              "url": "http://localhost:8888/mock-integration/varda/api/v1/henkilot/$responseId/",
-              "id": $responseId,
+              "url": "http://localhost:8888/mock-integration/varda/api/v1/henkilot/$id/",
+              "id": $id,
               "etunimet": "Testaaja Tessa",
               "kutsumanimi": "Testaaja",
               "sukunimi": "Holopainen",
-              "henkilo_oid": "1.2.246.562.24.$responseId",
+              "henkilo_oid": "1.2.246.562.24.$id",
               "syntyma_pvm": null,
               "lapsi": []
             }
         """.trimIndent()
     }
 
-    private fun getMockFeeDataResponse(id: Long? = null, feeData: VardaFeeData): String {
-        val responseId = id ?: (100000..999999).random().toLong()
+    private fun getMockFeeDataResponse(id: Long, feeData: VardaFeeData): String {
         return """
         {
-          "url": "https://backend-qa.varda-db.csc.fi/api/v1/maksutiedot/$responseId/",
-          "id": $responseId,
+          "url": "https://backend-qa.varda-db.csc.fi/api/v1/maksutiedot/$id/",
+          "id": $id,
           "huoltajat": [
             {
               "henkilo_oid": "1.2.246.562.24.23736347564",
@@ -347,18 +391,18 @@ class MockVardaIntegrationEndpoint(private val mapper: ObjectMapper) {
         """.trimIndent()
     }
 
-    private fun getMockDecisionResponse(id: Long? = null): String {
+    private fun getMockDecisionResponse(id: Long): String {
         return """
 {
-    "id": ${id ?: (100000..999999).random().toLong()}
+    "id": $id
 }
         """.trimIndent()
     }
 
-    private fun getMockPlacementResponse(id: Long? = null): String {
+    private fun getMockPlacementResponse(id: Long): String {
         return """
 {
-    "id": ${id ?: (100000..999999).random().toLong()}
+    "id": $id
 }
         """.trimIndent()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
@@ -55,6 +55,7 @@ class VardaClient(
 
     fun createUnit(unit: VardaUnit): VardaUnitResponse? {
         logger.info { "Creating a new unit ${unit.name} to Varda" }
+        logger.info { objectMapper.writeValueAsString(unit) }
         val (_, _, result) = fuel.post(unitUrl)
             .jsonBody(objectMapper.writeValueAsString(unit))
             .authenticatedResponseStringWithRetries()

--- a/service/src/main/resources/db/migration/V27__varda_fee_data_references.sql
+++ b/service/src/main/resources/db/migration/V27__varda_fee_data_references.sql
@@ -1,0 +1,7 @@
+ALTER TABLE varda_fee_data
+    ADD COLUMN varda_decision_id uuid REFERENCES varda_decision (id),
+    DROP COLUMN evaka_placement_id,
+    ADD UNIQUE (evaka_fee_decision_id, varda_decision_id),
+    ADD COLUMN varda_child_id uuid REFERENCES varda_child (id);
+
+ALTER TABLE varda_fee_data RENAME varda_fee_data_id TO varda_id;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -24,3 +24,4 @@ V23__mobile_device.sql
 V24__mobile_user_role.sql
 V25__mobile_device_token.sql
 V26__aad_to_external_id.sql
+V27__varda_fee_data_references.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Base Varda fee data on the actual decision data in Varda instead of doing unreliable pairing with evaka placement data. Since Varda requires fee data to match its decision data this increases reliability of the fee data integration and also prevents the old bug where identical fee data was sent to Varda multiple times.

Clean up related fee data from Varda when deleting a Varda decision. Currently, deleting Varda decisions fails every time they have overlapping fee data in Varda.

Improve the mock Varda client so that the stored data matches the actual operations.
