### PR TITLE
Only refresh mobile sessions with /auth/status

### DIFF
--- a/apigw/src/internal/__tests__/mobile-device-session.ts
+++ b/apigw/src/internal/__tests__/mobile-device-session.ts
@@ -62,29 +62,13 @@ describe('Mobile device pairing process', () => {
     tester.nockScope.done()
     expect(res.status).toBe(200)
   })
-  it('creates a long-term token that refreshes active session when any internal API is called', async () => {
-    const longTermToken = await finishPairing()
-
-    await tester.expireSession()
-    expect(await tester.getCookie(sessionCookie('employee'))).toBeUndefined()
-
-    tester.nockScope
-      .get(`/system/mobile-identity/${longTermToken}`)
-      .reply(200, { id: mobileDeviceId, longTermToken })
-    tester.nockScope.get('/some-proxied-api').reply(200)
-    const res = await tester.client.get('/api/internal/some-proxied-api')
-    tester.nockScope.done()
-    expect(res.status).toBe(200)
-  })
   it("expires the long-term token if backend doesn't recognize it during refresh", async () => {
     const longTermToken = await finishPairing()
     await tester.expireSession()
     tester.nockScope.get(`/system/mobile-identity/${longTermToken}`).reply(404)
-    const res = await tester.client.get('/api/internal/some-proxied-api', {
-      validateStatus: () => true
-    })
+    const res = await tester.client.get('/api/internal/auth/status')
     tester.nockScope.done()
-    expect(res.status).toBe(401)
+    expect(res.data).toStrictEqual({ loggedIn: false })
     expect(await tester.getCookie(mobileLongTermCookieName)).toBeUndefined()
   })
   it("expires the session if /auth/status can't find the mobile device", async () => {

--- a/apigw/src/internal/app.ts
+++ b/apigw/src/internal/app.ts
@@ -95,8 +95,13 @@ function internalApiRouter() {
   }
 
   router.post('/auth/mobile', mobileDeviceSession)
-  router.use(refreshMobileSession)
-  router.get('/auth/status', csrf, csrfCookie('employee'), authStatus)
+  router.get(
+    '/auth/status',
+    refreshMobileSession,
+    csrf,
+    csrfCookie('employee'),
+    authStatus
+  )
   router.all('/public/*', createProxy())
   router.use(requireAuthentication)
   router.use(csrf)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Requests that require CSRF tokens don't play nice with mobile refresh mechanism -> restrict refresh to /auth/status which is already used to create fresh CSRF state.

From the frontend point of view, this changes responses in expired session scenarios from 403 (Forbidden due to CSRF error) to 401 (Unauthorized due to expired session).

