### PR TITLE
Fix an accepted application's read rights

### DIFF
--- a/frontend/e2e-test/test/e2e/dev-api/index.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/index.ts
@@ -96,6 +96,20 @@ export async function execSimpleApplicationAction(
   }
 }
 
+export async function createPlacementPlan(
+  applicationId: string,
+  body: { unitId: string; period: { start: string; end: string } }
+): Promise<void> {
+  try {
+    await devClient.post(
+      `/applications/${applicationId}/actions/create-placement-plan`,
+      body
+    )
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}
+
 export async function execSimpleApplicationActions(
   applicationId: string,
   actions: ApplicationActionSimple[]
@@ -270,6 +284,16 @@ export async function deleteEmployeeFixture(externalId: string): Promise<void> {
 export async function deleteEmployeeById(id: UUID): Promise<void> {
   try {
     await devClient.delete(`/employee/${id}`)
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}
+
+export async function deleteEmployeeByExternalId(
+  externalId: UUID
+): Promise<void> {
+  try {
+    await devClient.delete(`/employee/external-id/${externalId}`)
   } catch (e) {
     throw new DevApiError(e)
   }

--- a/frontend/e2e-test/test/e2e/pages/admin/application-details-page.ts
+++ b/frontend/e2e-test/test/e2e/pages/admin/application-details-page.ts
@@ -20,4 +20,6 @@ export class ApplicationDetailsPage {
   readonly noOtherVtjGuardianText = Selector(
     '[data-qa="no-other-vtj-guardian"]'
   )
+
+  readonly applicationStatus = Selector('[data-qa="application-status"]')
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -76,7 +76,7 @@ WHERE application_id = :applicationId AND latest IS TRUE;
                 """
 SELECT role
 FROM application_view av
-LEFT JOIN placement_plan pp ON pp.application_id = av.id AND pp.deleted = false
+LEFT JOIN placement_plan pp ON pp.application_id = av.id
 JOIN daycare_acl acl ON acl.daycare_id = ANY(av.preferredunits) OR acl.daycare_id = pp.unit_id
 WHERE employee_id = :userId AND av.id = :applicationId AND av.status = ANY ('{SENT,WAITING_PLACEMENT,WAITING_CONFIRMATION,WAITING_DECISION,WAITING_MAILING,WAITING_UNIT_CONFIRMATION,ACTIVE}'::application_status_type[])
                 """.trimIndent()


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Previously if an application's placement plan was applied (i.e. its decisions were accepted) unit supervisors couldn't read the application unless the applicant had applied to the unit.

