### PR TITLE
Fix Varda placements for decisions to ghost units

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -114,6 +114,17 @@ val testClub = DevDaycare(
     uploadToKoski = false
 )
 
+val testGhostUnitDaycare = DevDaycare(
+    id = UUID.randomUUID(),
+    name = "Test Ghost Unit Daycare",
+    areaId = testAreaId,
+    type = setOf(CareType.CENTRE),
+    canApplyClub = true,
+    uploadToVarda = false,
+    uploadToKoski = false,
+    ghostUnit = true
+)
+
 val testDecisionMaker_1 = PersonData.WithName(
     id = UUID.randomUUID(),
     firstName = "Decision",
@@ -344,6 +355,7 @@ fun insertGeneralTestFixtures(h: Handle) {
         )
     )
     h.insertTestDaycare(testClub)
+    h.insertTestDaycare(testGhostUnitDaycare)
 
     testDecisionMaker_1.let {
         h.insertTestEmployee(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.testClub
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDaycare2
 import fi.espoo.evaka.testDaycareNotInvoiced
+import fi.espoo.evaka.testGhostUnitDaycare
 import fi.espoo.evaka.testPurchasedDaycare
 import fi.espoo.evaka.testVoucherDaycare
 import org.junit.jupiter.api.AfterEach
@@ -150,7 +151,15 @@ class TimeIntegrationTest : PureJdbiTest() {
         .map { it to january2020Weekdays.filter(filterDates) }
         .toMap()
 
-    private val defaultUnitIds: List<UUID> = listOf(testDaycare.id, testDaycare2.id, testDaycareNotInvoiced.id, testPurchasedDaycare.id, testVoucherDaycare.id, testClub.id!!)
+    private val defaultUnitIds: List<UUID> = listOf(
+        testDaycare.id,
+        testDaycare2.id,
+        testDaycareNotInvoiced.id,
+        testPurchasedDaycare.id,
+        testVoucherDaycare.id,
+        testClub.id!!,
+        testGhostUnitDaycare.id!!
+    )
 
     private val january2020Days = listOf(
         LocalDate.of(2020, 1, 1),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.ClosedPeriod
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.testGhostUnitDaycare
 import fi.espoo.evaka.varda.integration.MockVardaIntegrationEndpoint
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -50,6 +51,22 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
         val decisionId = insertDecisionWithApplication(db, testChild_1, period)
         val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
         val placementId = insertPlacement(db, testChild_1.id, period)
+
+        updatePlacements(db, vardaClient)
+
+        val result = getVardaPlacements(db)
+        assertEquals(1, result.size)
+        assertEquals(placementId, result.first().evakaPlacementId)
+        assertEquals(vardaDecisionId, result.first().decisionId)
+    }
+
+    @Test
+    fun `a daycare placement is sent when the corresponding decision has been sent even if the placement is to a different unit and the decision is to a ghost unit`() {
+        val period = ClosedPeriod(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))
+        insertVardaUnit(db)
+        val decisionId = insertDecisionWithApplication(db, testChild_1, period, unitId = testGhostUnitDaycare.id!!)
+        val vardaDecisionId = insertTestVardaDecision(db, decisionId = decisionId)
+        val placementId = insertPlacement(db, testChild_1.id, period, unitId = testDaycare.id)
 
         updatePlacements(db, vardaClient)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaPlacements.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaPlacements.kt
@@ -109,7 +109,7 @@ LEFT JOIN varda_placement vp ON p.id = vp.evaka_placement_id AND vp.deleted_at I
 JOIN daycare u ON p.unit_id = u.id AND u.upload_to_varda = true AND u.oph_unit_oid IS NOT NULL
 JOIN sent_decision d
     ON p.child_id = d.child_id
-    AND p.unit_id = d.unit_id
+    AND (p.unit_id = d.unit_id OR (SELECT ghost_unit FROM daycare WHERE id = d.unit_id))
     AND daterange(p.start_date, p.end_date, '[]') && daterange(d.start_date, d.end_date, '[]')
     """.trimIndent()
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Send all placements that overlap with decisions to ghost units instead of only placements to the same unit since children should never be placed to a ghost unit.

It might be a good idea to remove the requirement that decision and placement units match altogether.

