### PR TITLE
Initial theme installation for KeyCloak

### DIFF
--- a/compose/compose-keycloak
+++ b/compose/compose-keycloak
@@ -8,5 +8,14 @@ set -e
 
 cd "$( dirname "${BASH_SOURCE[0]}")"
 
-docker-compose -f docker-compose.yml -f docker-compose.keycloak.yml $@
+# We want to replace this with evaka in future
+if ! test -d "./keycloak/evaka-keycloak-theme/"; then
+  cd ./keycloak
+  git clone git@github.com:espoon-voltti/evaka-keycloak-theme.git
+  cd evaka-keycloak-theme
+  npm install
+  npm run build
+  cd ../..
+fi
 
+docker-compose -f docker-compose.yml -f docker-compose.keycloak.yml $@

--- a/compose/docker-compose.keycloak.yml
+++ b/compose/docker-compose.keycloak.yml
@@ -6,19 +6,26 @@ version: '3.5'
 
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:11.0.3
+    build: ./keycloak/evaka-keycloak-theme/
     ports:
       - "8080:8080"
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: admin
       DB_VENDOR: h2
+      KEYCLOAK_WELCOME_THEME: evaka
+    volumes:
+      - ./keycloak/configuration:/configuration
+      - ./keycloak/evaka-keycloak-theme/evaka:/opt/jboss/keycloak/themes/evaka
+    entrypoint: /configuration/entrypoint-configuration.sh
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]
       interval: 2s
       timeout: 5s
       retries: 5
       start_period: 5s
+    depends_on:
+      - smtp
 
   smtp:
     image: mailhog/mailhog
@@ -26,10 +33,13 @@ services:
       - "8025:8025"
 
   configure-keycloak:
-   image: quay.io/keycloak/keycloak:11.0.3
-   environment:
-     KEYCLOAK_USER: admin
-     KEYCLOAK_PASSWORD: admin
-   volumes:
-     - ./keycloak/configuration:/configuration
-   entrypoint: /configuration/entrypoint-realm.sh
+    image: quay.io/keycloak/keycloak:11.0.3
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+    volumes:
+      - ./keycloak/configuration:/configuration
+    entrypoint: /configuration/entrypoint-realm.sh
+    depends_on:
+      - keycloak
+

--- a/compose/keycloak/.gitignore
+++ b/compose/keycloak/.gitignore
@@ -1,0 +1,2 @@
+helsinki-keycloak-theme
+evaka-keycloak-theme

--- a/compose/keycloak/configuration/evaka.json
+++ b/compose/keycloak/configuration/evaka.json
@@ -952,9 +952,9 @@
     "from": "evaka@example.com",
     "ssl": ""
   },
-  "loginTheme": "base",
-  "accountTheme": "base",
-  "emailTheme": "base",
+  "loginTheme": "evaka",
+  "accountTheme": "evaka",
+  "emailTheme": "evaka",
   "eventsEnabled": false,
   "eventsListeners": [
     "jboss-logging"


### PR DESCRIPTION
#### Summary

Use <https://github.com/espoon-voltti/evaka-keycloak-theme> project in docker-compose for KeyCloak.

When `./compose-keycloak up` is executed first time the evaka theme should be enabled on <http://localhost:8080/auth/realms/evaka/account>.
