### PR TITLE
EVAKA-4098: Improve decision sending if non-disclosure order in place

### DIFF
--- a/frontend/e2e-test/test/e2e/dev-api/data-init.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/data-init.ts
@@ -15,6 +15,7 @@ import {
   familyWithSeparatedGuardians,
   restrictedPersonFixture,
   personFixtureChildZeroYearOld,
+  familyWithRestrictedDetailsGuardian,
   Fixture
 } from './fixtures'
 import * as devApi from '.'
@@ -31,7 +32,8 @@ const areaAndPersonFixtures = {
   familyWithTwoGuardians,
   familyWithSeparatedGuardians,
   restrictedPersonFixture,
-  personFixtureChildZeroYearOld
+  personFixtureChildZeroYearOld,
+  familyWithRestrictedDetailsGuardian
 }
 
 export type AreaAndPersonFixtures = typeof areaAndPersonFixtures
@@ -99,6 +101,24 @@ export const initializeAreaAndPersonData = async (): Promise<
   )
 
   await Fixture.person()
+    .with(areaAndPersonFixtures.familyWithRestrictedDetailsGuardian.guardian)
+    .saveAndUpdateMockVtj()
+
+  await Fixture.person()
+    .with(
+      areaAndPersonFixtures.familyWithRestrictedDetailsGuardian.otherGuardian
+    )
+    .saveAndUpdateMockVtj()
+
+  await Promise.all(
+    areaAndPersonFixtures.familyWithRestrictedDetailsGuardian.children.map(
+      async (child) => {
+        await Fixture.person().with(child).saveAndUpdateMockVtj()
+      }
+    )
+  )
+
+  await Fixture.person()
     .with(areaAndPersonFixtures.restrictedPersonFixture)
     .save()
 
@@ -111,6 +131,7 @@ export const initializeAreaAndPersonData = async (): Promise<
     areaAndPersonFixtures.enduserChildFixtureKaarina,
     ...areaAndPersonFixtures.familyWithTwoGuardians.children,
     ...areaAndPersonFixtures.familyWithSeparatedGuardians.children,
+    ...areaAndPersonFixtures.familyWithRestrictedDetailsGuardian.children,
     personFixtureChildZeroYearOld
   ])
 

--- a/frontend/e2e-test/test/e2e/dev-api/fixtures.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/fixtures.ts
@@ -314,6 +314,68 @@ export const familyWithSeparatedGuardians = {
   }))
 }
 
+const restrictedDetailsGuardian = {
+  id: '7699f488-3fdc-11eb-b378-0242ac130002',
+  ssn: '080884-999H',
+  firstName: 'Kaj Erik',
+  lastName: 'Pelimerkki',
+  email: 'kaj@example.com',
+  phone: '123456789',
+  language: 'fi',
+  dateOfBirth: '1984-08-08',
+  streetAddress: 'Kamreerintie 4',
+  postalCode: '02100',
+  postOffice: 'Espoo',
+  nationalities: ['FI'],
+  restrictedDetailsEnabled: true,
+  restrictedDetailsEndDate: null
+}
+
+const guardian2WithNoRestrictions = {
+  id: '1fd05a42-3fdd-11eb-b378-0242ac130002',
+  ssn: '130486-9980',
+  firstName: 'Helga Helen',
+  lastName: 'Lehtokurppa',
+  email: 'helga@example.com',
+  phone: '123456789',
+  language: 'fi',
+  dateOfBirth: '1986-04-13',
+  streetAddress: 'Westendinkatu 3',
+  postalCode: '02100',
+  postOffice: 'Espoo',
+  nationalities: ['FI'],
+  restrictedDetailsEnabled: false,
+  restrictedDetailsEndDate: null
+}
+
+const restrictedDetailsGuardiansChildren = [
+  {
+    id: '82a2586e-3fdd-11eb-b378-0242ac130002',
+    firstName: 'Vadelma',
+    lastName: 'Pelimerkki',
+    dateOfBirth: '2017-05-15',
+    ssn: '150517A9989',
+    streetAddress: 'Kamreerintie 4',
+    postalCode: '02100',
+    postOffice: 'Espoo'
+  }
+]
+
+export const familyWithRestrictedDetailsGuardian = {
+  guardian: {
+    ...restrictedDetailsGuardian,
+    dependants: restrictedDetailsGuardiansChildren
+  },
+  otherGuardian: {
+    ...guardian2WithNoRestrictions,
+    dependants: restrictedDetailsGuardiansChildren
+  },
+  children: restrictedDetailsGuardiansChildren.map((child) => ({
+    ...child,
+    guardians: [restrictedDetailsGuardian, guardian2WithNoRestrictions]
+  }))
+}
+
 export const personFixtureChildZeroYearOld: PersonDetail = {
   id: '0909e93d-3aa8-44f8-ac30-ecd77339d849',
   ssn: undefined,

--- a/frontend/e2e-test/test/e2e/dev-api/index.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/index.ts
@@ -527,7 +527,10 @@ const toVtjPerson = (
     `${person.streetAddress ?? ''}${person.postalCode ?? ''}${
       person.postOffice ?? ''
     }`.replace(' ', ''),
-  restrictedDetails: null
+  restrictedDetails: {
+    enabled: person.restrictedDetailsEnabled || false,
+    endDate: person.restrictedDetailsEndDate || null
+  }
 })
 
 export async function insertVtjPersonFixture(

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -48,7 +48,12 @@ class DecisionService(
     private val evakaMessageClient: IEvakaMessageClient,
     private val asyncJobRunner: AsyncJobRunner
 ) {
-    fun finalizeDecisions(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID, sendAsMessage: Boolean): List<UUID> {
+    fun finalizeDecisions(
+        tx: Database.Transaction,
+        user: AuthenticatedUser,
+        applicationId: UUID,
+        sendAsMessage: Boolean
+    ): List<UUID> {
         val decisionIds = finalizeDecisions(tx.handle, applicationId)
         asyncJobRunner.plan(tx, decisionIds.map { NotifyDecisionCreated(it, user, sendAsMessage) })
         return decisionIds
@@ -211,7 +216,7 @@ class DecisionService(
 
         deliverDecisionToGuardian(tx, decision, applicationGuardian, decision.documentUri.toString())
 
-        if (application.otherGuardianId != null && !decision.otherGuardianDocumentUri.isNullOrBlank()) {
+        if (application.otherGuardianId != null && !decision.otherGuardianDocumentUri.isNullOrBlank() && !applicationGuardian.restrictedDetailsEnabled) {
             val otherGuardian = tx.handle.getPersonById(application.otherGuardianId)
                 ?: error("Other guardian not found with id: ${application.otherGuardianId}")
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
If the applicant (guardian) has non-disclosure order, do not
automatically send decision to second guardian, even if he/she
didn't have non-disclosure order.

In this case, service worker contacts the guardian to determine where
and how to send the decision.

#### How to test

- Create an application with first guardian having non-disclosure order and second guardian not having one.
- Handle the application all the way to the decision phase
- Make sure the second guardian does not receive the decision as a Suomi.fi message

