### PR TITLE
Service: exceptions to logs where available, change max fee log level

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -643,7 +643,7 @@ class ApplicationStateService(
         }
 
         if (hasOverlappingDefiniteIncome || hasLaterIncome || preferredStartDate == null) {
-            logger.error { "Could not add a new max fee accepted income when moving to WAITING_FOR_PLACEMENT state" }
+            logger.debug { "Could not add a new max fee accepted income when moving to WAITING_FOR_PLACEMENT state" }
         } else {
             val period = Period(start = preferredOrNow, end = null)
             val validIncome = Income(

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -66,7 +66,7 @@ class AbsenceService {
             val userName = tx.getEmployeeNameById(userId)
             tx.upsertAbsences(absences, userName)
         } catch (e: Exception) {
-            logger.error { "Error: Updating absences by user $userId failed" }
+            logger.error(e) { "Error: Updating absences by user $userId failed" }
             throw BadRequest("Error: Updating absences failed: ${e.message}")
         }
     }
@@ -75,7 +75,7 @@ class AbsenceService {
         try {
             tx.upsertChildAbsence(childId, absenceType, careType, userId)
         } catch (e: Exception) {
-            logger.error { "Error: Updating absences by user $userId failed" }
+            logger.error(e) { "Error: Updating absences by user $userId failed" }
             throw BadRequest("Error: Updating absences failed: ${e.message}")
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
@@ -73,14 +73,14 @@ class DvvModificationsService(
                             else -> logger.info("Unsupported DVV modification: ${infoGroup.tietoryhma}")
                         }
                     } catch (e: Throwable) {
-                        logger.error(
+                        logger.error(e) {
                             "Could not process dvv modification for ${
                             personModifications.henkilotunnus.substring(
                                 0,
                                 6
                             )
                             }: ${e.message}"
-                        )
+                        }
                     }
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailClient.kt
@@ -59,9 +59,9 @@ class EmailClient(private val client: AmazonSimpleEmailService, env: Environment
             } catch (e: Exception) {
                 when (e) {
                     is MailFromDomainNotVerifiedException, is ConfigurationSetDoesNotExistException, is ConfigurationSetSendingPausedException, is AccountSendingPausedException ->
-                        logger.error { "Couldn't send application email (personId: $personId): ${e.message}" }
+                        logger.error(e) { "Couldn't send application email (personId: $personId): ${e.message}" }
                     else -> {
-                        logger.error { "Couldn't send application email (personId: $personId): ${e.message}" }
+                        logger.error(e) { "Couldn't send application email (personId: $personId): ${e.message}" }
                         throw e
                     }
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/service/persondetails/VTJPersonDetailsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/service/persondetails/VTJPersonDetailsService.kt
@@ -122,7 +122,7 @@ class VTJPersonDetailsService(
         } catch (e: VtjPersonNotFoundException) {
             return PersonDetails.PersonNotFound()
         } catch (e: Exception) {
-            logger.error("Error fetching VTJ data: $e")
+            logger.error(e) { "Error fetching VTJ data: $e" }
             return PersonDetails.QueryError(e.message ?: "")
         }.let(henkiloMapper::mapToVtjPerson)
 


### PR DESCRIPTION
#### Summary
- service: incl. exceptions in logs where available
  - By providing the exception object to the logger, it can create the 'exception' and 'stackTrace' fields which in turn makes debugging much easier
    - This was missing from a few places where exceptions are available, like VTJ error handler
- service: log max fee add failure at debug level
  - This is not an actual error but removing it completely loses valuable debug information -> change log level from error to debug