### PR TITLE
EVAKA-4040: preschool terms

### DIFF
--- a/frontend/packages/enduser-frontend/src/localization/app/en.json
+++ b/frontend/packages/enduser-frontend/src/localization/app/en.json
@@ -165,7 +165,8 @@
       "invalid-ssn": "Invalid personal identity code",
       "invalid-tel": "Invalid phone number",
       "invalid-timestring": "Invalid time of day (Please use the following form: 13:30)",
-      "invalid-daterange": "Date is not inside allowed range"
+      "invalid-daterange": "Date is not inside allowed range",
+      "outside-preschool-term": "The day you selected is not within the pre-primary education period. Please fill the early childhood education application instead.”"
     }
   },
   "care-type": {

--- a/frontend/packages/enduser-frontend/src/localization/app/fi.json
+++ b/frontend/packages/enduser-frontend/src/localization/app/fi.json
@@ -169,7 +169,8 @@
       "invalid-ssn": "Epäkelpo henkilötunnus",
       "invalid-tel": "Virheellinen puhelinnumero",
       "invalid-timestring": "Virheellinen kellonaika (anna muodossa 13:30)",
-      "invalid-daterange": "Päivämäärä ei ole sallitulla välillä"
+      "invalid-daterange": "Päivämäärä ei ole sallitulla välillä",
+      "outside-preschool-term": "Esiopetuskausi ei ole käynnissä tänä päivänä. Tälle ajalle on tehtävä varhaiskasvatushakemus."
     }
   },
   "care-type": {

--- a/frontend/packages/enduser-frontend/src/localization/app/sv.json
+++ b/frontend/packages/enduser-frontend/src/localization/app/sv.json
@@ -165,7 +165,8 @@
       "invalid-ssn": "Ogiltig personbeteckning",
       "invalid-tel": "Ogiltigt telefonnummer",
       "invalid-timestring": "Ogiltig tid (ange t.ex. 13:30)",
-      "invalid-daterange": "Datumet är inte inom tillåtet intervall"
+      "invalid-daterange": "Datumet är inte inom tillåtet intervall",
+      "outside-preschool-term": "Den här dagen är utanför förskolornas verksamhetsperiod. För den här dagen måste du göra en ansökan om plats inom småbarnspedagogiken."
     }
   },
   "care-type": {

--- a/frontend/packages/enduser-frontend/src/views/applications/daycare-application/daycare-application.vue
+++ b/frontend/packages/enduser-frontend/src/views/applications/daycare-application/daycare-application.vue
@@ -1219,6 +1219,7 @@ export default Vue.extend({
         return false
       }
 
+      // todo: use preschool term data from backend
       return date >= new Date('2021-06-05') && date < new Date('2021-08-01')
     },
     startdateIsUnderFourMonths(): boolean {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -429,11 +429,39 @@ fun insertGeneralTestFixtures(h: Handle) {
     h.insertTestVoucherValue(
         VoucherValue(id = UUID.randomUUID(), validity = Period(LocalDate.of(2000, 1, 1), null), voucherValue = 87000)
     )
+
+    h.insertPreschoolTerms()
 }
 
 fun Database.Transaction.resetDatabase() = execute("SELECT reset_database()")
 fun resetDatabase(h: Handle) {
     h.transaction { it.execute("SELECT reset_database()") }
+}
+
+fun Handle.insertPreschoolTerms() {
+    //language=SQL
+    val sql =
+        """
+-- 2020-2021
+INSERT INTO preschool_term (finnish_preschool, swedish_preschool, extended_term, application_period)
+VALUES (
+    '[2020-08-13,2021-06-04]',
+    '[2020-08-18,2021-06-04]',
+    '[2020-08-01,2021-06-04]',
+    '[2020-01-08,2020-01-20]'
+);
+
+-- 2021-2022
+INSERT INTO preschool_term (finnish_preschool, swedish_preschool, extended_term, application_period)
+VALUES (
+    '[2021-08-11,2022-06-03]',
+    '[2021-08-11,2022-06-03]',
+    '[2021-08-01,2022-06-03]',
+    '[2021-01-08,2021-01-20]'
+);
+        """.trimIndent()
+
+    createUpdate(sql).execute()
 }
 
 fun insertTestVardaOrganizer(h: Handle) {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -576,14 +576,6 @@ class ApplicationStateService(
 
         val unitIds = application.form.preferences.preferredUnits.map { it.id }
 
-        if (application.type == ApplicationType.PRESCHOOL && application.form.preferences.preferredStartDate != null) {
-            val currentTermEnd = LocalDate.of(2021, 6, 4)
-            val nextApplyPeriodStart = LocalDate.of(2021, 1, 8)
-            if (LocalDate.now(zoneId).isBefore(nextApplyPeriodStart) && application.form.preferences.preferredStartDate.isAfter(currentTermEnd)) {
-                result.add(ValidationError("form.preferences.preferredStartDate", "Application period for preschool term 2021-2022 has not started yet"))
-            }
-        }
-
         if (unitIds.isEmpty()) {
             result.add(ValidationError("form.preferences.preferredUnits", "Must have at least one preferred unit"))
         } else {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -559,7 +559,7 @@ class ApplicationStateService(
             throw BadRequest("Expected status to be one of [${statuses.joinToString(separator = ", ")}] but was ${application.status}")
     }
 
-    fun canApplyOnPreschoolTerm(tx: Database.Read, preferredStartDate: LocalDate): Boolean{
+    fun canApplyOnPreschoolTerm(tx: Database.Read, preferredStartDate: LocalDate): Boolean {
         val term = tx.getActivePreschoolTermAt(preferredStartDate) ?: return false
         val applicationsAccepted = ClosedPeriod(term.applicationPeriod.start, term.extendedTerm.end)
         return applicationsAccepted.includes(LocalDate.now(zoneId))
@@ -568,8 +568,8 @@ class ApplicationStateService(
     private fun validateApplication(tx: Database.Read, application: ApplicationDetails) {
         val result = ValidationResult()
 
-        if(application.type == ApplicationType.PRESCHOOL){
-            if(!canApplyOnPreschoolTerm(tx, application.form.preferences.preferredStartDate!!)){
+        if (application.type == ApplicationType.PRESCHOOL && application.form.preferences.preferredStartDate != null) {
+            if (!canApplyOnPreschoolTerm(tx, application.form.preferences.preferredStartDate)) {
                 result.add(ValidationError("form.preferences.preferredStartDate", "Cannot apply to preschool on the preferred time at the moment"))
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.application.persistence.DatabaseForm
 import fi.espoo.evaka.daycare.controllers.AdditionalInformation
 import fi.espoo.evaka.daycare.controllers.Child
 import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.daycare.getActivePreschoolTermAt
 import fi.espoo.evaka.daycare.getDaycare
 import fi.espoo.evaka.daycare.getUnitApplyPeriods
 import fi.espoo.evaka.daycare.upsertChild
@@ -558,54 +559,9 @@ class ApplicationStateService(
             throw BadRequest("Expected status to be one of [${statuses.joinToString(separator = ", ")}] but was ${application.status}")
     }
 
-    data class PreschoolTerm (
-        val finnishPreschool: ClosedPeriod,
-        val swedishPreschool: ClosedPeriod,
-        val extendedCare: ClosedPeriod,
-        val applicationPeriod: ClosedPeriod
-    )
-    val preschoolSeasons = listOf(
-        PreschoolTerm( // 2020-2021
-            finnishPreschool = ClosedPeriod(
-                LocalDate.of(2020, 8, 13),
-                LocalDate.of(2021, 6, 4)
-            ),
-            swedishPreschool = ClosedPeriod(
-                LocalDate.of(2020, 8, 18),
-                LocalDate.of(2021, 6, 4)
-            ),
-            extendedCare = ClosedPeriod(
-                LocalDate.of(2020, 8, 1),
-                LocalDate.of(2021, 6, 4)
-            ),
-            applicationPeriod = ClosedPeriod(
-                LocalDate.of(2020, 1, 8),
-                LocalDate.of(2020, 1, 20)
-            )
-        ),
-        PreschoolTerm( // 2021-2022
-            finnishPreschool = ClosedPeriod(
-                LocalDate.of(2022, 8, 11),
-                LocalDate.of(2022, 6, 4)
-            ),
-            swedishPreschool = ClosedPeriod(
-                LocalDate.of(2021, 8, 11),
-                LocalDate.of(2022, 6, 4)
-            ),
-            extendedCare = ClosedPeriod(
-                LocalDate.of(2021, 8, 1),
-                LocalDate.of(2022, 6, 4)
-            ),
-            applicationPeriod = ClosedPeriod(
-                LocalDate.of(2021, 1, 8),
-                LocalDate.of(2021, 1, 20)
-            )
-        )
-    )
-
-    fun isOnValidPreschoolSeason(preferredStartDate: LocalDate): Boolean{
-        val season = preschoolSeasons.find { it.extendedCare.includes(preferredStartDate) } ?: return false
-        val applicationsAccepted = ClosedPeriod(season.applicationPeriod.start, season.extendedCare.end)
+    fun canApplyOnPreschoolTerm(tx: Database.Read, preferredStartDate: LocalDate): Boolean{
+        val term = tx.getActivePreschoolTermAt(preferredStartDate) ?: return false
+        val applicationsAccepted = ClosedPeriod(term.applicationPeriod.start, term.extendedTerm.end)
         return applicationsAccepted.includes(LocalDate.now(zoneId))
     }
 
@@ -613,7 +569,7 @@ class ApplicationStateService(
         val result = ValidationResult()
 
         if(application.type == ApplicationType.PRESCHOOL){
-            if(!isOnValidPreschoolSeason(application.form.preferences.preferredStartDate!!)){
+            if(!canApplyOnPreschoolTerm(tx, application.form.preferences.preferredStartDate!!)){
                 result.add(ValidationError("form.preferences.preferredStartDate", "Cannot apply to preschool on the preferred time at the moment"))
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
@@ -1,0 +1,32 @@
+package fi.espoo.evaka.daycare
+
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.ClosedPeriod
+import fi.espoo.evaka.shared.utils.zoneId
+import org.jdbi.v3.core.kotlin.mapTo
+import java.time.LocalDate
+
+data class PreschoolTerm (
+    val finnishPreschool: ClosedPeriod,
+    val swedishPreschool: ClosedPeriod,
+    val extendedTerm: ClosedPeriod,
+    val applicationPeriod: ClosedPeriod
+)
+
+fun Database.Read.getPreschoolTerms(): List<PreschoolTerm>{
+    return createQuery("SELECT * FROM preschool_term order by extended_term")
+        .mapTo<PreschoolTerm>()
+        .list()
+}
+
+fun Database.Read.getActivePreschoolTermAt(date: LocalDate): PreschoolTerm? {
+    return getPreschoolTerms().firstOrNull { it.extendedTerm.includes(date) }
+}
+
+fun Database.Read.getCurrentPreschoolTerm(): PreschoolTerm? {
+    return getActivePreschoolTermAt(LocalDate.now(zoneId))
+}
+
+fun Database.Read.getNextPreschoolTerm(): PreschoolTerm? {
+    return getPreschoolTerms().firstOrNull { it.extendedTerm.start.isAfter(LocalDate.now(zoneId)) }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
@@ -6,14 +6,14 @@ import fi.espoo.evaka.shared.utils.zoneId
 import org.jdbi.v3.core.kotlin.mapTo
 import java.time.LocalDate
 
-data class PreschoolTerm (
+data class PreschoolTerm(
     val finnishPreschool: ClosedPeriod,
     val swedishPreschool: ClosedPeriod,
     val extendedTerm: ClosedPeriod,
     val applicationPeriod: ClosedPeriod
 )
 
-fun Database.Read.getPreschoolTerms(): List<PreschoolTerm>{
+fun Database.Read.getPreschoolTerms(): List<PreschoolTerm> {
     return createQuery("SELECT * FROM preschool_term order by extended_term")
         .mapTo<PreschoolTerm>()
         .list()

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
@@ -18,7 +18,9 @@ data class PreschoolTerm(
     /*The official application period. The end date is not enforced though, but applications are accepted
     until end of term.*/
     val applicationPeriod: ClosedPeriod
-)
+) {
+    fun isApplicationAccepted(date: LocalDate) = ClosedPeriod(applicationPeriod.start, extendedTerm.end).includes(date)
+}
 
 fun Database.Read.getPreschoolTerms(): List<PreschoolTerm> {
     return createQuery("SELECT * FROM preschool_term order by extended_term")

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
@@ -7,9 +7,16 @@ import org.jdbi.v3.core.kotlin.mapTo
 import java.time.LocalDate
 
 data class PreschoolTerm(
+    /*The period during which finnish speaking preschool is arranged.*/
     val finnishPreschool: ClosedPeriod,
+    /*The period during which swedish speaking preschool is arranged.*/
     val swedishPreschool: ClosedPeriod,
+    /*Children going to preschool may apply for connected daycare slightly outside the actual preschool term,
+    usually starting few weeks earlier. That is then essentially normal daycare with discounted price.
+    This period defines when that connected daycare is available.*/
     val extendedTerm: ClosedPeriod,
+    /*The official application period. The end date is not enforced though, but applications are accepted
+    until end of term.*/
     val applicationPeriod: ClosedPeriod
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/DevDataInitializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/DevDataInitializer.kt
@@ -22,6 +22,9 @@ class DevDataInitializer(jdbi: Jdbi) {
                 ClassPathResource("dev-data/employees.sql").file.readText().let {
                     h.createUpdate(it).execute()
                 }
+                ClassPathResource("dev-data/preschool-terms.sql").file.readText().let {
+                    h.createUpdate(it).execute()
+                }
             }
         }
     }

--- a/service/src/main/resources/db/migration/V28__preschool_term.sql
+++ b/service/src/main/resources/db/migration/V28__preschool_term.sql
@@ -1,0 +1,15 @@
+CREATE TABLE preschool_term (
+    id uuid PRIMARY KEY DEFAULT ext.uuid_generate_v1mc(),
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    updated timestamp with time zone DEFAULT now() NOT NULL,
+    finnish_preschool daterange NOT NULL,
+    swedish_preschool daterange NOT NULL,
+    extended_term daterange NOT NULL,
+    application_period daterange NOT NULL,
+
+    CONSTRAINT preschool_term$extended_care_contain_finnish_preschool CHECK ( extended_term @> finnish_preschool ),
+    CONSTRAINT preschool_term$extended_care_contain_swedish_preschool CHECK ( extended_term @> swedish_preschool ),
+    CONSTRAINT preschool_term$no_overlaps EXCLUDE ( extended_term WITH && )
+);
+
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON preschool_term FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();

--- a/service/src/main/resources/db/migration/V29__preschool_term.sql
+++ b/service/src/main/resources/db/migration/V29__preschool_term.sql
@@ -9,7 +9,7 @@ CREATE TABLE preschool_term (
 
     CONSTRAINT preschool_term$extended_care_contain_finnish_preschool CHECK ( extended_term @> finnish_preschool ),
     CONSTRAINT preschool_term$extended_care_contain_swedish_preschool CHECK ( extended_term @> swedish_preschool ),
-    CONSTRAINT preschool_term$no_overlaps EXCLUDE ( extended_term WITH && )
+    CONSTRAINT preschool_term$no_overlaps EXCLUDE USING gist ( extended_term WITH && )
 );
 
 CREATE TRIGGER set_timestamp BEFORE UPDATE ON preschool_term FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();

--- a/service/src/main/resources/dev-data/preschool-terms.sql
+++ b/service/src/main/resources/dev-data/preschool-terms.sql
@@ -1,0 +1,17 @@
+-- 2020-2021
+INSERT INTO preschool_term (finnish_preschool, swedish_preschool, extended_term, application_period)
+VALUES (
+    '[2020-08-13,2021-06-04]',
+    '[2020-08-18,2021-06-04]',
+    '[2020-08-01,2021-06-04]',
+    '[2020-01-08,2020-01-20]'
+);
+
+-- 2021-2022
+INSERT INTO preschool_term (finnish_preschool, swedish_preschool, extended_term, application_period)
+VALUES (
+    '[2021-08-11,2022-06-03]',
+    '[2021-08-11,2022-06-03]',
+    '[2021-08-01,2022-06-03]',
+    '[2021-01-08,2021-01-20]'
+);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -26,3 +26,4 @@ V25__mobile_device_token.sql
 V26__aad_to_external_id.sql
 V27__varda_fee_data_references.sql
 V28__unit_apply_dateranges.sql
+V29__preschool_term.sql


### PR DESCRIPTION
#### Summary

- model preschool terms in database
- use them when validating preferred start date
- minimum possible vue changes to validate that preferred start date for preschool cannot be between 5.6.2021 - 31.7.2021 (inclusive).
- next PR: replace other hard-codings

**When deploying run following:**
```
-- 2020-2021
INSERT INTO preschool_term (finnish_preschool, swedish_preschool, extended_term, application_period)
VALUES (
    '[2020-08-13,2021-06-04]',
    '[2020-08-18,2021-06-04]',
    '[2020-08-01,2021-06-04]',
    '[2020-01-08,2020-01-20]'
);

-- 2021-2022
INSERT INTO preschool_term (finnish_preschool, swedish_preschool, extended_term, application_period)
VALUES (
    '[2021-08-11,2022-06-03]',
    '[2021-08-11,2022-06-03]',
    '[2021-08-01,2022-06-03]',
    '[2021-01-08,2021-01-20]'
);
```

