### PR TITLE
EVAKA-FIX: notice restricted details on placement draft dialog

### DIFF
--- a/frontend/e2e-test/test/e2e/pages/admin/application-workbench-page.ts
+++ b/frontend/e2e-test/test/e2e/pages/admin/application-workbench-page.ts
@@ -247,7 +247,7 @@ export class ApplicationWorkbenchPage {
     await t.click(button)
   }
 
-  async openDaycarePlaementById(id: string) {
+  async openDaycarePlacementDialogById(id: string) {
     const link = this.getApplicationById(id).find(
       '[data-qa="primary-action-create-placement-plan"]'
     )

--- a/frontend/e2e-test/test/e2e/specs/1_application/club-application.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/1_application/club-application.spec.ts
@@ -123,7 +123,7 @@ test('Admin places application into a unit', async (t) => {
 
   // Place the submitted application
   await applicationWorkbench.openPlacementQueue()
-  await applicationWorkbench.openDaycarePlaementById(applicationId)
+  await applicationWorkbench.openDaycarePlacementDialogById(applicationId)
   await applicationWorkbench.placementPage.placeIn(0)
   await applicationWorkbench.placementPage.sendPlacement()
 

--- a/frontend/e2e-test/test/e2e/specs/1_application/daycare-application.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/1_application/daycare-application.spec.ts
@@ -138,7 +138,7 @@ test('Admin places application into a unit', async (t) => {
   // Place the submitted application
   await applicationWorkbench.openPlacementQueue()
   await applicationWorkbench.verifyApplication(applicationId)
-  await applicationWorkbench.openDaycarePlaementById(applicationId)
+  await applicationWorkbench.openDaycarePlacementDialogById(applicationId)
   await applicationWorkbench.placementPage.placeIn(0)
   await applicationWorkbench.placementPage.sendPlacement()
 

--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -1743,7 +1743,10 @@ export const fi = {
     dateError: 'Päällekkäinen sijoitus ajanjaksolle.',
     preparatoryPeriod: 'Valmistava opetus',
     dateOfBirth: 'Syntymäaika',
-    selectedUnit: 'Valittu yksikkö'
+    selectedUnit: 'Valittu yksikkö',
+    restrictedDetails: 'Huoltajalla on turvakielto',
+    restrictedDetailsTooltip:
+      'Päätös pitää lähettää käsin toiselle huoltajalle, kun hakijalla on turvakielto.'
   },
   decisionDraft: {
     title: 'Päätöksen teko ja lähetys',

--- a/frontend/packages/employee-frontend/src/components/placement-draft/PlacementDraft.tsx
+++ b/frontend/packages/employee-frontend/src/components/placement-draft/PlacementDraft.tsx
@@ -42,6 +42,8 @@ import Placements from './Placements'
 import { TitleContext, TitleState } from '~state/title'
 import { getPlacementDraft, createPlacementPlan } from 'api/applications'
 import FiniteDateRange from '@evaka/lib-common/src/finite-date-range'
+import WarningLabel from '~components/common/WarningLabel'
+import Tooltip from '~components/common/Tooltip'
 
 const ContainerNarrow = styled(Container)`
   max-width: 990px;
@@ -90,6 +92,10 @@ const DOBTitle = styled.span`
 
 const SelectContainer = styled.div`
   max-width: 400px;
+`
+
+const FloatRight = styled.div`
+  float: right;
 `
 
 function PlacementDraft({ match }: RouteComponentProps<{ id: UUID }>) {
@@ -280,6 +286,21 @@ function PlacementDraft({ match }: RouteComponentProps<{ id: UUID }>) {
         {placementDraft.isSuccess && placement.period && (
           <Fragment>
             <PlacementDraftInfo>
+              {placementDraft.value.guardianHasRestrictedDetails && (
+                <FloatRight>
+                  <Tooltip
+                    tooltipId={`tooltip_warning`}
+                    tooltipText={i18n.placementDraft.restrictedDetailsTooltip}
+                    place={'top'}
+                    delayShow={750}
+                  >
+                    <WarningLabel
+                      text={i18n.placementDraft.restrictedDetails}
+                      dataQa={`restricted-details-warning`}
+                    />
+                  </Tooltip>
+                </FloatRight>
+              )}
               <Title size={1}>{i18n.placementDraft.createPlacementDraft}</Title>
               <ChildName>
                 <Title size={3}>

--- a/frontend/packages/employee-frontend/src/types/placementdraft.ts
+++ b/frontend/packages/employee-frontend/src/types/placementdraft.ts
@@ -34,6 +34,7 @@ export interface PlacementDraft {
   period: FiniteDateRange
   preschoolDaycarePeriod?: FiniteDateRange
   placements: PlacementDraftPlacement[]
+  guardianHasRestrictedDetails: boolean
 }
 
 export interface DaycarePlacementPlan {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -212,6 +212,18 @@ val testAdult_6 = PersonData.Detailed(
     restrictedDetailsEnabled = false
 )
 
+val testAdult_7 = PersonData.Detailed(
+    id = UUID.randomUUID(),
+    dateOfBirth = LocalDate.of(1980, 1, 1),
+    ssn = "010180-969B",
+    firstName = "Tepi",
+    lastName = "Turvakiellollinen",
+    streetAddress = "Suojatie 112",
+    postalCode = "02230",
+    postOffice = "Espoo",
+    restrictedDetailsEnabled = true
+)
+
 val testChild_1 = PersonData.Detailed(
     id = UUID.randomUUID(),
     dateOfBirth = LocalDate.of(2017, 6, 1),
@@ -310,7 +322,7 @@ val testChildWithNamelessGuardian = PersonData.Detailed(
 )
 
 val allWorkers = setOf(testDecisionMaker_1)
-val allAdults = setOf(testAdult_1, testAdult_2, testAdult_3, testAdult_4, testAdult_5, testAdult_6)
+val allAdults = setOf(testAdult_1, testAdult_2, testAdult_3, testAdult_4, testAdult_5, testAdult_6, testAdult_7)
 val allChildren = setOf(testChild_1, testChild_2, testChild_3, testChild_4, testChild_5, testChild_6, testChild_7, testChildWithNamelessGuardian)
 val allBasicChildren = allChildren.map { PersonData.Basic(it.id, it.dateOfBirth, it.firstName, it.lastName, it.ssn) }
 val allDaycares = setOf(testDaycare, testDaycare2)
@@ -389,7 +401,8 @@ fun insertGeneralTestFixtures(h: Handle) {
                 streetAddress = it.streetAddress ?: "",
                 postalCode = it.postalCode ?: "",
                 postOffice = it.postOffice ?: "",
-                email = it.email
+                email = it.email,
+                restrictedDetailsEnabled = it.restrictedDetailsEnabled
             )
         )
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
@@ -43,7 +43,7 @@ class ScheduledOperationControllerIntegrationTest : FullApplicationTest() {
             setApplicationCreatedDate(tx, id_not_to_be_deleted, LocalDate.now().minusDays(31))
         }
 
-        db.transaction { tx ->
+        db.transaction { _ ->
             uploadAttachment(id_to_be_deleted, user)
             uploadAttachment(id_not_to_be_deleted, user)
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanDraft.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanDraft.kt
@@ -14,7 +14,8 @@ data class PlacementPlanDraft(
     val preferredUnits: List<PlacementDraftUnit>,
     val period: FiniteDateRange,
     val preschoolDaycarePeriod: FiniteDateRange?,
-    val placements: List<PlacementDraftPlacement>
+    val placements: List<PlacementDraftPlacement>,
+    val guardianHasRestrictedDetails: Boolean
 )
 
 data class PlacementDraftChild(val id: UUID, val firstName: String, val lastName: String, val dob: LocalDate)

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanQueries.kt
@@ -226,3 +226,18 @@ fun getPlacementDraftChild(h: Handle, childId: UUID): PlacementDraftChild? {
         .list()
         .singleOrNull()
 }
+
+fun getGuardiansRestrictedStatus(h: Handle, guardianId: UUID): Boolean? {
+    return h.createQuery(
+        // language=SQL
+        """
+            SELECT restricted_details_enabled
+            FROM person
+            WHERE id = :id
+        """
+    )
+        .bind("id", guardianId)
+        .mapTo<Boolean>()
+        .toList()
+        .singleOrNull()
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -33,6 +33,8 @@ class PlacementPlanService(
         val form = application.form
         val child = getPlacementDraftChild(tx.handle, application.childId)
             ?: throw NotFound("Cannot find child with id ${application.childId} to application ${application.id}")
+        val guardianHasRestrictedDetails = getGuardiansRestrictedStatus(tx.handle, application.guardianId)
+            ?: throw NotFound("Cannot find guardian with id ${application.guardianId} to application ${application.id}")
         val preferredUnits = form.preferences.preferredUnits.map {
             PlacementDraftUnit(
                 id = it.id,
@@ -57,7 +59,8 @@ class PlacementPlanService(
                     preferredUnits = preferredUnits,
                     period = period,
                     preschoolDaycarePeriod = preschoolDaycarePeriod,
-                    placements = placements
+                    placements = placements,
+                    guardianHasRestrictedDetails = guardianHasRestrictedDetails
                 )
             }
             ApplicationType.DAYCARE -> {
@@ -74,7 +77,8 @@ class PlacementPlanService(
                     preferredUnits = preferredUnits,
                     period = period,
                     preschoolDaycarePeriod = null,
-                    placements = placements
+                    placements = placements,
+                    guardianHasRestrictedDetails = guardianHasRestrictedDetails
                 )
             }
             ApplicationType.CLUB -> {
@@ -86,7 +90,8 @@ class PlacementPlanService(
                     preferredUnits = preferredUnits,
                     period = period,
                     preschoolDaycarePeriod = null,
-                    placements = placements
+                    placements = placements,
+                    guardianHasRestrictedDetails = guardianHasRestrictedDetails
                 )
             }
             else -> throw IllegalArgumentException("Unsupported application form type ${application.type}")


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
User should be notified about restricted details when they are creating a placement draft.
