### PR TITLE
Add advisory text that instead of deleting a parentship to a mod & add

### DIFF
--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -832,7 +832,8 @@ export const fi = {
       newChild: 'Uusi lapsi',
       editChild: 'Lapsen muokkaus',
       removeChild: 'Lapsen poisto',
-      confirmText: 'Haluatko varmasti poistaa lapsen?',
+      confirmText:
+        'Haluatko varmasti poistaa lapsen? Päämiehen vaihtuessa merkitse edelliselle suhteelle loppumisaika ja lisää sen jälkeen uusi',
       error: {
         add: {
           title: 'Lapsen lisäys epäonnistui!'


### PR DESCRIPTION
Service managers accidentally delete parentships when head of family changes. This causes errors in invoicing. Change the delete confirmation text to tell what the correct procedure is.
<img width="589" alt="Screenshot 2020-12-29 at 16 38 53" src="https://user-images.githubusercontent.com/158767/103291428-60370b00-49f4-11eb-927e-4ddfbb5b72be.png">
