### PR TITLE
EVAKA_FIX: flaky invoicing test

### DIFF
--- a/frontend/e2e-test/test/e2e/specs/4_invoicing/invoices.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/4_invoicing/invoices.spec.ts
@@ -121,9 +121,12 @@ test('Add a new invoice row, modify its amount and price and persist the changes
   await t.expect(page.invoicesPage.exists).ok()
   await page.openFirstInvoice(t)
   await t.expect(page.invoiceRow.count).eql(2)
-  await t.expect(page.costCenterInput.nth(1).value).eql('12345')
-  await t.expect(page.amountInput.nth(1).value).eql('10')
-  await t.expect(page.priceInput.nth(1).value).eql('100')
+
+  const rowNum: number =
+    (await page.costCenterInput.nth(1).value) === '12345' ? 1 : 0
+  await t.expect(page.costCenterInput.nth(rowNum).value).eql('12345')
+  await t.expect(page.amountInput.nth(rowNum).value).eql('10')
+  await t.expect(page.priceInput.nth(rowNum).value).eql('100')
 })
 
 test('Add a new invoice row, delete it, and delete the parent row', async (t) => {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
For now we shouldn't assume invoice rows to always be in the same order
