### PR TITLE
Add missing licenses, update reuse tool

### DIFF
--- a/bin/add-license-headers.sh
+++ b/bin/add-license-headers.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Configuration
-REUSE_VERSION=0.11.1
+REUSE_VERSION=0.12.1
 
 if [ "${1:-X}" = '--help' ]; then
   echo 'Usage: ./bin/add-license-headers.sh [OPTIONS]'
@@ -21,14 +21,18 @@ if [ "${1:-X}" = '--help' ]; then
   exit 0
 fi
 
+function run_reuse() {
+    docker run --rm --volume "$(pwd):/data" "fsfe/reuse:${REUSE_VERSION}" "$@"
+}
+
 function addheader() {
     local file="$1"
     shift
-    reuse addheader --license "LGPL-2.1-or-later" --copyright "City of Espoo" --year "2017-2020" "$@" "$file"
+    run_reuse addheader --license "LGPL-2.1-or-later" --copyright "City of Espoo" --year "2017-2020" "$@" "$file"
 }
 
 set +e
-REUSE_OUTPUT=$(docker run --rm --volume "$(pwd):/data" "fsfe/reuse:${REUSE_VERSION}" lint)
+REUSE_OUTPUT=$(run_reuse lint)
 REUSE_EXIT_CODE="$?"
 set -e
 

--- a/compose/docker-compose.keycloak.yml
+++ b/compose/docker-compose.keycloak.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2020 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 version: '3.5'
 
 services:

--- a/compose/keycloak/configuration/entrypoint-configuration.sh
+++ b/compose/keycloak/configuration/entrypoint-configuration.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2017-2020 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 set -e
 
 sed -i 's|<cacheThemes>.*<\/cacheThemes>|<cacheThemes>false<\/cacheThemes>|g' /opt/jboss/keycloak/standalone/configuration/standalone.xml

--- a/compose/keycloak/configuration/entrypoint-realm.sh
+++ b/compose/keycloak/configuration/entrypoint-realm.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2017-2020 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 set -e
 
 # Note this will not re-configure the realm. If you want to reconfigure realm then just delete the realm and run docker-compose down and then up.

--- a/compose/keycloak/configuration/evaka.json.license
+++ b/compose/keycloak/configuration/evaka.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2020 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later

--- a/compose/keycloak/ldap/Dockerfile
+++ b/compose/keycloak/ldap/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2020 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from debian:bullseye
 
 RUN apt-get -y update \

--- a/compose/keycloak/ldap/README.md
+++ b/compose/keycloak/ldap/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2017-2020 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+
 # LDAP (experimental)
 
 ```bash

--- a/compose/keycloak/ldap/ldap-docker-compose.yaml
+++ b/compose/keycloak/ldap/ldap-docker-compose.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2020 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 version: '3.5'
 
 services:

--- a/compose/keycloak/ldap/ldap.conf.license
+++ b/compose/keycloak/ldap/ldap.conf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2020 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later

--- a/frontend/packages/employee-frontend/src/utils/placements.ts
+++ b/frontend/packages/employee-frontend/src/utils/placements.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 import { PlacementType } from '~types/placementdraft'
 
 const partDayPlacementTypes: readonly PlacementType[] = [

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 package fi.espoo.evaka.pis
 
 import com.github.kittinunf.fuel.core.isSuccessful

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 package fi.espoo.evaka.shared.controllers
 
 import fi.espoo.evaka.FullApplicationTest

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.shared.db.Database

--- a/service/src/main/resources/dev-data/preschool-terms.sql
+++ b/service/src/main/resources/dev-data/preschool-terms.sql
@@ -1,3 +1,7 @@
+-- SPDX-FileCopyrightText: 2017-2020 City of Espoo
+--
+-- SPDX-License-Identifier: LGPL-2.1-or-later
+
 -- 2020-2021
 INSERT INTO preschool_term (finnish_preschool, swedish_preschool, extended_term, application_period)
 VALUES (


### PR DESCRIPTION
#### Summary
- reuse: update to 0.12.1 and fix script
   - Accidentally assumed a local `reuse` installation for the `addheader` command in our helper script instead of using the Docker container used for `lint` -> use the Docker container for all `reuse` actions
   - Update `reuse` to 0.12.1 to add support for `.ts` and `.tsx`
- Add missing license headers