### PR TITLE
CI: ensure only built proxy tags are pushed, general updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ aliases:
   - &nodejs_image cimg/node:14.15
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202010-01
-  - &builder_aws_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:1a7e0dec664ec27fa49d3eb76992be870c3f5b99
+  - &builder_aws_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:18.04-d7214c52ce3670639a5b6868607198bde918cbcb
 
   - &default_config
     working_directory: *workspace_root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,7 +496,6 @@ jobs:
   checkout_repo:
     executor: apigw_executor
     steps:
-      - *restore_repo
       - checkout
       - *store_repo
       - notify_slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@3.4.2
+  slack: circleci/slack@4.1.3
 
 aliases:
   - &workspace_root /home/circleci/repo
@@ -21,8 +21,10 @@ aliases:
   - &workspace_message_service /home/circleci/repo/message-service
   - &workspace_compose /home/circleci/repo/compose
   - &yarn_cache .yarn_cache
+
   # SSH key fingerprint for checking out other eVaka repositories
   - &ci_evaka_fingerprint 86:d0:b3:3d:aa:fc:d5:b9:6b:69:1e:c7:f5:56:66:aa
+
   # Version of remote Docker engine used with setup_remote_docker (not including machine executors)
   - &remote_docker_version "19.03.13"
   - &yarn_version '1.22.\*'
@@ -30,6 +32,15 @@ aliases:
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202010-01
   - &builder_aws_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:18.04-d7214c52ce3670639a5b6868607198bde918cbcb
+
+  - &default_contexts
+    context:
+      - voltti-slack
+      - voltti-dockerhub
+  - &aws_contexts
+    context:
+      - voltti-slack
+      - org-global
 
   - &default_config
     working_directory: *workspace_root
@@ -116,65 +127,6 @@ aliases:
         - message-service/.gradle
         - message-service/.gradle-user-home
 
-  - &attach_workspace
-    attach_workspace:
-      at: *workspace_root
-
-  - &persist_workspace_apigw
-    persist_to_workspace:
-      root: *workspace_root
-      paths:
-        - apigw/dist
-        - *yarn_cache
-
-  - &persist_workspace_frontend
-    persist_to_workspace:
-      root: *workspace_root
-      paths:
-        - frontend/packages/enduser-frontend/dist
-        - frontend/packages/citizen-frontend/dist
-        - frontend/packages/employee-frontend/dist
-        - frontend/packages/maintenance-page/dist
-        - frontend/packages/lib-components/storybook-build
-        - frontend/e2e-test/dist
-        - frontend/e2e-test/scripts
-        - *yarn_cache
-
-  - &persist_workspace_service
-    persist_to_workspace:
-      root: *workspace_root
-      paths:
-        - service/build
-
-  - &persist_workspace_message_service
-    persist_to_workspace:
-      root: *workspace_root
-      paths:
-        - message-service/build
-
-  - &deploy_frontend
-    executor: aws_executor
-    working_directory: *workspace_root
-    steps:
-      - *attach_workspace
-      - run:
-          name: Configure AWS CLI
-          command: replace-credentials
-      - deploy_to_s3:
-          from: frontend/packages/enduser-frontend
-          to: application
-      - deploy_to_s3:
-          from: frontend/packages/citizen-frontend
-          to: citizen
-      - deploy_to_s3:
-          from: frontend/packages/employee-frontend
-          to: employee
-      - deploy_to_s3:
-          from: frontend/packages/maintenance-page
-          to: maintenance-page
-      - storybook_to_s3
-      - notify_slack
-
 executors:
   aws_executor:
     <<: *default_config
@@ -233,6 +185,11 @@ executors:
       image: *ubuntu_machine_image
 
 commands:
+  attach_root_workspace:
+    steps:
+      - attach_workspace:
+          at: *workspace_root
+
   login_docker_hub:
     description: Log in to Docker Hub for authenticated pulls
     steps:
@@ -284,7 +241,7 @@ commands:
         default: *yarn_version
     steps:
       - *restore_repo
-      - *attach_workspace
+      - attach_root_workspace
       - run:
           name: Load docker images
           command: |
@@ -349,8 +306,38 @@ commands:
       - store_test_results:
           path: frontend/e2e-test/test-results
 
+  deploy_frontend:
+    parameters:
+      target_env:
+        type: string
+    steps:
+      - attach_root_workspace
+      - run:
+          name: Configure AWS CLI
+          command: replace-credentials
+      - deploy_to_s3:
+          target_env: << parameters.target_env >>
+          from: frontend/packages/enduser-frontend
+          to: application
+      - deploy_to_s3:
+          target_env: << parameters.target_env >>
+          from: frontend/packages/citizen-frontend
+          to: citizen
+      - deploy_to_s3:
+          target_env: << parameters.target_env >>
+          from: frontend/packages/employee-frontend
+          to: employee
+      - deploy_to_s3:
+          target_env: << parameters.target_env >>
+          from: frontend/packages/maintenance-page
+          to: maintenance-page
+      - storybook_to_s3:
+          target_env: << parameters.target_env >>
+
   deploy_to_s3:
     parameters:
+      target_env:
+        type: string
       from:
         type: string
       to:
@@ -360,31 +347,34 @@ commands:
           name: Deploy (<< parameters.from >>)
           working_directory: /home/circleci/repo/<< parameters.from >>
           command: |
-            aws s3 cp dist/index.html s3://evaka-static-$TARGET_ENV/<< parameters.to >>/index.html \
+            aws s3 cp dist/index.html s3://evaka-static-<< parameters.target_env >>/<< parameters.to >>/index.html \
               --acl public-read \
-              --profile voltti-$TARGET_ENV
+              --profile voltti-<< parameters.target_env >>
 
-            if [ "$TARGET_ENV" = "prod" ]; then
+            if [ "<< parameters.target_env >>" = "prod" ]; then
               echo 'Target environment is prod, excluding source maps from deploy'
               EXTRA_ARGS=(
                 '--exclude' '*.map'
               )
             fi
 
-            aws s3 sync dist s3://evaka-static-$TARGET_ENV/<< parameters.to >> \
+            aws s3 sync dist s3://evaka-static-<< parameters.target_env >>/<< parameters.to >> \
               --acl public-read \
               --exact-timestamps \
               --exclude "*index.html" \
               "${EXTRA_ARGS[@]}" \
-              --profile voltti-$TARGET_ENV
+              --profile voltti-<< parameters.target_env >>
 
   storybook_to_s3:
+    parameters:
+      target_env:
+        type: string
     steps:
       - run:
           name: Deploy Storybook
           working_directory: /home/circleci/repo/frontend/packages/lib-components
           command: |
-            if [ "$TARGET_ENV" = "dev" ]; then
+            if [ "<< parameters.target_env >>" = "dev" ]; then
               aws --profile voltti-dev s3 cp storybook-build/ s3://evaka-static-dev/master/storybook/ --recursive --acl public-read
             fi
 
@@ -455,7 +445,7 @@ commands:
       - add_ssh_keys:
           fingerprints:
             - *ci_evaka_fingerprint
-      - *attach_workspace
+      - attach_root_workspace
       - run:
           name: Deploy ECS services to << parameters.env >>
           command: |
@@ -478,18 +468,38 @@ commands:
   notify_slack:
     description: "Notify via Slack"
     steps:
-      - slack/status:
-          fail_only: true
-          only_for_branches: master
-          # Webhook URL defined as $SLACK_WEBHOOK in CircleCI project settings
+      - slack/notify:
+          branch_pattern: master
+          channel: ci
+          event: fail
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": { "type": "mrkdwn", "text": ":red_circle: Job *${CIRCLE_JOB}* has failed" },
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Project*:\n${CIRCLE_PROJECT_REPONAME}" },
+                    { "type": "mrkdwn", "text": "*Commiter*:\n${CIRCLE_USERNAME}" }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [ { "type": "button", "text": { "type": "plain_text", "text": "View Job" }, "url": "${CIRCLE_BUILD_URL}" } ]
+                }
+              ]
+            }
 
 jobs:
+  # MISC JOBS
+
   checkout_repo:
     executor: apigw_executor
     steps:
       - *restore_repo
       - checkout
       - *store_repo
+      - notify_slack
 
   fetch_private_dependencies:
     executor: aws_executor
@@ -505,25 +515,29 @@ jobs:
           root: *workspace_root
           paths:
             - frontend/vendor/fortawesome/*
+      - notify_slack
 
   clone_infra_repo:
-    executor: aws_executor
+    executor: service_executor
     steps:
       - add_ssh_keys:
           fingerprints:
             - *ci_evaka_fingerprint
-      - *attach_workspace
+      - attach_root_workspace
       - run: git clone git@github.com:espoon-voltti/evaka-infra.git
       - persist_to_workspace:
           root: *workspace_root
           paths:
             - evaka-infra
+      - notify_slack
+
+  # BUILD JOBS
 
   build_base_image:
     executor: apigw_executor
     steps:
       - *restore_repo
-      - *attach_workspace
+      - attach_root_workspace
       - setup_authenticated_remote_docker
       - run:
           name: Build base image
@@ -537,6 +551,7 @@ jobs:
           root: *workspace_root
           paths:
             - evaka-base.tar
+      - notify_slack
 
   apigw_build_and_test:
     executor: apigw_executor
@@ -550,7 +565,11 @@ jobs:
       - run:
           working_directory: *workspace_apigw
           command: yarn build
-      - *persist_workspace_apigw
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - apigw/dist
+            - *yarn_cache
       - run:
           working_directory: *workspace_apigw
           command: yarn lint
@@ -565,7 +584,7 @@ jobs:
     executor: aws_executor
     steps:
       - *restore_repo
-      - *attach_workspace
+      - attach_root_workspace
       - setup_remote_docker:
           version: *remote_docker_version
       - load_base_image
@@ -581,7 +600,7 @@ jobs:
   apigw_push_image:
     executor: aws_executor
     steps:
-      - *attach_workspace
+      - attach_root_workspace
       - setup_remote_docker:
           version: *remote_docker_version
       - push_docker_image:
@@ -589,25 +608,11 @@ jobs:
           dir: *workspace_apigw
       - notify_slack
 
-  services_deploy_dev:
-    executor: aws_executor
-    steps:
-      - deploy_services:
-          env: dev
-      - notify_slack
-
-  services_deploy_test:
-    executor: aws_executor
-    steps:
-      - deploy_services:
-          env: test
-      - notify_slack
-
   frontend_build_and_test:
     executor: frontend_executor
     steps:
       - *restore_repo
-      - *attach_workspace
+      - attach_root_workspace
       - *restore_frontend_node_modules
       - run:
           working_directory: *workspace_frontend
@@ -622,7 +627,17 @@ jobs:
       - build_frontend:
           dir: /home/circleci/repo/frontend/packages/maintenance-page
       - build_storybook
-      - *persist_workspace_frontend
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - frontend/packages/enduser-frontend/dist
+            - frontend/packages/citizen-frontend/dist
+            - frontend/packages/employee-frontend/dist
+            - frontend/packages/maintenance-page/dist
+            - frontend/packages/lib-components/storybook-build
+            - frontend/e2e-test/dist
+            - frontend/e2e-test/scripts
+            - *yarn_cache
       - run:
           working_directory: *workspace_frontend
           command: yarn lint
@@ -636,6 +651,8 @@ jobs:
       - store_test_results:
           path: /home/circleci/repo/frontend/packages/enduser-frontend/test-results
       - notify_slack
+
+  # E2E JOBS
 
   e2e-test-application:
     executor: e2e_executor
@@ -679,25 +696,27 @@ jobs:
           suite: e2e-ci-mobile
       - notify_slack
 
-  frontend_deploy_dev:
-    <<: *deploy_frontend
-    environment:
-      TARGET_ENV: dev
+  # DEPLOY JOBS
 
-  frontend_deploy_test:
-    <<: *deploy_frontend
-    environment:
-      TARGET_ENV: test
+  services_deploy:
+    executor: aws_executor
+    parameters:
+      target_env:
+        type: string
+    steps:
+      - deploy_services:
+          env: << parameters.target_env >>
+      - notify_slack
 
-  frontend_deploy_staging:
-    <<: *deploy_frontend
-    environment:
-      TARGET_ENV: staging
-
-  frontend_deploy_prod:
-    <<: *deploy_frontend
-    environment:
-      TARGET_ENV: prod
+  frontend_deploy:
+    executor: aws_executor
+    parameters:
+      target_env:
+        type: string
+    steps:
+      - deploy_frontend:
+          target_env: << parameters.target_env >>
+      - notify_slack
 
   proxy_build_and_push_image:
     executor: aws_executor
@@ -708,6 +727,7 @@ jobs:
           image: evaka/proxy
           dir: *workspace_proxy
           push_after: true
+      - notify_slack
 
   service_build:
     executor: service_executor
@@ -718,7 +738,10 @@ jobs:
           working_directory: *workspace_service
           command: ./gradlew assemble
       - *store_service_gradle
-      - *persist_workspace_service
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - service/build
       - run:
           working_directory: *workspace_service
           command: ./gradlew ktlintCheck
@@ -731,7 +754,7 @@ jobs:
     executor: aws_executor
     steps:
       - *restore_repo
-      - *attach_workspace
+      - attach_root_workspace
       - setup_remote_docker:
           version: *remote_docker_version
       - run:
@@ -752,7 +775,7 @@ jobs:
     executor: service_test_executor
     steps:
       - *restore_repo
-      - *attach_workspace
+      - attach_root_workspace
       - *restore_service_gradle
       - run:
           working_directory: *workspace_service
@@ -777,7 +800,7 @@ jobs:
     executor: aws_executor
     steps:
       - *restore_repo
-      - *attach_workspace
+      - attach_root_workspace
       - setup_remote_docker:
           version: *remote_docker_version
       - push_docker_image:
@@ -794,7 +817,10 @@ jobs:
           working_directory: *workspace_message_service
           command: ./gradlew assemble
       - *store_message_service_gradle
-      - *persist_workspace_message_service
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - message-service/build
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew ktlintCheck
@@ -804,7 +830,7 @@ jobs:
     executor: message_service_test_executor
     steps:
       - *restore_repo
-      - *attach_workspace
+      - attach_root_workspace
       - *restore_message_service_gradle
       - run:
           working_directory: *workspace_message_service
@@ -829,7 +855,7 @@ jobs:
     executor: aws_executor
     steps:
       - *restore_repo
-      - *attach_workspace
+      - attach_root_workspace
       - setup_remote_docker:
           version: *remote_docker_version
       - run:
@@ -848,80 +874,69 @@ workflows:
   build_test_and_deploy:
     jobs:
       - checkout_repo:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
       - fetch_private_dependencies:
-          context:
-            - org-global
+          <<: *aws_contexts
           requires:
             - checkout_repo
       - build_base_image:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - checkout_repo
 
       - apigw_build_and_test:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - checkout_repo
       - apigw_build_image:
-          context:
-            - org-global
+          <<: *aws_contexts
           requires:
             - build_base_image
             - apigw_build_and_test
       - apigw_push_image:
-          context:
-            - org-global
+          <<: *aws_contexts
           requires:
             - apigw_build_image
 
       - frontend_build_and_test:
           context:
-            - sentry-release
+            - voltti-slack
             - voltti-dockerhub
+            - sentry-release
           requires:
             - fetch_private_dependencies
       - e2e-test-application:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - frontend_build_and_test
             - apigw_build_image
             - service_build_image
       - e2e-test-citizen:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - frontend_build_and_test
             - apigw_build_image
             - service_build_image
       - e2e-test-invoicing:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - frontend_build_and_test
             - apigw_build_image
             - service_build_image
       - e2e-test-employee:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - frontend_build_and_test
             - apigw_build_image
             - service_build_image
       - e2e-test-employee-2:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - frontend_build_and_test
             - apigw_build_image
             - service_build_image
       - e2e-test-mobile:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - frontend_build_and_test
             - apigw_build_image
@@ -931,52 +946,45 @@ workflows:
           context:
             - org-global
             - voltti-dockerhub
+            - voltti-slack
           requires:
             - checkout_repo
 
       - service_build:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - checkout_repo
       - service_build_image:
-          context:
-            - org-global
+          <<: *aws_contexts
           requires:
             - build_base_image
             - service_build
       - service_test:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - service_build
       - service_push_image:
-          context:
-            - org-global
+          <<: *aws_contexts
           requires:
             - service_build_image
             - service_test
 
       - message_service_build:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - checkout_repo
       - message_service_test:
-          context:
-            - voltti-dockerhub
+          <<: *default_contexts
           requires:
             - message_service_build
       - message_service_build_and_push_image:
-          context:
-            - org-global
+          <<: *aws_contexts
           requires:
             - build_base_image
             - message_service_test
 
       - clone_infra_repo:
-          context:
-            - org-global
+          <<: *default_contexts
           requires:
             - e2e-test-application
             - e2e-test-citizen
@@ -992,40 +1000,29 @@ workflows:
             branches:
               only: master
 
-      - services_deploy_dev:
-          context:
-            - org-global
+      - services_deploy:
+          <<: *aws_contexts
+          name: services_deploy_<< matrix.target_env >>
           requires:
             - clone_infra_repo
           filters:
             branches:
               only: master
+          matrix:
+            parameters:
+              target_env: [dev, test]
 
-      - services_deploy_test:
-          context:
-            - org-global
+      - frontend_deploy:
+          <<: *aws_contexts
+          name: frontend_deploy_<< matrix.target_env >>
           requires:
             - clone_infra_repo
           filters:
             branches:
               only: master
-
-      - frontend_deploy_dev:
-          context:
-            - org-global
-          requires:
-            - clone_infra_repo
-          filters:
-            branches:
-              only: master
-      - frontend_deploy_test:
-          context:
-            - org-global
-          requires:
-            - clone_infra_repo
-          filters:
-            branches:
-              only: master
+          matrix:
+            parameters:
+              target_env: [dev, test]
       - frontend_approve_staging_deploy:
           type: approval
           requires:
@@ -1034,14 +1031,15 @@ workflows:
           filters:
             branches:
               only: master
-      - frontend_deploy_staging:
-          context:
-            - org-global
+      - frontend_deploy:
+          <<: *aws_contexts
+          name: frontend_deploy_staging
           requires:
             - frontend_approve_staging_deploy
           filters:
             branches:
               only: master
+          target_env: staging
       - frontend_approve_prod_deploy:
           type: approval
           requires:
@@ -1049,11 +1047,12 @@ workflows:
           filters:
             branches:
               only: master
-      - frontend_deploy_prod:
-          context:
-            - org-global
+      - frontend_deploy:
+          <<: *aws_contexts
+          name: frontend_deploy_prod
           requires:
             - frontend_approve_prod_deploy
           filters:
             branches:
               only: master
+          target_env: prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -585,6 +585,7 @@ jobs:
       - attach_root_workspace
       - setup_remote_docker:
           version: *remote_docker_version
+          docker_layer_caching: true
       - load_base_image
       - build_docker_image:
           image: evaka/api-gateway
@@ -755,6 +756,7 @@ jobs:
       - attach_root_workspace
       - setup_remote_docker:
           version: *remote_docker_version
+          docker_layer_caching: true
       - run:
           name: Unzip executable
           working_directory: *workspace_service
@@ -856,6 +858,7 @@ jobs:
       - attach_root_workspace
       - setup_remote_docker:
           version: *remote_docker_version
+          docker_layer_caching: true
       - run:
           name: Unzip executable
           working_directory: *workspace_message_service

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,7 +536,6 @@ jobs:
     executor: apigw_executor
     steps:
       - *restore_repo
-      - attach_root_workspace
       - setup_authenticated_remote_docker
       - run:
           name: Build base image

--- a/frontend/e2e-test/test/e2e/pages/citizen/citizen-homepage.ts
+++ b/frontend/e2e-test/test/e2e/pages/citizen/citizen-homepage.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 import { Selector, t } from 'testcafe'
 
 export default class CitizenHomepage {


### PR DESCRIPTION
#### Summary
- CI: Only push built tags for proxy (with `ecr-push`)
   - Update to the latest `voltti/builder-aws` to use the fixed version of `ecr-push` that only pushes the tags it creates instead of pushing all local tags
      - Local cache can contain tags from other builds when Docker Layer Caching is active and we obviously don't want to push any other tags (and spend time doing so)
- CI: Large image build speedup with Docker Layer Caching
   - Even though the cost of DLC is a bit ridiculous, both API gateway and service image builds currently benefit pretty significantly from layer caching (~30-40s vs 1-2s Docker builds)
- CI: Checkout and base image build small speedups
- CI: Update Slack orb & remove config duplication (matrix jobs, inline once-used aliases, parametrize jobs instead of duplicating)
   - Update to the new Slack Orb (v4) that uses a Slack app instead of a webhook (environment variable must be removed from CircleCI once this is in master), application token provided by `voltti-slack` context
- CI: Add `notify_slack` to all jobs, missing in places