### PR TITLE
EVAKA-HOTFIX: include file extension to attachment name

### DIFF
--- a/frontend/packages/enduser-frontend/src/localization/app/fi.json
+++ b/frontend/packages/enduser-frontend/src/localization/app/fi.json
@@ -677,6 +677,10 @@
           "message": {
             "title": "Ilta- ja vuorohoito",
             "text": "Ilta- ja vuorohoito (viikonloppu- ja ympärivuorokautinen varhaiskasvatus) on tarkoitettu lapsille, joiden molemmat huoltajat ovat vuorotyössä tai opiskelevat iltaisin ja viikonloppuisin. Hakemuksen liitteeksi toimitetaan molempien huoltajien osalta todistus työstä tai opiskelusta johtuvasta ilta- tai vuorohoidontarpeesta (varhaiskasvatuksen.palveluohjaus@espoo.fi)."
+          },
+          "attachments-message": {
+            "text": "Ilta-  ja vuorohoito on tarkoitettu lapsille, joiden molemmat vanhemmat ovat vuorotyössä tai opiskelevat pääsääntöisesti iltaisin ja/tai viikonloppuisin. Hakemuksen liitteeksi toimitetaan molempien vanhempien osalta työnantajan todistus vuorotyöstä tai opiskelusta johtuvasta ilta- tai vuorohoidon tarpeesta. Suosittelemme toimittamaan liitteen sähköisesti tässä, sillä kahden viikon käsittelyaika alkaa siitä, kun olemme vastaanottaneet hakemuksen tarvittavine liitteineen. Jos et voi lisätä liitteitä hakemukselle sähköisesti, lähetä ne postilla osoitteeseen Varhaiskasvatuksen palveluohjaus, PL 3125, 02070 Espoon kaupunki.",
+            "subtitle": "Lisää tähän molemmilta vanhemmilta joko työnantajan todistus vuorotyöstä tai todistus opiskelusta iltaisin/viikonloppuisin."
           }
         },
         "clubCare": {

--- a/frontend/packages/enduser-frontend/src/localization/app/sv.json
+++ b/frontend/packages/enduser-frontend/src/localization/app/sv.json
@@ -635,6 +635,10 @@
           "message": {
             "title": "Hakemus on kiireellinen",
             "text": "Mikäli varhaiskasvatuksen tarpeen alkamisajankohtaa ei ole voitu ennakoida ja varhaiskasvatuspaikan tarve johtuu <strong>äkillisestä ja ennalta- arvaamattomasta</strong> työllistymisestä, opiskelusta tai koulutuksesta, tulee paikkaa hakea viimeistään kaksi viikkoa ennen kuin tarve alkaa. Kahden viikon käsittelyaika alkaa siitä, kun työ- tai opiskelutodistukset on toimitettu palveluohjaukseen (varhaiskasvatuksen.palveluohjaus@espoo.fi)."
+          },
+          "attachments-message": {
+            "text": "Om behovet av en plats inom småbarnspedagogiken beror på att du plötsligt fått sysselsättning eller börjat studera, ska platsen sökas senast två veckor innan behovet börjar. Bifoga till ansökan ett arbets- eller studieintyg av båda vårdnadshavarna som bor i samma hushåll. Om du inte kan lägga till bilagor till ansökan elektroniskt, skicka dem per post till adressen Småbarnspedagogikens servicehänvisning, PB 3125, 02070 Esbo stad. Behandlingstiden på två veckor börjar när vi har tagit emot ansökan och bilagorna som behövs.",
+            "subtitle": "Lägg här till ett arbets- eller studieintyg av båda föräldrarna."
           }
         },
         "startDate": {
@@ -672,6 +676,10 @@
           "message": {
             "title": "Kvälls- och skiftesvård ",
             "text": "Kvälls- och skiftesvård (småbarnspedagogik, som ordnas under veckoslut och dygnet runt) är avsedd för barn vars vårdnadshavare har skiftesarbete eller studerar på kvällar och veckoslut. Som bilaga ska av båda vårdnadshavarna bifogas ett intyg över arbete eller studier som orsakar behovet av kvälls- eller skiftesvård (dagis@esbo.fi)."
+          },
+          "attachments-message": {
+            "text": "Kvälls- och skiftomsorg är avsedd för barn vars båda föräldrar har skiftarbete eller studerar huvudsakligen på kvällar och/eller veckoslut. Som bilaga till ansökan ska av båda föräldrarna lämnas ett intyg av arbetsgivaren över skiftarbete eller studier som orsakar behovet av kvälls- eller skiftomsorg. Vi rekommenderar att bilagan skickas elektroniskt här, eftersom behandlingstiden på två veckor börjar när vi har tagit emot ansökan med de bilagor som behövs. Om du inte kan lägga till bilagor till ansökan elektroniskt, skicka dem per post till adressen Småbarnspedagogikens servicehänvisning, PB 3125, 02070 Esbo stad.",
+            "subtitle": "Lägg här till för båda föräldrarna antingen arbetsgivarens intyg över skiftarbete eller ett intyg över studier på kvällar/veckoslut."
           }
         },
         "clubCare": {

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -147,9 +147,11 @@ class AttachmentsController(
         val attachment =
             db.read { it.getAttachment(attachmentId) ?: throw NotFound("Attachment $attachmentId not found") }
 
+        val extension = parseExtension(attachment.name) ?: throw Forbidden("Couldn't parse valid file extension for attachment $attachmentId")
+
         return s3Client.get(filesBucket, "$attachmentId").let { document ->
             ResponseEntity.ok()
-                .header("Content-Disposition", "attachment;filename=${document.getName()}")
+                .header("Content-Disposition", "attachment;filename=${document.getName()}.$extension")
                 .contentType(MediaType.valueOf(attachment.contentType))
                 .body(document.getBytes())
         }
@@ -186,6 +188,12 @@ fun Database.Read.userAttachmentCount(userId: UUID): Int {
         .bind("userId", userId)
         .mapTo<Int>()
         .first()
+}
+
+fun parseExtension(fileName: String): String? {
+    val extension = fileName.split(".").last()
+    val validExtensions = listOf("jpg", "jpeg", "png", "pdf", "doc", "docx", "xls", "xlsx")
+    return extension.takeIf { validExtensions.contains(extension) }
 }
 
 val contentTypesWithMagicNumbers = mapOf(

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -147,11 +147,9 @@ class AttachmentsController(
         val attachment =
             db.read { it.getAttachment(attachmentId) ?: throw NotFound("Attachment $attachmentId not found") }
 
-        val extension = parseExtension(attachment.name) ?: throw Forbidden("Couldn't parse valid file extension for attachment $attachmentId")
-
         return s3Client.get(filesBucket, "$attachmentId").let { document ->
             ResponseEntity.ok()
-                .header("Content-Disposition", "attachment;filename=${document.getName()}.$extension")
+                .header("Content-Disposition", "attachment;filename=${attachment.name}")
                 .contentType(MediaType.valueOf(attachment.contentType))
                 .body(document.getBytes())
         }
@@ -188,12 +186,6 @@ fun Database.Read.userAttachmentCount(userId: UUID): Int {
         .bind("userId", userId)
         .mapTo<Int>()
         .first()
-}
-
-fun parseExtension(fileName: String): String? {
-    val extension = fileName.split(".").last()
-    val validExtensions = listOf("jpg", "jpeg", "png", "pdf", "doc", "docx", "xls", "xlsx")
-    return extension.takeIf { validExtensions.contains(extension) }
 }
 
 val contentTypesWithMagicNumbers = mapOf(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
When user downloads an attachment, we use the file's UUID instead of it's original name and hence lose the file extension. Now it's parsed from the original name and appended to UUID. 

Also fixed some missing translations related to attachments.

