### PR TITLE
Disable editing of absence cells with backup care

### DIFF
--- a/frontend/packages/employee-frontend/src/components/absences/AbsenceCell.tsx
+++ b/frontend/packages/employee-frontend/src/components/absences/AbsenceCell.tsx
@@ -112,13 +112,15 @@ const MemoizedCell = memo(function AbsenceCell({
   toggle: (parts: CellPart[]) => void
 }) {
   const parts = getCellParts(childId, date, careTypes, absences, backupCare)
+  if (parts.length === 0) {
+    return <DisabledCell />
+  }
 
-  return parts.length === 0 ? (
-    <DisabledCell />
-  ) : (
+  const clickable = !backupCare
+  return (
     <div
       className={`absence-cell ${isSelected ? 'absence-cell-selected' : ''}`}
-      onClick={() => toggle(parts)}
+      onClick={clickable ? () => toggle(parts) : undefined}
     >
       {parts.map(({ id: partId, absenceType, position }) => (
         <AbsenceCellPart


### PR DESCRIPTION
#### Summary

Apparently staff in the original daycare should not mark absences during
the backup care period. Maybe supervisors could be allowed to do this,
but we don't handle this scenario at all in the UI, so it's probably
better to just disable it.

If we want to add support for supervisors later, we need to gracefully
handle the scenario where a cell has backup care *and* 0-2 absences.
Right now we don't even display absences if they exist, because the
backup care "takes over" the cell.