### PR TITLE
Smooth scroll polyfill for Safari & IE, update axios

### DIFF
--- a/apigw/src/shared/routes/auth/saml/index.ts
+++ b/apigw/src/shared/routes/auth/saml/index.ts
@@ -68,7 +68,7 @@ function createLoginHandler({
       (err: any, user: SamlUser | undefined) => {
         if (err || !user) {
           const description =
-            parseDescriptionFromSamlError(err) || 'Could not parse SAML error.'
+            parseDescriptionFromSamlError(err) || 'Could not parse SAML error'
           logAuditEvent(
             `evaka.saml.${strategyName}.sign_in_failed`,
             req,

--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import express from 'express'
-import axios, { AxiosError } from 'axios'
+import axios from 'axios'
 import { evakaServiceUrl } from './config'
 import { createAuthHeader } from './auth'
 import { SamlUser } from './routes/auth/saml/types'
@@ -75,10 +75,6 @@ export interface PersonIdentityRequest {
   socialSecurityNumber: string
   firstName: string
   lastName: string
-}
-
-export function isAxiosError(e: unknown): e is AxiosError {
-  return !!(e as AxiosError).isAxiosError
 }
 
 export async function getOrCreateEmployee(
@@ -164,7 +160,7 @@ export async function identifyMobileDevice(
     )
     return data
   } catch (e: unknown) {
-    if (isAxiosError(e) && e.response?.status === 404) {
+    if (axios.isAxiosError(e) && e.response?.status === 404) {
       return undefined
     } else {
       throw e
@@ -185,7 +181,7 @@ export async function getMobileDevice(
     )
     return data
   } catch (e: unknown) {
-    if (isAxiosError(e) && e.response?.status === 404) {
+    if (axios.isAxiosError(e) && e.response?.status === 404) {
       return undefined
     } else {
       throw e

--- a/frontend/e2e-test/package.json
+++ b/frontend/e2e-test/package.json
@@ -28,7 +28,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "axios": "^0.19.0"
+    "axios": "^0.21.1"
   },
   "devDependencies": {
     "@evaka/eslint-plugin": "0.0.1",

--- a/frontend/e2e-test/test/e2e/dev-api/index.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/index.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { BaseError } from 'make-error-cause'
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 import config from '../config'
 import {
   Application,
@@ -31,11 +31,10 @@ import {
 export class DevApiError extends BaseError {
   constructor(cause: Error) {
     let message: string
-    if ('isAxiosError' in cause) {
-      const axiosError = cause as AxiosError
-      message = `${axiosError.message}: ${formatRequest(
-        axiosError.config
-      )}\n${formatResponse(axiosError.response)}`
+    if (axios.isAxiosError(cause)) {
+      message = `${cause.message}: ${formatRequest(
+        cause.config
+      )}\n${formatResponse(cause.response)}`
     } else {
       message = 'Dev API error'
     }

--- a/frontend/packages/citizen-frontend/package.json
+++ b/frontend/packages/citizen-frontend/package.json
@@ -19,7 +19,7 @@
     "@evaka/lib-icons": "1.0.0",
     "@fortawesome/react-fontawesome": "0.1.11",
     "@sentry/browser": "^5.11.1",
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "lodash": "^4.17.15",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/frontend/packages/citizen-frontend/package.json
+++ b/frontend/packages/citizen-frontend/package.json
@@ -24,6 +24,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",
+    "seamless-scroll-polyfill": "1.2.3",
     "styled-components": "5.1.1"
   },
   "devDependencies": {

--- a/frontend/packages/citizen-frontend/src/index.tsx
+++ b/frontend/packages/citizen-frontend/src/index.tsx
@@ -6,6 +6,7 @@ import 'core-js/stable'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import * as Sentry from '@sentry/browser'
+import { polyfill as smoothScrollPolyfill } from 'seamless-scroll-polyfill'
 import App from './App'
 import { getEnvironment } from '@evaka/lib-common/src/utils/helpers'
 import { config } from './configs'
@@ -16,5 +17,10 @@ Sentry.init({
   dsn: config.sentry.dsn,
   environment: getEnvironment()
 })
+
+// Smooth-scrolling requires polyfilling in Safari, IE and older browsers:
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo#browser_compatibility
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#browser_compatibility
+smoothScrollPolyfill()
 
 ReactDOM.render(<App />, document.getElementById('app'))

--- a/frontend/packages/employee-frontend/package.json
+++ b/frontend/packages/employee-frontend/package.json
@@ -47,6 +47,7 @@
     "react-select": "^3.0.8",
     "react-spring": "^8.0.27",
     "react-tooltip": "^4.1.0",
+    "seamless-scroll-polyfill": "1.2.3",
     "styled-components": "5.1.1"
   },
   "devDependencies": {

--- a/frontend/packages/employee-frontend/package.json
+++ b/frontend/packages/employee-frontend/package.json
@@ -24,7 +24,7 @@
     "@types/react-datepicker": "2.11.0",
     "@types/react-tooltip": "^3.11.0",
     "@types/styled-components": "^5.1.0",
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "chart.js": "^2.9.3",
     "chartjs-adapter-date-fns": "^1.0.0",
     "classnames": "^2.2.6",

--- a/frontend/packages/employee-frontend/src/index.tsx
+++ b/frontend/packages/employee-frontend/src/index.tsx
@@ -10,6 +10,7 @@ import App from '~App'
 import './index.scss'
 import { getEnvironment } from '@evaka/lib-common/src/utils/helpers'
 import { config } from '@evaka/employee-frontend/src/configs'
+import { polyfill as smoothScrollPolyfill } from 'seamless-scroll-polyfill'
 
 // Load Sentry before React to make Sentry's integrations work automatically
 Sentry.init({
@@ -17,5 +18,10 @@ Sentry.init({
   dsn: config.sentry.dsn,
   environment: getEnvironment()
 })
+
+// Smooth-scrolling requires polyfilling in Safari, IE and older browsers:
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo#browser_compatibility
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#browser_compatibility
+smoothScrollPolyfill()
 
 ReactDOM.render(<App />, document.getElementById('app'))

--- a/frontend/packages/employee-frontend/src/index.tsx
+++ b/frontend/packages/employee-frontend/src/index.tsx
@@ -6,11 +6,11 @@ import 'core-js/stable'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import * as Sentry from '@sentry/browser'
+import { polyfill as smoothScrollPolyfill } from 'seamless-scroll-polyfill'
 import App from '~App'
 import './index.scss'
 import { getEnvironment } from '@evaka/lib-common/src/utils/helpers'
 import { config } from '@evaka/employee-frontend/src/configs'
-import { polyfill as smoothScrollPolyfill } from 'seamless-scroll-polyfill'
 
 // Load Sentry before React to make Sentry's integrations work automatically
 Sentry.init({

--- a/frontend/packages/enduser-frontend/package.json
+++ b/frontend/packages/enduser-frontend/package.json
@@ -26,7 +26,7 @@
     "@fortawesome/vue-fontawesome": "2.0.0",
     "@sentry/browser": "^5.11.1",
     "@sentry/integrations": "^5.11.1",
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "buefy": "0.7.10",
     "bulma": "0.7.5",
     "classnames": "^2.2.6",

--- a/frontend/packages/enduser-frontend/package.json
+++ b/frontend/packages/enduser-frontend/package.json
@@ -37,6 +37,7 @@
     "intl": "^1.2.5",
     "lodash": "^4.17.15",
     "moment": "2.24.0",
+    "seamless-scroll-polyfill": "1.2.3",
     "v-calendar": "^0.9.7",
     "vue": "^2.6.11",
     "vue-bulma": "0.0.35",

--- a/frontend/packages/enduser-frontend/src/main.ts
+++ b/frontend/packages/enduser-frontend/src/main.ts
@@ -31,6 +31,7 @@ import * as Sentry from '@sentry/browser'
 import * as Integrations from '@sentry/integrations'
 import { getEnvironment } from '@evaka/lib-common/src/utils/helpers'
 import { config } from '@evaka/enduser-frontend/src/config'
+import { polyfill as smoothScrollPolyfill } from 'seamless-scroll-polyfill'
 
 // Load Sentry as early as possible to catch all issues
 Sentry.init({
@@ -42,6 +43,11 @@ Sentry.init({
     new Integrations.Vue({ Vue, attachProps: true, logErrors: true })
   ]
 })
+
+// Smooth-scrolling requires polyfilling in Safari, IE and older browsers:
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo#browser_compatibility
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#browser_compatibility
+smoothScrollPolyfill()
 
 const runApp = (): void => {
   // FIXME localization variable
@@ -83,19 +89,15 @@ const runApp = (): void => {
     store,
     render: (h) => h(App)
   }).$mount('#app')
-
 }
 
 // Wrap app startup to make sure polyfills are loaded before they are needed (e.g. load Intl before VCalendar is setup)
 if (!global.Intl) {
-  require.ensure([
-      'intl',
-      'intl/locale-data/jsonp/fi.js'
-  ], function (require) {
-      require('intl')
-      require('intl/locale-data/jsonp/fi.js')
-      runApp()
-  });
+  require.ensure(['intl', 'intl/locale-data/jsonp/fi.js'], function (require) {
+    require('intl')
+    require('intl/locale-data/jsonp/fi.js')
+    runApp()
+  })
 } else {
   runApp()
 }

--- a/frontend/packages/enduser-frontend/src/main.ts
+++ b/frontend/packages/enduser-frontend/src/main.ts
@@ -29,9 +29,9 @@ import '@/api/error-interceptor'
 import { i18n } from '@/localization/lang'
 import * as Sentry from '@sentry/browser'
 import * as Integrations from '@sentry/integrations'
+import { polyfill as smoothScrollPolyfill } from 'seamless-scroll-polyfill'
 import { getEnvironment } from '@evaka/lib-common/src/utils/helpers'
 import { config } from '@evaka/enduser-frontend/src/config'
-import { polyfill as smoothScrollPolyfill } from 'seamless-scroll-polyfill'
 
 // Load Sentry as early as possible to catch all issues
 Sentry.init({

--- a/frontend/packages/lib-common/src/api.ts
+++ b/frontend/packages/lib-common/src/api.ts
@@ -2,11 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { AxiosError } from 'axios'
-
-function isAxiosError(e: Error): e is AxiosError {
-  return !!(e as AxiosError).isAxiosError
-}
+import axios from 'axios'
 
 export interface Response<T> {
   data: T
@@ -60,7 +56,7 @@ export class Failure<T> {
   }
 
   static fromError<T>(e: Error): Failure<T> {
-    if (isAxiosError(e)) {
+    if (axios.isAxiosError(e)) {
       return new Failure(e.message, e.response?.status)
     }
     return new Failure(e.message)

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3654,12 +3654,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
-axios@^0.19.0, axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.10.0"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -6551,19 +6551,19 @@ debug@4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@=3.1.0, debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
@@ -8065,17 +8065,15 @@ focus-lock@^0.7.0:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.7.0.tgz#b2bfb0ca7beacc8710a1ff74275fe0dc60a1d88a"
   integrity sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
-
 follow-redirects@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+
+follow-redirects@^1.10.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
+  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
 
 for-in@^0.1.3:
   version "0.1.8"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1351,6 +1351,7 @@
 
 "@fortawesome/pro-solid-svg-icons@file:./vendor/fortawesome/fortawesome-pro-solid-svg-icons-5.14.0.tgz":
   version "5.14.0"
+  uid "8da47f25a043acd4f47b837a4a696166415c9b97"
   resolved "file:./vendor/fortawesome/fortawesome-pro-solid-svg-icons-5.14.0.tgz#8da47f25a043acd4f47b837a4a696166415c9b97"
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.30"
@@ -14800,6 +14801,11 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+seamless-scroll-polyfill@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/seamless-scroll-polyfill/-/seamless-scroll-polyfill-1.2.3.tgz#53d42d5b8c00db9c70dd4160c448469de36735b3"
+  integrity sha512-emnwZtu6NrlBlvT6HrlbAOs024JX4orWew8H5owBOyUJ7eFXn8lGe4bsXTBD6AAWzP/p7LL86AjVIH8Apqec5w==
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### Summary
- Safari, IE and older browsers (e.g. Chrome 45 on OS X) don't support `ScrollToOptions` (and equivalent for other scroll methods) at all or `behavior: smooth` when other options are available -> all the browser are still supported, so include a conditional polyfill
  - Include polyfill in enduser, employee & citizen frontends
  - Polyfill is only applied when `scrollBehavior` isn't supported (`'scrollBehavior' in document.documentElement.style`)
- [`seamless-scroll-polyfill`](https://github.com/magic-akari/seamless-scroll-polyfill) appears to have fixed most of [`smoothscroll-polyfill`](https://github.com/iamdustan/smoothscroll)'s open issues (like SVG support) + adds official TypeScript typings which is nice
- Also update axios to the latest version (0.21.1) that contains vulnerability fixes (and an official `isAxiosError` implementation)

#### Testing

With `master` version:

1. Open enduser-frontend in **Safari**
2. Start creating a new application
3. Click one of the section headers
4. -> browser should **immediately** (i.e. not smoothly) scroll the page so the header is on top

If you have an old enough Chrome available on OS X (e.g. v49 on Mountain Lion/10.7, not sure which version fixes this as MDN simply states this as fixed for "Chrome" and does not separate the OS X and Windows/Linux builds): repeat and scrolling should fail altogether. **NOTE:** I tested this manually with Browserstack (v49 on Mountain Lion) and could repeat the issue.

With branch version:

1. Repeat
2. -> browser should **smoothly** scroll into the same position
3. Compare to e.g. Firefox / Chrome behaviour