### PR TITLE
Switch to a different ktlint gradle plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,7 +743,7 @@ jobs:
             - service/build
       - run:
           working_directory: *workspace_service
-          command: ./gradlew ktlintCheck
+          command: ./gradlew lintKotlin
       - run:
           working_directory: *workspace_service
           command: ./circle-check-migrations.sh
@@ -823,7 +823,7 @@ jobs:
             - message-service/build
       - run:
           working_directory: *workspace_message_service
-          command: ./gradlew ktlintCheck
+          command: ./gradlew lintKotlin
       - notify_slack
 
   message_service_test:

--- a/message-service/README.md
+++ b/message-service/README.md
@@ -49,7 +49,7 @@ Run integration tests:
 Run linter autofix:
 
 ```sh
-./gradlew ktlintFormat
+./gradlew formatKotlin
 ```
 
 If you want to set ktlint formatter rules as your IDEA kotlin formatting rules, run:

--- a/message-service/build.gradle.kts
+++ b/message-service/build.gradle.kts
@@ -14,6 +14,8 @@ buildscript {
         // needed by wsdl2java
         classpath("javax.jws:javax.jws-api:1.1")
         classpath("javax.xml.ws:jaxws-api:2.3.1")
+
+        classpath("com.pinterest:ktlint:${Version.ktlint}")
     }
 }
 
@@ -25,7 +27,7 @@ plugins {
     id("org.springframework.boot") version Version.springBoot
 
     id("com.github.ben-manes.versions") version Version.GradlePlugin.versions
-    id("org.jlleitschuh.gradle.ktlint") version Version.GradlePlugin.ktlint
+    id("org.jmailen.kotlinter") version Version.GradlePlugin.kotlinter
     id("no.nils.wsdl2java") version "0.10"
 
     idea
@@ -58,6 +60,8 @@ idea {
         testResourceDirs = testResourceDirs + sourceSets["integrationTest"].resources.srcDirs
     }
 }
+
+val ktlint by configurations.creating
 
 dependencies {
     // Kotlin + core
@@ -131,6 +135,8 @@ dependencies {
 
     integrationTestImplementation(platform("org.testcontainers:testcontainers-bom:${Version.testContainers}"))
     integrationTestImplementation("org.testcontainers:postgresql")
+
+    ktlint("com.pinterest:ktlint:${Version.ktlint}")
 }
 
 allOpen {
@@ -149,10 +155,6 @@ tasks.withType<KotlinCompile> {
         jvmTarget = Version.java
         allWarningsAsErrors = true
     }
-}
-
-ktlint {
-    version.set("0.40.0")
 }
 
 project.wsdl2javaExt {
@@ -193,5 +195,11 @@ tasks {
 
     bootRun {
         systemProperty("spring.profiles.active", "dev,local")
+    }
+
+    create("ktlintApplyToIdea", JavaExec::class) {
+        main = "com.pinterest.ktlint.Main"
+        classpath = ktlint
+        args = listOf("applyToIDEAProject", "-y")
     }
 }

--- a/message-service/buildSrc/src/main/kotlin/Version.kt
+++ b/message-service/buildSrc/src/main/kotlin/Version.kt
@@ -19,6 +19,7 @@ object Version {
     const val junit = "5.6.2"
     const val kotlin = "1.4.21"
     const val kotlinLogging = "1.8.3"
+    const val ktlint = "0.40.0"
     const val logbackSpringBoot = "2.7.1"
     const val logstashEncoder = "6.3"
     const val mockito = "3.4.6"
@@ -29,7 +30,7 @@ object Version {
     const val testContainers = "1.14.3"
 
     object GradlePlugin {
-        const val ktlint = "9.4.1"
+        const val kotlinter = "3.3.0"
         const val versions = "0.29.0"
     }
 }

--- a/service-lib/build.gradle.kts
+++ b/service-lib/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.spring")
 
     id("com.github.ben-manes.versions")
-    id("org.jlleitschuh.gradle.ktlint")
+    id("org.jmailen.kotlinter")
 }
 
 repositories {

--- a/service/README.md
+++ b/service/README.md
@@ -65,7 +65,7 @@ Enable running flyway commands against integration test database in `gradle.prop
 Run linter autofix:
 
 ```sh
-./gradlew ktlintFormat
+./gradlew formatKotlin
 ```
 
 If you want to set ktlint formatter rules as your IDEA kotlin formatting rules, run:

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -9,6 +9,10 @@ buildscript {
     repositories {
         jcenter()
     }
+    dependencies {
+        classpath(files("custom-ktlint-rules/custom-ktlint-rules.jar"))
+        classpath("com.pinterest:ktlint:${Version.ktlint}")
+    }
 }
 
 plugins {
@@ -19,7 +23,7 @@ plugins {
     id("org.flywaydb.flyway") version Version.flyway
 
     id("com.github.ben-manes.versions") version Version.GradlePlugin.versions
-    id("org.jlleitschuh.gradle.ktlint") version Version.GradlePlugin.ktlint
+    id("org.jmailen.kotlinter") version Version.GradlePlugin.kotlinter
 
     idea
 }
@@ -49,6 +53,8 @@ idea {
         testResourceDirs = testResourceDirs + sourceSets["integrationTest"].resources.srcDirs
     }
 }
+
+val ktlint by configurations.creating
 
 dependencies {
     // Kotlin + core
@@ -139,7 +145,7 @@ dependencies {
 
     implementation(project(":vtjclient"))
 
-    add("ktlint", files("custom-ktlint-rules/custom-ktlint-rules.jar"))
+    ktlint("com.pinterest:ktlint:${Version.ktlint}")
 }
 
 allOpen {
@@ -158,10 +164,6 @@ tasks.withType<KotlinCompile> {
         jvmTarget = Version.java
         allWarningsAsErrors = name != "compileIntegrationTestKotlin"
     }
-}
-
-ktlint {
-    version.set("0.40.0")
 }
 
 tasks {
@@ -194,5 +196,11 @@ tasks {
         systemProperty("spring.datasource.password", "evaka_it")
         systemProperty("flyway.username", "evaka_it")
         systemProperty("flyway.password", "evaka_it")
+    }
+
+    create("ktlintApplyToIdea", JavaExec::class) {
+        main = "com.pinterest.ktlint.Main"
+        classpath = ktlint
+        args = listOf("applyToIDEAProject", "-y")
     }
 }

--- a/service/buildSrc/src/main/kotlin/Version.kt
+++ b/service/buildSrc/src/main/kotlin/Version.kt
@@ -21,6 +21,7 @@ object Version {
     const val junit = "5.6.2"
     const val kotlin = "1.4.21"
     const val kotlinLogging = "1.8.3"
+    const val ktlint = "0.40.0"
     const val logbackSpringBoot = "2.7.1"
     const val logstashEncoder = "6.3"
     const val mockito = "3.4.6"
@@ -30,7 +31,7 @@ object Version {
     const val testContainers = "1.14.3"
 
     object GradlePlugin {
-        const val ktlint = "9.4.1"
+        const val kotlinter = "3.3.0"
         const val versions = "0.29.0"
     }
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- this one doesn't run a separate Java subprocess -> faster and more CI-friendly
- implement ktlintApplyToIdea by hand since the new plugin doesn't have such a task

