### PR TITLE
EVAKA-FIX: unit editor datepicker widths

### DIFF
--- a/frontend/packages/employee-frontend/src/components/unit/unit-details/UnitEditor.tsx
+++ b/frontend/packages/employee-frontend/src/components/unit/unit-details/UnitEditor.tsx
@@ -602,6 +602,7 @@ export default function UnitEditor(props: Props): JSX.Element {
                 placeholderText: i18n.unitEditor.placeholder.openingDate
               }}
               onChange={(openingDate) => updateForm({ openingDate })}
+              className="inline-block"
             />
           ) : (
             form.openingDate?.format()
@@ -615,6 +616,7 @@ export default function UnitEditor(props: Props): JSX.Element {
               }}
               onCleared={() => updateForm({ closingDate: null })}
               onChange={(closingDate) => updateForm({ closingDate })}
+              className="inline-block"
             />
           ) : (
             form.closingDate?.format()

--- a/frontend/packages/lib-components/src/molecules/DatePicker.tsx
+++ b/frontend/packages/lib-components/src/molecules/DatePicker.tsx
@@ -98,6 +98,10 @@ const DatePickerContainer = styled.div`
     width: 120px;
   }
 
+  &.inline-block {
+    display: inline-block;
+  }
+
   .react-datepicker-wrapper,
   .react-datepicker__input-container {
     width: 100%;
@@ -212,7 +216,10 @@ export function DatePickerClearable({
 }: DatePickerClearableProps) {
   const ref = React.createRef<HTMLInputElement>()
   return (
-    <div className={`${type} ${className ? className : ''}`} data-qa={dataQa}>
+    <DatePickerContainer
+      className={`${type} ${className ? className : ''}`}
+      data-qa={dataQa}
+    >
       <ReactDatePicker
         {...defaultProps}
         locale={fi}
@@ -233,6 +240,6 @@ export function DatePickerClearable({
         onFocus={onFocus}
         {...options}
       />
-    </div>
+    </DatePickerContainer>
   )
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Tweak css to fit inputs on the same line.

![Screenshot_2021-01-14 Aallonhuipun päiväkoti - Varhaiskasvatus(2)](https://user-images.githubusercontent.com/3275771/104560201-34e82900-564e-11eb-8dab-a34f98e1f451.png)

Before:
![Screenshot_2021-01-14 Aallonhuipun päiväkoti - Varhaiskasvatus(1)](https://user-images.githubusercontent.com/3275771/104560189-30237500-564e-11eb-8cdc-e125b8f51208.png)
