### PR TITLE
Add a mechanism that can refresh mobile sessions

### DIFF
--- a/frontend/packages/employee-frontend/src/App.tsx
+++ b/frontend/packages/employee-frontend/src/App.tsx
@@ -65,6 +65,8 @@ import VoucherServiceProviders from '~components/reports/VoucherServiceProviders
 import VoucherServiceProviderUnit from '~components/reports/VoucherServiceProviderUnit'
 import { featureFlags } from '~config'
 import PlacementSketching from '~components/reports/PlacementSketching'
+import { idleTracker } from '@evaka/lib-common/src/utils/idleTracker'
+import { client } from '~api/client'
 
 export default function App() {
   const { i18n } = useTranslation()
@@ -72,6 +74,16 @@ export default function App() {
 
   useEffect(() => {
     void getAuthStatus().then(setAuthStatus)
+  }, [])
+
+  useEffect(() => {
+    return idleTracker(
+      client,
+      () => {
+        void getAuthStatus().then(setAuthStatus)
+      },
+      { thresholdInMinutes: 20 }
+    )
   }, [])
 
   if (authStatus === undefined) {

--- a/frontend/packages/lib-common/src/utils/idleTracker.ts
+++ b/frontend/packages/lib-common/src/utils/idleTracker.ts
@@ -1,0 +1,47 @@
+import axios, { AxiosInstance } from 'axios'
+import { differenceInMinutes } from 'date-fns'
+
+export interface IdleTrackerOptions {
+  thresholdInMinutes: number
+}
+
+export function idleTracker(
+  client: AxiosInstance,
+  onVisibleAfterIdle: () => void,
+  { thresholdInMinutes }: IdleTrackerOptions = {
+    thresholdInMinutes: 20
+  }
+): () => void {
+  let lastResponse = new Date()
+  let visibilityState = document.visibilityState
+
+  function onVisibilityChange() {
+    if (visibilityState === document.visibilityState) return
+    const now = new Date()
+    visibilityState = document.visibilityState
+    if (
+      visibilityState === 'visible' &&
+      differenceInMinutes(now, lastResponse) >= thresholdInMinutes
+    ) {
+      onVisibleAfterIdle()
+    }
+  }
+  document.addEventListener('visibilitychange', onVisibilityChange)
+
+  const id = client.interceptors.response.use(
+    (res) => {
+      lastResponse = new Date()
+      return res
+    },
+    (err: unknown) => {
+      if (axios.isAxiosError(err) && err.response) {
+        lastResponse = new Date()
+      }
+      return Promise.reject(err)
+    }
+  )
+  return () => {
+    document.removeEventListener('visibilitychange', onVisibilityChange)
+    client.interceptors.response.eject(id)
+  }
+}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This "idle tracker" triggers an /auth/status call if the browser window
becomes visible after being non-visible *and* there is 20 minutes or
more since the last request to backend.

On mobile devices where a valid long term token is available, this means
if you open the browser after it has been hidden, the session is
refreshed and the user can immediately continue (assuming network
connectivity is ok).

On desktop devices, this can do a "force logout" if the session has
already disappeared, but this can actually be better than the current
situation where the application just stops working or throws errors
everywhere.

I'm not 100% happy with the idleTracker abstraction, but it works and we can change it later if necessary.