### PR TITLE
E2E: fix and add linting for broken Testcafe hooks

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -191,13 +191,42 @@ yarn workspace @evaka/lib-common run test
 
 ### Linting
 
-All frontends are currently in the process of being migrated to ESLint from TSLint. Please refer to each package's own configuration for more details about the linting rules.
+All frontends are currently in the process of being migrated to ESLint from TSLint. Please refer to each package's own
+configuration (in `package.json` files) for more details about the linting rules. We also have some
+[custom ESLint rules](#custom-eslint-rules)
 
 ```bash
 # Lint all files
 # Add --fix to fix lint errors automatically
 yarn lint
 ```
+
+#### Custom ESLint rules
+
+For rules not covered by existing ESLint rulesets, we can create our own in [`./eslint-plugin/`](./eslint-plugin/).
+The rules are a Yarn workspace, so they can be used in a project by:
+
+1. Adding a dependency to `@evaka/eslint-plugin`, example:
+
+    ```json
+    "devDependencies": {
+      "@evaka/eslint-plugin": "0.0.1",
+    ```
+
+1. And including the plugin ruleset in ESLint configs (`package.json`), example:
+
+    ```json
+    "eslintConfig": {
+      "extends": [
+        // ...
+        "plugin:@evaka/recommended"
+      ],
+    ```
+
+Some official documentation:
+
+- [Working with Rules](https://eslint.org/docs/developer-guide/working-with-rules)
+- [Selectors](https://eslint.org/docs/developer-guide/selectors)
 
 ### Unit tests
 

--- a/frontend/e2e-test/test/e2e/specs/0_citizen/citizen-decisions.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/0_citizen/citizen-decisions.spec.ts
@@ -36,8 +36,8 @@ fixture('Citizen decisions')
       .with({ roles: ['SERVICE_WORKER'] })
       .save()
   })
-  .afterEach(logConsoleMessages)
-  .afterEach(async () => {
+  .afterEach(async (t) => {
+    await logConsoleMessages(t)
     await deleteApplication(applicationId)
   })
   .after(async () => {

--- a/frontend/e2e-test/test/e2e/specs/1_application/application-attachment.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/1_application/application-attachment.spec.ts
@@ -31,8 +31,8 @@ fixture('Enduser attachments')
   .before(async () => {
     ;[fixtures, cleanUp] = await initializeAreaAndPersonData()
   })
-  .afterEach(logConsoleMessages)
-  .afterEach(async () => {
+  .afterEach(async (t) => {
+    await logConsoleMessages(t)
     await deleteApplication(applicationFixtureId)
   })
   .after(async () => {

--- a/frontend/e2e-test/test/e2e/specs/1_application/application-validations.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/1_application/application-validations.spec.ts
@@ -34,8 +34,8 @@ fixture('Enduser application validations')
   .before(async () => {
     ;[fixtures, cleanUp] = await initializeAreaAndPersonData()
   })
-  .afterEach(logConsoleMessages)
-  .afterEach(async () => {
+  .afterEach(async (t) => {
+    await logConsoleMessages(t)
     await deleteApplication(applicationFixtureId)
   })
   .after(async () => {

--- a/frontend/e2e-test/test/e2e/specs/1_application/transfer-preschool-application.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/1_application/transfer-preschool-application.spec.ts
@@ -39,8 +39,8 @@ fixture('New transfer preschool application')
       }
     ])
   })
-  .afterEach(logConsoleMessages)
-  .afterEach(async () => {
+  .afterEach(async (t) => {
+    await logConsoleMessages(t)
     applicationId ? await deleteApplication(applicationId) : false
   })
   .after(async () => {

--- a/frontend/e2e-test/test/e2e/specs/2_employee-2/application-search.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/2_employee-2/application-search.spec.ts
@@ -32,8 +32,8 @@ fixture('Employee searches applications')
   .beforeEach(async (t) => {
     await t.useRole(seppoAdminRole)
   })
-  .afterEach(logConsoleMessages)
-  .afterEach(async () => {
+  .afterEach(async (t) => {
+    await logConsoleMessages(t)
     await deleteApplication(applicationFixtureId)
   })
   .after(async () => {

--- a/frontend/e2e-test/test/e2e/specs/2_employee-2/employee-reads-application.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/2_employee-2/employee-reads-application.spec.ts
@@ -28,8 +28,8 @@ fixture('Employee reads applications')
   .before(async () => {
     ;[fixtures, cleanUp] = await initializeAreaAndPersonData()
   })
-  .afterEach(logConsoleMessages)
-  .afterEach(async () => {
+  .afterEach(async (t) => {
+    await logConsoleMessages(t)
     await deleteApplication(applicationFixtureId)
   })
   .after(async () => {

--- a/frontend/e2e-test/test/e2e/specs/5_employee/application-details.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/5_employee/application-details.spec.ts
@@ -109,8 +109,8 @@ fixture('Application - employee application details')
       restrictedDetailsGuardianApplication
     ])
   })
-  .afterEach(logConsoleMessages)
-  .afterEach(async () => {
+  .afterEach(async (t) => {
+    await logConsoleMessages(t)
     await cleanUpMessages()
     await deleteApplication(singleParentApplication.id)
     await deleteApplication(familyWithTwoGuardiansApplication.id)

--- a/frontend/e2e-test/test/e2e/specs/5_employee/placement-sketching-report.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/5_employee/placement-sketching-report.spec.ts
@@ -41,8 +41,8 @@ fixture('Placement sketching report')
   .before(async () => {
     ;[fixtures, cleanUp] = await initializeAreaAndPersonData()
   })
-  .afterEach(logConsoleMessages)
-  .afterEach(async () => {
+  .afterEach(async (t) => {
+    await logConsoleMessages(t)
     if (applicationId) await deleteApplication(applicationId)
     applicationId = null
   })

--- a/frontend/eslint-plugin/index.js
+++ b/frontend/eslint-plugin/index.js
@@ -4,13 +4,15 @@
 
 module.exports = {
   rules: {
-    'no-testonly': require('./rules/no-testonly')
+    'no-testonly': require('./rules/no-testonly'),
+    'no-duplicate-testcafe-hooks': require('./rules/no-duplicate-testcafe-hooks'),
   },
   configs: {
     recommended: {
       plugins: ['@evaka'],
       rules: {
-        '@evaka/no-testonly': 'error'
+        '@evaka/no-testonly': 'error',
+        '@evaka/no-duplicate-testcafe-hooks': 'error',
       }
     }
   }

--- a/frontend/eslint-plugin/rules/no-duplicate-testcafe-hooks.js
+++ b/frontend/eslint-plugin/rules/no-duplicate-testcafe-hooks.js
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+function getDuplicateNodeFinder(context, name) {
+  return () => {
+    const node = context.getAncestors().find(node => node.property && node.property.name === name)
+    return context.report({
+      node,
+      message: `Multiple "${name}" hooks not allowed in the same fixture`
+    })
+  }
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow test.only and fixture.only',
+      category: 'Possible Errors',
+      recommended: true
+    },
+    schema: []
+  },
+  create: (context) => {
+    return [
+      "before",
+      "beforeEach",
+      "after",
+      "afterEach"
+    ].reduce((o, hook) => {
+      return Object.assign(o, {
+        [`MemberExpression[property.name='${hook}'] MemberExpression[property.name='${hook}'] Identifier[name='fixture']`]: getDuplicateNodeFinder(context, hook)
+      })
+    }, {});
+  }
+}


### PR DESCRIPTION
#### Summary
- E2E: Fix duplicate test hooks not being triggered
  - Testcafe only allows setting a single hook (of each type) per fixture
    - See: https://github.com/DevExpress/testcafe/issues/5839 (not exactly the same thing but the only mention of this I can find)
- E2E: Prevent broken Testcafe hooks with ESLint
  - To prevent the above from happening again, create a custom ESLint rule (`no-duplicate-testcafe-hooks`) for catching the issue/"feature"
- Custom ESLint rule documentation