### PR TITLE
Fix user canceling second upload causing an error

### DIFF
--- a/frontend/packages/enduser-frontend/src/components/common/file-upload.vue
+++ b/frontend/packages/enduser-frontend/src/components/common/file-upload.vue
@@ -150,7 +150,11 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         })
       },
       onChange(event) {
-        this.onUpload(event.target.files[0])
+        // FileList is empty when one file is uploaded and then selecting another one is cancelled,
+        // clearing the input's value
+        if (event.target.files.length > 0) {
+          this.onUpload(event.target.files[0])
+        }
       },
       onDrop(event) {
         if (event.dataTransfer.files && event.dataTransfer.files[0]) {


### PR DESCRIPTION
#### Summary
- When user has uploaded at least one file and then opens the file picker to upload another but cancels, the input's value is cleared (i.e. the `FileList` is emptied) but the change-event is still triggered -> don't assume the list is always non-empty
- This doesn't affect user uploads, just causes unnecessary errors (and Sentry alerts)