### PR TITLE
Remove unnecessary ACL check from DECISION_CREATED async job

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
@@ -33,7 +33,7 @@ class DecisionMessageProcessor(
         logger.info { "Successfully created decision pdf(s) for decision (id: $decisionId)." }
         if (msg.sendAsMessage) {
             logger.info { "Sending decision pdf(s) for decision (id: $decisionId)." }
-            asyncJobRunner.plan(tx, listOf(SendDecision(decisionId, msg.user)))
+            asyncJobRunner.plan(tx, listOf(SendDecision(decisionId)))
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
@@ -8,8 +8,6 @@ import fi.espoo.evaka.decision.DecisionService
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyDecisionCreated
 import fi.espoo.evaka.shared.async.SendDecision
-import fi.espoo.evaka.shared.auth.AccessControlList
-import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
@@ -19,8 +17,7 @@ private val logger = KotlinLogging.logger {}
 @Component
 class DecisionMessageProcessor(
     private val asyncJobRunner: AsyncJobRunner,
-    private val decisionService: DecisionService,
-    private val acl: AccessControlList
+    private val decisionService: DecisionService
 ) {
     init {
         asyncJobRunner.notifyDecisionCreated = ::runCreateJob
@@ -30,8 +27,6 @@ class DecisionMessageProcessor(
     fun runCreateJob(db: Database, msg: NotifyDecisionCreated) = db.transaction { tx ->
         val user = msg.user
         val decisionId = msg.decisionId
-
-        acl.getRolesForDecision(user, msg.decisionId).requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
 
         decisionService.createDecisionPdfs(tx, user, decisionId)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/enduser/ApplicationSerializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/enduser/ApplicationSerializer.kt
@@ -41,7 +41,6 @@ class ApplicationSerializer(private val personService: PersonService) {
         val otherGuardian = if (requireFreshPersonData) personService.getOtherGuardian(tx, user, application.guardianId, application.childId) else null
         val guardiansLiveInSameAddress = if (otherGuardian != null && requireFreshPersonData) personService.personsLiveInTheSameAddress(
             tx,
-            user,
             application.guardianId,
             otherGuardian.id
         ) else false

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -81,7 +81,6 @@ class DecisionService(
             application.otherGuardianId != null &&
             !personService.personsLiveInTheSameAddress(
                 tx,
-                user,
                 application.guardianId,
                 application.otherGuardianId
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -115,7 +115,7 @@ class FamilyInitializerService(
         val otherGuardianId = application.otherGuardianId
         val fridgePartnerSSN = if (
             otherGuardianId != null &&
-            personService.personsLiveInTheSameAddress(tx, user, headOfFamilyId, otherGuardianId)
+            personService.personsLiveInTheSameAddress(tx, headOfFamilyId, otherGuardianId)
         ) {
             (tx.handle.getPersonById(otherGuardianId)?.identity as? SSN)?.ssn
         } else {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
@@ -56,7 +56,7 @@ class PersonService(
         }
     }
 
-    fun personsLiveInTheSameAddress(db: Database.Read, user: AuthenticatedUser, person1Id: UUID, person2Id: UUID): Boolean {
+    fun personsLiveInTheSameAddress(db: Database.Read, person1Id: UUID, person2Id: UUID): Boolean {
         val person1 = db.handle.getPersonById(person1Id)
         val person2 = db.handle.getPersonById(person2Id)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -96,7 +96,11 @@ data class NotifyDecisionCreated(val decisionId: UUID, override val user: Authen
     override val asyncJobType = AsyncJobType.DECISION_CREATED
 }
 
-data class SendDecision(val decisionId: UUID, override val user: AuthenticatedUser) : AsyncJobPayload {
+data class SendDecision(
+    val decisionId: UUID,
+    @Deprecated(message = "only for backwards compatibility")
+    override val user: AuthenticatedUser? = null
+) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.SEND_DECISION
 }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- remove ACL check which recently caused problems in prod. We check permissions in the original REST API handling code anyway
- also remove unused user parameter from SEND_DECISION async job
- audited `user: AuthenticatedUser` parameters in async jobs, and it looks like they are now just used in VTJ queries (= "who made the request")
