### PR TITLE
EVAKA-HOTFIX Removed history manipulation from attendance marking

### DIFF
--- a/frontend/packages/employee-frontend/src/components/attendances/AbsenceSelector.tsx
+++ b/frontend/packages/employee-frontend/src/components/attendances/AbsenceSelector.tsx
@@ -2,18 +2,16 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { Fragment, useContext, useState } from 'react'
+import React, { Fragment, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { Result } from '@evaka/lib-common/src/api'
-import { AttendanceResponse, getDaycareAttendances } from '~api/attendances'
+import { AttendanceResponse } from '~api/attendances'
 import AsyncButton from '@evaka/lib-components/src/atoms/buttons/AsyncButton'
 import Button from '@evaka/lib-components/src/atoms/buttons/Button'
 import colors from '@evaka/lib-components/src/colors'
-import { AttendanceUIContext } from '~state/attendance-ui'
 import { useTranslation } from '~state/i18n'
-import { UUID } from '~types'
 import { AbsenceType, AbsenceTypes } from '~types/absence'
 import { CustomButton, Flex } from './components'
 
@@ -22,19 +20,12 @@ const Actions = styled(Flex)`
 `
 
 interface Props {
-  unitId: UUID
-  groupId: UUID | 'all'
   selectAbsenceType: (type: AbsenceType) => Promise<Result<AttendanceResponse>>
 }
 
-export default function AbsenceSelector({
-  unitId,
-  groupId: groupIdOrAll,
-  selectAbsenceType
-}: Props) {
+export default function AbsenceSelector({ selectAbsenceType }: Props) {
   const history = useHistory()
   const { i18n } = useTranslation()
-  const { filterAndSetAttendanceResponse } = useContext(AttendanceUIContext)
   const [selectedAbsenceType, setSelectedAbsenceType] = useState<
     AbsenceType | undefined
   >(undefined)
@@ -87,12 +78,7 @@ export default function AbsenceSelector({
                   return undefined
                 })
               }
-              onSuccess={async () => {
-                await getDaycareAttendances(unitId).then((res) =>
-                  filterAndSetAttendanceResponse(res, groupIdOrAll)
-                )
-                history.goBack()
-              }}
+              onSuccess={() => history.goBack()}
               data-qa="mark-present"
             />
           </Actions>

--- a/frontend/packages/employee-frontend/src/components/attendances/AttendanceChildComing.tsx
+++ b/frontend/packages/employee-frontend/src/components/attendances/AttendanceChildComing.tsx
@@ -55,20 +55,6 @@ export default React.memo(function AttendanceChildComing({
     void getDaycareAttendances(unitId).then((res) =>
       filterAndSetAttendanceResponse(res, groupIdOrAll)
     )
-    return history.listen((location) => {
-      if (location.pathname.includes('/present')) {
-        setTime(getCurrentTime())
-        setMarkPresent(true)
-      } else if (location.pathname.includes('/absent')) {
-        setMarkAbsence(true)
-      } else {
-        setMarkPresent(false)
-        setMarkAbsence(false)
-        void getDaycareAttendances(unitId).then((res) =>
-          filterAndSetAttendanceResponse(res, groupIdOrAll)
-        )
-      }
-    })
   }, [])
 
   async function selectAbsenceType(absenceType: AbsenceType) {
@@ -86,11 +72,7 @@ export default React.memo(function AttendanceChildComing({
           <Fragment>
             <Gap size={'s'} />
 
-            <AbsenceSelector
-              unitId={unitId}
-              groupId={groupIdOrAll}
-              selectAbsenceType={selectAbsenceType}
-            />
+            <AbsenceSelector selectAbsenceType={selectAbsenceType} />
           </Fragment>
         ) : (
           <Loader />
@@ -102,21 +84,16 @@ export default React.memo(function AttendanceChildComing({
             <BigWideButton
               primary
               text={i18n.attendances.actions.markPresent}
-              onClick={() =>
-                history.push(
-                  `/units/${unitId}/groups/${groupIdOrAll}/childattendance/${child.id}/present`
-                )
-              }
+              onClick={() => {
+                setTime(getCurrentTime())
+                setMarkPresent(true)
+              }}
               data-qa="mark-present"
             />
 
             <BigWideInlineButton
               text={i18n.attendances.actions.markAbsent}
-              onClick={() =>
-                history.push(
-                  `/units/${unitId}/groups/${groupIdOrAll}/childattendance/${child.id}/absent`
-                )
-              }
+              onClick={() => setMarkAbsence(true)}
             />
           </FixedSpaceColumn>
         </Fragment>
@@ -140,12 +117,7 @@ export default React.memo(function AttendanceChildComing({
               primary
               text={i18n.common.confirm}
               onClick={() => childArrives()}
-              onSuccess={async () => {
-                await getDaycareAttendances(unitId).then((res) =>
-                  filterAndSetAttendanceResponse(res, groupIdOrAll)
-                )
-                history.goBack()
-              }}
+              onSuccess={async () => history.goBack()}
               data-qa="mark-present"
             />
           </FixedSpaceColumn>

--- a/frontend/packages/employee-frontend/src/components/attendances/AttendanceChildComing.tsx
+++ b/frontend/packages/employee-frontend/src/components/attendances/AttendanceChildComing.tsx
@@ -117,7 +117,7 @@ export default React.memo(function AttendanceChildComing({
               primary
               text={i18n.common.confirm}
               onClick={() => childArrives()}
-              onSuccess={async () => history.goBack()}
+              onSuccess={() => history.goBack()}
               data-qa="mark-present"
             />
           </FixedSpaceColumn>

--- a/frontend/packages/employee-frontend/src/components/attendances/AttendanceChildPresent.tsx
+++ b/frontend/packages/employee-frontend/src/components/attendances/AttendanceChildPresent.tsx
@@ -59,20 +59,6 @@ export default React.memo(function AttendanceChildPresent({
     void getDaycareAttendances(unitId).then((res) =>
       filterAndSetAttendanceResponse(res, groupIdOrAll)
     )
-    return history.listen((location) => {
-      if (location.pathname.includes('/depart')) {
-        void getChildDeparture(unitId, child.id, getCurrentTime()).then(
-          setChildDepartureInfo
-        )
-        setTime(getCurrentTime())
-        setMarkDepart(true)
-      } else {
-        setMarkDepart(false)
-        void getDaycareAttendances(unitId).then((res) =>
-          filterAndSetAttendanceResponse(res, groupIdOrAll)
-        )
-      }
-    })
   }, [])
 
   function markDeparted() {
@@ -125,11 +111,13 @@ export default React.memo(function AttendanceChildPresent({
           <BigWideButton
             primary
             text={i18n.attendances.actions.markLeaving}
-            onClick={() =>
-              history.push(
-                `/units/${unitId}/groups/${groupIdOrAll}/childattendance/${child.id}/depart`
+            onClick={() => {
+              void getChildDeparture(unitId, child.id, getCurrentTime()).then(
+                setChildDepartureInfo
               )
-            }
+              setTime(getCurrentTime())
+              setMarkDepart(true)
+            }}
           />
           <InlineWideAsyncButton
             text={i18n.attendances.actions.returnToComing}
@@ -187,11 +175,7 @@ export default React.memo(function AttendanceChildPresent({
                 child={child}
                 absentFrom={childDepartureInfo.value.absentFrom}
               />
-              <AbsenceSelector
-                unitId={unitId}
-                groupId={groupIdOrAll}
-                selectAbsenceType={selectAbsenceType}
-              />
+              <AbsenceSelector selectAbsenceType={selectAbsenceType} />
             </Fragment>
           ) : (
             <Fragment>
@@ -200,12 +184,7 @@ export default React.memo(function AttendanceChildPresent({
                 primary
                 text={i18n.common.confirm}
                 onClick={markDeparted}
-                onSuccess={async () => {
-                  await getDaycareAttendances(unitId).then((res) =>
-                    filterAndSetAttendanceResponse(res, groupIdOrAll)
-                  )
-                  history.goBack()
-                }}
+                onSuccess={() => history.goBack()}
                 data-qa="mark-departed"
                 disabled={timeError}
               />


### PR DESCRIPTION
#### Summary
After these changes the back button should always return the user to the last page user was before coming to the child page. In practice what this accomplishes is that when user clicks on a child in the list view and marks them present (or does other state transitions) the `history.goBack()` call will return the user to the list page instead of returning to the child page.

