### PR TITLE
Unit editor validation improvements

### DIFF
--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -2166,7 +2166,10 @@ export const fi = {
         email: 'Johtajan sähköposti puuttuu'
       },
       cannotApplyToDifferentType: 'Hakutyyppi ja palvelumuoto eivät vastaa',
-      financeDecisionHandler: 'Talouspäätösten käsittelijä puuttuu'
+      financeDecisionHandler: 'Talouspäätösten käsittelijä puuttuu',
+      ophUnitOid: 'Yksikön OID puuttuu',
+      ophOrganizerOid: 'Järjestäjän OID puuttuu',
+      ophOrganizationOid: 'Organisaation OID puuttuu'
     }
   },
   mobile: {

--- a/frontend/packages/employee-frontend/src/components/common/Select.tsx
+++ b/frontend/packages/employee-frontend/src/components/common/Select.tsx
@@ -22,6 +22,7 @@ export interface SelectProps {
   placeholder?: string
   'data-qa'?: string
   value?: ValueType<SelectOptionProps>
+  clearable?: boolean
 }
 
 interface ContainerProps {
@@ -51,7 +52,8 @@ const Select = memo(function Select({
   options,
   placeholder,
   'data-qa': dataQa,
-  value
+  value,
+  clearable
 }: SelectComponentProps) {
   return (
     <Container fullWidth={fullWidth} data-qa={dataQa} className={className}>
@@ -65,6 +67,7 @@ const Select = memo(function Select({
         onFocus={onFocus}
         value={value}
         styles={reactSelectStyles}
+        isClearable={clearable ?? false}
       />
     </Container>
   )

--- a/frontend/packages/employee-frontend/src/components/unit/unit-details/UnitEditor.tsx
+++ b/frontend/packages/employee-frontend/src/components/unit/unit-details/UnitEditor.tsx
@@ -350,7 +350,7 @@ function validateForm(
   ) {
     errors.push(i18n.unitEditor.error.cannotApplyToDifferentType)
   }
-  if (!form.financeDecisionHandlerId) {
+  if (form.invoicedByMunicipality && !form.financeDecisionHandlerId) {
     errors.push(i18n.unitEditor.error.financeDecisionHandler)
   }
   const {
@@ -1004,7 +1004,7 @@ export default function UnitEditor(props: Props): JSX.Element {
         )}
       </FormPart>
       <FormPart>
-        <div>{showRequired(i18n.unitEditor.label.financeDecisionHandler)}</div>
+        <div>{i18n.unitEditor.label.financeDecisionHandler}</div>
         {props.editable ? (
           <Select
             options={props.financeDecisionHandlerOptions}
@@ -1013,8 +1013,9 @@ export default function UnitEditor(props: Props): JSX.Element {
             onChange={(value) =>
               value && 'value' in value
                 ? updateForm({ financeDecisionHandlerId: value.value })
-                : undefined
+                : updateForm({ financeDecisionHandlerId: undefined })
             }
+            clearable
           />
         ) : (
           selectedFinanceDecisionManager?.label

--- a/frontend/packages/employee-frontend/src/components/unit/unit-details/UnitEditor.tsx
+++ b/frontend/packages/employee-frontend/src/components/unit/unit-details/UnitEditor.tsx
@@ -350,6 +350,17 @@ function validateForm(
   ) {
     errors.push(i18n.unitEditor.error.cannotApplyToDifferentType)
   }
+  if (form.uploadToVarda || form.uploadToKoski) {
+    if (!form.ophUnitOid) {
+      errors.push(i18n.unitEditor.error.ophUnitOid)
+    }
+    if (!form.ophOrganizerOid) {
+      errors.push(i18n.unitEditor.error.ophOrganizerOid)
+    }
+    if (!form.ophOrganizationOid) {
+      errors.push(i18n.unitEditor.error.ophOrganizationOid)
+    }
+  }
   if (form.invoicedByMunicipality && !form.financeDecisionHandlerId) {
     errors.push(i18n.unitEditor.error.financeDecisionHandler)
   }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
* Require finance decision handler only for units that are invoiced by municipality
* Require OPH OIDs when unit is marked to be sent to Varda or Koski

