### PR TITLE
Ignore unit decision handler for relief decisions

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -136,7 +136,7 @@ val testDecisionMaker_1 = PersonData.WithName(
 val testDecisionMaker_2 = PersonData.WithName(
     id = UUID.randomUUID(),
     firstName = "Decision",
-    lastName = "Maker"
+    lastName = "Maker 2"
 )
 
 val testAdult_1 = PersonData.Detailed(
@@ -322,7 +322,7 @@ val testChildWithNamelessGuardian = PersonData.Detailed(
     restrictedDetailsEnabled = false
 )
 
-val allWorkers = setOf(testDecisionMaker_1)
+val allWorkers = setOf(testDecisionMaker_1, testDecisionMaker_2)
 val allAdults = setOf(testAdult_1, testAdult_2, testAdult_3, testAdult_4, testAdult_5, testAdult_6, testAdult_7)
 val allChildren = setOf(testChild_1, testChild_2, testChild_3, testChild_4, testChild_5, testChild_6, testChild_7, testChildWithNamelessGuardian)
 val allBasicChildren = allChildren.map { PersonData.Basic(it.id, it.dateOfBirth, it.firstName, it.lastName, it.ssn) }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/Helpers.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/Helpers.kt
@@ -50,7 +50,8 @@ fun toDetailed(feeDecision: FeeDecision): FeeDecisionDetailed = FeeDecisionDetai
     approvedBy = allWorkers.find { it.id == feeDecision.approvedBy?.id },
     approvedAt = feeDecision.approvedAt,
     createdAt = feeDecision.createdAt,
-    financeDecisionHandlerName = null
+    financeDecisionHandlerName = allWorkers.find { it.id == feeDecision.decisionHandler?.id }
+        ?.let { "${it.firstName} ${it.lastName}" }
 )
 
 fun toSummary(feeDecision: FeeDecision): FeeDecisionSummary = FeeDecisionSummary(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
@@ -33,6 +33,7 @@ data class FeeDecision(
     val documentKey: String? = null,
     val approvedBy: PersonData.JustId? = null,
     val approvedAt: Instant? = null,
+    val decisionHandler: PersonData.JustId? = null,
     val createdAt: Instant = Instant.now(),
     val sentAt: Instant? = null
 ) : FinanceDecision<FeeDecisionPart, FeeDecision>, MergeableDecision<FeeDecisionPart, FeeDecision> {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Use decision approver instead of the unit's finance decision handler as decision handler for relief fee decisions.
