### PR TITLE
Add missing realm to keycloak docker-compose

### DIFF
--- a/compose/docker-compose.keycloak.yml
+++ b/compose/docker-compose.keycloak.yml
@@ -39,6 +39,7 @@ services:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: admin
       KEYCLOAK_FRONTEND_URL: "http://keycloak:8080/auth"
+      REALM: evaka
       ADMIN_FIRST_NAME: "He"
       ADMIN_LAST_NAME: "Man"
       ADMIN_EMAIL: "he-man@example.com"


### PR DESCRIPTION
#### Summary

`REALM` parameters was missing form KeyCloak docker-compose that caused the container to fail. This adds the correct parameter.