### PR TITLE
Employee: prevent downloads of pending decision PDFs

### DIFF
--- a/frontend/e2e-test/test/e2e/dev-api/index.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/index.ts
@@ -384,6 +384,14 @@ export async function deleteDecisionFixture(id: string): Promise<void> {
   }
 }
 
+export async function createDecisionPdf(id: string): Promise<void> {
+  try {
+    await devClient.post(`/decisions/${id}/actions/create-pdf`)
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}
+
 export async function insertFeeDecisionFixtures(
   fixture: FeeDecision[]
 ): Promise<void> {

--- a/frontend/e2e-test/test/e2e/pages/employee/applications/application-read-view.ts
+++ b/frontend/e2e-test/test/e2e/pages/employee/applications/application-read-view.ts
@@ -24,6 +24,20 @@ export default class ApplicationReadView {
     '[data-qa="application-status"]'
   )
 
+  async assertDecisionAvailableForDownload(type: DecisionType) {
+    const downloadLink = Selector(
+      `[data-qa="application-decision-${type}"]`
+    ).find('[data-qa="application-decision-download-available"]')
+    await t.expect(downloadLink.exists).ok()
+  }
+
+  async assertDecisionDownloadPending(type: DecisionType) {
+    const downloadLink = Selector(
+      `[data-qa="application-decision-${type}"]`
+    ).find('[data-qa="application-decision-download-pending"]')
+    await t.expect(downloadLink.exists).ok()
+  }
+
   async openApplicationByLink(id: UUID) {
     await t.navigateTo(`${this.url}/applications/${id}`)
   }

--- a/frontend/e2e-test/test/e2e/pages/employee/applications/application-read-view.ts
+++ b/frontend/e2e-test/test/e2e/pages/employee/applications/application-read-view.ts
@@ -32,10 +32,10 @@ export default class ApplicationReadView {
   }
 
   async assertDecisionDownloadPending(type: DecisionType) {
-    const downloadLink = Selector(
+    const downloadPendingTxt = Selector(
       `[data-qa="application-decision-${type}"]`
     ).find('[data-qa="application-decision-download-pending"]')
-    await t.expect(downloadLink.exists).ok()
+    await t.expect(downloadPendingTxt.exists).ok()
   }
 
   async openApplicationByLink(id: UUID) {

--- a/frontend/e2e-test/test/e2e/specs/2_employee-2/application-transitions.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/2_employee-2/application-transitions.spec.ts
@@ -7,19 +7,20 @@ import {
   initializeAreaAndPersonData,
   AreaAndPersonFixtures
 } from '../../dev-api/data-init'
-import { applicationFixture } from '../../dev-api/fixtures'
+import { applicationFixture, decisionFixture } from '../../dev-api/fixtures'
 import { logConsoleMessages } from '../../utils/fixture'
 import { EmployeeDetail } from '../../dev-api/types'
 import {
   cleanUpMessages,
+  createDecisionPdf,
   deleteAclForDaycare,
   deleteApplication,
   deleteEmployeeFixture,
   execSimpleApplicationAction,
   execSimpleApplicationActions,
   insertApplications,
+  insertDecisionFixtures,
   insertEmployeeFixture,
-  runPendingAsyncJobs,
   setAclForDaycares as setAclForDaycare
 } from '../../dev-api'
 import { seppoAdminRole, seppoManagerRole } from '../../config/users'
@@ -46,6 +47,7 @@ let fixtures: AreaAndPersonFixtures
 let cleanUp: () => Promise<void>
 let applicationId: string
 let applicationId2: string
+let supervisorId: string
 
 fixture('Application-transitions')
   .meta({ type: 'regression', subType: 'daycare-application' })
@@ -55,7 +57,7 @@ fixture('Application-transitions')
       ...supervisor,
       email: `${Math.random().toString(36).substring(7)}@espoo.fi`
     }
-    await insertEmployeeFixture(uniqueSupervisor)
+    supervisorId = await insertEmployeeFixture(uniqueSupervisor)
     await setAclForDaycare(
       config.supervisorExternalId,
       fixtures.daycareFixture.id
@@ -297,31 +299,41 @@ test('Placement proposal flow', async (t) => {
   await t.expect(unitPage.waitingGuardianConfirmationRow.count).eql(1)
 })
 
-test('Supervisor cannot download decision PDF while it is being generated', async (t) => {
-  const fixture = {
+test('Supervisor can download decision PDF only after it has been generated', async (t) => {
+  const application = {
     ...applicationFixture(
       fixtures.enduserChildFixtureJari,
       fixtures.enduserGuardianFixture
     ),
     status: 'SENT' as const
   }
-  applicationId = fixture.id
+  applicationId = application.id
 
-  await insertApplications([fixture])
+  await insertApplications([application])
 
+  const decision = decisionFixture(
+    applicationId,
+    application.form.preferredStartDate,
+    application.form.preferredStartDate
+  )
+  const decisionId = decision.id
+
+  // NOTE: This will NOT generate a PDF, just create the decision
+  await insertDecisionFixtures([
+    {
+      ...decision,
+      employeeId: supervisorId
+    }
+  ])
   await t.useRole(seppoManagerRole)
 
-  // NOTE: NOT running pending async jobs yet -> PDF won't have been generated from sent decision
-  await execSimpleApplicationActions(applicationId, [
-    'move-to-waiting-placement',
-    'create-default-placement-plan',
-    'send-decisions-without-proposal'
-  ])
+  await applicationReadView.openApplicationByLink(applicationId)
+  await applicationReadView.assertDecisionDownloadPending(decision.type)
+
+  // NOTE: No need to wait for pending async jobs as this is synchronous (unlike the normal flow of users creating
+  // decisions that would trigger PDF generation as an async job).
+  await createDecisionPdf(decisionId)
 
   await applicationReadView.openApplicationByLink(applicationId)
-  await applicationReadView.assertDecisionDownloadPending('DAYCARE')
-
-  await runPendingAsyncJobs()
-  await t.eval(() => location.reload())
-  await applicationReadView.assertDecisionAvailableForDownload('DAYCARE')
+  await applicationReadView.assertDecisionAvailableForDownload(decision.type)
 })

--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -380,6 +380,8 @@ export const fi = {
       },
       unit: 'Päätösyksikkö',
       download: 'Lataa päätös PDF-tiedostona',
+      downloadPending:
+        'Päätöksen PDF-tiedosto ei ole vielä ladattavissa. Yritä myöhemmin uudelleen.',
       response: {
         label: 'Vahvistus kuntalaisen puolesta',
         accept: 'Huoltaja on vastaanottanut paikan',

--- a/frontend/packages/employee-frontend/src/components/application-page/ApplicationDecisionsSection.tsx
+++ b/frontend/packages/employee-frontend/src/components/application-page/ApplicationDecisionsSection.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
-import { faFilePdf, faGavel } from '@evaka/lib-icons'
+import { faFilePdf, faGavel, fasExclamationTriangle } from '@evaka/lib-icons'
 import { Label } from '@evaka/lib-components/src/typography'
 import CollapsibleSection from '@evaka/lib-components/src/molecules/CollapsibleSection'
 import ListGrid from '@evaka/lib-components/src/layout/ListGrid'
@@ -29,6 +29,9 @@ const isBlocked = (decisions: Decision[], decision: Decision) =>
       (d.type === 'PRESCHOOL' || d.type === 'PREPARATORY_EDUCATION') &&
       (d.status === 'ACCEPTED' || d.status === 'REJECTED')
   )
+
+const isDownloadAvailable = (decision: Decision) =>
+  decision.documentUri !== null
 
 type Props = {
   applicationId: UUID
@@ -57,16 +60,26 @@ export default React.memo(function ApplicationDecisionsSection({
               <Label>{i18n.application.decisions.type}</Label>
               <FixedSpaceRow>
                 <span>{i18n.application.decisions.types[decision.type]}</span>
-                <a
-                  href={`/api/internal/decisions2/${decision.id}/download`}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  <FixedSpaceRow spacing={'xs'} alignItems={'center'}>
-                    <FontAwesomeIcon icon={faFilePdf} />
-                    <span>{i18n.application.decisions.download}</span>
-                  </FixedSpaceRow>
-                </a>
+                {isDownloadAvailable(decision) ? (
+                  <a
+                    href={`/api/internal/decisions2/${decision.id}/download`}
+                    target="_blank"
+                    rel="noreferrer"
+                    data-qa="application-decision-download-available"
+                  >
+                    <FixedSpaceRow spacing={'xs'} alignItems={'center'}>
+                      <FontAwesomeIcon icon={faFilePdf} />
+                      <span>{i18n.application.decisions.download}</span>
+                    </FixedSpaceRow>
+                  </a>
+                ) : (
+                  <span data-qa="application-decision-download-pending">
+                    <FixedSpaceRow spacing={'xs'} alignItems={'center'}>
+                      <FontAwesomeIcon icon={fasExclamationTriangle} />
+                      <span>{i18n.application.decisions.downloadPending}</span>
+                    </FixedSpaceRow>
+                  </span>
+                )}
               </FixedSpaceRow>
 
               <Label>{i18n.application.decisions.num}</Label>

--- a/frontend/packages/employee-frontend/src/types/decision.ts
+++ b/frontend/packages/employee-frontend/src/types/decision.ts
@@ -58,7 +58,7 @@ export interface Decision {
   applicationId: UUID
   childId: UUID
   childName: string
-  documentUri: string
+  documentUri: string | null
   decisionNumber: number
   sentDate: LocalDate
   status: DecisionStatus

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -386,6 +386,7 @@ WHERE id = :unitId
             assertNull(row.resolved)
             assertNull(row.resolvedBy)
             assertNotNull(row.sentDate)
+            assertNotNull(row.documentUri)
         }
         assertEquals(ApplicationStatus.WAITING_CONFIRMATION, getApplicationStatus(h, applicationId))
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -262,7 +262,7 @@ class ApplicationControllerV2(
             ResponseEntity.ok(
                 ApplicationResponse(
                     application = application,
-                    decisions = decisions.map { it.copy(documentUri = null) },
+                    decisions = decisions,
                     guardians = guardians,
                     attachments = application.attachments
                 )

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -275,7 +275,7 @@ class DecisionService(
                     path = "/",
                     bytes = it.getBytes()
                 )
-            } ?: error("Decision S3 url is not set for $decisionId.")
+            } ?: throw NotFound("Decision S3 URL is not set for $decisionId. Document generation is still in progress.")
     }
 
     private fun calculateDecisionFileName(tx: Database.Read, decision: Decision, lang: String): String {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -27,6 +27,7 @@ import fi.espoo.evaka.daycare.deleteDaycareGroup
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.decision.Decision
+import fi.espoo.evaka.decision.DecisionService
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.decision.getDecisionsByApplication
 import fi.espoo.evaka.decision.insertDecision
@@ -104,7 +105,8 @@ class DevApi(
     private val personService: PersonService,
     private val asyncJobRunner: AsyncJobRunner,
     private val placementPlanService: PlacementPlanService,
-    private val applicationStateService: ApplicationStateService
+    private val applicationStateService: ApplicationStateService,
+    private val decisionService: DecisionService
 ) {
     @PostMapping("/clean-up")
     fun cleanUpDatabase(db: Database): ResponseEntity<Unit> {
@@ -260,6 +262,12 @@ class DevApi(
     @DeleteMapping("/decisions/{id}")
     fun deleteDecisions(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
         db.transaction { it.handle.deleteDecision(id) }
+        return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/decisions/{id}/actions/create-pdf")
+    fun createDecisionPdf(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+        db.transaction { decisionService.createDecisionPdfs(it, fakeAdmin, id) }
         return ResponseEntity.noContent().build()
     }
 


### PR DESCRIPTION
#### Summary
- Employee: prevent download attempts for pending decision PDFs
   - Replace link with a warning message (see screenshot below)
   - The more robust solution would be to do a separate pre-download step (like in enduser-frontend file upload) but this is such an edge case, I felt this to be a satisfactory solution
   - Add a simple E2E test case for the new logic
- Service: return 404 instead of throwing an exception when attempting to download a pending decision PDF
  - A delay in processing is a valid state as PDF generation is done in a separate async job
  - 429 with some arbitrary retry time could've also worked but 404 feels more semantically correct as there's no way of knowing when the user should retry
- Service: create new Dev API endpoint for triggering decision PDF generation (allows for more stable testing of the above logic)
- Include document URI generation in decision integration tests
  - Ensure decisions have documentUri set (i.e. a PDF generated and uploaded to S3) once they've been created and async job queue is empty

![image](https://user-images.githubusercontent.com/5830147/105188200-4fce0800-5b3c-11eb-826a-57522d0f4d1c.png)
