### PR TITLE
EVAKA-4119: Restrict visibility of certain reports from finance admin

### DIFF
--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -1916,9 +1916,9 @@ export const fi = {
       info: 'Ajanjakson maksimipituus on kaksi viikkoa.'
     },
     serviceNeeds: {
-      title: 'Lapsien palvelutarpeet ja iät yksiköissä',
+      title: 'Lasten palvelutarpeet ja iät yksiköissä',
       description:
-        'Raportti listaa lapsien määriä yksiköissä palveluntarpeen ja iän mukaan.',
+        'Raportti listaa lasten määriä yksiköissä palveluntarpeen ja iän mukaan.',
       age: 'Ikä',
       fullDay: 'kokopäiväinen',
       partDay: 'osapäiväinen',
@@ -1938,20 +1938,20 @@ export const fi = {
       address2: 'Lapsen osoite'
     },
     childAgeLanguage: {
-      title: 'Lapsien kielet ja iät yksiköissä',
+      title: 'Lasten kielet ja iät yksiköissä',
       description:
-        'Raportti listaa lapsien määriä yksiköissä kielen ja iän mukaan. Vain vastaanotetut paikat otetaan huomioon.'
+        'Raportti listaa lasten määriä yksiköissä kielen ja iän mukaan. Vain vastaanotetut paikat otetaan huomioon.'
     },
     assistanceNeeds: {
-      title: 'Lapsien tuen tarpeet',
+      title: 'Lasten tuen tarpeet',
       description:
-        'Raportti listaa lapsien määriä yksiköissä ja ryhmissä tuen tarpeen perusteiden mukaan. Vain vastaanotetut paikat otetaan huomioon.',
+        'Raportti listaa lasten määriä yksiköissä ja ryhmissä tuen tarpeen perusteiden mukaan. Vain vastaanotetut paikat otetaan huomioon.',
       basisMissing: 'Peruste puuttuu'
     },
     assistanceActions: {
-      title: 'Lapsien tukitoimet',
+      title: 'Lasten tukitoimet',
       description:
-        'Raportti listaa lapsien määriä yksiköissä ja ryhmissä tukitoimien mukaan. Vain vastaanotetut paikat otetaan huomioon.',
+        'Raportti listaa lasten määriä yksiköissä ja ryhmissä tukitoimien mukaan. Vain vastaanotetut paikat otetaan huomioon.',
       actionMissing: 'Tukitoimi puuttuu'
     },
     occupancies: {

--- a/frontend/packages/employee-frontend/src/components/unit/tab-groups/Groups.tsx
+++ b/frontend/packages/employee-frontend/src/components/unit/tab-groups/Groups.tsx
@@ -159,13 +159,7 @@ export default React.memo(function Groups({
             dataQa="toggle-all-groups-collapsible"
           />
         </TitleContainer>
-        {requireRole(
-          roles,
-          'ADMIN',
-          'SERVICE_WORKER',
-          'FINANCE_ADMIN',
-          'UNIT_SUPERVISOR'
-        ) && (
+        {requireRole(roles, 'ADMIN', 'SERVICE_WORKER', 'UNIT_SUPERVISOR') && (
           <div>
             <Link to={`/units/${unit.id}/family-contacts`}>
               <InlineButton

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
@@ -29,7 +29,7 @@ class ChildAgeLanguageReportController(private val acl: AccessControlList) {
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): ResponseEntity<List<ChildAgeLanguageReportRow>> {
         Audit.ChildAgeLanguageReportRead.log()
-        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.ADMIN, UserRole.DIRECTOR, UserRole.SPECIAL_EDUCATION_TEACHER)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.DIRECTOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         return db.read { it.getChildAgeLanguageRows(date, acl.getAuthorizedUnits(user)) }.let(::ok)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
@@ -26,7 +26,7 @@ class FamilyContactReportController(private val acl: AccessControlList) {
         @RequestParam unitId: UUID
     ): ResponseEntity<List<FamilyContactReportRow>> {
         Audit.FamilyContactReportRead.log()
-        acl.getRolesForUnit(user, unitId).requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.DIRECTOR, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
+        acl.getRolesForUnit(user, unitId).requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.DIRECTOR, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
         return db.read { it.getFamilyContacts(unitId) }.let { ResponseEntity.ok(it) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -32,7 +32,7 @@ class OccupancyReportController {
         @RequestParam month: Int
     ): ResponseEntity<List<OccupancyUnitReportResultRow>> {
         Audit.OccupancyReportRead.log(targetId = careAreaId)
-        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.FINANCE_ADMIN, UserRole.DIRECTOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.DIRECTOR)
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 
@@ -89,7 +89,7 @@ class OccupancyReportController {
         @RequestParam month: Int
     ): ResponseEntity<List<OccupancyGroupReportResultRow>> {
         Audit.OccupancyReportRead.log(targetId = careAreaId)
-        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.FINANCE_ADMIN, UserRole.DIRECTOR)
+        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.DIRECTOR)
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 


### PR DESCRIPTION
#### Summary
These reports should not be visible for finance admin role.
They were already restricted from the frontend, but this change will also
prevent accessing backend endpoints.
- Child age and language report
- Family contact report
- Occupancy report


