### PR TITLE
Citizen buttons in mobile

### DIFF
--- a/frontend/e2e-test/test/e2e/pages/citizen/citizen-decisions.ts
+++ b/frontend/e2e-test/test/e2e/pages/citizen/citizen-decisions.ts
@@ -31,7 +31,7 @@ export default class CitizenDecisionsPage {
     Selector(`[data-qa="decision-status-${decisionId}"]`)
 
   readonly goRespondToDecisionBtn = (applicationId: string) =>
-    Selector(`[data-qa="response-link-${applicationId}"]`)
+    Selector(`[data-qa="button-confirm-decisions-${applicationId}"]`)
 
   async assertApplicationDecision(
     applicationId: string,

--- a/frontend/packages/citizen-frontend/src/applications/ApplicationCreation.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/ApplicationCreation.tsx
@@ -7,6 +7,7 @@ import {
 } from '@evaka/lib-components/src/layout/Container'
 import { H1, H2, P } from '@evaka/lib-components/src/typography'
 import { Gap, defaultMargins } from '@evaka/lib-components/src/white-space'
+import ButtonContainer from '@evaka/lib-components/src/layout/ButtonContainer'
 import AsyncButton from '@evaka/lib-components/src/atoms/buttons/AsyncButton'
 import Button from '@evaka/lib-components/src/atoms/buttons/Button'
 import ReturnButton from '@evaka/lib-components/src/atoms/buttons/ReturnButton'
@@ -92,29 +93,30 @@ export default React.memo(function ApplicationCreation() {
           }}
         />
       </ContentArea>
-      <Gap size="m" />
-      <ButtonContainer>
-        <AsyncButton
-          primary
-          text={t.applications.creation.create}
-          disabled={selectedType === undefined || duplicateExists}
-          onClick={() =>
-            selectedType !== undefined
-              ? createApplication(childId, selectedType).then((applicationId) =>
-                  history.push(`/applications/${applicationId}/edit`)
-                )
-              : Promise.resolve()
-          }
-          onSuccess={() => undefined}
-        />
-        <Gap size="s" />
-        <Gap size="s" horizontal />
-        <Button
-          text={t.common.cancel}
-          onClick={() => history.push('/applications')}
-        />
-      </ButtonContainer>
-      <Gap size="m" />
+      <ContentArea opaque={false} paddingVertical="L">
+        <ButtonContainer justify="center">
+          <AsyncButton
+            primary
+            text={t.applications.creation.create}
+            disabled={selectedType === undefined || duplicateExists}
+            onClick={() =>
+              selectedType !== undefined
+                ? createApplication(
+                    childId,
+                    selectedType
+                  ).then((applicationId) =>
+                    history.push(`/applications/${applicationId}/edit`)
+                  )
+                : Promise.resolve()
+            }
+            onSuccess={() => undefined}
+          />
+          <Button
+            text={t.common.cancel}
+            onClick={() => history.push('/applications')}
+          />
+        </ButtonContainer>
+      </ContentArea>
     </Container>
   )
 })
@@ -132,15 +134,4 @@ const PreschoolDaycareInfo = styled.p`
   ); // width of the radio input's icon + the margin on label
   font-weight: 600;
   font-size: 0.875em;
-`
-
-const ButtonContainer = styled.div`
-  display: flex;
-  flex-direction: row-reverse;
-  justify-content: center;
-  align-items: center;
-
-  @media (max-width: 600px) {
-    flex-direction: column;
-  }
 `

--- a/frontend/packages/citizen-frontend/src/decisions/decision-response-page/DecisionResponse.tsx
+++ b/frontend/packages/citizen-frontend/src/decisions/decision-response-page/DecisionResponse.tsx
@@ -10,10 +10,10 @@ import { OverlayContext } from '~overlay/state'
 import { H2, H3, Label, P } from '@evaka/lib-components/src/typography'
 import { Gap } from '@evaka/lib-components/src/white-space'
 import ListGrid from '@evaka/lib-components/src/layout/ListGrid'
+import ButtonContainer from '@evaka/lib-components/src/layout/ButtonContainer'
 import RoundIcon from '@evaka/lib-components/src/atoms/RoundIcon'
 import {
   FixedSpaceColumn,
-  FixedSpaceFlexWrap,
   FixedSpaceRow
 } from '@evaka/lib-components/src/layout/flex-helpers'
 import Radio from '@evaka/lib-components/src/atoms/form/Radio'
@@ -167,37 +167,34 @@ export default React.memo(function DecisionResponse({
           ) : (
             <Gap size="L" />
           )}
-          <FixedSpaceRow>
-            <FixedSpaceFlexWrap reverse>
-              <Button
-                text={t.decisions.applicationDecisions.response.cancel}
-                onClick={handleReturnToPreviousPage}
-                disabled={blocked || submitting}
-              />
-              <Button
-                text={t.decisions.applicationDecisions.response.submit}
-                primary
-                onClick={() => {
-                  if (!acceptChecked && rejectCascade) {
-                    setDisplayCascadeWarning(true)
-                  } else {
-                    void onSubmit().then((res) => {
-                      if (res.isFailure) {
-                        setErrorMessage({
-                          type: 'error',
-                          title:
-                            t.decisions.applicationDecisions.errors
-                              .submitFailure
-                        })
-                      }
-                    })
-                  }
-                }}
-                disabled={blocked || submitting}
-                dataQa={'submit-response'}
-              />
-            </FixedSpaceFlexWrap>
-          </FixedSpaceRow>
+          <ButtonContainer>
+            <Button
+              text={t.decisions.applicationDecisions.response.submit}
+              primary
+              onClick={() => {
+                if (!acceptChecked && rejectCascade) {
+                  setDisplayCascadeWarning(true)
+                } else {
+                  void onSubmit().then((res) => {
+                    if (res.isFailure) {
+                      setErrorMessage({
+                        type: 'error',
+                        title:
+                          t.decisions.applicationDecisions.errors.submitFailure
+                      })
+                    }
+                  })
+                }
+              }}
+              disabled={blocked || submitting}
+              dataQa={'submit-response'}
+            />
+            <Button
+              text={t.decisions.applicationDecisions.response.cancel}
+              onClick={handleReturnToPreviousPage}
+              disabled={blocked || submitting}
+            />
+          </ButtonContainer>
         </>
       )}
 

--- a/frontend/packages/citizen-frontend/src/decisions/decisions-page/ApplicationDecisionsBlock.tsx
+++ b/frontend/packages/citizen-frontend/src/decisions/decisions-page/ApplicationDecisionsBlock.tsx
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
+import { useHistory } from 'react-router-dom'
 import Button from '@evaka/lib-components/src/atoms/buttons/Button'
 import { ContentArea } from '@evaka/lib-components/src/layout/Container'
-import LinkWrapperInlineBlock from '@evaka/lib-components/src/atoms/LinkWrapperInlineBlock'
 import ListGrid from '@evaka/lib-components/src/layout/ListGrid'
+import ButtonContainer from '@evaka/lib-components/src/layout/ButtonContainer'
 import RoundIcon from '@evaka/lib-components/src/atoms/RoundIcon'
 import { H2, H3, Label, P } from '@evaka/lib-components/src/typography'
 import { Gap } from '@evaka/lib-components/src/white-space'
@@ -18,8 +19,6 @@ import {
   decisionStatusIcon
 } from '~decisions/shared'
 import { PdfLink } from '~decisions/PdfLink'
-
-const noop = () => undefined
 
 const preschoolInfoTypes: DecisionType[] = [
   'PRESCHOOL',
@@ -96,6 +95,7 @@ const ConfirmationDialog = React.memo(function ConfirmationDialog({
   type: DecisionType
 }) {
   const t = useTranslation()
+  const history = useHistory()
 
   return (
     <>
@@ -110,17 +110,16 @@ const ConfirmationDialog = React.memo(function ConfirmationDialog({
         <strong>{t.decisions.applicationDecisions.goToConfirmation}</strong>
       </P>
       <Gap size="s" />
-      <LinkWrapperInlineBlock
-        to={`/decisions/by-application/${applicationId}`}
-        data-qa={`response-link-${applicationId}`}
-      >
+      <ButtonContainer>
         <Button
           primary
           text={t.decisions.applicationDecisions.confirmationLink}
-          onClick={noop}
-          dataQa="button-confirm-decisions"
+          onClick={() =>
+            history.push(`/decisions/by-application/${applicationId}`)
+          }
+          dataQa={`button-confirm-decisions-${applicationId}`}
         />
-      </LinkWrapperInlineBlock>
+      </ButtonContainer>
     </>
   )
 })

--- a/frontend/packages/citizen-frontend/src/header/DesktopNav.tsx
+++ b/frontend/packages/citizen-frontend/src/header/DesktopNav.tsx
@@ -113,8 +113,8 @@ const Spacer = styled.div`
 `
 
 const Icon = styled(FontAwesomeIcon)`
-  height: 1rem !important;
-  width: 1rem !important;
+  height: 16px !important;
+  width: 16px !important;
   margin-right: 10px;
 `
 
@@ -123,10 +123,10 @@ const RoundIconBackground = styled.div`
   justify-content: center;
   align-items: center;
   background: ${colors.brandEspoo.espooTurquoise};
-  width: 2.5rem;
-  height: 2.5rem;
-  min-width: 2.5rem;
-  min-height: 2.5rem;
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  min-height: 40px;
   border-radius: 100%;
   margin-right: 10px;
 `
@@ -192,7 +192,7 @@ const LanguageButton = styled.button`
   font-size: 1rem;
   background: transparent;
   height: 100%;
-  padding: 1rem 1.2rem;
+  padding: 16px 18px;
   border: none;
   border-bottom: 4px solid transparent;
   cursor: pointer;
@@ -202,7 +202,7 @@ const LanguageButton = styled.button`
 const LanguageIcon = styled(FontAwesomeIcon)`
   height: 1em !important;
   width: 0.625em !important;
-  margin-left: 0.5rem;
+  margin-left: 8px;
 `
 
 const LanguageDropDown = styled.ul`
@@ -217,7 +217,7 @@ const LanguageDropDown = styled.ul`
 
 const LanguageListElement = styled.li`
   display: block;
-  width: 10.5rem;
+  width: 10.5em;
 `
 
 const LanguageDropDownButton = styled.button<{ selected: boolean }>`
@@ -243,5 +243,5 @@ const LanguageShort = styled.span`
 `
 
 const LanguageCheck = styled(FontAwesomeIcon)`
-  margin-left: 0.5rem;
+  margin-left: 8px;
 `

--- a/frontend/packages/citizen-frontend/src/header/Header.tsx
+++ b/frontend/packages/citizen-frontend/src/header/Header.tsx
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import colors from '@evaka/lib-components/src/colors'
 import { desktopMin } from '@evaka/lib-components/src/breakpoints'
-import EspooLogo from '../espoo-logo.svg'
+import Logo from './Logo'
 import DesktopNav from './DesktopNav'
 import MobileNav from './MobileNav'
 
@@ -14,53 +14,39 @@ const enduserBaseUrl =
   window.location.host === 'localhost:9094' ? 'http://localhost:9091' : ''
 
 export default React.memo(function Header() {
+  const [showMenu, setShowMenu] = useState(false)
+
   return (
-    <HeaderContainer>
-      <LogoContainer>
-        <Logo src={EspooLogo} alt="Espoo logo" />
-      </LogoContainer>
+    <HeaderContainer fixed={showMenu}>
+      <Logo />
       <DesktopNavContainer>
         <DesktopNav enduserBaseUrl={enduserBaseUrl} />
       </DesktopNavContainer>
       <MobileNavContainer>
-        <MobileNav enduserBaseUrl={enduserBaseUrl} />
+        <MobileNav
+          enduserBaseUrl={enduserBaseUrl}
+          showMenu={showMenu}
+          setShowMenu={setShowMenu}
+        />
       </MobileNavContainer>
     </HeaderContainer>
   )
 })
 
-const HeaderContainer = styled.header`
+const HeaderContainer = styled.header<{ fixed: boolean }>`
   z-index: 99;
   color: ${colors.greyscale.white};
   background-color: ${colors.brandEspoo.espooBlue};
-  position: relative;
+  position: ${({ fixed }) => (fixed ? 'fixed' : 'relative')};
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   height: 52px;
+  width: 100%;
 
   @media (min-width: ${desktopMin}) {
     height: 64px;
     justify-content: flex-start;
-  }
-`
-
-const LogoContainer = styled.div`
-  flex-grow: 0;
-  flex-shrink: 1;
-  flex-basis: 20%;
-  min-width: 180px;
-`
-
-const Logo = styled.img`
-  padding: 0;
-  margin-left: 1rem;
-  max-width: 150px;
-  width: auto;
-  height: 100%;
-
-  @media (min-width: ${desktopMin}) {
-    padding: 0 1.5rem;
   }
 `
 

--- a/frontend/packages/citizen-frontend/src/header/Logo.tsx
+++ b/frontend/packages/citizen-frontend/src/header/Logo.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+import { desktopMin } from '@evaka/lib-components/src/breakpoints'
+import EspooLogo from '../espoo-logo.svg'
+
+export default React.memo(function Logo() {
+  return (
+    <LogoContainer>
+      <Img src={EspooLogo} alt="Espoo logo" />
+    </LogoContainer>
+  )
+})
+
+const LogoContainer = styled.div`
+  flex-grow: 0;
+  flex-shrink: 1;
+  flex-basis: 20%;
+  min-width: 180px;
+`
+
+const Img = styled.img`
+  padding: 0;
+  margin-left: 16px;
+  max-width: 150px;
+  width: auto;
+  height: 100%;
+
+  @media (min-width: ${desktopMin}) {
+    padding: 0 24px;
+  }
+`

--- a/frontend/packages/citizen-frontend/src/header/MobileNav.tsx
+++ b/frontend/packages/citizen-frontend/src/header/MobileNav.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback, useState } from 'react'
+import React, { Dispatch, SetStateAction, useCallback } from 'react'
 import styled from 'styled-components'
 import { NavLink } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -16,12 +16,17 @@ import { langs, useLang, useTranslation } from '../localization'
 
 type Props = {
   enduserBaseUrl: string
+  showMenu: boolean
+  setShowMenu: Dispatch<SetStateAction<boolean>>
 }
 
-export default React.memo(function DesktopNav({ enduserBaseUrl }: Props) {
+export default React.memo(function DesktopNav({
+  enduserBaseUrl,
+  showMenu,
+  setShowMenu
+}: Props) {
   const user = useUser()
   const t = useTranslation()
-  const [showMenu, setShowMenu] = useState(false)
   const ref = useCloseOnOutsideClick<HTMLDivElement>(() => setShowMenu(false))
   const toggleMenu = useCallback(() => setShowMenu((show) => !show), [
     setShowMenu
@@ -30,11 +35,8 @@ export default React.memo(function DesktopNav({ enduserBaseUrl }: Props) {
 
   return (
     <div ref={ref}>
-      <MenuButton>
-        <FontAwesomeIcon
-          icon={showMenu ? faTimes : faBars}
-          onClick={toggleMenu}
-        />
+      <MenuButton onClick={toggleMenu}>
+        <FontAwesomeIcon icon={showMenu ? faTimes : faBars} />
       </MenuButton>
       {showMenu ? (
         <MenuContainer>
@@ -63,7 +65,7 @@ const MenuButton = styled.button`
   background: transparent;
   color: ${colors.greyscale.white};
   border: none;
-  padding: 1rem 1.2rem;
+  padding: 16px 18px;
   height: 100%;
   cursor: pointer;
 
@@ -74,7 +76,8 @@ const MenuButton = styled.button`
 `
 
 const MenuContainer = styled.div`
-  position: absolute;
+  position: fixed;
+  overflow-y: scroll;
   top: 0;
   right: 0;
   background: ${colors.blues.medium};

--- a/frontend/packages/employee-frontend/src/components/placement-draft/UnitCard.tsx
+++ b/frontend/packages/employee-frontend/src/components/placement-draft/UnitCard.tsx
@@ -20,8 +20,8 @@ import { useTranslation } from '~state/i18n'
 import { Loading, Result } from '@evaka/lib-common/src/api'
 import { getOccupancyRates, OccupancyResponse } from '~api/unit'
 
-import { EspooColours } from '../../utils/colours'
-
+import colors from '@evaka/lib-components/src/colors'
+import UnderRowStatusIcon from '@evaka/lib-components/src/atoms/StatusIcon'
 import { faCheck } from '@evaka/lib-icons'
 
 import { formatPercentage } from '../utils'
@@ -49,7 +49,7 @@ const Card = styled.div<{ active: boolean }>`
     active &&
     `
     box-shadow: 0px 0px 6px 4px lightgray;
-    border-top: 5px solid ${EspooColours.espooBlue};
+    border-top: 5px solid ${colors.brandEspoo.espooBlue};
     border-width: 5px 0 0 0;
   `}
 `
@@ -65,7 +65,7 @@ const RemoveBtn = styled.a`
 `
 
 const FailText = styled.div`
-  color: ${EspooColours.red};
+  color: ${colors.accents.red};
 `
 
 const Values = styled.div`
@@ -80,7 +80,7 @@ const ValueHeading = styled.span`
 `
 
 const ValuePercentage = styled.span`
-  color: ${EspooColours.greyDark};
+  color: ${colors.greyscale.dark};
   font-size: 3rem;
 `
 
@@ -89,6 +89,16 @@ const OccupancyContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
+`
+
+const Warning = styled.div`
+  color: ${colors.accents.orangeDark};
+  font-size: 0.75em;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: center;
 `
 
 interface OccupancyValueProps {
@@ -209,6 +219,12 @@ const MemoizedCard = memo(function UnitCard({
           <span>{i18n.unit.occupancy.noValidValues}</span>
         )}
       </OccupancyContainer>
+      {displayGhostUnitWarning ? (
+        <Warning>
+          {i18n.childInformation.placements.warning.ghostUnit}
+          <UnderRowStatusIcon status="warning" />
+        </Warning>
+      ) : null}
       <MarginBox>
         <InlineButton
           disabled={false}
@@ -219,14 +235,6 @@ const MemoizedCard = memo(function UnitCard({
             isSelectedUnit
               ? i18n.placementDraft.selectedUnit
               : i18n.common.select
-          }
-          info={
-            displayGhostUnitWarning
-              ? {
-                  text: i18n.childInformation.placements.warning.ghostUnit,
-                  status: 'warning'
-                }
-              : undefined
           }
         />
       </MarginBox>

--- a/frontend/packages/lib-components/src/atoms/buttons/Button.tsx
+++ b/frontend/packages/lib-components/src/atoms/buttons/Button.tsx
@@ -5,20 +5,14 @@
 import React from 'react'
 import styled from 'styled-components'
 import classNames from 'classnames'
+import { tabletMin } from '../../breakpoints'
 import colors, { greyscale } from '../../colors'
-import { defaultMargins } from '../../white-space'
 import { BaseProps } from '../../utils'
-import UnderRowStatusIcon, { InfoStatus } from '../StatusIcon'
 import { defaultButtonTextStyle } from './button-commons'
-
-const Wrapper = styled.div`
-  min-width: 0; // needed for correct overflow behavior
-`
 
 export const StyledButton = styled.button`
   min-height: 45px;
   padding: 0 27px;
-  width: fit-content;
   min-width: 100px;
 
   display: block;
@@ -27,7 +21,7 @@ export const StyledButton = styled.button`
 
   border: 1px solid ${colors.primary};
   border-radius: 2px;
-  background: none;
+  background: ${colors.greyscale.white};
 
   outline: none;
   cursor: pointer;
@@ -72,34 +66,11 @@ export const StyledButton = styled.button`
     }
   }
 
+  @media (min-width: ${tabletMin}) {
+    width: fit-content;
+  }
+
   ${defaultButtonTextStyle}
-`
-
-const ButtonUnderRow = styled.div`
-  padding: 0 12px;
-  margin-top: ${defaultMargins.xxs};
-  margin-bottom: -20px;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  position: absolute;
-
-  font-size: 12px;
-  text-overflow: ellipsis;
-
-  word-wrap:break-word;
-  width: 120px;
-  white-space: normal
-
-  color: ${colors.greyscale.dark};
-
-  &.success {
-    color: ${colors.accents.greenDark};
-  }
-
-  &.warning {
-    color: ${colors.accents.orangeDark};
-  }
 `
 
 interface ButtonProps extends BaseProps {
@@ -109,10 +80,6 @@ interface ButtonProps extends BaseProps {
   disabled?: boolean
   type?: 'submit' | 'button'
   'data-qa'?: string
-  info?: {
-    text: string
-    status?: InfoStatus
-  }
 }
 
 function Button({
@@ -123,8 +90,7 @@ function Button({
   text,
   primary = false,
   disabled = false,
-  type = 'button',
-  info
+  type = 'button'
 }: ButtonProps) {
   const [ignoreClick, setIgnoreClick] = React.useState(false)
   React.useEffect(() => {
@@ -144,21 +110,15 @@ function Button({
     }
   }
   return (
-    <Wrapper>
-      <StyledButton
-        className={classNames(className, { primary, disabled })}
-        data-qa={dataQa2 ?? dataQa}
-        onClick={handleOnClick}
-        disabled={disabled}
-        type={type}
-      >
-        {text}
-      </StyledButton>
-      <ButtonUnderRow className={classNames(info?.status)}>
-        <span>{info?.text}</span>
-        <UnderRowStatusIcon status={info?.status} />
-      </ButtonUnderRow>
-    </Wrapper>
+    <StyledButton
+      className={classNames(className, { primary, disabled })}
+      data-qa={dataQa2 ?? dataQa}
+      onClick={handleOnClick}
+      disabled={disabled}
+      type={type}
+    >
+      {text}
+    </StyledButton>
   )
 }
 

--- a/frontend/packages/lib-components/src/atoms/buttons/InlineButton.tsx
+++ b/frontend/packages/lib-components/src/atoms/buttons/InlineButton.tsx
@@ -10,12 +10,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import colors, { greyscale } from '../../colors'
 import { defaultMargins } from '../../white-space'
 import { BaseProps } from '../../utils'
-import UnderRowStatusIcon, { InfoStatus } from '../StatusIcon'
 import { defaultButtonTextStyle } from './button-commons'
-
-const Wrapper = styled.div`
-  min-width: 0; // needed for correct overflow behavior
-`
 
 const StyledButton = styled.button`
   width: fit-content;
@@ -55,38 +50,6 @@ const StyledButton = styled.button`
   ${defaultButtonTextStyle}
 `
 
-const InlineButtonUnderRow = styled.div`
-  height: 16px;
-  padding: 0 12px;
-  margin-top: ${defaultMargins.xxs};
-  margin-bottom: -20px;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  position: relative;
-  left: -50%;
-
-  font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-
-  color: ${colors.greyscale.dark};
-
-  &.success {
-    color: ${colors.accents.greenDark};
-  }
-
-  &.warning {
-    color: ${colors.accents.orangeDark};
-  }
-`
-
-const UnderRowWrapper = styled.div`
-  position: absolute;
-  left: 50%;
-`
-
 interface InlineButtonProps extends BaseProps {
   onClick: () => unknown
   text: string
@@ -94,10 +57,6 @@ interface InlineButtonProps extends BaseProps {
 
   icon?: IconDefinition
   disabled?: boolean
-  info?: {
-    text: string
-    status?: InfoStatus
-  }
 }
 
 function InlineButton({
@@ -107,30 +66,19 @@ function InlineButton({
   text,
   altText,
   icon,
-  disabled = false,
-  info = undefined
+  disabled = false
 }: InlineButtonProps) {
   return (
-    <Wrapper>
-      <StyledButton
-        className={classNames(className, { disabled })}
-        data-qa={dataQa}
-        onClick={onClick}
-        disabled={disabled}
-        aria-label={altText}
-      >
-        {icon && <FontAwesomeIcon icon={icon} />}
-        <span>{text}</span>
-      </StyledButton>
-      {info && (
-        <UnderRowWrapper>
-          <InlineButtonUnderRow className={classNames(info.status)}>
-            <span>{info.text}</span>
-            <UnderRowStatusIcon status={info?.status} />
-          </InlineButtonUnderRow>
-        </UnderRowWrapper>
-      )}
-    </Wrapper>
+    <StyledButton
+      className={classNames(className, { disabled })}
+      data-qa={dataQa}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={altText}
+    >
+      {icon && <FontAwesomeIcon icon={icon} />}
+      <span>{text}</span>
+    </StyledButton>
   )
 }
 

--- a/frontend/packages/lib-components/src/atoms/buttons/button-commons.tsx
+++ b/frontend/packages/lib-components/src/atoms/buttons/button-commons.tsx
@@ -7,8 +7,8 @@ import colors from '../../colors'
 export const defaultButtonTextStyle = `
   color: ${colors.primary};
   font-family: 'Open Sans', sans-serif;
-  font-size: 14px;
-  line-height: 16px;
+  font-size: 0.875em;
+  line-height: 1em;
   font-weight: 600;
   text-transform: uppercase;
   white-space: nowrap;

--- a/frontend/packages/lib-components/src/layout/ButtonContainer.tsx
+++ b/frontend/packages/lib-components/src/layout/ButtonContainer.tsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components'
+import { tabletMin } from '../breakpoints'
+import { defaultMargins } from '../white-space'
+
+type Props = {
+  justify?: 'flex-start' | 'flex-end' | 'center'
+}
+
+export default styled.div<Props>`
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: stretch;
+
+  flex-direction: column;
+  justify-content: center;
+
+  > * {
+    margin: 0;
+  }
+
+  @media (min-width: ${tabletMin}) {
+    flex-direction: row-reverse;
+    justify-content: ${({ justify: align }) => align ?? 'flex-end'};
+
+    > *:not(:first-child) {
+      margin-right: ${defaultMargins.s};
+    }
+  }
+
+  @media (max-width: calc(${tabletMin} + -1px)) {
+    > *:not(:last-child) {
+      margin-bottom: ${defaultMargins.s};
+    }
+  }
+`

--- a/frontend/packages/lib-components/src/molecules/modals/FormModal.tsx
+++ b/frontend/packages/lib-components/src/molecules/modals/FormModal.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components'
 import FocusLock from 'react-focus-lock'
 import Button from '../../atoms/buttons/Button'
 import AsyncButton from '../../atoms/buttons/AsyncButton'
-import { InfoStatus } from '../../atoms/StatusIcon'
+import UnderRowStatusIcon, { InfoStatus } from '../../atoms/StatusIcon'
 import Title from '../../atoms/Title'
 import colors from '../../colors'
 import { P } from '../../typography'
@@ -244,9 +244,14 @@ export default React.memo(function FormModal({
           onClick={resolve.action}
           disabled={resolve.disabled}
           text={resolve.label}
-          info={resolve.info}
         />
       </ModalButtons>
+      {resolve.info ? (
+        <ButtonUnderRow className={resolve.info?.status}>
+          <span>{resolve.info?.text}</span>
+          <UnderRowStatusIcon status={resolve.info?.status} />
+        </ButtonUnderRow>
+      ) : null}
     </ModalBase>
   )
 })
@@ -296,3 +301,29 @@ export const AsyncFormModal = React.memo(function AsyncFormModal({
     </ModalBase>
   )
 })
+
+const ButtonUnderRow = styled.div`
+  margin-top: calc(-${defaultMargins.X3L} + ${defaultMargins.xs});
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  left: 0;
+  right: 0;
+
+  font-size: 12px;
+  text-overflow: ellipsis;
+
+  word-wrap: break-word;
+  white-space: normal;
+
+  color: ${colors.greyscale.dark};
+
+  &.success {
+    color: ${colors.accents.greenDark};
+  }
+
+  &.warning {
+    color: ${colors.accents.orangeDark};
+  }
+`


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Make button sets match the UX spec. In short, buttons are in a horizontal layout and fit their content as before, but they expand to take full width of the container and are in a vertical layout when the view gets narrow enough.

Also,
* make the menu in mobile header sticky so that users can't scroll past it
* use `em` for scaling button text
* use `px` in header margins

