### PR TITLE
Application editor collapsible sections

### DIFF
--- a/frontend/packages/citizen-frontend/src/applications/editor/AdditionalDetailsSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/AdditionalDetailsSection.tsx
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import { ContentArea } from '@evaka/lib-components/src/layout/Container'
-import { H2, Label } from '@evaka/lib-components/src/typography'
+import { Label } from '@evaka/lib-components/src/typography'
 import { Gap } from '@evaka/lib-components/src/white-space'
 import { TextArea } from '@evaka/lib-components/src/atoms/form/InputField'
 import { useTranslation } from '~localization'
 import { ApplicationType } from '~applications/types'
 import { AdditionalDetailsFormData } from '~applications/editor/ApplicationFormData'
+import EditorSection from '~applications/editor/EditorSection'
 import InfoBallWrapper from '~applications/InfoBallWrapper'
 
 type Props = {
@@ -26,8 +26,10 @@ export default React.memo(function AdditionalDetailsSection({
   const t = useTranslation()
 
   return (
-    <ContentArea opaque paddingVertical="L">
-      <H2>{t.applications.editor.additionalDetails.title}</H2>
+    <EditorSection
+      title={t.applications.editor.additionalDetails.title}
+      validationErrors={0}
+    >
       <Label>
         {t.applications.editor.additionalDetails.otherInfoLabel}
         <TextArea
@@ -78,6 +80,6 @@ export default React.memo(function AdditionalDetailsSection({
           </Label>
         </>
       ) : null}
-    </ContentArea>
+    </EditorSection>
   )
 })

--- a/frontend/packages/citizen-frontend/src/applications/editor/ContactInfoSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/ContactInfoSection.tsx
@@ -3,16 +3,16 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useState } from 'react'
-import { ContentArea } from '@evaka/lib-components/src/layout/Container'
 import { useTranslation } from '~localization'
 import {
   FixedSpaceColumn,
   FixedSpaceRow
 } from '@evaka/lib-components/src/layout/flex-helpers'
 import Checkbox from '@evaka/lib-components/src/atoms/form/Checkbox'
-import { H2, H3, Label, P } from '@evaka/lib-components/src/typography'
+import { H3, Label, P } from '@evaka/lib-components/src/typography'
 import InputField from '@evaka/lib-components/src/atoms/form/InputField'
 import { ContactInfoFormData } from './ApplicationFormData'
+import EditorSection from '~applications/editor/EditorSection'
 import { DatePickerClearable } from '@evaka/lib-components/src/molecules/DatePicker'
 
 export type ContactInfoProps = {
@@ -39,9 +39,11 @@ export default React.memo(function ContactInfoSection({
   ] = useState<boolean>(false)
 
   return (
-    <ContentArea opaque paddingVertical="L">
-      <H2>{t.applications.editor.contactInfo.title}</H2>
-      <p>{t.applications.editor.contactInfo.info}</p>
+    <EditorSection
+      title={t.applications.editor.contactInfo.title}
+      validationErrors={0}
+    >
+      <P>{t.applications.editor.contactInfo.info}</P>
       <H3>{t.applications.editor.contactInfo.childInfoTitle}</H3>
       <FixedSpaceRow>
         <FixedSpaceColumn>
@@ -326,6 +328,6 @@ export default React.memo(function ContactInfoSection({
           label={`${child.firstName}`}
         />
       ))}
-    </ContentArea>
+    </EditorSection>
   )
 })

--- a/frontend/packages/citizen-frontend/src/applications/editor/EditorSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/EditorSection.tsx
@@ -1,0 +1,56 @@
+import React, { ReactNode, useCallback, useState } from 'react'
+import styled from 'styled-components'
+import colors from '@evaka/lib-components/src/colors'
+import { H2 } from '@evaka/lib-components/src/typography'
+import { defaultMargins } from '@evaka/lib-components/src/white-space'
+import { CollapsibleContentArea } from '@evaka/lib-components/src/layout/Container'
+import RoundIcon from '@evaka/lib-components/src/atoms/RoundIcon'
+
+type Props = {
+  title: string
+  validationErrors: number
+  openInitially?: boolean
+  children: ReactNode
+}
+
+export default React.memo(function EditorSection(props: Props) {
+  const [open, setOpen] = useState(props.openInitially === true)
+  const toggleOpen = useCallback(() => setOpen((previous) => !previous), [])
+
+  return (
+    <CollapsibleContentArea
+      open={open}
+      toggleOpen={toggleOpen}
+      title={
+        <>
+          <TitleWrapper>
+            <H2 noMargin>{props.title}</H2>
+            {props.validationErrors !== 0 ? (
+              <ErrorsIcon
+                content={props.validationErrors.toString()}
+                size="m"
+                color={colors.accents.orange}
+              />
+            ) : null}
+          </TitleWrapper>
+        </>
+      }
+      opaque
+      paddingVertical="L"
+    >
+      {props.children}
+    </CollapsibleContentArea>
+  )
+})
+
+const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: center;
+`
+
+const ErrorsIcon = styled(RoundIcon)`
+  margin: 0 ${defaultMargins.s};
+`

--- a/frontend/packages/citizen-frontend/src/applications/editor/FeeSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/FeeSection.tsx
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import { ContentArea } from '@evaka/lib-components/src/layout/Container'
-import { H2, P } from '@evaka/lib-components/src/typography'
+import { P } from '@evaka/lib-components/src/typography'
 import Checkbox from '@evaka/lib-components/src/atoms/form/Checkbox'
 import { useTranslation } from '~localization'
 import { FeeFormData } from '~applications/editor/ApplicationFormData'
+import EditorSection from '~applications/editor/EditorSection'
 
 type Props = {
   formData: FeeFormData
@@ -21,8 +21,7 @@ export default React.memo(function FeeSection({
   const t = useTranslation()
 
   return (
-    <ContentArea opaque paddingVertical="L">
-      <H2>{t.applications.editor.fee.title}</H2>
+    <EditorSection title={t.applications.editor.fee.title} validationErrors={0}>
       <P
         dangerouslySetInnerHTML={{
           __html: t.applications.editor.fee.info
@@ -43,6 +42,6 @@ export default React.memo(function FeeSection({
           __html: t.applications.editor.fee.links
         }}
       />
-    </ContentArea>
+    </EditorSection>
   )
 })

--- a/frontend/packages/citizen-frontend/src/applications/editor/ServiceNeedSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/ServiceNeedSection.tsx
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import { ContentArea } from '@evaka/lib-components/src/layout/Container'
 import { ServiceNeedFormData } from '~applications/editor/ApplicationFormData'
 import { DatePicker } from '@evaka/lib-components/src/molecules/DatePicker'
 import Checkbox from '@evaka/lib-components/src/atoms/form/Checkbox'
@@ -21,6 +20,7 @@ import colors from '@evaka/lib-components/src/colors'
 import RoundIcon from '@evaka/lib-components/src/atoms/RoundIcon'
 import { faInfo } from '@evaka/lib-icons'
 import { Gap } from '@evaka/lib-components/src/white-space'
+import EditorSection from '~applications/editor/EditorSection'
 
 export type ServiceNeedSectionProps = {
   formData: ServiceNeedFormData
@@ -43,10 +43,14 @@ export default React.memo(function ServiceNeedSection({
   updateFormData
 }: ServiceNeedSectionProps) {
   const t = useTranslation()
+
   return (
-    <ContentArea opaque paddingVertical="L">
+    <EditorSection
+      title={t.applications.editor.serviceNeed.serviceNeed}
+      validationErrors={0}
+      openInitially
+    >
       <FixedSpaceColumn>
-        <H3>{t.applications.editor.serviceNeed.serviceNeed}</H3>
         <H4>
           {t.applications.editor.serviceNeed.startDate.label}
           <Tooltip
@@ -212,6 +216,6 @@ export default React.memo(function ServiceNeedSection({
           />
         )}
       </FixedSpaceColumn>
-    </ContentArea>
+    </EditorSection>
   )
 })

--- a/frontend/packages/citizen-frontend/src/applications/editor/UnitPreferenceSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/UnitPreferenceSection.tsx
@@ -4,8 +4,7 @@
 
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { ContentArea } from '@evaka/lib-components/src/layout/Container'
-import { H2, H3, Label, P } from '@evaka/lib-components/src/typography'
+import { H3, Label, P } from '@evaka/lib-components/src/typography'
 import Checkbox from '@evaka/lib-components/src/atoms/form/Checkbox'
 import { UnitPreferenceFormData } from '~applications/editor/ApplicationFormData'
 import {
@@ -31,6 +30,7 @@ import MultiSelect from '@evaka/lib-components/src/atoms/form/MultiSelect'
 import colors from '@evaka/lib-components/src/colors'
 import ExternalLink from '@evaka/lib-components/src/atoms/ExternalLink'
 import { useTranslation } from '~localization'
+import EditorSection from '~applications/editor/EditorSection'
 
 const maxUnits = 3
 
@@ -73,9 +73,10 @@ export default React.memo(function UnitPreferenceSection({
   }, [applicationType, preparatory, preferredStartDate])
 
   return (
-    <ContentArea opaque paddingVertical="L">
-      <H2>{t.applications.editor.unitPreference.title}</H2>
-
+    <EditorSection
+      title={t.applications.editor.unitPreference.title}
+      validationErrors={0}
+    >
       <H3>{t.applications.editor.unitPreference.siblingBasis.title}</H3>
       <P>{t.applications.editor.unitPreference.siblingBasis.p1}</P>
       <P>{t.applications.editor.unitPreference.siblingBasis.p2}</P>
@@ -279,7 +280,7 @@ export default React.memo(function UnitPreferenceSection({
           )}
         </>
       )}
-    </ContentArea>
+    </EditorSection>
   )
 })
 

--- a/frontend/packages/lib-components/src/atoms/buttons/AddButton.tsx
+++ b/frontend/packages/lib-components/src/atoms/buttons/AddButton.tsx
@@ -65,8 +65,8 @@ const StyledButton = styled.button`
   &.flipped {
     flex-direction: row-reverse;
 
-    .icon-wrapper {
-      margin: 0 0 0 ${defaultMargins.s};
+    .icon-wrapper-outer {
+      margin: -4px -4px -4px ${defaultMargins.s};
     }
   }
 

--- a/frontend/packages/lib-components/src/layout/Container.tsx
+++ b/frontend/packages/lib-components/src/layout/Container.tsx
@@ -2,7 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import React, { KeyboardEvent, ReactNode } from 'react'
 import styled from 'styled-components'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronDown, faChevronUp } from '@evaka/lib-icons'
+import colors from '../colors'
 import { defaultMargins, SpacingSize } from '../white-space'
 import { BaseProps } from '../utils'
 
@@ -49,6 +53,60 @@ export const ContentArea = styled.section<ContentAreaProps>`
     }`};
   background-color: ${(props) => (props.opaque ? 'white' : 'transparent')};
   position: relative;
+`
+
+type CollapsibleContentAreaProps = ContentAreaProps & {
+  open: boolean
+  toggleOpen: () => void
+  title: ReactNode
+  children: ReactNode
+}
+
+export const CollapsibleContentArea = React.memo(
+  function CollapsibleContentArea({
+    open,
+    toggleOpen,
+    title,
+    children,
+    ...props
+  }: CollapsibleContentAreaProps) {
+    const toggleOnEnter = (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Enter') {
+        toggleOpen()
+      }
+    }
+
+    return (
+      <ContentArea {...props}>
+        <TitleContainer
+          tabIndex={0}
+          onClick={toggleOpen}
+          onKeyUp={toggleOnEnter}
+        >
+          <TitleWrapper>{title}</TitleWrapper>
+          <TitleIcon icon={open ? faChevronUp : faChevronDown} />
+        </TitleContainer>
+        {open ? children : null}
+      </ContentArea>
+    )
+  }
+)
+
+const TitleContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+`
+
+const TitleWrapper = styled.div`
+  flex-grow: 1;
+`
+
+const TitleIcon = styled(FontAwesomeIcon)`
+  color: ${colors.blues.primary};
+  height: 24px !important;
+  width: 24px !important;
 `
 
 export default Container


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Collapsible sections for citizen application editor sections. There is already support for validation error indicators.

Also fix `AddButton` styles when `reversed` prop is on.
