### PR TITLE
Disable manifest basic auth

### DIFF
--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -205,6 +205,18 @@ server {
     return 301 https://$host/employee;
   }
 
+  location ~ /employee/mobile/manifest\.([a-z0-9]+)\.json$ {
+    proxy_set_header        Authorization '';
+    proxy_hide_header       x-amz-id-2;
+    proxy_hide_header       x-amz-request-id;
+    proxy_hide_header       Set-Cookie;
+    proxy_ignore_headers    Set-Cookie;
+
+    proxy_pass              $staticEndpoint;
+
+    auth_basic off;
+  }
+
   location @static {
     proxy_set_header        Authorization '';
     proxy_hide_header       x-amz-id-2;


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Browsers fetch manifests without credentials, so in practice basic auth blocks the manifest completely

I think there's still something wrong, because "Add to home screen" functionality on mobile Chrome shows a spinner for some time (30 seconds?) and then clearly times out. But the manifest and logo are fetched correctly, so it's not clear what the problem is.

