### PR TITLE
Fix absence colors

### DIFF
--- a/frontend/packages/lib-components/src/colors.ts
+++ b/frontend/packages/lib-components/src/colors.ts
@@ -48,32 +48,6 @@ const colors = {
 }
 
 export const absenceColours = {
-  UNKNOWN_ABSENCE: colors.greyscale.darkest,
-  OTHER_ABSENCE: colors.greyscale.white,
-  SICKLEAVE: colors.greyscale.white,
-  PLANNED_ABSENCE: colors.greyscale.darkest,
-  PARENTLEAVE: colors.greyscale.white,
-  FORCE_MAJEURE: colors.greyscale.white,
-  TEMPORARY_RELOCATION: colors.greyscale.white,
-  TEMPORARY_VISITOR: colors.greyscale.white,
-  PRESENCE: colors.greyscale.white
-}
-
-type AbsenceType = keyof typeof absenceColours
-
-export const absenceBackgroundColours: { [k in AbsenceType]: string } = {
-  UNKNOWN_ABSENCE: colors.accents.green,
-  OTHER_ABSENCE: colors.blues.dark,
-  SICKLEAVE: colors.accents.violet,
-  PLANNED_ABSENCE: colors.blues.light,
-  PARENTLEAVE: colors.blues.primary,
-  FORCE_MAJEURE: colors.accents.red,
-  TEMPORARY_RELOCATION: colors.accents.orange,
-  TEMPORARY_VISITOR: colors.accents.yellow,
-  PRESENCE: colors.greyscale.white
-}
-
-export const absenceBorderColours: { [k in AbsenceType]: string } = {
   UNKNOWN_ABSENCE: colors.accents.green,
   OTHER_ABSENCE: colors.blues.dark,
   SICKLEAVE: colors.accents.violet,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The removal of `EspooColours` broke them because of misleading naming.

