### PR TITLE
EVAKA-4110 Fix part week placement service need warning

### DIFF
--- a/frontend/packages/employee-frontend/src/components/child-information/service-need/ServiceNeedForm.tsx
+++ b/frontend/packages/employee-frontend/src/components/child-information/service-need/ServiceNeedForm.tsx
@@ -88,17 +88,16 @@ function placementTypeAndHoursMismatch(
 ): boolean {
   switch (placement.type) {
     case 'CLUB':
+    case 'DAYCARE':
+    case 'PRESCHOOL_DAYCARE':
+    case 'PREPARATORY_DAYCARE':
       return false
     case 'PRESCHOOL':
       return hours > 20
-    case 'PRESCHOOL_DAYCARE':
-      return hours <= 20
     case 'PREPARATORY':
     case 'DAYCARE_PART_TIME':
     case 'TEMPORARY_DAYCARE_PART_DAY':
       return hours > 25
-    case 'PREPARATORY_DAYCARE':
-    case 'DAYCARE':
     case 'TEMPORARY_DAYCARE':
       return hours <= 25
   }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Show service need hours warning only when the hours go above a part day placement type's threshold since every other placement type gives the right to have less hours per week.

The only exception here is temporary daycare since it can't be part week and it's placement type should always be in sync with service need hours.

