### PR TITLE
Enable JUnit 5 test runner in service-lib

### DIFF
--- a/service-lib/build.gradle.kts
+++ b/service-lib/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
     // Kotlin + core
     implementation(platform(kotlin("bom")))
     implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("reflect"))
 
     // Logging
     implementation("io.github.microutils:kotlin-logging:${Version.kotlinLogging}")
@@ -31,7 +30,6 @@ dependencies {
 
     // Spring
     implementation(platform("org.springframework.boot:spring-boot-dependencies:${Version.springBoot}"))
-    implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     // Jackson
@@ -40,9 +38,7 @@ dependencies {
 
     // Auth0 JWT
     implementation("com.auth0:java-jwt:${Version.auth0Jwt}")
-    implementation("com.auth0:jwks-rsa:0.15.0")
 
-    testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.skyscreamer:jsonassert:1.5.0")
 }

--- a/service-lib/build.gradle.kts
+++ b/service-lib/build.gradle.kts
@@ -47,19 +47,9 @@ dependencies {
     testImplementation("org.skyscreamer:jsonassert:1.5.0")
 }
 
-allOpen {
-    annotation("org.springframework.boot.test.context.TestConfiguration")
-}
-
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         jvmTarget = Version.java
         allWarningsAsErrors = true
-    }
-}
-
-tasks {
-    test {
-        systemProperty("spring.profiles.active", "test")
     }
 }

--- a/service-lib/build.gradle.kts
+++ b/service-lib/build.gradle.kts
@@ -49,3 +49,9 @@ tasks.withType<KotlinCompile> {
         allWarningsAsErrors = true
     }
 }
+
+tasks {
+    test {
+        useJUnitPlatform()
+    }
+}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

JUnit 5 ("jupiter") tests were not detected or executed. The tests were updated to use JUnit 5 at some point, but the runner configuration was not added so they haven't been executed for a while.