### PR TITLE
Cleanup Varda and Koski error logs, KLogger extensions

### DIFF
--- a/service-lib/src/main/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggers.kt
+++ b/service-lib/src/main/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggers.kt
@@ -8,30 +8,32 @@ import mu.KLogger
 import net.logstash.logback.argument.StructuredArguments
 
 /**
- * Extensions to allow adding meta-fields (and technically any other) to app-misc logs
- * without requiring StructuredArguments wrapper and a dependency to net.logstash.logback.
+ * Extensions to allow adding meta-fields to app-misc logs without requiring StructuredArguments wrapper
+ * and an unnecessary dependency to net.logstash.logback.
  */
 
-fun KLogger.trace(args: Map<String, Any?>, m: () -> Any?) {
-    if (isTraceEnabled) trace(m.toStringSafe(), StructuredArguments.entries(args))
+fun KLogger.trace(meta: Map<String, Any?>, m: () -> Any?) {
+    if (isTraceEnabled) trace(m.toStringSafe(), metaToLoggerArgs(meta))
 }
 
-fun KLogger.debug(args: Map<String, Any?>, m: () -> Any?) {
-    if (isDebugEnabled) debug(m.toStringSafe(), StructuredArguments.entries(args))
+fun KLogger.debug(meta: Map<String, Any?>, m: () -> Any?) {
+    if (isDebugEnabled) debug(m.toStringSafe(), metaToLoggerArgs(meta))
 }
 
-fun KLogger.info(args: Map<String, Any?>, m: () -> Any?) {
-    if (isInfoEnabled) info(m.toStringSafe(), StructuredArguments.entries(args))
+fun KLogger.info(meta: Map<String, Any?>, m: () -> Any?) {
+    if (isInfoEnabled) info(m.toStringSafe(), metaToLoggerArgs(meta))
 }
 
-fun KLogger.warn(args: Map<String, Any?>, m: () -> Any?) {
-    if (isWarnEnabled) warn(m.toStringSafe(), StructuredArguments.entries(args))
+fun KLogger.warn(meta: Map<String, Any?>, m: () -> Any?) {
+    if (isWarnEnabled) warn(m.toStringSafe(), metaToLoggerArgs(meta))
 }
 
-fun KLogger.error(args: Map<String, Any?>, m: () -> Any?) {
-    if (isErrorEnabled) error(m.toStringSafe(), StructuredArguments.entries(args))
+fun KLogger.error(meta: Map<String, Any?>, m: () -> Any?) {
+    if (isErrorEnabled) error(m.toStringSafe(), metaToLoggerArgs(meta))
 }
 
-fun KLogger.error(error: Any, args: Map<String, Any?>, m: () -> Any?) {
-    if (isErrorEnabled) error(m.toStringSafe(), StructuredArguments.entries(args), error)
+fun KLogger.error(error: Any, meta: Map<String, Any?>, m: () -> Any?) {
+    if (isErrorEnabled) error(m.toStringSafe(), metaToLoggerArgs(meta), error)
 }
+
+private fun metaToLoggerArgs(meta: Map<String, Any?>) = StructuredArguments.entries(mapOf("meta" to meta))

--- a/service-lib/src/test/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggersTest.kt
+++ b/service-lib/src/test/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggersTest.kt
@@ -44,7 +44,7 @@ class AppMiscLoggersTest {
 
     @Test
     fun `arguments added to trace log entry`() {
-        val args = mapOf("argKey" to "argVal", "meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        val args = mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2")
         logger.trace(args) { message }
 
         val event = logger.getTestAppender().getEvents().first()
@@ -59,7 +59,7 @@ class AppMiscLoggersTest {
 
     @Test
     fun `arguments added to debug log entry`() {
-        val args = mapOf("argKey" to "argVal", "meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        val args = mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2")
         logger.debug(args) { message }
 
         val event = logger.getTestAppender().getEvents().first()
@@ -74,7 +74,7 @@ class AppMiscLoggersTest {
 
     @Test
     fun `arguments added to info log entry`() {
-        val args = mapOf("argKey" to "argVal", "meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        val args = mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2")
         logger.info(args) { message }
 
         val event = logger.getTestAppender().getEvents().first()
@@ -89,7 +89,7 @@ class AppMiscLoggersTest {
 
     @Test
     fun `arguments added to warn log entry`() {
-        val args = mapOf("argKey" to "argVal", "meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        val args = mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2")
         logger.warn(args) { message }
 
         val event = logger.getTestAppender().getEvents().first()
@@ -104,7 +104,7 @@ class AppMiscLoggersTest {
 
     @Test
     fun `arguments added to error log entry`() {
-        val args = mapOf("argKey" to "argVal", "meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        val args = mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2")
         logger.error(args) { message }
 
         val event = logger.getTestAppender().getEvents().first()
@@ -114,7 +114,7 @@ class AppMiscLoggersTest {
     @Test
     fun `throwable and all arguments included in error log entry`() {
         val exception = RuntimeException("This is a test exception")
-        val args = mapOf("meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        val args = mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2")
         logger.error(exception, args) { message }
 
         val event = logger.getTestAppender().getEvents().first()
@@ -124,6 +124,6 @@ class AppMiscLoggersTest {
     }
 
     private fun compareArgs(expectedArgs: Map<String, Any>, event: ILoggingEvent) {
-        assertEquals(expectedArgs.toString(), event.argumentArray.first().toString())
+        assertEquals(mapOf("meta" to expectedArgs.toString()).toString(), event.argumentArray.first().toString())
     }
 }

--- a/service-lib/src/test/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggersTest.kt
+++ b/service-lib/src/test/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggersTest.kt
@@ -7,6 +7,7 @@ package fi.espoo.voltti.logging.loggers
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.spi.ThrowableProxy
 import fi.espoo.voltti.logging.utils.clearTestMessages
 import fi.espoo.voltti.logging.utils.getTestAppender
 import fi.espoo.voltti.logging.utils.getTestMessages
@@ -108,6 +109,18 @@ class AppMiscLoggersTest {
 
         val event = logger.getTestAppender().getEvents().first()
         compareArgs(args, event)
+    }
+
+    @Test
+    fun `throwable and all arguments included in error log entry`() {
+        val exception = RuntimeException("This is a test exception")
+        val args = mapOf("meta" to mapOf("metaArg1" to "metaVal1", "metaArg2" to "metaVal2"))
+        logger.error(exception, args) { message }
+
+        val event = logger.getTestAppender().getEvents().first()
+        assertEquals(message, event.message)
+        compareArgs(args, event)
+        assertEquals((event.throwableProxy as ThrowableProxy).throwable, exception)
     }
 
     private fun compareArgs(expectedArgs: Map<String, Any>, event: ILoggingEvent) {

--- a/service/README.md
+++ b/service/README.md
@@ -122,3 +122,25 @@ plugin. Dependencies are checked on every build with the command `./gradlew depe
 minor vulnerabilities break the build, but they can
 be [suppressed](https://jeremylong.github.io/DependencyCheck/general/suppression.html) when needed. The suppression
 rules are configured [here](./owasp-suppressions.xml).
+
+### Add metadata to log entries
+
+Use the [KLogger extensions in service-lib](../service-lib/src/main/kotlin/fi/espoo/voltti/logging/loggers/AppMiscLoggers.kt)
+to add custom metadata to log entries (useful for querying/statistical analysis):
+
+```kotlin
+import fi.espoo.voltti.logging.loggers.error
+
+try {
+  logger.debug(mapOf("url" to url)) { "Doing something" }
+  something()
+} catch (error: FuelError) {
+  val meta = mapOf(
+      "method" to request.method,
+      "url" to request.url,
+      "body" to request.body.asString("application/json"),
+      "errorMessage" to error.errorData.decodeToString()
+  )
+  logger.error(error, meta) { "Request failed, status ${error.response.statusCode}" }
+}
+```

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -86,7 +86,7 @@ class KoskiClient(
                 )
                 logger.error(
                     error,
-                    mapOf("meta" to meta)
+                    meta
                 ) { "Koski upload ${msg.key} ${data.operation} failed, status ${error.response.statusCode}" }
                 throw error
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
@@ -299,7 +299,8 @@ class VardaClient(
 
     fun deletePlacement(vardaPlacementId: Long): Boolean {
         logger.info { "Deleting placement from Varda (id: $vardaPlacementId)" }
-        val (request, _, result) = fuel.delete(getPlacementUrl(vardaPlacementId)).authenticatedResponseStringWithRetries()
+        val (request, _, result) = fuel.delete(getPlacementUrl(vardaPlacementId))
+            .authenticatedResponseStringWithRetries()
 
         return when (result) {
             is Result.Success -> {
@@ -398,5 +399,5 @@ private fun logRequestError(request: Request, error: FuelError) {
         "body" to request.body.asString("application/json"),
         "errorMessage" to error.errorData.decodeToString()
     )
-    logger.error(error, mapOf("meta" to meta)) { "Varda request to ${request.url} failed, status ${error.response.statusCode}" }
+    logger.error(error, meta) { "Varda request to ${request.url} failed, status ${error.response.statusCode}" }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
@@ -398,5 +398,5 @@ private fun logRequestError(request: Request, error: FuelError) {
         "body" to request.body.asString("application/json"),
         "errorMessage" to error.errorData.decodeToString()
     )
-    logger.error(error, meta) { "Varda request failed" }
+    logger.error(error, mapOf("meta" to meta)) { "Varda request to ${request.url} failed, status ${error.response.statusCode}" }
 }


### PR DESCRIPTION
#### Summary
- Log Varda and Koski error metadata correctly
    - #417 added metadata to Varda logs but the missing `mapOf("meta" to meta)` was missed, resulting in logs where the meta-fields were actually top-level fields
        - The KLogger extensions don't actually map directly to the meta-field in our JSON logs but need an extra mapOf(meta to arg) wrapped around them
    - Unify Koski error logging with Varda and instead of outputting the whole multi-line error response, log the relevant fields in "meta"
- As a "lesson learned" from the above, map `KLogger` meta-arguments directly to meta-fields
    - There isn't a use case for overwriting any other fields than the freeform "meta" (as everything else is provided by the loggers and/or is structured data)
    - Handle the extra meta-mapping inside the logger extensions and rename the field (`args -> meta`) to better reflect its use case
    - Add documentation for logger extensions existence to make them more widely known
- service-lib: test for error logger with exception
   - New logger method was missing tests
   - It's not a great test but more of a sanity check

Snippet of incorrect log output:
```jsonc
    "logLevel": "ERROR",
    "hostIp": "10.230.25.167",
    "exception": "BubbleFuelError",
    "url": "https://backend.varda-db.csc.fi/api/v1/maksutiedot/", // <-- This shouldn't be here
    "version": 1
  }
```

and correct:

```jsonc
    "logLevel": "ERROR",
    "hostIp": "10.230.25.167",
    "exception": "BubbleFuelError",
    "meta": {
        "url": "https://backend.varda-db.csc.fi/api/v1/maksutiedot/", // <-- But here instead
        // ...
    }
    "version": 1
  }
```