### PR TITLE
Stop using opening dates with application periods

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/LocationServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/LocationServiceIntegrationTest.kt
@@ -85,18 +85,16 @@ class LocationServiceIntegrationTest : PureJdbiTest() {
 
     @Test
     fun `List of location contains future units`() {
-        val preschool1 = createDaycare(createGenericUnit(areaId = areaId), openingDate = LocalDate.now().minusYears(1), closingDate = LocalDate.now().minusMonths(1))
-        val preschool2 = createDaycare(createGenericUnit(areaId = areaId), openingDate = LocalDate.now().minusYears(1), closingDate = LocalDate.now().plusMonths(1))
-        val preschool3 = createDaycare(createGenericUnit(areaId = areaId), openingDate = LocalDate.now().plusYears(1), closingDate = LocalDate.now().plusYears(2))
+        val preschool1 = createDaycare(createGenericUnit(areaId = areaId), openingDate = LocalDate.now().minusYears(1), closingDate = LocalDate.now().plusMonths(1))
+        val preschool2 = createDaycare(createGenericUnit(areaId = areaId), openingDate = LocalDate.now().plusYears(1), closingDate = LocalDate.now().plusYears(2))
 
         val areas = jdbi.handle { it.getAreas().filter { it.id == areaId } }
         assertThat(areas).size().isEqualTo(1)
         val locationResults = areas.first().locations
 
         with(assertThat(locationResults)) {
-            filteredOn { it.id == preschool1 }.size().isEqualTo(0)
+            filteredOn { it.id == preschool1 }.size().isEqualTo(1)
             filteredOn { it.id == preschool2 }.size().isEqualTo(1)
-            filteredOn { it.id == preschool3 }.size().isEqualTo(1)
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
@@ -230,11 +230,11 @@ SELECT
     closing_date,
     ghost_unit
 FROM daycare
-WHERE daterange(opening_date, closing_date, '[]') @> :date AND (
-    (:club AND type && '{CLUB}'::care_types[] AND (NOT :onlyApplicable OR (club_apply_period IS NOT NULL AND club_apply_period @> :date)))
-    OR (:daycare AND type && '{CENTRE, FAMILY, GROUP_FAMILY}'::care_types[] AND (NOT :onlyApplicable OR (daycare_apply_period IS NOT NULL AND daycare_apply_period @> :date)))
-    OR (:preschool AND type && '{PRESCHOOL}'::care_types[] AND (NOT :onlyApplicable OR (preschool_apply_period IS NOT NULL AND preschool_apply_period @> :date)))
-    OR (:preparatory AND type && '{PREPARATORY_EDUCATION}'::care_types[] AND (NOT :onlyApplicable OR (preschool_apply_period IS NOT NULL AND preschool_apply_period @> :date)))
+WHERE (
+    (:club AND type && '{CLUB}'::care_types[] AND (NOT :onlyApplicable OR (club_apply_period @> :date)))
+    OR (:daycare AND type && '{CENTRE, FAMILY, GROUP_FAMILY}'::care_types[] AND (NOT :onlyApplicable OR (daycare_apply_period @> :date)))
+    OR (:preschool AND type && '{PRESCHOOL}'::care_types[] AND (NOT :onlyApplicable OR (preschool_apply_period @> :date)))
+    OR (:preparatory AND type && '{PREPARATORY_EDUCATION}'::care_types[] AND (NOT :onlyApplicable OR (preschool_apply_period @> :date)))
 )
 ORDER BY name ASC
     """.trimIndent()
@@ -269,10 +269,10 @@ SELECT
     closing_date,
     ghost_unit
 FROM daycare
-WHERE daterange(opening_date, closing_date, '[]') && daterange(:date, null) AND (
-    (club_apply_period IS NOT NULL AND club_apply_period && daterange(:date, null)) OR
-    (daycare_apply_period IS NOT NULL AND daycare_apply_period && daterange(:date, null)) OR
-    (preschool_apply_period IS NOT NULL AND preschool_apply_period && daterange(:date, null))
+WHERE (
+    (club_apply_period && daterange(:date, null, '[]')) OR
+    (daycare_apply_period && daterange(:date, null, '[]')) OR
+    (preschool_apply_period && daterange(:date, null, '[]'))
 )
 ORDER BY name ASC
     """.trimIndent()

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -187,7 +187,7 @@ data class AreaJSON(
 )
 
 fun Handle.getAreas(): List<CareArea> = createQuery(
-    // language=SQL
+    // language=sql
     """
 SELECT
   ca.id AS care_area_id, ca.name AS care_area_name, ca.short_name AS care_area_short_name,
@@ -196,10 +196,14 @@ SELECT
   u.type, u.url, u.provider_type, u.language, u.daycare_apply_period, u.preschool_apply_period, u.club_apply_period
 FROM care_area ca
 LEFT JOIN daycare u ON ca.id = u.care_area_id
-WHERE (u.daycare_apply_period IS NOT NULL OR u.preschool_apply_period IS NOT NULL OR u.club_apply_period IS NOT NULL )
-AND (u.closing_date IS NULL OR u.closing_date >= current_date)
+WHERE (
+    (u.club_apply_period && daterange(:now, null, '[]')) OR
+    (u.daycare_apply_period && daterange(:now, null, '[]')) OR
+    (u.preschool_apply_period && daterange(:now, null, '[]'))
+)
     """.trimIndent()
 )
+    .bind("now", LocalDate.now())
     .reduceRows(mutableMapOf<UUID, Pair<CareArea, MutableList<Location>>>()) { map, row ->
         val (_, locations) = map.computeIfAbsent(row.mapColumn("care_area_id")) { id ->
             Pair(
@@ -239,7 +243,6 @@ AND (:type = 'ALL' OR
     (:type = 'DAYCARE' AND '{CENTRE, FAMILY, GROUP_FAMILY}' && unit.type) OR
     (:type = 'PRESCHOOL' AND '{PRESCHOOL, PREPARATORY_EDUCATION}' && unit.type)
 )
-AND daterange(unit.opening_date, unit.closing_date) && daterange(current_date, null, '[]')
 ORDER BY name
     """.trimIndent()
 ).bindNullable("areaShortNames", areaShortNames.toTypedArray().takeIf { it.isNotEmpty() })

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
@@ -50,7 +50,7 @@ private fun Database.Read.getApplicationsRows(from: LocalDate, to: LocalDate): L
                 ch.id AS child_id,
                 date_part('year', age(:to, date_of_birth)) AS age
             FROM care_area ca
-            JOIN daycare u ON ca.id = u.care_area_id AND u.closing_date IS NULL
+            JOIN daycare u ON ca.id = u.care_area_id AND :from <= COALESCE(u.closing_date, 'infinity'::date)
             LEFT JOIN application_view a 
                 ON a.preferredunit = u.id 
                 AND a.status = ANY ('{SENT,WAITING_PLACEMENT,WAITING_DECISION}'::application_status_type[]) 


### PR DESCRIPTION
- Fix applications report closing date condition
- Remove opening dates from applicable units queries

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Do not use opening and closing dates in applicable units queries. The new application periods should replace them.

Also, fix applications report's closing date condition.

