### PR TITLE
EVAKA-4135: Restrict certain access rights from service worker

### DIFF
--- a/frontend/packages/employee-frontend/src/components/child-information/ServiceNeed.tsx
+++ b/frontend/packages/employee-frontend/src/components/child-information/ServiceNeed.tsx
@@ -68,14 +68,7 @@ const ServiceNeed = React.memo(function ServiceNeed({ id, open }: Props) {
         startCollapsed={!open}
         dataQa="service-need-collapsible"
       >
-        <RequireRole
-          oneOf={[
-            'SERVICE_WORKER',
-            'UNIT_SUPERVISOR',
-            'FINANCE_ADMIN',
-            'ADMIN'
-          ]}
-        >
+        <RequireRole oneOf={['UNIT_SUPERVISOR', 'ADMIN']}>
           <AddButtonRow
             text={i18n.childInformation.serviceNeed.create}
             onClick={() => {

--- a/frontend/packages/employee-frontend/src/components/child-information/service-need/ServiceNeedRow.tsx
+++ b/frontend/packages/employee-frontend/src/components/child-information/service-need/ServiceNeedRow.tsx
@@ -15,7 +15,6 @@ import Toolbar from '~components/common/Toolbar'
 import LabelValueList from '~components/common/LabelValueList'
 import { capitalizeFirstLetter, scrollToRef } from 'utils'
 import { removeServiceNeed } from 'api/child/service-needs'
-import { ALL_ROLES_BUT_STAFF } from 'utils/roles'
 
 export interface Props {
   serviceNeed: ServiceNeed

--- a/frontend/packages/employee-frontend/src/components/child-information/service-need/ServiceNeedRow.tsx
+++ b/frontend/packages/employee-frontend/src/components/child-information/service-need/ServiceNeedRow.tsx
@@ -83,12 +83,12 @@ function ServiceNeedRow({ serviceNeed, onReload }: Props) {
               setToggled(true)
               scrollToRef(refForm)
             }}
-            editableFor={ALL_ROLES_BUT_STAFF}
+            editableFor={['ADMIN', 'UNIT_SUPERVISOR']}
             dataQaEdit="btn-edit-service-need"
             onDelete={() =>
               toggleUiMode(`remove-service-need-${serviceNeed.id}`)
             }
-            deletableFor={ALL_ROLES_BUT_STAFF}
+            deletableFor={['ADMIN', 'UNIT_SUPERVISOR']}
             dataQaDelete="btn-remove-service-need"
             disableAll={!!uiMode && uiMode.startsWith('edit-service-need')}
           />

--- a/frontend/packages/employee-frontend/src/components/common/FormActions.tsx
+++ b/frontend/packages/employee-frontend/src/components/common/FormActions.tsx
@@ -11,7 +11,6 @@ import { FixedSpaceRow } from '@evaka/lib-components/src/layout/flex-helpers'
 const ButtonsContainer = styled.div`
   display: flex;
   justify-content: flex-end;
-  height: 80px;
 `
 
 interface AddButtonProps {

--- a/frontend/packages/employee-frontend/src/components/unit/TabGroups.tsx
+++ b/frontend/packages/employee-frontend/src/components/unit/TabGroups.tsx
@@ -33,12 +33,7 @@ function TabGroups({ reloadUnitData, openGroups, setOpenGroups }: Props) {
     savePosition
   } = useContext(UnitContext)
 
-  const isManager = requireRole(
-    roles,
-    'ADMIN',
-    'SERVICE_WORKER',
-    'UNIT_SUPERVISOR'
-  )
+  const isUnitSupervisor = requireRole(roles, 'ADMIN', 'UNIT_SUPERVISOR')
 
   if (unitInformation.isFailure || unitData.isFailure) {
     return <ErrorSegment />
@@ -52,7 +47,7 @@ function TabGroups({ reloadUnitData, openGroups, setOpenGroups }: Props) {
     <FixedSpaceColumn>
       <ContentArea opaque>
         <MissingGroupPlacements
-          canManageChildren={isManager}
+          canManageChildren={isUnitSupervisor}
           groups={unitData.value.groups}
           missingGroupPlacements={unitData.value.missingGroupPlacements}
           backupCares={unitData.value.backupCares}
@@ -64,8 +59,8 @@ function TabGroups({ reloadUnitData, openGroups, setOpenGroups }: Props) {
       <ContentArea opaque>
         <Groups
           unit={unitInformation.value.daycare}
-          canManageGroups={isManager}
-          canManageChildren={isManager}
+          canManageGroups={isUnitSupervisor}
+          canManageChildren={isUnitSupervisor}
           filters={filters}
           setFilters={setFilters}
           groups={unitData.value.groups}

--- a/frontend/packages/employee-frontend/src/components/unit/tab-groups/Groups.tsx
+++ b/frontend/packages/employee-frontend/src/components/unit/tab-groups/Groups.tsx
@@ -159,7 +159,7 @@ export default React.memo(function Groups({
             dataQa="toggle-all-groups-collapsible"
           />
         </TitleContainer>
-        {requireRole(roles, 'ADMIN', 'SERVICE_WORKER', 'UNIT_SUPERVISOR') && (
+        {canManageGroups && (
           <div>
             <Link to={`/units/${unit.id}/family-contacts`}>
               <InlineButton

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -64,7 +64,7 @@ val svebiTestCode = 400
 val defaultMunicipalOrganizerOid = "1.2.246.562.10.888888888888"
 val defaultPurchasedOrganizerOid = "1.2.246.562.10.66666666666"
 
-val testUnitSupervisorExternalId = ExternalId.of("espoo", "00000000-0000-0000-0009-000000000000")
+val unitSupervisorExternalId = ExternalId.of("test", UUID.randomUUID().toString())
 
 val testDaycare =
     UnitData.Detailed(
@@ -144,7 +144,7 @@ val testDecisionMaker_2 = PersonData.WithName(
     lastName = "Maker 2"
 )
 
-val testUnitSupervisor = PersonData.WithName(
+val unitSupervisorOfTestDaycare = PersonData.WithName(
     id = UUID.randomUUID(),
     firstName = "Sammy",
     lastName = "Supervisor"
@@ -435,14 +435,20 @@ fun insertGeneralTestFixtures(h: Handle) {
         )
     }
 
-    testUnitSupervisor.let {
+    unitSupervisorOfTestDaycare.let {
         h.insertTestEmployee(
             DevEmployee(
                 id = it.id,
                 firstName = it.firstName,
                 lastName = it.lastName,
-                externalId = testUnitSupervisorExternalId
+                externalId = unitSupervisorExternalId
             )
+        )
+        updateDaycareAcl(
+            h,
+            testDaycare.id,
+            unitSupervisorExternalId,
+            UserRole.UNIT_SUPERVISOR
         )
     }
 
@@ -549,15 +555,6 @@ VALUES (
         """.trimIndent()
 
     createUpdate(sql).execute()
-}
-
-fun insertUnitSupervisorAcl(h: Handle) {
-    updateDaycareAcl(
-        h,
-        testDaycare.id,
-        testUnitSupervisorExternalId,
-        UserRole.UNIT_SUPERVISOR
-    )
 }
 
 fun insertTestVardaOrganizer(h: Handle) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
@@ -9,7 +9,6 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.insertUnitSupervisorAcl
-
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -17,7 +16,6 @@ import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
-
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
 import fi.espoo.evaka.testDaycare

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -100,7 +100,7 @@ class DaycareController(
     ): ResponseEntity<DaycareGroup> {
         Audit.UnitGroupsCreate.log(targetId = daycareId)
         acl.getRolesForUnit(user, daycareId)
-            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
         return db.transaction { daycareService.createGroup(it, daycareId, body.name, body.startDate, body.initialCaretakers) }
             .let { created(it, URI.create("/$daycareId/groups/${it.id}")) }
@@ -121,7 +121,7 @@ class DaycareController(
     ): ResponseEntity<Unit> {
         Audit.UnitGroupsUpdate.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
-            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
         db.transaction { it.handle.updateGroup(groupId, body.name, body.startDate, body.endDate) }
 
@@ -176,7 +176,7 @@ class DaycareController(
     ): ResponseEntity<Unit> {
         Audit.UnitGroupsCaretakersCreate.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
-            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
         db.transaction {
             caretakerService.insert(
@@ -201,7 +201,7 @@ class DaycareController(
     ): ResponseEntity<Unit> {
         Audit.UnitGroupsCaretakersUpdate.log(targetId = id)
         acl.getRolesForUnitGroup(user, groupId)
-            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
         db.transaction {
             caretakerService.update(
@@ -226,7 +226,7 @@ class DaycareController(
     ): ResponseEntity<Unit> {
         Audit.UnitGroupsCaretakersDelete.log(targetId = id)
         acl.getRolesForUnitGroup(user, groupId)
-            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
         db.transaction {
             caretakerService.delete(

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -191,7 +191,7 @@ class PlacementController(
     ): ResponseEntity<UUID> {
         Audit.DaycareGroupPlacementCreate.log(targetId = placementId, objectId = body.groupId)
         acl.getRolesForPlacement(user, placementId)
-            .requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
         return db.transaction { tx ->
             tx.createGroupPlacement(
@@ -214,7 +214,7 @@ class PlacementController(
     ): ResponseEntity<Unit> {
         Audit.DaycareGroupPlacementDelete.log(targetId = groupPlacementId)
         acl.getRolesForPlacement(user, daycarePlacementId)
-            .requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
         val success = db.transaction { it.handle.deleteGroupPlacement(groupPlacementId) }
         if (!success) throw NotFound("Group placement not found")
@@ -231,7 +231,7 @@ class PlacementController(
     ): ResponseEntity<Unit> {
         Audit.DaycareGroupPlacementTransfer.log(targetId = groupPlacementId)
         acl.getRolesForPlacement(user, daycarePlacementId)
-            .requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
         return db.transaction {
             it.transferGroup(daycarePlacementId, groupPlacementId, body.groupId, body.startDate).let(::noContent)

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -191,7 +191,7 @@ class PlacementController(
     ): ResponseEntity<UUID> {
         Audit.DaycareGroupPlacementCreate.log(targetId = placementId, objectId = body.groupId)
         acl.getRolesForPlacement(user, placementId)
-            .requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
 
         return db.transaction { tx ->
             tx.createGroupPlacement(
@@ -214,7 +214,7 @@ class PlacementController(
     ): ResponseEntity<Unit> {
         Audit.DaycareGroupPlacementDelete.log(targetId = groupPlacementId)
         acl.getRolesForPlacement(user, daycarePlacementId)
-            .requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
 
         val success = db.transaction { it.handle.deleteGroupPlacement(groupPlacementId) }
         if (!success) throw NotFound("Group placement not found")
@@ -231,7 +231,7 @@ class PlacementController(
     ): ResponseEntity<Unit> {
         Audit.DaycareGroupPlacementTransfer.log(targetId = groupPlacementId)
         acl.getRolesForPlacement(user, daycarePlacementId)
-            .requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
 
         return db.transaction {
             it.transferGroup(daycarePlacementId, groupPlacementId, body.groupId, body.startDate).let(::noContent)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
@@ -26,7 +26,7 @@ class FamilyContactReportController(private val acl: AccessControlList) {
         @RequestParam unitId: UUID
     ): ResponseEntity<List<FamilyContactReportRow>> {
         Audit.FamilyContactReportRead.log()
-        acl.getRolesForUnit(user, unitId).requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.DIRECTOR, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
+        acl.getRolesForUnit(user, unitId).requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
         return db.read { it.getFamilyContacts(unitId) }.let { ResponseEntity.ok(it) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -36,7 +36,7 @@ class ServiceNeedController(
         @RequestBody body: ServiceNeedRequest
     ): ResponseEntity<ServiceNeed> {
         Audit.ChildServiceNeedCreate.log(targetId = childId)
-        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
         return serviceNeedService.createServiceNeed(
             db,
             user = user,
@@ -64,7 +64,7 @@ class ServiceNeedController(
         @RequestBody body: ServiceNeedRequest
     ): ResponseEntity<ServiceNeed> {
         Audit.ChildServiceNeedUpdate.log(targetId = serviceNeedId)
-        acl.getRolesForServiceNeed(user, serviceNeedId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+        acl.getRolesForServiceNeed(user, serviceNeedId).requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
         return serviceNeedService.updateServiceNeed(
             db,
             user = user,
@@ -80,7 +80,7 @@ class ServiceNeedController(
         @PathVariable("id") serviceNeedId: UUID
     ): ResponseEntity<Unit> {
         Audit.ChildServiceNeedDelete.log(targetId = serviceNeedId)
-        acl.getRolesForServiceNeed(user, serviceNeedId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+        acl.getRolesForServiceNeed(user, serviceNeedId).requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
         serviceNeedService.deleteServiceNeed(db, serviceNeedId)
         return noContent()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -36,7 +36,7 @@ class ServiceNeedController(
         @RequestBody body: ServiceNeedRequest
     ): ResponseEntity<ServiceNeed> {
         Audit.ChildServiceNeedCreate.log(targetId = childId)
-        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
+        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
         return serviceNeedService.createServiceNeed(
             db,
             user = user,
@@ -52,7 +52,14 @@ class ServiceNeedController(
         @PathVariable childId: UUID
     ): ResponseEntity<List<ServiceNeed>> {
         Audit.ChildServiceNeedRead.log(targetId = childId)
-        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
+        acl.getRolesForChild(user, childId).requireOneOfRoles(
+            UserRole.ADMIN,
+            UserRole.SERVICE_WORKER,
+            UserRole.UNIT_SUPERVISOR,
+            UserRole.FINANCE_ADMIN,
+            UserRole.STAFF,
+            UserRole.SPECIAL_EDUCATION_TEACHER
+        )
         return serviceNeedService.getServiceNeedsByChildId(db, childId).let(::ok)
     }
 
@@ -64,7 +71,7 @@ class ServiceNeedController(
         @RequestBody body: ServiceNeedRequest
     ): ResponseEntity<ServiceNeed> {
         Audit.ChildServiceNeedUpdate.log(targetId = serviceNeedId)
-        acl.getRolesForServiceNeed(user, serviceNeedId).requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
+        acl.getRolesForServiceNeed(user, serviceNeedId).requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
         return serviceNeedService.updateServiceNeed(
             db,
             user = user,
@@ -80,7 +87,7 @@ class ServiceNeedController(
         @PathVariable("id") serviceNeedId: UUID
     ): ResponseEntity<Unit> {
         Audit.ChildServiceNeedDelete.log(targetId = serviceNeedId)
-        acl.getRolesForServiceNeed(user, serviceNeedId).requireOneOfRoles(UserRole.UNIT_SUPERVISOR)
+        acl.getRolesForServiceNeed(user, serviceNeedId).requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
         serviceNeedService.deleteServiceNeed(db, serviceNeedId)
         return noContent()
     }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
 Service worker should not be allowed to
 - Create or modify groups in a daycare
 - Place children into groups (or transfer them within groups)
 - Retrieve family contact details report
 - Add or edit service needs

 All these actions are unit supervisor's duty. However, service worker is allowed to list groups,
 children in groups, service need etc.

 For some endpoints, there was even wider set of roles allowed, cleaned those as well.

