### PR TITLE
Only send one pending decision email per guardian

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -74,7 +74,9 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `Pending decision older than one week sends reminder email`() {
-        createPendingDecision(LocalDate.now().minusDays(8), null, null, 0)
+        createPendingDecision(LocalDate.now().minusDays(8), null, null, 0, type = DecisionType.PRESCHOOL)
+        createPendingDecision(LocalDate.now().minusDays(8), null, null, 0, type = DecisionType.PRESCHOOL_DAYCARE)
+
         Assertions.assertEquals(1, runPendingDecisionEmailAsyncJobs())
 
         val sentMails = MockEmailClient.emails
@@ -132,7 +134,7 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
         assert(email.textBody.contains(expectedTextPart, true))
     }
 
-    private fun createPendingDecision(sentDate: LocalDate, resolved: Instant?, pendingDecisionEmailSent: Instant?, pendingDecisionEmailsSentCount: Int) {
+    private fun createPendingDecision(sentDate: LocalDate, resolved: Instant?, pendingDecisionEmailSent: Instant?, pendingDecisionEmailsSentCount: Int, type: DecisionType = DecisionType.DAYCARE) {
         db.transaction { tx ->
             tx.handle.insertTestDecision(
                 TestDecision(
@@ -140,7 +142,7 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
                     status = DecisionStatus.PENDING,
                     createdBy = testDecisionMaker_1.id,
                     unitId = unitId,
-                    type = DecisionType.DAYCARE,
+                    type = type,
                     startDate = startDate,
                     endDate = endDate,
                     resolvedBy = testDecisionMaker_1.id,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -51,7 +51,7 @@ data class SendApplicationEmail(val guardianId: UUID, val language: Language) : 
     override val user: AuthenticatedUser? = null
 }
 
-data class SendPendingDecisionEmail(val decisionId: UUID) : AsyncJobPayload {
+data class SendPendingDecisionEmail(val guardianId: UUID, val decisionIds: List<UUID>) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.SEND_PENDING_DECISION_EMAIL
     override val user: AuthenticatedUser? = null
 }


### PR DESCRIPTION
#### Summary

It is common to have two simultaneous pending decisions as preschool and preschool daycare is applied together.
Instead of sending a reminder email per pending decision only send one per guardian if any pending decisions exists. 

REMINDER: delete current pending SEND_PENDING_DECISION_EMAIL async jobs when deploying this to staging
