### PR TITLE
lib-components: fix AsyncButton spinner clipping

### DIFF
--- a/frontend/packages/lib-components/src/atoms/buttons/AsyncButton.tsx
+++ b/frontend/packages/lib-components/src/atoms/buttons/AsyncButton.tsx
@@ -156,8 +156,8 @@ const Spinner = animated(styled.div`
   left: 0;
   display: inline-block;
   border-radius: 50%;
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
 
   border: 2px solid ${colors.greyscale.lighter};
   border-left-color: ${colors.primary};


### PR DESCRIPTION
#### Summary
- The actual height of the spinner is `height` + (`border-width` x 2), i.e. not 24px (which is the container's height/width) but 24px + 2px + 2px = 28px
- Instead of increasing the containers size and therefore altering the other elements of the button (namely the text/content), reduce spinner size by 4px so it actually is 24px

Before:

![async-button-before](https://user-images.githubusercontent.com/5830147/107769299-7862af80-6d40-11eb-95f1-51bafc7eb72d.png)

After:

![async-button-after](https://user-images.githubusercontent.com/5830147/107769308-7dbffa00-6d40-11eb-86d8-eb3ff299d17c.png)
