### PR TITLE
Hide closed units

### DIFF
--- a/frontend/e2e-test/test/e2e/pages/employee/units/units-page.ts
+++ b/frontend/e2e-test/test/e2e/pages/employee/units/units-page.ts
@@ -3,9 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Selector, t } from 'testcafe'
+import { Checkbox } from '../../../utils/helpers'
 
 export default class UnitsPage {
   readonly unitNameFilter = Selector('[data-qa="unit-name-filter"]')
+  readonly includeClosedCheckbox = new Checkbox(
+    Selector('[data-qa="include-closed"]')
+  )
   readonly unitRows = Selector('[data-qa="unit-row"]')
   readonly firstUnitRow = this.unitRows.nth(0)
 
@@ -15,5 +19,11 @@ export default class UnitsPage {
 
   async navigateToNthUnit(n: number) {
     await t.click(this.unitRows.nth(n).find('a').nth(0))
+  }
+
+  async showClosedUnits(show: boolean) {
+    return show === (await this.includeClosedCheckbox.checked)
+      ? undefined
+      : this.includeClosedCheckbox.click()
   }
 }

--- a/frontend/e2e-test/test/e2e/specs/5_employee/units.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/5_employee/units.spec.ts
@@ -17,7 +17,8 @@ import {
 } from '../../dev-api/data-init'
 import {
   createDaycarePlacementFixture,
-  daycareGroupFixture
+  daycareGroupFixture,
+  Fixture
 } from '../../dev-api/fixtures'
 import { logConsoleMessages } from '../../utils/fixture'
 import { Child, DaycarePlacement } from '../../dev-api/types'
@@ -218,4 +219,25 @@ test('Unit occupancy rates are correct with properly set caretaker counts', asyn
   await t
     .expect(unitPage.occupancies('planned').minimum.textContent)
     .contains('14,3 %')
+})
+
+test('Units list hides closed units unless toggled to show', async (t) => {
+  const area = await Fixture.careArea().save()
+  const closedUnit = await Fixture.daycare()
+    .careArea(area)
+    .with({
+      name: 'Wanha päiväkoti',
+      openingDate: '1900-01-01',
+      closingDate: '2000-01-01'
+    })
+    .save()
+  await t.eval(() => location.reload())
+
+  await unitsPage.filterByName(closedUnit.data.name)
+  await unitsPage.showClosedUnits(false)
+  await t.expect(unitsPage.unitRows.count).eql(0)
+
+  await unitsPage.showClosedUnits(true)
+  await t.expect(unitsPage.unitRows.count).eql(1)
+  await t.expect(unitsPage.unitRows.textContent).contains(closedUnit.data.name)
 })

--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -988,6 +988,7 @@ export const fi = {
     address: 'Osoite',
     type: 'Tyyppi',
     findByName: 'Etsi yksikön nimellä',
+    includeClosed: 'Näytä lopetetut yksiköt',
     noResults: 'Ei tuloksia'
   },
   unit: {

--- a/frontend/packages/employee-frontend/src/state/units.tsx
+++ b/frontend/packages/employee-frontend/src/state/units.tsx
@@ -2,7 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { createContext, useMemo, useState } from 'react'
+import React, {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useMemo,
+  useState
+} from 'react'
 import { Loading, Result } from '@evaka/lib-common/src/api'
 import { Unit } from '~types/unit'
 import { SearchOrder } from '~types'
@@ -16,6 +22,8 @@ export interface UnitsState {
   setSortColumn: (text: string) => void
   sortDirection: SearchOrder
   setSortDirection: (text: SearchOrder) => void
+  includeClosed: boolean
+  setIncludeClosed: Dispatch<SetStateAction<boolean>>
 }
 
 const defaultState: UnitsState = {
@@ -26,7 +34,9 @@ const defaultState: UnitsState = {
   sortColumn: 'name',
   setSortColumn: () => undefined,
   sortDirection: 'ASC',
-  setSortDirection: () => undefined
+  setSortDirection: () => undefined,
+  includeClosed: false,
+  setIncludeClosed: () => undefined
 }
 
 export const UnitsContext = createContext<UnitsState>(defaultState)
@@ -44,6 +54,7 @@ export const UnitsContextProvider = React.memo(function UnitsContextProvider({
   const [sortDirection, setSortDirection] = useState<SearchOrder>(
     defaultState.sortDirection
   )
+  const [includeClosed, setIncludeClosed] = useState(defaultState.includeClosed)
 
   const value = useMemo(
     () => ({
@@ -54,7 +65,9 @@ export const UnitsContextProvider = React.memo(function UnitsContextProvider({
       sortColumn,
       setSortColumn,
       sortDirection,
-      setSortDirection
+      setSortDirection,
+      includeClosed,
+      setIncludeClosed
     }),
     [
       units,
@@ -64,7 +77,9 @@ export const UnitsContextProvider = React.memo(function UnitsContextProvider({
       sortColumn,
       setSortColumn,
       sortDirection,
-      setSortDirection
+      setSortDirection,
+      includeClosed,
+      setIncludeClosed
     ]
   )
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Hide closed units from units page list unless the "include closed" checkbox is checked. Also, leave out units with closing date before the query date in application units queries.

