### PR TITLE
Filter empty other children on submit citizen application

### DIFF
--- a/frontend/packages/citizen-frontend/src/applications/editor/validations.ts
+++ b/frontend/packages/citizen-frontend/src/applications/editor/validations.ts
@@ -221,7 +221,7 @@ export const validateApplication = (
       otherChildren: {
         arrayErrors: undefined,
         itemErrors: form.contactInfo.otherChildren.map((child) =>
-          requireFullFamily
+          requireFullFamily && form.contactInfo.otherChildrenExists
             ? {
                 firstName: validate(child.firstName, required),
                 lastName: validate(child.lastName, required),


### PR DESCRIPTION
Summary:

Prevent form check error if the user selects `Children under 18 living in the same address` and immediately deselects.