### PR TITLE
EVAKA-4133: Restrict removing parentship from unit supervisor

### DIFF
--- a/frontend/packages/employee-frontend/src/components/person-profile/PersonFridgeChild.tsx
+++ b/frontend/packages/employee-frontend/src/components/person-profile/PersonFridgeChild.tsx
@@ -168,6 +168,7 @@ const PersonFridgeChild = React.memo(function PersonFridgeChild({
                     toggleUiMode(`remove-fridge-child-${fridgeChild.id}`)
                   }}
                   conflict={fridgeChild.conflict}
+                  deletableFor={['ADMIN', 'FINANCE_ADMIN']}
                 />
               </ButtonsTd>
             </Tr>

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -41,7 +41,12 @@ class ParentshipController(
         @RequestBody body: ParentshipRequest
     ): ResponseEntity<Parentship> {
         Audit.ParentShipsCreate.log(targetId = body.headOfChildId, objectId = body.childId)
-        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(
+            UserRole.ADMIN,
+            UserRole.SERVICE_WORKER,
+            UserRole.UNIT_SUPERVISOR,
+            UserRole.FINANCE_ADMIN
+        )
 
         with(body) {
             return db.transaction {
@@ -60,7 +65,12 @@ class ParentshipController(
         @RequestParam(value = "childId", required = false) childId: UUID? = null
     ): ResponseEntity<List<Parentship>> {
         Audit.ParentShipsRead.log(targetId = listOf(headOfChildId, childId))
-        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(
+            UserRole.ADMIN,
+            UserRole.SERVICE_WORKER,
+            UserRole.UNIT_SUPERVISOR,
+            UserRole.FINANCE_ADMIN
+        )
 
         return db.read {
             it.handle.getParentships(
@@ -73,7 +83,11 @@ class ParentshipController(
     }
 
     @GetMapping("/{id}")
-    fun getParentship(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Parentship> {
+    fun getParentship(
+        db: Database.Connection,
+        user: AuthenticatedUser,
+        @PathVariable(value = "id") id: UUID
+    ): ResponseEntity<Parentship> {
         Audit.ParentShipsRead.log(targetId = id)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
@@ -92,7 +106,12 @@ class ParentshipController(
         @RequestBody body: ParentshipUpdateRequest
     ): ResponseEntity<Parentship> {
         Audit.ParentShipsUpdate.log(targetId = id)
-        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(
+            UserRole.ADMIN,
+            UserRole.SERVICE_WORKER,
+            UserRole.UNIT_SUPERVISOR,
+            UserRole.FINANCE_ADMIN
+        )
 
         return db.transaction {
             parentshipService.updateParentshipDuration(it, id, body.startDate, body.endDate)
@@ -108,7 +127,12 @@ class ParentshipController(
         @PathVariable(value = "id") parentshipId: UUID
     ): ResponseEntity<Unit> {
         Audit.ParentShipsRetry.log(targetId = parentshipId)
-        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(
+            UserRole.ADMIN,
+            UserRole.SERVICE_WORKER,
+            UserRole.UNIT_SUPERVISOR,
+            UserRole.FINANCE_ADMIN
+        )
 
         db.transaction { parentshipService.retryParentship(it, parentshipId) }
         asyncJobRunner.scheduleImmediateRun()
@@ -116,9 +140,13 @@ class ParentshipController(
     }
 
     @DeleteMapping("/{id}")
-    fun deleteParentship(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Unit> {
+    fun deleteParentship(
+        db: Database.Connection,
+        user: AuthenticatedUser,
+        @PathVariable(value = "id") id: UUID
+    ): ResponseEntity<Unit> {
         Audit.ParentShipsDelete.log(targetId = id)
-        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
 
         db.transaction { parentshipService.deleteParentship(it, id) }
         asyncJobRunner.scheduleImmediateRun()


### PR DESCRIPTION
#### Summary

If there is a parentship relation created, removing it should not be
done on light terms. This change will restrict unit supervisors from
removing created parentship relation. If there is a need to remove this
relation, it should be done by either `ADMIN` or `FINANCE_ADMIN` (given
they know whether the change on parentship will have an effect on the
fee decisions).

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

