### PR TITLE
Remove an unnecessary alert box from citizen-frontend

### DIFF
--- a/frontend/packages/citizen-frontend/src/applications/editor/contact-info/GuardianSubSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/contact-info/GuardianSubSection.tsx
@@ -13,7 +13,6 @@ import { H3, Label } from '@evaka/lib-components/src/typography'
 import InputField from '@evaka/lib-components/src/atoms/form/InputField'
 import { Gap } from '@evaka/lib-components/src/white-space'
 import { errorToInputInfo } from '~form-validation'
-import { AlertBox } from '@evaka/lib-components/src/molecules/MessageBoxes'
 import DatePicker from '@evaka/lib-components/src/molecules/date-picker/DatePicker'
 import AdaptiveFlex from '@evaka/lib-components/src/layout/AdaptiveFlex'
 import { ContactInfoSectionProps } from '~applications/editor/contact-info/ContactInfoSection'
@@ -147,12 +146,6 @@ export default React.memo(function GuardianSubSection({
               )}
               hideErrorsBeforeTouched={!verificationRequested}
             />
-            {verificationRequested && errors.guardianMoveDate && (
-              <AlertBox
-                thin
-                message={t.validationErrors[errors.guardianMoveDate]}
-              />
-            )}
           </FixedSpaceColumn>
           <Gap size={'s'} />
           <FixedSpaceRow spacing={'XL'}>


### PR DESCRIPTION
Now that DatePicker supports alerts, this box doesn't look great. Let's remove it.

![image](https://user-images.githubusercontent.com/18037297/108198676-97888500-7124-11eb-848c-0050466ec64b.png)
