### PR TITLE
Proxy: redirect non-file citizen URLs to index.html

### DIFF
--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -232,7 +232,7 @@ server {
 
     rewrite     /employee/mobile/(.*) /employee/mobile/index.html break;
     rewrite     /employee/(.*) /employee/index.html break;
-    rewrite     /application/(.*) /application/index.html break;
+    rewrite     /citizen/(.*) /citizen/index.html break;
     proxy_pass  $staticEndpoint;
   }
 


### PR DESCRIPTION
#### Summary
- Missed config update when swapped from enduser-frontend to citizen-frontend being the root route
- The flow goes: "/decisions" request -> "location /" matches, rewrites to "/citizen/decisions" -> static handler fails to find file -> static error handler rewrites to "/citizen/index.html"

#### Testing
1. Go to https://evaka.test.espoon-voltti.fi/decisions -> 404
1. Wait for CI to deploy to dev
2. Open https://evaka.dev.espoon-voltti.fi/decisions -> redirects correctly

Compose's proxy is a bit different due to the mounting vs. S3 proxying difference so can't really be tested against it.