### PR TITLE
[EVAKA-4115] Map page E2E tests

### DIFF
--- a/frontend/e2e-test/.testcaferc.json
+++ b/frontend/e2e-test/.testcaferc.json
@@ -6,5 +6,6 @@
       "output": "test-results/junit.xml"
     }
   ],
-  "tsConfigPath": "./tsconfig.json"
+  "tsConfigPath": "./tsconfig.json",
+  "clientScripts": "./injected.js"
 }

--- a/frontend/e2e-test/injected.js
+++ b/frontend/e2e-test/injected.js
@@ -1,0 +1,1 @@
+window.evakaAutomatedTest = true

--- a/frontend/e2e-test/test/e2e/dev-api/fixtures.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/fixtures.ts
@@ -106,7 +106,11 @@ export const daycareFixture: Daycare = {
   decisionHandler: 'Käsittelijä',
   decisionHandlerAddress: 'Käsittelijän osoite',
   providerType: 'MUNICIPAL',
-  roundTheClock: true
+  roundTheClock: true,
+  location: {
+    lat: 60.20377343765089,
+    lon: 24.655715743526994
+  }
 }
 
 export const daycare2Fixture: Daycare = {
@@ -123,7 +127,11 @@ export const daycare2Fixture: Daycare = {
   decisionHandler: 'Käsittelijä 2',
   decisionHandlerAddress: 'Käsittelijän 2 osoite',
   providerType: 'MUNICIPAL',
-  roundTheClock: true
+  roundTheClock: true,
+  location: {
+    lat: 60.20350901607783,
+    lon: 24.65379611887424
+  }
 }
 
 export const preschoolFixture: Daycare = {
@@ -140,7 +148,11 @@ export const preschoolFixture: Daycare = {
   decisionHandler: 'Käsittelijä',
   decisionHandlerAddress: 'Käsittelijän osoite',
   providerType: 'MUNICIPAL',
-  roundTheClock: true
+  roundTheClock: true,
+  location: {
+    lat: 60.2040261560435,
+    lon: 24.65517745652623
+  }
 }
 
 export const enduserGuardianFixture: ApplicationPersonDetail = {

--- a/frontend/e2e-test/test/e2e/dev-api/index.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/index.ts
@@ -755,3 +755,29 @@ export async function getApplication(
     throw new DevApiError(e)
   }
 }
+
+interface DigitransitAutocomplete {
+  features: DigitransitFeature[]
+}
+
+export interface DigitransitFeature {
+  geometry: {
+    coordinates: [number, number]
+  }
+  properties: {
+    name: string
+    postalcode?: string
+    locality?: string
+    localadmin?: string
+  }
+}
+
+export async function putDigitransitAutocomplete(
+  mockResponse: DigitransitAutocomplete
+): Promise<void> {
+  try {
+    await devClient.put('/digitransit/autocomplete', mockResponse)
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}

--- a/frontend/e2e-test/test/e2e/dev-api/index.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/index.ts
@@ -201,7 +201,9 @@ export async function insertDaycareFixtures(fixture: Daycare[]): Promise<void> {
         preschoolApplyPeriod: it.preschoolApplyPeriod,
         clubApplyPeriod: it.clubApplyPeriod,
         providerType: it.providerType,
-        roundTheClock: it.roundTheClock
+        roundTheClock: it.roundTheClock,
+        location: it.location,
+        language: it.language
       }))
     )
   } catch (e) {

--- a/frontend/e2e-test/test/e2e/dev-api/types.ts
+++ b/frontend/e2e-test/test/e2e/dev-api/types.ts
@@ -15,6 +15,13 @@ type ISODate = string
 type Timestamp = string
 export type FeeDecisionStatus = 'DRAFT' | 'SENT'
 
+export type Language = 'fi' | 'sv' | 'en'
+
+export interface Coordinate {
+  lat: number
+  lon: number
+}
+
 export interface FeeDecision {
   id: UUID
   status: FeeDecisionStatus
@@ -208,6 +215,8 @@ export interface Daycare {
     | 'PRIVATE'
     | 'PRIVATE_SERVICE_VOUCHER'
   roundTheClock: boolean
+  language?: Language
+  location?: Coordinate | null
 }
 
 export interface DaycareGroup {

--- a/frontend/e2e-test/test/e2e/pages/citizen/citizen-map.ts
+++ b/frontend/e2e-test/test/e2e/pages/citizen/citizen-map.ts
@@ -19,10 +19,6 @@ export default class CitizenMapPage {
 
   readonly map = new Map(Selector('[data-qa="map-view"]'))
 
-  async setLanguageFilters(selected: { fi: boolean; sv: boolean }) {
-    await this.setLanguageFilter('fi', selected.fi)
-    await this.setLanguageFilter('sv', selected.sv)
-  }
   async setLanguageFilter(language: 'fi' | 'sv', selected: boolean) {
     const chip = new SelectionChip(
       Selector(`[data-qa="map-filter-${language}"]`)

--- a/frontend/e2e-test/test/e2e/pages/citizen/citizen-map.ts
+++ b/frontend/e2e-test/test/e2e/pages/citizen/citizen-map.ts
@@ -18,6 +18,11 @@ export default class CitizenMapPage {
   )
 
   readonly map = new Map(Selector('[data-qa="map-view"]'))
+  readonly searchInput = new MapSearchInput(
+    Selector('[data-qa="map-search-input"]')
+  )
+
+  readonly addressMarker = Selector('[data-qa="map-marker-address"]')
 
   async setLanguageFilter(language: 'fi' | 'sv', selected: boolean) {
     const chip = new SelectionChip(
@@ -28,15 +33,15 @@ export default class CitizenMapPage {
     }
   }
 
-  unitListItem(daycare: Daycare): Selector {
+  listItemFor(daycare: Daycare): Selector {
     return Selector(`[data-qa="map-unit-list-${daycare.id}"]`)
   }
 
-  unitMapMarker(daycare: Daycare): Selector {
+  mapMarkerFor(daycare: Daycare): Selector {
     return Selector(`[data-qa="map-marker-${daycare.id}"]`)
   }
 
-  unitMapPopup(daycare: Daycare): MapPopup {
+  mapPopupFor(daycare: Daycare): MapPopup {
     return new MapPopup(Selector(`[data-qa="map-popup-${daycare.id}"]`))
   }
 }
@@ -95,5 +100,31 @@ class MapPopup {
 
   get name(): Promise<string> {
     return this._name.textContent
+  }
+}
+
+class MapSearchInput {
+  private readonly _input: Selector
+  constructor(private readonly selector: Selector) {
+    this._input = selector.find('input')
+  }
+
+  async typeText(text: string) {
+    await t.expect(this._input.exists).ok()
+    await t.click(this.selector)
+    const keys = text.split('').join(' ')
+    await t.pressKey(keys)
+  }
+
+  async clickUnitResult(daycare: Daycare) {
+    await t.click(this.selector.find(`[data-qa="map-search-${daycare.id}"]`))
+  }
+
+  async clickAddressResult(streetAddress: string) {
+    await t.click(
+      this.selector.find(
+        `[data-qa="map-search-address"][data-address="${streetAddress}"]`
+      )
+    )
   }
 }

--- a/frontend/e2e-test/test/e2e/pages/citizen/citizen-map.ts
+++ b/frontend/e2e-test/test/e2e/pages/citizen/citizen-map.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Selector } from 'testcafe'
+import { Daycare } from '../../dev-api/types'
+import { SelectionChip } from '../../utils/helpers'
+
+export default class CitizenMapPage {
+  readonly mapView = Selector('[data-qa="map-view"]')
+
+  readonly daycareFilter = Selector('[data-qa="map-filter-daycare"]')
+  readonly preschoolFilter = Selector('[data-qa="map-filter-preschool"]')
+  readonly clubFilter = Selector('[data-qa="map-filter-club"]')
+
+  async setLanguageFilters(selected: { fi: boolean; sv: boolean }) {
+    await this.setLanguageFilter('fi', selected.fi)
+    await this.setLanguageFilter('sv', selected.sv)
+  }
+  async setLanguageFilter(language: 'fi' | 'sv', selected: boolean) {
+    const chip = new SelectionChip(
+      Selector(`[data-qa="map-filter-${language}"]`)
+    )
+    if ((await chip.selected) !== selected) {
+      await chip.click()
+    }
+  }
+
+  unitListItem(daycare: Daycare): Selector {
+    return Selector(`[data-qa="map-unit-list-${daycare.id}"]`)
+  }
+
+  unitMapMarker(daycare: Daycare): Selector {
+    return Selector(`[data-qa="map-marker-${daycare.id}"]`)
+  }
+}

--- a/frontend/e2e-test/test/e2e/pages/citizen/citizen-map.ts
+++ b/frontend/e2e-test/test/e2e/pages/citizen/citizen-map.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Selector } from 'testcafe'
+import { Selector, t } from 'testcafe'
 import { Daycare } from '../../dev-api/types'
 import { SelectionChip } from '../../utils/helpers'
 
@@ -12,6 +12,12 @@ export default class CitizenMapPage {
   readonly daycareFilter = Selector('[data-qa="map-filter-daycare"]')
   readonly preschoolFilter = Selector('[data-qa="map-filter-preschool"]')
   readonly clubFilter = Selector('[data-qa="map-filter-club"]')
+
+  readonly unitDetailsPanel = new UnitDetailsPanel(
+    Selector('[data-qa="map-unit-details"]')
+  )
+
+  readonly map = new Map(Selector('[data-qa="map-view"]'))
 
   async setLanguageFilters(selected: { fi: boolean; sv: boolean }) {
     await this.setLanguageFilter('fi', selected.fi)
@@ -32,5 +38,66 @@ export default class CitizenMapPage {
 
   unitMapMarker(daycare: Daycare): Selector {
     return Selector(`[data-qa="map-marker-${daycare.id}"]`)
+  }
+
+  unitMapPopup(daycare: Daycare): MapPopup {
+    return new MapPopup(Selector(`[data-qa="map-popup-${daycare.id}"]`))
+  }
+}
+
+class UnitDetailsPanel {
+  private readonly _name: Selector
+  readonly backButton: Selector
+  constructor(private readonly selector: Selector) {
+    this._name = selector.find('[data-qa="map-unit-details-name"]')
+    this.backButton = selector.find('[data-qa="map-unit-details-back"]')
+  }
+
+  get exists(): Promise<boolean> {
+    return this.selector.exists
+  }
+
+  get name(): Promise<string> {
+    return this._name.textContent
+  }
+}
+
+class Map {
+  static readonly MAX_ZOOM_ATTEMPTS = 20
+  private readonly _zoomIn: Selector
+
+  constructor(readonly selector: Selector) {
+    this._zoomIn = selector.find('.leaflet-control-zoom-in')
+  }
+
+  get zoomInDisabled(): Promise<boolean> {
+    return this._zoomIn.hasClass('leaflet-disabled')
+  }
+
+  async zoomInFully() {
+    let attempts = 0
+    while (attempts < Map.MAX_ZOOM_ATTEMPTS) {
+      if (await this.zoomInDisabled) {
+        return
+      }
+      await t.click(this._zoomIn)
+      attempts++
+    }
+    throw new Error(`Failed to zoom in after ${attempts} attempts`)
+  }
+}
+
+class MapPopup {
+  private readonly _name: Selector
+  constructor(private readonly selector: Selector) {
+    this._name = selector.find('[data-qa="map-popup-name"]')
+  }
+
+  get visible(): Promise<boolean> {
+    return this.selector.visible
+  }
+
+  get name(): Promise<string> {
+    return this._name.textContent
   }
 }

--- a/frontend/e2e-test/test/e2e/specs/0_citizen/citizen-map.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/0_citizen/citizen-map.spec.ts
@@ -65,17 +65,15 @@ test('Unit type filter affects the unit list', async (t) => {
 
 test('Unit language filter affects the unit list', async (t) => {
   await t.expect(mapPage.daycareFilter.find('input').checked).ok()
-
-  await mapPage.setLanguageFilters({ fi: false, sv: false })
   await t.expect(mapPage.unitListItem(daycare2Fixture).exists).ok()
   await t.expect(mapPage.unitListItem(swedishDaycare).exists).ok()
 
   await mapPage.setLanguageFilter('fi', true)
-  await t.debug()
   await t.expect(mapPage.unitListItem(swedishDaycare).exists).notOk()
   await t.expect(mapPage.unitListItem(daycare2Fixture).exists).ok()
 
-  await mapPage.setLanguageFilters({ fi: false, sv: true })
+  await mapPage.setLanguageFilter('sv', true)
+  await mapPage.setLanguageFilter('fi', false)
   await t.expect(mapPage.unitListItem(swedishDaycare).exists).ok()
   await t.expect(mapPage.unitListItem(daycare2Fixture).exists).notOk()
 })

--- a/frontend/e2e-test/test/e2e/specs/0_citizen/citizen-map.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/0_citizen/citizen-map.spec.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { logConsoleMessages } from '../../utils/fixture'
+import {
+  careAreaFixture,
+  clubFixture,
+  daycare2Fixture,
+  Fixture,
+  preschoolFixture
+} from '../../dev-api/fixtures'
+import config from '../../config'
+import CitizenMapPage from '../../pages/citizen/citizen-map'
+import { Daycare } from '../../dev-api/types'
+
+const mapPage = new CitizenMapPage()
+
+const swedishDaycare: Daycare = {
+  ...daycare2Fixture,
+  name: 'Svart hål svenska daghem',
+  id: '9db9e8f7-2091-4be1-b091-fe107906e1b9',
+  language: 'sv'
+}
+
+fixture('Citizen map page')
+  .meta({ type: 'regression', subType: 'citizen-map' })
+  .before(async () => {
+    const careArea = await Fixture.careArea().with(careAreaFixture).save()
+    await Fixture.daycare().with(clubFixture).careArea(careArea).save()
+    await Fixture.daycare().with(daycare2Fixture).careArea(careArea).save()
+    await Fixture.daycare().with(preschoolFixture).careArea(careArea).save()
+    await Fixture.daycare().with(swedishDaycare).careArea(careArea).save()
+  })
+  .beforeEach(async (t) => {
+    await t.navigateTo(config.enduserUrl)
+    await t.click('[data-qa="nav-map"]')
+    await t.expect(mapPage.mapView.visible).ok()
+  })
+  .afterEach(logConsoleMessages)
+  .after(async () => {
+    await Fixture.cleanup()
+  })
+
+test('Unit type filter affects the unit list', async (t) => {
+  await t.expect(mapPage.daycareFilter.find('input').checked).ok()
+  await t.expect(mapPage.unitListItem(daycare2Fixture).exists).ok()
+  await t.expect(mapPage.unitListItem(clubFixture).exists).notOk()
+  await t.expect(mapPage.unitListItem(preschoolFixture).exists).ok()
+
+  await t.click(mapPage.clubFilter)
+  await t.expect(mapPage.unitListItem(clubFixture).exists).ok()
+  await t.expect(mapPage.unitListItem(daycare2Fixture).exists).notOk()
+  await t.expect(mapPage.unitListItem(preschoolFixture).exists).notOk()
+
+  await t.click(mapPage.preschoolFilter)
+  await t.expect(mapPage.unitListItem(clubFixture).exists).notOk()
+  await t.expect(mapPage.unitListItem(preschoolFixture).exists).ok()
+  await t.expect(mapPage.unitListItem(daycare2Fixture).exists).notOk()
+})
+
+test('Unit language filter affects the unit list', async (t) => {
+  await t.expect(mapPage.daycareFilter.find('input').checked).ok()
+
+  await mapPage.setLanguageFilters({ fi: false, sv: false })
+  await t.expect(mapPage.unitListItem(daycare2Fixture).exists).ok()
+  await t.expect(mapPage.unitListItem(swedishDaycare).exists).ok()
+
+  await mapPage.setLanguageFilter('fi', true)
+  await t.debug()
+  await t.expect(mapPage.unitListItem(swedishDaycare).exists).notOk()
+  await t.expect(mapPage.unitListItem(daycare2Fixture).exists).ok()
+
+  await mapPage.setLanguageFilters({ fi: false, sv: true })
+  await t.expect(mapPage.unitListItem(swedishDaycare).exists).ok()
+  await t.expect(mapPage.unitListItem(daycare2Fixture).exists).notOk()
+})

--- a/frontend/e2e-test/test/e2e/specs/0_citizen/citizen-map.spec.ts
+++ b/frontend/e2e-test/test/e2e/specs/0_citizen/citizen-map.spec.ts
@@ -20,7 +20,11 @@ const swedishDaycare: Daycare = {
   ...daycare2Fixture,
   name: 'Svart hål svenska daghem',
   id: '9db9e8f7-2091-4be1-b091-fe107906e1b9',
-  language: 'sv'
+  language: 'sv',
+  location: {
+    lat: 60.200745762705296,
+    lon: 24.785286409387005
+  }
 }
 
 fixture('Citizen map page')
@@ -74,4 +78,31 @@ test('Unit language filter affects the unit list', async (t) => {
   await mapPage.setLanguageFilters({ fi: false, sv: true })
   await t.expect(mapPage.unitListItem(swedishDaycare).exists).ok()
   await t.expect(mapPage.unitListItem(daycare2Fixture).exists).notOk()
+})
+
+test('Unit details can be viewed by clicking a list item', async (t) => {
+  await t.click(mapPage.unitListItem(daycare2Fixture))
+  await t.expect(mapPage.unitDetailsPanel.exists).ok()
+  await t.expect(mapPage.unitDetailsPanel.name).eql(daycare2Fixture.name)
+
+  await t.click(mapPage.unitDetailsPanel.backButton())
+  await t.click(mapPage.unitListItem(swedishDaycare))
+
+  await t.expect(mapPage.unitDetailsPanel.name).eql(swedishDaycare.name)
+})
+
+test('Viewing unit details automatically pans the map to the right marker', async (t) => {
+  const daycare2Marker = mapPage.unitMapMarker(daycare2Fixture)
+  const swedishMarker = mapPage.unitMapMarker(swedishDaycare)
+
+  // Zoom in fully to make sure we start without either marker visible.
+  await mapPage.map.zoomInFully()
+  await t.expect(daycare2Marker.visible).ok()
+
+  await t.click(mapPage.unitListItem(daycare2Fixture))
+  await t.expect(daycare2Marker.visible).ok()
+
+  await t.click(mapPage.unitDetailsPanel.backButton())
+  await t.click(mapPage.unitListItem(swedishDaycare))
+  await t.expect(swedishMarker.visible).ok()
 })

--- a/frontend/e2e-test/test/e2e/utils/helpers.ts
+++ b/frontend/e2e-test/test/e2e/utils/helpers.ts
@@ -54,6 +54,28 @@ export class Checkbox {
   }
 }
 
+export class SelectionChip {
+  private _input: Selector
+
+  constructor(private readonly selector: Selector) {
+    this._input = selector.find('input')
+  }
+
+  async click(): Promise<void> {
+    await scrollTo(0, (await this.selector.boundingClientRect).bottom)
+    await testcafe.t.click(this.selector)
+  }
+
+  get selected(): Promise<boolean> {
+    // cast needed because checked is Promise<boolean | undefined>
+    return (this._input.checked as unknown) as Promise<boolean>
+  }
+
+  get exists(): Promise<boolean> {
+    return this.selector.exists
+  }
+}
+
 export const selectFirstOption = async (
   container: Selector,
   searchString: string

--- a/frontend/packages/citizen-frontend/src/map/MapView.tsx
+++ b/frontend/packages/citizen-frontend/src/map/MapView.tsx
@@ -89,7 +89,7 @@ export default React.memo(function MapView() {
   }, [selectedAddress, filteredUnits])
 
   return (
-    <FullScreen>
+    <FullScreen data-qa="map-view">
       <FlexContainer
         className={`mobile-mode-${mobileMode}`}
         breakpoint={mapViewBreakpoint}

--- a/frontend/packages/citizen-frontend/src/map/SearchInput.tsx
+++ b/frontend/packages/citizen-frontend/src/map/SearchInput.tsx
@@ -83,7 +83,7 @@ export default React.memo(function SearchInput({
   }
 
   return (
-    <div>
+    <div data-qa="map-search-input">
       <ReactSelect
         isSearchable
         isClearable
@@ -121,28 +121,27 @@ export default React.memo(function SearchInput({
         components={{
           Option: function Option({ innerRef, innerProps, ...props }) {
             const option = props.data as MapAddress
+            const addressLabel = [option.streetAddress, option.postOffice].join(
+              ', '
+            )
 
             return (
               <OptionWrapper
+                data-qa={
+                  option.unit
+                    ? `map-search-${option.unit.id}`
+                    : 'map-search-address'
+                }
+                data-address={option.streetAddress}
                 ref={innerRef}
                 {...innerProps}
-                key={
-                  option.unit?.id ??
-                  `${option.streetAddress}, ${option.postOffice}`
-                }
+                key={option.unit?.id ?? addressLabel}
                 className={classNames({ focused: props.isFocused })}
               >
                 <OptionContents
-                  label={
-                    option.unit?.name ??
-                    `${option.streetAddress}, ${option.postOffice}`
-                  }
-                  secondaryText={
-                    option.unit
-                      ? `${option.streetAddress}, ${option.postOffice}`
-                      : undefined
-                  }
-                  isUnit={option.unit !== undefined}
+                  label={option.unit?.name ?? addressLabel}
+                  secondaryText={option.unit ? addressLabel : undefined}
+                  isUnit={!!option.unit}
                 />
               </OptionWrapper>
             )

--- a/frontend/packages/citizen-frontend/src/map/SearchSection.tsx
+++ b/frontend/packages/citizen-frontend/src/map/SearchSection.tsx
@@ -86,16 +86,19 @@ export default React.memo(function SearchSection({
         <Label>{t.map.careType}</Label>
         <FixedSpaceFlexWrap>
           <Radio
+            dataQa="map-filter-daycare"
             checked={careType === 'DAYCARE'}
             label={t.map.careTypes.DAYCARE}
             onChange={() => setCareType('DAYCARE')}
           />
           <Radio
+            dataQa="map-filter-preschool"
             checked={careType === 'PRESCHOOL'}
             label={t.map.careTypes.PRESCHOOL}
             onChange={() => setCareType('PRESCHOOL')}
           />
           <Radio
+            dataQa="map-filter-club"
             checked={careType === 'CLUB'}
             label={t.map.careTypes.CLUB}
             onChange={() => setCareType('CLUB')}
@@ -109,6 +112,7 @@ export default React.memo(function SearchSection({
         <Label>{t.map.language}</Label>
         <FixedSpaceRow>
           <SelectionChip
+            data-qa="map-filter-fi"
             text={t.common.unit.languagesShort.fi}
             selected={languages.includes('fi')}
             onChange={(selected) => {
@@ -118,6 +122,7 @@ export default React.memo(function SearchSection({
             }}
           />
           <SelectionChip
+            data-qa="map-filter-sv"
             text={t.common.unit.languagesShort.sv}
             selected={languages.includes('sv')}
             onChange={(selected) => {

--- a/frontend/packages/citizen-frontend/src/map/UnitDetailsPanel.tsx
+++ b/frontend/packages/citizen-frontend/src/map/UnitDetailsPanel.tsx
@@ -95,16 +95,17 @@ export default React.memo(function UnitDetailsPanel({
   const routeLink = getRouteLink()
 
   return (
-    <Wrapper>
+    <Wrapper data-qa="map-unit-details">
       <Area opaque>
         <Gap size="s" />
         <InlineButton
+          dataQa="map-unit-details-back"
           text={'Takaisin hakuun'}
           icon={faArrowLeft}
           onClick={onClose}
         />
         <Gap size="s" />
-        <H2>{unit.name}</H2>
+        <H2 data-qa="map-unit-details-name">{unit.name}</H2>
 
         {selectedAddress && distance && distance.isLoading ? null : (
           <>

--- a/frontend/packages/citizen-frontend/src/map/UnitListItem.tsx
+++ b/frontend/packages/citizen-frontend/src/map/UnitListItem.tsx
@@ -22,7 +22,7 @@ export default React.memo(function UnitListItem({
   const provider = t.common.unit.providerTypes[unit.providerType].toLowerCase()
 
   return (
-    <Wrapper onClick={onClick}>
+    <Wrapper onClick={onClick} data-qa={`map-unit-list-${unit.id}`}>
       <MainRow>
         <UnitName>{unit.name}</UnitName>
         {distance !== null && <Distance>{distance}</Distance>}

--- a/frontend/packages/citizen-frontend/webpack.config.js
+++ b/frontend/packages/citizen-frontend/webpack.config.js
@@ -122,6 +122,9 @@ module.exports = function (env, argv) {
       proxy: {
         '/api/application': {
           target: process.env.API_PROXY_URL || 'http://localhost:3010'
+        },
+        '/api/internal': {
+          target: process.env.API_PROXY_URL || 'http://localhost:3020'
         }
       },
       watchOptions: {

--- a/frontend/packages/lib-common/src/utils/helpers.ts
+++ b/frontend/packages/lib-common/src/utils/helpers.ts
@@ -25,3 +25,5 @@ export const getEnvironment = (): string => {
 export const isProduction = (): boolean => {
   return getEnvironment() === 'prod'
 }
+
+export const isAutomatedTest = 'evakaAutomatedTest' in window

--- a/frontend/packages/lib-components/src/atoms/Chip.tsx
+++ b/frontend/packages/lib-components/src/atoms/Chip.tsx
@@ -37,17 +37,19 @@ type SelectionChipProps = {
   text: string
   selected: boolean
   onChange: (selected: boolean) => void
+  'data-qa'?: string
 }
 
 export const SelectionChip = React.memo(function SelectionChip({
   text,
   selected,
-  onChange
+  onChange,
+  'data-qa': dataQa
 }: SelectionChipProps) {
   const ariaId = Math.random().toString(36).substring(2, 15)
 
   return (
-    <div>
+    <div data-qa={dataQa}>
       <SelectionChipWrapper
         onClick={(e) => {
           e.preventDefault()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/MockDigitransit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/MockDigitransit.kt
@@ -1,0 +1,30 @@
+package fi.espoo.evaka.shared.dev
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+class MockDigitransit {
+    private val lock = ReentrantReadWriteLock()
+    private var mockAutocomplete: Autocomplete = Autocomplete(emptyList())
+
+    fun autocomplete(): Autocomplete = lock.read { mockAutocomplete }
+    fun setAutocomplete(mockResponse: Autocomplete) = lock.write { mockAutocomplete = mockResponse }
+
+    data class Autocomplete(val features: List<Feature>)
+
+    data class Feature(val geometry: Geometry, val properties: FeatureProperties)
+
+    data class Geometry(
+        @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+        val coordinates: Pair<Double, Double>
+    )
+
+    data class FeatureProperties(
+        val name: String,
+        val postalcode: String?,
+        val locality: String?,
+        val localadmin: String?
+    )
+}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

* add basic E2E tests for the map page. Not all functionality is tested
* add a flag for detecting frontend is running an E2E test
* digitransit API is replaced with static mock responses + configurable dev api. Using dev API to set the mock response guarantees the test data is local to the actual E2E test, instead of the test relying on some data in a completely different place