### PR TITLE
Minor Koski OID usage fixes

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
@@ -119,11 +119,11 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
                                 "vahvistus": {
                                     "päivä":"2020-05-29",
                                     "paikkakunta":{"koodiarvo":"049","koodistoUri":"kunta"},
-                                    "myöntäjäOrganisaatio":{"oid":"$defaultMunicipalOrganizerOid"},
+                                    "myöntäjäOrganisaatio":{"oid":"1.2.3.4.5"},
                                     "myöntäjäHenkilöt":[{
                                         "nimi":"Unit Manager",
                                         "titteli":{"fi":"Esiopetusyksikön johtaja"},
-                                        "organisaatio":{"oid":"1.2.3.4.5"}
+                                        "organisaatio":{"oid":"$defaultMunicipalOrganizerOid"}
                                     }]
                                 },
                                 "osasuoritukset": null
@@ -420,11 +420,11 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
                                     "vahvistus": {
                                         "päivä":"2019-05-31",
                                         "paikkakunta":{"koodiarvo":"049","koodistoUri":"kunta"},
-                                        "myöntäjäOrganisaatio":{"oid":"$defaultMunicipalOrganizerOid"},
+                                        "myöntäjäOrganisaatio":{"oid":"1.2.3.4.5"},
                                         "myöntäjäHenkilöt":[{
                                             "nimi":"Unit Manager",
                                             "titteli":{"fi":"Esiopetusyksikön johtaja"},
-                                            "organisaatio":{"oid":"1.2.3.4.5"}
+                                            "organisaatio":{"oid":"$defaultMunicipalOrganizerOid"}
                                         }]
                                     },
                                     "osasuoritukset": null
@@ -671,7 +671,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
                                         "koodistoUri": "kunta"
                                     },
                                     "myöntäjäOrganisaatio": {
-                                        "oid": "$defaultMunicipalOrganizerOid"
+                                        "oid": "1.2.3.4.5"
                                     },
                                     "myöntäjäHenkilöt": [
                                         {
@@ -680,7 +680,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
                                                 "fi": "Esiopetusyksikön johtaja"
                                             },
                                             "organisaatio": {
-                                                "oid": "1.2.3.4.5"
+                                                "oid": "$defaultMunicipalOrganizerOid"
                                             }
                                         }
                                     ]

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -71,7 +71,7 @@ class KoskiClient(
                 .authentication()
                 .basic(koskiUser, koskiSecret)
                 .header(Headers.ACCEPT, "application/json")
-                .header("Caller-Id", "${data.organizerOid}.espooevaka")
+                .header("Caller-Id", "${data.organizationOid}.espooevaka")
                 .jsonBody(payload)
                 .responseString()
 

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -247,12 +247,12 @@ data class KoskiActiveDataRaw(
     fun haeVahvistus(qualifiedDate: LocalDate) = Vahvistus(
         päivä = qualifiedDate,
         paikkakunta = VahvistusPaikkakunta(koodiarvo = VahvistusPaikkakuntaKoodi.ESPOO),
-        myöntäjäOrganisaatio = MyöntäjäOrganisaatio(oid = unit.ophOrganizerOid),
+        myöntäjäOrganisaatio = MyöntäjäOrganisaatio(oid = unit.ophOrganizationOid),
         myöntäjäHenkilöt = listOf(
             MyöntäjäHenkilö(
                 nimi = approverName,
                 titteli = MyöntäjäHenkilönTitteli(approverTitle),
-                organisaatio = MyöntäjäOrganisaatio(unit.ophOrganizationOid)
+                organisaatio = MyöntäjäOrganisaatio(unit.ophOrganizerOid)
             )
         )
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 data class KoskiData(
     val oppija: Oppija,
     val operation: KoskiOperation,
-    val organizerOid: String
+    val organizationOid: String
 )
 
 enum class KoskiOperation {
@@ -84,7 +84,7 @@ data class KoskiVoidedDataRaw(
             henkilö = child.toHenkilö(),
             opiskeluoikeudet = listOf(haeOpiskeluOikeus(sourceSystem))
         ),
-        organizerOid = unit.ophOrganizerOid,
+        organizationOid = unit.ophOrganizationOid,
         operation = KoskiOperation.VOID
     )
 
@@ -166,7 +166,7 @@ data class KoskiActiveDataRaw(
                 opiskeluoikeudet = listOf(haeOpiskeluoikeus(sourceSystem, today, qualifiedDate))
             ),
             operation = if (studyRightOid == null) KoskiOperation.CREATE else KoskiOperation.UPDATE,
-            organizerOid = unit.ophOrganizerOid
+            organizationOid = unit.ophOrganizationOid
         )
     }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Organization OID = "Espoo"
Organizer OID = "Espoo" or possibly "SomePrivateDaycareCompany Oy" (purchased/voucher)

:arrow_down: 

* use *organization* (not the *organizer*) as the "caller ID" when making Koski requests
* the manager of the preschool unit is working for the *organizer*, but the *organization* using eVaka confirms the studies -> swap OIDs in Koski data