### PR TITLE
Disable pending decision email sending for testing

### DIFF
--- a/service/src/integrationTest/resources/application-integration-test.yaml
+++ b/service/src/integrationTest/resources/application-integration-test.yaml
@@ -111,3 +111,5 @@ application:
     name:
       fi: Test email sender fi
       sv: Test email sender sv
+enable_pending_decision_email_sending: true
+

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -30,6 +30,7 @@ class PendingDecisionEmailService(
     }
 
     val fromAddress = env.getRequiredProperty("mail_reply_to_address")
+    val emailSendingEnabled = env.getProperty("enable_pending_decision_email_sending")?.let { it.toBoolean() } ?: false
 
     fun doSendPendingDecisionsEmail(db: Database, msg: SendPendingDecisionEmail) {
         logger.info("Sending pending decision reminder email to guardian ${msg.guardianId}")
@@ -103,15 +104,21 @@ GROUP BY application.guardian_id
         db.transaction { tx ->
             logger.info("Sending pending decision email to guardian ${pendingDecision.guardianId}")
 
-            val lang = getLanguage(pendingDecision.language)
-            emailClient.sendEmail(
-                "${pendingDecision.guardianId} - ${pendingDecision.decisionIds.joinToString { "-" }}",
-                pendingDecision.email,
-                fromAddress,
-                getSubject(lang),
-                getHtml(lang),
-                getText(lang)
-            )
+            if (emailSendingEnabled) {
+                val lang = getLanguage(pendingDecision.language)
+
+                emailClient.sendEmail(
+                    "${pendingDecision.guardianId} - ${pendingDecision.decisionIds.joinToString("-")}",
+                    pendingDecision.email,
+                    fromAddress,
+                    getSubject(lang),
+                    getHtml(lang),
+                    getText(lang)
+                )
+            } else {
+                // To do a dry run in production
+                logger.info("Would have sent pending decision email ${pendingDecision.guardianId} - ${pendingDecision.decisionIds.joinToString("-")}")
+            }
 
             // Mark as sent
             pendingDecision.decisionIds.forEach { decisionId ->

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -144,10 +144,12 @@ WHERE id = :id
     }
 
     private fun getSubject(language: Language): String {
+        val postfix = if (System.getenv("VOLTTI_ENV") == "staging") " [staging]" else ""
+
         return when (language) {
-            Language.en -> "Decision on early childhood education"
-            Language.sv -> "Beslut om förskoleundervisning"
-            else -> "Päätös varhaiskasvatuksesta"
+            Language.en -> "Decision on early childhood education$postfix"
+            Language.sv -> "Beslut om förskoleundervisning$postfix"
+            else -> "Päätös varhaiskasvatuksesta$postfix"
         }
     }
 


### PR DESCRIPTION
Disable pending decision email sending by default to allow production dry run testing

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

