### PR TITLE
Make map box shorter in mobile

### DIFF
--- a/frontend/packages/citizen-frontend/src/map/MapBox.tsx
+++ b/frontend/packages/citizen-frontend/src/map/MapBox.tsx
@@ -189,7 +189,7 @@ const Wrapper = styled.div`
   min-height: 500px;
 
   @media (max-width: ${mapViewBreakpoint}) {
-    height: calc(100vh - 80px);
+    height: calc(100vh - 120px);
     min-height: unset;
   }
 `


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Safari blocks all other content under address bar and navigation buttons which makes it impossible to scroll out. This should make the situation better even on tallest iphones.


