### PR TITLE
EVAKA-HOTFIX input text size

### DIFF
--- a/frontend/packages/lib-components/src/atoms/form/InputField.tsx
+++ b/frontend/packages/lib-components/src/atoms/form/InputField.tsx
@@ -55,7 +55,7 @@ const StyledInput = styled.input<StyledInputProps>`
   text-align: ${(p) => p.align ?? 'left'};
   background-color: ${colors.greyscale.white};
 
-  font-size: 15px;
+  font-size: 1rem;
   color: ${colors.greyscale.darkest};
   padding: 6px ${(p) => (p.clearable ? '36px' : '12px')} 6px 12px;
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Use `1rem` font size for inputs. This makes sure that inputs scale up with user's browser's font size and also disables automatic zooming on input focus on ios. Ios safari is automatically zoomed in on an input if its font size is smaller than `16px`.


