### PR TITLE
Allow non-string elements as labels for Radio

### DIFF
--- a/frontend/packages/citizen-frontend/src/decisions/decision-response-page/DecisionResponse.tsx
+++ b/frontend/packages/citizen-frontend/src/decisions/decision-response-page/DecisionResponse.tsx
@@ -148,37 +148,53 @@ export default React.memo(function DecisionResponse({
           <FixedSpaceColumn>
             <FixedSpaceRow alignItems="center" spacing="xs">
               <Radio
+                id={`${decision.id}-accept`}
                 checked={acceptChecked}
                 onChange={() => setAcceptChecked(true)}
                 name={`${decision.id}-accept`}
-                label={t.decisions.applicationDecisions.response.accept1}
+                label={
+                  <>
+                    {t.decisions.applicationDecisions.response.accept1}
+                    {['PRESCHOOL', 'PREPARATORY_EDUCATION'].includes(
+                      decisionType
+                    ) ? (
+                      <span>{startDate}</span>
+                    ) : (
+                      <span onClick={(e) => e.stopPropagation()}>
+                        <DatePicker
+                          date={requestedStartDate}
+                          onChange={(date: string) =>
+                            setRequestedStartDate(date)
+                          }
+                          isValidDate={(date: LocalDate) =>
+                            isValidDecisionStartDate(
+                              date,
+                              startDate,
+                              decisionType
+                            )
+                          }
+                          locale={lang}
+                          info={
+                            dateErrorMessage !== ''
+                              ? {
+                                  text: dateErrorMessage,
+                                  status: 'warning'
+                                }
+                              : undefined
+                          }
+                        />
+                      </span>
+                    )}
+                    {t.decisions.applicationDecisions.response.accept2}
+                  </>
+                }
+                ariaLabel={`${t.decisions.applicationDecisions.response.accept1} ${requestedStartDate} ${t.decisions.applicationDecisions.response.accept2}`}
                 disabled={blocked || submitting}
                 dataQa={'radio-accept'}
               />
-              {['PRESCHOOL', 'PREPARATORY_EDUCATION'].includes(decisionType) ? (
-                <span>{startDate}</span>
-              ) : (
-                <DatePicker
-                  date={requestedStartDate}
-                  onChange={(date: string) => setRequestedStartDate(date)}
-                  isValidDate={(date: LocalDate) =>
-                    isValidDecisionStartDate(date, startDate, decisionType)
-                  }
-                  locale={lang}
-                  info={
-                    dateErrorMessage !== ''
-                      ? {
-                          text: dateErrorMessage,
-                          status: 'warning'
-                        }
-                      : undefined
-                  }
-                />
-              )}
-
-              <div>{t.decisions.applicationDecisions.response.accept2}</div>
             </FixedSpaceRow>
             <Radio
+              id={`${decision.id}-reject`}
               checked={!acceptChecked}
               onChange={() => setAcceptChecked(false)}
               name={`${decision.id}-reject`}

--- a/frontend/packages/employee-frontend/src/components/common/Filters.tsx
+++ b/frontend/packages/employee-frontend/src/components/common/Filters.tsx
@@ -698,14 +698,17 @@ export function ApplicationTypeFilter({
             <Fragment key={id}>
               <Radio
                 key={id}
-                label={i18n.applications.types[id]}
-                labelIcon={
-                  <ApplicationOpenIcon
-                    icon={toggled === id ? faAngleUp : faAngleDown}
-                    size={'lg'}
-                    color={colors.greyscale.dark}
-                  />
+                label={
+                  <>
+                    {i18n.applications.types[id]}
+                    <ApplicationOpenIcon
+                      icon={toggled === id ? faAngleUp : faAngleDown}
+                      size={'lg'}
+                      color={colors.greyscale.dark}
+                    />
+                  </>
                 }
+                ariaLabel={i18n.applications.types[id]}
                 checked={toggled === id}
                 onChange={toggle(id)}
                 dataQa={`application-type-filter-${id}`}
@@ -791,16 +794,19 @@ export function ApplicationStatusFilter({
         {statuses.map((id: ApplicationSummaryStatusOptions) => (
           <Radio
             key={id}
-            label={i18n.application.statuses[id]}
-            labelIcon={
-              id === 'ALL' ? (
-                <ApplicationOpenIcon
-                  icon={toggled === id ? faAngleUp : faAngleDown}
-                  size={'lg'}
-                  color={colors.greyscale.dark}
-                />
-              ) : undefined
+            label={
+              <>
+                {i18n.application.statuses[id]}
+                {id === 'ALL' ? (
+                  <ApplicationOpenIcon
+                    icon={toggled === id ? faAngleUp : faAngleDown}
+                    size={'lg'}
+                    color={colors.greyscale.dark}
+                  />
+                ) : undefined}
+              </>
             }
+            ariaLabel={i18n.application.statuses[id]}
             checked={toggled === id}
             onChange={toggle(id)}
             dataQa={`application-status-filter-${id}`}

--- a/frontend/packages/lib-components/src/atoms/form/Radio.tsx
+++ b/frontend/packages/lib-components/src/atoms/form/Radio.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useRef } from 'react'
+import React, { ReactNode, useRef } from 'react'
 import styled from 'styled-components'
 import classNames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -92,30 +92,28 @@ const IconWrapper = styled.div<SizeProps>`
   color: ${colors.greyscale.white};
 `
 
-interface RadioProps extends BaseProps {
+type RadioProps = BaseProps & {
   checked: boolean
-  label: string
-  labelIcon?: JSX.Element
   onChange?: () => void
   name?: string
   disabled?: boolean
   small?: boolean
   id?: string
-}
+} & ({ label: string } | { label: ReactNode; ariaLabel: string })
 
 function Radio({
   checked,
-  label,
-  labelIcon,
   onChange,
   name,
   disabled,
   className,
   dataQa,
   small,
-  id
+  id,
+  ...props
 }: RadioProps) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const ariaLabel: string = 'ariaLabel' in props ? props.ariaLabel : props.label
 
   return (
     <Wrapper
@@ -131,7 +129,7 @@ function Radio({
           type="radio"
           checked={checked}
           name={name}
-          aria-label={label}
+          aria-label={ariaLabel}
           disabled={disabled}
           onChange={(e) => {
             e.stopPropagation()
@@ -146,8 +144,7 @@ function Radio({
           <FontAwesomeIcon icon={faCheck} />
         </IconWrapper>
       </Circle>
-      <label>{label}</label>
-      {labelIcon && labelIcon}
+      <label htmlFor={id}>{props.label}</label>
     </Wrapper>
   )
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
This enables using any kind of `ReactNode` as a label for a `Radio` component. Non string type elements require a separate aria label for accessibility. Main motivation is to fix the citizen decision accept radio option.

Before: 
<img width="350" alt="image" src="https://user-images.githubusercontent.com/4426547/108957200-bf726e00-7679-11eb-82e1-157c16218d1f.png">

After:
<img width="342" alt="image" src="https://user-images.githubusercontent.com/4426547/108957215-c4cfb880-7679-11eb-978c-8e34465bf252.png">


