### PR TITLE
EVAKA-4122 tweak income from application

### DIFF
--- a/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
+++ b/frontend/packages/employee-frontend/src/assets/i18n/fi.ts
@@ -920,6 +920,8 @@ export const fi = {
         name: 'Nimi',
         updated: 'Tulotiedot päivitetty',
         handler: 'Käsittelijä',
+        originApplication:
+          'Huoltaja on hakemuksella suostunut korkeimpaan maksuluokkaan',
         dateRange: 'Ajalle',
         effect: 'Maksun peruste',
         effectOptions: {

--- a/frontend/packages/employee-frontend/src/components/person-profile/income/IncomeItemBody.tsx
+++ b/frontend/packages/employee-frontend/src/components/person-profile/income/IncomeItemBody.tsx
@@ -38,7 +38,11 @@ const IncomeItemBody = React.memo(function IncomeItemBody({ income }: Props) {
         <Label>{i18n.personProfile.income.details.updated}</Label>
         <span>{formatDate(income.updatedAt)}</span>
         <Label>{i18n.personProfile.income.details.handler}</Label>
-        <span>{income.updatedBy}</span>
+        <span>
+          {income.applicationId
+            ? i18n.personProfile.income.details.originApplication
+            : income.updatedBy}
+        </span>
       </ListGrid>
       {income.effect === 'INCOME' ? (
         <>

--- a/frontend/packages/employee-frontend/src/types/income.ts
+++ b/frontend/packages/employee-frontend/src/types/income.ts
@@ -26,6 +26,7 @@ export interface Income extends PartialIncome {
   totalExpenses: number
   updatedAt: Date
   updatedBy: string
+  applicationId: UUID | null
 }
 
 export const deserializeIncome = (json: JsonOf<Income>): Income => ({

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -248,584 +248,6 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     }
 
     @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - new income has been created`() {
-        db.transaction { tx ->
-            // given
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read {
-            // then
-            val application = fetchApplicationDetails(it.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.MAX_FEE_ACCEPTED, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - existing overlapping indefinite income will be handled`() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val earlierIndefinite = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.of(2020, 8, 1).minusDays(10),
-                validTo = null
-            )
-            upsertIncome(tx.handle, mapper, earlierIndefinite, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read {
-            // then
-            val application = fetchApplicationDetails(it.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(2, incomes.size)
-            assertEquals(IncomeEffect.MAX_FEE_ACCEPTED, incomes.first().effect)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes[1].effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - existing overlapping income will be handled by not adding a new income for user`() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val earlierIncome = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.of(2020, 8, 1).minusDays(10),
-                validTo = LocalDate.of(2020, 8, 1).plusMonths(5)
-            )
-            upsertIncome(tx.handle, mapper, earlierIncome, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read {
-            // then
-            val application = fetchApplicationDetails(it.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - later indefinite income will be handled by not adding a new income`() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val laterIndefiniteIncome = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.of(2020, 8, 1).plusMonths(5),
-                validTo = null
-            )
-            upsertIncome(tx.handle, mapper, laterIndefiniteIncome, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read {
-            // then
-            val application = fetchApplicationDetails(it.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - earlier income does not affect creating a new income`() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val earlierIncome = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.of(2020, 8, 1).minusMonths(7),
-                validTo = LocalDate.of(2020, 8, 1).minusMonths(5)
-            )
-            upsertIncome(tx.handle, mapper, earlierIncome, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read {
-            // then
-            val application = fetchApplicationDetails(it.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(2, incomes.size)
-            assertEquals(IncomeEffect.MAX_FEE_ACCEPTED, incomes.first().effect)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes[1].effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - later income will be handled by not adding a new income`() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val laterIncome = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.of(2020, 8, 1).plusMonths(5),
-                validTo = LocalDate.of(2020, 8, 1).plusMonths(6)
-            )
-            upsertIncome(tx.handle, mapper, laterIncome, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read {
-            // then
-            val application = fetchApplicationDetails(it.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - if application does not have a preferred start date income will not be created`() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val earlierIndefinite = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.now().minusDays(10),
-                validTo = null
-            )
-            upsertIncome(tx.handle, mapper, earlierIndefinite, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                preferredStartDate = null,
-                applicationId = applicationId
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read {
-            // then
-            val application = fetchApplicationDetails(it.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists indefinite income for the same day `() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val sameDayIncomeIndefinite = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.now().plusMonths(4),
-                validTo = null
-            )
-            upsertIncome(tx.handle, mapper, sameDayIncomeIndefinite, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read { tx ->
-            // then
-            val application = fetchApplicationDetails(tx.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists income for the same day `() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val sameDayIncome = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.now().plusMonths(4),
-                validTo = LocalDate.now().plusMonths(5)
-            )
-            upsertIncome(tx.handle, mapper, sameDayIncome, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read { tx ->
-            // then
-            val application = fetchApplicationDetails(tx.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - new income will be created if there exists indefinite income for the same day - 1 `() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val dayBeforeIncomeIndefinite = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.of(2020, 8, 1).minusDays(1),
-                validTo = null
-            )
-            upsertIncome(tx.handle, mapper, dayBeforeIncomeIndefinite, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read { tx ->
-            // then
-            val application = fetchApplicationDetails(tx.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(2, incomes.size)
-            assertEquals(IncomeEffect.MAX_FEE_ACCEPTED, incomes.first().effect)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes[1].effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists indefinite income for the same day + 1 `() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val nextDayIncomeIndefinite = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.now().plusMonths(4).plusDays(1),
-                validTo = null
-            )
-            upsertIncome(tx.handle, mapper, nextDayIncomeIndefinite, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read { tx ->
-            // then
-            val application = fetchApplicationDetails(tx.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists income for the same day - 1 `() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val incomeDayBefore = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.now().plusMonths(4).minusDays(1),
-                validTo = LocalDate.now().plusMonths(5)
-            )
-            upsertIncome(tx.handle, mapper, incomeDayBefore, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read { tx ->
-            // then
-            val application = fetchApplicationDetails(tx.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists income that ends on the same day`() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val earlierIncomeEndingOnSameDay = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.now().minusMonths(4),
-                validTo = LocalDate.now().plusMonths(4)
-            )
-            upsertIncome(tx.handle, mapper, earlierIncomeEndingOnSameDay, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read { tx ->
-            // then
-            val application = fetchApplicationDetails(tx.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists income that ends on the same day + 1`() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val earlierIncomeEndingOnNextDay = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.now().minusMonths(4),
-                validTo = LocalDate.now().plusMonths(4).plusDays(1)
-            )
-            upsertIncome(tx.handle, mapper, earlierIncomeEndingOnNextDay, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read { tx ->
-            // then
-            val application = fetchApplicationDetails(tx.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(1, incomes.size)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
-        }
-    }
-
-    @Test
-    fun `moveToWaitingPlacement with maxFeeAccepted - no new income will be created if there exists income that ends on the same day - 1`() {
-        db.transaction { tx ->
-            // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
-            val earlierIncomeEndingOnDayBefore = Income(
-                id = UUID.randomUUID(),
-                data = mapOf(),
-                effect = IncomeEffect.NOT_AVAILABLE,
-                notes = "Income not available",
-                personId = testAdult_5.id,
-                validFrom = LocalDate.of(2020, 8, 1).minusMonths(4),
-                validTo = LocalDate.of(2020, 8, 1).minusDays(1)
-            )
-            upsertIncome(tx.handle, mapper, earlierIncomeEndingOnDayBefore, financeUser.id)
-            insertApplication(
-                tx.handle,
-                guardian = testAdult_5,
-                maxFeeAccepted = true,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1)
-            )
-            service.sendApplication(tx, serviceWorker, applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        }
-        db.read { tx ->
-            // then
-            val application = fetchApplicationDetails(tx.handle, applicationId)!!
-            assertEquals(true, application.form.maxFeeAccepted)
-            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
-            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
-            assertEquals(2, incomes.size)
-            assertEquals(IncomeEffect.MAX_FEE_ACCEPTED, incomes.first().effect)
-            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes[1].effect)
-        }
-    }
-
-    @Test
     fun `moveToWaitingPlacement - guardian contact details are updated`() {
         db.transaction { tx ->
             // given
@@ -1735,6 +1157,576 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 assertEquals(PlacementType.PRESCHOOL, type)
             }
         }
+
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.MAX_FEE_ACCEPTED, incomes.first().effect)
+        }
+    }
+    @Test
+    fun `accept preschool application with maxFeeAccepted - new income has been created`() {
+        db.transaction { tx ->
+            // given
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(1, incomes.size)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - existing overlapping indefinite income will be handled`() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val earlierIndefinite = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.of(2020, 8, 1).minusDays(10),
+                validTo = null
+            )
+            upsertIncome(tx.handle, mapper, earlierIndefinite, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
+            assertEquals(2, incomes.size)
+            assertEquals(IncomeEffect.MAX_FEE_ACCEPTED, incomes.first().effect)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes[1].effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - existing overlapping income will be handled by not adding a new income for user`() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val earlierIncome = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.of(2020, 8, 1).minusDays(10),
+                validTo = LocalDate.of(2020, 8, 1).plusMonths(5)
+            )
+            upsertIncome(tx.handle, mapper, earlierIncome, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - later indefinite income will be handled by not adding a new income`() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val laterIndefiniteIncome = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.of(2020, 8, 1).plusMonths(5),
+                validTo = null
+            )
+            upsertIncome(tx.handle, mapper, laterIndefiniteIncome, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - earlier income does not affect creating a new income`() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val earlierIncome = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.of(2020, 8, 1).minusMonths(7),
+                validTo = LocalDate.of(2020, 8, 1).minusMonths(5)
+            )
+            upsertIncome(tx.handle, mapper, earlierIncome, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(2, incomes.size)
+            assertEquals(IncomeEffect.MAX_FEE_ACCEPTED, incomes.first().effect)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes[1].effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - later income will be handled by not adding a new income`() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val laterIncome = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.of(2020, 8, 1).plusMonths(5),
+                validTo = LocalDate.of(2020, 8, 1).plusMonths(6)
+            )
+            upsertIncome(tx.handle, mapper, laterIncome, financeUser.id)
+            insertApplication(
+                tx.handle,
+                guardian = testAdult_5,
+                maxFeeAccepted = true,
+                applicationId = applicationId,
+                preferredStartDate = LocalDate.of(2020, 8, 1)
+            )
+            service.sendApplication(tx, serviceWorker, applicationId)
+        }
+        db.transaction { tx ->
+            // when
+            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+        }
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - if application does not have a preferred start date income will not be created`() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val earlierIndefinite = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.now().minusDays(10),
+                validTo = null
+            )
+            upsertIncome(tx.handle, mapper, earlierIndefinite, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx, preferredStartDate = null)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read {
+            // then
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(it.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists indefinite income for the same day `() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val sameDayIncomeIndefinite = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.now().plusMonths(4),
+                validTo = null
+            )
+            upsertIncome(tx.handle, mapper, sameDayIncomeIndefinite, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read { tx ->
+            // then
+            val application = fetchApplicationDetails(tx.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists income for the same day `() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val sameDayIncome = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.now().plusMonths(4),
+                validTo = LocalDate.now().plusMonths(5)
+            )
+            upsertIncome(tx.handle, mapper, sameDayIncome, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read { tx ->
+            // then
+            val application = fetchApplicationDetails(tx.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - new income will be created if there exists indefinite income for the same day - 1 `() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val dayBeforeIncomeIndefinite = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.of(2020, 8, 1).minusDays(1),
+                validTo = null
+            )
+            upsertIncome(tx.handle, mapper, dayBeforeIncomeIndefinite, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read { tx ->
+            // then
+            val application = fetchApplicationDetails(tx.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(2, incomes.size)
+            assertEquals(IncomeEffect.MAX_FEE_ACCEPTED, incomes.first().effect)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes[1].effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists indefinite income for the same day + 1 `() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val nextDayIncomeIndefinite = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.now().plusMonths(4).plusDays(1),
+                validTo = null
+            )
+            upsertIncome(tx.handle, mapper, nextDayIncomeIndefinite, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read { tx ->
+            // then
+            val application = fetchApplicationDetails(tx.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists income for the same day - 1 `() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val incomeDayBefore = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.now().plusMonths(4).minusDays(1),
+                validTo = LocalDate.now().plusMonths(5)
+            )
+            upsertIncome(tx.handle, mapper, incomeDayBefore, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read { tx ->
+            // then
+            val application = fetchApplicationDetails(tx.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists income that ends on the same day`() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val earlierIncomeEndingOnSameDay = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.now().minusMonths(4),
+                validTo = LocalDate.now().plusMonths(4)
+            )
+            upsertIncome(tx.handle, mapper, earlierIncomeEndingOnSameDay, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read { tx ->
+            // then
+            val application = fetchApplicationDetails(tx.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists income that ends on the same day + 1`() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val earlierIncomeEndingOnNextDay = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.now().minusMonths(4),
+                validTo = LocalDate.now().plusMonths(4).plusDays(1)
+            )
+            upsertIncome(tx.handle, mapper, earlierIncomeEndingOnNextDay, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read { tx ->
+            // then
+            val application = fetchApplicationDetails(tx.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(1, incomes.size)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes.first().effect)
+        }
+    }
+
+    @Test
+    fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists income that ends on the same day - 1`() {
+        db.transaction { tx ->
+            // given
+            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val earlierIncomeEndingOnDayBefore = Income(
+                id = UUID.randomUUID(),
+                data = mapOf(),
+                effect = IncomeEffect.NOT_AVAILABLE,
+                notes = "Income not available",
+                personId = testAdult_5.id,
+                validFrom = LocalDate.of(2020, 8, 1).minusMonths(4),
+                validTo = LocalDate.of(2020, 8, 1).minusDays(1)
+            )
+            upsertIncome(tx.handle, mapper, earlierIncomeEndingOnDayBefore, financeUser.id)
+            workflowForPreschoolDaycareDecisions(tx)
+        }
+        db.transaction { tx ->
+            // when
+            service.acceptDecision(
+                tx,
+                serviceWorker,
+                applicationId,
+                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                mainPeriod.start
+            )
+        }
+        db.read { tx ->
+            // then
+            val application = fetchApplicationDetails(tx.handle, applicationId)!!
+            assertEquals(true, application.form.maxFeeAccepted)
+            val incomes = getIncomesForPerson(tx.handle, mapper, testAdult_5.id)
+            assertEquals(ApplicationStatus.ACTIVE, application.status)
+            assertEquals(2, incomes.size)
+            assertEquals(IncomeEffect.MAX_FEE_ACCEPTED, incomes.first().effect)
+            assertEquals(IncomeEffect.NOT_AVAILABLE, incomes[1].effect)
+        }
     }
 
     @Test
@@ -1989,12 +1981,14 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     private fun getDecision(h: Handle, type: DecisionType): Decision =
         getDecisionsByApplication(h, applicationId, AclAuthorization.All).first { it.type == type }
 
-    private fun workflowForPreschoolDaycareDecisions(tx: Database.Transaction) {
+    private fun workflowForPreschoolDaycareDecisions(tx: Database.Transaction, preferredStartDate: LocalDate? = LocalDate.of(2020, 8, 1)) {
         insertApplication(
             tx.handle,
+            guardian = testAdult_5,
+            maxFeeAccepted = true,
             appliedType = PlacementType.PRESCHOOL_DAYCARE,
             applicationId = applicationId,
-            preferredStartDate = LocalDate.of(2020, 8, 1)
+            preferredStartDate = preferredStartDate
         )
         service.sendApplication(tx, serviceWorker, applicationId)
         service.moveToWaitingPlacement(tx, serviceWorker, applicationId)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -148,7 +148,6 @@ class ApplicationStateService(
         )
 
         setCheckedByAdminToDefault(tx.handle, applicationId, application.form)
-        if (application.form.maxFeeAccepted) setHighestFeeForUser(tx, application)
 
         asyncJobRunner.plan(tx, listOf(InitializeFamilyFromApplication(application.id, user)))
         updateApplicationStatus(tx.handle, application.id, WAITING_PLACEMENT)
@@ -365,6 +364,7 @@ class ApplicationStateService(
         placementPlanService.softDeleteUnusedPlacementPlanByApplication(tx, applicationId)
 
         if (application.status == WAITING_CONFIRMATION) {
+            if (application.form.maxFeeAccepted) setHighestFeeForUser(tx, application)
             updateApplicationStatus(tx.handle, application.id, ACTIVE)
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -364,7 +364,7 @@ class ApplicationStateService(
         placementPlanService.softDeleteUnusedPlacementPlanByApplication(tx, applicationId)
 
         if (application.status == WAITING_CONFIRMATION) {
-            if (application.form.maxFeeAccepted) setHighestFeeForUser(tx, application)
+            if (application.form.maxFeeAccepted) setHighestFeeForUser(tx, application, requestedStartDate)
             updateApplicationStatus(tx.handle, application.id, ACTIVE)
         }
     }
@@ -564,32 +564,31 @@ class ApplicationStateService(
     private fun livesInSameAddress(residenceCode1: String?, residenceCode2: String?): Boolean =
         !residenceCode1.isNullOrBlank() && !residenceCode2.isNullOrBlank() && residenceCode1 == residenceCode2
 
-    private fun setHighestFeeForUser(tx: Database.Transaction, application: ApplicationDetails) {
+    private fun setHighestFeeForUser(tx: Database.Transaction, application: ApplicationDetails, validFrom: LocalDate) {
         val incomes = getIncomesForPerson(tx.handle, mapper, application.guardianId)
-        val preferredStartDate = application.form.preferences.preferredStartDate
-        val preferredOrNow = preferredStartDate ?: LocalDate.now()
 
         val hasOverlappingDefiniteIncome = incomes.any { income ->
             income.validTo != null &&
-                DateRange(income.validFrom, income.validTo).overlaps(DateRange(preferredOrNow, null))
+                DateRange(income.validFrom, income.validTo).overlaps(DateRange(validFrom, null))
         }
 
         val hasLaterIncome = incomes.any { income ->
-            income.validFrom.plusDays(1).isAfter(preferredOrNow)
+            income.validFrom.plusDays(1).isAfter(validFrom)
         }
 
-        if (hasOverlappingDefiniteIncome || hasLaterIncome || preferredStartDate == null) {
-            logger.debug { "Could not add a new max fee accepted income when moving to WAITING_FOR_PLACEMENT state" }
+        if (hasOverlappingDefiniteIncome || hasLaterIncome) {
+            logger.debug { "Could not add a new max fee accepted income from application ${application.id}" }
         } else {
-            val period = DateRange(start = preferredOrNow, end = null)
+            val period = DateRange(start = validFrom, end = null)
             val validIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
                 effect = IncomeEffect.MAX_FEE_ACCEPTED,
                 notes = "created automatically from application",
                 personId = application.guardianId,
-                validFrom = preferredOrNow,
-                validTo = null
+                validFrom = validFrom,
+                validTo = null,
+                applicationId = application.id
             ).let(::validateIncome)
             splitEarlierIncome(tx.handle, validIncome.personId, period)
             upsertIncome(tx.handle, mapper, validIncome, application.guardianId)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
@@ -31,7 +31,8 @@ fun upsertIncome(h: Handle, mapper: ObjectMapper, income: Income, updatedBy: UUI
             valid_to,
             notes,
             updated_at,
-            updated_by
+            updated_by,
+            application_id
         ) VALUES (
             :id,
             :person_id,
@@ -43,7 +44,8 @@ fun upsertIncome(h: Handle, mapper: ObjectMapper, income: Income, updatedBy: UUI
             :valid_to,
             :notes,
             now(),
-            :updated_by
+            :updated_by,
+            :application_id
         ) ON CONFLICT (id) DO UPDATE SET
             effect = :effect,
             data = :data,
@@ -71,7 +73,8 @@ fun upsertIncome(h: Handle, mapper: ObjectMapper, income: Income, updatedBy: UUI
                 "valid_from" to income.validFrom,
                 "valid_to" to income.validTo,
                 "notes" to income.notes,
-                "updated_by" to updatedBy
+                "updated_by" to updatedBy,
+                "application_id" to income.applicationId
             )
         )
 
@@ -166,6 +169,7 @@ fun toIncome(objectMapper: ObjectMapper) = { rs: ResultSet, _: StatementContext 
         validTo = rs.getDate("valid_to")?.toLocalDate(),
         notes = rs.getString("notes"),
         updatedAt = rs.getTimestamp("updated_at").toInstant(),
-        updatedBy = (rs.getString("updated_by_employee"))
+        updatedBy = (rs.getString("updated_by_employee")),
+        applicationId = rs.getString("application_id")?.let { UUID.fromString(it) },
     )
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
@@ -24,7 +24,8 @@ data class Income(
     val validTo: LocalDate?,
     val notes: String,
     val updatedAt: Instant? = null,
-    val updatedBy: String? = null
+    val updatedBy: String? = null,
+    val applicationId: UUID? = null
 ) {
     @JsonProperty("totalIncome")
     fun totalIncome(): Int =

--- a/service/src/main/resources/db/migration/V42__income_references_application.sql
+++ b/service/src/main/resources/db/migration/V42__income_references_application.sql
@@ -1,0 +1,1 @@
+ALTER TABLE income ADD COLUMN application_id uuid REFERENCES application(id);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -39,3 +39,4 @@ V38__add_child_preferred_name.sql
 V39__add_unit_id_to_bulletin.sql
 V40__unit_id_in_bulletin_as_not_null.sql
 V41__daycare_daily_note_v2.sql
+V42__income_references_application.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Let `income` reference `application` when it originates from one. 
Show employee that income is created from application. 
Postpone income creation to the point where enduser accepts decision.  

<img width="980" alt="Screenshot 2021-02-24 at 12 20 12" src="https://user-images.githubusercontent.com/3275771/108986383-bb0a7d00-769a-11eb-81ab-9069a8be7688.png">
