### PR TITLE
Citizen: add basic CSS reset

### DIFF
--- a/frontend/packages/citizen-frontend/src/index.css
+++ b/frontend/packages/citizen-frontend/src/index.css
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2021 City of Espoo
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+body {
+  font-family: 'Open Sans', 'Arial', sans-serif;
+  background-color: #f5f5f5;
+  margin: 0;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+html {
+  box-sizing: border-box;
+  background-color: #f5f5f5;
+  font-size: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  text-rendering: optimizeLegibility;
+  text-size-adjust: 100%;
+}
+
+a {
+  color: #0050bb;
+  cursor: pointer;
+  text-decoration: none;
+}

--- a/frontend/packages/citizen-frontend/src/index.html
+++ b/frontend/packages/citizen-frontend/src/index.html
@@ -17,16 +17,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
       href="https://fonts.googleapis.com/css?family=Montserrat:200,300,400,500,700|Open+Sans:300,400,600,700"
       rel="stylesheet"
     />
-    <style>
-      body {
-        font-family: 'Open Sans', sans-serif;
-        margin: 0;
-        text-rendering: optimizeLegibility;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        background-color: #f5f5f5;
-      }
-    </style>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/packages/citizen-frontend/src/index.tsx
+++ b/frontend/packages/citizen-frontend/src/index.tsx
@@ -8,6 +8,7 @@ import ReactDOM from 'react-dom'
 import * as Sentry from '@sentry/browser'
 import { polyfill as smoothScrollPolyfill } from 'seamless-scroll-polyfill'
 import App from './App'
+import './index.css'
 import { getEnvironment } from '@evaka/lib-common/src/utils/helpers'
 import { config } from './configs'
 


### PR DESCRIPTION
#### Summary
- Move base styles to `index.css`, out of `index.html`
- Inherit font styles for buttons, inputs etc. from global styles
    - By default, browser styles would override e.g. font family configuration
- NOTE: Decided to exclude `min-width` for `html` as that's not really the business of the reset to configure