### PR TITLE
EVAKA radio and checkbox layout

### DIFF
--- a/frontend/packages/citizen-frontend/src/applications/ApplicationCreation.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/ApplicationCreation.tsx
@@ -84,7 +84,10 @@ export default React.memo(function ApplicationCreation() {
             {child.firstName} {child.lastName}
           </H2>
           <Gap size="XL" />
-          <ExpandingInfo info={t.applications.creation.daycareInfo}>
+          <ExpandingInfo
+            info={t.applications.creation.daycareInfo}
+            ariaLabel={t.common.openExpandingInfo}
+          >
             <Radio
               checked={selectedType === 'DAYCARE'}
               onChange={() => setSelectedType('DAYCARE')}
@@ -93,7 +96,10 @@ export default React.memo(function ApplicationCreation() {
             />
           </ExpandingInfo>
           <Gap size="s" />
-          <ExpandingInfo info={t.applications.creation.preschoolInfo}>
+          <ExpandingInfo
+            info={t.applications.creation.preschoolInfo}
+            ariaLabel={t.common.openExpandingInfo}
+          >
             <Radio
               checked={selectedType === 'PRESCHOOL'}
               onChange={() => setSelectedType('PRESCHOOL')}
@@ -105,7 +111,10 @@ export default React.memo(function ApplicationCreation() {
             {t.applications.creation.preschoolDaycareInfo}
           </PreschoolDaycareInfo>
           <Gap size="s" />
-          <ExpandingInfo info={t.applications.creation.clubInfo}>
+          <ExpandingInfo
+            info={t.applications.creation.clubInfo}
+            ariaLabel={t.common.openExpandingInfo}
+          >
             <Radio
               checked={selectedType === 'CLUB'}
               onChange={() => setSelectedType('CLUB')}

--- a/frontend/packages/citizen-frontend/src/applications/editor/AdditionalDetailsSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/AdditionalDetailsSection.tsx
@@ -61,6 +61,7 @@ export default React.memo(function AdditionalDetailsSection({
           <FixedSpaceColumn spacing="xs">
             <ExpandingInfo
               info={t.applications.editor.additionalDetails.dietInfo}
+              ariaLabel={t.common.openExpandingInfo}
             >
               <Label>{t.applications.editor.additionalDetails.dietLabel}</Label>
             </ExpandingInfo>
@@ -81,6 +82,7 @@ export default React.memo(function AdditionalDetailsSection({
           <FixedSpaceColumn spacing="xs">
             <ExpandingInfo
               info={t.applications.editor.additionalDetails.allergiesInfo}
+              ariaLabel={t.common.openExpandingInfo}
             >
               <Label>
                 {t.applications.editor.additionalDetails.allergiesLabel}

--- a/frontend/packages/citizen-frontend/src/applications/editor/contact-info/ChildSubSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/contact-info/ChildSubSection.tsx
@@ -56,7 +56,10 @@ export default React.memo(function ChildSubSection({
       </FixedSpaceColumn>
       <Gap size={'m'} />
 
-      <ExpandingInfo info={t.applications.editor.contactInfo.futureAddressInfo}>
+      <ExpandingInfo
+        info={t.applications.editor.contactInfo.futureAddressInfo}
+        ariaLabel={t.common.openExpandingInfo}
+      >
         <Checkbox
           label={t.applications.editor.contactInfo.hasFutureAddress}
           checked={formData.childFutureAddressExists}

--- a/frontend/packages/citizen-frontend/src/applications/editor/contact-info/GuardianSubSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/contact-info/GuardianSubSection.tsx
@@ -92,7 +92,10 @@ export default React.memo(function GuardianSubSection({
       </FixedSpaceRow>
       <Gap size={'m'} />
 
-      <ExpandingInfo info={t.applications.editor.contactInfo.futureAddressInfo}>
+      <ExpandingInfo
+        info={t.applications.editor.contactInfo.futureAddressInfo}
+        ariaLabel={t.common.openExpandingInfo}
+      >
         <Checkbox
           label={t.applications.editor.contactInfo.hasFutureAddress}
           checked={formData.guardianFutureAddressExists}

--- a/frontend/packages/citizen-frontend/src/applications/editor/service-need/AssistanceNeedSubSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/service-need/AssistanceNeedSubSection.tsx
@@ -29,6 +29,7 @@ export default React.memo(function AssistanceNeedSubSection({
         <>
           <ExpandingInfo
             info={t.applications.editor.serviceNeed.preparatoryInfo}
+            ariaLabel={t.common.openExpandingInfo}
           >
             {' '}
             <Checkbox
@@ -48,6 +49,7 @@ export default React.memo(function AssistanceNeedSubSection({
 
       <ExpandingInfo
         info={t.applications.editor.serviceNeed.assistanceNeedInstructions}
+        ariaLabel={t.common.openExpandingInfo}
       >
         {' '}
         <Checkbox

--- a/frontend/packages/citizen-frontend/src/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -106,6 +106,7 @@ export default React.memo(function PreferredStartSubSection({
         {type !== 'CLUB' ? (
           <ExpandingInfo
             info={t.applications.editor.serviceNeed.startDate.instructions}
+            ariaLabel={t.common.openExpandingInfo}
           >
             <Label htmlFor={labelId}>
               {t.applications.editor.serviceNeed.startDate.label[type]} *
@@ -200,6 +201,7 @@ export default React.memo(function PreferredStartSubSection({
               info={
                 t.applications.editor.serviceNeed.clubDetails.wasOnDaycareInfo
               }
+              ariaLabel={t.common.openExpandingInfo}
             >
               <Checkbox
                 checked={formData.wasOnDaycare}
@@ -219,6 +221,7 @@ export default React.memo(function PreferredStartSubSection({
               info={
                 t.applications.editor.serviceNeed.clubDetails.wasOnClubCareInfo
               }
+              ariaLabel={t.common.openExpandingInfo}
             >
               <Checkbox
                 checked={formData.wasOnClubCare}

--- a/frontend/packages/citizen-frontend/src/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -117,6 +117,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
             applicationType
           ]
         }
+        ariaLabel={t.common.openExpandingInfo}
       >
         <Label>
           {t.applications.editor.serviceNeed.dailyTime.usualArrivalAndDeparture[
@@ -167,6 +168,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
 
       <ExpandingInfo
         info={t.applications.editor.serviceNeed.shiftCare.instructions}
+        ariaLabel={t.common.openExpandingInfo}
       >
         <Checkbox
           checked={formData.shiftCare}

--- a/frontend/packages/citizen-frontend/src/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -104,6 +104,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
                 applicationType
               ]
             }
+            ariaLabel={t.common.openExpandingInfo}
           >
             <Label>
               {t.applications.editor.serviceNeed.dailyTime
@@ -153,6 +154,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
 
           <ExpandingInfo
             info={t.applications.editor.serviceNeed.shiftCare.instructions}
+            ariaLabel={t.common.openExpandingInfo}
           >
             <Checkbox
               checked={formData.shiftCare}

--- a/frontend/packages/citizen-frontend/src/localization/en.tsx
+++ b/frontend/packages/citizen-frontend/src/localization/en.tsx
@@ -37,6 +37,7 @@ const en: Translations = {
         sv: 'swedish'
       }
     },
+    openExpandingInfo: 'Open the details',
     errors: {
       genericGetError: 'Error in fetching the requested information'
     }

--- a/frontend/packages/citizen-frontend/src/localization/fi.tsx
+++ b/frontend/packages/citizen-frontend/src/localization/fi.tsx
@@ -36,6 +36,7 @@ export default {
         sv: 'ruotsi'
       }
     },
+    openExpandingInfo: 'Avaa lisätietokenttä',
     errors: {
       genericGetError: 'Tietojen hakeminen ei onnistunut'
     }

--- a/frontend/packages/citizen-frontend/src/localization/sv.tsx
+++ b/frontend/packages/citizen-frontend/src/localization/sv.tsx
@@ -37,6 +37,7 @@ const sv: Translations = {
         sv: 'svenska'
       }
     },
+    openExpandingInfo: 'Öppna detaljer',
     errors: {
       genericGetError: 'Hämtning av information misslyckades'
     }

--- a/frontend/packages/lib-components/src/atoms/form/Checkbox.tsx
+++ b/frontend/packages/lib-components/src/atoms/form/Checkbox.tsx
@@ -15,11 +15,12 @@ const diameter = '30px'
 
 const Wrapper = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   cursor: pointer;
 
   label {
     font-size: 15px;
+    margin-top: 6px;
     margin-left: ${defaultMargins.s};
     cursor: pointer;
   }
@@ -42,6 +43,7 @@ const Box = styled.div`
   position: relative;
   width: ${diameter};
   height: ${diameter};
+  margin-top: ${defaultMargins.xxs};
 `
 
 const CheckboxInput = styled.input`

--- a/frontend/packages/lib-components/src/atoms/form/Radio.tsx
+++ b/frontend/packages/lib-components/src/atoms/form/Radio.tsx
@@ -13,12 +13,13 @@ import { BaseProps } from '../../utils'
 
 const diameter = '36px'
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<SizeProps>`
   display: inline-flex;
-  align-items: center;
+  align-items: flex-start;
   cursor: pointer;
 
   label {
+    margin-top: ${(p) => (p.small ? '3px' : '6px')};
     margin-left: ${defaultMargins.s};
     cursor: pointer;
   }
@@ -122,6 +123,7 @@ function Radio({
         if (!disabled && onChange) onChange()
       }}
       className={classNames(className, { disabled })}
+      small={small}
       data-qa={dataQa}
     >
       <Circle small={small}>

--- a/frontend/packages/lib-components/src/molecules/ExpandingInfo.tsx
+++ b/frontend/packages/lib-components/src/molecules/ExpandingInfo.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { fasInfo, faTimes } from '@evaka/lib-icons'
-import React, { useState } from 'react'
+import React, { ReactNode, useState } from 'react'
 import styled from 'styled-components'
 import colors from '../colors'
 import RoundIcon from '../atoms/RoundIcon'
@@ -46,27 +46,35 @@ const InfoContainer = styled.div`
   padding: 0 ${defaultMargins.s};
 `
 
+const RoundIconWithMargin = styled(RoundIcon)`
+  margin-top: ${defaultMargins.xs};
+`
+
 type ExpandingInfoProps = {
   children: React.ReactNode
-  info: JSX.Element | string
+  info: ReactNode
+  ariaLabel: string
 }
 
-export default function ExpandingInfo({ children, info }: ExpandingInfoProps) {
+export default function ExpandingInfo({
+  children,
+  info,
+  ariaLabel
+}: ExpandingInfoProps) {
   const [expanded, setExpanded] = useState<boolean>(false)
 
   return (
     <span aria-live="polite">
       <FixedSpaceRow spacing="xs">
         <div>{children}</div>
-        <RoundIcon
+        <RoundIconWithMargin
           content={fasInfo}
           color={colors.brandEspoo.espooTurquoise}
           size="s"
           onClick={() => setExpanded(!expanded)}
           tabindex={0}
           role="button"
-          // TODO: add translation
-          aria-label="Avaa lisätietokenttä"
+          aria-label={ariaLabel}
         />
       </FixedSpaceRow>
       {expanded && (


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Align Radio and Checkbox label content with the center of the icon. Also add a small margin to the top of ExpandingInfo's icon to align it with text and use a localized aria label.

