### PR TITLE
Do not send pending decision reminder emails for old decisions

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -125,6 +125,14 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
         Assertions.assertEquals(0, sentMails.size)
     }
 
+    @Test
+    fun `Pending decision older than two months does not send an email`() {
+        createPendingDecision(LocalDate.now().minusMonths(2), null, null, 0)
+        Assertions.assertEquals(0, runPendingDecisionEmailAsyncJobs())
+        val sentMails = MockEmailClient.emails
+        Assertions.assertEquals(0, sentMails.size)
+    }
+
     private fun assertEmail(email: MockEmail?, expectedToAddress: String, expectedFromAddress: String, expectedSubject: String, expectedHtmlPart: String, expectedTextPart: String) {
         Assertions.assertNotNull(email)
         Assertions.assertEquals(expectedToAddress, email?.toAddress)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -56,7 +56,7 @@ SELECT id, application_id
 FROM decision d
 WHERE d.status = 'PENDING'
 AND d.resolved IS NULL
-AND d.sent_date < current_date - INTERVAL '1 week'
+AND (d.sent_date < current_date - INTERVAL '1 week' AND d.sent_date > current_date - INTERVAL '2 month')
 AND d.pending_decision_emails_sent_count < 2
 AND d.pending_decision_email_sent IS NULL or d.pending_decision_email_sent < current_date - INTERVAL '1 week')
 SELECT application.guardian_id as guardian_id, array_agg(pending_decisions.id::uuid) AS decision_ids


### PR DESCRIPTION
Do not send pending decision reminder emails for decisions older than 2 months

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

