### PR TITLE
Move Espoo client to profile-activated config

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
@@ -5,8 +5,9 @@
 package fi.espoo.evaka.shared.async
 
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.SharedIntegrationTestConfig
+import fi.espoo.evaka.shared.config.getTestDataSource
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.db.configureJdbi
 import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,8 +17,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
@@ -25,20 +24,17 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 
-@SpringJUnitConfig(SharedIntegrationTestConfig::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AsyncJobRunnerTest {
     private lateinit var asyncJobRunner: AsyncJobRunner
-
-    @Autowired
-    lateinit var jdbi: Jdbi
-
-    lateinit var db: Database
+    private lateinit var jdbi: Jdbi
+    private lateinit var db: Database
 
     private val user = AuthenticatedUser(UUID.randomUUID(), setOf())
 
     @BeforeAll
     fun setup() {
+        jdbi = configureJdbi(Jdbi.create(getTestDataSource()))
         asyncJobRunner = AsyncJobRunner(jdbi, syncMode = false)
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -12,8 +12,10 @@ import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.auth0.jwt.algorithms.Algorithm
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.configureJdbi
 import fi.espoo.evaka.shared.db.handle
@@ -147,4 +149,7 @@ class SharedIntegrationTestConfig {
             SecurityConfig::class.java.getResourceAsStream("/evaka-integration-test/jwks.json").use { loadPublicKeys(it) }
         return Algorithm.RSA256(JwtKeys(privateKeyId = null, privateKey = null, publicKeys = publicKeys))
     }
+
+    @Bean
+    fun invoiceIntegrationClient(objectMapper: ObjectMapper): InvoiceIntegrationClient = InvoiceIntegrationClient.MockClient(objectMapper)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -2,16 +2,18 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-package fi.espoo.evaka.invoicing
+package fi.espoo.evaka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.core.env.Environment
 
 @Configuration
-class Application {
+@Profile("espoo_evaka")
+class EspooConfig {
     @Bean
     fun invoiceIntegrationClient(env: Environment, objectMapper: ObjectMapper): InvoiceIntegrationClient =
         if (env.getProperty("fi.espoo.integration.invoice.enabled", Boolean::class.java, true))

--- a/service/src/main/kotlin/fi/espoo/evaka/Main.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Main.kt
@@ -25,8 +25,8 @@ class Main
 
 fun main(args: Array<String>) {
     val profiles = when (System.getenv("VOLTTI_ENV")) {
-        "dev", "test" -> arrayOf("enable_dev_api")
-        else -> emptyArray()
+        "dev", "test" -> arrayOf("espoo_evaka", "enable_dev_api")
+        else -> arrayOf("espoo_evaka")
     }
 
     SpringApplicationBuilder()


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

* this is better for other cities, because they are explicitly required to provide an alternative implementation (vs. accidentally using a mock or Espoo client)
* also remove Spring stuff from AsyncJobRunnerTest since it's no longer needed. This makes it possible to put the mock client in `SharedIntegrationTestConfig`, which is now only used by bigger Spring tests