### PR TITLE
EVAKA-HOTFIX minor citizen improvements

### DIFF
--- a/frontend/packages/citizen-frontend/src/applications/ChildApplicationsBlock.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/ChildApplicationsBlock.tsx
@@ -26,7 +26,7 @@ import AddButton from '@evaka/lib-components/src/atoms/buttons/AddButton'
 import { Link, useHistory } from 'react-router-dom'
 import { CitizenApplicationSummary } from '@evaka/lib-common/src/api-types/application/ApplicationsOfChild'
 import { ApplicationStatus } from '@evaka/lib-common/src/api-types/application/enums'
-import { FixedSpaceRow } from '@evaka/lib-components/src/layout/flex-helpers'
+import { FixedSpaceFlexWrap } from '@evaka/lib-components/src/layout/flex-helpers'
 import InlineButton from '@evaka/lib-components/src/atoms/buttons/InlineButton'
 import { noop } from 'lodash'
 import { removeUnprocessedApplication } from '~applications/api'
@@ -270,7 +270,7 @@ export default React.memo(function ChildApplicationsBlock({
                 <Gap size="xs" horizontal />
               </ListGrid>
               <Gap size="s" />
-              <FixedSpaceRow flexWrap>
+              <FixedSpaceFlexWrap>
                 {applicationStatus === 'CREATED' ||
                 applicationStatus === 'SENT' ? (
                   <Link to={`/applications/${applicationId}/edit`}>
@@ -306,7 +306,7 @@ export default React.memo(function ChildApplicationsBlock({
                     dataQa={`button-remove-application-${applicationId}`}
                   />
                 )}
-              </FixedSpaceRow>
+              </FixedSpaceFlexWrap>
 
               {index != applicationSummaries.length - 1 && <LineBreak />}
             </React.Fragment>

--- a/frontend/packages/citizen-frontend/src/applications/editor/ApplicationEditor.tsx
+++ b/frontend/packages/citizen-frontend/src/applications/editor/ApplicationEditor.tsx
@@ -95,7 +95,10 @@ const ApplicationEditorContent = React.memo(function DaycareApplicationEditor({
       setVerifying(true)
     }
 
-    window.scrollTo({ left: 0, top: 0, behavior: 'smooth' })
+    setTimeout(
+      () => window.scrollTo({ left: 0, top: 0, behavior: 'smooth' }),
+      50
+    )
   }
 
   const onSaveDraft = () => {

--- a/frontend/packages/lib-components/src/layout/flex-helpers.ts
+++ b/frontend/packages/lib-components/src/layout/flex-helpers.ts
@@ -95,7 +95,6 @@ interface FixedSpaceFlexWrapProps {
 export const FixedSpaceFlexWrap = styled.div<FixedSpaceFlexWrapProps>`
   display: flex;
   flex-direction: row;
-  width: 100%;
   flex-wrap: ${(p) => (p.reverse ? 'wrap-reverse' : 'wrap')};
 
   margin-bottom: -${(p) => (p.verticalSpacing ? defaultMargins[p.verticalSpacing] : defaultMargins.s)};

--- a/frontend/packages/lib-components/src/layout/flex-helpers.ts
+++ b/frontend/packages/lib-components/src/layout/flex-helpers.ts
@@ -11,14 +11,12 @@ interface FixedSpaceRowProps {
   justifyContent?: Property.JustifyContent
   alignItems?: Property.AlignItems
   marginBottom?: SpacingSize | string
-  flexWrap?: boolean
 }
 export const FixedSpaceRow = styled.div<FixedSpaceRowProps>`
   display: flex;
   flex-direction: row;
   ${(p) => (p.justifyContent ? `justify-content: ${p.justifyContent};` : '')}
   ${(p) => (p.alignItems ? `align-items: ${p.alignItems};` : '')}
-  ${(p) => (p.flexWrap ? 'flex-wrap: wrap;' : '')}
 
   ${(p) =>
     p.marginBottom


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Scroll to top of application verification view because smooth scrolling breaks if it happens during rendering.
Remove `flexWrap` prop from `FixedSpaceRow` since `FixedSpaceFlexWrap` should be used instead.
Fix `FixedSpaceFlexWrap` width, `width: 100%` actually makes the element too short.

