### PR TITLE
EVAKA-4147 part month invoices for round the clock units

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -132,6 +132,15 @@ val testGhostUnitDaycare = DevDaycare(
     ghostUnit = true
 )
 
+val testRoundTheClockDaycare = DevDaycare(
+    id = UUID.randomUUID(),
+    name = "Test Ghost Unit Daycare",
+    areaId = testAreaId,
+    type = setOf(CareType.CENTRE),
+    roundTheClock = true,
+    operationDays = setOf(1, 2, 3, 4, 5, 6, 7)
+)
+
 val testDecisionMaker_1 = PersonData.WithName(
     id = UUID.randomUUID(),
     firstName = "Decision",
@@ -414,6 +423,7 @@ fun insertGeneralTestFixtures(h: Handle) {
     )
     h.insertTestDaycare(testClub)
     h.insertTestDaycare(testGhostUnitDaycare)
+    h.insertTestDaycare(testRoundTheClockDaycare)
 
     testDecisionMaker_1.let {
         h.insertTestEmployee(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -71,7 +71,7 @@ INSERT INTO daycare (
   location, mailing_street_address, mailing_po_box, mailing_postal_code, mailing_post_office,
   unit_manager_id,
   decision_daycare_name, decision_preschool_name, decision_handler, decision_handler_address,
-  oph_unit_oid, oph_organizer_oid, oph_organization_oid, round_the_clock
+  oph_unit_oid, oph_organizer_oid, oph_organization_oid, round_the_clock, operation_days
 ) VALUES (
   :id, :name, :openingDate, :closingDate, :areaId, :type::care_types[], :daycareApplyPeriod, :preschoolApplyPeriod, :clubApplyPeriod, :providerType,
   :capacity, :language, :ghostUnit, :uploadToVarda, :uploadToKoski, :invoicedByMunicipality, :costCenter,
@@ -80,7 +80,7 @@ INSERT INTO daycare (
   :location, :mailingAddress.streetAddress, :mailingAddress.poBox, :mailingAddress.postalCode, :mailingAddress.postOffice,
   (SELECT id FROM insert_unit_manager),
   :decisionCustomization.daycareName, :decisionCustomization.preschoolName, :decisionCustomization.handler, :decisionCustomization.handlerAddress,
-  :ophUnitOid, :ophOrganizerOid, :ophOrganizationOid, :roundTheClock
+  :ophUnitOid, :ophOrganizerOid, :ophOrganizationOid, :roundTheClock, :operationDays
 )
 RETURNING id
 """

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -915,7 +915,8 @@ data class DevDaycare(
     val ophUnitOid: String? = "1.2.3.4.5",
     val ophOrganizerOid: String? = "1.2.3.4.5",
     val ophOrganizationOid: String? = "1.2.3.4.5",
-    val roundTheClock: Boolean? = false
+    val roundTheClock: Boolean? = false,
+    val operationDays: Set<Int> = setOf(1, 2, 3, 4, 5)
 )
 
 data class DevDaycareGroup(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Alters the behavior of part months invoices for children in round the clock units. Previously the daily prices used in part month invoices would be calculated as a fraction of a units total operational day count, but now we use the same daily price for all units. In the case of round the clock units, which have more operational days that other units, it means that we only count as many operational days in a week as a "regular" unit would have. The code assumes that round the clock units mark absences only for the days that a child is supposed to come to daycare. That is the way that Espoo does things currently.
