### PR TITLE
Private daycares should use "purchased" type in Koski

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -618,6 +618,22 @@ class KoskiIntegrationTest : FullApplicationTest() {
     }
 
     @Test
+    fun `a daycare with private provider type is marked as purchased in study rights`() {
+        val daycareId = jdbi.handle {
+            it.insertTestDaycare(
+                DevDaycare(areaId = testAreaId, providerType = ProviderType.PRIVATE)
+            )
+        }
+        insertPlacement(daycareId = daycareId)
+
+        val today = preschoolTerm2019.end.plusDays(1)
+        koskiTester.triggerUploads(today)
+
+        val opiskeluoikeus = koskiServer.getStudyRights().values.single().opiskeluoikeus
+        assertEquals(Järjestämismuoto(JärjestämismuotoKoodi.PURCHASED), opiskeluoikeus.järjestämismuoto)
+    }
+
+    @Test
     fun `absences have no effect on preschool study rights`() {
         insertPlacement(period = preschoolTerm2020, type = PlacementType.PRESCHOOL)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -64,7 +64,7 @@ data class KoskiUnitRaw(
         ProviderType.PURCHASED -> Järjestämismuoto(JärjestämismuotoKoodi.PURCHASED)
         ProviderType.PRIVATE_SERVICE_VOUCHER -> Järjestämismuoto(JärjestämismuotoKoodi.PRIVATE_SERVICE_VOUCHER)
         ProviderType.MUNICIPAL -> null
-        ProviderType.PRIVATE -> null
+        ProviderType.PRIVATE -> Järjestämismuoto(JärjestämismuotoKoodi.PURCHASED)
         ProviderType.MUNICIPAL_SCHOOL -> null
     }
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

In our terminology this can seem confusing, but it's the correct way from the Koski point of view.

This should fix the majority of current Koski upload errors, since permission checking works differently in Koski with the "purchased" type