### PR TITLE
Allow KeyCloak SAML requests

### DIFF
--- a/compose/proxy/nginx.conf
+++ b/compose/proxy/nginx.conf
@@ -41,7 +41,8 @@ server {
   add_header X-Content-Type-Options nosniff;
   add_header X-XSS-Protection '1; mode=block';
   add_header X-DNS-Prefetch-Control off;
-  add_header Content-Security-Policy "block-all-mixed-content; form-action 'self'; frame-ancestors 'none'; default-src 'self'; script-src 'self' 'unsafe-eval' https://maps.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://maps.gstatic.com https://maps.googleapis.com; connect-src 'self' https://o318158.ingest.sentry.io; object-src 'none'";
+  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://maps.gstatic.com https://maps.googleapis.com https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
+  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' https://maps.googleapis.com; frame-ancestors 'none'; form-action 'self';";
 
   # Tracing
   add_header X-Request-ID $request_id always;
@@ -142,21 +143,23 @@ server {
   }
 
   set $authUrl "http://keycloak:8080";
-  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; form-action 'self'; default-src 'self'; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://maps.gstatic.com https://maps.googleapis.com; connect-src 'self' https://o318158.ingest.sentry.io; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
+  set $formActionUrl "http://localhost:8080/idp/profile/SAML2/POST/SSO";
 
   location /auth {
+    add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'; form-action 'self' ${formActionUrl}";
+
     proxy_http_version 1.1;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
     proxy_set_header X-Forwarded-Host $http_host;
-    proxy_set_header X-Original-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header X-Original-Forwarded-Proto "https";
     proxy_set_header X-Request-ID $request_id;
     proxy_set_header Host $http_host;
 
     # Actual caching headers should be set by downstream API Gateways;
     # this is just to prevent caching at the proxy level.
     proxy_no_cache 1;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto "https";
     add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'";
 
     proxy_pass $authUrl;

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -124,8 +124,8 @@ server {
   add_header X-DNS-Prefetch-Control off;
   add_header Report-To '{"group","csp-endpoint","max_age":31536000,"endpoints":[{"url":"https://$host/api/csp"}]}';
 
-  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; form-action 'self'; default-src 'self'; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://maps.gstatic.com https://maps.googleapis.com https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
-  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' https://maps.googleapis.com; frame-ancestors 'none';";
+  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://maps.gstatic.com https://maps.googleapis.com https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
+  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' https://maps.googleapis.com; frame-ancestors 'none'; form-action 'self';";
 
   # Tracing
   # Return the request ID to the client to make tracing of test requests very easy
@@ -269,16 +269,32 @@ server {
   <% if ENV.key?("KEYCLOAK_URL") && ENV["KEYCLOAK_URL"] != "" %>
 
   set $authUrl "<%= ENV["KEYCLOAK_URL"] %>";
+  set $formActionUrl "<%= ENV["FORM_ACTION_URL"] %>";
 
   location /auth {
     <% if ENV["BASIC_AUTH_ENABLED"] == "true" %>
     auth_basic "off";
     <% end %>
-    include    proxy_params;
-    limit_req  zone=req_zone burst=100 nodelay;
-    add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'";
 
+    limit_req  zone=req_zone burst=100 nodelay;
+
+    add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'; form-action 'self' ${formActionUrl}";
+
+    proxy_ssl_verify off;
+
+    proxy_http_version 1.1;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+    proxy_set_header X-Forwarded-Host $http_host;
+    proxy_set_header X-Original-Forwarded-Proto "https";
+    proxy_set_header X-Request-ID $request_id;
+    proxy_set_header Host $http_host;
+
+    # Actual caching headers should be set by downstream API Gateways;
+    # this is just to prevent caching at the proxy level.
+    proxy_no_cache 1;
     proxy_set_header X-Forwarded-Proto "https";
+
     proxy_pass $authUrl;
   }
   <% end %>


### PR DESCRIPTION
#### Summary

We need to be able to allow form-action URLs for KeyCloak SAML authentication. Also cleared proxy parameters so there is no duplicates.
