### PR TITLE
EVAKA-HOTFIX hide ssn from log meta fields

### DIFF
--- a/service-lib/src/main/kotlin/fi/espoo/voltti/logging/SsnMasker.kt
+++ b/service-lib/src/main/kotlin/fi/espoo/voltti/logging/SsnMasker.kt
@@ -1,0 +1,12 @@
+package fi.espoo.voltti.logging
+
+import com.fasterxml.jackson.core.JsonStreamContext
+import net.logstash.logback.mask.ValueMasker
+
+class SsnMasker : ValueMasker {
+    override fun mask(context: JsonStreamContext?, value: Any?): Any {
+        return if (value is String) {
+            value.replace(Regex("(?<!-|[\\dA-z])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](?!-)"), "REDACTED-SSN")
+        } else value ?: "null"
+    }
+}

--- a/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
+++ b/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
@@ -14,7 +14,7 @@ Sanitized default appender logback configuration provided for import
   <conversionRule
     conversionWord="stacktrace"
     converterClass="net.logstash.logback.stacktrace.ShortenedThrowableConverter" />
-  
+
   <appender name="VOLTTI_DEFAULT_APPENDER_SANITIZED" class="ch.qos.logback.core.ConsoleAppender">
     <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
       <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
@@ -26,6 +26,10 @@ Sanitized default appender logback configuration provided for import
     </filter>
     <!-- With a Composite encoder, desired fields need to be explicitly defined -->
     <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+      <jsonGeneratorDecorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+        <!--Hide social security numbers from logs-->
+        <valueMasker class="fi.espoo.voltti.logging.SsnMasker" />
+      </jsonGeneratorDecorator>
       <providers>
         <logLevel><fieldName>logLevel</fieldName></logLevel>
         <throwableClassName><fieldName>exception</fieldName></throwableClassName>
@@ -38,9 +42,8 @@ Sanitized default appender logback configuration provided for import
           <omitEmptyFields>true</omitEmptyFields>
           <pattern>
             {
-            <!--Hide social security numbers in message and in stack trace-->
-            "message": "%replace(%message){'(?&lt;!-|[\\dA-z])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](?!-)', 'REDACTED-SSN'}",
-            "stackTrace": "%replace(%stacktrace{60,40,32000,rootFirst,inlineHash}){'(?&lt;!-|[\\dA-z])(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-z](?!-)', 'REDACTED-SSN'}",
+            "message": "%message",
+            "stackTrace": "%stacktrace",
             "type": "app-misc",
             "appBuild": "${APP_BUILD}",
             "appCommit": "${APP_COMMIT}",

--- a/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
+++ b/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.voltti.logging.logback
 
+import fi.espoo.voltti.logging.loggers.info
 import mu.KLogger
 import mu.KMarkerFactory
 import mu.KotlinLogging
@@ -90,19 +91,22 @@ class AppenderTest {
             it.withLatestSanitized { actual -> defaultInfoAssertions(actual) }
 
             testSSNs.forEach { ssn ->
-                logger.info { "Accidental SSN logging: $ssn}" }
+                logger.info(mapOf("body" to """{"ssn": "$ssn"}""")) { "Accidental SSN logging: $ssn}" }
                 it.withLatestSanitized { actual ->
-                    defaultInfoAssertions(actual)
                     assertThat(actual["message"] as String).doesNotContain(ssn)
                     assertThat(actual["message"] as String).contains(redactedSSN)
+                    assertThat((actual["meta"] as Map<*, *>)["body"] as String).doesNotContain(ssn)
+                    assertThat((actual["meta"] as Map<*, *>)["body"] as String).contains(redactedSSN)
                 }
             }
 
             UUIDWithSSNs.forEach { uuid ->
-                logger.info { "UUID has SSN in it: $uuid" }
+                logger.info(mapOf("body" to """{"id": "$uuid"}""")) { "UUID has SSN in it: $uuid" }
                 it.withLatestSanitized { actual ->
                     assertThat(actual["message"] as String).contains(uuid)
                     assertThat(actual["message"] as String).doesNotContain(redactedSSN)
+                    assertThat((actual["meta"] as Map<*, *>)["body"] as String).contains(uuid)
+                    assertThat((actual["meta"] as Map<*, *>)["body"] as String).doesNotContain(redactedSSN)
                 }
             }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Use a `ValueMasker` to hide ssns from all log fields. Uses the same regex used previously for masking `message` and `stackTrace` fields.

