### PR TITLE
Fix empty result pagination

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Paging.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Paging.kt
@@ -6,7 +6,7 @@ import org.jdbi.v3.core.mapper.RowMapper
 data class Paged<T>(val data: List<T>, val total: Int, val pages: Int)
 
 fun <T> mapToPaged(pageSize: Int): (Iterable<WithCount<T>>) -> Paged<T> = { rows ->
-    if (rows.firstOrNull() == null) Paged(listOf(), 0, 0)
+    if (rows.firstOrNull() == null) Paged(listOf(), 0, 1)
     else {
         val count = rows.first().count
         Paged(


### PR DESCRIPTION
#### Summary
If there are no results, employee application list breaks with org.postgresql.util.PSQLException: ERROR: OFFSET must not be negative because page=0 whereas it should be 1. This fixes the default value to 1.
