### PR TITLE
EVAKA-HOTFIX handle parsefi throws better

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/ApplicationEditor.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationEditor.tsx
@@ -103,7 +103,7 @@ const ApplicationEditorContent = React.memo(function DaycareApplicationEditor({
   }
 
   const onSaveDraft = () => {
-    const reqBody = formDataToApiData(apiData, formData)
+    const reqBody = formDataToApiData(apiData, formData, true)
     setSubmitting(true)
     void saveApplicationDraft(apiData.id, reqBody).then((res) => {
       setSubmitting(false)

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormData.ts
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormData.ts
@@ -264,7 +264,8 @@ export function formDataToApiData(
     otherGuardianId,
     otherGuardianLivesInSameAddress
   }: ApplicationDetails,
-  form: ApplicationFormData
+  form: ApplicationFormData,
+  isDraft = false
 ): ApplicationFormUpdate {
   const fullFamily =
     type === 'DAYCARE' ||
@@ -281,7 +282,9 @@ export function formDataToApiData(
             street: form.contactInfo.childFutureStreet,
             postalCode: form.contactInfo.childFuturePostalCode,
             postOffice: form.contactInfo.childFuturePostOffice,
-            movingDate: LocalDate.parseFiOrNull(form.contactInfo.childMoveDate)
+            movingDate: isDraft
+              ? LocalDate.parseFiOrNull(form.contactInfo.childMoveDate)
+              : LocalDate.parseFiOrThrow(form.contactInfo.childMoveDate)
           }
         : null,
       allergies: type !== 'CLUB' ? form.additionalDetails.allergies : '',
@@ -295,9 +298,9 @@ export function formDataToApiData(
             street: form.contactInfo.guardianFutureStreet,
             postalCode: form.contactInfo.guardianFuturePostalCode,
             postOffice: form.contactInfo.guardianFuturePostOffice,
-            movingDate: LocalDate.parseFiOrNull(
-              form.contactInfo.guardianMoveDate
-            )
+            movingDate: isDraft
+              ? LocalDate.parseFiOrNull(form.contactInfo.guardianMoveDate)
+              : LocalDate.parseFiOrThrow(form.contactInfo.guardianMoveDate)
           }
         : null,
       phoneNumber: form.contactInfo.guardianPhone,

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormData.ts
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormData.ts
@@ -281,7 +281,7 @@ export function formDataToApiData(
             street: form.contactInfo.childFutureStreet,
             postalCode: form.contactInfo.childFuturePostalCode,
             postOffice: form.contactInfo.childFuturePostOffice,
-            movingDate: LocalDate.parseFi(form.contactInfo.childMoveDate)
+            movingDate: LocalDate.parseFiOrNull(form.contactInfo.childMoveDate)
           }
         : null,
       allergies: type !== 'CLUB' ? form.additionalDetails.allergies : '',
@@ -295,7 +295,9 @@ export function formDataToApiData(
             street: form.contactInfo.guardianFutureStreet,
             postalCode: form.contactInfo.guardianFuturePostalCode,
             postOffice: form.contactInfo.guardianFuturePostOffice,
-            movingDate: LocalDate.parseFi(form.contactInfo.guardianMoveDate)
+            movingDate: LocalDate.parseFiOrNull(
+              form.contactInfo.guardianMoveDate
+            )
           }
         : null,
       phoneNumber: form.contactInfo.guardianPhone,

--- a/frontend/src/citizen-frontend/applications/editor/validations.ts
+++ b/frontend/src/citizen-frontend/applications/editor/validations.ts
@@ -92,12 +92,16 @@ export const isValidDecisionStartDate = (
   startDate: string,
   type: DecisionType
 ): boolean => {
-  return date !== null
-    ? date.isEqualOrAfter(LocalDate.parseFi(startDate)) &&
-        date.isEqualOrBefore(
-          maxDecisionStartDate(LocalDate.parseFi(startDate), type)
-        )
-    : false
+  try {
+    return date !== null
+      ? date.isEqualOrAfter(LocalDate.parseFi(startDate)) &&
+          date.isEqualOrBefore(
+            maxDecisionStartDate(LocalDate.parseFi(startDate), type)
+          )
+      : false
+  } catch (e) {
+    return false
+  }
 }
 
 const preferredStartDateValidator = (

--- a/frontend/src/citizen-frontend/applications/editor/validations.ts
+++ b/frontend/src/citizen-frontend/applications/editor/validations.ts
@@ -92,16 +92,20 @@ export const isValidDecisionStartDate = (
   startDate: string,
   type: DecisionType
 ): boolean => {
+  let parsedDate: LocalDate
   try {
-    return date !== null
-      ? date.isEqualOrAfter(LocalDate.parseFi(startDate)) &&
-          date.isEqualOrBefore(
-            maxDecisionStartDate(LocalDate.parseFi(startDate), type)
-          )
-      : false
+    parsedDate = LocalDate.parseFi(startDate)
   } catch (e) {
-    return false
+    if (e instanceof RangeError) {
+      return false
+    }
+    // Unexpected
+    throw e
   }
+  return date !== null
+    ? date.isEqualOrAfter(parsedDate) &&
+        date.isEqualOrBefore(maxDecisionStartDate(parsedDate, type))
+    : false
 }
 
 const preferredStartDateValidator = (

--- a/frontend/src/citizen-frontend/applications/editor/validations.ts
+++ b/frontend/src/citizen-frontend/applications/editor/validations.ts
@@ -92,7 +92,7 @@ export const isValidDecisionStartDate = (
 ): boolean => {
   let parsedDate: LocalDate
   try {
-    parsedDate = LocalDate.parseFi(startDate)
+    parsedDate = LocalDate.parseFiOrThrow(startDate)
   } catch (e) {
     if (e instanceof RangeError) {
       return false

--- a/frontend/src/citizen-frontend/applications/editor/validations.ts
+++ b/frontend/src/citizen-frontend/applications/editor/validations.ts
@@ -67,8 +67,6 @@ export const isValidPreferredStartDate = (
   status: ApplicationStatus,
   type: ApplicationType
 ): boolean => {
-  if (date === null) return false
-
   if (
     date.isBefore(
       minPreferredStartDate(status, type, originalPreferredStartDate)
@@ -102,10 +100,10 @@ export const isValidDecisionStartDate = (
     // Unexpected
     throw e
   }
-  return date !== null
-    ? date.isEqualOrAfter(parsedDate) &&
-        date.isEqualOrBefore(maxDecisionStartDate(parsedDate, type))
-    : false
+  return (
+    date.isEqualOrAfter(parsedDate) &&
+    date.isEqualOrBefore(maxDecisionStartDate(parsedDate, type))
+  )
 }
 
 const preferredStartDateValidator = (

--- a/frontend/src/citizen-frontend/decisions/api.ts
+++ b/frontend/src/citizen-frontend/decisions/api.ts
@@ -35,22 +35,15 @@ export async function getApplicationDecisions(
 export async function acceptDecision(
   applicationId: UUID,
   decisionId: UUID,
-  requestedStartDate: string
+  requestedStartDate: LocalDate
 ): Promise<Result<void>> {
-  let date
-  try {
-    date = LocalDate.parseFi(requestedStartDate)
-  } catch (e) {
-    return Failure.fromError(e)
-  }
-  const body = {
-    decisionId,
-    requestedStartDate: date
-  }
   return client
     .post<void>(
       `/citizen/applications/${applicationId}/actions/accept-decision`,
-      body
+      {
+        decisionId,
+        requestedStartDate
+      }
     )
     .then(() => Success.of(undefined))
     .catch((e) => Failure.fromError(e))

--- a/frontend/src/citizen-frontend/decisions/api.ts
+++ b/frontend/src/citizen-frontend/decisions/api.ts
@@ -37,9 +37,15 @@ export async function acceptDecision(
   decisionId: UUID,
   requestedStartDate: string
 ): Promise<Result<void>> {
+  let date
+  try {
+    date = LocalDate.parseFi(requestedStartDate)
+  } catch (e) {
+    return Failure.fromError(e)
+  }
   const body = {
     decisionId,
-    requestedStartDate: LocalDate.parseFi(requestedStartDate).formatIso()
+    requestedStartDate: date
   }
   return client
     .post<void>(

--- a/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
+++ b/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
@@ -78,7 +78,7 @@ export default React.memo(function DecisionResponse({
     }
   }
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
     if (acceptChecked) {
       return handleAcceptDecision()
     } else {
@@ -86,7 +86,7 @@ export default React.memo(function DecisionResponse({
     }
   }
 
-  const handleAcceptDecision = () => {
+  const handleAcceptDecision = async () => {
     if (parsedDate === null) throw new Error('Parsed date was null')
     setSubmitting(true)
     return acceptDecision(applicationId, decisionId, parsedDate)
@@ -105,7 +105,7 @@ export default React.memo(function DecisionResponse({
       })
   }
 
-  const handleRejectDecision = () => {
+  const handleRejectDecision = async () => {
     setSubmitting(true)
     return rejectDecision(applicationId, decisionId)
       .then((res) => {

--- a/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
+++ b/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
@@ -78,13 +78,36 @@ export default React.memo(function DecisionResponse({
     }
   }
 
-  const onSubmit = async () => {
+  const onSubmit = () => {
+    if (acceptChecked) {
+      handleAcceptDecision()
+    } else {
+      handleRejectDecision()
+    }
+  }
+
+  const handleAcceptDecision = () => {
     if (parsedDate === null) throw new Error('Parsed date was null')
     setSubmitting(true)
-    return (acceptChecked
-      ? acceptDecision(applicationId, decisionId, parsedDate)
-      : rejectDecision(applicationId, decisionId)
-    )
+    acceptDecision(applicationId, decisionId, parsedDate)
+      .then((res) => {
+        if (res.isFailure) {
+          setErrorMessage({
+            type: 'error',
+            title: t.decisions.applicationDecisions.errors.submitFailure,
+            resolveLabel: t.common.ok
+          })
+        }
+      })
+      .finally(() => {
+        setSubmitting(false)
+        refreshDecisionList()
+      })
+  }
+
+  const handleRejectDecision = () => {
+    setSubmitting(true)
+    rejectDecision(applicationId, decisionId)
       .then((res) => {
         if (res.isFailure) {
           setErrorMessage({

--- a/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
+++ b/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
@@ -80,16 +80,16 @@ export default React.memo(function DecisionResponse({
 
   const onSubmit = () => {
     if (acceptChecked) {
-      handleAcceptDecision()
+      return handleAcceptDecision()
     } else {
-      handleRejectDecision()
+      return handleRejectDecision()
     }
   }
 
   const handleAcceptDecision = () => {
     if (parsedDate === null) throw new Error('Parsed date was null')
     setSubmitting(true)
-    acceptDecision(applicationId, decisionId, parsedDate)
+    return acceptDecision(applicationId, decisionId, parsedDate)
       .then((res) => {
         if (res.isFailure) {
           setErrorMessage({
@@ -107,7 +107,7 @@ export default React.memo(function DecisionResponse({
 
   const handleRejectDecision = () => {
     setSubmitting(true)
-    rejectDecision(applicationId, decisionId)
+    return rejectDecision(applicationId, decisionId)
       .then((res) => {
         if (res.isFailure) {
           setErrorMessage({

--- a/frontend/src/lib-common/local-date.ts
+++ b/frontend/src/lib-common/local-date.ts
@@ -153,7 +153,7 @@ export default class LocalDate {
     }
     return result
   }
-  static parseFi(value: string): LocalDate {
+  static parseFiOrThrow(value: string): LocalDate {
     const parts = fiPattern.exec(value)
     if (!parts) {
       throw new RangeError(`Invalid FI date ${value}`)
@@ -170,7 +170,7 @@ export default class LocalDate {
   }
   static parseFiOrNull(value: string): LocalDate | null {
     try {
-      return this.parseFi(value)
+      return this.parseFiOrThrow(value)
     } catch (e) {
       return null
     }

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
@@ -30,7 +30,7 @@ function DatePickerDay({
 
   function convertToDate(date: string) {
     try {
-      return LocalDate.parseFi(date).toSystemTzDate()
+      return LocalDate.parseFiOrThrow(date).toSystemTzDate()
     } catch (e) {
       return undefined
     }


### PR DESCRIPTION
#### Summary
Change `parseFi` calls to `parseFiOrNull` and when using `parseFi` wrap them in a `try...catch`. This should help out with the sentry errors.
