### PR TITLE
EVAKA-4016 tests for voucher value report

### DIFF
--- a/service/reports/sql/zero_fee_children_by_year.sql
+++ b/service/reports/sql/zero_fee_children_by_year.sql
@@ -13,7 +13,7 @@ LEFT JOIN LATERAL (
  ) effects
  WHERE effects.id = fee_decision_part.id
 ) fee_alteration_effects ON true
-WHERE fee_decision.status = 'SENT'
+WHERE fee_decision.status IN ('SENT', 'WAITING_FOR_SENDING', 'WAITING_FOR_MANUAL_SENDING')
 AND (fee_decision_part.fee + COALESCE(fee_alteration_effects.sum, 0)) = 0
 AND daterange(fee_decision.valid_from, fee_decision.valid_to, '[]') @> '2020-09-15'::date
 GROUP BY DATE_PART('year', fee_decision_part.date_of_birth)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -1,0 +1,262 @@
+package fi.espoo.evaka.reports
+
+import com.github.kittinunf.fuel.jackson.objectBody
+import com.github.kittinunf.fuel.jackson.responseObject
+import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.insertGeneralTestFixtures
+import fi.espoo.evaka.invoicing.createVoucherValueDecisionFixture
+import fi.espoo.evaka.invoicing.createVoucherValueDecisionPartFixture
+import fi.espoo.evaka.invoicing.data.upsertValueDecisions
+import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
+import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
+import fi.espoo.evaka.reports.VoucherReportRowType.CORRECTION
+import fi.espoo.evaka.reports.VoucherReportRowType.ORIGINAL
+import fi.espoo.evaka.reports.VoucherReportRowType.REFUND
+import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.testAdult_1
+import fi.espoo.evaka.testChild_1
+import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.testDaycare2
+import fi.espoo.evaka.testDecisionMaker_1
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
+import java.util.UUID
+
+class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
+    @Autowired
+    private lateinit var asyncJobRunner: AsyncJobRunner
+
+    @BeforeEach
+    fun beforeEach() {
+        db.transaction { insertGeneralTestFixtures(it.handle) }
+    }
+
+    @AfterEach
+    fun afterEach() {
+        db.transaction { it.resetDatabase() }
+    }
+
+    private val janFirst = LocalDate.of(2020, 1, 1)
+    private val febFirst = LocalDate.of(2020, 2, 1)
+    private val marFirst = LocalDate.of(2020, 3, 1)
+
+    @Test
+    fun `unfrozen service voucher report includes value decisions that begin in the beginning of reports month`() {
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 28800)
+
+        val janReport = getUnitReport(testDaycare.id, janFirst.year, janFirst.monthValue)
+        assertEquals(1, janReport.size)
+        janReport.assertContainsRow(ORIGINAL, janFirst, janFirst.toEndOfMonth(), 87000, 28800, 58200)
+    }
+
+    @Test
+    fun `unfrozen service voucher report includes value decisions that begin in the middle of reports month`() {
+        val middleOfMonth = LocalDate.of(2020, 1, 15)
+        createVoucherDecision(middleOfMonth, unitId = testDaycare.id, value = 87000, coPayment = 28800)
+
+        val janReport = getUnitReport(testDaycare.id, middleOfMonth.year, middleOfMonth.monthValue)
+        assertEquals(1, janReport.size)
+        // 31916 is 17 / 31 * 58200 rounded to closest integer
+        janReport.assertContainsRow(ORIGINAL, middleOfMonth, middleOfMonth.toEndOfMonth(), 87000, 28800, 31916)
+    }
+
+    @Test
+    fun `unfrozen service voucher report does not include value decisions to other units`() {
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 28800)
+
+        val janReport = getUnitReport(testDaycare2.id, janFirst.year, janFirst.monthValue)
+        assertEquals(0, janReport.size)
+    }
+
+    @Test
+    fun `frozen service voucher report includes value decisions that begin in the beginning of reports month`() {
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 28800)
+        db.transaction { freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue) }
+
+        val janReport = getUnitReport(testDaycare.id, janFirst.year, janFirst.monthValue)
+        assertEquals(1, janReport.size)
+        janReport.assertContainsRow(ORIGINAL, janFirst, janFirst.toEndOfMonth(), 87000, 28800, 58200)
+    }
+
+    @Test
+    fun `frozen service voucher report keeps previously frozen rows intact`() {
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 0)
+        db.transaction { freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue) }
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 10000)
+
+        val janReport = getUnitReport(testDaycare.id, janFirst.year, janFirst.monthValue)
+        assertEquals(1, janReport.size)
+        janReport.assertContainsRow(ORIGINAL, janFirst, janFirst.toEndOfMonth(), 87000, 0, 87000)
+    }
+
+    @Test
+    fun `new value decisions appear as corrections in next months report after freezing`() {
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 0)
+        db.transaction { freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue) }
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 10000)
+
+        val febReport = getUnitReport(testDaycare.id, febFirst.year, febFirst.monthValue)
+        assertEquals(3, febReport.size)
+        febReport.assertContainsRow(REFUND, janFirst, janFirst.toEndOfMonth(), 87000, 0, -87000)
+        febReport.assertContainsRow(CORRECTION, janFirst, janFirst.toEndOfMonth(), 87000, 10000, 77000)
+        febReport.assertContainsRow(ORIGINAL, febFirst, febFirst.toEndOfMonth(), 87000, 10000, 77000)
+    }
+
+    @Test
+    fun `new value decisions to a different unit cause refunds in the old unit but corrections in the new unit`() {
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 0)
+        db.transaction { freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue) }
+        createVoucherDecision(janFirst, unitId = testDaycare2.id, value = 87000, coPayment = 10000)
+
+        val febReportInOldUnit = getUnitReport(testDaycare.id, febFirst.year, febFirst.monthValue)
+        assertEquals(1, febReportInOldUnit.size)
+        febReportInOldUnit.assertContainsRow(REFUND, janFirst, janFirst.toEndOfMonth(), 87000, 0, -87000)
+
+        val febReportInNewUnit = getUnitReport(testDaycare2.id, febFirst.year, febFirst.monthValue)
+        assertEquals(2, febReportInNewUnit.size)
+        febReportInNewUnit.assertContainsRow(CORRECTION, janFirst, janFirst.toEndOfMonth(), 87000, 10000, 77000)
+        febReportInNewUnit.assertContainsRow(ORIGINAL, febFirst, febFirst.toEndOfMonth(), 87000, 10000, 77000)
+    }
+
+    @Test
+    fun `value decision double corrections refund the latest corrected value`() {
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 0)
+        db.transaction { freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue) }
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 10000)
+        db.transaction { freezeVoucherValueReportRows(it, febFirst.year, febFirst.monthValue) }
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 5000)
+
+        val marchReport = getUnitReport(testDaycare.id, marFirst.year, marFirst.monthValue)
+        assertEquals(5, marchReport.size)
+        marchReport.assertContainsRow(REFUND, janFirst, janFirst.toEndOfMonth(), 87000, 10000, -77000)
+        marchReport.assertContainsRow(CORRECTION, janFirst, janFirst.toEndOfMonth(), 87000, 5000, 82000)
+        marchReport.assertContainsRow(REFUND, febFirst, febFirst.toEndOfMonth(), 87000, 10000, -77000)
+        marchReport.assertContainsRow(CORRECTION, febFirst, febFirst.toEndOfMonth(), 87000, 5000, 82000)
+        marchReport.assertContainsRow(ORIGINAL, marFirst, marFirst.toEndOfMonth(), 87000, 5000, 82000)
+    }
+
+    @Test
+    fun `decisions not included in previous months report are included as corrections in the next`() {
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 0)
+
+        val febReport = getUnitReport(testDaycare.id, febFirst.year, febFirst.monthValue)
+        assertEquals(2, febReport.size)
+        febReport.assertContainsRow(CORRECTION, janFirst, janFirst.toEndOfMonth(), 87000, 0, 87000)
+        febReport.assertContainsRow(ORIGINAL, febFirst, febFirst.toEndOfMonth(), 87000, 0, 87000)
+    }
+
+    @Test
+    fun `split old decisions are both refunded`() {
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 0)
+        val middleOfMonth = LocalDate.of(2020, 1, 15)
+        createVoucherDecision(middleOfMonth, unitId = testDaycare.id, value = 87000, coPayment = 28800)
+        db.transaction { freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue) }
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 10000)
+
+        val febReport = getUnitReport(testDaycare.id, febFirst.year, febFirst.monthValue)
+        assertEquals(4, febReport.size)
+        febReport.assertContainsRow(REFUND, janFirst, middleOfMonth.minusDays(1), 87000, 0, -39290)
+        febReport.assertContainsRow(REFUND, middleOfMonth, middleOfMonth.toEndOfMonth(), 87000, 28800, -31916)
+        febReport.assertContainsRow(CORRECTION, janFirst, janFirst.toEndOfMonth(), 87000, 10000, 77000)
+        febReport.assertContainsRow(ORIGINAL, febFirst, febFirst.toEndOfMonth(), 87000, 10000, 77000)
+    }
+
+    @Test
+    fun `split new decisions are both corrected`() {
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 10000)
+        db.transaction { freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue) }
+        createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 0)
+        val middleOfMonth = LocalDate.of(2020, 1, 15)
+        createVoucherDecision(middleOfMonth, unitId = testDaycare.id, value = 87000, coPayment = 28800)
+
+        val febReport = getUnitReport(testDaycare.id, febFirst.year, febFirst.monthValue)
+        assertEquals(4, febReport.size)
+        febReport.assertContainsRow(REFUND, janFirst, janFirst.toEndOfMonth(), 87000, 10000, -77000)
+        febReport.assertContainsRow(CORRECTION, janFirst, middleOfMonth.minusDays(1), 87000, 0, 39290)
+        febReport.assertContainsRow(CORRECTION, middleOfMonth, middleOfMonth.toEndOfMonth(), 87000, 28800, 31916)
+        febReport.assertContainsRow(ORIGINAL, febFirst, febFirst.toEndOfMonth(), 87000, 28800, 58200)
+    }
+
+    private fun List<ServiceVoucherValueRow>.assertContainsRow(
+        type: VoucherReportRowType,
+        periodStart: LocalDate,
+        periodEnd: LocalDate,
+        value: Int,
+        coPayment: Int,
+        realizedValue: Int
+    ) {
+        val row = this.find {
+            it.type == type && it.realizedPeriod.start == periodStart && it.realizedPeriod.end == periodEnd
+        }
+        assertNotNull(row)
+        row!!.let {
+            assertEquals(value, row.serviceVoucherValue)
+            assertEquals(coPayment, row.serviceVoucherCoPayment)
+            assertEquals(realizedValue, row.realizedAmount)
+        }
+    }
+
+    private fun LocalDate.toEndOfMonth() = this.plusMonths(1).withDayOfMonth(1).minusDays(1)
+
+    private val adminUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.ADMIN))
+
+    private fun getUnitReport(unitId: UUID, year: Int, month: Int): List<ServiceVoucherValueRow> {
+        val (_, response, data) = http.get(
+            "/reports/service-voucher-value/units/$unitId",
+            listOf("year" to year, "month" to month)
+        )
+            .asUser(adminUser)
+            .responseObject<List<ServiceVoucherValueRow>>(objectMapper)
+        assertEquals(200, response.statusCode)
+
+        return data.get()
+    }
+
+    private val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+
+    private fun createVoucherDecision(
+        validFrom: LocalDate,
+        unitId: UUID,
+        value: Int,
+        coPayment: Int
+    ): VoucherValueDecision {
+        val decision = db.transaction {
+            val parts = listOf(
+                createVoucherValueDecisionPartFixture(
+                    childId = testChild_1.id,
+                    dateOfBirth = testChild_1.dateOfBirth,
+                    unitId = unitId,
+                    value = value,
+                    coPayment = coPayment
+                )
+            )
+            val decision = createVoucherValueDecisionFixture(
+                status = VoucherValueDecisionStatus.DRAFT,
+                validFrom = validFrom,
+                validTo = null,
+                headOfFamilyId = testAdult_1.id,
+                parts = parts
+            )
+            it.handle.upsertValueDecisions(objectMapper, listOf(decision))
+            decision
+        }
+
+        val (_, response, _) = http.post("/value-decisions/send")
+            .asUser(financeUser)
+            .objectBody(listOf(decision.id), mapper = objectMapper)
+            .response()
+        assertEquals(204, response.statusCode)
+        asyncJobRunner.runPendingJobsSync()
+
+        return decision
+    }
+}

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -139,6 +139,7 @@ class SharedIntegrationTestConfig {
         client.createBucket("evaka-clubdecisions-it")
         client.createBucket("evaka-daycaredecisions-it")
         client.createBucket("evaka-paymentdecisions-it")
+        client.createBucket("evaka-vouchervaluedecisions-it")
         client.createBucket("evaka-attachments-it")
         return client
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -135,7 +135,7 @@ class VoucherValueDecisionController(
         return ResponseEntity(pdf, headers, HttpStatus.OK)
     }
 
-    private fun sendVoucherValueDecisions(tx: Database.Transaction, user: AuthenticatedUser, ids: List<UUID>) {
+    fun sendVoucherValueDecisions(tx: Database.Transaction, user: AuthenticatedUser, ids: List<UUID>) {
         tx.handle.lockValueDecisions(ids)
         val decisions = tx.handle.getValueDecisionsByIds(objectMapper, ids)
         if (decisions.isEmpty()) return

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
@@ -345,7 +345,7 @@ fun searchFeeDecisions(
         if (unit != null) "part.placement_unit = :unit" else null,
         if (withNullHours) "part.service_need = :missingServiceNeed" else null,
         if (havingExternalChildren) "child.post_office <> '' AND child.post_office NOT ILIKE :espooPostOffice" else null,
-        if (retroactiveOnly) "decision.valid_from < date_trunc('month', COALESCE(decision.sent_at, now()))" else null,
+        if (retroactiveOnly) "decision.valid_from < date_trunc('month', COALESCE(decision.approved_at, now()))" else null,
         if (numberParamsRaw.isNotEmpty()) numberQuery else null,
         if (searchTextWithoutNumbers.isNotBlank()) freeTextQuery else null,
         if ((startDate != null || endDate != null) && !searchByStartDate) "daterange(:start_date, :end_date, '[]') && daterange(valid_from, valid_to, '[]')" else null,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
@@ -82,7 +82,14 @@ enum class FeeDecisionStatus {
     WAITING_FOR_SENDING,
     WAITING_FOR_MANUAL_SENDING,
     SENT,
-    ANNULLED
+    ANNULLED;
+
+    companion object {
+        /**
+         *  list of statuses that have an overlap exclusion constraint at the database level and that signal that a decision is in effect
+         */
+        val effective = arrayOf(SENT, WAITING_FOR_SENDING, WAITING_FOR_MANUAL_SENDING)
+    }
 }
 
 enum class FeeDecisionType {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/VoucherValueDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/VoucherValueDecisions.kt
@@ -77,7 +77,14 @@ enum class VoucherValueDecisionStatus {
     WAITING_FOR_SENDING,
     WAITING_FOR_MANUAL_SENDING,
     SENT,
-    ANNULLED
+    ANNULLED;
+
+    companion object {
+        /**
+         *  list of statuses that have an overlap exclusion constraint at the database level and that signal that a decision is in effect
+         */
+        val effective = arrayOf(SENT, WAITING_FOR_SENDING, WAITING_FOR_MANUAL_SENDING)
+    }
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -156,7 +156,7 @@ private fun Database.Read.getServiceVoucherValues(
     // language=sql
     val sql = """
 WITH min_voucher_decision_date AS (
-    SELECT coalesce(min(valid_from), :reportDate) AS min_date FROM voucher_value_decision WHERE status = :sent
+    SELECT coalesce(min(valid_from), :reportDate) AS min_date FROM voucher_value_decision WHERE status = ANY(:effective)
 ), min_change_month AS (
     SELECT make_date(extract(year from min_date)::int, extract(month from min_date)::int, 1) AS month FROM min_voucher_decision_date
 ), month_periods AS (
@@ -170,14 +170,14 @@ WITH min_voucher_decision_date AS (
     FROM month_periods p
     JOIN voucher_value_decision decision ON daterange(decision.valid_from, decision.valid_to, '[]') && p.period
     JOIN voucher_value_decision_part part ON decision.id = part.voucher_value_decision_id
-    WHERE decision.status = :sent AND lower(p.period) = :reportDate
+    WHERE decision.status = ANY(:effective) AND lower(p.period) = :reportDate
 ), corrections AS (
     SELECT part.child, p.*, part.id AS part_id, daterange(decision.valid_from, decision.valid_to, '[]') * p.period AS realized_period
     FROM month_periods p
     JOIN voucher_value_decision decision ON daterange(decision.valid_from, decision.valid_to, '[]') && p.period
     JOIN voucher_value_decision_part part on decision.id = part.voucher_value_decision_id
-    WHERE decision.status = 'SENT'
-      AND decision.sent_at > (SELECT coalesce(max(created), '-infinity'::timestamptz) FROM voucher_value_report_snapshot)
+    WHERE decision.status = ANY(:effective)
+      AND decision.approved_at > (SELECT coalesce(max(created), '-infinity'::timestamptz) FROM voucher_value_report_snapshot)
       AND lower(p.period) < :reportDate
 ), refund_months AS (
     SELECT DISTINCT c.child, c.year, c.month, c.period FROM corrections c
@@ -271,7 +271,7 @@ ORDER BY child_last_name, child_first_name, child_id, type_sort, realized_period
 """
 
     return createQuery(sql)
-        .bind("sent", VoucherValueDecisionStatus.SENT)
+        .bind("effective", VoucherValueDecisionStatus.effective)
         .bind("reportDate", LocalDate.of(year, month, 1))
         .bindNullable("areaId", areaId)
         .bindNullable("unitId", unitId)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -120,7 +120,7 @@ data class ServiceVoucherValueUnitAggregate(
     )
 }
 
-enum class RowType {
+enum class VoucherReportRowType {
     ORIGINAL,
     REFUND,
     CORRECTION
@@ -144,7 +144,7 @@ data class ServiceVoucherValueRow(
     val realizedAmount: Int,
     val realizedPeriod: FiniteDateRange,
     val numberOfDays: Int,
-    val type: RowType
+    val type: VoucherReportRowType
 )
 
 private fun Database.Read.getServiceVoucherValues(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
 import java.time.LocalDate
 
 private val logger = KotlinLogging.logger { }
@@ -114,7 +115,7 @@ class ScheduledOperationController(
         db: Database.Connection
     ): ResponseEntity<Unit> {
         val currentDate = LocalDate.now()
-        db.transaction { freezeVoucherValueReportRows(it, currentDate.year, currentDate.monthValue) }
+        db.transaction { freezeVoucherValueReportRows(it, currentDate.year, currentDate.monthValue, Instant.now()) }
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/resources/db/migration/V46__voucher_value_report_snapshot_taken.sql
+++ b/service/src/main/resources/db/migration/V46__voucher_value_report_snapshot_taken.sql
@@ -1,0 +1,1 @@
+ALTER TABLE voucher_value_report_snapshot ADD COLUMN taken_at timestamp with time zone NOT NULL;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -43,3 +43,4 @@ V42__income_references_application.sql
 V43__rename_bulletin_guardian_id.sql
 V44__voucher_value_report_snapshot.sql
 V45__add_sent_at_to_bulletin_instance.sql
+V46__voucher_value_report_snapshot_taken.sql

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
@@ -19,11 +19,15 @@ import fi.espoo.evaka.invoicing.domain.Invoice
 import fi.espoo.evaka.invoicing.domain.InvoiceRow
 import fi.espoo.evaka.invoicing.domain.InvoiceStatus
 import fi.espoo.evaka.invoicing.domain.PermanentPlacement
+import fi.espoo.evaka.invoicing.domain.PermanentPlacementWithHours
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.PlacementType
 import fi.espoo.evaka.invoicing.domain.Pricing
 import fi.espoo.evaka.invoicing.domain.Product
 import fi.espoo.evaka.invoicing.domain.ServiceNeed
+import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
+import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionPart
+import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.invoicing.service.DaycareCodes
 import fi.espoo.evaka.pis.service.Parentship
 import fi.espoo.evaka.pis.service.PersonJSON
@@ -283,6 +287,54 @@ fun createFeeDecisionFixture(
     partnerIncome = null,
     familySize = parts.size + 1,
     pricing = pricing,
+    parts = parts
+)
+
+fun createVoucherValueDecisionPartFixture(
+    childId: UUID,
+    dateOfBirth: LocalDate,
+    unitId: UUID,
+    placementType: PlacementType = PlacementType.DAYCARE,
+    serviceNeed: ServiceNeed = ServiceNeed.MISSING,
+    hoursPerWeek: Double? = null,
+    baseValue: Int = 87000,
+    ageCoefficient: Int = 100,
+    serviceCoefficient: Int = 100,
+    value: Int = 87000,
+    baseCoPayment: Int = 28900,
+    siblingDiscount: Int = 0,
+    coPayment: Int = 28900,
+    feeAlterations: List<FeeAlterationWithEffect> = listOf()
+) = VoucherValueDecisionPart(
+    child = PersonData.WithDateOfBirth(id = childId, dateOfBirth = dateOfBirth),
+    placement = PermanentPlacementWithHours(unitId, placementType, serviceNeed, hoursPerWeek),
+    baseValue = baseValue,
+    ageCoefficient = ageCoefficient,
+    serviceCoefficient = serviceCoefficient,
+    value = value,
+    baseCoPayment = baseCoPayment,
+    siblingDiscount = siblingDiscount,
+    coPayment = coPayment,
+    feeAlterations = feeAlterations
+)
+
+fun createVoucherValueDecisionFixture(
+    status: VoucherValueDecisionStatus,
+    validFrom: LocalDate,
+    validTo: LocalDate?,
+    headOfFamilyId: UUID,
+    parts: List<VoucherValueDecisionPart>
+) = VoucherValueDecision(
+    id = UUID.randomUUID(),
+    status = status,
+    validFrom = validFrom,
+    validTo = validTo,
+    headOfFamily = PersonData.JustId(headOfFamilyId),
+    partner = null,
+    headOfFamilyIncome = null,
+    partnerIncome = null,
+    familySize = parts.size + 1,
+    pricing = testPricing,
     parts = parts
 )
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
This PR has integration tests for voucher value report's different cases.

Also start using `WAITING_FOR_SENDING` and `WAITING_FOR_MANUAL_SENDING` statuses similarly as `SENT` when data from decisions that are in effect is needed. Since the database prevents multiple decisions with those statuses from being in effect simultaneously, they should all be treated similarly to prevent inconsistencies in invoicing or voucher value reporting.

Also add a `taken_at` timestamp to voucher value report snapshots that should be used in business logic instead of the more technical `created` timestamp.

