### PR TITLE
EVAKA-HOTFIX fee decision approved_at timestamp

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
@@ -302,7 +303,7 @@ class FeeDecisionQueriesTest : PureJdbiTest() {
         jdbi.handle { h ->
             val draft = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
             upsertFeeDecisions(h, objectMapper, listOf(draft))
-            approveFeeDecisionDraftsForSending(h, listOf(draft.id), testDecisionMaker_1.id, approvedAt = LocalDate.now())
+            approveFeeDecisionDraftsForSending(h, listOf(draft.id), testDecisionMaker_1.id, approvedAt = Instant.now())
 
             val result = getFeeDecision(h, objectMapper, testDecisions[0].id)!!
             assertEquals(FeeDecisionStatus.WAITING_FOR_SENDING, result.status)
@@ -325,7 +326,7 @@ class FeeDecisionQueriesTest : PureJdbiTest() {
             )
             upsertFeeDecisions(h, objectMapper, decisions)
 
-            approveFeeDecisionDraftsForSending(h, decisions.map { it.id }, testDecisionMaker_1.id, approvedAt = LocalDate.now())
+            approveFeeDecisionDraftsForSending(h, decisions.map { it.id }, testDecisionMaker_1.id, approvedAt = Instant.now())
 
             val result = getFeeDecisionsByIds(h, objectMapper, decisions.map { it.id }).sortedBy { it.decisionNumber }
             with(result[0]) {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID
@@ -119,7 +120,7 @@ class FeeDecisionController(
         Audit.FeeDecisionConfirm.log(targetId = feeDecisionIds)
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         db.transaction { tx ->
-            val confirmedDecisions = service.confirmDrafts(tx, user, feeDecisionIds, LocalDate.now())
+            val confirmedDecisions = service.confirmDrafts(tx, user, feeDecisionIds, Instant.now())
             asyncJobRunner.plan(tx, confirmedDecisions.map { NotifyFeeDecisionApproved(it) })
         }
         asyncJobRunner.scheduleImmediateRun()

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
@@ -37,6 +37,7 @@ import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.statement.StatementContext
 import org.postgresql.util.PGobject
 import java.sql.ResultSet
+import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.UUID
@@ -509,7 +510,7 @@ fun findFeeDecisionsForHeadOfFamily(
         .let { it.merge() }
 }
 
-fun approveFeeDecisionDraftsForSending(h: Handle, ids: List<UUID>, approvedBy: UUID, approvedAt: LocalDate, isRetroactive: Boolean = false) {
+fun approveFeeDecisionDraftsForSending(h: Handle, ids: List<UUID>, approvedBy: UUID, approvedAt: Instant, isRetroactive: Boolean = false) {
     val sql =
         """
         WITH youngest_child AS (


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Use an `Instant` instead of `LocalDate` to set a fee decision's `approved_at` value to get an accurate timestamp.

