### PR TITLE
Generalize AD SAML code by making espoo specific things configurable

### DIFF
--- a/apigw/generate-jwts.ts
+++ b/apigw/generate-jwts.ts
@@ -5,7 +5,7 @@
 import { createJwt } from './src/shared/auth/jwt'
 
 const token = createJwt({
-  kind: 'EspooAD',
+  kind: 'AD',
   // user UUID
   sub: '70c93dbc-217d-11ea-84c9-1bc36b5e1f74',
   // list of roles that are added to the user separated by space

--- a/apigw/src/internal/app.ts
+++ b/apigw/src/internal/app.ts
@@ -25,7 +25,7 @@ import mobileDeviceSession, {
 } from './mobile-device-session'
 import authStatus from './routes/auth-status'
 import createSamlRouter from '../shared/routes/auth/saml'
-import createEspooAdSamlStrategy from '../shared/auth/espoo-ad-saml'
+import createAdSamlStrategy from '../shared/auth/ad-saml'
 import createEvakaSamlStrategy from '../shared/auth/keycloak-saml'
 
 const app = express()
@@ -73,7 +73,7 @@ function internalApiRouter() {
   router.use(
     createSamlRouter({
       strategyName: 'ead',
-      strategy: createEspooAdSamlStrategy(),
+      strategy: createAdSamlStrategy(),
       sessionType: 'employee',
       pathIdentifier: 'saml'
     })

--- a/apigw/src/shared/auth/ad-saml.ts
+++ b/apigw/src/shared/auth/ad-saml.ts
@@ -15,38 +15,38 @@ import { readFileSync } from 'fs'
 import { upsertEmployee } from '../dev-api'
 import { getOrCreateEmployee, UserRole } from '../service-client'
 
-const ESPOO_AD_USER_ID_KEY =
+const AD_USER_ID_KEY =
   'http://schemas.microsoft.com/identity/claims/objectidentifier'
-const ESPOO_AD_ROLES_KEY =
+const AD_ROLES_KEY =
   'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'
-const ESPOO_AD_GIVEN_NAME_KEY =
+const AD_GIVEN_NAME_KEY =
   'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname'
-const ESPOO_AD_FAMILY_NAME_KEY =
+const AD_FAMILY_NAME_KEY =
   'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname'
-const ESPOO_AD_EMAIL_KEY =
+const AD_EMAIL_KEY =
   'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'
 
-interface EspooAdProfile {
+interface AdProfile {
   nameID?: Profile['nameID']
   nameIDFormat?: Profile['nameIDFormat']
   nameQualifier?: Profile['nameQualifier']
   spNameQualifier?: Profile['spNameQualifier']
   sessionIndex?: Profile['sessionIndex']
-  [ESPOO_AD_USER_ID_KEY]: string
-  [ESPOO_AD_ROLES_KEY]: string | string[]
-  [ESPOO_AD_GIVEN_NAME_KEY]: string
-  [ESPOO_AD_FAMILY_NAME_KEY]: string
-  [ESPOO_AD_EMAIL_KEY]: string
+  [AD_USER_ID_KEY]: string
+  [AD_ROLES_KEY]: string | string[]
+  [AD_GIVEN_NAME_KEY]: string
+  [AD_FAMILY_NAME_KEY]: string
+  [AD_EMAIL_KEY]: string
 }
 
-async function verifyProfile(profile: EspooAdProfile): Promise<SamlUser> {
-  const aad = profile[ESPOO_AD_USER_ID_KEY]
+async function verifyProfile(profile: AdProfile): Promise<SamlUser> {
+  const aad = profile[AD_USER_ID_KEY]
   if (!aad) throw Error('No user ID in SAML data')
   const person = await getOrCreateEmployee({
     externalId: `espoo-ad:${aad}`,
-    firstName: profile[ESPOO_AD_GIVEN_NAME_KEY],
-    lastName: profile[ESPOO_AD_FAMILY_NAME_KEY],
-    email: profile[ESPOO_AD_EMAIL_KEY]
+    firstName: profile[AD_GIVEN_NAME_KEY],
+    lastName: profile[AD_FAMILY_NAME_KEY],
+    email: profile[AD_EMAIL_KEY]
   })
   return {
     id: person.id,
@@ -60,17 +60,15 @@ async function verifyProfile(profile: EspooAdProfile): Promise<SamlUser> {
   }
 }
 
-export default function createEspooAdStrategy():
-  | SamlStrategy
-  | DevPassportStrategy {
+export default function createAdStrategy(): SamlStrategy | DevPassportStrategy {
   if (devLoginEnabled) {
     const getter = async (userId: string) =>
       verifyProfile({
-        [ESPOO_AD_USER_ID_KEY]: userId,
-        [ESPOO_AD_ROLES_KEY]: [],
-        [ESPOO_AD_GIVEN_NAME_KEY]: '',
-        [ESPOO_AD_FAMILY_NAME_KEY]: '',
-        [ESPOO_AD_EMAIL_KEY]: ''
+        [AD_USER_ID_KEY]: userId,
+        [AD_ROLES_KEY]: [],
+        [AD_GIVEN_NAME_KEY]: '',
+        [AD_FAMILY_NAME_KEY]: '',
+        [AD_EMAIL_KEY]: ''
       })
 
     const upserter = async (
@@ -89,17 +87,17 @@ export default function createEspooAdStrategy():
         roles: roles as UserRole[]
       })
       return verifyProfile({
-        [ESPOO_AD_USER_ID_KEY]: userId,
-        [ESPOO_AD_ROLES_KEY]: roles,
-        [ESPOO_AD_GIVEN_NAME_KEY]: firstName,
-        [ESPOO_AD_FAMILY_NAME_KEY]: lastName,
-        [ESPOO_AD_EMAIL_KEY]: email
+        [AD_USER_ID_KEY]: userId,
+        [AD_ROLES_KEY]: roles,
+        [AD_GIVEN_NAME_KEY]: firstName,
+        [AD_FAMILY_NAME_KEY]: lastName,
+        [AD_EMAIL_KEY]: email
       })
     }
 
     return new DevPassportStrategy(getter, upserter)
   } else {
-    if (!eadConfig) throw Error('Missing Espoo AD SAML configuration')
+    if (!eadConfig) throw Error('Missing AD SAML configuration')
     return new SamlStrategy(
       {
         callbackUrl: eadConfig.callbackUrl,
@@ -121,7 +119,7 @@ export default function createEspooAdStrategy():
       },
       (profile: Profile, done: VerifiedCallback) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        verifyProfile((profile as any) as EspooAdProfile)
+        verifyProfile((profile as any) as AdProfile)
           .then((user) => done(null, user))
           .catch(done)
       }

--- a/apigw/src/shared/auth/index.ts
+++ b/apigw/src/shared/auth/index.ts
@@ -32,7 +32,7 @@ export function requireAuthentication(
 
 export function createAuthHeader(user: SamlUser): string {
   const token = createJwt({
-    kind: gatewayRole === 'enduser' ? 'SuomiFI' : 'EspooAD',
+    kind: gatewayRole === 'enduser' ? 'SuomiFI' : 'AD',
     sub: user.id,
     scope: user.roles
       .map((role) => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))

--- a/apigw/src/shared/auth/jwt.ts
+++ b/apigw/src/shared/auth/jwt.ts
@@ -9,7 +9,7 @@ import { jwtKid, jwtPrivateKey } from '../config'
 const privateKey = readFileSync(jwtPrivateKey)
 
 export function createJwt(payload: {
-  kind: 'SuomiFI' | 'EspooAD' | 'EspooAdDummy'
+  kind: 'SuomiFI' | 'AD' | 'AdDummy'
   sub: string
   scope: string
 }): string {

--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -136,12 +136,16 @@ const certificateNames = Object.keys(certificates) as ReadonlyArray<
 export const devLoginEnabled =
   env('DEV_LOGIN', parseBoolean) ?? ifNodeEnv(['local', 'test'], true) ?? false
 
-const eadCallbackUrl = process.env.EAD_SAML_CALLBACK_URL
+const adCallbackUrl = process.env.EAD_SAML_CALLBACK_URL
+const adEntryPointUrl = process.env.AD_SAML_ENTRYPOINT_URL
+const adLogoutUrl = process.env.AD_SAML_LOGOUT_URL
 
-export const eadConfig =
-  eadCallbackUrl && !devLoginEnabled
+export const adConfig =
+  adCallbackUrl && !devLoginEnabled
     ? {
-        callbackUrl: required(eadCallbackUrl),
+        callbackUrl: required(adCallbackUrl),
+        entryPointUrl: required(adEntryPointUrl),
+        logoutUrl: required(adLogoutUrl),
         issuer: required(process.env.EAD_SAML_ISSUER),
         publicCert: required(
           envArray('EAD_SAML_PUBLIC_CERT', parseEnum(certificateNames))
@@ -149,6 +153,8 @@ export const eadConfig =
         privateCert: required(process.env.EAD_SAML_PRIVATE_CERT)
       }
     : undefined
+
+export const adExternalIdPrefix = process.env.AD_SAML_EXTERNAL_ID_PREFIX || 'espoo-ad'
 
 export const sfiMock =
   env('SFI_MOCK', parseBoolean) ?? ifNodeEnv(['local', 'test'], true) ?? false

--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -136,7 +136,7 @@ const certificateNames = Object.keys(certificates) as ReadonlyArray<
 export const devLoginEnabled =
   env('DEV_LOGIN', parseBoolean) ?? ifNodeEnv(['local', 'test'], true) ?? false
 
-const adCallbackUrl = process.env.EAD_SAML_CALLBACK_URL
+const adCallbackUrl = process.env.AD_SAML_CALLBACK_URL
 const adEntryPointUrl = process.env.AD_SAML_ENTRYPOINT_URL
 const adLogoutUrl = process.env.AD_SAML_LOGOUT_URL
 
@@ -146,15 +146,16 @@ export const adConfig =
         callbackUrl: required(adCallbackUrl),
         entryPointUrl: required(adEntryPointUrl),
         logoutUrl: required(adLogoutUrl),
-        issuer: required(process.env.EAD_SAML_ISSUER),
+        issuer: required(process.env.AD_SAML_ISSUER),
         publicCert: required(
-          envArray('EAD_SAML_PUBLIC_CERT', parseEnum(certificateNames))
+          envArray('AD_SAML_PUBLIC_CERT', parseEnum(certificateNames))
         ),
-        privateCert: required(process.env.EAD_SAML_PRIVATE_CERT)
+        privateCert: required(process.env.AD_SAML_PRIVATE_CERT)
       }
     : undefined
 
-export const adExternalIdPrefix = process.env.AD_SAML_EXTERNAL_ID_PREFIX || 'espoo-ad'
+export const adExternalIdPrefix =
+  process.env.AD_SAML_EXTERNAL_ID_PREFIX ?? 'espoo-ad'
 
 export const sfiMock =
   env('SFI_MOCK', parseBoolean) ?? ifNodeEnv(['local', 'test'], true) ?? false


### PR DESCRIPTION
#### Summary
- Rename espoo-ad-saml.ts as ad-saml.ts
- Remove the word "espoo" from code
- Parameterize externalId, logout url, entrypoint url
Requires https://github.com/espoon-voltti/evaka-infra/pull/365
