### PR TITLE
[EVAKA-HOTFIX] Add tracing support for all APIGW log types, fix compose build script

### DIFF
--- a/apigw/src/pino-cli/__tests__/cli/bin.ts
+++ b/apigw/src/pino-cli/__tests__/cli/bin.ts
@@ -368,6 +368,24 @@ describe('transport', () => {
       })
     })
 
+    describe('given a log message with a missing parentSpanId field', () => {
+      test('returns a valid log message in proper format with the parentSpanId field set to an empty string', () => {
+        const invalidPinoAccessLogMessage = deepCopyObj(
+          validPinoAccessLogMessage
+        )
+        delete invalidPinoAccessLogMessage.req.parentSpanId
+        const logMessage = deepCopyObj(expected.validAccessLogMessage)
+        logMessage.parentSpanId = ''
+
+        const cli = spawnSync(process.argv[0], [cliPath], {
+          input: objToLogMessage(invalidPinoAccessLogMessage)
+        })
+
+        expect(logMessageToObj(cli.stdout)).toEqual(logMessage)
+        expect(cli.status).toEqual(0)
+      })
+    })
+
     describe('given a log message with a missing spanId field', () => {
       test('returns a valid log message in proper format with the spanId field set to an empty string', () => {
         const invalidPinoAccessLogMessage = deepCopyObj(
@@ -706,6 +724,60 @@ describe('transport', () => {
         expect(cli.status).toEqual(0)
       })
     })
+
+    describe('given a log message with a missing parentSpanId field', () => {
+      test('returns a valid log message in proper format without the parentSpanId field set to an empty string', () => {
+        const invalidPinoAppAuditLogMessage = deepCopyObj(
+          validPinoAppAuditLogMessage
+        )
+        delete invalidPinoAppAuditLogMessage.parentSpanId
+        const logMessage = deepCopyObj(expected.validAuditLogMessage)
+        logMessage.parentSpanId = ''
+
+        const cli = spawnSync(process.argv[0], [cliPath], {
+          input: objToLogMessage(invalidPinoAppAuditLogMessage)
+        })
+
+        expect(logMessageToObj(cli.stdout)).toEqual(logMessage)
+        expect(cli.status).toEqual(0)
+      })
+    })
+
+    describe('given a log message with a missing spanId field', () => {
+      test('returns a valid log message in proper format without the spanId field set to an empty string', () => {
+        const invalidPinoAppAuditLogMessage = deepCopyObj(
+          validPinoAppAuditLogMessage
+        )
+        delete invalidPinoAppAuditLogMessage.spanId
+        const logMessage = deepCopyObj(expected.validAuditLogMessage)
+        logMessage.spanId = ''
+
+        const cli = spawnSync(process.argv[0], [cliPath], {
+          input: objToLogMessage(invalidPinoAppAuditLogMessage)
+        })
+
+        expect(logMessageToObj(cli.stdout)).toEqual(logMessage)
+        expect(cli.status).toEqual(0)
+      })
+    })
+
+    describe('given a log message with a missing traceId field', () => {
+      test('returns a valid log message in proper format without the traceId field set to an empty string', () => {
+        const invalidPinoAppAuditLogMessage = deepCopyObj(
+          validPinoAppAuditLogMessage
+        )
+        delete invalidPinoAppAuditLogMessage.traceId
+        const logMessage = deepCopyObj(expected.validAuditLogMessage)
+        logMessage.traceId = ''
+
+        const cli = spawnSync(process.argv[0], [cliPath], {
+          input: objToLogMessage(invalidPinoAppAuditLogMessage)
+        })
+
+        expect(logMessageToObj(cli.stdout)).toEqual(logMessage)
+        expect(cli.status).toEqual(0)
+      })
+    })
   })
 
   describe('pino misc log', () => {
@@ -937,6 +1009,54 @@ describe('transport', () => {
         delete invalidPinoMiscLogMessage.version
         const logMessage = deepCopyObj(expected.validMiscLogMessage)
         delete logMessage.version
+
+        const cli = spawnSync(process.argv[0], [cliPath], {
+          input: objToLogMessage(invalidPinoMiscLogMessage)
+        })
+
+        expect(logMessageToObj(cli.stdout)).toEqual(logMessage)
+        expect(cli.status).toEqual(0)
+      })
+    })
+
+    describe('given a log message with a missing parentSpanId field', () => {
+      test('returns a valid log message in proper format with the parentSpanId field set to an empty string', () => {
+        const invalidPinoMiscLogMessage = deepCopyObj(validPinoMiscLogMessage)
+        delete invalidPinoMiscLogMessage.parentSpanId
+        const logMessage = deepCopyObj(expected.validMiscLogMessage)
+        logMessage.parentSpanId = ''
+
+        const cli = spawnSync(process.argv[0], [cliPath], {
+          input: objToLogMessage(invalidPinoMiscLogMessage)
+        })
+
+        expect(logMessageToObj(cli.stdout)).toEqual(logMessage)
+        expect(cli.status).toEqual(0)
+      })
+    })
+
+    describe('given a log message with a missing spanId field', () => {
+      test('returns a valid log message in proper format with the spanId field set to an empty string', () => {
+        const invalidPinoMiscLogMessage = deepCopyObj(validPinoMiscLogMessage)
+        delete invalidPinoMiscLogMessage.spanId
+        const logMessage = deepCopyObj(expected.validMiscLogMessage)
+        logMessage.spanId = ''
+
+        const cli = spawnSync(process.argv[0], [cliPath], {
+          input: objToLogMessage(invalidPinoMiscLogMessage)
+        })
+
+        expect(logMessageToObj(cli.stdout)).toEqual(logMessage)
+        expect(cli.status).toEqual(0)
+      })
+    })
+
+    describe('given a log message with a missing traceId field', () => {
+      test('returns a valid log message in proper format with the traceId field set to an empty string', () => {
+        const invalidPinoMiscLogMessage = deepCopyObj(validPinoMiscLogMessage)
+        delete invalidPinoMiscLogMessage.traceId
+        const logMessage = deepCopyObj(expected.validMiscLogMessage)
+        logMessage.traceId = ''
 
         const cli = spawnSync(process.argv[0], [cliPath], {
           input: objToLogMessage(invalidPinoMiscLogMessage)

--- a/apigw/src/pino-cli/cli/index.ts
+++ b/apigw/src/pino-cli/cli/index.ts
@@ -15,6 +15,9 @@ export interface BaseLog {
   appName: string
   env: string
   hostIp: string
+  parentSpanId?: string
+  spanId?: string
+  traceId?: string
 }
 
 export interface AccessLog extends BaseLog {
@@ -24,9 +27,7 @@ export interface AccessLog extends BaseLog {
   path: string
   queryString: string
   responseTime: number
-  spanId?: string
   statusCode: string
-  traceId?: string
   type: 'app-requests-received'
   userIdHash: string
   version: number
@@ -61,18 +62,22 @@ export interface MiscLog extends BaseLog {
 }
 
 export interface PinoBaseLog {
-  level: string
   '@timestamp': string
-  message?: string
-  appName: string
   appBuild: string
   appCommit: string
+  appName: string
   env: string
   hostIp: string
+  level: string
+  message?: string
+  parentSpanId?: string
+  spanId?: string
+  traceId?: string
 }
 
 export interface PinoAccessLog extends PinoBaseLog {
   req: Omit<SerializedRequest, 'raw'> & {
+    parentSpanId?: string
     path: string
     queryString: string
     spanId?: string
@@ -88,10 +93,10 @@ export interface PinoAccessLog extends PinoBaseLog {
 export interface PinoAppAuditLog extends PinoBaseLog {
   description: string
   eventCode: string
-  targetId: string | string[]
   objectId?: string
-  securityLevel: string
   securityEvent: boolean
+  securityLevel: string
+  targetId: string | string[]
   type: 'app-audit-events'
   userId: string
   userIdHash: string
@@ -130,7 +135,10 @@ const mapPinoBaseLogToBaseLog = (obj: PinoBaseLog): BaseLog => ({
   appCommit: obj.appCommit || '',
   appName: obj.appName,
   env: obj.env,
-  hostIp: obj.hostIp || ''
+  hostIp: obj.hostIp || '',
+  parentSpanId: obj.parentSpanId || '',
+  spanId: obj.spanId || '',
+  traceId: obj.traceId || ''
 })
 
 const mapPinoLogToAccessLog = (obj: PinoAccessLog): AccessLog => ({
@@ -145,6 +153,7 @@ const mapPinoLogToAccessLog = (obj: PinoAccessLog): AccessLog => ({
   queryString: obj.req.queryString || '',
   responseTime: obj.responseTime || -1,
   statusCode: (obj.res.statusCode && `${obj.res.statusCode}`) || '',
+  parentSpanId: obj.req.parentSpanId || '',
   spanId: obj.req.spanId || '',
   traceId: obj.req.traceId || '',
   type: 'app-requests-received',

--- a/apigw/src/pino-cli/test-utils/fixtures/log-messages.ts
+++ b/apigw/src/pino-cli/test-utils/fixtures/log-messages.ts
@@ -42,6 +42,7 @@ export const validPinoAccessLogMessage: PinoAccessLog = {
     },
     remoteAddress: '::ffff:172.19.0.1',
     remotePort: 43768,
+    parentSpanId: '6692ad9c54ff94f9',
     spanId: '8e26717c418d7b8b',
     traceId: '181b7fe0c99486593ad9c545794f97f3',
     userIdHash:
@@ -83,6 +84,9 @@ export const validPinoAppAuditLogMessage: PinoAppAuditLog = {
   securityLevel: 'low',
   securityEvent: true,
   type: 'app-audit-events',
+  parentSpanId: '6692ad9c54ff94f9',
+  spanId: '8e26717c418d7b8b',
+  traceId: '181b7fe0c99486593ad9c545794f97f3',
   userId: '26e43b70-d0b4-4549-b14e-7532c6c47c06',
   userIdHash:
     'af8dcd13ce05e32f4aeb2f18f10231ff8dfaf055066155fd985a3e46a484f855',
@@ -104,6 +108,9 @@ export const validPinoMiscLogMessage: PinoMiscLog = {
   },
   message: 'User signed in',
   type: 'app-misc',
+  parentSpanId: '6692ad9c54ff94f9',
+  spanId: '8e26717c418d7b8b',
+  traceId: '181b7fe0c99486593ad9c545794f97f3',
   userIdHash:
     'af8dcd13ce05e32f4aeb2f18f10231ff8dfaf055066155fd985a3e46a484f855',
   version: 1
@@ -123,6 +130,9 @@ export const validPinoMiscLogMessageWithError: PinoMiscLog = {
   },
   message: 'User signed in',
   type: 'app-misc',
+  parentSpanId: '6692ad9c54ff94f9',
+  spanId: '8e26717c418d7b8b',
+  traceId: '181b7fe0c99486593ad9c545794f97f3',
   exception: 'ValidTestException',
   stackTrace: `Valid test exception
 multiline
@@ -153,6 +163,7 @@ export const expected: Expected = {
     path: validPinoAccessLogMessage.req.path,
     queryString: validPinoAccessLogMessage.req.queryString,
     responseTime: validPinoAccessLogMessage.responseTime,
+    parentSpanId: validPinoAccessLogMessage.req.parentSpanId,
     spanId: validPinoAccessLogMessage.req.spanId,
     statusCode: `${validPinoAccessLogMessage.res.statusCode}`,
     traceId: validPinoAccessLogMessage.req.traceId,
@@ -174,6 +185,9 @@ export const expected: Expected = {
     targetId: validPinoAppAuditLogMessage.targetId,
     objectId: validPinoAppAuditLogMessage.objectId,
     type: validPinoAppAuditLogMessage.type,
+    parentSpanId: validPinoAppAuditLogMessage.parentSpanId,
+    spanId: validPinoAppAuditLogMessage.spanId,
+    traceId: validPinoAppAuditLogMessage.traceId,
     userId: validPinoAppAuditLogMessage.userId,
     userIdHash: validPinoAppAuditLogMessage.userIdHash,
     userIp: validPinoAppAuditLogMessage.userIp,
@@ -195,6 +209,9 @@ export const expected: Expected = {
       /* eslint-enable @typescript-eslint/no-non-null-assertion */
     },
     type: validPinoMiscLogMessage.type,
+    parentSpanId: validPinoAppAuditLogMessage.parentSpanId,
+    spanId: validPinoAppAuditLogMessage.spanId,
+    traceId: validPinoAppAuditLogMessage.traceId,
     userIdHash: validPinoMiscLogMessage.userIdHash,
     version: validPinoMiscLogMessage.version
   },
@@ -216,6 +233,9 @@ export const expected: Expected = {
     },
     stackTrace: validPinoMiscLogMessageWithError.stackTrace,
     type: validPinoMiscLogMessage.type,
+    parentSpanId: validPinoAppAuditLogMessage.parentSpanId,
+    spanId: validPinoAppAuditLogMessage.spanId,
+    traceId: validPinoAppAuditLogMessage.traceId,
     userIdHash: validPinoMiscLogMessage.userIdHash,
     version: validPinoMiscLogMessage.version
   }

--- a/apigw/src/shared/routes/auth/saml/error-utils.ts
+++ b/apigw/src/shared/routes/auth/saml/error-utils.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { Request } from 'express'
 import { parse } from 'fast-xml-parser'
 import { logDebug, logError } from '../../../logging'
 import {
@@ -37,10 +38,11 @@ function parseErrorMessage(status: StatusObject): string {
 }
 
 export function parseDescriptionFromSamlError(
-  error: PassportSamlError
+  error: PassportSamlError,
+  req: Request
 ): string | undefined {
   if (!error.statusXml) {
-    logDebug('No statusXml found from SAML error', undefined, { error })
+    logDebug('No statusXml found from SAML error', req, { error })
     return
   }
 
@@ -52,7 +54,7 @@ export function parseDescriptionFromSamlError(
   if (!statusObject) {
     logError(
       'Failed to parse status object from XML',
-      undefined,
+      req,
       undefined,
       new Error('Failed to parse status object from XML')
     )

--- a/apigw/src/shared/routes/auth/saml/index.ts
+++ b/apigw/src/shared/routes/auth/saml/index.ts
@@ -74,7 +74,8 @@ function createLoginHandler({
       (err: any, user: SamlUser | undefined) => {
         if (err || !user) {
           const description =
-            parseDescriptionFromSamlError(err) || 'Could not parse SAML error'
+            parseDescriptionFromSamlError(err, req) ||
+            'Could not parse SAML error'
           logAuditEvent(
             `evaka.saml.${strategyName}.sign_in_failed`,
             req,
@@ -130,12 +131,13 @@ function createLogoutHandler({
         const redirectUrl = await fromCallback<string>((cb) =>
           strategy.logout(req, cb)
         )
-        logDebug('Logging user out from passport.')
+        logDebug('Logging user out from passport.', req)
         await logoutExpress(req, res, sessionType)
         return res.redirect(redirectUrl)
       } catch (err) {
         const description =
-          parseDescriptionFromSamlError(err) || 'Could not parse SAML error.'
+          parseDescriptionFromSamlError(err, req) ||
+          'Could not parse SAML error.'
         logAuditEvent(
           `evaka.saml.${strategyName}.sign_out_failed`,
           req,
@@ -149,7 +151,7 @@ function createLogoutHandler({
         req,
         'User signed out'
       )
-      logDebug('Logging user out from passport.')
+      logDebug('Logging user out from passport.', req)
       await logoutExpress(req, res, sessionType)
       res.redirect(getRedirectUrl(req))
     }

--- a/compose/build.sh
+++ b/compose/build.sh
@@ -10,8 +10,5 @@ set -euo pipefail
 (cd ../apigw && ./build-docker.sh)
 (cd ../service && ./build-docker.sh)
 (cd ../message-service && ./build-docker.sh)
-if [ "${ICONS:-X}" = "pro" ]; then
-    (cd ../frontend && ICONS=pro yarn install --immutable)
-else
-    (cd ../frontend && yarn install --immutable)
-fi
+(cd ../frontend && yarn install --immutable)
+(cd ../frontend && yarn build:dev)


### PR DESCRIPTION
#### Summary
- APIGW: add tracing support for all log types and request parameters to all logging calls (where available)
   - Add initial `parentSpanId` support for access logs
   - Include `parentSpanId`, `spanId` and `traceId` support in all pino-cli log types, not just access logs
   - This will help in debugging some SAML issues that are hard to pinpoint due to duplicate events / double-clicking
- Compose: fix frontend build regression in build script
   - The frontend build was accidentally removed during frontend build rework, add it back
   - Remove unnecessary ICONS checks from compose build script
      - Environment variables are already passed to all build commands and otherwise free & pro icons builds are identical