### PR TITLE
[EVAKA-4159] Add English application received email texts

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailService.kt
@@ -113,6 +113,26 @@ Palvelusetelin hakeminen: <a href="https://www.espoo.fi/fi-FI/Kasvatus_ja_opetus
 <p>
 Hakeminen yksityisiin varhaiskasvatusyksiköihin: <a href="https://www.espoo.fi/fi-FI/Kasvatus_ja_opetus/Varhaiskasvatus/Yksityinen_varhaiskasvatus">https://www.espoo.fi/fi-FI/Kasvatus_ja_opetus/Varhaiskasvatus/Yksityinen_varhaiskasvatus</a>
 </p>
+<hr>
+<p>
+Dear guardian(s), <br>
+We have received your child’s application for early childhood education. The <strong>application period</strong> for early childhood education applications is <strong>four (4) months</strong>. The guardian who submitted the application can make changes to it at <a href="https://www.espoonvarhaiskasvatus.fi">www.espoonvarhaiskasvatus.fi</a> until its processing starts.
+</p>
+<p>
+You will be informed of your child’s early childhood education unit approximately one month before the end of the statutory processing period. The statutory processing period of an application is four (4) months from the receipt of the application. You can see the decision and accept/reject it at <a href="https://www.espoonvarhaiskasvatus.fi">www.espoonvarhaiskasvatus.fi</a>. If you chose to have your application processed urgently, you will also need to provide <strong>a document as proof of sudden employment at a new workplace or a sudden offer of a new study place</strong>.
+</p>
+<p>
+In this case, the <strong>minimum application period is two (2) weeks</strong> and it begins from the date on which the required document was received. When applying for <strong>round-the-clock or evening care</strong>, both guardians living in the same household need to provide a document issued by their employer concerning shift work or a document issued by their educational institution concerning evening studies. <strong>Your application will only be processed as an application for round-the-clock care after you have provided the required documents</strong>.
+</p>
+<p>
+You can add your supporting documents to your online application or send them by post to City of Espoo, Early childhood education service guidance, P.O. Box 3125, 02070 City of Espoo or as an email attachment to <a href="mailto:varhaiskasvatuksen.palveluohjaus@espoo.fi">varhaiskasvatuksen.palveluohjaus@espoo.fi</a> (please note that the connection is not encrypted).
+</p>
+<p>
+When applying for a <strong>transfer</strong> to a different <strong>municipal early childhood education unit</strong>, your application will not have a specific application period. Your application will be valid for one (1) year from the date on which it was received. If your child’s current place is terminated, your transfer application will be deleted from the system.
+</p>
+<p>
+Information about applying to private early childhood education units: <a href="https://www.espoo.fi/en-US/Childcare_and_education/Early_childhood_education/Private_early_childhood_education">www.espoo.fi/en-US/Childcare_and_education/Early_childhood_education/Private_early_childhood_education</a>. You can send your supporting documents by post to City of Espoo, Early childhood education service guidance, P.O. Box 3125, 02070 City of Espoo or as an email attachment to <a href="mailto:varhaiskasvatuksen.palveluohjaus@espoo.fi">varhaiskasvatuksen.palveluohjaus@espoo.fi</a> (please note that the connection is not encrypted).
+</p>
             """.trimIndent()
         }
     }
@@ -166,6 +186,21 @@ Hakiessanne lapsellenne siirtoa toiseen kunnalliseen varhaiskasvatusyksikköön,
 Palvelusetelin hakeminen: https://www.espoo.fi/fi-FI/Kasvatus_ja_opetus/Varhaiskasvatus/Hakeminen_varhaiskasvatukseen/Palveluseteli/Tietoa_perheille
 
 Hakeminen yksityisiin varhaiskasvatusyksiköihin: https://www.espoo.fi/fi-FI/Kasvatus_ja_opetus/Varhaiskasvatus/Yksityinen_varhaiskasvatus
+
+-----
+
+Dear guardian(s),
+We have received your child’s application for early childhood education. The application period for early childhood education applications is four (4) months. The guardian who submitted the application can make changes to it at www.espoonvarhaiskasvatus.fi until its processing starts.
+
+You will be informed of your child’s early childhood education unit approximately one month before the end of the statutory processing period. The statutory processing period of an application is four (4) months from the receipt of the application. You can see the decision and accept/reject it at www.espoonvarhaiskasvatus.fi. If you chose to have your application processed urgently, you will also need to provide a document as proof of sudden employment at a new workplace or a sudden offer of a new study place.
+
+In this case, the minimum application period is two (2) weeks and it begins from the date on which the required document was received. When applying for round-the-clock or evening care, both guardians living in the same household need to provide a document issued by their employer concerning shift work or a document issued by their educational institution concerning evening studies. Your application will only be processed as an application for round-the-clock care after you have provided the required documents.
+
+You can add your supporting documents to your online application or send them by post to City of Espoo, Early childhood education service guidance, P.O. Box 3125, 02070 City of Espoo or as an email attachment to varhaiskasvatuksen.palveluohjaus@espoo.fi (please note that the connection is not encrypted).
+
+When applying for a transfer to a different municipal early childhood education unit, your application will not have a specific application period. Your application will be valid for one (1) year from the date on which it was received. If your child’s current place is terminated, your transfer application will be deleted from the system.
+
+Information about applying to private early childhood education units: www.espoo.fi/en-US/Childcare_and_education/Early_childhood_education/Private_early_childhood_education. You can send your supporting documents by post to City of Espoo, Early childhood education service guidance, P.O. Box 3125, 02070 City of Espoo or as an email attachment to varhaiskasvatuksen.palveluohjaus@espoo.fi (please note that the connection is not encrypted).
             """.trimIndent()
         }
     }


### PR DESCRIPTION
#### Summary
- No separate English message is sent but instead the texts should be prepended to the Finnish messages
- Decided to use the hr-element to split the sections