### PR TITLE
EVAKA-HOTFIX planned absences and discounts

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
@@ -18,8 +18,8 @@ import fi.espoo.evaka.test.validPreschoolApplication
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1
 import fi.espoo.voltti.pdfgen.PDFService
-import junit.framework.Assert.assertNotNull
 import mu.KotlinLogging
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Do not give discounts for "planned absences". They are only used to indicate a child's schedule and are not actual absences.

