### PR TITLE
Fridge child duration checks

### DIFF
--- a/frontend/src/employee-frontend/api/parentships.ts
+++ b/frontend/src/employee-frontend/api/parentships.ts
@@ -23,7 +23,7 @@ async function getParentships(
       dataArray.map((data) => ({
         ...data,
         startDate: LocalDate.parseIso(data.startDate),
-        endDate: LocalDate.parseNullableIso(data.endDate),
+        endDate: LocalDate.parseIso(data.endDate),
         headOfChild: deserializePersonDetails(data.headOfChild),
         child: deserializePersonDetails(data.child)
       }))
@@ -48,7 +48,7 @@ export async function addParentship(
   headOfChildId: UUID,
   childId: UUID,
   startDate: LocalDate,
-  endDate: LocalDate | null
+  endDate: LocalDate
 ): Promise<Result<Parentship>> {
   const body = {
     headOfChildId,
@@ -62,7 +62,7 @@ export async function addParentship(
     .then((data) => ({
       ...data,
       startDate: LocalDate.parseIso(data.startDate),
-      endDate: LocalDate.parseNullableIso(data.endDate),
+      endDate: LocalDate.parseIso(data.endDate),
       headOfChild: deserializePersonDetails(data.headOfChild),
       child: deserializePersonDetails(data.child)
     }))
@@ -73,7 +73,7 @@ export async function addParentship(
 export async function updateParentship(
   id: UUID,
   startDate: LocalDate,
-  endDate: LocalDate | null
+  endDate: LocalDate
 ): Promise<Result<Parentship>> {
   const body = {
     startDate,
@@ -85,7 +85,7 @@ export async function updateParentship(
     .then((data) => ({
       ...data,
       startDate: LocalDate.parseIso(data.startDate),
-      endDate: LocalDate.parseNullableIso(data.endDate),
+      endDate: LocalDate.parseIso(data.endDate),
       headOfChild: deserializePersonDetails(data.headOfChild),
       child: deserializePersonDetails(data.child)
     }))

--- a/frontend/src/employee-frontend/components/person-profile/PersonFridgeChild.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFridgeChild.tsx
@@ -146,7 +146,7 @@ const PersonFridgeChild = React.memo(function PersonFridgeChild({
                 {getAge(fridgeChild.child.dateOfBirth)}
               </Td>
               <DateTd>{fridgeChild.startDate.format()}</DateTd>
-              <DateTd>{fridgeChild.endDate?.format()}</DateTd>
+              <DateTd>{fridgeChild.endDate.format()}</DateTd>
               <ButtonsTd>
                 <Toolbar
                   dateRange={fridgeChild}

--- a/frontend/src/employee-frontend/components/person-profile/person-fridge-child/FridgeChildModal.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/person-fridge-child/FridgeChildModal.tsx
@@ -19,10 +19,7 @@ import { Result } from '@evaka/lib-common/api'
 import { faChild } from '@evaka/lib-icons'
 import { formatName } from '../../../utils'
 import PersonSearch from '../../../components/common/PersonSearch'
-import {
-  DatePickerDeprecated,
-  DatePickerClearableDeprecated
-} from '@evaka/lib-components/molecules/DatePickerDeprecated'
+import { DatePickerDeprecated } from '@evaka/lib-components/molecules/DatePickerDeprecated'
 import { addParentship, updateParentship } from '../../../api/parentships'
 import { PersonDetails } from '../../../types/person'
 
@@ -42,7 +39,7 @@ interface FormValidationResult {
 export interface FridgeChildForm {
   child?: PersonDetails
   startDate: LocalDate
-  endDate: LocalDate | null
+  endDate: LocalDate
 }
 
 function FridgeChildModal({ headPersonId, onSuccess, parentship }: Props) {
@@ -52,7 +49,7 @@ function FridgeChildModal({ headPersonId, onSuccess, parentship }: Props) {
   const initialForm: FridgeChildForm = {
     child: parentship && parentship.child,
     startDate: parentship ? parentship.startDate : LocalDate.today(),
-    endDate: parentship ? parentship.endDate : null
+    endDate: parentship ? parentship.endDate : LocalDate.today()
   }
   const [form, setForm] = useState<FridgeChildForm>(initialForm)
 
@@ -151,8 +148,8 @@ function FridgeChildModal({ headPersonId, onSuccess, parentship }: Props) {
                 <PersonSearch
                   onResult={(person: PersonDetails | undefined) => {
                     let endDate = form.endDate
-                    if (person && person.dateOfBirth) {
-                      endDate = person.dateOfBirth.addYears(18)
+                    if (person) {
+                      endDate = person.dateOfBirth.addYears(18).subDays(1)
                     }
                     assignFridgeChildForm({ child: person, endDate })
                   }}
@@ -166,15 +163,18 @@ function FridgeChildModal({ headPersonId, onSuccess, parentship }: Props) {
             <DatePickerDeprecated
               date={form.startDate}
               onChange={(startDate) => assignFridgeChildForm({ startDate })}
+              minDate={form.child?.dateOfBirth}
+              maxDate={form.child?.dateOfBirth.addYears(18).subDays(1)}
               type="full-width"
             />
           </section>
           <section>
             <div className="bold">{i18n.common.form.endDate}</div>
-            <DatePickerClearableDeprecated
+            <DatePickerDeprecated
               date={form.endDate}
               onChange={(endDate) => assignFridgeChildForm({ endDate })}
-              onCleared={() => assignFridgeChildForm({ endDate: null })}
+              minDate={form.child?.dateOfBirth}
+              maxDate={form.child?.dateOfBirth.addYears(18).subDays(1)}
               type="full-width"
             />
           </section>

--- a/frontend/src/employee-frontend/types/fridge.ts
+++ b/frontend/src/employee-frontend/types/fridge.ts
@@ -21,6 +21,6 @@ export interface Parentship {
   childId: string
   child: PersonDetails
   startDate: LocalDate
-  endDate: LocalDate | null
+  endDate: LocalDate
   conflict: boolean
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
@@ -43,7 +43,7 @@ class FeeDecisionGeneratorController(private val asyncJobRunner: AsyncJobRunner)
     private fun generateAllStartingFrom(db: Database.Connection, starting: LocalDate, targetHeads: List<UUID>) {
         db.transaction { tx ->
             val heads = if (targetHeads.isEmpty()) {
-                tx.createQuery("SELECT head_of_child FROM fridge_child WHERE COALESCE(end_date, '9999-01-01') >= :from AND conflict = false")
+                tx.createQuery("SELECT head_of_child FROM fridge_child WHERE end_date >= :from AND conflict = false")
                     .bind("from", starting)
                     .mapTo<UUID>()
                     .list()

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -165,11 +165,11 @@ class ParentshipController(
         val headOfChildId: UUID,
         val childId: UUID,
         val startDate: LocalDate,
-        val endDate: LocalDate?
+        val endDate: LocalDate
     )
 
     data class ParentshipUpdateRequest(
         val startDate: LocalDate,
-        val endDate: LocalDate?
+        val endDate: LocalDate
     )
 }

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
@@ -32,6 +32,7 @@ import fi.espoo.evaka.invoicing.service.DaycareCodes
 import fi.espoo.evaka.pis.service.Parentship
 import fi.espoo.evaka.pis.service.PersonJSON
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -185,7 +186,7 @@ val testPeriod = LocalDate.now().let {
 fun testParentship(
     child: PersonJSON = testPisPerson(testPisFridgeChild),
     parent: PersonJSON = testPisPerson(testPisFridgeParent),
-    period: DateRange = testPeriod
+    period: FiniteDateRange = testPeriod.asFiniteDateRange()!!
 ) = Parentship(
     id = UUID.randomUUID(),
     childId = child.id,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Check that new or updated fridge child-parent relationships are effective only before the child turns 18 and after the child has been born.

Data has to be updated manually so that it matches these constraints.

