### PR TITLE
EVAKA-4075 voucher decisions to Varda

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -421,6 +421,7 @@ fun insertGeneralTestFixtures(h: Handle) {
             id = testVoucherDaycare.id,
             name = testVoucherDaycare.name,
             providerType = ProviderType.PRIVATE_SERVICE_VOUCHER,
+            ophOrganizerOid = defaultPurchasedOrganizerOid,
             invoicedByMunicipality = false
         )
     )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -34,6 +34,7 @@ import fi.espoo.evaka.testChild_3
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1
 import fi.espoo.evaka.testPurchasedDaycare
+import fi.espoo.evaka.testVoucherDaycare
 import fi.espoo.evaka.toDaycareFormAdult
 import fi.espoo.evaka.toDaycareFormChild
 import fi.espoo.evaka.varda.integration.MockVardaIntegrationEndpoint
@@ -80,7 +81,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
     }
 
     @Test
-    fun `PAOS decision is sent when it has all required data`() {
+    fun `PAOS decision to purchased daycare is sent when it has all required data`() {
         val decisionId = insertPlacementWithDecision(db, testChild_1, testPurchasedDaycare.id, FiniteDateRange(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))).first
         updateChildren()
 
@@ -92,6 +93,25 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         val vardaDecisions = mockEndpoint.decisions
         assertEquals(1, vardaDecisions.size)
         assertEquals(VardaUnitProviderType.PURCHASED.vardaCode, vardaDecisions.values.first().providerTypeCode)
+
+        val decisionRows = getVardaDecisions()
+        assertEquals(1, decisionRows.size)
+        assertEquals(decisionId, decisionRows.first().evakaDecisionId)
+    }
+
+    @Test
+    fun `PAOS decision to voucher daycare is sent when it has all required data`() {
+        val decisionId = insertPlacementWithDecision(db, testChild_1, testVoucherDaycare.id, FiniteDateRange(LocalDate.of(2019, 8, 1), LocalDate.of(2020, 7, 31))).first
+        updateChildren()
+
+        val children = getUploadedChildren(db)
+        assertEquals(1, children.size)
+
+        updateDecisions(db, vardaClient)
+
+        val vardaDecisions = mockEndpoint.decisions
+        assertEquals(1, vardaDecisions.size)
+        assertEquals(VardaUnitProviderType.PRIVATE_SERVICE_VOUCHER.vardaCode, vardaDecisions.values.first().providerTypeCode)
 
         val decisionRows = getVardaDecisions()
         assertEquals(1, decisionRows.size)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Added a test to verify that decisions to voucher units are sent to Varda.

