### PR TITLE
EVAKA-4027 send voucher decisions to Varda

### DIFF
--- a/service/src/main/resources/db/migration/V49__varda_voucher_values.sql
+++ b/service/src/main/resources/db/migration/V49__varda_voucher_values.sql
@@ -1,0 +1,8 @@
+ALTER TABLE varda_fee_data ADD COLUMN evaka_voucher_value_decision_id uuid REFERENCES voucher_value_decision(id);
+ALTER TABLE varda_fee_data ALTER COLUMN evaka_fee_decision_id DROP NOT NULL;
+ALTER TABLE varda_fee_data ADD CONSTRAINT evaka_decision_reference CHECK (
+    (evaka_fee_decision_id IS NOT NULL AND evaka_voucher_value_decision_id IS NULL)
+    OR (evaka_fee_decision_id IS NULL AND evaka_voucher_value_decision_id IS NOT NULL)
+);
+CREATE INDEX varda_fee_data_evaka_fee_decision_id ON varda_fee_data (evaka_fee_decision_id);
+CREATE INDEX varda_fee_data_evaka_voucher_value_decision_id ON varda_fee_data (evaka_voucher_value_decision_id);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -46,3 +46,4 @@ V45__add_sent_at_to_bulletin_instance.sql
 V46__voucher_value_report_snapshot_taken.sql
 V47__drop_iban_from_varda_organizer.sql
 V48__messaging_blocklist.sql
+V49__varda_voucher_values.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Send voucher value decisions to Varda. In essence the fee data integration stays the same, voucher value decision data is just included in the data sets with `UNION`.
