### PR TITLE
Allow web service message sender customization

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/config/KeyManagerConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/config/KeyManagerConfig.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.vtjclient.config
 import fi.espoo.evaka.vtjclient.properties.XRoadProperties
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -20,6 +21,7 @@ class KeyManagerConfig {
 
     @Bean
     @ConditionalOnExpression("'\${voltti.env}' == 'prod' || '\${voltti.env}' == 'staging'")
+    @ConditionalOnProperty(prefix = "fi.espoo.voltti.vtj.xroad", name = ["key-store.location"])
     fun keyManagers(@Qualifier("keyStore") keyStore: KeyStoreFactoryBean, xroadProps: XRoadProperties) = KeyManagersFactoryBean()
         .apply {
             setKeyStore(keyStore.`object`)
@@ -28,6 +30,7 @@ class KeyManagerConfig {
 
     @Bean("keyStore")
     @ConditionalOnExpression("'\${voltti.env}' == 'prod' || '\${voltti.env}' == 'staging'")
+    @ConditionalOnProperty(prefix = "fi.espoo.voltti.vtj.xroad", name = ["key-store.location"])
     fun keyStore(xroadProps: XRoadProperties) = KeyStoreFactoryBean()
         .apply {
             val keyStore = checkNotNull(xroadProps.keyStore.location) { "Xroad security server client authentication key store location is not set" }

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/config/TrustManagerConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/config/TrustManagerConfig.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.vtjclient.config
 
 import fi.espoo.evaka.vtjclient.properties.XRoadProperties
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -18,10 +19,12 @@ import org.springframework.ws.soap.security.support.TrustManagersFactoryBean
 class TrustManagerConfig {
 
     @Bean
+    @ConditionalOnProperty(prefix = "fi.espoo.voltti.vtj.xroad", name = ["trust-store.location"])
     fun trustManagers(@Qualifier("trustStore") trustStore: KeyStoreFactoryBean) = TrustManagersFactoryBean()
         .apply { setKeyStore(trustStore.`object`) }
 
     @Bean("trustStore")
+    @ConditionalOnProperty(prefix = "fi.espoo.voltti.vtj.xroad", name = ["trust-store.location"])
     fun trustStore(xroadProps: XRoadProperties) = KeyStoreFactoryBean()
         .apply {
             val trustStore = checkNotNull(xroadProps.trustStore.location) { "Xroad security server trust store location is not set" }

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/config/XroadSoapClientConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/config/XroadSoapClientConfig.kt
@@ -13,6 +13,7 @@ import fi.espoo.voltti.logging.MdcKey
 import mu.KotlinLogging
 import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -26,7 +27,7 @@ import org.springframework.ws.client.core.WebServiceTemplate
 import org.springframework.ws.soap.SoapMessage
 import org.springframework.ws.soap.security.support.KeyManagersFactoryBean
 import org.springframework.ws.soap.security.support.TrustManagersFactoryBean
-import org.springframework.ws.transport.http.HttpUrlConnectionMessageSender
+import org.springframework.ws.transport.WebServiceMessageSender
 import org.springframework.ws.transport.http.HttpsUrlConnectionMessageSender
 import javax.xml.bind.helpers.DefaultValidationEventHandler
 
@@ -53,7 +54,7 @@ class XroadSoapClientConfig {
     fun wsTemplate(
         marshaller: Jaxb2Marshaller,
         xRoadProperties: XRoadProperties,
-        messageSender: HttpUrlConnectionMessageSender,
+        messageSender: WebServiceMessageSender,
         faultMessageResolver: FaultMessageResolver
     ) = WebServiceTemplate()
         .apply {
@@ -92,6 +93,7 @@ class XroadSoapClientConfig {
 
     @Bean
     @ConditionalOnExpression("'\${voltti.env}' != 'prod' && '\${voltti.env}' != 'staging'")
+    @ConditionalOnMissingBean(WebServiceMessageSender::class)
     fun httpsMessageSender(trustManagersFactoryBean: TrustManagersFactoryBean) = HttpsUrlConnectionMessageSender()
         .apply {
             setTrustManagers(trustManagersFactoryBean.`object`)
@@ -103,6 +105,7 @@ class XroadSoapClientConfig {
 
     @Bean
     @ConditionalOnExpression("'\${voltti.env}' == 'prod' || '\${voltti.env}' == 'staging'")
+    @ConditionalOnMissingBean(WebServiceMessageSender::class)
     fun httpsClientAuthMessageSender(
         trustManagersFactoryBean: TrustManagersFactoryBean,
         keyManagersFactoryBean: KeyManagersFactoryBean

--- a/service/src/test/kotlin/fi/espoo/evaka/vtjclient/config/KeyManagerConfigTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/vtjclient/config/KeyManagerConfigTest.kt
@@ -88,6 +88,19 @@ class KeyManagerConfigTest {
             }
     }
 
+    @Test
+    fun `private key bean factory and key should NOT be loaded with keystore location false`() {
+        contextRunner.withPropertyValues(
+            "spring.profiles.active=production",
+            "voltti.env=prod",
+            "fi.espoo.voltti.vtj.xroad.keyStore.location=false"
+        )
+            .run {
+                assertThat(it).doesNotHaveBean(KeyManagersFactoryBean::class.java)
+                assertThat(it).doesNotHaveBean(KeyStoreFactoryBean::class.java)
+            }
+    }
+
     @Configuration
     @Import(KeyManagerConfig::class)
     class KeyManagerTestConfig {


### PR DESCRIPTION
#### Summary

Trevaka requires basic authentication in the http request which is
possible with HttpComponentsMessageSender.