### PR TITLE
Refresh user roles on page load + refactor role data model in apigw slightly

### DIFF
--- a/apigw/src/internal/__tests__/csrf.ts
+++ b/apigw/src/internal/__tests__/csrf.ts
@@ -5,11 +5,14 @@
 import { GatewayTester } from '../../shared/test/gateway-tester'
 import app from '../app'
 import { csrfCookieName } from '../../shared/middleware/csrf'
-import { AuthenticatedUser } from '../../shared/service-client'
+import { EmployeeUser } from '../../shared/service-client'
 
-const mockUser: AuthenticatedUser = {
+const mockUser: EmployeeUser = {
   id: '8fc11215-6d55-4059-bd59-038bfa36f294',
-  roles: ['SERVICE_WORKER']
+  firstName: '',
+  lastName: '',
+  globalRoles: ['SERVICE_WORKER'],
+  allScopedRoles: []
 }
 
 describe('CSRF middleware and cookie handling in internal-gw', () => {
@@ -22,9 +25,7 @@ describe('CSRF middleware and cookie handling in internal-gw', () => {
   afterAll(async () => tester?.stop())
 
   async function setupCsrfToken() {
-    tester.nockScope.get(`/employee/${mockUser.id}`).reply(200, {
-      id: mockUser.id
-    })
+    tester.nockScope.get(`/system/employee/${mockUser.id}`).reply(200, mockUser)
     await tester.client.get('/api/internal/auth/status')
     tester.nockScope.done()
 

--- a/apigw/src/internal/mobile-device-session.ts
+++ b/apigw/src/internal/mobile-device-session.ts
@@ -38,7 +38,8 @@ async function mobileLogin(
     req.logIn(
       {
         id: device.id,
-        roles: ['MOBILE'],
+        globalRoles: [],
+        allScopedRoles: ['MOBILE'],
         userType: 'MOBILE'
       },
       cb

--- a/apigw/src/internal/routes/auth-status.ts
+++ b/apigw/src/internal/routes/auth-status.ts
@@ -16,15 +16,16 @@ export default toRequestHandler(async (req, res) => {
   if (user) {
     if (user.userType === 'MOBILE') {
       const device = await getMobileDevice(req, user.id)
+      const globalRoles = user.globalRoles ?? []
+      const allScopedRoles = user.allScopedRoles ?? ['MOBILE']
       if (device) {
         const { id, name, unitId } = device
         res.status(200).json({
           loggedIn: true,
           user: { id, name, unitId },
-          roles: user.roles ?? [
-            ...(user.globalRoles ?? []),
-            ...(user.allScopedRoles ?? [])
-          ]
+          globalRoles,
+          allScopedRoles,
+          roles: [...globalRoles, ...allScopedRoles]
         })
       } else {
         // device has been removed
@@ -54,6 +55,8 @@ export default toRequestHandler(async (req, res) => {
       res.status(200).json({
         loggedIn: true,
         user: { id, name },
+        globalRoles,
+        allScopedRoles,
         roles: [...globalRoles, ...allScopedRoles]
       })
     }

--- a/apigw/src/internal/routes/auth-status.ts
+++ b/apigw/src/internal/routes/auth-status.ts
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { eq } from 'lodash'
 import { toRequestHandler } from '../../shared/express'
 import {
   getEmployeeDetails,
   getMobileDevice
 } from '../../shared/service-client'
 import { logoutExpress } from '../../shared/session'
+import { fromCallback } from '../../shared/promise-utils'
 
 export default toRequestHandler(async (req, res) => {
   const user = req.user
@@ -19,7 +21,10 @@ export default toRequestHandler(async (req, res) => {
         res.status(200).json({
           loggedIn: true,
           user: { id, name, unitId },
-          roles: user.roles
+          roles: user.roles ?? [
+            ...(user.globalRoles ?? []),
+            ...(user.allScopedRoles ?? [])
+          ]
         })
       } else {
         // device has been removed
@@ -27,12 +32,29 @@ export default toRequestHandler(async (req, res) => {
         res.status(200).json({ loggedIn: false })
       }
     } else {
-      const { id, firstName, lastName } = await getEmployeeDetails(req, user.id)
+      const {
+        id,
+        firstName,
+        lastName,
+        globalRoles,
+        allScopedRoles
+      } = await getEmployeeDetails(req, user.id)
       const name = [firstName, lastName].filter((x) => !!x).join(' ')
+
+      // Refresh roles if necessary
+      if (
+        !eq(user.globalRoles, globalRoles) ||
+        !eq(user.allScopedRoles, allScopedRoles)
+      ) {
+        await fromCallback((cb) =>
+          req.logIn({ ...user, globalRoles, allScopedRoles }, cb)
+        )
+      }
+
       res.status(200).json({
         loggedIn: true,
         user: { id, name },
-        roles: user.roles
+        roles: [...globalRoles, ...allScopedRoles]
       })
     }
   } else {

--- a/apigw/src/shared/auth/ad-saml.ts
+++ b/apigw/src/shared/auth/ad-saml.ts
@@ -50,8 +50,9 @@ async function verifyProfile(profile: AdProfile): Promise<SamlUser> {
   })
   return {
     id: person.id,
-    roles: person.roles,
     userType: 'EMPLOYEE',
+    globalRoles: person.globalRoles,
+    allScopedRoles: person.allScopedRoles,
     nameID: profile.nameID,
     nameIDFormat: profile.nameIDFormat,
     nameQualifier: profile.nameQualifier,

--- a/apigw/src/shared/auth/index.ts
+++ b/apigw/src/shared/auth/index.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { concat } from 'lodash'
 import { NextFunction, Request, Response } from 'express'
 import { logAuditEvent } from '../logging'
 import { gatewayRole } from '../config'
@@ -31,10 +32,12 @@ export function requireAuthentication(
 }
 
 export function createAuthHeader(user: SamlUser): string {
+  const roles =
+    user.roles ?? concat(user.globalRoles ?? [], user.allScopedRoles ?? [])
   const token = createJwt({
     kind: gatewayRole === 'enduser' ? 'SuomiFI' : 'AD',
     sub: user.id,
-    scope: user.roles
+    scope: roles
       .map((role) => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))
       .join(' ')
   })

--- a/apigw/src/shared/auth/keycloak-saml.ts
+++ b/apigw/src/shared/auth/keycloak-saml.ts
@@ -66,8 +66,9 @@ async function verifyKeycloakProfile(
   })
   return {
     id: person.id,
-    roles: person.roles,
     userType: 'EMPLOYEE',
+    globalRoles: person.globalRoles,
+    allScopedRoles: person.allScopedRoles,
     nameID: profile.nameID,
     nameIDFormat: profile.nameIDFormat,
     nameQualifier: profile.nameQualifier,

--- a/apigw/src/shared/auth/suomi-fi-saml.ts
+++ b/apigw/src/shared/auth/suomi-fi-saml.ts
@@ -42,8 +42,9 @@ async function verifyProfile(profile: SuomiFiProfile): Promise<SamlUser> {
   })
   return {
     id: person.id,
-    roles: person.roles,
     userType: 'ENDUSER',
+    globalRoles: ['END_USER'],
+    allScopedRoles: [],
     nameID: profile.nameID,
     nameIDFormat: profile.nameIDFormat,
     nameQualifier: profile.nameQualifier,

--- a/apigw/src/shared/routes/auth/saml/types.ts
+++ b/apigw/src/shared/routes/auth/saml/types.ts
@@ -41,10 +41,13 @@ export interface StatusObject {
 }
 
 export interface SamlUser {
-  // eVaka id from person table
+  // eVaka id
   id: string
-  roles: string[]
   userType: UserType | undefined
+  // all are optional because of legacy sessions
+  roles?: string[]
+  globalRoles?: string[]
+  allScopedRoles?: string[]
   // fields used by passport-saml during logout flow
   nameID?: string
   nameIDFormat?: string

--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -61,14 +61,12 @@ export interface EmployeeIdentityRequest {
   email?: string
 }
 
-export interface EmployeeResponse {
+export interface EmployeeUser {
   id: string
-  externalId: string | null
   firstName: string
   lastName: string
-  email: string
-  created: string
-  updated: string
+  globalRoles: UserRole[]
+  allScopedRoles: UserRole[]
 }
 
 export interface PersonIdentityRequest {
@@ -79,8 +77,8 @@ export interface PersonIdentityRequest {
 
 export async function getOrCreateEmployee(
   employee: EmployeeIdentityRequest
-): Promise<AuthenticatedUser> {
-  const { data } = await client.post<AuthenticatedUser>(
+): Promise<EmployeeUser> {
+  const { data } = await client.post<EmployeeUser>(
     `/system/employee-identity`,
     employee,
     {
@@ -94,10 +92,10 @@ export async function getEmployeeDetails(
   req: express.Request,
   employeeId: string
 ) {
-  const { data } = await client.get<EmployeeResponse>(
-    `/employee/${employeeId}`,
+  const { data } = await client.get<EmployeeUser>(
+    `/system/employee/${employeeId}`,
     {
-      headers: createServiceRequestHeaders(req)
+      headers: createServiceRequestHeaders(req, machineUser)
     }
   )
   return data

--- a/apigw/src/shared/test/gateway-tester.ts
+++ b/apigw/src/shared/test/gateway-tester.ts
@@ -10,7 +10,7 @@ import nock from 'nock'
 import { evakaServiceUrl } from '../config'
 import { sessionCookie, SessionType } from '../session'
 import { csrfCookieName } from '../middleware/csrf'
-import { AuthenticatedUser } from '../service-client'
+import { AuthenticatedUser, EmployeeUser } from '../service-client'
 
 export class GatewayTester {
   public readonly client: AxiosInstance
@@ -68,7 +68,7 @@ export class GatewayTester {
     )
   }
 
-  public async login(user: AuthenticatedUser): Promise<void> {
+  public async login(user: AuthenticatedUser | EmployeeUser): Promise<void> {
     if (this.sessionType === 'employee') {
       this.nockScope.post('/system/employee-identity').reply(200, user)
       await this.client.post(

--- a/frontend/src/e2e-test/specs/2_employee-2/employee-dailynote.spec.ts
+++ b/frontend/src/e2e-test/specs/2_employee-2/employee-dailynote.spec.ts
@@ -61,7 +61,7 @@ fixture('Mobile daily notes')
       firstName: 'Yrjö',
       lastName: 'Yksikkö',
       email: 'yy@example.com',
-      roles: ['MOBILE']
+      roles: []
     })
 
     careArea = await Fixture.careArea().save()

--- a/frontend/src/e2e-test/specs/6_mobile/attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/attendances.spec.ts
@@ -62,7 +62,7 @@ fixture('Mobile attendances')
         firstName: 'Yrjö',
         lastName: 'Yksikkö',
         email: 'yy@example.com',
-        roles: ['MOBILE']
+        roles: []
       })
     ])
 

--- a/frontend/src/e2e-test/specs/6_mobile/dailynotes.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/dailynotes.spec.ts
@@ -65,7 +65,7 @@ fixture('Mobile daily notes')
         firstName: 'Yrjö',
         lastName: 'Yksikkö',
         email: 'yy@example.com',
-        roles: ['MOBILE']
+        roles: []
       })
     ])
 

--- a/service/src/main/resources/db/migration/V54__employee_only_global_roles.sql
+++ b/service/src/main/resources/db/migration/V54__employee_only_global_roles.sql
@@ -1,0 +1,13 @@
+UPDATE employee SET roles = array(
+    SELECT DISTINCT role
+    FROM (
+         SELECT role
+         FROM unnest(roles) AS role
+         WHERE role IN ('ADMIN', 'DIRECTOR', 'FINANCE_ADMIN', 'SERVICE_WORKER')
+    ) AS filtered_roles
+    ORDER BY role
+);
+
+ALTER TABLE employee ADD CONSTRAINT "chk$valid_role" CHECK (
+  array['ADMIN', 'DIRECTOR', 'FINANCE_ADMIN', 'SERVICE_WORKER']::user_role[] @> roles
+);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -51,3 +51,4 @@ V50__add_bulletin_reciever.sql
 V51__refactor_bulletin_receiver.sql
 V52__backup_pickup.sql
 V53__create_family_contacts_table.sql
+V54__employee_only_global_roles.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

* pass roles in two arrays to apigw, separating "global" and "scoped" roles. This separation will later be applied to frontend and service code as well to avoid mixing the two types of roles accidentally
* remove old leftover scoped roles from employee table `roles` column, which is supposed to only contain global roles
* add database constraint to prevent scoped roles from being added to the employee table
* refresh apigw session roles in /auth/status endpoint if they have been changed in the database. In practice this means a page reload is enough for changes in user roles to be applied in frontend (no longer needs logout + login!)
