### PR TITLE
[EVAKA] CI workflow for forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -941,6 +941,11 @@ workflows:
     jobs:
       - checkout_repo:
           <<: *default_contexts
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              # Currently ALL jobs require secrets -> stop already at checkout for forks
+              ignore: /pull\/[0-9]+/
       - fetch_private_dependencies:
           <<: *aws_contexts
           requires:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,38 @@ The applications consists of several sub-projects:
 Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for further
 instructions regarding code contributions.
 
+### Running CI for forked Pull Requests
+
+**After** the code in a forked PR has been reviewed to not pose a security risk
+for CI:
+
+In CircleCI, "Build forked pull requests" must be enabled for repository.
+
+**IMPORTANT:** "Pass secrets to builds from forked pull requests" must still be
+**disabled**.
+
+```sh
+# Add remote (can be done only once if expecting more PRs from same remote)
+git remote add <name for remote> <address of remote>
+# E.g.: git remote add Tampere git@github.com:Tampere/evaka.git
+
+# Fetch remote references
+git fetch --all
+
+# Push refs as-is to origin
+# NOTE: Upstream branch name doesn't need to match downstream, just the refs
+# need to be identical
+git push --force origin "refs/remotes/<name for remote>/<source branch>:refs/heads/<upstream branch>"
+# E.g. git push --force origin "refs/remotes/Tampere/cool-branch-sauce:refs/heads/cool-branch-sauce"
+
+# Remove remote (can be skipped if expecting more PRs from same remote)
+git remote remove <name for remote>
+# E.g. git remote remove Tampere
+```
+
+If any changes are made to the PR, they must similarly pushed to origin. You
+can use the same method as above.
+
 ## Security issues
 
 In case you notice any information security related issue in our


### PR DESCRIPTION
#### Summary

- CI: Don't run jobs for fork branches, only origin
   - All jobs currently require secrets due to Slack notifications -> need to stop already at checkout
   - **NOTE:** This does not prevent our actual workflow for fork pull requests where we push the references to origin as then `CIRCLE_BRANCH` will be our name for it, instead of `pull/[0-9]+` and the CircleCI setting "Build forked pull requests" will enable the builds (a bit confusingly, I admit)
- Docs: CI for forked PRs