### PR TITLE
EVAKA-4031 child family contacts

### DIFF
--- a/frontend/src/employee-frontend/api/family-overview.ts
+++ b/frontend/src/employee-frontend/api/family-overview.ts
@@ -45,3 +45,18 @@ export async function getFamilyContacts(
     .then((res) => Success.of(res.data))
     .catch((e) => Failure.fromError(e))
 }
+
+interface FamilyContactUpdateBody {
+  childId: string
+  contactPersonId: string
+  priority?: number
+}
+
+export async function updateFamilyContacts(
+  body: FamilyContactUpdateBody
+): Promise<Result<void>> {
+  return client
+    .post<void>('/family/contacts', body)
+    .then(() => Success.of(undefined))
+    .catch((e) => Failure.fromError(e))
+}

--- a/frontend/src/employee-frontend/assets/i18n/fi.ts
+++ b/frontend/src/employee-frontend/assets/i18n/fi.ts
@@ -470,6 +470,7 @@ export const fi = {
         REMOTE_GUARDIAN: 'Huoltaja'
       },
       contact: 'S-posti ja puhelin',
+      contactPerson: 'Yhteyshlö',
       address: 'Osoite'
     },
     serviceNeed: {

--- a/frontend/src/employee-frontend/components/ChildInformation.tsx
+++ b/frontend/src/employee-frontend/components/ChildInformation.tsx
@@ -107,7 +107,8 @@ const layouts: Layouts<typeof components> = {
     { component: 'backup-care', open: false },
     { component: 'service-need', open: false },
     { component: 'assistance', open: false },
-    { component: 'applications', open: false }
+    { component: 'applications', open: false },
+    { component: 'family-contacts', open: false }
   ],
   ['FINANCE_ADMIN']: [
     { component: 'fee-alterations', open: true },
@@ -124,7 +125,8 @@ const layouts: Layouts<typeof components> = {
     { component: 'backup-care', open: false },
     { component: 'service-need', open: false },
     { component: 'assistance', open: false },
-    { component: 'applications', open: false }
+    { component: 'applications', open: false },
+    { component: 'family-contacts', open: false }
   ],
   ['STAFF']: [
     { component: 'family-contacts', open: true },

--- a/frontend/src/employee-frontend/types/family-overview.ts
+++ b/frontend/src/employee-frontend/types/family-overview.ts
@@ -48,6 +48,7 @@ export type FamilyContactRole =
   | 'REMOTE_GUARDIAN'
 
 export interface FamilyContact {
+  id: string
   role: FamilyContactRole
   firstName: string | null
   lastName: string | null
@@ -56,4 +57,5 @@ export interface FamilyContact {
   streetAddress: string
   postalCode: string
   postOffice: string
+  priority: number
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -97,6 +97,7 @@ enum class Audit(
     FamilyConflictReportRead("evaka.family-conflict-report.read"),
     FamilyContactReportRead("evaka.family-contact-report.read"),
     FamilyContactsRead("evaka.family-contacts.read"),
+    FamilyContactsUpdate("evaka.family-contacts.update"),
     FeeDecisionConfirm("evaka.fee-decision.confirm"),
     FeeDecisionGenerate("evaka.fee-decision.generate"),
     FeeDecisionHeadOfFamilyRead("evaka.fee-decision.head-of-family.read"),

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/FamilyContact.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/FamilyContact.kt
@@ -4,6 +4,8 @@
 
 package fi.espoo.evaka.pis
 
+import java.util.UUID
+
 enum class FamilyContactRole {
     LOCAL_GUARDIAN,
     LOCAL_ADULT,
@@ -12,6 +14,7 @@ enum class FamilyContactRole {
 }
 
 data class FamilyContact(
+    val id: UUID,
     val role: FamilyContactRole,
     val firstName: String?,
     val lastName: String?,
@@ -19,5 +22,6 @@ data class FamilyContact(
     val phone: String?,
     val streetAddress: String,
     val postalCode: String,
-    val postOffice: String
+    val postOffice: String,
+    val priority: Int?
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
@@ -6,15 +6,20 @@ package fi.espoo.evaka.pis.controllers
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.pis.FamilyContact
+import fi.espoo.evaka.pis.FamilyContactRole.LOCAL_GUARDIAN
+import fi.espoo.evaka.pis.FamilyContactRole.REMOTE_GUARDIAN
 import fi.espoo.evaka.pis.service.FamilyOverview
 import fi.espoo.evaka.pis.service.FamilyOverviewService
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
+import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -27,7 +32,11 @@ class FamilyController(
     private val acl: AccessControlList
 ) {
     @GetMapping("/by-adult/{id}")
-    fun getFamilyByPerson(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<FamilyOverview> {
+    fun getFamilyByPerson(
+        db: Database.Connection,
+        user: AuthenticatedUser,
+        @PathVariable(value = "id") id: UUID
+    ): ResponseEntity<FamilyOverview> {
         Audit.PisFamilyRead.log(targetId = id)
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         val result = db.read { familyOverviewService.getFamilyByAdult(it, id) }
@@ -42,74 +51,162 @@ class FamilyController(
         @RequestParam(value = "childId", required = true) childId: UUID
     ): ResponseEntity<List<FamilyContact>> {
         Audit.FamilyContactsRead.log(targetId = childId)
-        acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.ADMIN, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
+        acl.getRolesForChild(user, childId)
+            .requireOneOfRoles(
+                UserRole.ADMIN,
+                UserRole.UNIT_SUPERVISOR,
+                UserRole.STAFF,
+                UserRole.SPECIAL_EDUCATION_TEACHER
+            )
         return db
             .read { it.fetchFamilyContacts(childId) }
+            .let { addDefaultPriorities(it) }
             .let { ResponseEntity.ok(it) }
     }
+
+    @PostMapping("/contacts")
+    fun updateFamilyContactPriority(
+        db: Database.Connection,
+        user: AuthenticatedUser,
+        @RequestBody body: FamilyContactUpdate
+    ): ResponseEntity<Unit> {
+        Audit.FamilyContactsUpdate.log(targetId = body.childId, objectId = body.contactPersonId)
+        acl.getRolesForChild(user, body.childId)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
+
+        db.transaction { it.updateFamilyContact(body.childId, body.contactPersonId, body.priority) }
+
+        return ResponseEntity.noContent().build()
+    }
+}
+
+data class FamilyContactUpdate(
+    val childId: UUID,
+    val contactPersonId: UUID,
+    val priority: Int?
+)
+
+private fun Database.Transaction.updateFamilyContact(childId: UUID, contactPersonId: UUID, priority: Int?) {
+    this.execute("SET CONSTRAINTS unique_child_contact_person_pair, unique_child_priority_pair DEFERRED")
+
+    this.createUpdate(
+        """
+WITH deleted_contact AS (
+    DELETE FROM family_contact WHERE child_id = :childId AND contact_person_id = :contactPersonId RETURNING priority AS old_priority
+)
+UPDATE family_contact SET priority = priority - 1
+FROM deleted_contact
+WHERE child_id = :childId AND priority > old_priority
+"""
+    )
+        .bind("childId", childId)
+        .bind("contactPersonId", contactPersonId)
+        .execute()
+
+    if (priority == null) return
+
+    this.createUpdate(
+        """
+UPDATE family_contact SET priority = priority + 1 WHERE child_id = :childId AND priority >= :priority;
+INSERT INTO family_contact (child_id, contact_person_id, priority) VALUES (:childId, :contactPersonId, :priority);
+"""
+    )
+        .bind("childId", childId)
+        .bind("contactPersonId", contactPersonId)
+        .bind("priority", priority)
+        .execute()
 }
 
 private fun Database.Read.fetchFamilyContacts(childId: UUID): List<FamilyContact> {
     // language=sql
     val sql =
         """
-        -- adults in the same household
-        SELECT 
-            CASE
-                WHEN EXISTS (SELECT 1 FROM guardian g WHERE g.guardian_id = p.id AND g.child_id = :id)
-                THEN 'LOCAL_GUARDIAN' ELSE 'LOCAL_ADULT'
-            END AS role, p.first_name, p.last_name, p.email, p.phone, p.street_address, p.postal_code, p.post_office
-        FROM person p
-        WHERE EXISTS ( -- is either head of child or their partner
+WITH contact AS (
+    -- adults in the same household
+    SELECT
+        CASE
+            WHEN EXISTS (SELECT 1 FROM guardian g WHERE g.guardian_id = p.id AND g.child_id = :id)
+            THEN 'LOCAL_GUARDIAN' ELSE 'LOCAL_ADULT'
+        END AS role, p.id, p.first_name, p.last_name, p.email, p.phone, p.street_address, p.postal_code, p.post_office, family_contact.priority
+    FROM person p
+    LEFT JOIN family_contact ON family_contact.contact_person_id = p.id AND family_contact.child_id = :id
+    WHERE EXISTS ( -- is either head of child or their partner
+        SELECT 1 FROM fridge_child fc
+        WHERE fc.child_id = :id AND daterange(fc.start_date, fc.end_date, '[]') @> now()::date AND (
+            fc.head_of_child = p.id OR EXISTS(
+                SELECT 1 FROM fridge_partner_view fp
+                WHERE fp.person_id = fc.head_of_child AND fp.partner_person_id = p.id AND daterange(fp.start_date, fp.end_date, '[]') @> now()::date
+            )
+        )
+    )
+
+    UNION
+
+    -- siblings in the same household
+    SELECT 'LOCAL_SIBLING' AS role, p.id, p.first_name, p.last_name, NULL AS email, NULL AS phone, p.street_address, p.postal_code, p.post_office, family_contact.priority
+    FROM person p
+    LEFT JOIN family_contact ON family_contact.contact_person_id = p.id AND family_contact.child_id = :id
+    WHERE EXISTS (
+        SELECT 1 FROM fridge_child fc1
+        WHERE fc1.child_id = :id AND daterange(fc1.start_date, fc1.end_date, '[]') @> now()::date AND EXISTS (
+            SELECT 1 FROM fridge_child fc2
+            WHERE
+                fc2.head_of_child = fc1.head_of_child
+                AND fc2.child_id = p.id
+                AND fc2.child_id <> fc1.child_id
+                AND daterange(fc1.start_date, fc1.end_date, '[]') @> now()::date
+        )
+    )
+
+    UNION
+
+    -- guardians in other households
+    SELECT 'REMOTE_GUARDIAN' AS role, p.id, p.first_name, p.last_name, p.email, p.phone, p.street_address, p.postal_code, p.post_office, family_contact.priority
+    FROM person p
+    LEFT JOIN family_contact ON family_contact.contact_person_id = p.id AND family_contact.child_id = :id
+    WHERE
+        EXISTS (SELECT 1 FROM guardian g WHERE g.guardian_id = p.id AND g.child_id = :id) -- is a guardian
+        AND NOT EXISTS ( -- but is neither head of child nor their partner
             SELECT 1 FROM fridge_child fc
             WHERE fc.child_id = :id AND daterange(fc.start_date, fc.end_date, '[]') @> now()::date AND (
-                fc.head_of_child = p.id OR EXISTS(
+                fc.head_of_child = p.id OR EXISTS (
                     SELECT 1 FROM fridge_partner_view fp
-                    WHERE fp.person_id = fc.head_of_child AND fp.partner_person_id = p.id AND daterange(fp.start_date, fp.end_date, '[]') @> now()::date
+                    WHERE
+                        fp.person_id = fc.head_of_child
+                        AND fp.partner_person_id = p.id
+                        AND daterange(fp.start_date, fp.end_date, '[]') @> now()::date
                 )
             )
         )
-        
-        UNION 
-        
-        -- siblings in the same household
-        SELECT 'LOCAL_SIBLING' AS role, p.first_name, p.last_name, NULL AS email, NULL AS phone, p.street_address, p.postal_code, p.post_office
-        FROM person p
-        WHERE EXISTS (
-            SELECT 1 FROM fridge_child fc1
-            WHERE fc1.child_id = :id AND daterange(fc1.start_date, fc1.end_date, '[]') @> now()::date AND EXISTS(
-                SELECT 1 FROM fridge_child fc2 
-                WHERE 
-                    fc2.head_of_child = fc1.head_of_child 
-                    AND fc2.child_id = p.id
-                    AND fc2.child_id <> fc1.child_id
-                    AND daterange(fc1.start_date, fc1.end_date, '[]') @> now()::date
-            )
-        )
-        
-        UNION 
-        
-        -- guardians in other households
-        SELECT 'REMOTE_GUARDIAN' AS role, p.first_name, p.last_name, p.email, p.phone, p.street_address, p.postal_code, p.post_office
-        FROM person p
-        WHERE 
-            EXISTS (SELECT 1 FROM guardian g WHERE g.guardian_id = p.id AND g.child_id = :id) -- is a guardian
-            AND NOT EXISTS ( -- but is neither head of child nor their partner
-                SELECT 1 FROM fridge_child fc
-                WHERE fc.child_id = :id AND daterange(fc.start_date, fc.end_date, '[]') @> now()::date AND (
-                    fc.head_of_child = p.id OR EXISTS(
-                        SELECT 1 FROM fridge_partner_view fp
-                        WHERE 
-                            fp.person_id = fc.head_of_child 
-                            AND fp.partner_person_id = p.id 
-                            AND daterange(fp.start_date, fp.end_date, '[]') @> now()::date
-                    )
-                )
-            )
+)
+SELECT
+    *,
+    (CASE role
+        WHEN 'LOCAL_GUARDIAN' THEN 1
+        WHEN 'LOCAL_ADULT' THEN 2
+        WHEN 'LOCAL_SIBLING' THEN 3
+        WHEN 'REMOTE_GUARDIAN' THEN 4
+    END) AS role_order
+FROM contact
+ORDER BY priority ASC, role_order ASC
     """
 
     return createQuery(sql)
         .bind("id", childId)
-        .mapTo(FamilyContact::class.java)
-        .list()
+        .mapTo<FamilyContact>()
+        .toList()
 }
+
+private val defaultContacts = setOf(LOCAL_GUARDIAN, REMOTE_GUARDIAN)
+
+private fun addDefaultPriorities(contacts: List<FamilyContact>): List<FamilyContact> =
+    if (contacts.none { it.priority != null })
+        contacts
+            .fold(listOf<FamilyContact>()) { acc, contact ->
+                acc + if (defaultContacts.contains(contact.role)) {
+                    val highestPriority = acc.mapNotNull { it.priority }.maxOrNull() ?: 0
+                    contact.copy(priority = highestPriority + 1)
+                } else contact
+            }
+            .sortedWith(compareBy(nullsLast()) { it.priority })
+    else contacts

--- a/service/src/main/resources/db/migration/V53__create_family_contacts_table.sql
+++ b/service/src/main/resources/db/migration/V53__create_family_contacts_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE family_contact (
+    id uuid PRIMARY KEY DEFAULT ext.uuid_generate_v1mc(),
+    child_id uuid NOT NULL REFERENCES person(id),
+    contact_person_id uuid NOT NULL REFERENCES person(id),
+    priority int NOT NULL,
+    CONSTRAINT unique_child_contact_person_pair UNIQUE (child_id, contact_person_id) DEFERRABLE,
+    CONSTRAINT unique_child_priority_pair UNIQUE (child_id, priority) DEFERRABLE
+);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -50,3 +50,4 @@ V49__varda_voucher_values.sql
 V50__add_bulletin_reciever.sql
 V51__refactor_bulletin_receiver.sql
 V52__backup_pickup.sql
+V53__create_family_contacts_table.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Allow assigning priority to family contacts. If a child has no family contact priorities assigned, by default the guardian living with the child is assigned priority 1 and the other guardian is assigned priority 2. The family contacts section is added to service worker and unit supervisor layout so that they are able to read and edit the information.

