### PR TITLE
Use a BOM module to constrain dependencies

### DIFF
--- a/evaka-bom/.gitignore
+++ b/evaka-bom/.gitignore
@@ -1,0 +1,3 @@
+.gradle
+/build/
+/target/

--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+plugins {
+    `java-platform`
+}
+
+object Version {
+    const val bouncyCastle = "1.68"
+    const val flyingSaucer = "9.1.20"
+    const val fuel = "2.3.1"
+    const val mockito = "3.7.7"
+}
+
+javaPlatform {
+    allowDependencies()
+}
+
+dependencies {
+    constraints {
+        api("com.auth0:java-jwt:3.13.0")
+        api("com.auth0:jwks-rsa:0.15.0")
+        api("com.github.kittinunf.fuel:fuel:${Version.fuel}")
+        api("com.github.kittinunf.fuel:fuel-jackson:${Version.fuel}")
+        api("com.nhaarman:mockito-kotlin:1.6.0")
+        api("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
+        api("com.zaxxer:HikariCP:4.0.2")
+        api("io.github.microutils:kotlin-logging-jvm:2.0.4")
+        api("io.javalin:javalin:3.13.3")
+        api("io.springfox:springfox-swagger2:3.0.0")
+        api("javax.annotation:javax.annotation-api:1.3.2")
+        api("javax.jws:javax.jws-api:1.1")
+        api("javax.xml.ws:jaxws-api:2.3.1")
+        api("net.bytebuddy:byte-buddy:1.10.21")
+        api("net.logstash.logback:logstash-logback-encoder:6.6")
+        api("net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1")
+        api("org.apache.commons:commons-pool2:2.8.1")
+        api("org.apache.commons:commons-text:1.9")
+        api("org.apache.wss4j:wss4j-ws-security-dom:2.3.0")
+        api("org.bouncycastle:bcpkix-jdk15on:${Version.bouncyCastle}")
+        api("org.bouncycastle:bcprov-jdk15on:${Version.bouncyCastle}")
+        api("org.flywaydb:flyway-core:7.5.3")
+        api("org.glassfish.jaxb:jaxb-runtime:2.3.2")
+        api("org.jetbrains:annotations:20.1.0")
+        api("org.mockito:mockito-core:${Version.mockito}")
+        api("org.mockito:mockito-junit-jupiter:${Version.mockito}")
+        api("org.postgresql:postgresql:42.2.19")
+        api("org.skyscreamer:jsonassert:1.5.0")
+        api("org.thymeleaf.extras:thymeleaf-extras-java8time:3.0.3.RELEASE")
+        api("org.thymeleaf:thymeleaf:3.0.11.RELEASE")
+        api("org.xhtmlrenderer:flying-saucer-core:${Version.flyingSaucer}")
+        api("org.xhtmlrenderer:flying-saucer-pdf-openpdf:${Version.flyingSaucer}")
+        api("redis.clients:jedis:3.5.1")
+    }
+
+    api(platform("com.amazonaws:aws-java-sdk-bom:1.11.959"))
+    api(platform("com.fasterxml.jackson:jackson-bom:2.12.1"))
+    api(platform("org.jdbi:jdbi3-bom:3.18.0"))
+    api(platform("org.jetbrains.kotlin:kotlin-bom:1.4.30"))
+    api(platform("org.junit:junit-bom:5.7.1"))
+    api(platform("org.springframework.boot:spring-boot-dependencies:2.4.3"))
+    api(platform("org.testcontainers:testcontainers-bom:1.15.2"))
+}

--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
         api("com.auth0:jwks-rsa:0.15.0")
         api("com.github.kittinunf.fuel:fuel:${Version.fuel}")
         api("com.github.kittinunf.fuel:fuel-jackson:${Version.fuel}")
+        api("com.google.guava:guava:30.1.1-jre")
         api("com.nhaarman:mockito-kotlin:1.6.0")
         api("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
         api("com.zaxxer:HikariCP:4.0.2")

--- a/message-service/build.gradle.kts
+++ b/message-service/build.gradle.kts
@@ -20,11 +20,11 @@ buildscript {
 }
 
 plugins {
-    id("org.flywaydb.flyway") version Version.flyway
-    id("org.jetbrains.kotlin.jvm") version Version.kotlin
-    id("org.jetbrains.kotlin.plugin.allopen") version Version.kotlin
-    id("org.jetbrains.kotlin.plugin.spring") version Version.kotlin
-    id("org.springframework.boot") version Version.springBoot
+    id("org.flywaydb.flyway") version Version.GradlePlugin.flyway
+    id("org.jetbrains.kotlin.jvm") version Version.GradlePlugin.kotlin
+    id("org.jetbrains.kotlin.plugin.allopen") version Version.GradlePlugin.kotlin
+    id("org.jetbrains.kotlin.plugin.spring") version Version.GradlePlugin.kotlin
+    id("org.springframework.boot") version Version.GradlePlugin.springBoot
 
     id("com.github.ben-manes.versions") version Version.GradlePlugin.versions
     id("org.jmailen.kotlinter") version Version.GradlePlugin.kotlinter
@@ -65,16 +65,18 @@ idea {
 val ktlint by configurations.creating
 
 dependencies {
+    implementation(platform(project(":evaka-bom")))
+    testImplementation(platform(project(":evaka-bom")))
+    integrationTestImplementation(platform(project(":evaka-bom")))
+
     // Kotlin + core
-    implementation(platform(kotlin("bom")))
     implementation(kotlin("stdlib-jdk8"))
 
     // Logging
-    implementation("io.github.microutils:kotlin-logging-jvm:${Version.kotlinLogging}")
-    implementation("net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1")
+    implementation("io.github.microutils:kotlin-logging-jvm")
+    implementation("net.rakugakibox.spring.boot:logback-access-spring-boot-starter")
 
     // Spring
-    implementation(platform("org.springframework.boot:spring-boot-dependencies:${Version.springBoot}"))
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-aop")
@@ -84,7 +86,6 @@ dependencies {
     implementation("org.springframework.ws:spring-ws-support")
 
     // Jackson
-    implementation(platform("com.fasterxml.jackson:jackson-bom:${Version.jackson}"))
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
@@ -93,17 +94,15 @@ dependencies {
     runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
 
     // AWS SDK
-    implementation(platform("com.amazonaws:aws-java-sdk-bom:${Version.awsSdk}"))
     implementation("com.amazonaws:aws-java-sdk-s3")
     implementation("com.amazonaws:aws-java-sdk-sts")
 
     // Database-related dependencies
-    implementation("com.zaxxer:HikariCP:${Version.hikariCp}")
-    implementation("org.postgresql:postgresql:${Version.postgresDriver}")
-    implementation("org.flywaydb:flyway-core:${Version.flyway}")
+    implementation("com.zaxxer:HikariCP")
+    implementation("org.postgresql:postgresql")
+    implementation("org.flywaydb:flyway-core")
 
     // JDBI
-    implementation(platform("org.jdbi:jdbi3-bom:${Version.jdbi}"))
     implementation("org.jdbi:jdbi3-core")
     implementation("org.jdbi:jdbi3-jackson2")
     implementation("org.jdbi:jdbi3-kotlin")
@@ -116,25 +115,24 @@ dependencies {
     }
 
     // Miscellaneous
-    implementation("com.auth0:java-jwt:${Version.auth0Jwt}")
-    implementation("javax.annotation:javax.annotation-api:1.3.2")
-    implementation("io.springfox:springfox-swagger2:${Version.springFox}")
-    implementation("javax.jws:javax.jws-api:1.1")
-    implementation("javax.xml.ws:jaxws-api:2.3.1")
-    implementation("org.apache.commons:commons-text:${Version.apacheCommonsText}")
-    implementation("org.apache.wss4j:wss4j-ws-security-dom:${Version.apacheWss4j}")
-    implementation("org.glassfish.jaxb:jaxb-runtime:${Version.jaxbRuntime}")
-    implementation("org.bouncycastle:bcprov-jdk15on:${Version.bouncyCastle}")
-    implementation("org.bouncycastle:bcpkix-jdk15on:${Version.bouncyCastle}")
+    implementation("com.auth0:java-jwt")
+    implementation("javax.annotation:javax.annotation-api")
+    implementation("io.springfox:springfox-swagger2")
+    implementation("javax.jws:javax.jws-api")
+    implementation("javax.xml.ws:jaxws-api")
+    implementation("org.apache.commons:commons-text")
+    implementation("org.apache.wss4j:wss4j-ws-security-dom")
+    implementation("org.glassfish.jaxb:jaxb-runtime")
+    implementation("org.bouncycastle:bcprov-jdk15on")
+    implementation("org.bouncycastle:bcpkix-jdk15on")
 
     // JUnit
     testImplementation("org.junit.jupiter:junit-jupiter")
 
-    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:${Version.mockitoKotlin}")
-    testImplementation("net.bytebuddy:byte-buddy:${Version.byteBuddy}")
+    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin")
+    testImplementation("net.bytebuddy:byte-buddy")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
-    integrationTestImplementation(platform("org.testcontainers:testcontainers-bom:${Version.testContainers}"))
     integrationTestImplementation("org.testcontainers:postgresql")
 
     ktlint("com.pinterest:ktlint:${Version.ktlint}")

--- a/message-service/buildSrc/src/main/kotlin/Version.kt
+++ b/message-service/buildSrc/src/main/kotlin/Version.kt
@@ -3,34 +3,15 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 object Version {
-    const val apacheCommonsText = "1.9"
-    const val apacheWss4j = "2.3.0"
-    const val auth0Jwt = "3.13.0"
-    const val awsSdk = "1.11.959"
-    const val bouncyCastle = "1.68"
-    const val byteBuddy = "1.10.21"
-    const val flyway = "7.5.3"
-    const val hikariCp = "4.0.2"
-    const val jackson = "2.12.1"
     const val java = "11"
-    const val jaxbRuntime = "2.3.2"
-    const val jdbi = "3.18.0"
-    const val junit = "5.7.1"
-    const val kotlin = "1.4.30"
-    const val kotlinLogging = "2.0.4"
     const val ktlint = "0.40.0"
-    const val logbackSpringBoot = "2.7.1"
-    const val logstashEncoder = "6.6"
-    const val mockito = "3.7.7"
-    const val mockitoKotlin = "2.2.0"
-    const val postgresDriver = "42.2.19"
-    const val springBoot = "2.4.3"
-    const val springFox = "3.0.0"
-    const val testContainers = "1.15.2"
 
     object GradlePlugin {
+        const val flyway = "7.5.3"
+        const val kotlin = "1.4.30"
         const val kotlinter = "3.3.0"
         const val owasp = "6.1.1"
+        const val springBoot = "2.4.3"
         const val versions = "0.36.0"
     }
 }

--- a/message-service/owasp-suppressions.xml
+++ b/message-service/owasp-suppressions.xml
@@ -43,20 +43,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     </suppress>
     <suppress>
         <notes><![CDATA[
-        Dependency of spring-ws-security, which is already at latest version (3.0.10.RELEASE).
-        ]]></notes>
-        <filePath regex="true">.*/guava-19\.0\.jar</filePath>
-        <cve>CVE-2018-10237</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        Dependency of spring-ws-security, which is already at latest version (3.0.10.RELEASE).
-        ]]></notes>
-        <filePath regex="true">.*/guava-29\.0-jre\.jar</filePath>
-        <cve>CVE-2020-8908</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
         Not relevant for us as we do not use velocity templates.
         ]]></notes>
         <cve>CVE-2020-13936</cve>

--- a/message-service/settings.gradle.kts
+++ b/message-service/settings.gradle.kts
@@ -4,5 +4,7 @@
 
 rootProject.name = "evaka-message-service"
 include("service-lib")
+include("evaka-bom")
 
 project(":service-lib").projectDir = file("../service-lib")
+project(":evaka-bom").projectDir = file("../evaka-bom")

--- a/service-lib/build.gradle.kts
+++ b/service-lib/build.gradle.kts
@@ -19,28 +19,28 @@ repositories {
 }
 
 dependencies {
+    implementation(platform(project(":evaka-bom")))
+    testImplementation(platform(project(":evaka-bom")))
+
     // Kotlin + core
-    implementation(platform(kotlin("bom")))
     implementation(kotlin("stdlib-jdk8"))
 
     // Logging
-    implementation("io.github.microutils:kotlin-logging-jvm:${Version.kotlinLogging}")
-    implementation("net.logstash.logback:logstash-logback-encoder:${Version.logstashEncoder}")
-    implementation("net.rakugakibox.spring.boot:logback-access-spring-boot-starter:${Version.logbackSpringBoot}")
+    implementation("io.github.microutils:kotlin-logging-jvm")
+    implementation("net.logstash.logback:logstash-logback-encoder")
+    implementation("net.rakugakibox.spring.boot:logback-access-spring-boot-starter")
 
     // Spring
-    implementation(platform("org.springframework.boot:spring-boot-dependencies:${Version.springBoot}"))
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     // Jackson
-    implementation(platform("com.fasterxml.jackson:jackson-bom:${Version.jackson}"))
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // Auth0 JWT
-    implementation("com.auth0:java-jwt:${Version.auth0Jwt}")
+    implementation("com.auth0:java-jwt")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.skyscreamer:jsonassert:1.5.0")
+    testImplementation("org.skyscreamer:jsonassert")
 }
 
 tasks.withType<KotlinCompile> {

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -17,11 +17,11 @@ buildscript {
 }
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version Version.kotlin
-    id("org.jetbrains.kotlin.plugin.allopen") version Version.kotlin
-    id("org.jetbrains.kotlin.plugin.spring") version Version.kotlin
-    id("org.springframework.boot") version Version.springBoot
-    id("org.flywaydb.flyway") version Version.flyway
+    id("org.jetbrains.kotlin.jvm") version Version.GradlePlugin.kotlin
+    id("org.jetbrains.kotlin.plugin.allopen") version Version.GradlePlugin.kotlin
+    id("org.jetbrains.kotlin.plugin.spring") version Version.GradlePlugin.kotlin
+    id("org.springframework.boot") version Version.GradlePlugin.springBoot
+    id("org.flywaydb.flyway") version Version.GradlePlugin.flyway
 
     id("com.github.ben-manes.versions") version Version.GradlePlugin.versions
     id("org.jmailen.kotlinter") version Version.GradlePlugin.kotlinter
@@ -59,16 +59,18 @@ idea {
 val ktlint by configurations.creating
 
 dependencies {
+    implementation(platform(project(":evaka-bom")))
+    testImplementation(platform(project(":evaka-bom")))
+    integrationTestImplementation(platform(project(":evaka-bom")))
+
     // Kotlin + core
-    api(platform(kotlin("bom")))
     api(kotlin("stdlib-jdk8"))
 
     // Logging
-    implementation("io.github.microutils:kotlin-logging-jvm:${Version.kotlinLogging}")
-    implementation("net.rakugakibox.spring.boot:logback-access-spring-boot-starter:${Version.logbackSpringBoot}")
+    implementation("io.github.microutils:kotlin-logging-jvm")
+    implementation("net.rakugakibox.spring.boot:logback-access-spring-boot-starter")
 
     // Spring
-    api(platform("org.springframework.boot:spring-boot-dependencies:${Version.springBoot}"))
     api("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-aop")
@@ -80,24 +82,22 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-devtools")
 
     // Database-related dependencies
-    implementation("com.zaxxer:HikariCP:${Version.hikariCp}")
-    implementation("org.flywaydb:flyway-core:${Version.flyway}")
-    implementation("org.postgresql:postgresql:${Version.postgresDriver}")
-    implementation("redis.clients:jedis:${Version.jedis}")
+    implementation("com.zaxxer:HikariCP")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.postgresql:postgresql")
+    implementation("redis.clients:jedis")
 
     // JDBI
-    implementation(platform("org.jdbi:jdbi3-bom:${Version.jdbi}"))
     implementation("org.jdbi:jdbi3-core")
     implementation("org.jdbi:jdbi3-jackson2")
     implementation("org.jdbi:jdbi3-kotlin")
     implementation("org.jdbi:jdbi3-postgres")
 
     // Fuel
-    implementation("com.github.kittinunf.fuel:fuel:${Version.fuel}")
-    implementation("com.github.kittinunf.fuel:fuel-jackson:${Version.fuel}")
+    implementation("com.github.kittinunf.fuel:fuel")
+    implementation("com.github.kittinunf.fuel:fuel-jackson")
 
     // Jackson
-    implementation(platform("com.fasterxml.jackson:jackson-bom:${Version.jackson}"))
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
@@ -106,7 +106,6 @@ dependencies {
     runtimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
 
     // AWS SDK
-    implementation(platform("com.amazonaws:aws-java-sdk-bom:${Version.awsSdk}"))
     implementation("com.amazonaws:aws-java-sdk-s3")
     implementation("com.amazonaws:aws-java-sdk-sts")
     implementation("com.amazonaws:aws-java-sdk-ses")
@@ -115,34 +114,32 @@ dependencies {
     implementation(project(":service-lib"))
 
     // Flying Saucer <=>
-    implementation("org.thymeleaf:thymeleaf:3.0.11.RELEASE")
-    implementation("org.thymeleaf.extras:thymeleaf-extras-java8time:3.0.3.RELEASE")
-    implementation("org.xhtmlrenderer:flying-saucer-core:${Version.flyingSaucer}")
-    implementation("org.xhtmlrenderer:flying-saucer-pdf-openpdf:${Version.flyingSaucer}")
+    implementation("org.thymeleaf:thymeleaf")
+    implementation("org.thymeleaf.extras:thymeleaf-extras-java8time")
+    implementation("org.xhtmlrenderer:flying-saucer-core")
+    implementation("org.xhtmlrenderer:flying-saucer-pdf-openpdf")
 
     // Miscellaneous
-    implementation("com.auth0:java-jwt:${Version.auth0Jwt}")
-    implementation("javax.annotation:javax.annotation-api:1.3.2")
-    implementation("org.apache.commons:commons-pool2:${Version.commonsPool2}")
-    implementation("org.glassfish.jaxb:jaxb-runtime:2.3.2")
-    implementation("org.bouncycastle:bcprov-jdk15on:${Version.bouncyCastle}")
-    implementation("org.bouncycastle:bcpkix-jdk15on:${Version.bouncyCastle}")
+    implementation("com.auth0:java-jwt")
+    implementation("javax.annotation:javax.annotation-api")
+    implementation("org.apache.commons:commons-pool2")
+    implementation("org.glassfish.jaxb:jaxb-runtime")
+    implementation("org.bouncycastle:bcprov-jdk15on")
+    implementation("org.bouncycastle:bcpkix-jdk15on")
 
     // JUnit
-    testImplementation(platform("org.junit:junit-bom:${Version.junit}"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 
-    testImplementation("com.nhaarman:mockito-kotlin:${Version.mockitoKotlin}")
-    testImplementation("net.bytebuddy:byte-buddy:${Version.byteBuddy}")
-    testImplementation("net.logstash.logback:logstash-logback-encoder:${Version.logstashEncoder}")
-    testImplementation("org.jetbrains:annotations:${Version.jetbrainsAnnotations}")
-    testImplementation("org.mockito:mockito-core:${Version.mockito}")
-    testImplementation("org.mockito:mockito-junit-jupiter:${Version.mockito}")
+    testImplementation("com.nhaarman:mockito-kotlin")
+    testImplementation("net.bytebuddy:byte-buddy")
+    testImplementation("net.logstash.logback:logstash-logback-encoder")
+    testImplementation("org.jetbrains:annotations")
+    testImplementation("org.mockito:mockito-core")
+    testImplementation("org.mockito:mockito-junit-jupiter")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.ws:spring-ws-test")
 
-    integrationTestImplementation("io.javalin:javalin:${Version.javalin}")
-    integrationTestImplementation(platform("org.testcontainers:testcontainers-bom:${Version.testContainers}"))
+    integrationTestImplementation("io.javalin:javalin")
     integrationTestImplementation("org.testcontainers:postgresql")
 
     implementation(project(":vtjclient"))

--- a/service/buildSrc/src/main/kotlin/Version.kt
+++ b/service/buildSrc/src/main/kotlin/Version.kt
@@ -3,36 +3,15 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 object Version {
-    const val auth0Jwt = "3.13.0"
-    const val awsSdk = "1.11.959"
-    const val bouncyCastle = "1.68"
-    const val byteBuddy = "1.10.21"
-    const val commonsPool2 = "2.8.1"
-    const val flyingSaucer = "9.1.20"
-    const val flyway = "7.5.3"
-    const val fuel = "2.3.1"
-    const val hikariCp = "4.0.2"
-    const val jackson = "2.12.1"
     const val java = "11"
-    const val javalin = "3.13.3"
-    const val jdbi = "3.18.0"
-    const val jedis = "3.5.1"
-    const val jetbrainsAnnotations = "20.1.0"
-    const val junit = "5.7.1"
-    const val kotlin = "1.4.30"
-    const val kotlinLogging = "2.0.4"
     const val ktlint = "0.40.0"
-    const val logbackSpringBoot = "2.7.1"
-    const val logstashEncoder = "6.6"
-    const val mockito = "3.7.7"
-    const val mockitoKotlin = "1.6.0"
-    const val postgresDriver = "42.2.19"
-    const val springBoot = "2.4.3"
-    const val testContainers = "1.15.2"
 
     object GradlePlugin {
+        const val flyway = "7.5.3"
+        const val kotlin = "1.4.30"
         const val kotlinter = "3.3.0"
         const val owasp = "6.1.1"
+        const val springBoot = "2.4.3"
         const val versions = "0.36.0"
     }
 }

--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -43,20 +43,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     </suppress>
     <suppress>
         <notes><![CDATA[
-        Dependency of spring-ws-security, which is already at latest version (3.0.10.RELEASE).
-        ]]></notes>
-        <filePath regex="true">.*/guava-19\.0\.jar</filePath>
-        <cve>CVE-2018-10237</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        Dependency of spring-ws-security, which is already at latest version (3.0.10.RELEASE).
-        ]]></notes>
-        <filePath regex="true">.*/guava-19\.0\.jar</filePath>
-        <cve>CVE-2020-8908</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
         Not relevant for us as we do not use velocity templates.
         ]]></notes>
         <cve>CVE-2020-13936</cve>

--- a/service/settings.gradle.kts
+++ b/service/settings.gradle.kts
@@ -5,5 +5,7 @@
 rootProject.name = "evaka-service"
 include("service-lib")
 include("vtjclient")
+include("evaka-bom")
 
 project(":service-lib").projectDir = file("../service-lib")
+project(":evaka-bom").projectDir = file("../evaka-bom")

--- a/service/vtjclient/build.gradle.kts
+++ b/service/vtjclient/build.gradle.kts
@@ -25,8 +25,9 @@ repositories {
 }
 
 dependencies {
-    implementation("javax.jws:javax.jws-api:1.1")
-    implementation("javax.xml.ws:jaxws-api:2.3.1")
+    implementation(platform(project(":evaka-bom")))
+    implementation("javax.jws:javax.jws-api")
+    implementation("javax.xml.ws:jaxws-api")
 }
 
 project.wsdl2javaExt {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

* doesn't apply to Gradle plugins, ktlint, or build script dependencies
* one place for dependency constraints -> better consistency between evaka-service and evaka-message-service
* allows downstream projects (e.g. trevaka) to depend on the BOM and get the same version constraints automatically