### PR TITLE
EVAKA-4182_change-wording-in-linguistic-challenge-translation

### DIFF
--- a/frontend/src/employee-frontend/assets/i18n/fi.ts
+++ b/frontend/src/employee-frontend/assets/i18n/fi.ts
@@ -528,7 +528,7 @@ export const fi = {
           DEVELOPMENTAL_DISABILITY_2_INFO:
             'Käytetään silloin, kun esiopetuksessa oleva lapsi on vaikeasti kehitysvammainen.',
           FOCUS_CHALLENGE: 'Keskittymisen / tarkkaavaisuuden vaikeus',
-          LINGUISTIC_CHALLENGE: 'Kielellinen erityisvaikeus',
+          LINGUISTIC_CHALLENGE: 'Kielellinen vaikeus',
           DEVELOPMENT_MONITORING: 'Lapsen kehityksen seuranta',
           DEVELOPMENT_MONITORING_PENDING:
             'Lapsen kehityksen seuranta, tutkimukset kesken',


### PR DESCRIPTION
#### Summary

Change wording in Finnish translation:
`Kielellinen erityisvaikeus` --> `Kielellinen vaikeus`

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

