### PR TITLE
EVAKA-HOTFIX: add missing local env vars

### DIFF
--- a/service/src/main/resources/application-local.yaml
+++ b/service/src/main/resources/application-local.yaml
@@ -36,6 +36,9 @@ logging:
           autoconfigure: INFO
 
 application:
+  frontend:
+    baseurl: http://localhost:9099
+    baseurl.sv: http://localhost:9099
   email:
     enabled: false
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Add missing local vars `application.frontend.baseurl` and `application.frontend.baseurl.sv`