### PR TITLE
Evaka hotfix pending email send

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -127,7 +127,7 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
     }
 
     @Test
-    fun `Bug verification - Pending decision with pending_decision_email_sent older than 1 week should not send reminder`() {
+    fun `Bug verification - Pending decision with pending_decision_email_sent older than 1 week but already two reminders should not send reminder`() {
         createPendingDecision(LocalDate.now().minusDays(8), null, LocalDate.now().minusDays(8).atStartOfDay().toInstant(ZoneOffset.UTC), 2)
         Assertions.assertEquals(0, runPendingDecisionEmailAsyncJobs())
         val sentMails = MockEmailClient.emails

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.UUID
 
 class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
@@ -120,6 +121,14 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
     @Test
     fun `Pending decision older than one week but already two reminders does not send third`() {
         createPendingDecision(LocalDate.now().minusDays(8), null, null, 2)
+        Assertions.assertEquals(0, runPendingDecisionEmailAsyncJobs())
+        val sentMails = MockEmailClient.emails
+        Assertions.assertEquals(0, sentMails.size)
+    }
+
+    @Test
+    fun `Bug verification - Pending decision with pending_decision_email_sent older than 1 week should not send reminder`() {
+        createPendingDecision(LocalDate.now().minusDays(8), null, LocalDate.now().minusDays(8).atStartOfDay().toInstant(ZoneOffset.UTC), 2)
         Assertions.assertEquals(0, runPendingDecisionEmailAsyncJobs())
         val sentMails = MockEmailClient.emails
         Assertions.assertEquals(0, sentMails.size)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -63,7 +63,7 @@ WHERE d.status = 'PENDING'
 AND d.resolved IS NULL
 AND (d.sent_date < current_date - INTERVAL '1 week' AND d.sent_date > current_date - INTERVAL '2 month')
 AND d.pending_decision_emails_sent_count < 2
-AND d.pending_decision_email_sent IS NULL or d.pending_decision_email_sent < current_date - INTERVAL '1 week')
+AND (d.pending_decision_email_sent IS NULL OR d.pending_decision_email_sent < current_date - INTERVAL '1 week'))
 SELECT application.guardian_id as guardian_id, array_agg(pending_decisions.id::uuid) AS decision_ids
 FROM pending_decisions JOIN application ON pending_decisions.application_id = application.id
 GROUP BY application.guardian_id

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -51,7 +51,7 @@ class PendingDecisionEmailService(
 
     fun scheduleSendPendingDecisionsEmails(db: Database.Connection): Int {
         val jobCount = db.transaction { tx ->
-            tx.createUpdate("DELETE FROM async_job WHERE type = 'SEND_PENDING_DECISION_EMAIL' AND (claimed_by IS NULL OR completed_at IS NOT NULL)")
+            tx.createUpdate("DELETE FROM async_job WHERE type = 'SEND_PENDING_DECISION_EMAIL' AND claimed_by IS NULL")
                 .execute()
 
             val pendingGuardianDecisions = tx.createQuery(
@@ -174,7 +174,7 @@ Du har ett obesvarat beslut av småbarnspedagogiken i Esbo. Beslutet ska godkän
 Den som lämnat in ansökan kan godkänna eller förkasta obesvarade beslut genom att logga in på adressen <a href="https://espoonvarhaiskasvatus.fi">espoonvarhaiskasvatus.fi</a> eller genom att returnera den ifyllda blanketten som finns på sista sidan av beslutet till den adress som nämns på sidan.
 </p>
 <p>
-Detta meddelande kan inte besvaras. Kontakta vid behov servicehänvisningen inom småbarnspedagogiken, tfn 09 816 7600
+Detta meddelande kan inte besvaras. Kontakta vid behov servicehänvisningen inom småbarnspedagogiken, tfn 09 816 27600
 </p>                
             """.trimIndent()
             else -> """


### PR DESCRIPTION
- Pending decision reminder emails were being sent related to decisions that were already accepted. Fix the bug and add a test.
- To ease up further debugging do not clean up related finished async_job
- Fix svebi phone number