### PR TITLE
Compose fixes

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -83,10 +83,6 @@ Then, start eVaka projects with PM2:
 pm2 start
 ```
 
-`yarn install` might fail on frontends when running `pm2 start`. To
-fix this, try to running `yarn cache clean && yarn install` in failing
-repositories.
-
 ### Useful commands
 
 ```bash

--- a/compose/README.md
+++ b/compose/README.md
@@ -104,9 +104,9 @@ pm2 flush # Clears old logs
 Once the development environment is correctly set up, you can access
 the frontends at following URLs:
 
-- <http://localhost:9094> – Frontend for the citizen
-- <http://localhost:9093/employee> – Frontend for the employee roles
-- <http://localhost:9095/employee/mobile> – Frontend for the employee mobile frontend
+- <http://localhost:9099> – Frontend for the citizen
+- <http://localhost:9099/employee> – Frontend for the employee roles
+- <http://localhost:9099/employee/mobile> – Frontend for the employee mobile frontend
 
 ## Running the full stack for E2E tests
 

--- a/compose/ecosystem.config.js
+++ b/compose/ecosystem.config.js
@@ -11,12 +11,12 @@ const defaults = {
 module.exports = {
   apps: [{
     name: 'apigw',
-    script: 'yarn clean && yarn && yarn dev',
+    script: 'yarn && yarn clean && yarn dev',
     cwd: path.resolve(__dirname, '../apigw'),
     ...defaults
   }, {
     name: 'frontend',
-    script: 'yarn clean && yarn && yarn dev',
+    script: 'yarn && yarn clean && yarn dev',
     cwd: path.resolve(__dirname, '../frontend'),
     env: {
       'ICONS': process.env.ICONS


### PR DESCRIPTION
#### Summary

* Fix development environment URLs in `compose/README.md`
* Run `yarn` and `yarn clean` in the correct order in pm2. Now, any manual `yarn` runs are not required before `pm2 start`.

