### PR TITLE
EVAKA-4171 format bulletin receivers in sent & draft lists

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessageList.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageList.tsx
@@ -38,21 +38,27 @@ export default React.memo(function MessageList({
   const { i18n } = useTranslation()
 
   const renderReceivers = (msg: Bulletin): string => {
-    const maxShow = 3
+    const visibleNamesCount = 3
     const parseFirstName = (firstNames: string) =>
       firstNames.trim().split(/\s+/)[0]
     const maybeVisible = [
-      ...msg.receiverUnits.slice(0, maxShow).map(({ unitName }) => unitName),
-      ...msg.receiverGroups.slice(0, maxShow).map(({ groupName }) => groupName),
+      ...msg.receiverUnits
+        .slice(0, visibleNamesCount)
+        .map(({ unitName }) => unitName),
+      ...msg.receiverGroups
+        .slice(0, visibleNamesCount)
+        .map(({ groupName }) => groupName),
       ...msg.receiverChildren
-        .slice(0, maxShow)
+        .slice(0, visibleNamesCount)
         .map(
           ({ firstName, lastName }) =>
             `${parseFirstName(firstName)} ${lastName}`
         )
     ]
-    const basePart = maybeVisible.slice(0, maxShow).join(', ')
-    return maybeVisible.length > maxShow ? `${basePart}, ...` : basePart
+    const visibleNames = maybeVisible.slice(0, visibleNamesCount).join(', ')
+    return maybeVisible.length > visibleNamesCount
+      ? `${visibleNames}, ...`
+      : visibleNames
   }
 
   return (

--- a/frontend/src/employee-frontend/components/messages/MessageList.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageList.tsx
@@ -33,10 +33,27 @@ export default React.memo(function MessageList({
   nextPage,
   loadNextPage,
   messageBoxType,
-  selectMessage,
-  groups
+  selectMessage
 }: Props) {
   const { i18n } = useTranslation()
+
+  const renderReceivers = (msg: Bulletin): string => {
+    const maxShow = 3
+    const parseFirstName = (firstNames: string) =>
+      firstNames.trim().split(/\s+/)[0]
+    const maybeVisible = [
+      ...msg.receiverUnits.slice(0, maxShow).map(({ unitName }) => unitName),
+      ...msg.receiverGroups.slice(0, maxShow).map(({ groupName }) => groupName),
+      ...msg.receiverChildren
+        .slice(0, maxShow)
+        .map(
+          ({ firstName, lastName }) =>
+            `${parseFirstName(firstName)} ${lastName}`
+        )
+    ]
+    const basePart = maybeVisible.slice(0, maxShow).join(', ')
+    return maybeVisible.length > maxShow ? `${basePart}, ...` : basePart
+  }
 
   return (
     <Container>
@@ -47,16 +64,13 @@ export default React.memo(function MessageList({
         <React.Fragment key={msg.id}>
           <MessageListItem onClick={() => selectMessage(msg)}>
             <MessageTopRow>
-              <MessageTitle noMargin>
-                {msg.title || `(${i18n.messages.noTitle})`}
-              </MessageTitle>
-              {msg.sentAt ? (
-                <FixedSpaceRow>
-                  <span>
-                    {msg.receiverUnits
-                      .map(({ unitName }) => unitName)
-                      .join(', ')}
-                  </span>
+              <FixedSpaceRow
+                justifyContent="space-between"
+                alignItems="baseline"
+              >
+                <MessageReceivers>{renderReceivers(msg)}</MessageReceivers>
+
+                {msg.sentAt ? (
                   <span>
                     {formatDate(
                       msg.sentAt,
@@ -67,12 +81,16 @@ export default React.memo(function MessageList({
                         : 'd.M.'
                     )}
                   </span>
-                </FixedSpaceRow>
-              ) : (
-                <span>{i18n.messages.notSent}</span>
-              )}
+                ) : (
+                  <span>{i18n.messages.notSent}</span>
+                )}
+              </FixedSpaceRow>
             </MessageTopRow>
             <MessageSummary>
+              <MessageTitle>
+                {msg.title || `(${i18n.messages.noTitle})`}
+              </MessageTitle>
+              {' - '}
               {msg.content.substring(0, 200).replace('\n', ' ')}
             </MessageSummary>
           </MessageListItem>
@@ -125,16 +143,19 @@ const MessageListItem = styled.button`
 `
 
 const MessageTopRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
   width: 100%;
 `
 
-const MessageTitle = styled(H3)`
+const MessageReceivers = styled(H3)`
   font-size: 16px;
   font-weight: 600;
   color: ${colors.greyscale.dark};
+`
+
+const MessageTitle = styled.span`
+  font-size: 16px;
+  font-weight: 600;
+  color: ${colors.greyscale.darkest};
 `
 
 const MessageSummary = styled.div`


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Format receivers according to Figma.

<img width="1172" alt="Screenshot 2021-04-07 at 11 58 34" src="https://user-images.githubusercontent.com/3275771/113841221-2a938200-979a-11eb-9a39-33b1df6af1e4.png">
