### PR TITLE
EVAKA-4155 Applications report voucher fix

### DIFF
--- a/frontend/src/e2e-test/pages/reports.ts
+++ b/frontend/src/e2e-test/pages/reports.ts
@@ -37,18 +37,16 @@ export default class ReportsPage {
     await t.typeText(toInput, format(to, 'dd.MM.yyyy'))
   }
 
-  private async areaWithNameExistsAssertion(
-    area: string,
-    exists = true
-  ): Promise<Assertion<boolean>> {
+  private async areaWithNameExistsAssertion(area: string, exists = true) {
     const applicationTableSelector = Selector(
       `[data-qa="report-application-table"]`
     )
     await t.expect(applicationTableSelector.exists).ok()
-    return t
+    await t
       .expect(
-        applicationTableSelector.find('td:first-child').withExactText(area)
-          .exists
+        applicationTableSelector
+          .find(`[data-qa="care-area-name"]`)
+          .withExactText(area).exists
       )
       .eql(exists)
   }
@@ -70,7 +68,7 @@ export default class ReportsPage {
       await t
         .expect(
           applicationTableSelector
-            .find('td:nth-child(3)')
+            .find(`[data-qa="unit-provider-type"]`)
             .withExactText(provider).exists
         )
         .ok(`Service provider ${provider} does not exist`)

--- a/frontend/src/e2e-test/pages/reports.ts
+++ b/frontend/src/e2e-test/pages/reports.ts
@@ -37,12 +37,44 @@ export default class ReportsPage {
     await t.typeText(toInput, format(to, 'dd.MM.yyyy'))
   }
 
-  async assertApplicationsReportContainsArea(area: string) {
+  private async areaWithNameExistsAssertion(
+    area: string,
+    exists = true
+  ): Promise<Assertion<boolean>> {
     const applicationTableSelector = Selector(
       `[data-qa="report-application-table"]`
     )
     await t.expect(applicationTableSelector.exists).ok()
-    await t.expect(applicationTableSelector.find('td').innerText).eql(area)
+    return t
+      .expect(
+        applicationTableSelector.find('td:first-child').withExactText(area)
+          .exists
+      )
+      .eql(exists)
+  }
+
+  async assertApplicationsReportContainsArea(area: string) {
+    await this.areaWithNameExistsAssertion(area, true)
+  }
+
+  async assertApplicationsReportNotContainsArea(area: string) {
+    await this.areaWithNameExistsAssertion(area, false)
+  }
+
+  async assertApplicationsReportContainsServiceProviders(providers: string[]) {
+    const applicationTableSelector = Selector(
+      `[data-qa="report-application-table"]`
+    )
+    await t.expect(applicationTableSelector.exists).ok()
+    for (const provider of providers) {
+      await t
+        .expect(
+          applicationTableSelector
+            .find('td:nth-child(3)')
+            .withExactText(provider).exists
+        )
+        .ok(`Service provider ${provider} does not exist`)
+    }
   }
 
   async assertPlacementSketchingRow(

--- a/frontend/src/e2e-test/specs/5_employee/application-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-report.spec.ts
@@ -2,25 +2,64 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import ReportsPage from '../../pages/reports'
+import { deleteApplication } from '../../../e2e-test-common/dev-api'
+import {
+  AreaAndPersonFixtures,
+  initializeAreaAndPersonData
+} from '../../../e2e-test-common/dev-api/data-init'
+import { Fixture } from '../../../e2e-test-common/dev-api/fixtures'
 import { seppoAdminRole } from '../../config/users'
+import Home from '../../pages/home'
+import ReportsPage from '../../pages/reports'
+import { logConsoleMessages } from '../../utils/fixture'
 
-fixture('Reporting - applications').meta({
-  type: 'regression',
-  subType: 'reports'
-})
+let fixtures: AreaAndPersonFixtures
+let cleanUp: () => Promise<void>
 
+const home = new Home()
 const reports = new ReportsPage()
+
+let applicationId: string | null = null
+
+fixture('Reporting - applications')
+  .meta({ type: 'regression', subType: 'reports' })
+  .page(home.homePage('admin'))
+  .before(async () => {
+    ;[fixtures, cleanUp] = await initializeAreaAndPersonData()
+
+    const careArea = await Fixture.careArea()
+      .with({ name: 'Toinen alue' })
+      .save()
+
+    await Fixture.daycare()
+      .with({
+        name: 'Palvelusetelikoti',
+        providerType: 'PRIVATE_SERVICE_VOUCHER'
+      })
+      .careArea(careArea)
+      .save()
+  })
+  .afterEach(async (t) => {
+    await logConsoleMessages(t)
+    if (applicationId) await deleteApplication(applicationId)
+    applicationId = null
+  })
+  .after(async () => await cleanUp())
 
 test('application report is generated correctly, respecting care area filter', async (t) => {
   await t.useRole(seppoAdminRole)
   await reports.selectReportsTab()
   await reports.selectApplicationsReport()
 
-  await reports.assertApplicationsReportContainsArea(
-    'Espoon keskus (eteläinen)'
-  )
-  await reports.selectArea('Espoonlahti')
+  await reports.assertApplicationsReportContainsArea('Superkeskus')
+  await reports.assertApplicationsReportContainsArea('Toinen alue')
+  await reports.assertApplicationsReportContainsServiceProviders([
+    'Kunnallinen',
+    'Palveluseteli'
+  ])
+
+  await reports.selectArea('Toinen alue')
   await reports.selectDateRangePickerDates(new Date(), new Date())
-  await reports.assertApplicationsReportContainsArea('Espoonlahti')
+  await reports.assertApplicationsReportContainsArea('Toinen alue')
+  await reports.assertApplicationsReportNotContainsArea('Superkeskus')
 })

--- a/frontend/src/e2e-test/specs/5_employee/application-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-report.spec.ts
@@ -51,7 +51,9 @@ test('application report is generated correctly, respecting care area filter', a
   await reports.selectReportsTab()
   await reports.selectApplicationsReport()
 
-  await reports.assertApplicationsReportContainsArea('Superkeskus')
+  await reports.assertApplicationsReportContainsArea(
+    fixtures.careAreaFixture.name
+  )
   await reports.assertApplicationsReportContainsArea('Toinen alue')
   await reports.assertApplicationsReportContainsServiceProviders([
     'Kunnallinen',
@@ -61,5 +63,7 @@ test('application report is generated correctly, respecting care area filter', a
   await reports.selectArea('Toinen alue')
   await reports.selectDateRangePickerDates(new Date(), new Date())
   await reports.assertApplicationsReportContainsArea('Toinen alue')
-  await reports.assertApplicationsReportNotContainsArea('Superkeskus')
+  await reports.assertApplicationsReportNotContainsArea(
+    fixtures.careAreaFixture.name
+  )
 })

--- a/frontend/src/e2e-test/specs/5_employee/application-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-report.spec.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { deleteApplication } from '../../../e2e-test-common/dev-api'
 import {
   AreaAndPersonFixtures,
   initializeAreaAndPersonData
@@ -18,8 +17,6 @@ let cleanUp: () => Promise<void>
 
 const home = new Home()
 const reports = new ReportsPage()
-
-let applicationId: string | null = null
 
 fixture('Reporting - applications')
   .meta({ type: 'regression', subType: 'reports' })
@@ -39,11 +36,7 @@ fixture('Reporting - applications')
       .careArea(careArea)
       .save()
   })
-  .afterEach(async (t) => {
-    await logConsoleMessages(t)
-    if (applicationId) await deleteApplication(applicationId)
-    applicationId = null
-  })
+  .afterEach(async (t) => await logConsoleMessages(t))
   .after(async () => await cleanUp())
 
 test('application report is generated correctly, respecting care area filter', async (t) => {

--- a/frontend/src/employee-frontend/assets/i18n/fi.ts
+++ b/frontend/src/employee-frontend/assets/i18n/fi.ts
@@ -1862,7 +1862,8 @@ export const fi = {
         MUNICIPAL: 'Kunnallinen',
         PURCHASED: 'Ostopalvelu',
         PRIVATE: 'Yksityinen',
-        MUNICIPAL_SCHOOL: 'Kunnallinen'
+        MUNICIPAL_SCHOOL: 'Kunnallinen',
+        PRIVATE_SERVICE_VOUCHER: 'Palveluseteli'
       },
       period: 'Ajanjakso',
       date: 'Päivämäärä',

--- a/frontend/src/employee-frontend/components/reports/Applications.tsx
+++ b/frontend/src/employee-frontend/components/reports/Applications.tsx
@@ -144,9 +144,8 @@ function Applications() {
             <ReportDownload
               data={filteredRows.map((row) => ({
                 ...row,
-                unitProviderType: String(
+                unitProviderType:
                   i18n.reports.common.unitProviderTypes[row.unitProviderType]
-                )
               }))}
               headers={[
                 {

--- a/frontend/src/employee-frontend/components/reports/Applications.tsx
+++ b/frontend/src/employee-frontend/components/reports/Applications.tsx
@@ -195,11 +195,11 @@ function Applications() {
               <Tbody>
                 {filteredRows.map((row: ApplicationsReportRow) => (
                   <Tr key={row.unitId}>
-                    <Td>{row.careAreaName}</Td>
+                    <Td data-qa="care-area-name">{row.careAreaName}</Td>
                     <Td>
                       <Link to={`/units/${row.unitId}`}>{row.unitName}</Link>
                     </Td>
-                    <Td>
+                    <Td data-qa="unit-provider-type">
                       {
                         i18n.reports.common.unitProviderTypes[
                           row.unitProviderType

--- a/frontend/src/employee-frontend/types/reports.ts
+++ b/frontend/src/employee-frontend/types/reports.ts
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { UUID } from '../types/index'
+import { UUID } from './index'
 import LocalDate from 'lib-common/local-date'
-import { AbsenceType } from '../types/absence'
+import { AbsenceType } from './absence'
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { ProviderType } from './unit'
 
 export interface InvoiceReportRow {
   areaCode: number
@@ -62,7 +63,7 @@ export interface ApplicationsReportRow {
   careAreaName: string
   unitId: UUID
   unitName: string
-  unitProviderType: string
+  unitProviderType: ProviderType
   under3Years: number
   over3Years: number
   preschool: number
@@ -86,7 +87,7 @@ export interface RawReportRow {
   unitName: string
   careArea: string
   unitType: 'DAYCARE' | 'FAMILY' | 'GROUP_FAMILY' | 'CLUB' | null
-  unitProviderType: 'MUNICIPAL' | 'PURCHASED' | 'PRIVATE' | 'MUNICIPAL_SCHOOL'
+  unitProviderType: ProviderType
   daycareGroupId: UUID | null
   groupName: string | null
   caretakersPlanned: number | null
@@ -118,7 +119,7 @@ export interface ServiceNeedReportRow {
   careAreaName: string
   unitName: string
   unitType: 'DAYCARE' | 'FAMILY' | 'GROUP_FAMILY' | 'CLUB' | null
-  unitProviderType: 'MUNICIPAL' | 'PURCHASED' | 'PRIVATE' | 'MUNICIPAL_SCHOOL'
+  unitProviderType: ProviderType
   age: number
   fullDay: number
   partDay: number
@@ -182,7 +183,7 @@ export interface UnitBasicsAbstractReportRow {
   unitId: UUID
   unitName: string
   unitType: 'DAYCARE' | 'FAMILY' | 'GROUP_FAMILY' | 'CLUB' | null
-  unitProviderType: 'MUNICIPAL' | 'PURCHASED' | 'PRIVATE' | 'MUNICIPAL_SCHOOL'
+  unitProviderType: ProviderType
 }
 
 export interface GroupBasicsAbstractReportRow


### PR DESCRIPTION
#### Summary

- Add missing `PRIVATE_SERVICE_VOUCHER` translation to frontend.
- Add type safety `unitProviderType` access. Adding new values to `ProviderType` now properly triggers lint errors.
- Refactor application report test with proper setup and teardown.