### PR TITLE
Split AuthenticatedUser to separate variants - part 1

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/ServerSmokeTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/ServerSmokeTest.kt
@@ -32,7 +32,7 @@ class ServerSmokeTest : FullApplicationTest() {
         val (_, res, _) = http.get("/daycares").responseString()
         assertEquals(401, res.statusCode)
 
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val (_, res2, _) = http.get("/daycares").asUser(user).responseString()
         assertEquals(200, res2.statusCode)
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
@@ -48,8 +48,8 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     private val validDaycareForm = DaycareFormV0.fromApplication2(validDaycareApplication)
     private val validClubForm = ClubFormV0.fromForm2(validClubApplication.form, false, false)
 
-    private val serviceWorker = AuthenticatedUser(testAdult_1.id, setOf(UserRole.SERVICE_WORKER))
-    private val endUser = AuthenticatedUser(testAdult_1.id, setOf(UserRole.END_USER))
+    private val serviceWorker = AuthenticatedUser.Employee(testAdult_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val endUser = AuthenticatedUser.Citizen(testAdult_1.id)
     private val guardian = testAdult_1.copy(email = "john.doe@espootest.com")
     private val guardianAsDaycareAdult = Adult(
         firstName = guardian.firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -76,7 +76,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     @Autowired
     lateinit var mapper: ObjectMapper
 
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     private val applicationId = UUID.randomUUID()
     val address = Address(
@@ -1216,7 +1216,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - existing overlapping indefinite income will be handled`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIndefinite = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1255,7 +1255,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - existing overlapping income will be handled by not adding a new income for user`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1294,7 +1294,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - later indefinite income will be handled by not adding a new income`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val laterIndefiniteIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1333,7 +1333,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - earlier income does not affect creating a new income`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1374,7 +1374,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - later income will be handled by not adding a new income`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val laterIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1413,7 +1413,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - if application does not have a preferred start date income will still be created`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIndefinite = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1450,7 +1450,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists indefinite income for the same day `() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val sameDayIncomeIndefinite = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1488,7 +1488,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists income for the same day `() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val sameDayIncome = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1527,7 +1527,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - new income will be created if there exists indefinite income for the same day - 1 `() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val dayBeforeIncomeIndefinite = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1567,7 +1567,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists indefinite income for the same day + 1 `() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val nextDayIncomeIndefinite = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1606,7 +1606,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists income for the same day - 1`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val incomeDayBefore = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1645,7 +1645,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists income that ends on the same day`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncomeEndingOnSameDay = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1684,7 +1684,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - no new income will be created if there exists income that ends on the same day + 1`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncomeEndingOnNextDay = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1723,7 +1723,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `accept preschool application with maxFeeAccepted - new income will be created if there exists income that ends on the same day - 1`() {
         db.transaction { tx ->
             // given
-            val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+            val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncomeEndingOnDayBefore = Income(
                 id = UUID.randomUUID(),
                 data = mapOf(),
@@ -1766,7 +1766,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         }
         db.transaction { tx ->
             // when
-            val user = AuthenticatedUser(testAdult_5.id, setOf(UserRole.END_USER))
+            val user = AuthenticatedUser.Citizen(testAdult_5.id)
             service.acceptDecision(
                 tx,
                 user,
@@ -1796,7 +1796,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             workflowForPreschoolDaycareDecisions(tx)
         }
         db.transaction { tx ->
-            val user = AuthenticatedUser(testAdult_1.id, setOf(UserRole.END_USER))
+            val user = AuthenticatedUser.Citizen(testAdult_1.id)
             // when
             assertThrows<Forbidden> {
                 service.acceptDecision(
@@ -1819,7 +1819,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         }
         db.transaction { tx ->
             // when
-            val user = AuthenticatedUser(testAdult_1.id, setOf(UserRole.END_USER))
+            val user = AuthenticatedUser.Citizen(testAdult_1.id)
             assertThrows<Forbidden> {
                 service.rejectDecision(
                     tx,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 class ApplicationUpdateIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -44,11 +44,11 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
     @Autowired
     lateinit var stateService: ApplicationStateService
 
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
-    private val enduser = AuthenticatedUser(testAdult_1.id, setOf(UserRole.END_USER))
-    private val testDaycareSupervisor = AuthenticatedUser(unitSupervisorOfTestDaycare.id, setOf())
+    private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val enduser = AuthenticatedUser.Citizen(testAdult_1.id)
+    private val testDaycareSupervisor = AuthenticatedUser.Employee(unitSupervisorOfTestDaycare.id, setOf())
     private val testRoundTheClockDaycareSupervisorExternalId = ExternalId.of("test", UUID.randomUUID().toString())
-    private val testRoundTheClockDaycareSupervisor = AuthenticatedUser(UUID.randomUUID(), setOf())
+    private val testRoundTheClockDaycareSupervisor = AuthenticatedUser.Employee(UUID.randomUUID(), setOf())
 
     private val validDaycareForm = DaycareFormV0.fromApplication2(validDaycareApplication)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -174,7 +174,7 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
 
     private fun runPendingDecisionEmailAsyncJobs(): Int {
         val (_, res, _) = http.post("/scheduled/send-pending-decision-reminder-emails")
-            .asUser(AuthenticatedUser.machineUser)
+            .asUser(AuthenticatedUser.SystemInternalUser)
             .response()
 
         Assertions.assertEquals(204, res.statusCode)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
@@ -26,7 +26,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class AssistanceActionIntegrationTest : FullApplicationTest() {
-    private val assistanceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val assistanceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
@@ -26,7 +26,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class AssistanceNeedIntegrationTest : FullApplicationTest() {
-    private val assistanceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val assistanceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsControllerIntegrationTest.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.insertApplication
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.testAdult_5
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -29,7 +28,7 @@ class AttachmentsControllerIntegrationTest : FullApplicationTest() {
         db.transaction {
             resetDatabase(it.handle)
             insertGeneralTestFixtures(it.handle)
-            user = AuthenticatedUser(testAdult_5.id, setOf(UserRole.END_USER))
+            user = AuthenticatedUser.Citizen(testAdult_5.id)
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
@@ -38,7 +38,7 @@ import java.util.UUID
 
 class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
     private val userId = UUID.randomUUID()
-    private val mobileUser = AuthenticatedUser(userId, emptySet())
+    private val mobileUser = AuthenticatedUser.MobileDevice(userId)
     private val groupId = UUID.randomUUID()
     private val groupName = "Testaajat"
     private val daycarePlacementId = UUID.randomUUID()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
@@ -38,7 +38,7 @@ import java.util.UUID
 
 class GetAttendancesIntegrationTest : FullApplicationTest() {
     private val userId = UUID.randomUUID()
-    private val mobileUser = AuthenticatedUser(userId, emptySet())
+    private val mobileUser = AuthenticatedUser.MobileDevice(userId)
     private val groupId = UUID.randomUUID()
     private val groupId2 = UUID.randomUUID()
     private val groupName = "Testaajat"

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
@@ -32,7 +32,7 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class BackupCareIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
@@ -35,7 +35,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class DaycareEditIntegrationTest : FullApplicationTest() {
-    private val admin = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.ADMIN))
+    private val admin = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.ADMIN))
     private val fields = DaycareFields(
         name = "Uusi päiväkoti",
         openingDate = LocalDate.of(2020, 1, 1),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareGroupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareGroupIntegrationTest.kt
@@ -42,7 +42,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class DaycareGroupIntegrationTest : FullApplicationTest() {
-    private val admin = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.ADMIN))
+    private val admin = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.ADMIN))
 
     @BeforeEach
     protected fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
@@ -57,17 +57,17 @@ class ChildrenControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `get additional info returns correct reply with service worker`() {
-        getAdditionalInfo(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
+        getAdditionalInfo(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `get additional info returns correct reply with finance admin`() {
-        getAdditionalInfo(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
+        getAdditionalInfo(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     @Test
     fun `get additional info throws forbidden with enduser`() {
-        assertThrows<Forbidden> { getAdditionalInfo(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))) }
+        assertThrows<Forbidden> { getAdditionalInfo(AuthenticatedUser.Citizen(UUID.randomUUID())) }
     }
 
     fun getAdditionalInfo(user: AuthenticatedUser) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
@@ -26,7 +26,7 @@ class DaycareControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `smoke test for groups`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
         val existingGroups = daycareController.getGroups(db, user, daycareId).body!!
         assertEquals(2, existingGroups.size)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -42,7 +42,7 @@ class UnitAclControllerIntegrationTest : FullApplicationTest() {
     protected fun beforeEach() {
         jdbi.handle { h ->
             resetDatabase(h)
-            admin = AuthenticatedUser(h.insertTestEmployee(DevEmployee(roles = setOf(UserRole.ADMIN))), roles = setOf(UserRole.ADMIN))
+            admin = AuthenticatedUser.Employee(h.insertTestEmployee(DevEmployee(roles = setOf(UserRole.ADMIN))), roles = setOf(UserRole.ADMIN))
             h.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
             h.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
             employee.also {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -54,7 +54,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class DecisionCreationIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @Autowired
     private lateinit var asyncJobRunner: AsyncJobRunner
@@ -414,7 +414,7 @@ WHERE id = :unitId
         )
         invalidRoleLists.forEach { roles ->
             val (_, res, _) = http.get("/v2/applications/$applicationId/decision-drafts")
-                .asUser(AuthenticatedUser(testDecisionMaker_1.id, roles))
+                .asUser(AuthenticatedUser.Employee(testDecisionMaker_1.id, roles))
                 .response()
             assertEquals(403, res.statusCode)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
@@ -56,8 +56,8 @@ import java.util.stream.Stream
 data class DecisionResolutionTestCase(val isServiceWorker: Boolean, val isAccept: Boolean)
 
 class DecisionResolutionIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
-    private val endUser = AuthenticatedUser(testAdult_1.id, setOf(UserRole.END_USER))
+    private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val endUser = AuthenticatedUser.Citizen(testAdult_1.id)
     private val applicationId = UUID.randomUUID()
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeAlterationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeAlterationIntegrationTest.kt
@@ -46,7 +46,7 @@ class FeeAlterationIntegrationTest : FullApplicationTest() {
         jdbi.handle(::resetDatabase)
     }
 
-    private val user = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
+    private val user = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
     private val personId = UUID.randomUUID()
 
     private val testFeeAlteration = FeeAlteration(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -50,7 +50,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
     @Autowired
     lateinit var asyncJobRunner: AsyncJobRunner
 
-    private val user = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
+    private val user = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
 
     private val testDecisions = listOf(
         createFeeDecisionFixture(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/IncomeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/IncomeIntegrationTest.kt
@@ -66,7 +66,7 @@ class IncomeIntegrationTest : FullApplicationTest() {
         notes = ""
     )
 
-    private val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+    private val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
 
     @Test
     fun `getIncome works with no data in DB`() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -145,7 +145,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         )
     )
 
-    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
+    private val testUser = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
 
     @BeforeEach
     fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
@@ -61,11 +61,11 @@ class BulletinIntegrationTest : FullApplicationTest() {
     private val secondUnitId = testDaycare2.id
 
     private val supervisorId = UUID.randomUUID()
-    private val supervisor = AuthenticatedUser(supervisorId, emptySet())
+    private val supervisor = AuthenticatedUser.Employee(supervisorId, emptySet())
     private val staffId = UUID.randomUUID()
-    private val staffMember = AuthenticatedUser(staffId, emptySet())
+    private val staffMember = AuthenticatedUser.Employee(staffId, emptySet())
     private val guardianPerson = testAdult_6
-    private val guardian = AuthenticatedUser(guardianPerson.id, setOf(UserRole.END_USER))
+    private val guardian = AuthenticatedUser.Citizen(guardianPerson.id)
     private val groupId = UUID.randomUUID()
     private val groupName = "Testaajat"
     private val secondGroupId = UUID.randomUUID()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/ConfirmedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/ConfirmedOccupancyTest.kt
@@ -586,7 +586,7 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
         )
     }
 
-    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val testUser = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     private fun fetchAndParseOccupancy(unitId: UUID, period: FiniteDateRange): List<OccupancyPeriod> {
         val (_, response, result) = http

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/PlannedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/PlannedOccupancyTest.kt
@@ -471,7 +471,7 @@ class PlannedOccupancyTest : FullApplicationTest() {
         assertEquals(0, reportResult2?.headcount)
     }
 
-    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val testUser = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     private fun fetchAndParseOccupancy(unitId: UUID, period: FiniteDateRange): List<OccupancyPeriod> {
         val (_, response, result) = http.get("/occupancy/by-unit/$unitId?from=${period.start}&to=${period.end}&type=PLANNED")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealizedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealizedOccupancyTest.kt
@@ -227,7 +227,7 @@ class RealizedOccupancyTest : FullApplicationTest() {
         )
     }
 
-    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val testUser = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     private fun fetchAndParseOccupancy(unitId: UUID, period: FiniteDateRange): List<OccupancyPeriod> {
         val (_, response, result) = http

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -26,7 +26,7 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 class PairingIntegrationTest : FullApplicationTest() {
-    private val user = AuthenticatedUser(testDecisionMaker_1.id, emptySet())
+    private val user = AuthenticatedUser.Employee(testDecisionMaker_1.id, emptySet())
     private val testUnitId = testDaycare.id
 
     @BeforeEach
@@ -497,7 +497,7 @@ class PairingIntegrationTest : FullApplicationTest() {
                     )
                 )
             )
-            .asUser(AuthenticatedUser.machineUser)
+            .asUser(AuthenticatedUser.SystemInternalUser)
             .responseObject<MobileDeviceIdentity>(objectMapper)
 
         assertEquals(200, res.statusCode)
@@ -514,7 +514,7 @@ class PairingIntegrationTest : FullApplicationTest() {
                     )
                 )
             )
-            .asUser(AuthenticatedUser.machineUser)
+            .asUser(AuthenticatedUser.SystemInternalUser)
             .response()
 
         assertEquals(status, res.statusCode)
@@ -540,7 +540,7 @@ class PairingIntegrationTest : FullApplicationTest() {
 
     private fun getMobileDeviceAssertOk(id: UUID): MobileDevice {
         val (_, res, result) = http.get("/system/mobile-devices/$id")
-            .asUser(AuthenticatedUser.machineUser)
+            .asUser(AuthenticatedUser.SystemInternalUser)
             .responseObject<MobileDevice>(objectMapper)
 
         assertEquals(200, res.statusCode)
@@ -549,7 +549,7 @@ class PairingIntegrationTest : FullApplicationTest() {
 
     private fun getMobileDeviceAssertFail(id: UUID, status: Int) {
         val (_, res, _) = http.get("/system/mobile-devices/$id")
-            .asUser(AuthenticatedUser.machineUser)
+            .asUser(AuthenticatedUser.SystemInternalUser)
             .response()
 
         assertEquals(status, res.statusCode)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
@@ -42,7 +42,7 @@ class SystemIdentityControllerTest : FullApplicationTest() {
         val token = UUID.randomUUID()
         val deviceId = db.transaction { it.insertTestDevice(longTermToken = token) }
 
-        val (_, res, result) = http.get("/system/mobile-identity/$token").asUser(AuthenticatedUser.machineUser)
+        val (_, res, result) = http.get("/system/mobile-identity/$token").asUser(AuthenticatedUser.SystemInternalUser)
             .responseObject<MobileDeviceIdentity>()
         assertTrue(res.isSuccessful)
         assertEquals(MobileDeviceIdentity(id = deviceId, longTermToken = token), result.get())
@@ -53,7 +53,7 @@ class SystemIdentityControllerTest : FullApplicationTest() {
         val token = UUID.randomUUID()
         db.transaction { it.insertTestDevice(longTermToken = token, deleted = true) }
 
-        val (_, res, _) = http.get("/system/mobile-identity/$token").asUser(AuthenticatedUser.machineUser)
+        val (_, res, _) = http.get("/system/mobile-identity/$token").asUser(AuthenticatedUser.SystemInternalUser)
             .response()
         assertEquals(404, res.statusCode)
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
@@ -25,7 +25,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `no employees return empty list`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
         val response = employeeController.getEmployees(db, user)
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(emptyList<Employee>(), response.body)
@@ -33,7 +33,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `admin can add employee`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
         val response = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(employee1.firstName, response.body!!.firstName)
@@ -44,7 +44,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `admin gets all employees`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
         assertEquals(HttpStatus.OK, employeeController.createEmployee(db, user, requestFromEmployee(employee1)).statusCode)
         assertEquals(HttpStatus.OK, employeeController.createEmployee(db, user, requestFromEmployee(employee2)).statusCode)
         val response = employeeController.getEmployees(db, user)
@@ -56,7 +56,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `admin can first create, then get employee`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
         assertEquals(0, employeeController.getEmployees(db, user).body?.size)
 
         val responseCreate = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
@@ -71,7 +71,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `admin can delete employee`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
         val createdEmployeeResponse = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, createdEmployeeResponse.statusCode)
         val response = employeeController.deleteEmployee(db, user, createdEmployeeResponse.body?.id!!)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
@@ -109,7 +109,7 @@ class FamilyOverviewTest : FullApplicationTest() {
         )
     }
 
-    private val testUser = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
+    private val testUser = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
 
     private fun fetchAndParseFamilyDetails(personId: UUID): FamilyOverview {
         val (_, response, result) = http.get("/family/by-adult/$personId")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
@@ -32,17 +32,17 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can create and fetch parentships`() {
-        `can create and fetch parentships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
+        `can create and fetch parentships`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can create and fetch parentships`() {
-        `can create and fetch parentships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
+        `can create and fetch parentships`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can create and fetch parentships`() {
-        `can create and fetch parentships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
+        `can create and fetch parentships`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can create and fetch parentships`(user: AuthenticatedUser) {
@@ -78,17 +78,17 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can update parentships`() {
-        `can update parentship duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
+        `can update parentship duration`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can update parentships`() {
-        `can update parentship duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
+        `can update parentship duration`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can update parentships`() {
-        `can update parentship duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
+        `can update parentship duration`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can update parentship duration`(user: AuthenticatedUser) {
@@ -117,17 +117,17 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker cannot delete parentships`() {
-        `cannot delete parentship`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
+        `cannot delete parentship`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor cannot delete parentships`() {
-        `cannot delete parentship`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
+        `cannot delete parentship`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can delete parentships`() {
-        `can delete parentship`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
+        `can delete parentship`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can delete parentship`(user: AuthenticatedUser) {
@@ -157,7 +157,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to get parentships`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
         val parent = testPerson1()
         val child = testPerson2()
         jdbi.handle { h ->
@@ -168,7 +168,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to update parentship`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
         val parent = testPerson1()
         val child = testPerson2()
         jdbi.handle { h ->
@@ -182,7 +182,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to delete parentship`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
         val parent = testPerson1()
         val child = testPerson2()
         jdbi.handle { h ->
@@ -193,7 +193,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if service worker tries to create a partnership with a start date before child's date of birth`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val parent = testPerson1()
         val child = testPerson2()
         val request = ParentshipController.ParentshipRequest(parent.id, child.id, child.dateOfBirth.minusDays(1), child.dateOfBirth.plusYears(1))
@@ -202,7 +202,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if service worker tries to create a partnership with a end date after child's 18th birthday`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val parent = testPerson1()
         val child = testPerson2()
         val request = ParentshipController.ParentshipRequest(parent.id, child.id, child.dateOfBirth, child.dateOfBirth.plusYears(18))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
@@ -33,17 +33,17 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can create and fetch partnerships`() {
-        `can create and fetch partnerships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
+        `can create and fetch partnerships`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can create and fetch partnerships`() {
-        `can create and fetch partnerships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
+        `can create and fetch partnerships`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can create and fetch partnerships`() {
-        `can create and fetch partnerships`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
+        `can create and fetch partnerships`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can create and fetch partnerships`(user: AuthenticatedUser) {
@@ -75,17 +75,17 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can delete partnerships`() {
-        `can delete partnership`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
+        `can delete partnership`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can delete partnerships`() {
-        `can delete partnership`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
+        `can delete partnership`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can delete partnerships`() {
-        `can delete partnership`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
+        `can delete partnership`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can delete partnership`(user: AuthenticatedUser) = jdbi.handle { h ->
@@ -102,17 +102,17 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `service worker can update partnerships`() {
-        `can update partnership duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
+        `can update partnership duration`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `unit supervisor can update partnerships`() {
-        `can update partnership duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
+        `can update partnership duration`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `finance admin can update partnerships`() {
-        `can update partnership duration`(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
+        `can update partnership duration`(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     fun `can update partnership duration`(user: AuthenticatedUser) = jdbi.handle { h ->
@@ -141,7 +141,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `can updating partnership duration to overlap throws conflict`() = jdbi.handle { h ->
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val partnership1 = h.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
@@ -157,7 +157,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to get partnerships`() = jdbi.handle { h ->
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         h.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
@@ -169,7 +169,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to create a partnership`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val startDate = LocalDate.now()
@@ -183,7 +183,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to update partnerships`() = jdbi.handle { h ->
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val partnership = h.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
@@ -196,7 +196,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to delete a partnership`() = jdbi.handle { h ->
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
         val partnership = h.createPartnership(testPerson1().id, testPerson2().id, LocalDate.now(), LocalDate.now().plusDays(200))
 
         assertThrows<Forbidden> {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -41,22 +41,22 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `Finance admin can update end user's contact info`() {
-        updateContactInfo(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
+        updateContactInfo(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.FINANCE_ADMIN)))
     }
 
     @Test
     fun `Service worker can update end user's contact info`() {
-        updateContactInfo(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
+        updateContactInfo(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER)))
     }
 
     @Test
     fun `Unit supervisor can update end user's contact info`() {
-        updateContactInfo(AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
+        updateContactInfo(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)))
     }
 
     @Test
     fun `End user cannot end update end user's contact info`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.END_USER))
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
         assertThrows<Forbidden> {
             controller.updateContactInfo(db, user, UUID.randomUUID(), contactInfo)
         }
@@ -64,7 +64,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `Search finds person by first and last name`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
@@ -84,7 +84,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `Search treats tabs as spaces in search terms`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
@@ -104,7 +104,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `Search treats non-breaking spaces as spaces in search terms`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
@@ -124,7 +124,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `Search treats obscrube unicode spaces as spaces in search terms`() {
-        val user = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
+        val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
         val person = createPerson()
 
         // IDEOGRAPHIC SPACE, not supported by default in regexes

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -45,7 +45,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
     lateinit var service: VTJBatchRefreshService
 
     val lastDayBefore18YearsOld = testChild_1.dateOfBirth.plusYears(18).minusDays(1)
-    private val user = AuthenticatedUser(UUID.fromString("00000000-0000-0000-0000-000000000000"), setOf())
+    private val user = AuthenticatedUser.Employee(UUID.randomUUID(), emptySet())
 
     @BeforeEach
     internal fun setUp() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
@@ -39,9 +39,9 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
     final val placementEnd = placementStart.plusDays(200)
     lateinit var testPlacement: DaycarePlacementDetails
 
-    private val unitSupervisor = AuthenticatedUser(testDecisionMaker_1.id, emptySet())
-    private val staff = AuthenticatedUser(testDecisionMaker_2.id, emptySet())
-    private val serviceWorker = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
+    private val unitSupervisor = AuthenticatedUser.Employee(testDecisionMaker_1.id, emptySet())
+    private val staff = AuthenticatedUser.Employee(testDecisionMaker_2.id, emptySet())
+    private val serviceWorker = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     fun setUp() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
@@ -45,7 +45,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class PlacementPlanIntegrationTest : FullApplicationTest() {
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {
@@ -275,7 +275,7 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
         )
         invalidRoleLists.forEach { roles ->
             val (_, res, _) = http.get("/v2/applications/$applicationId/placement-draft")
-                .asUser(AuthenticatedUser(testDecisionMaker_1.id, roles))
+                .asUser(AuthenticatedUser.Employee(testDecisionMaker_1.id, roles))
                 .response()
             assertEquals(403, res.statusCode)
         }
@@ -286,7 +286,7 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
         invalidRoleLists.forEach { roles ->
             val (_, res, _) = http.post("/v2/applications/$applicationId/actions/create-placement-plan")
                 .jsonBody(objectMapper.writeValueAsString(proposal))
-                .asUser(AuthenticatedUser(testDecisionMaker_1.id, roles))
+                .asUser(AuthenticatedUser.Employee(testDecisionMaker_1.id, roles))
                 .response()
             assertEquals(403, res.statusCode)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReportTest.kt
@@ -25,7 +25,7 @@ class DuplicatePeopleReportTest : FullApplicationTest() {
         db.transaction { it.resetDatabase() }
     }
 
-    private val adminUser = AuthenticatedUser(id = UUID.randomUUID(), roles = setOf(UserRole.ADMIN))
+    private val adminUser = AuthenticatedUser.Employee(id = UUID.randomUUID(), roles = setOf(UserRole.ADMIN))
 
     @Test
     fun `two people with identical names and dates of birth are matched`() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
@@ -71,7 +71,7 @@ class InvoicingReportTest : FullApplicationTest() {
         )
     }
 
-    private val testUser = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.DIRECTOR))
+    private val testUser = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.DIRECTOR))
 
     private fun getAndAssert(date: LocalDate, expected: InvoiceReport) {
         val (_, response, result) = http.get(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class ReportSmokeTests : FullApplicationTest() {
-    private val testUser = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
+    private val testUser = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
 
     @BeforeAll
     fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
@@ -112,7 +112,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
         assertEquals(sum, row!!.monthlyPaymentSum)
     }
 
-    private val adminUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.ADMIN))
+    private val adminUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.ADMIN))
 
     private fun getAreaReport(areaId: UUID, year: Int, month: Int): List<ServiceVoucherValueUnitAggregate> {
         val (_, response, data) = http.get(
@@ -138,7 +138,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
         }
     }
 
-    private val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+    private val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
 
     private fun createVoucherDecision(
         validFrom: LocalDate,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -272,7 +272,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
     private fun LocalDate.toEndOfMonth() = this.plusMonths(1).withDayOfMonth(1).minusDays(1)
     private fun LocalDate.toInstant() = this.atStartOfDay(helsinkiZone).toInstant()
 
-    private val adminUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.ADMIN))
+    private val adminUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.ADMIN))
 
     private fun getUnitReport(unitId: UUID, year: Int, month: Int): List<ServiceVoucherValueRow> {
         val (_, response, data) = http.get(
@@ -286,7 +286,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
         return data.get().rows
     }
 
-    private val financeUser = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
+    private val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
 
     private fun createVoucherDecision(
         validFrom: LocalDate,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
@@ -107,7 +107,7 @@ class StartingPlacementsReportTest : FullApplicationTest() {
         getAndAssert(date, listOf(toReportRow(testChild_1, placementStart)))
     }
 
-    private val testUser = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.DIRECTOR))
+    private val testUser = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.DIRECTOR))
 
     private fun getAndAssert(date: LocalDate, expected: List<StartingPlacementsRow>) {
         val (_, response, result) = http.get(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
@@ -29,9 +29,9 @@ import java.time.LocalDate
 import java.util.UUID
 
 class ServiceNeedIntegrationTest : FullApplicationTest() {
-    private val unitSupervisor = AuthenticatedUser(unitSupervisorOfTestDaycare.id, setOf(UserRole.UNIT_SUPERVISOR))
-    private val admin = AuthenticatedUser(UUID.randomUUID(), setOf(UserRole.ADMIN))
-    private val serviceWorker = AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
+    private val unitSupervisor = AuthenticatedUser.Employee(unitSupervisorOfTestDaycare.id, setOf(UserRole.UNIT_SUPERVISOR))
+    private val admin = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
+    private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
@@ -21,7 +21,7 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 class AsyncJobQueriesTest : PureJdbiTest() {
-    private val user = AuthenticatedUser(UUID.randomUUID(), setOf())
+    private val user = AuthenticatedUser.SystemInternalUser
 
     @BeforeEach
     fun beforeEach() {
@@ -109,7 +109,7 @@ class AsyncJobQueriesTest : PureJdbiTest() {
             ).map { row -> row.mapJsonColumn<AuthenticatedUser>("user") }.asSequence().first()
         }
         assertEquals(
-            AuthenticatedUser(
+            AuthenticatedUser.Employee(
                 UUID.fromString("44e1ff31-fce4-4ca1-922a-a385fb21c69e"),
                 setOf(UserRole.FINANCE_ADMIN)
             ),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
@@ -30,7 +30,7 @@ class AsyncJobRunnerTest {
     private lateinit var jdbi: Jdbi
     private lateinit var db: Database
 
-    private val user = AuthenticatedUser(UUID.randomUUID(), setOf())
+    private val user = AuthenticatedUser.SystemInternalUser
 
     @BeforeAll
     fun setup() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -6,6 +6,8 @@ package fi.espoo.evaka.shared.auth
 
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.decision.DecisionType
+import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
+import fi.espoo.evaka.messaging.daycarydailynote.createDaycareDailyNote
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevChild
@@ -43,6 +45,7 @@ class AclIntegrationTest : PureJdbiTest() {
     private lateinit var decisionId: UUID
     private lateinit var placementId: UUID
     private lateinit var mobileId: UUID
+    private lateinit var noteId: UUID
 
     private lateinit var acl: AccessControlList
 
@@ -68,6 +71,21 @@ class AclIntegrationTest : PureJdbiTest() {
             )
             placementId = insertTestPlacement(it.handle, childId = childId, unitId = daycareId)
             mobileId = it.handle.insertTestEmployee(DevEmployee())
+            noteId = it.createDaycareDailyNote(
+                DaycareDailyNote(
+                    id = null,
+                    groupId = groupId,
+                    childId = null,
+                    date = LocalDate.of(2019, 1, 7),
+                    note = "Test",
+                    feedingNote = null,
+                    modifiedAt = null,
+                    reminderNote = null,
+                    reminders = emptyList(),
+                    sleepingHours = null,
+                    sleepingNote = null
+                )
+            )
             it.insertTestMobileDevice(DevMobileDevice(id = mobileId, unitId = daycareId))
         }
         acl = AccessControlList(jdbi)
@@ -92,6 +110,7 @@ class AclIntegrationTest : PureJdbiTest() {
         assertEquals(aclRoles, acl.getRolesForDecision(user, decisionId))
         assertEquals(aclRoles, acl.getRolesForPlacement(user, placementId))
         assertEquals(aclRoles, acl.getRolesForUnitGroup(user, groupId))
+        assertEquals(aclRoles, acl.getRolesForDailyNote(user, noteId))
     }
 
     @ParameterizedTest(name = "{0}")
@@ -109,6 +128,7 @@ class AclIntegrationTest : PureJdbiTest() {
         assertEquals(negativeAclRoles, acl.getRolesForDecision(user, decisionId))
         assertEquals(negativeAclRoles, acl.getRolesForPlacement(user, placementId))
         assertEquals(negativeAclRoles, acl.getRolesForUnitGroup(user, groupId))
+        assertEquals(negativeAclRoles, acl.getRolesForDailyNote(user, noteId))
 
         jdbi.handle { it.insertDaycareAclRow(daycareId, employeeId, role) }
 
@@ -118,6 +138,7 @@ class AclIntegrationTest : PureJdbiTest() {
         assertEquals(positiveAclRoles, acl.getRolesForDecision(user, decisionId))
         assertEquals(positiveAclRoles, acl.getRolesForPlacement(user, placementId))
         assertEquals(positiveAclRoles, acl.getRolesForUnitGroup(user, groupId))
+        assertEquals(positiveAclRoles, acl.getRolesForDailyNote(user, noteId))
     }
 
     @Test
@@ -133,5 +154,6 @@ class AclIntegrationTest : PureJdbiTest() {
         assertEquals(expectedAclRoles, acl.getRolesForDecision(user, decisionId))
         assertEquals(expectedAclRoles, acl.getRolesForPlacement(user, placementId))
         assertEquals(expectedAclRoles, acl.getRolesForUnitGroup(user, groupId))
+        assertEquals(expectedAclRoles, acl.getRolesForDailyNote(user, noteId))
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -81,7 +81,7 @@ class AclIntegrationTest : PureJdbiTest() {
     @ParameterizedTest(name = "{0}")
     @EnumSource(names = ["ADMIN", "SERVICE_WORKER", "FINANCE_ADMIN"])
     fun testGlobalRoleAuthorization(role: UserRole) {
-        val user = AuthenticatedUser(employeeId, setOf(role))
+        val user = AuthenticatedUser.Employee(employeeId, setOf(role))
         val aclAuth = AclAuthorization.All
         val aclRoles = AclAppliedRoles(setOf(role))
 
@@ -97,7 +97,7 @@ class AclIntegrationTest : PureJdbiTest() {
     @ParameterizedTest(name = "{0}")
     @EnumSource(names = ["UNIT_SUPERVISOR", "STAFF"])
     fun testAclRoleAuthorization(role: UserRole) {
-        val user = AuthenticatedUser(employeeId, setOf(role))
+        val user = AuthenticatedUser.Employee(employeeId, setOf(role))
         val negativeAclAuth = AclAuthorization.Subset(emptySet())
         val negativeAclRoles = AclAppliedRoles(emptySet())
         val positiveAclAuth = AclAuthorization.Subset(setOf(daycareId))
@@ -122,7 +122,7 @@ class AclIntegrationTest : PureJdbiTest() {
 
     @Test
     fun testMobileAclRoleAuthorization() {
-        val user = AuthenticatedUser(mobileId, setOf(UserRole.MOBILE))
+        val user = AuthenticatedUser.MobileDevice(mobileId)
 
         val expectedAclAuth = AclAuthorization.Subset(setOf(daycareId))
         val expectedAclRoles = AclAppliedRoles(setOf(UserRole.MOBILE))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
@@ -51,7 +51,7 @@ class ScheduledOperationControllerIntegrationTest : FullApplicationTest() {
     @Autowired
     private lateinit var applicationStateService: ApplicationStateService
 
-    private val serviceWorker = AuthenticatedUser(id = testDecisionMaker_1.id, roles = setOf(UserRole.SERVICE_WORKER))
+    private val serviceWorker = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
     private fun beforeEach() {
@@ -65,7 +65,7 @@ class ScheduledOperationControllerIntegrationTest : FullApplicationTest() {
     fun `Draft application and attachments older than 30 days is cleaned up`() {
         val id_to_be_deleted = UUID.randomUUID()
         val id_not_to_be_deleted = UUID.randomUUID()
-        val user = AuthenticatedUser(testAdult_5.id, setOf(UserRole.END_USER))
+        val user = AuthenticatedUser.Citizen(testAdult_5.id)
 
         db.transaction { tx ->
             insertApplication(tx.handle, guardian = testAdult_5, applicationId = id_to_be_deleted)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/utils/SpringMvcTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/utils/SpringMvcTest.kt
@@ -27,7 +27,7 @@ class SpringMvcTest : FullApplicationTest() {
 
     @Test
     fun `a database connection passed to a controller is closed automatically on success`() {
-        val (_, res, _) = http.get("/integration-test/db-connection-pass").asUser(AuthenticatedUser.machineUser)
+        val (_, res, _) = http.get("/integration-test/db-connection-pass").asUser(AuthenticatedUser.SystemInternalUser)
             .response()
         assertTrue(res.isSuccessful)
         val connection = controller.lastDbConnection.get()
@@ -37,7 +37,7 @@ class SpringMvcTest : FullApplicationTest() {
 
     @Test
     fun `a database connection passed to a controller is closed automatically on failure`() {
-        val (_, res, _) = http.get("/integration-test/db-connection-fail").asUser(AuthenticatedUser.machineUser)
+        val (_, res, _) = http.get("/integration-test/db-connection-fail").asUser(AuthenticatedUser.SystemInternalUser)
             .response()
         assertEquals(500, res.statusCode)
         val connection = controller.lastDbConnection.get()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -750,7 +750,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
     private fun FeeDecision.send(): FeeDecision {
         val (_, response, _) = http.post("/fee-decisions/confirm")
-            .asUser(AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)))
+            .asUser(AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)))
             .jsonBody(objectMapper.writeValueAsString(listOf(this.id)))
             .response()
         assertEquals(204, response.statusCode)
@@ -760,7 +760,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
     private fun VoucherValueDecision.send(): VoucherValueDecision {
         val (_, response, _) = http.post("/value-decisions/send")
-            .asUser(AuthenticatedUser(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)))
+            .asUser(AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)))
             .jsonBody(objectMapper.writeValueAsString(listOf(this.id)))
             .response()
         assertEquals(204, response.statusCode)

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -99,8 +99,8 @@ class AttachmentsController(
                 name,
                 contentType,
                 applicationId,
-                uploadedByEnduser = user.id.takeIf { user.isEndUser() },
-                uploadedByEmployee = user.id.takeUnless { user.isEndUser() },
+                uploadedByEnduser = user.id.takeIf { user.isEndUser },
+                uploadedByEmployee = user.id.takeUnless { user.isEndUser },
                 type = type
             )
             documentClient.upload(

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -39,7 +39,7 @@ class LocationController {
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
         @RequestParam shiftCare: Boolean?
     ): ResponseEntity<List<PublicUnit>> {
-        val units = db.read { it.handle.getApplicationUnits(type, date, shiftCare, onlyApplicable = user.isEndUser()) }
+        val units = db.read { it.handle.getApplicationUnits(type, date, shiftCare, onlyApplicable = user.isEndUser) }
         return ResponseEntity.ok(units)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
@@ -104,7 +104,7 @@ class DecisionController(
                 application.guardianId
             ) ?: error("Cannot find user for guardian id '${application.guardianId}'")
 
-            if ((child.restrictedDetailsEnabled || guardian.restrictedDetailsEnabled) && !user.isAdmin())
+            if ((child.restrictedDetailsEnabled || guardian.restrictedDetailsEnabled) && !user.isAdmin)
                 throw Forbidden("Päätöksen alaisella henkilöllä on voimassa turvakielto. Osoitetietojen suojaamiseksi vain pääkäyttäjä voi ladata tämän päätöksen.")
 
             decisionService.getDecisionPdf(tx, decisionId)

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -173,7 +173,7 @@ class DecisionService(
         val application = fetchApplicationDetails(tx.handle, applicationId)
             ?: throw NotFound("Application $applicationId was not found")
 
-        val currentVtjGuardianIds = personService.getGuardians(tx, AuthenticatedUser.machineUser, decision.childId).map { person -> person.id }
+        val currentVtjGuardianIds = personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, decision.childId).map { person -> person.id }
 
         val applicationGuardian = tx.handle.getPersonById(application.guardianId)
             ?: error("Guardian not found with id: ${application.guardianId}")

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
@@ -167,7 +167,7 @@ class DvvModificationsService(
         ssn: String,
         custodianLimitedDvvInfoGroup: CustodianLimitedDvvInfoGroup
     ) {
-        val user = AuthenticatedUser.machineUser
+        val user = AuthenticatedUser.SystemInternalUser
         db.transaction { tx ->
             personService.getOrCreatePerson(tx, user, ExternalIdentifier.SSN.getInstance(ssn))
         }?.let {
@@ -180,7 +180,7 @@ class DvvModificationsService(
         db: Database,
         caretakerLimitedDvvInfoGroup: CaretakerLimitedDvvInfoGroup
     ) {
-        val user = AuthenticatedUser.machineUser
+        val user = AuthenticatedUser.SystemInternalUser
         if (caretakerLimitedDvvInfoGroup.huoltaja.henkilotunnus != null) {
             db.transaction { tx ->
                 personService.getOrCreatePerson(
@@ -203,7 +203,7 @@ class DvvModificationsService(
         personNameDvvInfoGroup: PersonNameDvvInfoGroup
     ) = db.transaction { tx ->
         tx.handle.getPersonBySSN(ssn)?.let {
-            val user = AuthenticatedUser.machineUser
+            val user = AuthenticatedUser.SystemInternalUser
             personService.getOrCreatePerson(tx, user, ExternalIdentifier.SSN.getInstance(ssn))?.let {
                 logger.info("Dvv modification for ${it.id}: name ${personNameDvvInfoGroup.muutosattribuutti}, refreshed all info from DVV")
             }
@@ -216,7 +216,7 @@ class DvvModificationsService(
         personNameChangeDvvInfoGroup: PersonNameChangeDvvInfoGroup
     ) = db.transaction { tx ->
         tx.handle.getPersonBySSN(ssn)?.let {
-            val user = AuthenticatedUser.machineUser
+            val user = AuthenticatedUser.SystemInternalUser
             personService.getOrCreatePerson(tx, user, ExternalIdentifier.SSN.getInstance(ssn))?.let {
                 logger.info("Dvv modification for ${it.id}: name has changed: ${personNameChangeDvvInfoGroup.muutosattribuutti} - ${personNameChangeDvvInfoGroup.nimilaji}, refreshed all info from DVV")
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteController.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.domain.Forbidden
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -123,9 +122,8 @@ class DaycareDailyNoteController(
     ) {
         Audit.DaycareDailyNoteDelete.log(user.id)
 
-        if (!user.hasOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF, UserRole.MOBILE)) {
-            throw Forbidden("Permission denied")
-        }
+        acl.getRolesForDailyNote(user, noteId)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF, UserRole.MOBILE)
 
         return db.transaction { it.deleteDaycareDailyNote(noteId) }.let { ResponseEntity.ok() }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
@@ -43,7 +43,7 @@ class MobileDevicesController(
         @PathVariable id: UUID
     ): ResponseEntity<MobileDevice> {
         Audit.MobileDevicesRead.log(targetId = id)
-        user.assertMachineUser()
+        user.assertSystemInternalUser()
 
         return db
             .read { it.getDevice(id) }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
@@ -28,7 +28,7 @@ class FridgeFamilyService(
         val head = db.transaction {
             personService.getUpToDatePersonWithChildren(
                 it,
-                user = AuthenticatedUser(msg.requestingUserId, setOf()),
+                user = AuthenticatedUser.Employee(msg.requestingUserId, setOf()),
                 id = msg.personId
             )
         }
@@ -41,7 +41,7 @@ class FridgeFamilyService(
                     db.transaction {
                         personService.getUpToDatePersonWithChildren(
                             it,
-                            user = AuthenticatedUser(msg.requestingUserId, setOf()),
+                            user = AuthenticatedUser.Employee(msg.requestingUserId, setOf()),
                             id = partnerId
                         )
                     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
@@ -29,7 +29,9 @@ sealed class AuthenticatedUser : RoleContainer {
         override val isEndUser = true
     }
 
-    data class Employee(override val id: UUID, override val roles: Set<UserRole>) : AuthenticatedUser() {
+    data class Employee private constructor(override val id: UUID, val globalRoles: Set<UserRole>, val allScopedRoles: Set<UserRole>) : AuthenticatedUser() {
+        constructor(id: UUID, roles: Set<UserRole>) : this(id, roles - UserRole.SCOPED_ROLES, roles.intersect(UserRole.SCOPED_ROLES))
+        override val roles: Set<UserRole> = globalRoles + allScopedRoles
         override val isAdmin = roles.contains(UserRole.ADMIN)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
@@ -4,25 +4,42 @@
 
 package fi.espoo.evaka.shared.auth
 
-import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import fi.espoo.evaka.shared.domain.Forbidden
 import java.util.UUID
 
 @JsonSerialize(using = AuthenticatedUserJsonSerializer::class)
-data class AuthenticatedUser(@JsonInclude val id: UUID, @JsonInclude override val roles: Set<UserRole>) : RoleContainer {
-    fun isEndUser() = roles.contains(UserRole.END_USER)
-    fun isServiceWorker() = roles.contains(UserRole.SERVICE_WORKER)
-    fun isUnitSupervisor() = roles.contains(UserRole.UNIT_SUPERVISOR)
-    fun isFinanceAdmin() = roles.contains(UserRole.FINANCE_ADMIN)
-    fun isAdmin() = roles.contains(UserRole.ADMIN)
-    fun isMachineUser() = this == machineUser
+@JsonDeserialize(using = AuthenticatedUserJsonDeserializer::class)
+sealed class AuthenticatedUser : RoleContainer {
+    open val isEndUser = false
+    open val isAdmin = false
+    open val isSystemInternalUser = false
 
-    fun assertMachineUser() {
-        if (this != machineUser) throw Forbidden("Only accessible to the machine user")
+    abstract val id: UUID
+
+    fun assertSystemInternalUser() {
+        if (!this.isSystemInternalUser) {
+            throw Forbidden("Only accessible to the system internal user")
+        }
     }
 
-    companion object {
-        val machineUser = AuthenticatedUser(UUID.fromString("00000000-0000-0000-0000-000000000000"), setOf())
+    data class Citizen(override val id: UUID) : AuthenticatedUser() {
+        override val roles: Set<UserRole> = setOf(UserRole.END_USER)
+        override val isEndUser = true
+    }
+
+    data class Employee(override val id: UUID, override val roles: Set<UserRole>) : AuthenticatedUser() {
+        override val isAdmin = roles.contains(UserRole.ADMIN)
+    }
+
+    data class MobileDevice(override val id: UUID) : AuthenticatedUser() {
+        override val roles: Set<UserRole> = emptySet()
+    }
+
+    object SystemInternalUser : AuthenticatedUser() {
+        override val id: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
+        override val roles: Set<UserRole> = emptySet()
+        override val isSystemInternalUser = true
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonDeserializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonDeserializer.kt
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.auth
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import java.util.UUID
+
+// Custom deserializer to temporarily support legacy JSON
+class AuthenticatedUserJsonDeserializer : JsonDeserializer<AuthenticatedUser>() {
+    private data class LegacyAuthenticatedUser(val type: String?, val id: UUID?, val roles: Set<UserRole> = emptySet())
+
+    override fun deserialize(p: JsonParser, ctx: DeserializationContext): AuthenticatedUser {
+        val user = p.readValueAs(LegacyAuthenticatedUser::class.java)
+        return when (user.type) {
+            "citizen" -> AuthenticatedUser.Citizen(user.id!!)
+            "employee" -> AuthenticatedUser.Employee(user.id!!, user.roles)
+            "mobile" -> AuthenticatedUser.MobileDevice(user.id!!)
+            "system" -> AuthenticatedUser.SystemInternalUser
+            else -> {
+                when {
+                    user.id == AuthenticatedUser.SystemInternalUser.id ->
+                        AuthenticatedUser.SystemInternalUser
+                    user.roles.contains(UserRole.END_USER) ->
+                        AuthenticatedUser.Citizen(user.id!!)
+                    user.roles.contains(UserRole.MOBILE) ->
+                        AuthenticatedUser.MobileDevice(user.id!!)
+                    else ->
+                        AuthenticatedUser.Employee(user.id!!, user.roles)
+                }
+            }
+        }
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonDeserializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonDeserializer.kt
@@ -11,13 +11,13 @@ import java.util.UUID
 
 // Custom deserializer to temporarily support legacy JSON
 class AuthenticatedUserJsonDeserializer : JsonDeserializer<AuthenticatedUser>() {
-    private data class LegacyAuthenticatedUser(val type: String?, val id: UUID?, val roles: Set<UserRole> = emptySet())
+    private data class AllFields(val type: String?, val id: UUID?, val roles: Set<UserRole> = emptySet(), val globalRoles: Set<UserRole> = emptySet(), val allScopedRoles: Set<UserRole> = emptySet())
 
     override fun deserialize(p: JsonParser, ctx: DeserializationContext): AuthenticatedUser {
-        val user = p.readValueAs(LegacyAuthenticatedUser::class.java)
+        val user = p.readValueAs(AllFields::class.java)
         return when (user.type) {
             "citizen" -> AuthenticatedUser.Citizen(user.id!!)
-            "employee" -> AuthenticatedUser.Employee(user.id!!, user.roles)
+            "employee" -> AuthenticatedUser.Employee(user.id!!, user.globalRoles + user.allScopedRoles)
             "mobile" -> AuthenticatedUser.MobileDevice(user.id!!)
             "system" -> AuthenticatedUser.SystemInternalUser
             else -> {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonSerializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonSerializer.kt
@@ -20,7 +20,8 @@ class AuthenticatedUserJsonSerializer : JsonSerializer<AuthenticatedUser>() {
             is AuthenticatedUser.Employee -> {
                 gen.writeObjectField("type", "employee")
                 gen.writeObjectField("id", value.id.toString())
-                gen.writeObjectField("roles", value.roles)
+                gen.writeObjectField("globalRoles", value.globalRoles)
+                gen.writeObjectField("allScopedRoles", value.allScopedRoles)
             }
             is AuthenticatedUser.MobileDevice -> {
                 gen.writeObjectField("type", "mobile")

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonSerializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonSerializer.kt
@@ -12,8 +12,24 @@ import com.fasterxml.jackson.databind.SerializerProvider
 class AuthenticatedUserJsonSerializer : JsonSerializer<AuthenticatedUser>() {
     override fun serialize(value: AuthenticatedUser, gen: JsonGenerator, serializers: SerializerProvider) {
         gen.writeStartObject()
-        gen.writeObjectField("id", value.id.toString())
-        gen.writeObjectField("roles", value.roles)
+        when (value) {
+            is AuthenticatedUser.Citizen -> {
+                gen.writeObjectField("type", "citizen")
+                gen.writeObjectField("id", value.id.toString())
+            }
+            is AuthenticatedUser.Employee -> {
+                gen.writeObjectField("type", "employee")
+                gen.writeObjectField("id", value.id.toString())
+                gen.writeObjectField("roles", value.roles)
+            }
+            is AuthenticatedUser.MobileDevice -> {
+                gen.writeObjectField("type", "mobile")
+                gen.writeObjectField("id", value.id.toString())
+            }
+            is AuthenticatedUser.SystemInternalUser -> {
+                gen.writeObjectField("type", "system")
+            }
+        }
         gen.writeEndObject()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/JwtTokens.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/JwtTokens.kt
@@ -19,16 +19,43 @@ private val tokenExpiration = Duration.ofHours(1)
 
 fun DecodedJWT.toAuthenticatedUser(): AuthenticatedUser? = this.subject?.let { subject ->
     val id = UUID.fromString(subject)
+    val type = this.claims["evaka_type"]?.asString()
     val roles = (this.claims["scope"]?.asString() ?: "")
         .let {
             if (it.isNullOrEmpty()) emptyList()
             else it.split(' ')
         }
-    return AuthenticatedUser(id, roles.map { UserRole.parse(it) }.toSet())
+        .map { UserRole.parse(it) }
+        .toSet()
+    return when (type) {
+        "citizen" -> AuthenticatedUser.Citizen(id)
+        "employee" -> AuthenticatedUser.Employee(id, roles)
+        "mobile" -> AuthenticatedUser.MobileDevice(id)
+        "system" -> AuthenticatedUser.SystemInternalUser
+        else -> {
+            // support legacy format temporarily
+            when {
+                id == AuthenticatedUser.SystemInternalUser.id -> AuthenticatedUser.SystemInternalUser
+                roles == setOf(UserRole.END_USER) -> AuthenticatedUser.Citizen(id)
+                roles == setOf(UserRole.MOBILE) -> AuthenticatedUser.MobileDevice(id)
+                else ->
+                    AuthenticatedUser.Employee(id, roles)
+            }
+        }
+    }
 }
 
 fun AuthenticatedUser.applyToJwt(jwt: JWTCreator.Builder): JWTCreator.Builder = jwt
     .withSubject(id.toString())
+    .withClaim(
+        "evaka_type",
+        when (this) {
+            is AuthenticatedUser.SystemInternalUser -> "system"
+            is AuthenticatedUser.MobileDevice -> "mobile"
+            is AuthenticatedUser.Employee -> "employee"
+            is AuthenticatedUser.Citizen -> "citizen"
+        }
+    )
     .withClaim("scope", roles.joinToString(" "))
 
 fun encodeSignedJwtToken(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
@@ -75,7 +75,7 @@ class HttpFilterConfig {
         }
 
         private fun HttpServletRequest.isAuthorized(user: AuthenticatedUser): Boolean {
-            if (requestURI.startsWith("/system/")) return user.isMachineUser()
+            if (requestURI.startsWith("/system/")) return user.isSystemInternalUser
             return true
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -93,7 +93,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.util.UUID
 
-private val fakeAdmin = AuthenticatedUser(
+private val fakeAdmin = AuthenticatedUser.Employee(
     id = UUID.fromString("00000000-0000-0000-0000-000000000000"),
     roles = setOf(UserRole.ADMIN)
 )
@@ -609,7 +609,7 @@ RETURNING id
 
             uuid?.let {
                 // Refresh Pis data by forcing refresh from VTJ
-                val dummyUser = AuthenticatedUser(it, setOf(UserRole.SERVICE_WORKER))
+                val dummyUser = AuthenticatedUser.Employee(it, setOf(UserRole.SERVICE_WORKER))
                 personService.getUpToDatePerson(tx, dummyUser, it)
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageClient.kt
@@ -65,7 +65,7 @@ class EvakaMessageClient(
     }
 
     private fun sendRequest(msg: SuomiFiMessage, path: String) {
-        val token = encodeSignedJwtToken(algorithm, user = AuthenticatedUser.machineUser)
+        val token = encodeSignedJwtToken(algorithm, user = AuthenticatedUser.SystemInternalUser)
         val (_, _, result) = Fuel.post(path)
             .authentication().bearer(token)
             .jsonBody(objectMapper.writeValueAsString(msg))

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaFeeData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaFeeData.kt
@@ -67,7 +67,7 @@ fun createAndUpdateFeeData(db: Database.Connection, client: VardaClient, personS
         logger.info { "Varda: Deleting ${outdatedFeeData.size} outdated fee data" }
         deleteFeeData(db, client, outdatedFeeData)
 
-        val guardians = db.transaction { personService.getEvakaOrVtjGuardians(it, AuthenticatedUser.machineUser, childId) }
+        val guardians = db.transaction { personService.getEvakaOrVtjGuardians(it, AuthenticatedUser.SystemInternalUser, childId) }
             .filter { (it.firstName + it.lastName).isNotBlank() }
         if (guardians.isEmpty()) return@forEach
 

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -64,7 +64,7 @@ class VtjController(
     ): PersonResult {
         Audit.VtjRequest.log(targetId = personId)
         return when {
-            user.isEndUser() -> {
+            user.isEndUser -> {
                 if (personId != user.id) {
                     PersonResult.Error("Query not allowed")
                         .also { logger.error { "Error preparing request for person data: ${it.msg}" } }

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserTest.kt
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.auth
+
+import fi.espoo.evaka.shared.config.defaultObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class AuthenticatedUserTest {
+    private val id = UUID.fromString("e4d7a125-2b2c-465c-994f-38c2915534a6")
+
+    @Test
+    fun `legacy authenticated citizens can be deserialized`() {
+        val json = """
+            {
+                "id": "$id",
+                "roles": ["END_USER"]
+            }
+        """.trimIndent()
+        val user = defaultObjectMapper().readValue(json, AuthenticatedUser::class.java)
+        assertEquals(AuthenticatedUser.Citizen(id), user)
+    }
+
+    @Test
+    fun `legacy authenticated system user can be deserialized`() {
+        val json = """
+            {
+                "id": "${AuthenticatedUser.SystemInternalUser.id}",
+                "roles": []
+            }
+        """.trimIndent()
+        val user = defaultObjectMapper().readValue(json, AuthenticatedUser::class.java)
+        assertEquals(AuthenticatedUser.SystemInternalUser, user)
+    }
+
+    @Test
+    fun `legacy authenticated mobile device can be deserialized`() {
+        val json = """
+            {
+                "id": "$id",
+                "roles": ["MOBILE"]
+            }
+        """.trimIndent()
+        val user = defaultObjectMapper().readValue(json, AuthenticatedUser::class.java)
+        assertEquals(AuthenticatedUser.MobileDevice(id), user)
+    }
+
+    @Test
+    fun `legacy authenticated employee can be deserialized`() {
+        val json = """
+            {
+                "id": "$id",
+                "roles": ["SERVICE_WORKER"]
+            }
+        """.trimIndent()
+        val user = defaultObjectMapper().readValue(json, AuthenticatedUser::class.java)
+        assertEquals(AuthenticatedUser.Employee(id, setOf(UserRole.SERVICE_WORKER)), user)
+    }
+}

--- a/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/MockDataServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/MockDataServiceTest.kt
@@ -177,6 +177,6 @@ class MockDataServiceTest {
 
     private fun mapToQuery(ssn: String) = DetailsQuery(
         targetIdentifier = getInstance(ssn),
-        requestingUser = AuthenticatedUser(UUID.randomUUID(), setOf())
+        requestingUser = AuthenticatedUser.Employee(UUID.randomUUID(), setOf())
     )
 }

--- a/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/MockPersonDetailsServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/MockPersonDetailsServiceTest.kt
@@ -150,6 +150,6 @@ class MockPersonDetailsServiceTest {
 
     private fun mapToQuery(ssn: String) = IPersonDetailsService.DetailsQuery(
         targetIdentifier = ExternalIdentifier.SSN.getInstance(ssn),
-        requestingUser = AuthenticatedUser(UUID.randomUUID(), setOf())
+        requestingUser = AuthenticatedUser.Employee(UUID.randomUUID(), setOf())
     )
 }

--- a/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/persondetails/VTJPersonDetailsServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/persondetails/VTJPersonDetailsServiceTest.kt
@@ -191,7 +191,7 @@ class VTJPersonDetailsServiceTest {
     private fun queryAboutSelf(vtjPerson: VtjPerson = validPerson) =
         vtjPerson
             .toPersonDTO()
-            .let { DetailsQuery(requestingUser = AuthenticatedUser(it.id, setOf()), targetIdentifier = it.identity as SSN) }
+            .let { DetailsQuery(requestingUser = AuthenticatedUser.Employee(it.id, setOf()), targetIdentifier = it.identity as SSN) }
 
     private fun DetailsQuery.asMinimalVtjResponse(): Henkilo = minimalVtjResponse("${requestingUser.id}")
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

* it's now possible to do different things depending on what kind of session the user is using without relying on fragile role checks
* we can add extra fields to only some of the session types (e.g. mobile device session could include id of the actual user)
* this change makes several invalid combinations impossible
