### PR TITLE
OWASP: suppress msg-service non-risk vuln

### DIFF
--- a/message-service/owasp-suppressions.xml
+++ b/message-service/owasp-suppressions.xml
@@ -47,4 +47,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         ]]></notes>
         <cve>CVE-2020-13936</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Not a risk in our use case (no OAuth + only server-to-server usage)
+        ]]></notes>
+        <cve>CVE-2021-22696</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Summary
- No real risk in our context/use case (no OAuth + only server-to-server comms)