### PR TITLE
Customer weak login

### DIFF
--- a/apigw/src/enduser/app.ts
+++ b/apigw/src/enduser/app.ts
@@ -8,7 +8,10 @@ import cookieParser from 'cookie-parser'
 import passport from 'passport'
 import publicRoutes from './publicRoutes'
 import routes from './routes'
-import { createAuthEndpoints } from '../shared/routes/auth/suomi-fi'
+import {
+  createSuomiFiAuthEndpoints,
+  createKeycloakAuthEndpoints
+} from '../shared/routes/auth/suomi-fi'
 import { errorHandler } from '../shared/middleware/error-handler'
 import { requireAuthentication } from '../shared/auth'
 import session, { refreshLogoutToken } from '../shared/session'
@@ -46,7 +49,9 @@ function apiRouter() {
   const router = Router()
 
   router.use(publicRoutes)
-  router.use(createAuthEndpoints('enduser'))
+  router.use(createSuomiFiAuthEndpoints('enduser'))
+  router.use(createKeycloakAuthEndpoints('enduser'))
+
   router.get('/auth/status', csrf, csrfCookie('enduser'), authStatus)
   router.use(requireAuthentication)
   router.use(csrf)

--- a/apigw/src/enduser/routes/auth-status.ts
+++ b/apigw/src/enduser/routes/auth-status.ts
@@ -8,6 +8,7 @@ import { toRequestHandler } from '../../shared/express'
 export default toRequestHandler(async (req, res) => {
   if (req.user) {
     const data = await getUserDetails(req, req.user.id)
+    data.userType = req.user.userType
     res.status(200).send({ loggedIn: true, user: data })
   } else {
     res.status(200).send({ loggedIn: false })

--- a/apigw/src/shared/auth/customer-saml.ts
+++ b/apigw/src/shared/auth/customer-saml.ts
@@ -75,8 +75,8 @@ async function verifyKeycloakProfile(
 
   return {
     id: person.id,
-    userType: 'ENDUSER',
-    globalRoles: ['END_USER'],
+    userType: 'CITIZEN_WEAK',
+    globalRoles: ['CITIZEN_WEAK'],
     allScopedRoles: [],
     nameID: profile.nameID,
     nameIDFormat: profile.nameIDFormat,

--- a/apigw/src/shared/auth/customer-saml.ts
+++ b/apigw/src/shared/auth/customer-saml.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import {
+  Profile,
+  Strategy as SamlStrategy,
+  VerifiedCallback
+} from 'passport-saml'
+import { SamlUser } from '../routes/auth/saml/types'
+import { getOrCreatePerson } from '../service-client'
+import { evakaCustomerSamlConfig, EvakaSamlConfig } from '../config'
+import fs from 'fs'
+
+export default function createEvakaCustomerSamlStrategy(): SamlStrategy {
+  return createKeycloakSamlStrategy(evakaCustomerSamlConfig)
+}
+
+function createKeycloakSamlStrategy(
+  samlConfig: EvakaSamlConfig | undefined
+): SamlStrategy {
+  if (!samlConfig) throw new Error('Missing Keycloak SAML configuration')
+  const publicCert = fs.readFileSync(samlConfig.publicCert, {
+    encoding: 'utf8'
+  })
+  const privateCert = fs.readFileSync(samlConfig.privateCert, {
+    encoding: 'utf8'
+  })
+  return new SamlStrategy(
+    {
+      issuer: 'evaka-customer',
+      callbackUrl: samlConfig.callbackUrl,
+      entryPoint: samlConfig.entryPoint,
+      logoutUrl: samlConfig.entryPoint,
+      acceptedClockSkewMs: -1,
+      cert: publicCert,
+      privateCert: privateCert,
+      decryptionPvk: privateCert,
+      identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+      signatureAlgorithm: 'sha256'
+    },
+    (profile: Profile, done: VerifiedCallback) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      verifyKeycloakProfile((profile as any) as KeycloakProfile)
+        .then((user) => done(null, user))
+        .catch(done)
+    }
+  )
+}
+
+interface KeycloakProfile {
+  id?: string
+  socialSecurityNumber: string
+  email: string
+  firstName: string
+  lastName: string
+  nameID?: string
+  nameIDFormat?: string
+  nameQualifier?: string
+  spNameQualifier?: string
+  sessionIndex?: string
+}
+
+async function verifyKeycloakProfile(
+  profile: KeycloakProfile
+): Promise<SamlUser> {
+  if (!profile.socialSecurityNumber)
+    throw Error('No socialSecurityNumber in evaka IDP SAML data')
+
+  const person = await getOrCreatePerson({
+    socialSecurityNumber: profile.socialSecurityNumber,
+    firstName: profile.firstName,
+    lastName: profile.lastName
+  })
+
+  return {
+    id: person.id,
+    userType: 'ENDUSER',
+    globalRoles: ['END_USER'],
+    allScopedRoles: [],
+    nameID: profile.nameID,
+    nameIDFormat: profile.nameIDFormat,
+    nameQualifier: profile.nameQualifier,
+    spNameQualifier: profile.spNameQualifier,
+    sessionIndex: profile.sessionIndex
+  }
+}

--- a/apigw/src/shared/auth/index.ts
+++ b/apigw/src/shared/auth/index.ts
@@ -42,7 +42,10 @@ function createJwtToken(user: SamlUser): string {
 
   switch (type) {
     case 'ENDUSER':
+    case 'CITIZEN_STRONG':
       return createJwt({ ...common, evaka_type: 'citizen' })
+    case 'CITIZEN_WEAK':
+      return createJwt({ ...common, evaka_type: 'citizen_weak' })
     case 'MOBILE':
       return createJwt({ ...common, evaka_type: 'mobile' })
     case 'SYSTEM':

--- a/apigw/src/shared/auth/jwt.ts
+++ b/apigw/src/shared/auth/jwt.ts
@@ -12,7 +12,7 @@ export function createJwt(payload: {
   kind: 'SuomiFI' | 'AD' | 'AdDummy'
   sub: string
   scope?: string
-  evaka_type: 'citizen' | 'employee' | 'mobile' | 'system'
+  evaka_type: 'citizen' | 'citizen_weak' | 'employee' | 'mobile' | 'system'
 }): string {
   return jwt.sign(payload, privateKey, {
     algorithm: 'RS256',

--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -180,7 +180,14 @@ const evakaCallbackUrl =
   process.env.EVAKA_SAML_CALLBACK_URL ??
   ifNodeEnv(
     ['local', 'test'],
-    `http://localhost:9093/api/internal/auth/evaka/login/callback`
+    `http://localhost:9099/api/internal/auth/evaka/login/callback`
+  )
+
+const evakaCustomerCallbackUrl =
+  process.env.EVAKA_CUSTOMER_SAML_CALLBACK_URL ??
+  ifNodeEnv(
+    ['local', 'test'],
+    `http://localhost:9099/api/application/auth/evaka-customer/login/callback`
   )
 
 export const evakaSamlConfig = evakaCallbackUrl
@@ -199,6 +206,36 @@ export const evakaSamlConfig = evakaCallbackUrl
       ),
       privateCert: required(
         process.env.EVAKA_SAML_PRIVATE_CERT ??
+          ifNodeEnv(['local', 'test'], 'config/test-cert/saml-private.pem')
+      )
+    }
+  : undefined
+
+export interface EvakaSamlConfig {
+  callbackUrl: string
+  entryPoint: string
+  publicCert: string
+  privateCert: string
+}
+
+export const evakaCustomerSamlConfig:
+  | EvakaSamlConfig
+  | undefined = evakaCustomerCallbackUrl
+  ? {
+      callbackUrl: required(evakaCustomerCallbackUrl),
+      entryPoint: required(
+        process.env.EVAKA_CUSTOMER_SAML_ENTRYPOINT ??
+          ifNodeEnv(
+            ['local', 'test'],
+            'http://localhost:8080/auth/realms/evaka-customer/protocol/saml'
+          )
+      ),
+      publicCert: required(
+        process.env.EVAKA_CUSTOMER_SAML_PUBLIC_CERT ??
+          ifNodeEnv(['local', 'test'], 'config/test-cert/keycloak-local.pem')
+      ),
+      privateCert: required(
+        process.env.EVAKA_CUSTOMER_SAML_PRIVATE_CERT ??
           ifNodeEnv(['local', 'test'], 'config/test-cert/saml-private.pem')
       )
     }

--- a/apigw/src/shared/routes/auth/suomi-fi.ts
+++ b/apigw/src/shared/routes/auth/suomi-fi.ts
@@ -5,12 +5,22 @@
 import createSamlRouter from './saml'
 import createSuomiFiStrategy from '../../auth/suomi-fi-saml'
 import { SessionType } from '../../session'
+import createEvakaCustomerSamlStrategy from '../../auth/customer-saml'
 
-export function createAuthEndpoints(sessionType: SessionType) {
+export function createSuomiFiAuthEndpoints(sessionType: SessionType) {
   return createSamlRouter({
     strategyName: 'suomifi',
     strategy: createSuomiFiStrategy(),
     sessionType,
     pathIdentifier: 'saml'
+  })
+}
+
+export function createKeycloakAuthEndpoints(sessionType: SessionType) {
+  return createSamlRouter({
+    strategyName: 'evaka-customer',
+    strategy: createEvakaCustomerSamlStrategy(),
+    sessionType,
+    pathIdentifier: 'evaka-customer'
   })
 }

--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -20,10 +20,17 @@ const machineUser: SamlUser = {
   userType: 'SYSTEM'
 }
 
-export type UserType = 'ENDUSER' | 'EMPLOYEE' | 'MOBILE' | 'SYSTEM'
+export type UserType =
+  | 'ENDUSER'
+  | 'EMPLOYEE'
+  | 'MOBILE'
+  | 'SYSTEM'
+  | 'CITIZEN_STRONG'
+  | 'CITIZEN_WEAK'
 
 export type UserRole =
   | 'ENDUSER'
+  | 'CITIZEN_WEAK'
   | 'ADMIN'
   | 'DIRECTOR'
   | 'FINANCE_ADMIN'

--- a/compose/docker-compose.e2e.yml
+++ b/compose/docker-compose.e2e.yml
@@ -38,6 +38,8 @@ services:
       REDIS_PORT: ${EVAKA_REDIS_PORT}
       REDIS_DISABLE_SECURITY: "true"
       JWT_PRIVATE_KEY: /home/evaka/test-cert/jwt_private_key.pem
+      EVAKA_CUSTOMER_SAML_PUBLIC_CERT: /home/evaka/test-cert/keycloak-local.pem
+      EVAKA_CUSTOMER_SAML_PRIVATE_CERT: /home/evaka/test-cert/saml-private.pem
       ENABLE_DEV_API: "true"
       PRETTY_LOGS: "false"
 
@@ -73,6 +75,7 @@ services:
     depends_on:
       - db
       - redis
+      - s3.mock.evaka
     environment:
       VOLTTI_ENV: local
       SPRING_PROFILES_ACTIVE: local

--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -67,7 +67,7 @@ export default function App() {
                     <Route
                       exact
                       path="/messages"
-                      component={requireAuth(MessagesPage)}
+                      component={requireAuth(MessagesPage, false)}
                     />
                   )}
                   <Route path="/" component={RedirectToMap} />

--- a/frontend/src/citizen-frontend/auth/requireAuth.tsx
+++ b/frontend/src/citizen-frontend/auth/requireAuth.tsx
@@ -7,19 +7,32 @@ import { AuthContext } from '../auth/state'
 import { RouteComponentProps } from 'react-router'
 import { Redirect } from 'react-router-dom'
 import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
+import { getWeakLoginUri, getLoginUri } from 'citizen-frontend/header/const'
+
+function refreshRedirect(uri: string) {
+  window.location.replace(uri)
+  return null
+}
 
 export default function requireAuth<T>(
-  WrappedComponent: React.ComponentType<RouteComponentProps<T>>
+  WrappedComponent: React.ComponentType<RouteComponentProps<T>>,
+  requireStrong = true
 ) {
   return function WithRequireAuth(props: RouteComponentProps<T>) {
     const { user, loading } = useContext(AuthContext)
 
     return user ? (
-      <WrappedComponent {...props} />
+      requireStrong && user.userType === 'CITIZEN_WEAK' ? (
+        refreshRedirect(getLoginUri(props.location.pathname))
+      ) : (
+        <WrappedComponent {...props} />
+      )
     ) : loading ? (
       <SpinnerSegment />
-    ) : (
+    ) : requireStrong ? (
       <Redirect to={'/'} />
+    ) : (
+      refreshRedirect(getWeakLoginUri(props.location.pathname))
     )
   }
 }

--- a/frontend/src/citizen-frontend/auth/state.tsx
+++ b/frontend/src/citizen-frontend/auth/state.tsx
@@ -19,6 +19,7 @@ export type Person = {
 
 export type User = Person & {
   children: Person[]
+  userType: string
 }
 
 type AuthState = {

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -13,7 +13,7 @@ import useCloseOnOutsideClick from 'lib-components/utils/useCloseOnOutsideClick'
 import { faCheck, faChevronDown, faChevronUp, faSignIn } from 'lib-icons'
 import { useUser } from '../auth'
 import { Lang, langs, useLang, useTranslation } from '../localization'
-import { getLoginUri } from '../header/const'
+import { getLoginUri, getLogoutUri } from '../header/const'
 import { featureFlags } from '../config'
 
 interface Props {
@@ -53,7 +53,7 @@ export default React.memo(function DesktopNav({ unreadMessagesCount }: Props) {
       </Nav>
       <LanguageMenu />
       {user ? (
-        <Logout href="/api/application/auth/saml/logout" data-qa="logout-btn">
+        <Logout href={getLogoutUri(user)} data-qa="logout-btn">
           {user ? (
             <UserName>
               <span>{user.firstName}</span> <span>{user.lastName}</span>

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -14,7 +14,7 @@ import { Gap, defaultMargins } from 'lib-components/white-space'
 import { tabletMin } from 'lib-components/breakpoints'
 import { useUser } from '../auth'
 import { langs, useLang, useTranslation } from '../localization'
-import { getLoginUri } from '../header/const'
+import { getLoginUri, getLogoutUri } from '../header/const'
 import { featureFlags } from '../config'
 import { CircledChar } from './DesktopNav'
 
@@ -54,10 +54,7 @@ export default React.memo(function MobileNav({
             }`}</UserName>
             <Gap size="s" />
             {user ? (
-              <a
-                href={'/api/application/auth/saml/logout'}
-                data-qa="logout-btn"
-              >
+              <a href={getLogoutUri(user)} data-qa="logout-btn">
                 <LogInLogOutButton>
                   <FontAwesomeIcon icon={faSignOut} size="lg" />
                   <Gap size="xs" horizontal />

--- a/frontend/src/citizen-frontend/header/const.ts
+++ b/frontend/src/citizen-frontend/header/const.ts
@@ -2,9 +2,23 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-export const getLoginUri = () =>
-  `/api/application/auth/saml/login?RelayState=${encodeURIComponent(
-    `${window.location.pathname}${window.location.search}${window.location.hash}`
+import { User } from 'citizen-frontend/auth/state'
+
+export const getWeakLoginUri = (path: string) =>
+  `/api/application/auth/evaka-customer/login?RelayState=${encodeURIComponent(
+    path
   )}`
+
+export const getLoginUri = (path?: string) =>
+  `/api/application/auth/saml/login?RelayState=${encodeURIComponent(
+    `${path ? path : window.location.pathname}${window.location.search}${
+      window.location.hash
+    }`
+  )}`
+
+export const getLogoutUri = (user: User) =>
+  `/api/application/auth/${
+    user?.userType === 'CITIZEN_WEAK' ? 'evaka-customer' : 'saml'
+  }/logout`
 
 export const headerHeight = '80px'

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/bulletin/BulletinControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/bulletin/BulletinControllerCitizen.kt
@@ -30,7 +30,7 @@ class BulletinControllerCitizen {
         @RequestParam pageSize: Int
     ): ResponseEntity<Paged<ReceivedBulletin>> {
         Audit.MessagingBulletinRead.log()
-        user.requireOneOfRoles(UserRole.END_USER)
+        user.requireOneOfRoles(UserRole.END_USER, UserRole.CITIZEN_WEAK)
 
         return db
             .read { it.getReceivedBulletinsByGuardian(user, page, pageSize) }
@@ -43,7 +43,7 @@ class BulletinControllerCitizen {
         user: AuthenticatedUser
     ): ResponseEntity<Int> {
         Audit.MessagingUnreadCountRead.log()
-        user.requireOneOfRoles(UserRole.END_USER)
+        user.requireOneOfRoles(UserRole.END_USER, UserRole.CITIZEN_WEAK)
 
         return db.read {
             it.getUnreadBulletinCountByGuardian(user)
@@ -57,7 +57,7 @@ class BulletinControllerCitizen {
         @PathVariable id: UUID
     ): ResponseEntity<Unit> {
         Audit.MessagingBulletinMarkRead.log(id)
-        user.requireOneOfRoles(UserRole.END_USER)
+        user.requireOneOfRoles(UserRole.END_USER, UserRole.CITIZEN_WEAK)
 
         db.transaction {
             it.markBulletinRead(user, id)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
@@ -30,6 +30,11 @@ sealed class AuthenticatedUser : RoleContainer {
         override val isEndUser = true
     }
 
+    data class WeakCitizen(override val id: UUID) : AuthenticatedUser() {
+        override val roles: Set<UserRole> = setOf(UserRole.CITIZEN_WEAK)
+        override val isEndUser = true
+    }
+
     data class Employee private constructor(override val id: UUID, val globalRoles: Set<UserRole>, val allScopedRoles: Set<UserRole>) : AuthenticatedUser() {
         constructor(id: UUID, roles: Set<UserRole>) : this(id, roles - UserRole.SCOPED_ROLES, roles.intersect(UserRole.SCOPED_ROLES))
         constructor(employeeUser: EmployeeUser) : this(employeeUser.id, employeeUser.globalRoles, employeeUser.allScopedRoles)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/JwtTokens.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/JwtTokens.kt
@@ -29,6 +29,7 @@ fun DecodedJWT.toAuthenticatedUser(): AuthenticatedUser? = this.subject?.let { s
         .toSet()
     return when (type) {
         "citizen" -> AuthenticatedUser.Citizen(id)
+        "citizen_weak" -> AuthenticatedUser.WeakCitizen(id)
         "employee" -> AuthenticatedUser.Employee(id, roles)
         "mobile" -> AuthenticatedUser.MobileDevice(id)
         "system" -> AuthenticatedUser.SystemInternalUser
@@ -54,6 +55,7 @@ fun AuthenticatedUser.applyToJwt(jwt: JWTCreator.Builder): JWTCreator.Builder = 
             is AuthenticatedUser.MobileDevice -> "mobile"
             is AuthenticatedUser.Employee -> "employee"
             is AuthenticatedUser.Citizen -> "citizen"
+            is AuthenticatedUser.WeakCitizen -> "citizen_weak"
         }
     )
     .withClaim("scope", roles.joinToString(" "))

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/UserRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/UserRole.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.domain.Forbidden
 
 enum class UserRole {
     END_USER,
+    CITIZEN_WEAK,
 
     ADMIN,
     DIRECTOR,

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -36,7 +36,7 @@ class VtjController(
         @PathVariable(value = "personId") personId: UUID
     ): CitizenUserDetails {
         Audit.VtjRequest.log(targetId = personId)
-        user.requireOneOfRoles(UserRole.END_USER)
+        user.requireOneOfRoles(UserRole.END_USER, UserRole.CITIZEN_WEAK)
         if (user.id != personId) {
             throw Forbidden("Query not allowed")
         }


### PR DESCRIPTION
#### Summary

Enable customer weak authentication.

##### Testing

=> new shell
```bash
cd evaka/compose
docker-compose up
```

=> new shell
```bash
pm2 start all
```

=> new shell
bring up the keycloak

=> <http://localhost:9099/messages> => weak login => create account or weak => come back to messages succesfully logged in
=> click decicions => fake strong login commences

