### PR TITLE
 EVAKA-4160 Add receivedAt and missing indexes to attachment

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -53,6 +53,7 @@ export default React.memo(function PreferredStartSubSection({
                 name: file.name,
                 contentType: file.type,
                 updated: new Date(),
+                receivedAt: new Date(),
                 type: 'URGENCY'
               }
             ]

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -57,6 +57,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
                 name: file.name,
                 contentType: file.type,
                 updated: new Date(),
+                receivedAt: new Date(),
                 type: 'EXTENDED_CARE'
               }
             ]

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -56,6 +56,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
                 name: file.name,
                 contentType: file.type,
                 updated: new Date(),
+                receivedAt: new Date(),
                 type: 'EXTENDED_CARE'
               }
             ]

--- a/frontend/src/employee-frontend/api/applications.ts
+++ b/frontend/src/employee-frontend/api/applications.ts
@@ -49,7 +49,8 @@ export async function getApplication(
       })),
       attachments: data.attachments.map((attachment) => ({
         ...attachment,
-        updated: new Date(attachment.updated)
+        updated: new Date(attachment.updated),
+        receivedAt: new Date(attachment.receivedAt)
       }))
     }))
     .then((v) => Success.of(v))

--- a/frontend/src/lib-common/api-types/application/ApplicationDetails.ts
+++ b/frontend/src/lib-common/api-types/application/ApplicationDetails.ts
@@ -96,9 +96,10 @@ export const deserializeApplicationDetails = (
   modifiedDate: json.modifiedDate ? new Date(json.modifiedDate) : null,
   sentDate: LocalDate.parseNullableIso(json.sentDate),
   dueDate: LocalDate.parseNullableIso(json.dueDate),
-  attachments: json.attachments.map(({ updated, ...rest }) => ({
+  attachments: json.attachments.map(({ updated, receivedAt, ...rest }) => ({
     ...rest,
-    updated: new Date(updated)
+    updated: new Date(updated),
+    receivedAt: new Date(receivedAt)
   }))
 })
 
@@ -217,5 +218,6 @@ export interface Attachment {
 
 export interface ApplicationAttachment extends Attachment {
   updated: Date
+  receivedAt: Date
   type: AttachmentType
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -100,6 +100,7 @@ data class Attachment(
     val name: String,
     val contentType: String,
     val updated: OffsetDateTime,
+    val receivedAt: OffsetDateTime,
     val type: AttachmentType
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -547,7 +547,7 @@ fun fetchApplicationDetails(h: Handle, applicationId: UUID): ApplicationDetails?
         LEFT JOIN person c ON c.id = a.child_id
         LEFT JOIN person g1 ON g1.id = a.guardian_id
         LEFT JOIN (
-            SELECT application_id, jsonb_agg(jsonb_build_object('id', id, 'name', name, 'contentType', content_type, 'updated', updated, 'type', type)) json
+            SELECT application_id, jsonb_agg(jsonb_build_object('id', id, 'name', name, 'contentType', content_type, 'updated', updated, 'receivedAt', received_at, 'type', type)) json
             FROM attachment GROUP BY application_id
         ) att ON a.id = att.application_id
         WHERE a.id = :id
@@ -897,7 +897,7 @@ RETURNING id
     .toList()
 
 fun Database.Read.getApplicationAttachments(applicationId: UUID): List<Attachment> =
-    createQuery("SELECT id, name, content_type, updated, type FROM attachment WHERE application_id = :applicationId")
+    createQuery("SELECT id, name, content_type, updated, received_at, type FROM attachment WHERE application_id = :applicationId")
         .bind("applicationId", applicationId)
         .mapTo<Attachment>()
         .toList()
@@ -905,7 +905,7 @@ fun Database.Read.getApplicationAttachments(applicationId: UUID): List<Attachmen
 fun Database.Read.getApplicationAttachmentsForUnitSupervisor(applicationId: UUID): List<Attachment> =
     createQuery(
         """
-SELECT attachment.id, attachment.name, attachment.content_type, attachment.updated, attachment.type
+SELECT attachment.id, attachment.name, attachment.content_type, attachment.updated, attachment.received_at, attachment.type
 FROM attachment
 JOIN application ON application.id = attachment.application_id
 JOIN placement_plan ON placement_plan.application_id = application.id

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.application.AttachmentType
 import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.s3.DocumentWrapper
-import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -38,7 +37,6 @@ const val attachmentsPath = "/"
 @RestController
 @RequestMapping("/attachments")
 class AttachmentsController(
-    private val acl: AccessControlList,
     private val documentClient: DocumentService,
     env: Environment
 ) {
@@ -54,7 +52,7 @@ class AttachmentsController(
         @RequestPart("file") file: MultipartFile
     ): ResponseEntity<UUID> {
         Audit.AttachmentsUpload.log(targetId = applicationId)
-        user.requireOneOfRoles(UserRole.ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
         val id = handleFileUpload(db, user, applicationId, file, type)
         return ResponseEntity.ok(id)

--- a/service/src/main/resources/db/migration/V61__add_received_date_to_attachment.sql
+++ b/service/src/main/resources/db/migration/V61__add_received_date_to_attachment.sql
@@ -1,0 +1,7 @@
+ALTER TABLE attachment
+    ADD COLUMN received_at timestamp with time zone DEFAULT now();
+
+UPDATE attachment SET received_at = updated;
+
+ALTER TABLE attachment
+    ALTER COLUMN received_at SET NOT NULL;

--- a/service/src/main/resources/db/migration/V62__add_indexes_to_attachment.sql
+++ b/service/src/main/resources/db/migration/V62__add_indexes_to_attachment.sql
@@ -1,0 +1,2 @@
+CREATE INDEX attachment_application_id_idx ON attachment(application_id);
+CREATE INDEX attachment_uploaded_by_person_idx ON attachment(uploaded_by_person);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -58,3 +58,5 @@ V57__add_missing_enums.sql
 V58__add_pin_to_employee.sql
 V59__child_service_time.sql
 V60__application_person_foreign_keys.sql
+V61__add_received_date_to_attachment.sql
+V62__add_indexes_to_attachment.sql


### PR DESCRIPTION
#### Summary

- Add `receivedAt` to Attachment, use `updated` as the initial value
  - `receivedAt` can later be updated by service workers to the actual date that may differ from the upload date
- Also add missing indexes to columns that are used in queries