### PR TITLE
EVAKA-4171 bulletin sender dropdown

### DIFF
--- a/frontend/src/e2e-test/pages/employee/messaging/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messaging/messages-page.ts
@@ -11,11 +11,11 @@ export default class MessagesPage {
 
   async createNewBulletin(sender: string, title: string, content: string) {
     await t.click(Selector('[data-qa="new-bulletin-btn"]'))
-    await t.typeText(Selector('[data-qa="input-sender"]'), sender, {
-      replace: true
-    })
     await t.typeText(Selector('[data-qa="input-title"]'), title)
     await t.typeText(Selector('[data-qa="input-content"]'), content)
+    await t.click(Selector('[data-qa="select-sender"]'))
+    await t.typeText(Selector('[data-qa="select-sender"]'), sender)
+    await t.pressKey('enter')
     await t.click(Selector('[data-qa="send-bulletin-btn"]'))
   }
 }

--- a/frontend/src/e2e-test/specs/7_messaging/sending-and-receiving-bulletins.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/sending-and-receiving-bulletins.spec.ts
@@ -103,7 +103,11 @@ test('Supervisor sends bulletin and guardian reads it', async (t) => {
 
   await t.click(messagesPage.unitsListUnit(daycareId))
 
-  await messagesPage.createNewBulletin('Test sender', 'Hello', 'This is a test')
+  await messagesPage.createNewBulletin(
+    'Alkuräjähdyksen päiväkoti',
+    'Hello',
+    'This is a test'
+  )
 
   await t.useRole(enduserRole)
 
@@ -116,8 +120,8 @@ test('Supervisor sends bulletin and guardian reads it', async (t) => {
 
   await t.expect(citizenMessages.messageReaderTitle.textContent).eql('Hello')
   await t
-    .expect(citizenMessages.messageReaderSender.textContent)
-    .eql('Test sender')
+    .expect(await citizenMessages.messageReaderSender.textContent)
+    .eql('Alkuräjähdyksen päiväkoti')
   await t
     .expect(citizenMessages.messageReaderContent.textContent)
     .eql('This is a test')
@@ -158,7 +162,11 @@ test('Admin sends bulletin and blocked guardian does not get it', async (t) => {
 
   await t.click(messagesPage.unitsListUnit(daycareId))
 
-  await messagesPage.createNewBulletin('Test sender', 'Hello', 'This is a test')
+  await messagesPage.createNewBulletin(
+    'Alkuräjähdyksen päiväkoti',
+    'Hello',
+    'This is a test'
+  )
 
   await t.useRole(enduserRole)
   await t.expect(citizenHome.nav.messages.textContent).notContains('1')

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from '../../state/i18n'
 import { Bulletin } from './types'
 import { SelectorChange } from 'employee-frontend/components/messages/receiver-selection-utils'
 import MultiSelect from 'lib-components/atoms/form/MultiSelect'
+import Select from '../common/Select'
 
 type Option = {
   label: string
@@ -25,6 +26,7 @@ type Option = {
 
 type Props = {
   bulletin: Bulletin
+  senderOptions: string[]
   onChange: (change: Partial<Bulletin>) => void
   onDeleteDraft: () => void
   onClose: () => void
@@ -36,6 +38,7 @@ type Props = {
 
 export default React.memo(function MessageEditor({
   bulletin,
+  senderOptions,
   onChange,
   onDeleteDraft,
   onClose,
@@ -45,6 +48,11 @@ export default React.memo(function MessageEditor({
   updateSelection
 }: Props) {
   const { i18n } = useTranslation()
+
+  const mappedSenderOptions = senderOptions.map((name) => ({
+    value: name,
+    label: name
+  }))
 
   return (
     <Container>
@@ -94,10 +102,19 @@ export default React.memo(function MessageEditor({
         <Gap size={'xs'} />
         <div>{i18n.messages.messageEditor.sender}</div>
         <Gap size={'xs'} />
-        <InputField
-          value={bulletin.sender}
-          onChange={(sender) => onChange({ sender })}
-          data-qa={'input-sender'}
+        <Select
+          options={mappedSenderOptions}
+          onChange={(selected) =>
+            selected &&
+            'value' in selected &&
+            onChange({ sender: selected.value })
+          }
+          value={
+            mappedSenderOptions.find(
+              ({ value }) => value === bulletin.sender
+            ) || null
+          }
+          data-qa="select-sender"
         />
         <Gap size={'xs'} />
         <div>{i18n.messages.messageEditor.title}</div>

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -17,6 +17,7 @@ import {
   getDraftBulletins,
   getGroups,
   getReceivers,
+  getSenderOptions,
   getSentBulletins,
   getUnits,
   initNewBulletin,
@@ -67,8 +68,16 @@ export default React.memo(function MessagesPage() {
   >(Loading.of())
 
   const loadReceivers = useRestApi(getReceivers, setReceiversResult)
+
+  const [senderOptions, setSenderOptions] = useState<string[]>([])
+  const loadSenderOptions = useRestApi(
+    getSenderOptions,
+    (result) => result.isSuccess && setSenderOptions(result.value)
+  )
+
   useEffect(() => {
     selectedUnit && loadReceivers(selectedUnit.id)
+    selectedUnit && loadSenderOptions(selectedUnit.id)
   }, [selectedUnit])
 
   const [receiverSelection, setReceiverSelection] = useState<SelectorNode>()
@@ -281,6 +290,7 @@ export default React.memo(function MessagesPage() {
                   selectedReceivers={getReceiverSelection(receiverSelection)}
                   receiverOptions={getReceiverOptions(receiverSelection)}
                   updateSelection={updateSelection}
+                  senderOptions={senderOptions}
                 />
               )}
             </div>

--- a/frontend/src/employee-frontend/components/messages/api.ts
+++ b/frontend/src/employee-frontend/components/messages/api.ts
@@ -116,3 +116,14 @@ export async function getReceivers(
     )
     .catch((e) => Failure.fromError(e))
 }
+
+export async function getSenderOptions(
+  unitId: UUID
+): Promise<Result<string[]>> {
+  return client
+    .get<JsonOf<string[]>>('/bulletins/sender-options', {
+      params: { unitId }
+    })
+    .then((res) => Success.of(res.data))
+    .catch((e) => Failure.fromError(e))
+}

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
@@ -348,6 +348,36 @@ class BulletinIntegrationTest : FullApplicationTest() {
         assertEquals(2, childWithTwoReceiverPersons.receiverPersons.size)
     }
 
+    @Test
+    fun `Sender options endpoint works for unit 1`() {
+        val (_, res, result) = http.get("/bulletins/sender-options?unitId=$unitId")
+            .asUser(supervisor)
+            .responseObject<List<String>>()
+
+        assertEquals(200, res.statusCode)
+
+        val senderOptions = result.get()
+
+        assertEquals(3, senderOptions.size)
+
+        assertEquals(setOf("Elina Esimies", "Testaajat", "Test Daycare"), senderOptions.toSet())
+    }
+
+    @Test
+    fun `Sender options endpoint works for unit 2`() {
+        val (_, res, result) = http.get("/bulletins/sender-options?unitId=$secondUnitId")
+            .asUser(supervisor)
+            .responseObject<List<String>>()
+
+        assertEquals(200, res.statusCode)
+
+        val senderOptions = result.get()
+
+        assertEquals(3, senderOptions.size)
+
+        assertEquals(setOf("Elina Esimies", "Koekaniinit", "Test Daycare 2"), senderOptions.toSet())
+    }
+
     private fun initBulletin(user: AuthenticatedUser, receivers: List<BulletinReceiverTriplet>): UUID {
         val (_, res, result) = http.post("/bulletins")
             .asUser(user)

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -130,6 +130,7 @@ enum class Audit(
     MessagingBulletinReceiversRead("messaging.bulletin.receivers.read"),
     MessagingBulletinMarkRead("messaging.bulletin.mark-read"),
     MessagingUnreadCountRead("messaging.bulletin.unread-count.read"),
+    MessagingSenderOptionsRead("messaging.bulletin.sender-options.read"),
     MissingHeadOfFamilyReportRead("evaka.missing-head-of-family-report.read"),
     MissingServiceNeedReportRead("evaka.missing-service-need-report.read"),
     MobileDevicesList("evaka.mobile-devices.list"),


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Let user choose sender from a dropdown instead of using free text input field. Under the hood, this `sender` is just a string and not a reference.
