### PR TITLE
Fix missing attachments positioning and Finnish assistance need instructions

### DIFF
--- a/frontend/src/citizen-frontend/localization/fi.tsx
+++ b/frontend/src/citizen-frontend/localization/fi.tsx
@@ -590,7 +590,7 @@ export default {
         assistanceNeeded: 'Lapsella on tuen tarve',
         assistanceNeedPlaceholder: 'Kerro lapsen tuen tarpeesta.',
         assistanceNeedInstructions:
-          'Tehostetun ja tuen tarpeella tarkoitetaan sellaisten tukitoimien tarvetta, jotka on osoitettu asiantuntijalausunnoin. Tuen tarpeissa Espoon varhaiskasvatuksesta otetaan erikseen yhteyttä hakemuksen jättämisen jälkeen. Tukitoimet toteutuvat lapsen arjessa osana varhaiskasvatuksen muuta toimintaa. Osa varhaiskasvatuspaikoista on varattu tukea tarvitseville lapsille.',
+          'Lapsen tuen tarpeella tarkoitetaan sellaisten tukitoimien tarvetta, jotka on osoitettu asiantuntijalausunnoin. Tuen tarpeissa Espoon varhaiskasvatuksesta otetaan erikseen yhteyttä hakemuksen jättämisen jälkeen. Tukitoimet toteutuvat lapsen arjessa osana varhaiskasvatuksen muuta toimintaa. Osa varhaiskasvatuspaikoista on varattu tukea tarvitseville lapsille.',
         preparatory:
           'Lapsi tarvitsee tukea suomen kielen oppimisessa. Haen myös perusopetukseen valmistavaan opetukseen. Ei koske ruotsinkielistä esiopetusta.',
         preparatoryInfo:

--- a/frontend/src/employee-frontend/components/application-page/ApplicationReadView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationReadView.tsx
@@ -157,26 +157,26 @@ function ApplicationReadView({
               ) : (
                 <AttachmentContainer>
                   {urgencyAttachments.length ? (
-                    <span>
-                      {i18n.application.serviceNeed.isUrgentWithAttachments}
-                    </span>
-                  ) : (
                     <>
                       <span>
-                        {i18n.application.serviceNeed.isUrgent}{' '}
-                        <Dimmed>
-                          {i18n.application.serviceNeed.missingAttachment}
-                        </Dimmed>
+                        {i18n.application.serviceNeed.isUrgentWithAttachments}
                       </span>
+                      {urgencyAttachments.map((attachment) => (
+                        <Attachment
+                          key={attachment.id}
+                          attachment={attachment}
+                          dataQa={`urgent-attachment-${attachment.name}`}
+                        />
+                      ))}
+                    </>
+                  ) : (
+                    <>
+                      <span>{i18n.application.serviceNeed.isUrgent}</span>
+                      <Dimmed>
+                        {i18n.application.serviceNeed.missingAttachment}
+                      </Dimmed>
                     </>
                   )}
-                  {urgencyAttachments.map((attachment) => (
-                    <Attachment
-                      key={attachment.id}
-                      attachment={attachment}
-                      dataQa={`urgent-attachment-${attachment.name}`}
-                    />
-                  ))}
                 </AttachmentContainer>
               )}
 
@@ -216,26 +216,28 @@ function ApplicationReadView({
               ) : (
                 <AttachmentContainer>
                   {extendedCareAttachments.length ? (
-                    <span>
-                      {i18n.application.serviceNeed.shiftCareWithAttachments}
-                    </span>
+                    <>
+                      <span>
+                        {i18n.application.serviceNeed.shiftCareWithAttachments}
+                      </span>
+                      {extendedCareAttachments.map((attachment) => (
+                        <Attachment
+                          key={attachment.id}
+                          attachment={attachment}
+                          dataQa={`extended-care-attachment-${attachment.name}`}
+                        />
+                      ))}
+                    </>
                   ) : (
                     <>
                       <span>
-                        {i18n.application.serviceNeed.shiftCareNeeded}{' '}
-                        <Dimmed>
-                          {i18n.application.serviceNeed.missingAttachment}
-                        </Dimmed>
+                        {i18n.application.serviceNeed.shiftCareNeeded}
                       </span>
+                      <Dimmed>
+                        {i18n.application.serviceNeed.missingAttachment}
+                      </Dimmed>
                     </>
                   )}
-                  {extendedCareAttachments.map((attachment) => (
-                    <Attachment
-                      key={attachment.id}
-                      attachment={attachment}
-                      dataQa={`extended-care-attachment-${attachment.name}`}
-                    />
-                  ))}
                 </AttachmentContainer>
               )}
             </>


### PR DESCRIPTION
#### Summary

- Fix Finnish `assistanceNeedInstructions`.
- The dimmed _attachment missing_ text was supposed to be on its own line.

Without attachments:
![kuva](https://user-images.githubusercontent.com/1176169/114574755-30013880-9c82-11eb-9198-4ba097dadec4.png)

With attachments:
![kuva](https://user-images.githubusercontent.com/1176169/114574775-342d5600-9c82-11eb-96d4-abfc11d2e490.png)
