### PR TITLE
EVAKA-4160 Show receivedAt in attachment list

### DIFF
--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -102,6 +102,12 @@ export default class ApplicationReadView {
       .ok()
   }
 
+  async assertReceivedAtTextExists(fileName: string) {
+    await t
+      .expect(Selector(`[data-qa="attachment-${fileName}-received-at"]`).exists)
+      .ok()
+  }
+
   async assertUrgentAttachmentDoesNotExists(fileName: string) {
     await t
       .expect(Selector(`[data-qa="urgent-attachment-${fileName}"]`).exists)

--- a/frontend/src/e2e-test/specs/2_employee-2/application-attachments.spec.ts
+++ b/frontend/src/e2e-test/specs/2_employee-2/application-attachments.spec.ts
@@ -67,4 +67,8 @@ test('Employee can add and remove attachments', async (t) => {
 
   await applicationEditView.deleteShiftCareFile(testFileName)
   await applicationEditView.assertUploadedShiftCareFile(testFileName, false)
+  await applicationEditView.saveApplication()
+
+  await applicationReadView.openApplicationByLink(applicationFixtureId)
+  await applicationReadView.assertReceivedAtTextExists(testFileName)
 })

--- a/frontend/src/employee-frontend/assets/i18n/fi.ts
+++ b/frontend/src/employee-frontend/assets/i18n/fi.ts
@@ -422,7 +422,8 @@ export const fi = {
       none: 'Hakemukseen ei liity liitteitä',
       name: 'Tiedostonimi',
       updated: 'Muutettu',
-      contentType: 'Tyyppi'
+      contentType: 'Tyyppi',
+      receivedAt: 'Liite lähetetty'
     },
     state: {
       title: 'Hakemuksen tila',

--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -135,9 +135,9 @@ export default React.memo(function ApplicationEditView({
                   contentType: file.type,
                   id: res.value,
                   name: file.name,
-                  receivedAt: new Date(),
-                  type: type,
-                  updated: new Date()
+                  type,
+                  updated: new Date(),
+                  receivedAt: new Date()
                 }
               ]
             }

--- a/frontend/src/employee-frontend/components/common/Attachment.tsx
+++ b/frontend/src/employee-frontend/components/common/Attachment.tsx
@@ -18,10 +18,18 @@ import FileDownloadButton from 'lib-components/molecules/FileDownloadButton'
 import { getAttachmentBlob } from '../../api/applications'
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
+import { defaultMargins } from 'lib-components/white-space'
+import { Dimmed } from 'lib-components/typography'
+import LocalDate from 'lib-common/local-date'
 
 const AttachmentContainer = styled.div`
   display: flex;
   justify-content: flex-start;
+`
+
+const ReceivedAtText = styled(Dimmed)`
+  font-style: italic;
+  margin-left: ${defaultMargins.s};
 `
 
 interface Props {
@@ -68,6 +76,10 @@ function Attachment({ attachment, dataQa }: Props) {
           }
           dataQa={'attachment-download'}
         />
+        <ReceivedAtText>
+          {i18n.application.attachments.receivedAt}{' '}
+          {LocalDate.fromSystemTzDate(attachment.receivedAt).format()}
+        </ReceivedAtText>
       </FixedSpaceRow>
     </AttachmentContainer>
   )

--- a/frontend/src/employee-frontend/components/common/Attachment.tsx
+++ b/frontend/src/employee-frontend/components/common/Attachment.tsx
@@ -76,7 +76,7 @@ function Attachment({ attachment, dataQa }: Props) {
           }
           dataQa={'attachment-download'}
         />
-        <ReceivedAtText>
+        <ReceivedAtText data-qa={`attachment-${attachment.name}-received-at`}>
           {i18n.application.attachments.receivedAt}{' '}
           {LocalDate.fromSystemTzDate(attachment.receivedAt).format()}
         </ReceivedAtText>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Show `receivedAt` in attachment list by mapping received timestamp string to LocalDate while deserializing (wonder if we should have `LocalDateTime` too). 
