### PR TITLE
EVAKA-4160 urgent due date based on attachments

### DIFF
--- a/frontend/src/e2e-test/pages/citizen/citizen-application-editor.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-application-editor.ts
@@ -194,7 +194,7 @@ export default class CitizenApplicationEditor {
 
   async assertUrgentFileHasBeenUploaded(filename: string) {
     await t
-      .expect(this.urgentAttachmentDownloadButton(filename).visible)
+      .expect(this.urgentAttachmentDownloadButton(filename).exists)
       .ok({ timeout: 2000 }) // Uploading test files shouldn't take very long
   }
 

--- a/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
@@ -159,12 +159,12 @@ export default class ApplicationEditView {
     fileName: string,
     visible = true
   ) {
-    await t
-      .expect(
-        selector.find('[data-qa="file-download-button"]').withText(fileName)
-          .visible
-      )
-      .eql(visible)
+    const baseSelector = selector
+      .find('[data-qa="file-download-button"]')
+      .withText(fileName)
+    visible
+      ? await t.expect(baseSelector.visible).ok()
+      : await t.expect(baseSelector.with({ timeout: 50 }).exists).notOk()
   }
 
   async assertUploadedUrgentFile(fileName: string) {

--- a/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
@@ -161,10 +161,8 @@ export default class ApplicationEditView {
   ) {
     await t
       .expect(
-        selector
-          .find('[data-qa="file-download-button"]')
-          .with({ timeout: 50 })
-          .withText(fileName).visible
+        selector.find('[data-qa="file-download-button"]').withText(fileName)
+          .visible
       )
       .eql(visible)
   }

--- a/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
@@ -163,7 +163,7 @@ export default class ApplicationEditView {
       .find('[data-qa="file-download-button"]')
       .withText(fileName)
     visible
-      ? await t.expect(baseSelector.visible).ok()
+      ? await t.expect(baseSelector.exists).ok()
       : await t.expect(baseSelector.with({ timeout: 50 }).exists).notOk()
   }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -41,6 +41,7 @@ import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.message.MockEvakaMessageClient
+import fi.espoo.evaka.shared.utils.zoneId
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_4
 import fi.espoo.evaka.testAdult_5
@@ -56,11 +57,14 @@ import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.Instant
 import java.time.LocalDate
+import java.time.Period
 import java.util.UUID
 
 class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
@@ -145,12 +149,24 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         }
     }
 
+    private fun assertDueDate(applicationId: UUID, expected: Instant?) {
+        db.read {
+            val application = fetchApplicationDetails(it.handle, applicationId)!!
+            if (expected != null) {
+                assertEquals(LocalDate.ofInstant(expected, zoneId), application.dueDate)
+            } else {
+                assertNull(application.dueDate)
+            }
+        }
+    }
+
     @Test
-    fun `sendApplication - daycare has due date after 2 weeks if urgent`() {
+    fun `sendApplication - daycare has due date after 2 weeks if urgent and has attachments`() {
         db.transaction { tx ->
             // given
             insertApplication(
                 tx.handle,
+                guardian = testAdult_1,
                 appliedType = PlacementType.DAYCARE,
                 urgent = true,
                 applicationId = applicationId,
@@ -161,11 +177,58 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // when
             service.sendApplication(tx, serviceWorker, applicationId)
         }
-        db.read {
-            // then
-            val application = fetchApplicationDetails(it.handle, applicationId)!!
-            assertEquals(LocalDate.now().plusWeeks(2), application.dueDate)
+        // then
+        assertDueDate(applicationId, null) // missing attachment
+
+        // when
+        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id)))
+        db.transaction { tx ->
+            tx.createUpdate("UPDATE attachment set received_at = :receivedAt")
+                .bind("receivedAt", Instant.now().minus(Period.ofWeeks(1)))
+                .execute()
         }
+        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id)))
+        // then
+        assertDueDate(applicationId, Instant.now().plus(Period.ofWeeks(2))) // end date >= earliest attachment.receivedAt
+    }
+
+    @Test
+    fun `sendApplication - urgent daycare application gets due date from first received attachment`() {
+        db.transaction { tx ->
+            // given
+            insertApplication(
+                tx.handle,
+                guardian = testAdult_1,
+                appliedType = PlacementType.DAYCARE,
+                urgent = true,
+                applicationId = applicationId,
+                preferredStartDate = LocalDate.of(2020, 8, 1)
+            )
+        }
+        // when
+        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id), AttachmentType.EXTENDED_CARE))
+        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id), AttachmentType.URGENCY))
+
+        // then
+        assertDueDate(applicationId, null) // application not sent
+
+        // when
+        db.transaction { tx ->
+            tx.createUpdate("UPDATE attachment set received_at = :receivedAt WHERE type = :type")
+                .bind("type", AttachmentType.EXTENDED_CARE)
+                .bind("receivedAt", Instant.now().plus(Period.ofWeeks(1)))
+                .execute()
+            tx.createUpdate("UPDATE attachment set received_at = :receivedAt WHERE type = :type")
+                .bind("type", AttachmentType.URGENCY)
+                .bind("receivedAt", Instant.now().plus(Period.ofDays(3)))
+                .execute()
+        }
+        db.transaction { tx ->
+            // when
+            service.sendApplication(tx, serviceWorker, applicationId)
+        }
+        // then
+        assertDueDate(applicationId, Instant.now().plus(Period.ofDays(14 + 3))) // attachments received after application sent
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -183,7 +183,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         // when
         assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id)))
         db.transaction { tx ->
-            tx.createUpdate("UPDATE attachment set received_at = :receivedAt")
+            tx.createUpdate("UPDATE attachment SET received_at = :receivedAt WHERE application_id = :applicationId")
+                .bind("applicationId", applicationId)
                 .bind("receivedAt", Instant.now().minus(Period.ofWeeks(1)))
                 .execute()
         }
@@ -214,12 +215,14 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
         // when
         db.transaction { tx ->
-            tx.createUpdate("UPDATE attachment set received_at = :receivedAt WHERE type = :type")
+            tx.createUpdate("UPDATE attachment SET received_at = :receivedAt WHERE type = :type AND application_id = :applicationId")
                 .bind("type", AttachmentType.EXTENDED_CARE)
+                .bind("applicationId", applicationId)
                 .bind("receivedAt", Instant.now().plus(Period.ofWeeks(1)))
                 .execute()
-            tx.createUpdate("UPDATE attachment set received_at = :receivedAt WHERE type = :type")
+            tx.createUpdate("UPDATE attachment SET received_at = :receivedAt WHERE type = :type AND application_id = :applicationId")
                 .bind("type", AttachmentType.URGENCY)
+                .bind("applicationId", applicationId)
                 .bind("receivedAt", Instant.now().plus(Period.ofDays(3)))
                 .execute()
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -101,8 +101,8 @@ data class Attachment(
     val id: UUID,
     val name: String,
     val contentType: String,
-    val updated: Instant,
-    val receivedAt: Instant,
+    val updated: OffsetDateTime,
+    val receivedAt: OffsetDateTime,
     val type: AttachmentType
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -101,8 +101,8 @@ data class Attachment(
     val id: UUID,
     val name: String,
     val contentType: String,
-    val updated: OffsetDateTime,
-    val receivedAt: OffsetDateTime,
+    val updated: Instant,
+    val receivedAt: Instant,
     val type: AttachmentType
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -561,7 +561,7 @@ class ApplicationStateService(
                 // due date should not be set at all if attachments are missing
                 if (attachments.isEmpty()) return null
                 // due date is two weeks from application.sentDate or the first attachment, whichever is later
-                val minAttachmentDate = attachments.minByOrNull { it.receivedAt }?.let { LocalDate.ofInstant(it.receivedAt, zoneId) }
+                val minAttachmentDate = attachments.minByOrNull { it.receivedAt }?.let { LocalDate.from(it.receivedAt) }
                 listOfNotNull(minAttachmentDate, sentDate).maxOrNull()?.plusWeeks(2)
             } else {
                 sentDate.plusMonths(4)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -16,7 +16,6 @@ import fi.espoo.evaka.application.ApplicationStatus.WAITING_DECISION
 import fi.espoo.evaka.application.ApplicationStatus.WAITING_MAILING
 import fi.espoo.evaka.application.ApplicationStatus.WAITING_PLACEMENT
 import fi.espoo.evaka.application.ApplicationStatus.WAITING_UNIT_CONFIRMATION
-import fi.espoo.evaka.application.utils.toHelsinkiLocalDateTime
 import fi.espoo.evaka.daycare.controllers.AdditionalInformation
 import fi.espoo.evaka.daycare.controllers.Child
 import fi.espoo.evaka.daycare.domain.ProviderType
@@ -562,7 +561,7 @@ class ApplicationStateService(
                 // due date should not be set at all if attachments are missing
                 if (attachments.isEmpty()) return null
                 // due date is two weeks from application.sentDate or the first attachment, whichever is later
-                val minAttachmentDate = attachments.map { it.receivedAt }.minOrNull()?.toHelsinkiLocalDateTime()?.toLocalDate()
+                val minAttachmentDate = attachments.map { it.receivedAt }.minOrNull()?.let { LocalDate.ofInstant(it, zoneId) }
                 listOfNotNull(minAttachmentDate, sentDate).maxOrNull()?.plusWeeks(2)
             } else {
                 sentDate.plusMonths(4)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -561,7 +561,7 @@ class ApplicationStateService(
                 // due date should not be set at all if attachments are missing
                 if (attachments.isEmpty()) return null
                 // due date is two weeks from application.sentDate or the first attachment, whichever is later
-                val minAttachmentDate = attachments.map { it.receivedAt }.minOrNull()?.let { LocalDate.ofInstant(it, zoneId) }
+                val minAttachmentDate = attachments.minByOrNull { it.receivedAt }?.let { LocalDate.ofInstant(it.receivedAt, zoneId) }
                 listOfNotNull(minAttachmentDate, sentDate).maxOrNull()?.plusWeeks(2)
             } else {
                 sentDate.plusMonths(4)

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.attachment
 
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.application.ApplicationStateService
 import fi.espoo.evaka.application.AttachmentType
 import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.s3.DocumentWrapper
@@ -38,6 +39,7 @@ const val attachmentsPath = "/"
 @RequestMapping("/attachments")
 class AttachmentsController(
     private val documentClient: DocumentService,
+    private val stateService: ApplicationStateService,
     env: Environment
 ) {
     private val filesBucket = env.getProperty("fi.espoo.voltti.document.bucket.attachments")!!
@@ -111,6 +113,8 @@ class AttachmentsController(
                 contentType
             )
         }
+        db.transaction { stateService.reCalculateDueDate(it, applicationId) }
+
         return id
     }
 


### PR DESCRIPTION
#### Summary

Set application due date based on attachments for urgent applications

If the application is urgent:
- the due date should not be set at all if attachments are missing
- the due date is the day application is sent or the first attachment received date, whichever is later