### PR TITLE
WCAG contrast compliance tweaks

### DIFF
--- a/frontend/src/employee-frontend/components/common/CheckedRowsInfo.tsx
+++ b/frontend/src/employee-frontend/components/common/CheckedRowsInfo.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import colors from 'lib-components/colors'
 
 export const CheckedRowsInfo = styled.div`
-  color: ${colors.greyscale.medium};
+  color: ${colors.greyscale.dark};
   font-style: italic;
   font-weight: bold;
   margin: 0 20px;

--- a/frontend/src/lib-components/atoms/buttons/AddButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AddButton.tsx
@@ -26,10 +26,10 @@ const StyledButton = styled.button`
   cursor: pointer;
 
   &.disabled {
-    color: ${colors.greyscale.medium};
+    color: ${colors.greyscale.dark};
 
-    .icon-wrapper {
-      background: ${colors.greyscale.medium};
+    .icon-wrapper-inner {
+      background: ${colors.greyscale.dark};
     }
   }
 

--- a/frontend/src/lib-components/atoms/buttons/Button.tsx
+++ b/frontend/src/lib-components/atoms/buttons/Button.tsx
@@ -45,8 +45,8 @@ export const StyledButton = styled.button`
   }
 
   &.disabled {
-    color: ${greyscale.medium};
-    border-color: ${greyscale.medium};
+    color: ${greyscale.dark};
+    border-color: ${greyscale.dark};
   }
 
   &.primary {
@@ -62,6 +62,7 @@ export const StyledButton = styled.button`
     }
 
     &.disabled {
+      border-color: ${greyscale.medium};
       background: ${greyscale.medium};
     }
   }

--- a/frontend/src/lib-components/atoms/buttons/InlineButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/InlineButton.tsx
@@ -39,7 +39,7 @@ const StyledButton = styled.button<{ color?: string }>`
   }
 
   &.disabled {
-    color: ${greyscale.medium};
+    color: ${greyscale.dark};
     cursor: not-allowed;
   }
 

--- a/frontend/src/lib-components/typography.ts
+++ b/frontend/src/lib-components/typography.ts
@@ -108,5 +108,5 @@ export const P = styled.p<ParagraphProps>`
   }
 `
 export const Dimmed = styled.span`
-  color: ${greyscale.medium};
+  color: ${greyscale.dark};
 `


### PR DESCRIPTION
#### Summary

- All dimmed text on white background should use #6e6e6e instead of #b1b1b1 to be contrast compliant.
- Same goes for disabled buttons