### PR TITLE
Add experimental HelsinkiDateTime type

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -41,7 +41,7 @@ import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.message.MockEvakaMessageClient
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_4
 import fi.espoo.evaka.testAdult_5
@@ -153,7 +153,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.read {
             val application = fetchApplicationDetails(it.handle, applicationId)!!
             if (expected != null) {
-                assertEquals(LocalDate.ofInstant(expected, zoneId), application.dueDate)
+                assertEquals(LocalDate.ofInstant(expected, europeHelsinki), application.dueDate)
             } else {
                 assertNull(application.dueDate)
             }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
@@ -21,7 +21,7 @@ import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacement
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -65,7 +65,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
 
         assertEquals(AttendanceStatus.PRESENT, child.status)
         assertNotNull(child.attendance)
-        assertEquals(arrived, LocalTime.ofInstant(child.attendance!!.arrived, zoneId))
+        assertEquals(arrived, LocalTime.ofInstant(child.attendance!!.arrived, europeHelsinki))
         assertNull(child.attendance!!.departed)
         assertTrue(child.absences.isEmpty())
     }
@@ -222,7 +222,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
 
         assertEquals(AttendanceStatus.DEPARTED, child.status)
         assertNotNull(child.attendance)
-        assertEquals(departed, LocalTime.ofInstant(child.attendance!!.departed, zoneId))
+        assertEquals(departed, LocalTime.ofInstant(child.attendance!!.departed, europeHelsinki))
         assertTrue(child.absences.isEmpty())
     }
 
@@ -237,7 +237,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
 
         assertEquals(AttendanceStatus.DEPARTED, child.status)
         assertNotNull(child.attendance)
-        assertEquals(departed, LocalTime.ofInstant(child.attendance!!.departed, zoneId))
+        assertEquals(departed, LocalTime.ofInstant(child.attendance!!.departed, europeHelsinki))
         assertEquals(1, child.absences.size)
         assertEquals(CareType.PRESCHOOL_DAYCARE, child.absences.first().careType)
     }
@@ -253,7 +253,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
 
         assertEquals(AttendanceStatus.DEPARTED, child.status)
         assertNotNull(child.attendance)
-        assertEquals(departed, LocalTime.ofInstant(child.attendance!!.departed, zoneId))
+        assertEquals(departed, LocalTime.ofInstant(child.attendance!!.departed, europeHelsinki))
         assertEquals(1, child.absences.size)
         assertEquals(CareType.PRESCHOOL, child.absences.first().careType)
     }
@@ -269,7 +269,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
 
         assertEquals(AttendanceStatus.DEPARTED, child.status)
         assertNotNull(child.attendance)
-        assertEquals(departed, LocalTime.ofInstant(child.attendance!!.departed, zoneId))
+        assertEquals(departed, LocalTime.ofInstant(child.attendance!!.departed, europeHelsinki))
         assertEquals(2, child.absences.size)
         assertTrue(child.absences.any { it.careType == CareType.PRESCHOOL })
         assertTrue(child.absences.any { it.careType == CareType.PRESCHOOL_DAYCARE })
@@ -326,8 +326,8 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
                 h = it.handle,
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
-                arrived = ZonedDateTime.now(zoneId).minusDays(1).minusHours(1).toInstant(),
-                departed = ZonedDateTime.now(zoneId).minusDays(1).minusMinutes(1).toInstant()
+                arrived = ZonedDateTime.now(europeHelsinki).minusDays(1).minusHours(1).toInstant(),
+                departed = ZonedDateTime.now(europeHelsinki).minusDays(1).minusMinutes(1).toInstant()
             )
         }
         givenChildPlacement(PlacementType.PRESCHOOL)
@@ -467,7 +467,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
                 h = it.handle,
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
-                arrived = ZonedDateTime.of(LocalDate.now(zoneId).atTime(arrived), zoneId).toInstant(),
+                arrived = ZonedDateTime.of(LocalDate.now(europeHelsinki).atTime(arrived), europeHelsinki).toInstant(),
                 departed = null
             )
         }
@@ -484,8 +484,8 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
                 h = it.handle,
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
-                arrived = ZonedDateTime.of(LocalDate.now(zoneId).atTime(arrived), zoneId).toInstant(),
-                departed = ZonedDateTime.of(LocalDate.now(zoneId).atTime(departed), zoneId).toInstant()
+                arrived = ZonedDateTime.of(LocalDate.now(europeHelsinki).atTime(arrived), europeHelsinki).toInstant(),
+                departed = ZonedDateTime.of(LocalDate.now(europeHelsinki).atTime(departed), europeHelsinki).toInstant()
             )
         }
         val child = expectOneChild()
@@ -636,5 +636,5 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
         return response.children.first()
     }
 
-    private fun roundedTimeNow() = LocalTime.now(zoneId).withSecond(0).withNano(0)
+    private fun roundedTimeNow() = LocalTime.now(europeHelsinki).withSecond(0).withNano(0)
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacement
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import org.jdbi.v3.core.kotlin.mapTo
@@ -61,7 +61,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest() {
         // test with daylight saving time change on 25.10.2020
         val arrived = ZonedDateTime.of(
             LocalDate.of(2020, 10, 25).atTime(LocalTime.of(9, 0)),
-            zoneId
+            europeHelsinki
         ).toInstant()
 
         db.transaction {
@@ -91,7 +91,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest() {
         assertEquals(1, attendances.size)
         val expectedDeparted = ZonedDateTime.of(
             LocalDate.of(2020, 10, 25).atTime(LocalTime.of(23, 59)),
-            zoneId
+            europeHelsinki
         ).toInstant()
         assertEquals(expectedDeparted, attendances.first().departed)
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
@@ -24,7 +24,7 @@ import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacement
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDaycare2
@@ -111,8 +111,8 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
                 childId = testChild_1.id,
                 unitId = testDaycare2.id,
                 groupId = groupId2,
-                startDate = LocalDate.now(zoneId),
-                endDate = LocalDate.now(zoneId)
+                startDate = LocalDate.now(europeHelsinki),
+                endDate = LocalDate.now(europeHelsinki)
             )
         }
         val response = fetchAttendances()
@@ -127,8 +127,8 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 groupId = groupId,
-                startDate = LocalDate.now(zoneId),
-                endDate = LocalDate.now(zoneId)
+                startDate = LocalDate.now(europeHelsinki),
+                endDate = LocalDate.now(europeHelsinki)
             )
         }
         val child = expectOneChild()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.updateDaycareAclWithEmployee
-import fi.espoo.evaka.shared.utils.europeHelsinki
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.time.ZonedDateTime
 import java.util.UUID
 
 class PairingIntegrationTest : FullApplicationTest() {
@@ -125,7 +124,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_CHALLENGE,
             challengeKey = "foo",
             responseKey = null,
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
+            expires = HelsinkiDateTime.now().plusMinutes(1)
         )
         givenPairing(pairing)
         postPairingChallengeAssertOk(pairing.challengeKey)
@@ -144,7 +143,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_CHALLENGE,
             challengeKey = "foo",
             responseKey = null,
-            expires = ZonedDateTime.now(europeHelsinki).minusMinutes(1).toInstant()
+            expires = HelsinkiDateTime.now().minusMinutes(1)
         )
         givenPairing(pairing)
         postPairingChallengeAssertFail(pairing.challengeKey, 404)
@@ -158,7 +157,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
+            expires = HelsinkiDateTime.now().plusMinutes(1)
         )
         givenPairing(pairing)
         postPairingChallengeAssertFail(pairing.challengeKey, 404)
@@ -172,7 +171,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
+            expires = HelsinkiDateTime.now().plusMinutes(1)
         )
         givenPairing(pairing)
         postPairingResponseAssertOk(pairing.id, pairing.challengeKey, pairing.responseKey!!)
@@ -186,7 +185,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
+            expires = HelsinkiDateTime.now().plusMinutes(1)
         )
         givenPairing(pairing)
         postPairingResponseAssertFail(UUID.randomUUID(), pairing.challengeKey, pairing.responseKey!!, 404)
@@ -200,7 +199,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
+            expires = HelsinkiDateTime.now().plusMinutes(1)
         )
         givenPairing(pairing)
         postPairingResponseAssertFail(pairing.id, "wrong", pairing.responseKey!!, 404)
@@ -214,7 +213,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
+            expires = HelsinkiDateTime.now().plusMinutes(1)
         )
         givenPairing(pairing)
         postPairingResponseAssertFail(pairing.id, pairing.challengeKey, "wrong", 404)
@@ -228,7 +227,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
+            expires = HelsinkiDateTime.now().plusMinutes(1)
         )
         givenPairing(pairing)
         postPairingResponseAssertFail(pairing.id, pairing.challengeKey, pairing.responseKey!!, 404)
@@ -242,7 +241,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
+            expires = HelsinkiDateTime.now().plusMinutes(1)
         )
         givenPairing(pairing, attempts = 101)
         postPairingResponseAssertFail(pairing.id, pairing.challengeKey, pairing.responseKey!!, 404)
@@ -256,7 +255,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).minusMinutes(1).toInstant()
+            expires = HelsinkiDateTime.now().minusMinutes(1)
         )
         givenPairing(pairing)
         postPairingResponseAssertFail(pairing.id, pairing.challengeKey, pairing.responseKey!!, 404)
@@ -270,7 +269,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
+            expires = HelsinkiDateTime.now().plusMinutes(1),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)
@@ -285,7 +284,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
+            expires = HelsinkiDateTime.now().plusMinutes(1),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)
@@ -300,7 +299,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
+            expires = HelsinkiDateTime.now().plusMinutes(1),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)
@@ -315,7 +314,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
+            expires = HelsinkiDateTime.now().plusMinutes(1),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)
@@ -330,7 +329,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.PAIRED,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
+            expires = HelsinkiDateTime.now().plusMinutes(1),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)
@@ -345,7 +344,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
+            expires = HelsinkiDateTime.now().plusMinutes(1),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing, attempts = 101)
@@ -360,7 +359,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(europeHelsinki).minusMinutes(1).toInstant(),
+            expires = HelsinkiDateTime.now().minusMinutes(1),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.updateDaycareAclWithEmployee
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -125,7 +125,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_CHALLENGE,
             challengeKey = "foo",
             responseKey = null,
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant()
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
         )
         givenPairing(pairing)
         postPairingChallengeAssertOk(pairing.challengeKey)
@@ -144,7 +144,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_CHALLENGE,
             challengeKey = "foo",
             responseKey = null,
-            expires = ZonedDateTime.now(zoneId).minusMinutes(1).toInstant()
+            expires = ZonedDateTime.now(europeHelsinki).minusMinutes(1).toInstant()
         )
         givenPairing(pairing)
         postPairingChallengeAssertFail(pairing.challengeKey, 404)
@@ -158,7 +158,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant()
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
         )
         givenPairing(pairing)
         postPairingChallengeAssertFail(pairing.challengeKey, 404)
@@ -172,7 +172,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant()
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
         )
         givenPairing(pairing)
         postPairingResponseAssertOk(pairing.id, pairing.challengeKey, pairing.responseKey!!)
@@ -186,7 +186,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant()
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
         )
         givenPairing(pairing)
         postPairingResponseAssertFail(UUID.randomUUID(), pairing.challengeKey, pairing.responseKey!!, 404)
@@ -200,7 +200,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant()
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
         )
         givenPairing(pairing)
         postPairingResponseAssertFail(pairing.id, "wrong", pairing.responseKey!!, 404)
@@ -214,7 +214,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant()
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
         )
         givenPairing(pairing)
         postPairingResponseAssertFail(pairing.id, pairing.challengeKey, "wrong", 404)
@@ -228,7 +228,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant()
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
         )
         givenPairing(pairing)
         postPairingResponseAssertFail(pairing.id, pairing.challengeKey, pairing.responseKey!!, 404)
@@ -242,7 +242,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant()
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant()
         )
         givenPairing(pairing, attempts = 101)
         postPairingResponseAssertFail(pairing.id, pairing.challengeKey, pairing.responseKey!!, 404)
@@ -256,7 +256,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).minusMinutes(1).toInstant()
+            expires = ZonedDateTime.now(europeHelsinki).minusMinutes(1).toInstant()
         )
         givenPairing(pairing)
         postPairingResponseAssertFail(pairing.id, pairing.challengeKey, pairing.responseKey!!, 404)
@@ -270,7 +270,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant(),
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)
@@ -285,7 +285,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant(),
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)
@@ -300,7 +300,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant(),
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)
@@ -315,7 +315,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant(),
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)
@@ -330,7 +330,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.PAIRED,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant(),
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)
@@ -345,7 +345,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).plusMinutes(1).toInstant(),
+            expires = ZonedDateTime.now(europeHelsinki).plusMinutes(1).toInstant(),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing, attempts = 101)
@@ -360,7 +360,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             status = PairingStatus.READY,
             challengeKey = "foo",
             responseKey = "bar",
-            expires = ZonedDateTime.now(zoneId).minusMinutes(1).toInstant(),
+            expires = ZonedDateTime.now(europeHelsinki).minusMinutes(1).toInstant(),
             mobileDeviceId = UUID.randomUUID()
         )
         givenPairing(pairing)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
@@ -14,7 +14,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testAdult_3
@@ -56,7 +56,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
     private val janFirst = LocalDate.of(2020, 1, 1)
     private val febFirst = LocalDate.of(2020, 2, 1)
 
-    private val janFreeze = ZonedDateTime.of(LocalDateTime.of(2020, 1, 21, 22, 0), zoneId).toInstant()
+    private val janFreeze = ZonedDateTime.of(LocalDateTime.of(2020, 1, 21, 22, 0), europeHelsinki).toInstant()
 
     @Test
     fun `unfrozen area voucher report includes value decisions that begin in the beginning of reports month`() {
@@ -144,7 +144,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
         coPayment: Int,
         adultId: UUID,
         child: PersonData.Detailed,
-        approvedAt: Instant = ZonedDateTime.of(validFrom, LocalTime.of(15, 0), zoneId).toInstant()
+        approvedAt: Instant = ZonedDateTime.of(validFrom, LocalTime.of(15, 0), europeHelsinki).toInstant()
     ): VoucherValueDecision {
         val decision = db.transaction {
             val decision = createVoucherValueDecisionFixture(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -17,7 +17,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
@@ -56,8 +56,8 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
     private val febFirst = LocalDate.of(2020, 2, 1)
     private val marFirst = LocalDate.of(2020, 3, 1)
 
-    private val janFreeze = ZonedDateTime.of(LocalDateTime.of(2020, 1, 21, 22, 0), zoneId).toInstant()
-    private val febFreeze = ZonedDateTime.of(LocalDateTime.of(2020, 2, 21, 22, 0), zoneId).toInstant()
+    private val janFreeze = ZonedDateTime.of(LocalDateTime.of(2020, 1, 21, 22, 0), europeHelsinki).toInstant()
+    private val febFreeze = ZonedDateTime.of(LocalDateTime.of(2020, 2, 21, 22, 0), europeHelsinki).toInstant()
 
     @Test
     fun `unfrozen service voucher report includes value decisions that begin in the beginning of reports month`() {
@@ -292,7 +292,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
         unitId: UUID,
         value: Int,
         coPayment: Int,
-        approvedAt: Instant = ZonedDateTime.of(validFrom, LocalTime.of(15, 0), zoneId).toInstant()
+        approvedAt: Instant = ZonedDateTime.of(validFrom, LocalTime.of(15, 0), europeHelsinki).toInstant()
     ): VoucherValueDecision {
         val decision = db.transaction {
             val decision = createVoucherValueDecisionFixture(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
@@ -10,7 +10,7 @@ import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.intellij.lang.annotations.Language
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.json.Json
@@ -133,7 +133,7 @@ class JdbiExtensionsTest : PureJdbiTest() {
 
     @Test
     fun testHelsinkiDateTime() {
-        val input = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(13, 59), zoneId))
+        val input = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(13, 59), europeHelsinki))
 
         val match = db.read { it.checkMatch("SELECT :input = '2020-05-07T10:59Z'", input) }
         assertTrue(match)
@@ -160,7 +160,7 @@ class JdbiExtensionsTest : PureJdbiTest() {
         val result = db.read {
             it.createQuery("SELECT jsonb_build_object('value', '2020-05-07T10:59Z'::timestamptz) AS jsonb").mapTo<QueryResult>().single()
         }
-        val expected = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(13, 59), zoneId))
+        val expected = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(13, 59), europeHelsinki))
         assertEquals(expected, result.jsonb.value)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -62,7 +62,7 @@ import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.NotFound
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -514,7 +514,7 @@ class ApplicationStateService(
         val preferredStartDate = application.preferences.preferredStartDate
         if (type == ApplicationType.PRESCHOOL && preferredStartDate != null) {
             val canApplyForPreferredDate = tx.getActivePreschoolTermAt(preferredStartDate)
-                ?.isApplicationAccepted(LocalDate.now(zoneId))
+                ?.isApplicationAccepted(LocalDate.now(europeHelsinki))
                 ?: false
             if (!canApplyForPreferredDate) {
                 throw BadRequest("Cannot apply to preschool on $preferredStartDate at the moment")

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -22,7 +22,7 @@ import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.utils.dateNow
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.format.annotation.DateTimeFormat
@@ -145,7 +145,7 @@ class ChildAttendanceController(
                 tx.insertAttendance(
                     childId = childId,
                     unitId = unitId,
-                    arrived = ZonedDateTime.of(LocalDate.now(zoneId).atTime(body.arrived), zoneId).toInstant(),
+                    arrived = ZonedDateTime.of(LocalDate.now(europeHelsinki).atTime(body.arrived), europeHelsinki).toInstant(),
                     departed = null
                 )
             } catch (e: Exception) {
@@ -211,7 +211,7 @@ class ChildAttendanceController(
                 throw Conflict("Cannot depart, already departed")
             }
 
-            val arrived = LocalTime.ofInstant(attendance.arrived, zoneId)
+            val arrived = LocalTime.ofInstant(attendance.arrived, europeHelsinki)
             DepartureInfoResponse(
                 absentFrom = getPartialAbsenceCareTypes(placementBasics, arrived, time)
             )
@@ -243,7 +243,7 @@ class ChildAttendanceController(
                 throw Conflict("Cannot depart, already departed")
             }
 
-            val absentFrom = getPartialAbsenceCareTypes(placementBasics, LocalTime.ofInstant(attendance.arrived, zoneId), body.departed)
+            val absentFrom = getPartialAbsenceCareTypes(placementBasics, LocalTime.ofInstant(attendance.arrived, europeHelsinki), body.departed)
             tx.deleteCurrentDayAbsences(childId)
             if (absentFrom.isNotEmpty()) {
                 if (body.absenceType == null) {
@@ -251,7 +251,7 @@ class ChildAttendanceController(
                 }
 
                 absentFrom.forEach { careType ->
-                    tx.insertAbsence(user, childId, LocalDate.now(zoneId), careType, body.absenceType)
+                    tx.insertAbsence(user, childId, LocalDate.now(europeHelsinki), careType, body.absenceType)
                 }
             } else if (body.absenceType != null) {
                 throw BadRequest("Request defines absenceType but child was not absent.")
@@ -260,7 +260,7 @@ class ChildAttendanceController(
             try {
                 tx.updateAttendanceEnd(
                     attendanceId = attendance.id,
-                    departed = ZonedDateTime.of(LocalDate.now(zoneId).atTime(body.departed), zoneId).toInstant()
+                    departed = ZonedDateTime.of(LocalDate.now(europeHelsinki).atTime(body.departed), europeHelsinki).toInstant()
                 )
             } catch (e: Exception) {
                 throw mapPSQLException(e)

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -19,7 +19,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.NotFound
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.jdbi.v3.core.kotlin.mapTo
 import java.time.Instant
 import java.time.LocalDate
@@ -76,8 +76,8 @@ fun Database.Read.getChildCurrentDayAttendance(childId: UUID, unitId: UUID): Chi
     return createQuery(sql)
         .bind("childId", childId)
         .bind("unitId", unitId)
-        .bind("todayStart", LocalDate.now(zoneId).atStartOfDay(zoneId).toInstant())
-        .bind("todayEnd", LocalDate.now(zoneId).plusDays(1).atStartOfDay(zoneId).toInstant())
+        .bind("todayStart", LocalDate.now(europeHelsinki).atStartOfDay(europeHelsinki).toInstant())
+        .bind("todayEnd", LocalDate.now(europeHelsinki).plusDays(1).atStartOfDay(europeHelsinki).toInstant())
         .mapTo<ChildAttendance>()
         .list()
         .firstOrNull()
@@ -112,7 +112,7 @@ fun Database.Read.fetchUnitInfo(unitId: UUID): UnitInfo {
 
     val groups = createQuery(groupsSql)
         .bind("unitId", unitId)
-        .bind("today", LocalDate.now(zoneId))
+        .bind("today", LocalDate.now(europeHelsinki))
         .mapTo<GroupInfo>()
         .list()
 
@@ -210,7 +210,7 @@ fun Database.Read.fetchChildrenBasics(unitId: UUID): List<ChildBasics> {
 
     return createQuery(sql)
         .bind("unitId", unitId)
-        .bind("today", LocalDate.now(zoneId))
+        .bind("today", LocalDate.now(europeHelsinki))
         .map { row ->
             ChildBasics(
                 id = row.mapColumn("id"),
@@ -260,7 +260,7 @@ fun Database.Read.fetchChildrenAttendances(unitId: UUID): List<ChildAttendance> 
 
     return createQuery(sql)
         .bind("unitId", unitId)
-        .bind("today", LocalDate.now(zoneId))
+        .bind("today", LocalDate.now(europeHelsinki))
         .mapTo<ChildAttendance>()
         .list()
 }
@@ -279,7 +279,7 @@ fun Database.Read.fetchChildrenAbsences(unitId: UUID): List<ChildAbsence> {
 
     return createQuery(sql)
         .bind("unitId", unitId)
-        .bind("today", LocalDate.now(zoneId))
+        .bind("today", LocalDate.now(europeHelsinki))
         .mapTo<ChildAbsence>()
         .list()
 }
@@ -295,7 +295,7 @@ fun Database.Read.fetchChildDaycareDailyNotes(unitId: UUID): List<DaycareDailyNo
 
     return createQuery(sql)
         .bind("unitId", unitId)
-        .bind("today", LocalDate.now(zoneId))
+        .bind("today", LocalDate.now(europeHelsinki))
         .mapTo<DaycareDailyNote>()
         .list()
 }
@@ -354,7 +354,7 @@ fun Database.Transaction.deleteCurrentDayAbsences(childId: UUID) {
 
     createUpdate(sql)
         .bind("childId", childId)
-        .bind("today", LocalDate.now(zoneId))
+        .bind("today", LocalDate.now(europeHelsinki))
         .execute()
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
@@ -16,7 +16,7 @@ import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.kotlin.mapTo
@@ -288,7 +288,7 @@ ORDER BY name ASC
     """.trimIndent()
 
     return createQuery(sql)
-        .bind("date", LocalDate.now(zoneId))
+        .bind("date", LocalDate.now(europeHelsinki))
         .mapTo<PublicUnit>()
         .toList()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.jdbi.v3.core.kotlin.mapTo
 import java.time.LocalDate
 
@@ -37,9 +37,9 @@ fun Database.Read.getActivePreschoolTermAt(date: LocalDate): PreschoolTerm? {
 }
 
 fun Database.Read.getCurrentPreschoolTerm(): PreschoolTerm? {
-    return getActivePreschoolTermAt(LocalDate.now(zoneId))
+    return getActivePreschoolTermAt(LocalDate.now(europeHelsinki))
 }
 
 fun Database.Read.getNextPreschoolTerm(): PreschoolTerm? {
-    return getPreschoolTerms().firstOrNull { it.extendedTerm.start.isAfter(LocalDate.now(zoneId)) }
+    return getPreschoolTerms().firstOrNull { it.extendedTerm.start.isAfter(LocalDate.now(europeHelsinki)) }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -29,8 +29,8 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.NotFound
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.shared.utils.parseEnum
-import fi.espoo.evaka.shared.utils.zoneId
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -112,7 +112,7 @@ class VoucherValueDecisionController(
                 objectMapper = objectMapper,
                 asyncJobRunner = asyncJobRunner,
                 user = user,
-                now = ZonedDateTime.now(zoneId).toInstant(),
+                now = ZonedDateTime.now(europeHelsinki).toInstant(),
                 ids = decisionIds
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -54,7 +54,7 @@ import fi.espoo.evaka.shared.domain.asDistinctPeriods
 import fi.espoo.evaka.shared.domain.mergePeriods
 import fi.espoo.evaka.shared.domain.minEndDate
 import fi.espoo.evaka.shared.domain.orMax
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import mu.KotlinLogging
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
@@ -580,7 +580,7 @@ private fun getActivePaidPlacements(h: Handle, childId: UUID, from: LocalDate): 
         .toList()
 }
 
-fun isEntitledToFreeFiveYearsOldDaycare(dateOfBirth: LocalDate, date: LocalDate = LocalDate.now(zoneId)): Boolean {
+fun isEntitledToFreeFiveYearsOldDaycare(dateOfBirth: LocalDate, date: LocalDate = LocalDate.now(europeHelsinki)): Boolean {
     return getFiveYearOldTerm(dateOfBirth).includes(date)
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/bulletin/BulletinQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/bulletin/BulletinQueries.kt
@@ -9,7 +9,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.mapToPaged
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.shared.withCountMapper
 import org.jdbi.v3.core.kotlin.mapTo
 import java.time.Instant
@@ -146,7 +146,7 @@ fun Database.Transaction.sendBulletin(
     val sent = this.createUpdate(updateBulletinSql)
         .bind("id", id)
         .bind("userId", user.id)
-        .bind("sentAt", OffsetDateTime.now(zoneId))
+        .bind("sentAt", OffsetDateTime.now(europeHelsinki))
         .execute()
 
     if (sent == 0) throw NotFound("No bulletin $id found by user ${user.id} in draft state")
@@ -201,7 +201,7 @@ fun Database.Transaction.sendBulletin(
 
     this.createUpdate(insertBulletinInstancesSql)
         .bind("bulletinId", id)
-        .bind("date", LocalDate.now(zoneId))
+        .bind("date", LocalDate.now(europeHelsinki))
         .execute()
 }
 
@@ -485,7 +485,7 @@ fun Database.Read.getReceiversForNewBulletin(
     """.trimIndent()
 
     return this.createQuery(sql)
-        .bind("date", LocalDate.now(zoneId))
+        .bind("date", LocalDate.now(europeHelsinki))
         .bind("userId", user.id)
         .bind("unitId", unitId)
         .mapTo<BulletinReceiversResult>()
@@ -574,7 +574,7 @@ fun Database.Transaction.markBulletinRead(
     this.createUpdate(sql)
         .bind("id", id)
         .bind("userId", user.id)
-        .bind("readAt", OffsetDateTime.now(zoneId))
+        .bind("readAt", OffsetDateTime.now(europeHelsinki))
         .execute()
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/bulletin/ChildRecipientsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/bulletin/ChildRecipientsController.kt
@@ -5,7 +5,7 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -122,7 +122,7 @@ fun fetchRecipients(tx: Database.Read, now: Instant, childId: UUID): List<Recipi
 
     return tx.createQuery(sql)
         .bind("childId", childId)
-        .bind("date", LocalDate.ofInstant(now, zoneId))
+        .bind("date", LocalDate.ofInstant(now, europeHelsinki))
         .mapTo<Recipient>()
         .list()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/Pairing.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/Pairing.kt
@@ -4,7 +4,7 @@
 
 package fi.espoo.evaka.pairing
 
-import java.time.Instant
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.util.UUID
 
 data class Pairing(
@@ -12,7 +12,7 @@ data class Pairing(
     val unitId: UUID,
     val challengeKey: String,
     val responseKey: String?,
-    val expires: Instant,
+    val expires: HelsinkiDateTime,
     val status: PairingStatus,
     val mobileDeviceId: UUID? = null
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
@@ -5,11 +5,10 @@
 package fi.espoo.evaka.pairing
 
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
-import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.jdbi.v3.core.kotlin.mapTo
 import java.security.SecureRandom
-import java.time.ZonedDateTime
 import java.util.UUID
 
 const val maxAttempts = 100 // additional brute-force protection
@@ -26,7 +25,7 @@ fun Database.Transaction.initPairing(unitId: UUID): Pairing {
 
     return createQuery(sql)
         .bind("unitId", unitId)
-        .bind("expires", ZonedDateTime.now(europeHelsinki).plusMinutes(expiresInMinutes).toInstant())
+        .bind("expires", HelsinkiDateTime.now().plusMinutes(expiresInMinutes))
         .bind("challenge", generatePairingKey())
         .mapTo<Pairing>()
         .first()
@@ -44,7 +43,7 @@ fun Database.Transaction.challengePairing(challengeKey: String): Pairing {
     return createQuery(sql)
         .bind("challenge", challengeKey)
         .bind("response", generatePairingKey())
-        .bind("now", ZonedDateTime.now(europeHelsinki).toInstant())
+        .bind("now", HelsinkiDateTime.now())
         .bind("maxAttempts", maxAttempts)
         .mapTo<Pairing>()
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
@@ -84,7 +83,7 @@ fun Database.Transaction.respondPairingChallengeCreateDevice(id: UUID, challenge
         .bind("challenge", challengeKey)
         .bind("response", responseKey)
         .bind("name", defaultDeviceName)
-        .bind("now", ZonedDateTime.now(europeHelsinki).toInstant())
+        .bind("now", HelsinkiDateTime.now())
         .bind("maxAttempts", maxAttempts)
         .mapTo<Pairing>()
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
@@ -108,7 +107,7 @@ RETURNING id, long_term_token
         .bind("id", id)
         .bind("challenge", challengeKey)
         .bind("response", responseKey)
-        .bind("now", ZonedDateTime.now(europeHelsinki).toInstant())
+        .bind("now", HelsinkiDateTime.now())
         .bind("maxAttempts", maxAttempts)
         .bind("longTermToken", UUID.randomUUID())
         .mapTo<MobileDeviceIdentity>()
@@ -125,7 +124,7 @@ fun Database.Read.fetchPairingStatus(id: UUID): PairingStatus {
 
     return createQuery(sql)
         .bind("id", id)
-        .bind("now", ZonedDateTime.now(europeHelsinki).toInstant())
+        .bind("now", HelsinkiDateTime.now())
         .bind("maxAttempts", maxAttempts)
         .mapTo<PairingStatus>()
         .list()

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.pairing
 
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.NotFound
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.jdbi.v3.core.kotlin.mapTo
 import java.security.SecureRandom
 import java.time.ZonedDateTime
@@ -26,7 +26,7 @@ fun Database.Transaction.initPairing(unitId: UUID): Pairing {
 
     return createQuery(sql)
         .bind("unitId", unitId)
-        .bind("expires", ZonedDateTime.now(zoneId).plusMinutes(expiresInMinutes).toInstant())
+        .bind("expires", ZonedDateTime.now(europeHelsinki).plusMinutes(expiresInMinutes).toInstant())
         .bind("challenge", generatePairingKey())
         .mapTo<Pairing>()
         .first()
@@ -44,7 +44,7 @@ fun Database.Transaction.challengePairing(challengeKey: String): Pairing {
     return createQuery(sql)
         .bind("challenge", challengeKey)
         .bind("response", generatePairingKey())
-        .bind("now", ZonedDateTime.now(zoneId).toInstant())
+        .bind("now", ZonedDateTime.now(europeHelsinki).toInstant())
         .bind("maxAttempts", maxAttempts)
         .mapTo<Pairing>()
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
@@ -84,7 +84,7 @@ fun Database.Transaction.respondPairingChallengeCreateDevice(id: UUID, challenge
         .bind("challenge", challengeKey)
         .bind("response", responseKey)
         .bind("name", defaultDeviceName)
-        .bind("now", ZonedDateTime.now(zoneId).toInstant())
+        .bind("now", ZonedDateTime.now(europeHelsinki).toInstant())
         .bind("maxAttempts", maxAttempts)
         .mapTo<Pairing>()
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
@@ -108,7 +108,7 @@ RETURNING id, long_term_token
         .bind("id", id)
         .bind("challenge", challengeKey)
         .bind("response", responseKey)
-        .bind("now", ZonedDateTime.now(zoneId).toInstant())
+        .bind("now", ZonedDateTime.now(europeHelsinki).toInstant())
         .bind("maxAttempts", maxAttempts)
         .bind("longTermToken", UUID.randomUUID())
         .mapTo<MobileDeviceIdentity>()
@@ -125,7 +125,7 @@ fun Database.Read.fetchPairingStatus(id: UUID): PairingStatus {
 
     return createQuery(sql)
         .bind("id", id)
-        .bind("now", ZonedDateTime.now(zoneId).toInstant())
+        .bind("now", ZonedDateTime.now(europeHelsinki).toInstant())
         .bind("maxAttempts", maxAttempts)
         .mapTo<PairingStatus>()
         .list()

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.NotFound
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -54,7 +54,7 @@ class PairingsController(
                 tx = tx,
                 payloads = listOf(GarbageCollectPairing(pairingId = pairing.id)),
                 runAt = ZonedDateTime
-                    .ofInstant(pairing.expires, zoneId)
+                    .ofInstant(pairing.expires, europeHelsinki)
                     .plusDays(1)
                     .toInstant()
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -13,14 +13,12 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.NotFound
-import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-import java.time.ZonedDateTime
 import java.util.UUID
 
 @RestController
@@ -53,10 +51,7 @@ class PairingsController(
             asyncJobRunner.plan(
                 tx = tx,
                 payloads = listOf(GarbageCollectPairing(pairingId = pairing.id)),
-                runAt = ZonedDateTime
-                    .ofInstant(pairing.expires, europeHelsinki)
-                    .plusDays(1)
-                    .toInstant()
+                runAt = pairing.expires.plusDays(1).toInstant()
             )
 
             pairing

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -12,7 +12,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.domain.FiniteDateRange
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -330,7 +330,7 @@ private fun Database.Read.getSnapshotDate(year: Int, month: Int): LocalDate? {
         .bind("month", month)
         .mapTo<Instant>()
         .firstOrNull()
-        ?.let { LocalDate.ofInstant(it, zoneId) }
+        ?.let { LocalDate.ofInstant(it, europeHelsinki) }
 }
 
 private fun Database.Read.getSnapshotVoucherValues(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
@@ -20,7 +20,7 @@ import fi.espoo.evaka.reports.freezeVoucherValueReportRows
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.ScheduleKoskiUploads
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.varda.VardaUpdateService
 import mu.KotlinLogging
 import org.springframework.http.ResponseEntity
@@ -123,8 +123,8 @@ class ScheduledOperationController(
         db.transaction {
             freezeVoucherValueReportRows(
                 it,
-                year ?: LocalDate.now(zoneId).year,
-                month ?: LocalDate.now(zoneId).monthValue,
+                year ?: LocalDate.now(europeHelsinki).year,
+                month ?: LocalDate.now(europeHelsinki).monthValue,
                 Instant.now()
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.generic.GenericType
@@ -77,10 +78,12 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
     jdbi.registerArgument(coordinateArgumentFactory)
     jdbi.registerArgument(identityArgumentFactory)
     jdbi.registerArgument(externalIdArgumentFactory)
+    jdbi.registerArgument(helsinkiDateTimeArgumentFactory)
     jdbi.registerColumnMapper(FiniteDateRange::class.java, finiteDateRangeColumnMapper)
     jdbi.registerColumnMapper(DateRange::class.java, dateRangeColumnMapper)
     jdbi.registerColumnMapper(Coordinate::class.java, coordinateColumnMapper)
     jdbi.registerColumnMapper(ExternalId::class.java, externalIdColumnMapper)
+    jdbi.registerColumnMapper(HelsinkiDateTime::class.java, helsinkiDateTimeColumnMapper)
     jdbi.registerArrayType(UUID::class.java, "uuid")
     return jdbi
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.domain
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.util.StdConverter
+import fi.espoo.evaka.shared.utils.zoneId
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZonedDateTime
+
+fun Instant.toHelsinkiDateTime(): HelsinkiDateTime = HelsinkiDateTime.from(this)
+fun ZonedDateTime.toHelsinkiDateTime(): HelsinkiDateTime = HelsinkiDateTime.from(this)
+
+/**
+ * A timestamp in Europe/Helsinki timezone
+ */
+@JsonSerialize(converter = HelsinkiDateTime.ToJson::class)
+@JsonDeserialize(converter = HelsinkiDateTime.FromJson::class)
+data class HelsinkiDateTime private constructor(private val instant: Instant) : Comparable<HelsinkiDateTime> {
+    fun toInstant(): Instant = this.instant
+    fun toZonedDateTime(): ZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId)
+
+    fun update(f: (ZonedDateTime) -> ZonedDateTime): HelsinkiDateTime = HelsinkiDateTime(f(toZonedDateTime()).toInstant())
+
+    override fun compareTo(other: HelsinkiDateTime): Int = this.instant.compareTo(other.instant)
+    override fun toString(): String = toZonedDateTime().toString()
+
+    companion object {
+        fun of(date: LocalDate, time: LocalTime): HelsinkiDateTime = from(ZonedDateTime.of(date, time, zoneId))
+        fun of(dateTime: LocalDateTime): HelsinkiDateTime = from(ZonedDateTime.of(dateTime, zoneId))
+        fun now(clock: Clock? = Clock.systemUTC()): HelsinkiDateTime = HelsinkiDateTime(Instant.now(clock))
+        fun from(value: Instant): HelsinkiDateTime = HelsinkiDateTime(value)
+        fun from(value: ZonedDateTime): HelsinkiDateTime = HelsinkiDateTime(value.toInstant())
+    }
+
+    class FromJson : StdConverter<ZonedDateTime, HelsinkiDateTime>() {
+        override fun convert(value: ZonedDateTime): HelsinkiDateTime = value.toHelsinkiDateTime()
+    }
+
+    class ToJson : StdConverter<HelsinkiDateTime, ZonedDateTime>() {
+        override fun convert(value: HelsinkiDateTime): ZonedDateTime = value.toZonedDateTime()
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
@@ -61,10 +61,33 @@ data class HelsinkiDateTime private constructor(private val instant: Instant) : 
     fun isAfter(other: HelsinkiDateTime): Boolean = this.instant.isAfter(other.instant)
     fun isBefore(other: HelsinkiDateTime): Boolean = this.instant.isBefore(other.instant)
 
+    /**
+     * Returns the Europe/Helsinki local date+time at the point in time represented by this timestamp
+     */
     fun toLocalDateTime(): LocalDateTime = LocalDateTime.ofInstant(instant, europeHelsinki)
+
+    /**
+     * Returns the Europe/Helsinki local time at the point in time represented by this timestamp
+     */
     fun toLocalTime(): LocalTime = LocalTime.ofInstant(instant, europeHelsinki)
+
+    /**
+     * Returns the Europe/Helsinki local date at the point in time represented by this timestamp
+     */
     fun toLocalDate(): LocalDate = LocalDate.ofInstant(instant, europeHelsinki)
+
+    /**
+     * Converts this timestamp to an `Instant`.
+     *
+     * The returned value represents the same point in time as this timestamp.
+     */
     fun toInstant(): Instant = instant
+
+    /**
+     * Converts this timestamp to a `ZonedDateTime`.
+     *
+     * The returned value represents the same point in time as this timestamp, and is guaranteed to use the Europe/Helsinki timezone.
+     */
     fun toZonedDateTime(): ZonedDateTime = ZonedDateTime.ofInstant(instant, europeHelsinki)
 
     /**
@@ -83,10 +106,29 @@ data class HelsinkiDateTime private constructor(private val instant: Instant) : 
     override fun toString(): String = toZonedDateTime().toString()
 
     companion object {
+        /**
+         * Creates a `HelsinkiDateTime` of the point in time when the Europe/Helsinki local time matches the given values
+         */
         fun of(date: LocalDate, time: LocalTime): HelsinkiDateTime = from(ZonedDateTime.of(date, time, europeHelsinki))
+
+        /**
+         * Creates a `HelsinkiDateTime` of the point in time when the Europe/Helsinki local time matches the given value
+         */
         fun of(dateTime: LocalDateTime): HelsinkiDateTime = from(ZonedDateTime.of(dateTime, europeHelsinki))
+
+        /**
+         * Returns the current `HelsinkiDateTime` based on the given clock, or the system default clock
+         */
         fun now(clock: Clock? = Clock.systemUTC()): HelsinkiDateTime = HelsinkiDateTime(Instant.now(clock))
+
+        /**
+         * Converts an `Instant` to `HelsinkiDateTime` by reinterpreting its timestamp in Europe/Helsinki timezone
+         */
         fun from(value: Instant): HelsinkiDateTime = HelsinkiDateTime(value)
+
+        /**
+         * Converts a `ZonedDateTime` to `HelsinkiDateTime` by reinterpreting its timestamp in Europe/Helsinki timezone
+         */
         fun from(value: ZonedDateTime): HelsinkiDateTime = HelsinkiDateTime(value.toInstant())
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.shared.domain
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.util.StdConverter
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -25,7 +25,7 @@ fun ZonedDateTime.toHelsinkiDateTime(): HelsinkiDateTime = HelsinkiDateTime.from
 @JsonDeserialize(converter = HelsinkiDateTime.FromJson::class)
 data class HelsinkiDateTime private constructor(private val instant: Instant) : Comparable<HelsinkiDateTime> {
     fun toInstant(): Instant = this.instant
-    fun toZonedDateTime(): ZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId)
+    fun toZonedDateTime(): ZonedDateTime = ZonedDateTime.ofInstant(instant, europeHelsinki)
 
     fun update(f: (ZonedDateTime) -> ZonedDateTime): HelsinkiDateTime = HelsinkiDateTime(f(toZonedDateTime()).toInstant())
 
@@ -33,8 +33,8 @@ data class HelsinkiDateTime private constructor(private val instant: Instant) : 
     override fun toString(): String = toZonedDateTime().toString()
 
     companion object {
-        fun of(date: LocalDate, time: LocalTime): HelsinkiDateTime = from(ZonedDateTime.of(date, time, zoneId))
-        fun of(dateTime: LocalDateTime): HelsinkiDateTime = from(ZonedDateTime.of(dateTime, zoneId))
+        fun of(date: LocalDate, time: LocalTime): HelsinkiDateTime = from(ZonedDateTime.of(date, time, europeHelsinki))
+        fun of(dateTime: LocalDateTime): HelsinkiDateTime = from(ZonedDateTime.of(dateTime, europeHelsinki))
         fun now(clock: Clock? = Clock.systemUTC()): HelsinkiDateTime = HelsinkiDateTime(Instant.now(clock))
         fun from(value: Instant): HelsinkiDateTime = HelsinkiDateTime(value)
         fun from(value: ZonedDateTime): HelsinkiDateTime = HelsinkiDateTime(value.toInstant())

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/utils/Time.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/utils/Time.kt
@@ -7,6 +7,6 @@ package fi.espoo.evaka.shared.utils
 import java.time.LocalDate
 import java.time.ZoneId
 
-val zoneId: ZoneId = ZoneId.of("Europe/Helsinki")
+val europeHelsinki: ZoneId = ZoneId.of("Europe/Helsinki")
 
-fun dateNow(): LocalDate = LocalDate.now(zoneId)
+fun dateNow(): LocalDate = LocalDate.now(europeHelsinki)

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTimeTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTimeTest.kt
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.domain
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import fi.espoo.evaka.shared.config.defaultObjectMapper
+import fi.espoo.evaka.shared.utils.zoneId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZonedDateTime
+
+class HelsinkiDateTimeTest {
+    private val objectMapper = defaultObjectMapper()
+    private val summerValue = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2021, 4, 14), LocalTime.of(16, 2), zoneId))
+    private val winterValue = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.of(23, 59), zoneId))
+
+    @Test
+    fun `a JSON timestamp with +3 offset (with DST) is deserialized correctly`() {
+        val hdt = objectMapper.readValue("\"2021-04-14T16:02:00+03:00\"", HelsinkiDateTime::class.java)
+        assertEquals(summerValue, hdt)
+    }
+
+    @Test
+    fun `a JSON timestamp with +2 offset (without DST) is deserialized correctly`() {
+        val hdt = objectMapper.readValue("\"2020-12-01T23:59:00+02:00\"", HelsinkiDateTime::class.java)
+        assertEquals(winterValue, hdt)
+    }
+
+    @Test
+    fun `a JSON timestamp with +0 offset is deserialized correctly`() {
+        val hdt = objectMapper.readValue("\"2021-04-14T13:02:00+00:00\"", HelsinkiDateTime::class.java)
+        assertEquals(summerValue, hdt)
+    }
+
+    @Test
+    fun `a JSON timestamp with Z offset is deserialized correctly`() {
+        val hdt = objectMapper.readValue("\"2021-04-14T13:02:00Z\"", HelsinkiDateTime::class.java)
+        assertEquals(summerValue, hdt)
+    }
+
+    @Test
+    fun `a JSON timestamp with a ridiculous offset is deserialized correctly`() {
+        val hdt = objectMapper.readValue("\"2021-04-15T02:29:00+13:27\"", HelsinkiDateTime::class.java)
+        assertEquals(summerValue, hdt)
+    }
+
+    @Test
+    fun `a JSON timestamp with no offset throws an error`() {
+        assertThrows<InvalidFormatException> {
+            objectMapper.readValue("\"2021-04-14T13:02:00\"", HelsinkiDateTime::class.java)
+        }
+    }
+
+    @Test
+    fun `serialization to a JSON timestamp works`() {
+        assertEquals("\"2021-04-14T16:02:00+03:00\"", objectMapper.writeValueAsString(summerValue))
+        assertEquals("\"2020-12-01T23:59:00+02:00\"", objectMapper.writeValueAsString(winterValue))
+    }
+}

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTimeTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTimeTest.kt
@@ -10,6 +10,8 @@ import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Clock
+import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZonedDateTime
@@ -60,5 +62,19 @@ class HelsinkiDateTimeTest {
     fun `serialization to a JSON timestamp works`() {
         assertEquals("\"2021-04-14T16:02:00+03:00\"", objectMapper.writeValueAsString(summerValue))
         assertEquals("\"2020-12-01T23:59:00+02:00\"", objectMapper.writeValueAsString(winterValue))
+    }
+
+    @Test
+    fun `plus and minus functions work correctly()`() {
+        val value = summerValue.plusYears(1).plusMonths(1).plusWeeks(1).plusDays(1).plusHours(1).plusMinutes(1).plusSeconds(1)
+        assertEquals(HelsinkiDateTime.of(LocalDate.of(2022, 5, 22), LocalTime.of(17, 3, 1)), value)
+        assertEquals(summerValue, value.minusYears(1).minusMonths(1).minusWeeks(1).minusDays(1).minusHours(1).minusMinutes(1).minusSeconds(1))
+    }
+
+    @Test
+    fun `elapsed works correctly`() {
+        val end = winterValue.toZonedDateTime().plusDays(42).plusSeconds(1)
+        val clock = Clock.fixed(end.toInstant(), europeHelsinki)
+        assertEquals(Duration.ofDays(42).plusSeconds(1), winterValue.elapsed(clock))
     }
 }

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTimeTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTimeTest.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.shared.domain
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import fi.espoo.evaka.shared.config.defaultObjectMapper
-import fi.espoo.evaka.shared.utils.zoneId
+import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -16,8 +16,8 @@ import java.time.ZonedDateTime
 
 class HelsinkiDateTimeTest {
     private val objectMapper = defaultObjectMapper()
-    private val summerValue = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2021, 4, 14), LocalTime.of(16, 2), zoneId))
-    private val winterValue = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.of(23, 59), zoneId))
+    private val summerValue = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2021, 4, 14), LocalTime.of(16, 2), europeHelsinki))
+    private val winterValue = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.of(23, 59), europeHelsinki))
 
     @Test
     fun `a JSON timestamp with +3 offset (with DST) is deserialized correctly`() {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- basically a wrapper for `Instant` with an implicitly defined but guaranteed Europe/Helsinki timezone
- consistent serialization with Jackson and JDBI, which takes care of interpreting the timestamp in the correct time zone. Serialization to/from a zoneless timestamp throws an error, so "local date time" type of values are not accidentally used
- `from()` functions always re-interpret the given timestamp in Europe/Helsinki
- `to*()` functions and serialization always guarantee the resulting value is in Europe/Helsinki
- switch to `HelsinkiDateTime` in pairing functionality as a demo
