### PR TITLE
Add support for darker inline and add buttons

### DIFF
--- a/frontend/src/employee-frontend/components/application-page/ApplicationNotes.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationNotes.tsx
@@ -100,6 +100,7 @@ export default React.memo(function ApplicationNotes({ applicationId }: Props) {
               <AddButton
                 onClick={() => setCreating(true)}
                 text={i18n.application.notes.add}
+                darker
                 dataQa="add-note"
               />
             )}

--- a/frontend/src/lib-components/atoms/buttons/AddButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AddButton.tsx
@@ -27,9 +27,18 @@ const StyledButton = styled.button`
 
   &.disabled {
     color: ${colors.greyscale.dark};
+    cursor: not-allowed;
 
     .icon-wrapper-inner {
       background: ${colors.greyscale.dark};
+    }
+  }
+
+  &.darker:not(.disabled) {
+    color: ${colors.primaryActive};
+
+    .icon-wrapper-inner {
+      background: ${colors.primaryActive};
     }
   }
 
@@ -78,6 +87,7 @@ interface AddButtonProps extends BaseProps {
   onClick: () => unknown
   disabled?: boolean
   flipped?: boolean
+  darker?: boolean
   'data-qa'?: string
 }
 
@@ -88,11 +98,12 @@ function AddButton({
   onClick,
   disabled = false,
   flipped = false,
+  darker = false,
   'data-qa': dataQa2
 }: AddButtonProps) {
   return (
     <StyledButton
-      className={classNames(className, { disabled, flipped })}
+      className={classNames(className, { disabled, flipped, darker })}
       data-qa={dataQa2 ?? dataQa}
       onClick={onClick}
       disabled={disabled}

--- a/frontend/src/lib-components/atoms/buttons/Button.stories.tsx
+++ b/frontend/src/lib-components/atoms/buttons/Button.stories.tsx
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
-import { faPen, faTrash } from 'lib-icons'
+import { storiesOf } from '@storybook/react'
+import { faChevronLeft, faPen, faTrash } from 'lib-icons'
+import React from 'react'
 import { H3 } from '../../typography'
 import { Gap } from '../../white-space'
 import AddButton from './AddButton'
@@ -41,7 +41,7 @@ storiesOf('evaka/atoms/buttons', module)
       <InlineButton onClick={onClick} text="Muokkaa" />
       <Gap />
 
-      <H3>Disabled</H3>
+      <H3>Default, disabled</H3>
       <InlineButton onClick={onClick} text="Poista" disabled />
       <Gap />
 
@@ -51,6 +51,34 @@ storiesOf('evaka/atoms/buttons', module)
 
       <H3>With icon, disabled</H3>
       <InlineButton onClick={onClick} text="Poista" icon={faTrash} disabled />
+      <Gap />
+
+      <H3>Darker</H3>
+      <p>Darker inline button is used on grey background.</p>
+      <InlineButton onClick={onClick} text="Palaa" darker />
+      <Gap />
+
+      <H3>Darker, disabled</H3>
+      <InlineButton onClick={onClick} text="Palaa" darker disabled />
+      <Gap />
+
+      <H3>Darker, with icon</H3>
+      <InlineButton
+        onClick={onClick}
+        text="Palaa"
+        icon={faChevronLeft}
+        darker
+      />
+      <Gap />
+
+      <H3>Darker, with icon, disabled</H3>
+      <InlineButton
+        onClick={onClick}
+        text="Palaa"
+        icon={faChevronLeft}
+        darker
+        disabled
+      />
       <Gap />
     </div>
   ))
@@ -78,62 +106,67 @@ storiesOf('evaka/atoms/buttons', module)
       <H3>Flipped</H3>
       <AddButton onClick={onClick} text="Luo uusi sijoitus" flipped />
       <Gap />
+
+      <H3>Darker</H3>
+      <AddButton onClick={onClick} text="Luo uusi sijoitus" darker />
+
+      <H3>Darker, disabled</H3>
+      <AddButton onClick={onClick} text="Luo uusi sijoitus" darker disabled />
+      <Gap />
     </div>
   ))
-  .add('AsyncButton', () => {
-    return (
-      <div>
-        <H3>Default (Success)</H3>
-        <AsyncButton
-          onClick={() =>
-            new Promise<void>((resolve) => void setTimeout(resolve, 2000))
-          }
-          onSuccess={() => undefined}
-          text="Save"
-          textInProgress="Saving"
-          textDone="Saved"
-        />
-        <Gap />
+  .add('AsyncButton', () => (
+    <div>
+      <H3>Default (Success)</H3>
+      <AsyncButton
+        onClick={() =>
+          new Promise<void>((resolve) => void setTimeout(resolve, 2000))
+        }
+        onSuccess={() => undefined}
+        text="Save"
+        textInProgress="Saving"
+        textDone="Saved"
+      />
+      <Gap />
 
-        <H3>Default (Failure)</H3>
-        <AsyncButton
-          onClick={() =>
-            new Promise<void>((resolve) => void setTimeout(resolve, 2000)).then(
-              () => {
-                throw 'Error'
-              }
-            )
-          }
-          onSuccess={() => undefined}
-          text="Save"
-          textInProgress="Saving"
-          textDone="Saved"
-        />
-        <Gap />
+      <H3>Default (Failure)</H3>
+      <AsyncButton
+        onClick={() =>
+          new Promise<void>((resolve) => void setTimeout(resolve, 2000)).then(
+            () => {
+              throw 'Error'
+            }
+          )
+        }
+        onSuccess={() => undefined}
+        text="Save"
+        textInProgress="Saving"
+        textDone="Saved"
+      />
+      <Gap />
 
-        <H3>Primary</H3>
-        <AsyncButton
-          onClick={() =>
-            new Promise<void>((resolve) => void setTimeout(resolve, 2000))
-          }
-          onSuccess={() => undefined}
-          text="Save"
-          textInProgress="Saving"
-          textDone="Saved"
-          primary
-        />
-        <Gap />
+      <H3>Primary</H3>
+      <AsyncButton
+        onClick={() =>
+          new Promise<void>((resolve) => void setTimeout(resolve, 2000))
+        }
+        onSuccess={() => undefined}
+        text="Save"
+        textInProgress="Saving"
+        textDone="Saved"
+        primary
+      />
+      <Gap />
 
-        <H3>Disabled</H3>
-        <AsyncButton
-          onClick={() => new Promise(() => undefined)}
-          onSuccess={() => undefined}
-          text="Save"
-          textInProgress="Saving"
-          textDone="Saved"
-          disabled
-        />
-        <Gap />
-      </div>
-    )
-  })
+      <H3>Disabled</H3>
+      <AsyncButton
+        onClick={() => new Promise(() => undefined)}
+        onSuccess={() => undefined}
+        text="Save"
+        textInProgress="Saving"
+        textDone="Saved"
+        disabled
+      />
+      <Gap />
+    </div>
+  ))

--- a/frontend/src/lib-components/atoms/buttons/InlineButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/InlineButton.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components'
 import classNames from 'classnames'
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import colors, { greyscale } from '../../colors'
+import colors, { blueColors, greyscale } from '../../colors'
 import { defaultMargins } from '../../white-space'
 import { BaseProps } from '../../utils'
 import { defaultButtonTextStyle } from './button-commons'
@@ -43,6 +43,10 @@ const StyledButton = styled.button<{ color?: string }>`
     cursor: not-allowed;
   }
 
+  &.darker:not(.disabled) {
+    color: ${blueColors.dark};
+  }
+
   svg {
     margin-right: ${defaultMargins.xs};
     font-size: 1.25em;
@@ -63,6 +67,7 @@ interface InlineButtonProps extends BaseProps {
   color?: string
   icon?: IconDefinition
   disabled?: boolean
+  darker?: boolean
   iconRight?: boolean
 }
 
@@ -74,13 +79,14 @@ function InlineButton({
   altText,
   icon,
   disabled = false,
+  darker = false,
   color,
   iconRight,
   'data-qa': dataQa2
 }: InlineButtonProps) {
   return (
     <StyledButton
-      className={classNames(className, { disabled })}
+      className={classNames(className, { disabled, darker })}
       data-qa={dataQa2 ?? dataQa}
       onClick={onClick}
       disabled={disabled}


### PR DESCRIPTION
#### Summary

Fixes WCAG compliance on light grey background.
Design system: Button color is exceptionally #013C8c if it's on light grey background.

<img width="392" alt="image" src="https://user-images.githubusercontent.com/1176169/114846115-07de1a80-9de5-11eb-8d22-256047b2c224.png">

Also add `cursor: not-allowed;` to disabled AddButton. Update stories.
