### PR TITLE
EVAKA-4157 Daily service times UX enhancements & E2E tests

### DIFF
--- a/frontend/src/e2e-playwright/pages/employee/child-information.ts
+++ b/frontend/src/e2e-playwright/pages/employee/child-information.ts
@@ -1,27 +1,16 @@
 import { Page } from 'playwright'
 import { RawElement } from 'e2e-playwright/utils/element'
 
-export type Collapsible = 'dailyServiceTimes'
-
 export default class ChildInformationPage {
   constructor(private readonly page: Page) {}
 
-  readonly #collapsibles: Record<Collapsible, RawElement> = {
-    dailyServiceTimes: new RawElement(
-      this.page,
-      '[data-qa="child-daily-service-times-collapsible"]'
-    )
-  }
-
-  async openCollapsible(collapsible: Collapsible) {
-    const element = this.#collapsibles[collapsible]
+  async openCollapsible<C extends Collapsible>(
+    collapsible: C
+  ): Promise<SectionFor<C>> {
+    const { selector, section } = collapsibles[collapsible]
+    const element = new RawElement(this.page, selector)
     await element.click()
-    return element
-  }
-
-  async openDailyServiceTimesCollapsible() {
-    const element = await this.openCollapsible('dailyServiceTimes')
-    return new DailyServiceTimeSection(element)
+    return new section(element) as SectionFor<C>
   }
 }
 
@@ -88,3 +77,16 @@ export class DailyServiceTimesSectionEdit {
     await this.#submitButton.click()
   }
 }
+
+const collapsibles = {
+  dailyServiceTimes: {
+    selector: '[data-qa="child-daily-service-times-collapsible"]',
+    section: DailyServiceTimeSection
+  }
+}
+
+type Collapsibles = typeof collapsibles
+type Collapsible = keyof Collapsibles
+type SectionFor<C extends Collapsible> = InstanceType<
+  Collapsibles[C]['section']
+>

--- a/frontend/src/e2e-playwright/pages/employee/child-information.ts
+++ b/frontend/src/e2e-playwright/pages/employee/child-information.ts
@@ -1,0 +1,90 @@
+import { Page } from 'playwright'
+import { RawElement } from 'e2e-playwright/utils/element'
+
+export type Collapsible = 'dailyServiceTimes'
+
+export default class ChildInformationPage {
+  constructor(private readonly page: Page) {}
+
+  readonly #collapsibles: Record<Collapsible, RawElement> = {
+    dailyServiceTimes: new RawElement(
+      this.page,
+      '[data-qa="child-daily-service-times-collapsible"]'
+    )
+  }
+
+  async openCollapsible(collapsible: Collapsible) {
+    const element = this.#collapsibles[collapsible]
+    await element.click()
+    return element
+  }
+
+  async openDailyServiceTimesCollapsible() {
+    const element = await this.openCollapsible('dailyServiceTimes')
+    return new DailyServiceTimeSection(element)
+  }
+}
+
+export class DailyServiceTimeSection {
+  constructor(private section: RawElement) {}
+
+  readonly #typeText = this.section.find('[data-qa="times-type"]')
+  readonly #timesText = this.section.find('[data-qa="times"]')
+  readonly #editButton = this.section.find('[data-qa="edit-button"]')
+
+  get typeText(): Promise<string> {
+    return this.#typeText.innerText
+  }
+
+  get timesText(): Promise<string> {
+    return this.#timesText.innerText
+  }
+
+  get hasTimesText(): Promise<boolean> {
+    return this.#timesText.visible
+  }
+
+  async edit() {
+    await this.#editButton.click()
+    return new DailyServiceTimesSectionEdit(this.section)
+  }
+}
+
+export class DailyServiceTimesSectionEdit {
+  readonly #notSetRadio = this.section.find('[data-qa="radio-not-set"]')
+
+  readonly #regularRadio = this.section.find('[data-qa="radio-regular"]')
+  readonly #irregularRadio = this.section.find('[data-qa="radio-irregular"]')
+  readonly #submitButton = this.section.find('[data-qa="submit-button"]')
+
+  constructor(private section: RawElement) {}
+
+  async selectTimeNotSet() {
+    await this.#notSetRadio.click()
+  }
+
+  async selectRegularTime() {
+    await this.#regularRadio.click()
+  }
+
+  async selectIrregularTime() {
+    await this.#irregularRadio.click()
+  }
+
+  async fillTimeRange(which: string, start: string, end: string) {
+    await this.section.findInput(`[data-qa="${which}-start"]`).fill(start)
+    await this.section.findInput(`[data-qa="${which}-end"]`).fill(end)
+  }
+
+  async selectDay(day: string) {
+    await this.section.find(`[data-qa="${day}-checkbox"]`).click()
+  }
+
+  get submitIsDisabled(): Promise<boolean> {
+    return this.#submitButton.disabled
+  }
+
+  async submit() {
+    await this.#submitButton.click()
+  }
+}

--- a/frontend/src/e2e-playwright/specs/5_employee/child-information.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/child-information.spec.ts
@@ -54,7 +54,7 @@ beforeEach(async () => {
 describe('Child Information - daily service times', () => {
   let section: DailyServiceTimeSection
   beforeEach(async () => {
-    section = await childInformationPage.openDailyServiceTimesCollapsible()
+    section = await childInformationPage.openCollapsible('dailyServiceTimes')
   })
 
   test('no service times initially', async () => {

--- a/frontend/src/e2e-playwright/specs/5_employee/child-information.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/child-information.spec.ts
@@ -17,6 +17,11 @@ import ChildInformationPage, {
   DailyServiceTimeSection
 } from 'e2e-playwright/pages/employee/child-information'
 import { newBrowserContext } from 'e2e-playwright/browser'
+import {
+  waitUntilEqual,
+  waitUntilFalse,
+  waitUntilTrue
+} from 'e2e-playwright/utils'
 
 let page: Page
 let childInformationPage: ChildInformationPage
@@ -53,14 +58,14 @@ describe('Child Information - daily service times', () => {
   })
 
   test('no service times initially', async () => {
-    expect(await section.typeText).toEqual('Ei asetettu')
-    expect(await section.hasTimesText).toEqual(false)
+    await waitUntilEqual(() => section.typeText, 'Ei asetettu')
+    await waitUntilFalse(() => section.hasTimesText)
   })
 
   test('cannot save regular without setting times', async () => {
     const editor = await section.edit()
     await editor.selectRegularTime()
-    expect(await editor.submitIsDisabled).toEqual(true)
+    await waitUntilTrue(() => editor.submitIsDisabled)
   })
 
   test('set regular daily service times', async () => {
@@ -69,14 +74,20 @@ describe('Child Information - daily service times', () => {
     await editor.fillTimeRange('regular', '09:00', '17:00')
     await editor.submit()
 
-    expect(await section.typeText).toEqual('Säännöllinen varhaiskasvatusaika')
-    expect(await section.timesText).toEqual('maanantai-perjantai 09:00–17:00')
+    await waitUntilEqual(
+      () => section.typeText,
+      'Säännöllinen varhaiskasvatusaika'
+    )
+    await waitUntilEqual(
+      () => section.timesText,
+      'maanantai-perjantai 09:00–17:00'
+    )
   })
 
   test('cannot save irregular without setting times', async () => {
     const editor = await section.edit()
     await editor.selectIrregularTime()
-    expect(await editor.submitIsDisabled).toEqual(true)
+    await waitUntilTrue(() => editor.submitIsDisabled)
   })
 
   test('set irregular daily service times', async () => {
@@ -88,10 +99,12 @@ describe('Child Information - daily service times', () => {
     await editor.fillTimeRange('friday', '09:00', '13:30')
     await editor.submit()
 
-    expect(await section.typeText).toEqual(
+    await waitUntilEqual(
+      () => section.typeText,
       'Epäsäännöllinen varhaiskasvatusaika'
     )
-    expect(await section.timesText).toEqual(
+    await waitUntilEqual(
+      () => section.timesText,
       'maanantai 08:15-16:45, perjantai 09:00-13:30'
     )
   })

--- a/frontend/src/e2e-playwright/specs/5_employee/child-information.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/child-information.spec.ts
@@ -1,0 +1,98 @@
+import { Page } from 'playwright'
+import config from 'e2e-test-common/config'
+import {
+  insertDaycareGroupFixtures,
+  insertDaycarePlacementFixtures,
+  resetDatabase
+} from 'e2e-test-common/dev-api'
+import { initializeAreaAndPersonData } from 'e2e-test-common/dev-api/data-init'
+import {
+  createDaycarePlacementFixture,
+  daycareGroupFixture,
+  uuidv4
+} from 'e2e-test-common/dev-api/fixtures'
+import { UUID } from 'e2e-test-common/dev-api/types'
+import EmployeeNav from 'e2e-playwright/pages/employee/employee-nav'
+import ChildInformationPage, {
+  DailyServiceTimeSection
+} from 'e2e-playwright/pages/employee/child-information'
+import { newBrowserContext } from 'e2e-playwright/browser'
+
+let page: Page
+let childInformationPage: ChildInformationPage
+let childId: UUID
+
+beforeEach(async () => {
+  await resetDatabase()
+
+  const [fixtures] = await initializeAreaAndPersonData()
+  await insertDaycareGroupFixtures([daycareGroupFixture])
+
+  const unitId = fixtures.daycareFixture.id
+  childId = fixtures.familyWithTwoGuardians.children[0].id
+
+  const daycarePlacementFixture = createDaycarePlacementFixture(
+    uuidv4(),
+    childId,
+    unitId
+  )
+  await insertDaycarePlacementFixtures([daycarePlacementFixture])
+
+  page = await (await newBrowserContext()).newPage()
+  await page.goto(config.employeeUrl)
+  const nav = new EmployeeNav(page)
+  await nav.login('admin')
+  await page.goto(config.employeeUrl + '/child-information/' + childId)
+  childInformationPage = new ChildInformationPage(page)
+})
+
+describe('Child Information - daily service times', () => {
+  let section: DailyServiceTimeSection
+  beforeEach(async () => {
+    section = await childInformationPage.openDailyServiceTimesCollapsible()
+  })
+
+  test('no service times initially', async () => {
+    expect(await section.typeText).toEqual('Ei asetettu')
+    expect(await section.hasTimesText).toEqual(false)
+  })
+
+  test('cannot save regular without setting times', async () => {
+    const editor = await section.edit()
+    await editor.selectRegularTime()
+    expect(await editor.submitIsDisabled).toEqual(true)
+  })
+
+  test('set regular daily service times', async () => {
+    const editor = await section.edit()
+    await editor.selectRegularTime()
+    await editor.fillTimeRange('regular', '09:00', '17:00')
+    await editor.submit()
+
+    expect(await section.typeText).toEqual('Säännöllinen varhaiskasvatusaika')
+    expect(await section.timesText).toEqual('maanantai-perjantai 09:00–17:00')
+  })
+
+  test('cannot save irregular without setting times', async () => {
+    const editor = await section.edit()
+    await editor.selectIrregularTime()
+    expect(await editor.submitIsDisabled).toEqual(true)
+  })
+
+  test('set irregular daily service times', async () => {
+    const editor = await section.edit()
+    await editor.selectIrregularTime()
+    await editor.selectDay('monday')
+    await editor.fillTimeRange('monday', '08:15', '16:45')
+    await editor.selectDay('friday')
+    await editor.fillTimeRange('friday', '09:00', '13:30')
+    await editor.submit()
+
+    expect(await section.typeText).toEqual(
+      'Epäsäännöllinen varhaiskasvatusaika'
+    )
+    expect(await section.timesText).toEqual(
+      'maanantai 08:15-16:45, perjantai 09:00-13:30'
+    )
+  })
+})

--- a/frontend/src/e2e-playwright/utils/element.ts
+++ b/frontend/src/e2e-playwright/utils/element.ts
@@ -32,6 +32,10 @@ export class RawElement {
     return this.page.isVisible(this.selector)
   }
 
+  get disabled(): Promise<boolean> {
+    return this.page.isDisabled(this.selector)
+  }
+
   async click(): Promise<void> {
     await this.page.click(this.selector)
   }
@@ -42,6 +46,10 @@ export class RawElement {
 
   find(descendant: string): RawElement {
     return new RawElement(this.page, `${this.selector} ${descendant}`)
+  }
+
+  findInput(descendant: string): RawTextInput {
+    return new RawTextInput(this.page, `${this.selector} ${descendant}`)
   }
 }
 
@@ -72,6 +80,11 @@ export const WithTextInput = <T extends Constructor<RawElement>>(
     async type(text: string): Promise<void> {
       await this.page.type(this.#input, text)
     }
+
+    async fill(text: string): Promise<void> {
+      await this.page.fill(this.#input, text)
+    }
+
     async clear(): Promise<void> {
       await this.page.click(this.#input, { clickCount: 3 })
       await this.page.keyboard.press('Backspace')

--- a/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
@@ -339,6 +339,7 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
                     text={i18n.common.edit}
                     icon={faPen}
                     onClick={startEditing}
+                    dataQa="edit-button"
                   />
                 </RightAlign>
 
@@ -346,17 +347,17 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
               </RequireRole>
 
               {apiData.value === null ? (
-                <FixedWidthLabel>
+                <FixedWidthLabel data-qa="times-type">
                   {i18n.childInformation.dailyServiceTimes.types.notSet}
                 </FixedWidthLabel>
               ) : (
                 <>
                   {isRegular(apiData.value) && (
                     <FixedSpaceRow>
-                      <FixedWidthLabel>
+                      <FixedWidthLabel data-qa="times-type">
                         {i18n.childInformation.dailyServiceTimes.types.regular}
                       </FixedWidthLabel>
-                      <div>
+                      <div data-qa="times">
                         {i18n.childInformation.dailyServiceTimes.weekdays.monday.toLowerCase()}
                         -
                         {i18n.childInformation.dailyServiceTimes.weekdays.friday.toLowerCase()}{' '}
@@ -367,13 +368,13 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
                   )}
                   {isIrregular(apiData.value) && (
                     <FixedSpaceRow>
-                      <FixedWidthLabel>
+                      <FixedWidthLabel data-qa="times-type">
                         {
                           i18n.childInformation.dailyServiceTimes.types
                             .irregular
                         }
                       </FixedWidthLabel>
-                      <div>
+                      <div data-qa="times">
                         {weekdays
                           .map((wd) =>
                             apiData.value &&
@@ -404,6 +405,7 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
                     label={i18n.childInformation.dailyServiceTimes.types.notSet}
                     checked={formData.type === 'NOT_SET'}
                     onChange={setType('NOT_SET')}
+                    data-qa="radio-not-set"
                   />
                   <Radio
                     label={
@@ -411,6 +413,7 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
                     }
                     checked={formData.type === 'REGULAR'}
                     onChange={setType('REGULAR')}
+                    dataQa="radio-regular"
                   />
                   {formData.type === 'REGULAR' && (
                     <FixedSpaceRow style={{ marginLeft: defaultMargins.XXL }}>
@@ -435,6 +438,7 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
                     }
                     checked={formData.type === 'IRREGULAR'}
                     onChange={setType('IRREGULAR')}
+                    dataQa="radio-irregular"
                   />
                   {formData.type === 'IRREGULAR' && (
                     <FixedSpaceColumn>
@@ -451,6 +455,7 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
                               }
                               checked={formData[wd].selected}
                               onChange={setWeekdaySelected(wd)}
+                              dataQa={`${wd}-checkbox`}
                             />
                           </div>
                           <FixedSpaceRow
@@ -492,6 +497,7 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
                     onClick={onSubmit}
                     disabled={submitting || !formIsValid}
                     primary
+                    dataQa="submit-button"
                   />
                 </FixedSpaceRow>
               </RightAlign>

--- a/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
@@ -24,18 +24,18 @@ import {
   getChildDailyServiceTimes,
   putChildDailyServiceTimes
 } from '../../api/child/daily-service-times'
-import { faClock, faPen } from '../../../lib-icons'
+import { faClock, faPen } from 'lib-icons'
 import styled from 'styled-components'
-import InlineButton from '../../../lib-components/atoms/buttons/InlineButton'
+import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import {
   FixedSpaceColumn,
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
-import Button from '../../../lib-components/atoms/buttons/Button'
+import Button from 'lib-components/atoms/buttons/Button'
 import { defaultMargins, Gap } from 'lib-components/white-space'
-import Radio from '../../../lib-components/atoms/form/Radio'
-import InputField from '../../../lib-components/atoms/form/InputField'
-import Checkbox from '../../../lib-components/atoms/form/Checkbox'
+import Radio from 'lib-components/atoms/form/Radio'
+import InputField from 'lib-components/atoms/form/InputField'
+import Checkbox from 'lib-components/atoms/form/Checkbox'
 import { UIContext } from '../../state/ui'
 import { RequireRole } from '../../utils/roles'
 import { NullableValues } from '../../types'
@@ -82,6 +82,7 @@ const emptyForm: FormData = {
 
 interface ValidationResult {
   regular: NullableValues<TimeInputRange>
+  irregular: true | null
   monday: NullableValues<TimeInputRange>
   tuesday: NullableValues<TimeInputRange>
   wednesday: NullableValues<TimeInputRange>
@@ -195,6 +196,11 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
           end:
             formData.type === 'REGULAR' ? required(formData.regular.end) : null
         },
+        irregular:
+          formData.type === 'IRREGULAR' &&
+          !weekdays.some((day) => formData[day].selected)
+            ? true
+            : null,
         monday: validateWeekday(formData, 'monday'),
         tuesday: validateWeekday(formData, 'tuesday'),
         wednesday: validateWeekday(formData, 'wednesday'),
@@ -283,6 +289,7 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
 
   const formIsValid =
     validationResult !== null &&
+    validationResult.irregular === null &&
     Object.values(validationResult.regular).find((v) => v !== null) ===
       undefined &&
     Object.values(validationResult.monday).find((v) => v !== null) ===

--- a/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
@@ -526,6 +526,7 @@ const TimeRangeInput = React.memo(function TimeRangeInput({
               }
             : undefined
         }
+        hideErrorsBeforeTouched
         width="s"
       />
       <span> - </span>
@@ -543,6 +544,7 @@ const TimeRangeInput = React.memo(function TimeRangeInput({
               }
             : undefined
         }
+        hideErrorsBeforeTouched
         width="s"
       />
     </>

--- a/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
@@ -453,7 +453,13 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
                               onChange={setWeekdaySelected(wd)}
                             />
                           </div>
-                          <FixedSpaceRow>
+                          <FixedSpaceRow
+                            style={
+                              !formData[wd].selected
+                                ? { display: 'none' }
+                                : undefined
+                            }
+                          >
                             <TimeRangeInput
                               value={formData[wd]}
                               onChange={setTimes(wd)}

--- a/frontend/src/employee-mobile-frontend/assets/i18n/fi.ts
+++ b/frontend/src/employee-mobile-frontend/assets/i18n/fi.ts
@@ -103,7 +103,8 @@ export const fi = {
     serviceTime: {
       serviceToday: (start: string, end: string) =>
         `Varhaiskasvatusaika tänään ${start}-${end}`,
-      noServiceToday: 'Ei varattua varhaiskasvatusaikaa tänään'
+      noServiceToday: 'Ei varattua varhaiskasvatusaikaa tänään',
+      notSet: 'Varhaiskasvatusaikaa ei asetettuna'
     },
     notes: {
       dailyNotes: 'Päivän muistiinpanot',


### PR DESCRIPTION
#### Summary

- UX improvements:
    - Require at least one day to be selected in irregular times
    - Show irregular time inputs only after checking the checkbox for that day
    - Show time input errors only after they've been touched
    - Mobile: Indicate not set daily service times
- Add employee side e2e tests
- Reduce duplication in employee-side code

![Screenshot-2021-04-15T13:17:08+03:00](https://user-images.githubusercontent.com/70927/114853928-f6990c00-9dec-11eb-997d-6a39c90b7a51.png)
