### PR TITLE
Apply global styles in storybook stories so that fonts work

### DIFF
--- a/frontend/src/lib-components/.storybook/preview-head.html
+++ b/frontend/src/lib-components/.storybook/preview-head.html
@@ -5,11 +5,22 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 -->
 
 <link
-  href="https://fonts.googleapis.com/css?family=Montserrat:200,300,400,700|Open+Sans:300,400,600,700"
+  href="https://fonts.googleapis.com/css?family=Montserrat:200,300,400,500,700|Open+Sans:300,400,600,700"
   rel="stylesheet"
 />
 
 <style>
+  html {
+    color: #0f0f0f;
+    font-size: 100%;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+  body {
+    font-family: 'Open Sans', 'Arial', sans-serif;
+    background-color: #f5f5f5;
+    margin: 0;
+  }
   .root {
     padding: 1em;
   }


### PR DESCRIPTION
Before
<img width="292" alt="image" src="https://user-images.githubusercontent.com/1176169/114908419-bf465180-9e24-11eb-941f-a5b1f420292d.png">

After
<img width="302" alt="image" src="https://user-images.githubusercontent.com/1176169/114908528-dc7b2000-9e24-11eb-9bb7-d95731bcae4b.png">
