### PR TITLE
EVAKA-4160 show attachment uploader 

### DIFF
--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -102,10 +102,19 @@ export default class ApplicationReadView {
       .ok()
   }
 
-  async assertReceivedAtTextExists(fileName: string) {
-    await t
-      .expect(Selector(`[data-qa="attachment-${fileName}-received-at"]`).exists)
-      .ok()
+  async assertUrgencyAttachmentReceivedAtVisible(
+    fileName: string,
+    byPaper = true
+  ) {
+    const attachment = Selector(`[data-qa="urgent-attachment-${fileName}"]`)
+    await t.expect(attachment.exists).ok()
+
+    const text = attachment.find(`[data-qa="attachment-received-at"]`)
+    await t.expect(text.visible).ok()
+
+    byPaper
+      ? await t.expect(text.textContent).match(/^Toimitettu paperisena/)
+      : await t.expect(text.textContent).match(/^Toimitettu sähköisesti/)
   }
 
   async assertUrgentAttachmentDoesNotExists(fileName: string) {

--- a/frontend/src/e2e-test/specs/2_employee-2/application-attachments.spec.ts
+++ b/frontend/src/e2e-test/specs/2_employee-2/application-attachments.spec.ts
@@ -70,5 +70,7 @@ test('Employee can add and remove attachments', async (t) => {
   await applicationEditView.saveApplication()
 
   await applicationReadView.openApplicationByLink(applicationFixtureId)
-  await applicationReadView.assertReceivedAtTextExists(testFileName)
+  await applicationReadView.assertUrgencyAttachmentReceivedAtVisible(
+    testFileName
+  )
 })

--- a/frontend/src/employee-frontend/assets/i18n/fi.ts
+++ b/frontend/src/employee-frontend/assets/i18n/fi.ts
@@ -423,7 +423,8 @@ export const fi = {
       name: 'Tiedostonimi',
       updated: 'Muutettu',
       contentType: 'Tyyppi',
-      receivedAt: 'Liite lähetetty'
+      receivedByPaperAt: 'Toimitettu paperisena',
+      receivedAt: 'Toimitettu sähköisesti'
     },
     state: {
       title: 'Hakemuksen tila',

--- a/frontend/src/employee-frontend/components/common/Attachment.tsx
+++ b/frontend/src/employee-frontend/components/common/Attachment.tsx
@@ -76,8 +76,10 @@ function Attachment({ attachment, dataQa }: Props) {
           }
           dataQa={'attachment-download'}
         />
-        <ReceivedAtText data-qa={`attachment-${attachment.name}-received-at`}>
-          {i18n.application.attachments.receivedAt}{' '}
+        <ReceivedAtText data-qa={`attachment-received-at`}>
+          {attachment.uploadedByEmployee
+            ? i18n.application.attachments.receivedByPaperAt
+            : i18n.application.attachments.receivedAt}{' '}
           {LocalDate.fromSystemTzDate(attachment.receivedAt).format()}
         </ReceivedAtText>
       </FixedSpaceRow>

--- a/frontend/src/lib-common/api-types/application/ApplicationDetails.ts
+++ b/frontend/src/lib-common/api-types/application/ApplicationDetails.ts
@@ -220,4 +220,6 @@ export interface ApplicationAttachment extends Attachment {
   updated: Date
   receivedAt: Date
   type: AttachmentType
+  uploadedByEmployee?: UUID
+  uploadedByPerson?: UUID
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -103,7 +103,9 @@ data class Attachment(
     val contentType: String,
     val updated: OffsetDateTime,
     val receivedAt: OffsetDateTime,
-    val type: AttachmentType
+    val type: AttachmentType,
+    val uploadedByEmployee: UUID?,
+    val uploadedByPerson: UUID?
 )
 
 enum class ApplicationType {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -566,7 +566,7 @@ fun fetchApplicationDetails(h: Handle, applicationId: UUID, includeCitizenAttach
         LEFT JOIN person c ON c.id = a.child_id
         LEFT JOIN person g1 ON g1.id = a.guardian_id
         LEFT JOIN (
-            SELECT application_id, jsonb_agg(jsonb_build_object('id', id, 'name', name, 'contentType', content_type, 'updated', updated, 'receivedAt', received_at, 'type', type)) json
+            SELECT application_id, jsonb_agg(jsonb_build_object('id', id, 'name', name, 'contentType', content_type, 'updated', updated, 'receivedAt', received_at, 'type', type, 'uploadedByEmployee', uploaded_by_employee, 'uploadedByPerson', uploaded_by_person)) json
             FROM attachment $attachmentWhereClause
             GROUP BY application_id
         ) att ON a.id = att.application_id
@@ -917,7 +917,7 @@ RETURNING id
     .toList()
 
 fun Database.Read.getApplicationAttachments(applicationId: UUID): List<Attachment> =
-    createQuery("SELECT id, name, content_type, updated, received_at, type FROM attachment WHERE application_id = :applicationId")
+    createQuery("SELECT id, name, content_type, updated, received_at, type, uploaded_by_employee, uploaded_by_person FROM attachment WHERE application_id = :applicationId")
         .bind("applicationId", applicationId)
         .mapTo<Attachment>()
         .toList()
@@ -925,7 +925,7 @@ fun Database.Read.getApplicationAttachments(applicationId: UUID): List<Attachmen
 fun Database.Read.getApplicationAttachmentsForUnitSupervisor(applicationId: UUID): List<Attachment> =
     createQuery(
         """
-SELECT attachment.id, attachment.name, attachment.content_type, attachment.updated, attachment.received_at, attachment.type
+SELECT attachment.id, attachment.name, attachment.content_type, attachment.updated, attachment.received_at, attachment.type, attachment.uploaded_by_employee, attachment.uploaded_by_person
 FROM attachment
 JOIN application ON application.id = attachment.application_id
 JOIN placement_plan ON placement_plan.application_id = application.id


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Show that attachment is (or is not) uploaded by employee. For now this is indicated only in the application read view for the FileUpload component is too general for context dependant details like this (discussed & approved with UX).

<img width="1028" alt="Screenshot 2021-04-16 at 10 46 28" src="https://user-images.githubusercontent.com/3275771/114990577-50f3a480-9ea1-11eb-9c9b-3ef8666c9937.png">
