### PR TITLE
Don't use jcenter repository

### DIFF
--- a/message-service/build.gradle.kts
+++ b/message-service/build.gradle.kts
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -35,7 +35,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 

--- a/message-service/buildSrc/build.gradle.kts
+++ b/message-service/buildSrc/build.gradle.kts
@@ -7,6 +7,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }

--- a/service-lib/build.gradle.kts
+++ b/service-lib/build.gradle.kts
@@ -14,7 +14,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -8,7 +8,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath(files("custom-ktlint-rules/custom-ktlint-rules.jar"))
@@ -31,7 +31,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 

--- a/service/buildSrc/build.gradle.kts
+++ b/service/buildSrc/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 

--- a/service/custom-ktlint-rules/build.gradle
+++ b/service/custom-ktlint-rules/build.gradle
@@ -4,7 +4,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -20,7 +20,6 @@ sourceSets {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 

--- a/service/vtjclient/build.gradle.kts
+++ b/service/vtjclient/build.gradle.kts
@@ -4,7 +4,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -20,7 +20,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

JCenter should no longer be used:

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

