### PR TITLE
EVAKA-HOTFIX: display original preferred start date on child's application list

### DIFF
--- a/frontend/src/employee-frontend/api/person.ts
+++ b/frontend/src/employee-frontend/api/person.ts
@@ -108,7 +108,7 @@ export async function getGuardianApplicationSummaries(
     .then((res) =>
       res.data.map((data) => ({
         ...data,
-        startDate: LocalDate.parseIso(data.startDate),
+        preferredStartDate: LocalDate.parseIso(data.preferredStartDate),
         sentDate: LocalDate.parseNullableIso(data.sentDate)
       }))
     )
@@ -124,7 +124,7 @@ export async function getChildApplicationSummaries(
     .then((res) =>
       res.data.map((data) => ({
         ...data,
-        startDate: LocalDate.parseIso(data.startDate),
+        preferredStartDate: LocalDate.parseIso(data.preferredStartDate),
         sentDate: LocalDate.parseNullableIso(data.sentDate)
       }))
     )

--- a/frontend/src/employee-frontend/components/child-information/ChildApplications.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildApplications.tsx
@@ -75,7 +75,7 @@ const ChildApplications = React.memo(function ChildApplications({
               </Link>
             </Td>
             <DateTd data-qa="application-start-date">
-              {application.startDate.format()}
+              {application.preferredStartDate.format()}
             </DateTd>
             <DateTd data-qa="application-sent-date">
               {application.sentDate?.format()}

--- a/frontend/src/employee-frontend/components/child-information/ChildApplications.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildApplications.tsx
@@ -56,7 +56,7 @@ const ChildApplications = React.memo(function ChildApplications({
     } else
       return _.orderBy(
         applications.value,
-        ['startDate', 'preferredUnitName'],
+        ['preferredStartDate', 'preferredUnitName'],
         ['desc', 'desc']
       ).map((application: ApplicationSummary) => {
         return (

--- a/frontend/src/employee-frontend/components/person-profile/PersonApplications.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonApplications.tsx
@@ -63,7 +63,7 @@ const PersonApplications = React.memo(function PersonApplications({
                 </Link>
               </Td>
               <DateTd data-qa="application-start-date">
-                {application.startDate.format()}
+                {application.preferredStartDate.format()}
               </DateTd>
               <DateTd data-qa="application-sent-date">
                 {application.sentDate?.format()}

--- a/frontend/src/employee-frontend/components/person-profile/PersonApplications.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonApplications.tsx
@@ -44,7 +44,7 @@ const PersonApplications = React.memo(function PersonApplications({
     applications.isSuccess
       ? _.orderBy(
           applications.value,
-          ['startDate', 'preferredUnitName'],
+          ['preferredStartDate', 'preferredUnitName'],
           ['desc', 'desc']
         ).map((application: ApplicationSummary) => {
           return (

--- a/frontend/src/employee-frontend/types/application.ts
+++ b/frontend/src/employee-frontend/types/application.ts
@@ -28,7 +28,7 @@ export interface ApplicationSummary {
   childName: string
   childSsn: string
   guardianName: string
-  startDate: LocalDate
+  preferredStartDate: LocalDate
   sentDate: LocalDate | null
   preferredUnitId: UUID
   preferredUnitName: string

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -66,7 +66,7 @@ data class PersonApplicationSummary(
     val childName: String?,
     val childSsn: String?,
     val guardianName: String,
-    val startDate: LocalDate?,
+    val preferredStartDate: LocalDate?,
     val sentDate: LocalDate?,
     val type: String,
     val status: ApplicationStatus,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -423,7 +423,7 @@ fun fetchApplicationSummariesForGuardian(h: Handle, guardianId: UUID): List<Pers
     val sql =
         """
         SELECT
-            a.id, a.preferredUnit, a.preferredStartDate AS startDate, a.sentDate, a.document->>'type' AS type,
+            a.id, a.preferredUnit, a.preferredStartDate, a.sentDate, a.document->>'type' AS type,
             a.childId, a.childName, a.childSsn,
             a.guardianId, concat(p.first_name, ' ', p.last_name) as guardianName,
             a.connecteddaycare,
@@ -449,7 +449,7 @@ fun fetchApplicationSummariesForChild(h: Handle, childId: UUID): List<PersonAppl
     val sql =
         """
         SELECT
-            a.id, a.preferredUnit, a.preferredStartDate AS startDate, a.sentDate, a.document->>'type' AS type,
+            a.id, a.preferredUnit, a.preferredStartDate, a.sentDate, a.document->>'type' AS type,
             a.childId, a.childName, a.childSsn,
             a.guardianId, concat(p.first_name, ' ', p.last_name) as guardianName,
             a.connecteddaycare,
@@ -526,7 +526,7 @@ private val toPersonApplicationSummary: (ResultSet, StatementContext) -> PersonA
         childName = rs.getString("childName"),
         childSsn = rs.getString("childSsn"),
         guardianName = rs.getString("guardianName"),
-        startDate = rs.getDate("startDate")?.toLocalDate(),
+        preferredStartDate = rs.getDate("preferredStartDate")?.toLocalDate(),
         sentDate = rs.getDate("sentDate")?.toLocalDate(),
         type = rs.getString("type"),
         status = rs.getEnum("application_status"),

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -423,7 +423,7 @@ fun fetchApplicationSummariesForGuardian(h: Handle, guardianId: UUID): List<Pers
     val sql =
         """
         SELECT
-            a.id, a.preferredUnit, a.startDate, a.sentDate, a.document->>'type' AS type,
+            a.id, a.preferredUnit, a.preferredStartDate AS startDate, a.sentDate, a.document->>'type' AS type,
             a.childId, a.childName, a.childSsn,
             a.guardianId, concat(p.first_name, ' ', p.last_name) as guardianName,
             a.connecteddaycare,
@@ -449,7 +449,7 @@ fun fetchApplicationSummariesForChild(h: Handle, childId: UUID): List<PersonAppl
     val sql =
         """
         SELECT
-            a.id, a.preferredUnit, a.startDate, a.sentDate, a.document->>'type' AS type,
+            a.id, a.preferredUnit, a.preferredStartDate AS startDate, a.sentDate, a.document->>'type' AS type,
             a.childId, a.childName, a.childSsn,
             a.guardianId, concat(p.first_name, ' ', p.last_name) as guardianName,
             a.connecteddaycare,

--- a/service/src/main/resources/db/migration/R__application_view.sql
+++ b/service/src/main/resources/db/migration/R__application_view.sql
@@ -12,6 +12,7 @@ CREATE OR REPLACE VIEW application_view (
   status,
   type,
   urgent,
+  preferredStartDate,
   startDate,
   childName,
   childFirstName,
@@ -57,6 +58,7 @@ SELECT
   status,
   type,
   urgent,
+  preferredStartDate,
   startDate,
   childFirstName || ' ' || childLastName AS childName,
   childFirstName,
@@ -132,6 +134,7 @@ SELECT
   appl.other_guardian_id                                                                      AS otherGuardianId,
   data.document ->> 'type'                                                                    AS type,
   (data.document ->> 'urgent') :: BOOLEAN                                                     AS urgent,
+  (data.document ->> 'preferredStartDate')::DATE                                              AS preferredStartDate,
   COALESCE(
       (SELECT min(coalesce(d.requested_start_date, d.start_date)) FROM decision d WHERE d.application_id = appl.id AND d.status != 'REJECTED'),
       placement_plan.start_date,


### PR DESCRIPTION
#### Summary
Application list on child's and guardian's page should display the preferred start date given on application instead of the "estimated start date" calculated by application_view

slack discussion: https://voltti.slack.com/archives/CP6E9QKFE/p1618835024069300
