### PR TITLE
[EVAKA] service-lib: add basic docs and known issues, suppress message-service vuln

### DIFF
--- a/message-service/owasp-suppressions.xml
+++ b/message-service/owasp-suppressions.xml
@@ -53,4 +53,11 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         ]]></notes>
         <cve>CVE-2021-22696</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Not a high enough risk in our use case (containerized workloads and hardly any file reads).
+        Not worth effort for upgrading right now.
+        ]]></notes>
+        <cve>CVE-2021-29425</cve>
+    </suppress>
 </suppressions>

--- a/service-lib/README.md
+++ b/service-lib/README.md
@@ -1,0 +1,16 @@
+# service-lib
+
+A collection of library-like functionalities for eVaka Kotlin services, such
+as a common logger and JWT authentication.
+
+## Development
+
+Building and testing is done as a part of the using Kotlin service builds,
+i.e. evaka-service and evaka-message-service, using this project as a
+sub-project dependency.
+
+## Known issues
+
+- [ ] Multiple Logback `ConsoleAppender`s could theoretically corrupt
+    eachother's JSON logs if more than one of them output at the same time
+    (w/ multiline content)


### PR DESCRIPTION
#### Summary
- As we currently have no known cases nor a solution for the known issue with multiple Logback ConsoleAppenders theoretically corrupting eachother's JSON outputs, just document it in the (newly created) service-lib README
- message-service: suppress CVE-2021-29425
    - Not high risk enough in message-service's context, suppressing