### PR TITLE
EVAKA-4195 Send email confirmation for club application

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.application.ApplicationStatus.WAITING_PLACEMENT
 import fi.espoo.evaka.application.ApplicationStatus.WAITING_UNIT_CONFIRMATION
 import fi.espoo.evaka.daycare.controllers.AdditionalInformation
 import fi.espoo.evaka.daycare.controllers.Child
+import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.getActivePreschoolTermAt
 import fi.espoo.evaka.daycare.getDaycare
@@ -130,8 +131,12 @@ class ApplicationStateService(
                 tx.handle.getDaycare(application.form.preferences.preferredUnits.first().id)!! // should never be null after validation
 
             if (preferredUnit.providerType != ProviderType.PRIVATE_SERVICE_VOUCHER) {
-                asyncJobRunner.plan(tx, listOf(SendApplicationEmail(application.guardianId, preferredUnit.language)))
+                asyncJobRunner.plan(tx, listOf(SendApplicationEmail(application.guardianId, preferredUnit.language, ApplicationType.DAYCARE)))
             }
+        }
+
+        if (!application.hideFromGuardian && application.type == ApplicationType.CLUB) {
+            asyncJobRunner.plan(tx, listOf(SendApplicationEmail(application.guardianId, Language.fi, ApplicationType.CLUB)))
         }
 
         updateApplicationStatus(tx.handle, application.id, SENT)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/SendApplicationReceivedEmailAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/SendApplicationReceivedEmailAsyncJobs.kt
@@ -28,7 +28,7 @@ class SendApplicationReceivedEmailAsyncJobs(
             ?: throw Exception("Didn't find guardian when sending application email (guardianId: ${msg.guardianId})")
 
         if (!guardian.email.isNullOrBlank()) {
-            applicationReceivedEmailService.sendApplicationEmail(guardian.id, guardian.email, msg.language)
+            applicationReceivedEmailService.sendApplicationEmail(guardian.id, guardian.email, msg.language, msg.type)
         } else {
             logger.warn("Cannot send application received email to guardian ${guardian.id}: missing email")
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.async
 
+import fi.espoo.evaka.application.ApplicationType
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.koski.KoskiSearchParams
 import fi.espoo.evaka.koski.KoskiStudyRightKey
@@ -47,7 +48,7 @@ data class GarbageCollectPairing(val pairingId: UUID) : AsyncJobPayload {
     override val user: AuthenticatedUser? = null
 }
 
-data class SendApplicationEmail(val guardianId: UUID, val language: Language) : AsyncJobPayload {
+data class SendApplicationEmail(val guardianId: UUID, val language: Language, val type: ApplicationType = ApplicationType.DAYCARE) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.SEND_APPLICATION_EMAIL
     override val user: AuthenticatedUser? = null
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Send citizen a confirmation email when club application is received. This is just a trivial extension to an existing feature.