### PR TITLE
Evaka fix update every person vtj changes

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -66,9 +66,7 @@ private fun Database.Transaction.deleteOldJobs() =
 private fun Database.Read.getPersonSsnsToUpdate(): List<String> = createQuery(
     //language=sql
     """
-SELECT DISTINCT(social_security_number) from PERSON p JOIN (
-SELECT head_of_child FROM fridge_child
-WHERE daterange(start_date, end_date, '[]') @> current_date AND conflict = false) hoc ON p.id = hoc.head_of_child
+SELECT DISTINCT(social_security_number) FROM person
     """.trimIndent()
 )
     .mapTo<String>()

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
@@ -70,7 +70,7 @@ class DvvModificationsService(
                                 infoGroup
                             )
                             is HomeMunicipalityDvvInfoGroup -> handleHomeMunicipalityChangeDvvInfoGroup()
-                            else -> logger.info("Unsupported DVV modification: ${infoGroup.tietoryhma}")
+                            else -> logger.info("Unsupported DVV modification: ${infoGroup.tietoryhma} (all modification in this group: ${personModifications.tietoryhmat.map{it.tietoryhma}.joinToString(", ")})")
                         }
                     } catch (e: Throwable) {
                         logger.error(e) {


### PR DESCRIPTION
#### Summary
- Get vtj updates on all persons (has been agreed with DVV)
- When encountering an unknown modification, print out all the modifications in the group so that it can be ensured we handle at least one modification in the group. 

