### PR TITLE
[EVAKA-HOTFIX] Revert "EVAKA temporary fix for owasp dependency check"

### DIFF
--- a/message-service/build.gradle.kts
+++ b/message-service/build.gradle.kts
@@ -204,10 +204,6 @@ tasks {
     }
 
     dependencyCheck {
-        cve.apply {
-            urlBase = "https://freedumbytes.gitlab.io/setup/nist-nvd-mirror/nvdcve-1.1-%d.json.gz"
-            urlModified = "https://freedumbytes.gitlab.io/setup/nist-nvd-mirror/nvdcve-1.1-modified.json.gz"
-        }
         failBuildOnCVSS = 0.0f
         analyzers.apply {
             assemblyEnabled = false

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -211,10 +211,6 @@ tasks {
     }
 
     dependencyCheck {
-        cve.apply {
-            urlBase = "https://freedumbytes.gitlab.io/setup/nist-nvd-mirror/nvdcve-1.1-%d.json.gz"
-            urlModified = "https://freedumbytes.gitlab.io/setup/nist-nvd-mirror/nvdcve-1.1-modified.json.gz"
-        }
         failBuildOnCVSS = 0.0f
         analyzers.apply {
             assemblyEnabled = false


### PR DESCRIPTION
#### Summary

- According to reports, the NIST NVD data feed issue is now resolved
- This reverts commit e67a8fa87e332a220456b31de7a9fd3623d7e95b