### PR TITLE
Fix reminder toggle in daily daycare note

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-groups/daycare-daily-notes/DaycareDailyNoteModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/daycare-daily-notes/DaycareDailyNoteModal.tsx
@@ -73,7 +73,9 @@ export default React.memo(function DaycareDailyNoteModal({
     initialFormData(note, childId, groupId)
   )
 
-  const updateForm = (updates: Partial<DaycareDailyNoteFormData>) => {
+  const updateForm = <K extends keyof DaycareDailyNoteFormData>(
+    updates: Pick<DaycareDailyNoteFormData, K>
+  ) => {
     setForm({ ...form, ...updates })
   }
 

--- a/frontend/src/employee-frontend/components/unit/tab-groups/daycare-daily-notes/DaycareDailyNoteModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/daycare-daily-notes/DaycareDailyNoteModal.tsx
@@ -74,8 +74,7 @@ export default React.memo(function DaycareDailyNoteModal({
   )
 
   const updateForm = (updates: Partial<DaycareDailyNoteFormData>) => {
-    const newForm = { ...form, ...updates }
-    setForm(newForm)
+    setForm({ ...form, ...updates })
   }
 
   const submit = () => {
@@ -100,10 +99,10 @@ export default React.memo(function DaycareDailyNoteModal({
   }
 
   const toggleReminder = (reminder: DaycareDailyNoteReminder) => {
-    const newReminders = form.reminders.some((r) => r == reminder)
-      ? note?.reminders.filter((r) => r != reminder)
+    const reminders = form.reminders.some((r) => r == reminder)
+      ? form.reminders.filter((r) => r != reminder)
       : [...form.reminders, reminder]
-    updateForm({ reminders: newReminders })
+    updateForm({ reminders })
   }
 
   return groupId !== null ? (


### PR DESCRIPTION
#### Summary

Previous implementation was reading from the `note` itself which was only used for initial state.
Toggling any reminder off resulted in a) crash if working on a new note or b) reset of state for all the other toggles that were touched during that edit session.