### PR TITLE
EVAKA-FIX: Remove unnecessary restrictions on preferred start time

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -25,7 +25,6 @@ import { featureFlags } from 'lib-customizations/citizen'
 const clubTerms = ['13.08.2020 - 04.06.2021', '11.8.2021 - 03.06.2022']
 
 export default React.memo(function PreferredStartSubSection({
-  status,
   originalPreferredStartDate,
   type,
   formData,
@@ -142,12 +141,7 @@ export default React.memo(function PreferredStartSubSection({
           info={errorToInputInfo(errors.preferredStartDate, t.validationErrors)}
           hideErrorsBeforeTouched={!verificationRequested}
           isValidDate={(date: LocalDate) =>
-            isValidPreferredStartDate(
-              date,
-              originalPreferredStartDate,
-              status,
-              type
-            )
+            isValidPreferredStartDate(date, originalPreferredStartDate, type)
           }
           data-qa={'preferredStartDate-input'}
           id={labelId}

--- a/frontend/src/citizen-frontend/applications/editor/validations.ts
+++ b/frontend/src/citizen-frontend/applications/editor/validations.ts
@@ -19,10 +19,7 @@ import {
 } from '../../form-validation'
 import { ApplicationFormData } from '../../applications/editor/ApplicationFormData'
 import { ApplicationDetails } from 'lib-common/api-types/application/ApplicationDetails'
-import {
-  ApplicationStatus,
-  ApplicationType
-} from 'lib-common/api-types/application/enums'
+import { ApplicationType } from 'lib-common/api-types/application/enums'
 import LocalDate from 'lib-common/local-date'
 import { DecisionType } from '../../decisions/types'
 
@@ -38,19 +35,9 @@ export const applicationHasErrors = (errors: ApplicationFormDataErrors) => {
 }
 
 const minPreferredStartDate = (
-  status: ApplicationStatus,
-  type: ApplicationType,
   originalPreferredStartDate: LocalDate | null
 ): LocalDate => {
-  if (status !== 'CREATED') {
-    return originalPreferredStartDate
-      ? originalPreferredStartDate
-      : LocalDate.today()
-  } else {
-    return type === 'DAYCARE'
-      ? LocalDate.today().addDays(14)
-      : LocalDate.today()
-  }
+  return originalPreferredStartDate ?? LocalDate.today()
 }
 
 const maxPreferredStartDate = (): LocalDate => {
@@ -69,14 +56,9 @@ const maxDecisionStartDate = (
 export const isValidPreferredStartDate = (
   date: LocalDate,
   originalPreferredStartDate: LocalDate | null,
-  status: ApplicationStatus,
   type: ApplicationType
 ): boolean => {
-  if (
-    date.isBefore(
-      minPreferredStartDate(status, type, originalPreferredStartDate)
-    )
-  )
+  if (date.isBefore(minPreferredStartDate(originalPreferredStartDate)))
     return false
 
   if (date.isAfter(maxPreferredStartDate())) return false
@@ -113,7 +95,6 @@ export const isValidDecisionStartDate = (
 
 const preferredStartDateValidator = (
   originalPreferredStartDate: LocalDate | null,
-  status: ApplicationStatus,
   type: ApplicationType
 ) => (
   val: string,
@@ -121,7 +102,7 @@ const preferredStartDateValidator = (
 ): ErrorKey | undefined => {
   const date = LocalDate.parseFiOrNull(val)
   return date &&
-    isValidPreferredStartDate(date, originalPreferredStartDate, status, type)
+    isValidPreferredStartDate(date, originalPreferredStartDate, type)
     ? undefined
     : err
 }
@@ -145,7 +126,6 @@ export const validateApplication = (
         validDate,
         preferredStartDateValidator(
           apiData.form.preferences.preferredStartDate,
-          apiData.status,
           apiData.type
         )
       ),

--- a/frontend/src/e2e-test/pages/citizen/citizen-application-editor.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-application-editor.ts
@@ -181,9 +181,11 @@ export default class CitizenApplicationEditor {
   }
 
   async setPreferredStartDate(date: Date) {
-    await t.typeText(this.preferredStartDateInput, format(date, 'dd.MM.yyyy'), {
-      replace: true
-    })
+    await t
+      .typeText(this.preferredStartDateInput, format(date, 'dd.MM.yyyy'), {
+        replace: true
+      })
+      .pressKey('tab')
   }
 
   async uploadUrgentFile(file: string) {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
So it turned out that actually, by the law, citizens must be able to choose their preferred start date to be as early as they wish - we shouldn't limit their choice at all. 
