### PR TITLE
Add type safety to form updates

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/AdditionalDetailsSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/AdditionalDetailsSection.tsx
@@ -2,23 +2,24 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import { ApplicationType } from 'lib-common/api-types/application/enums'
+import { UpdateStateFn } from 'lib-common/form-state'
+import { TextArea } from 'lib-components/atoms/form/InputField'
+import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 import { Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
-import { TextArea } from 'lib-components/atoms/form/InputField'
-import { useTranslation } from '../../localization'
-import { AdditionalDetailsFormData } from '../../applications/editor/ApplicationFormData'
-import EditorSection from '../../applications/editor/EditorSection'
-import { ApplicationType } from 'lib-common/api-types/application/enums'
-import { ApplicationFormDataErrors } from '../../applications/editor/validations'
-import { getErrorCount } from '../../form-validation'
-import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import React from 'react'
 import styled from 'styled-components'
-import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
+import EditorSection from '../../applications/editor/EditorSection'
+import { getErrorCount } from '../../form-validation'
+import { useTranslation } from '../../localization'
+import { AdditionalDetailsFormData } from './ApplicationFormData'
+import { ApplicationFormDataErrors } from './validations'
 
 type Props = {
   formData: AdditionalDetailsFormData
-  updateFormData: (v: Partial<AdditionalDetailsFormData>) => void
+  updateFormData: UpdateStateFn<AdditionalDetailsFormData>
   errors: ApplicationFormDataErrors['additionalDetails']
   verificationRequested: boolean
   applicationType: ApplicationType

--- a/frontend/src/citizen-frontend/applications/editor/FeeSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/FeeSection.tsx
@@ -2,19 +2,20 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
-import Checkbox from 'lib-components/atoms/form/Checkbox'
-import { useTranslation } from '../../localization'
-import { FeeFormData } from '../../applications/editor/ApplicationFormData'
-import EditorSection from '../../applications/editor/EditorSection'
-import { ApplicationFormDataErrors } from '../../applications/editor/validations'
-import { getErrorCount } from '../../form-validation'
 import { ApplicationType } from 'lib-common/api-types/application/enums'
+import { UpdateStateFn } from 'lib-common/form-state'
+import Checkbox from 'lib-components/atoms/form/Checkbox'
+import React from 'react'
+import EditorSection from '../../applications/editor/EditorSection'
+import { getErrorCount } from '../../form-validation'
+import { useTranslation } from '../../localization'
+import { FeeFormData } from './ApplicationFormData'
+import { ApplicationFormDataErrors } from './validations'
 
 type Props = {
   applicationType: ApplicationType
   formData: FeeFormData
-  updateFormData: (v: Partial<FeeFormData>) => void
+  updateFormData: UpdateStateFn<FeeFormData>
   errors: ApplicationFormDataErrors['fee']
   verificationRequested: boolean
 }

--- a/frontend/src/citizen-frontend/applications/editor/contact-info/ChildSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/ChildSubSection.tsx
@@ -15,7 +15,7 @@ import { Gap } from 'lib-components/white-space'
 import { errorToInputInfo } from '../../../form-validation'
 import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
 import AdaptiveFlex from 'lib-components/layout/AdaptiveFlex'
-import { ContactInfoSectionProps } from '../../../applications/editor/contact-info/ContactInfoSection'
+import { ContactInfoSectionProps } from './ContactInfoSection'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 
 export default React.memo(function ChildSubSection({
@@ -86,11 +86,12 @@ export default React.memo(function ChildSubSection({
               date={formData.childMoveDate}
               data-qa={'childMoveDate-input'}
               onChange={(value) =>
-                updateFormData(
-                  formData.guardianFutureAddressEqualsChild
-                    ? { guardianMoveDate: value, childMoveDate: value }
-                    : { childMoveDate: value }
-                )
+                formData.guardianFutureAddressEqualsChild
+                  ? updateFormData({
+                      guardianMoveDate: value,
+                      childMoveDate: value
+                    })
+                  : updateFormData({ childMoveDate: value })
               }
               locale={lang}
               info={errorToInputInfo(errors.childMoveDate, t.validationErrors)}
@@ -109,16 +110,14 @@ export default React.memo(function ChildSubSection({
                   value={formData.childFutureStreet}
                   dataQa={'childFutureStreet-input'}
                   onChange={(value) =>
-                    updateFormData(
-                      formData.guardianFutureAddressEqualsChild
-                        ? {
-                            childFutureStreet: value,
-                            guardianFutureStreet: value
-                          }
-                        : {
-                            childFutureStreet: value
-                          }
-                    )
+                    formData.guardianFutureAddressEqualsChild
+                      ? updateFormData({
+                          childFutureStreet: value,
+                          guardianFutureStreet: value
+                        })
+                      : updateFormData({
+                          childFutureStreet: value
+                        })
                   }
                   info={errorToInputInfo(
                     errors.childFutureStreet,
@@ -140,16 +139,12 @@ export default React.memo(function ChildSubSection({
                   value={formData.childFuturePostalCode}
                   dataQa={'childFuturePostalCode-input'}
                   onChange={(value) =>
-                    updateFormData(
-                      formData.guardianFutureAddressEqualsChild
-                        ? {
-                            guardianFuturePostalCode: value,
-                            childFuturePostalCode: value
-                          }
-                        : {
-                            childFuturePostalCode: value
-                          }
-                    )
+                    formData.guardianFutureAddressEqualsChild
+                      ? updateFormData({
+                          guardianFuturePostalCode: value,
+                          childFuturePostalCode: value
+                        })
+                      : updateFormData({ childFuturePostalCode: value })
                   }
                   info={errorToInputInfo(
                     errors.childFuturePostalCode,
@@ -171,16 +166,12 @@ export default React.memo(function ChildSubSection({
                   value={formData.childFuturePostOffice}
                   dataQa={'childFuturePostOffice-input'}
                   onChange={(value) =>
-                    updateFormData(
-                      formData.guardianFutureAddressEqualsChild
-                        ? {
-                            guardianFuturePostOffice: value,
-                            childFuturePostOffice: value
-                          }
-                        : {
-                            childFuturePostOffice: value
-                          }
-                    )
+                    formData.guardianFutureAddressEqualsChild
+                      ? updateFormData({
+                          guardianFuturePostOffice: value,
+                          childFuturePostOffice: value
+                        })
+                      : updateFormData({ childFuturePostOffice: value })
                   }
                   info={errorToInputInfo(
                     errors.childFuturePostOffice,

--- a/frontend/src/citizen-frontend/applications/editor/contact-info/ContactInfoSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/ContactInfoSection.tsx
@@ -2,12 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { UpdateStateFn } from 'lib-common/form-state'
 import React from 'react'
 import { useTranslation } from '../../../localization'
 import { ContactInfoFormData } from '../ApplicationFormData'
 import EditorSection from '../../../applications/editor/EditorSection'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
-import { ApplicationFormDataErrors } from '../../../applications/editor/validations'
+import { ApplicationFormDataErrors } from '../validations'
 import { getErrorCount } from '../../../form-validation'
 import ChildSubSection from '../../../applications/editor/contact-info/ChildSubSection'
 import GuardianSubSection from '../../../applications/editor/contact-info/GuardianSubSection'
@@ -19,7 +20,7 @@ import { ApplicationType } from 'lib-common/api-types/application/enums'
 export type ContactInfoSectionProps = {
   type: ApplicationType
   formData: ContactInfoFormData
-  updateFormData: (update: Partial<ContactInfoFormData>) => void
+  updateFormData: UpdateStateFn<ContactInfoFormData>
   errors: ApplicationFormDataErrors['contactInfo']
   verificationRequested: boolean
   fullFamily: boolean

--- a/frontend/src/citizen-frontend/applications/editor/contact-info/SecondGuardianSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/SecondGuardianSubSection.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
+import { UpdateStateFn } from 'lib-common/form-state'
 import { useTranslation } from '../../../localization'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { H3, Label, P } from 'lib-components/typography'
@@ -10,8 +11,8 @@ import {
   ApplicationGuardianAgreementStatus,
   ApplicationType
 } from 'lib-common/api-types/application/enums'
-import { ContactInfoFormData } from '../../../applications/editor/ApplicationFormData'
-import { ApplicationFormDataErrors } from '../../../applications/editor/validations'
+import { ContactInfoFormData } from '../ApplicationFormData'
+import { ApplicationFormDataErrors } from '../validations'
 import Radio from 'lib-components/atoms/form/Radio'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 import { Gap } from 'lib-components/white-space'
@@ -22,7 +23,7 @@ import AdaptiveFlex from 'lib-components/layout/AdaptiveFlex'
 type SecondGuardianSubSectionProps = {
   type: ApplicationType
   formData: ContactInfoFormData
-  updateFormData: (v: Partial<ContactInfoFormData>) => void
+  updateFormData: UpdateStateFn<ContactInfoFormData>
   errors: ApplicationFormDataErrors['contactInfo']
   verificationRequested: boolean
   otherGuardianStatus: 'NO' | 'SAME_ADDRESS' | 'DIFFERENT_ADDRESS'

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceNeedSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceNeedSection.tsx
@@ -2,29 +2,30 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
-import { ServiceNeedFormData } from '../../../applications/editor/ApplicationFormData'
-import { useTranslation } from '../../../localization'
-import HorizontalLine from 'lib-components/atoms/HorizontalLine'
-import EditorSection from '../../../applications/editor/EditorSection'
-import { ApplicationFormDataErrors } from '../../../applications/editor/validations'
-import { getErrorCount } from '../../../form-validation'
-import PreferredStartSubSection from '../../../applications/editor/service-need/PreferredStartSubSection'
-import AssistanceNeedSubSection from '../../../applications/editor/service-need/AssistanceNeedSubSection'
 import {
   ApplicationStatus,
   ApplicationType
 } from 'lib-common/api-types/application/enums'
+import { UpdateStateFn } from 'lib-common/form-state'
+import LocalDate from 'lib-common/local-date'
+import HorizontalLine from 'lib-components/atoms/HorizontalLine'
+import React from 'react'
+import EditorSection from '../../../applications/editor/EditorSection'
+import AssistanceNeedSubSection from '../../../applications/editor/service-need/AssistanceNeedSubSection'
+import PreferredStartSubSection from '../../../applications/editor/service-need/PreferredStartSubSection'
 import ServiceTimeSubSectionDaycare from '../../../applications/editor/service-need/ServiceTimeSubSectionDaycare'
 import ServiceTimeSubSectionPreschool from '../../../applications/editor/service-need/ServiceTimeSubSectionPreschool'
-import LocalDate from 'lib-common/local-date'
+import { getErrorCount } from '../../../form-validation'
+import { useTranslation } from '../../../localization'
+import { ServiceNeedFormData } from '../ApplicationFormData'
+import { ApplicationFormDataErrors } from '../validations'
 
 export type ServiceNeedSectionProps = {
   status: ApplicationStatus
   originalPreferredStartDate: LocalDate | null
   type: ApplicationType
   formData: ServiceNeedFormData
-  updateFormData: (update: Partial<ServiceNeedFormData>) => void
+  updateFormData: UpdateStateFn<ServiceNeedFormData>
   errors: ApplicationFormDataErrors['serviceNeed']
   verificationRequested: boolean
 }

--- a/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitPreferenceSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitPreferenceSection.tsx
@@ -2,21 +2,22 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
-import { UnitPreferenceFormData } from '../../../applications/editor/ApplicationFormData'
-import HorizontalLine from 'lib-components/atoms/HorizontalLine'
-import LocalDate from 'lib-common/local-date'
-import { useTranslation } from '../../../localization'
-import EditorSection from '../../../applications/editor/EditorSection'
 import { ApplicationType } from 'lib-common/api-types/application/enums'
-import { ApplicationFormDataErrors } from '../../../applications/editor/validations'
-import { getErrorCount } from '../../../form-validation'
+import { UpdateStateFn } from 'lib-common/form-state'
+import LocalDate from 'lib-common/local-date'
+import HorizontalLine from 'lib-components/atoms/HorizontalLine'
+import React from 'react'
+import EditorSection from '../../../applications/editor/EditorSection'
 import SiblingBasisSubSection from '../../../applications/editor/unit-preference/SiblingBasisSubSection'
 import UnitsSubSection from '../../../applications/editor/unit-preference/UnitsSubSection'
+import { getErrorCount } from '../../../form-validation'
+import { useTranslation } from '../../../localization'
+import { UnitPreferenceFormData } from '../ApplicationFormData'
+import { ApplicationFormDataErrors } from '../validations'
 
 export type UnitPreferenceSectionCommonProps = {
   formData: UnitPreferenceFormData
-  updateFormData: (update: Partial<UnitPreferenceFormData>) => void
+  updateFormData: UpdateStateFn<UnitPreferenceFormData>
   errors: ApplicationFormDataErrors['unitPreference']
   verificationRequested: boolean
   applicationType: ApplicationType

--- a/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
@@ -5,6 +5,7 @@
 import React, { FormEvent, useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import LocalDate from 'lib-common/local-date'
+import { UpdateStateFn } from '../../../../lib-common/form-state'
 import { useTranslation } from '../../../state/i18n'
 import { UIContext } from '../../../state/ui'
 import { Gap } from 'lib-components/white-space'
@@ -146,7 +147,7 @@ function AssistanceActionForm(props: Props) {
 
   const checkAnyConflict = () => checkHardConflict() || checkSoftConflict()
 
-  const updateFormState = (values: Partial<FormState>) => {
+  const updateFormState: UpdateStateFn<FormState> = (values) => {
     const newState = { ...form, ...values }
     setForm(newState)
   }

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
@@ -5,6 +5,7 @@
 import React, { FormEvent, useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import LocalDate from 'lib-common/local-date'
+import { UpdateStateFn } from '../../../../lib-common/form-state'
 import { useTranslation } from '../../../state/i18n'
 import { UIContext } from '../../../state/ui'
 import { Gap } from 'lib-components/white-space'
@@ -164,7 +165,7 @@ function AssistanceNeedForm(props: Props) {
 
   const checkAnyConflict = () => checkHardConflict() || checkSoftConflict()
 
-  const updateFormState = (values: Partial<FormState>) => {
+  const updateFormState: UpdateStateFn<FormState> = (values) => {
     const newState = { ...form, ...values }
     setForm(newState)
   }

--- a/frontend/src/employee-frontend/components/child-information/backup-care/BackupCareForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/backup-care/BackupCareForm.tsx
@@ -11,6 +11,7 @@ import React, {
 } from 'react'
 import _ from 'lodash'
 import LocalDate from 'lib-common/local-date'
+import { UpdateStateFn } from '../../../../lib-common/form-state'
 import { UUID } from '../../../types'
 import { useTranslation } from '../../../state/i18n'
 import { UIContext } from '../../../state/ui'
@@ -122,7 +123,7 @@ export default function BackupCareForm({
     setFormErrors(evaluateFormErrors(form))
   }
 
-  const updateFormState = (value: Partial<FormState>) => {
+  const updateFormState: UpdateStateFn<FormState> = (value) => {
     const newState = { ...formState, ...value }
     setFormState(newState)
     validateForm(newState)

--- a/frontend/src/employee-frontend/components/child-information/service-need/ServiceNeedForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/service-need/ServiceNeedForm.tsx
@@ -5,6 +5,7 @@
 import React, { FormEvent, useContext, useEffect, useState } from 'react'
 import LocalDate from 'lib-common/local-date'
 import DateRange from 'lib-common/date-range'
+import { UpdateStateFn } from '../../../../lib-common/form-state'
 import { useTranslation } from '../../../state/i18n'
 import { UIContext } from '../../../state/ui'
 import { Gap } from 'lib-components/white-space'
@@ -152,7 +153,7 @@ function ServiceNeedForm(props: Props) {
 
   const checkAnyConflict = () => checkHardConflict() || checkSoftConflict()
 
-  const updateFormState = (value: Partial<FormState>) => {
+  const updateFormState: UpdateStateFn<FormState> = (value) => {
     const newState = { ...form, ...value }
     setForm(newState)
   }

--- a/frontend/src/employee-frontend/components/group-caretakers/GroupCaretakersModal.tsx
+++ b/frontend/src/employee-frontend/components/group-caretakers/GroupCaretakersModal.tsx
@@ -64,7 +64,9 @@ function GroupCaretakersModal({
   const [submitting, setSubmitting] = useState<boolean>(false)
   const [conflict, setConflict] = useState<boolean>(false)
 
-  const assignForm = (values: Partial<FormState>) => {
+  const assignForm = <K extends keyof FormState>(
+    values: Pick<FormState, K>
+  ) => {
     setForm({
       ...form,
       ...values

--- a/frontend/src/employee-frontend/components/invoice/InvoiceRowsSectionRow.tsx
+++ b/frontend/src/employee-frontend/components/invoice/InvoiceRowsSectionRow.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { faTrash } from 'lib-icons'
+import { UpdateStateFn } from 'lib-common/form-state'
 import LocalDate from 'lib-common/local-date'
 import { Td, Tr } from 'lib-components/layout/Table'
 import InputField from 'lib-components/atoms/form/InputField'
@@ -32,7 +33,7 @@ interface InvoiceRowStub {
 
 interface Props {
   row: InvoiceRowStub
-  update: (v: Partial<InvoiceRowStub>) => void
+  update: UpdateStateFn<InvoiceRowStub>
   remove: () => void
   invoiceCodes: Result<InvoiceCodes>
   editable: boolean

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -4,8 +4,8 @@
 
 import React from 'react'
 import styled from 'styled-components'
-import _ from 'lodash'
 import { faTimes, faTrash } from 'lib-icons'
+import { UpdateStateFn } from 'lib-common/form-state'
 import colors from 'lib-components/colors'
 import InputField from 'lib-components/atoms/form/InputField'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
@@ -27,7 +27,7 @@ type Option = {
 type Props = {
   bulletin: Bulletin
   senderOptions: string[]
-  onChange: (change: Partial<Bulletin>) => void
+  onChange: UpdateStateFn<Bulletin>
   onDeleteDraft: () => void
   onClose: () => void
   onSend: () => void

--- a/frontend/src/employee-frontend/components/person-profile/person-fridge-child/FridgeChildModal.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/person-fridge-child/FridgeChildModal.tsx
@@ -4,6 +4,7 @@
 
 import React, { useState, useContext, useEffect } from 'react'
 import LocalDate from 'lib-common/local-date'
+import { UpdateStateFn } from '../../../../lib-common/form-state'
 import { useTranslation } from '../../../state/i18n'
 import { UIContext } from '../../../state/ui'
 import {
@@ -100,7 +101,7 @@ function FridgeChildModal({ headPersonId, onSuccess, parentship }: Props) {
     })
   }
 
-  const assignFridgeChildForm = (value: Partial<FridgeChildForm>) => {
+  const assignFridgeChildForm: UpdateStateFn<FridgeChildForm> = (value) => {
     const mergedFridgeChild = { ...form, ...value }
     setForm(mergedFridgeChild)
   }

--- a/frontend/src/employee-frontend/components/person-profile/person-fridge-head/PersonFridgeHeadForm.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/person-fridge-head/PersonFridgeHeadForm.tsx
@@ -58,7 +58,9 @@ function PersonFridgeHeadForm({ id, personFridgeHead }: Props) {
     } else setFormValidation(isFormValid(headPersonForm))
   }, [headPersonForm])
 
-  const assignHeadPersonForm = (value: Partial<PersonContactInfo>) => {
+  const assignHeadPersonForm = <K extends keyof PersonContactInfo>(
+    value: Pick<PersonContactInfo, K>
+  ) => {
     if (!headPersonForm) throw new Error(`Undefined form data`)
     const mergedHeadPerson = { ...headPersonForm, ...value }
     setHeadPersonForm(mergedHeadPerson)

--- a/frontend/src/employee-frontend/components/person-profile/person-fridge-partner/FridgePartnerModal.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/person-fridge-partner/FridgePartnerModal.tsx
@@ -4,6 +4,7 @@
 
 import React, { useState, useContext, useEffect } from 'react'
 import LocalDate from 'lib-common/local-date'
+import { UpdateStateFn } from '../../../../lib-common/form-state'
 import { useTranslation } from '../../../state/i18n'
 import { UIContext } from '../../../state/ui'
 import {
@@ -110,7 +111,9 @@ function FridgePartnerModal({ partnership, onSuccess, headPersonId }: Props) {
     })
   }
 
-  const assignFridgePartnerForm = (values: Partial<FridgePartnerForm>) => {
+  const assignFridgePartnerForm: UpdateStateFn<FridgePartnerForm> = (
+    values
+  ) => {
     const mergedFridgePartner = { ...form, ...values }
     setForm(mergedFridgePartner)
   }

--- a/frontend/src/employee-frontend/components/person-shared/PersonDetails.tsx
+++ b/frontend/src/employee-frontend/components/person-shared/PersonDetails.tsx
@@ -5,6 +5,7 @@
 import * as React from 'react'
 import { faPen } from 'lib-icons'
 import { Result } from 'lib-common/api'
+import { UpdateStateFn } from '../../../lib-common/form-state'
 import { PersonDetails } from '../../types/person'
 import { useTranslation } from '../../state/i18n'
 import { useContext, useEffect, useState } from 'react'
@@ -141,7 +142,7 @@ const PersonDetails = React.memo(function PersonDetails({
   const person = personResult.value
   const powerEditing = editing && person.socialSecurityNumber == null
 
-  const updateForm = (values: Partial<Form>) => {
+  const updateForm: UpdateStateFn<Form> = (values) => {
     setForm({
       ...form,
       ...values

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useContext, useEffect, useState } from 'react'
+import { UpdateStateFn } from 'lib-common/form-state'
 import FormModal from 'lib-components/molecules/modals/FormModal'
 import { Label } from 'lib-components/typography'
 import { useTranslation } from '../../../../state/i18n'
@@ -63,7 +64,7 @@ function GroupModal({ unitId, reload }: Props) {
     })
   }, [form])
 
-  const assignForm = (values: Partial<CreateGroupForm>) => {
+  const assignForm: UpdateStateFn<CreateGroupForm> = (values) => {
     setForm({ ...form, ...values })
   }
 

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupTransferModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupTransferModal.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useState, useContext } from 'react'
+import { UpdateStateFn } from 'lib-common/form-state'
 import LocalDate from 'lib-common/local-date'
 import { useTranslation } from '../../../../../state/i18n'
 import { UIContext } from '../../../../../state/ui'
@@ -76,7 +77,7 @@ export default React.memo(function GroupTransferModal({
     return errors
   }
 
-  const assignFormValues = (values: Partial<GroupPlacementForm>) => {
+  const assignFormValues: UpdateStateFn<GroupPlacementForm> = (values) => {
     setForm({
       ...form,
       ...values,

--- a/frontend/src/employee-frontend/components/unit/tab-groups/missing-group-placements/GroupPlacementModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/missing-group-placements/GroupPlacementModal.tsx
@@ -5,6 +5,7 @@
 import React, { useState, useContext } from 'react'
 import styled from 'styled-components'
 
+import { UpdateStateFn } from 'lib-common/form-state'
 import LocalDate from 'lib-common/local-date'
 import { useTranslation } from '../../../../state/i18n'
 import { UIContext } from '../../../../state/ui'
@@ -90,7 +91,7 @@ export default React.memo(function GroupPlacementModal({
   }
   const [form, setForm] = useState<GroupPlacementForm>(getInitialFormState())
 
-  const assignFormValues = (values: Partial<GroupPlacementForm>) => {
+  const assignFormValues: UpdateStateFn<GroupPlacementForm> = (values) => {
     setForm({
       ...form,
       ...values,

--- a/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useMemo, useState } from 'react'
+import { UpdateStateFn } from 'lib-common/form-state'
 import LocalDate from 'lib-common/local-date'
 import styled from 'styled-components'
 import Select from '../../../components/common/Select'
@@ -183,7 +184,7 @@ function AddressEditor({
   dataQaPrefix: string
 }) {
   const { i18n } = useTranslation()
-  const update = (updates: Partial<Address>) =>
+  const update: UpdateStateFn<Address> = (updates) =>
     onChange({ ...address, ...updates })
   if (!editable) {
     return (
@@ -526,13 +527,13 @@ export default function UnitEditor(props: Props): JSX.Element {
   }
   const updateCareTypes = (updates: Partial<Record<CareType, boolean>>) =>
     updateForm({ careTypes: { ...form.careTypes, ...updates } })
-  const updateDecisionCustomization = (
-    updates: Partial<UnitDecisionCustomization>
+  const updateDecisionCustomization: UpdateStateFn<UnitDecisionCustomization> = (
+    updates
   ) =>
     updateForm({
       decisionCustomization: { ...form.decisionCustomization, ...updates }
     })
-  const updateUnitManager = (updates: Partial<UnitManager>) =>
+  const updateUnitManager: UpdateStateFn<UnitManager> = (updates) =>
     updateForm({ unitManager: { ...form.unitManager, ...updates } })
 
   const selectedFinanceDecisionManager = useMemo(

--- a/frontend/src/lib-common/form-state.d.ts
+++ b/frontend/src/lib-common/form-state.d.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+export type UpdateStateFn<T> = <K extends keyof T>(values: Pick<T, K>) => void


### PR DESCRIPTION
#### Summary

Using `Pick` instead of `Partial` prevents setting required properties to `undefined`. [TS Playground](https://www.typescriptlang.org/play?ts=4.2.3#code/LAKAlgdgLgpgTgMwIYGMYAICyBPAIkqJdAb1HXQGco4wUoAbbAVQgBMYFIZWAuS6yAHN0AH3QBXNhy6sy6APYAHKGHkQk9APx8qNCILlwYAR3FgjvfnoMgAvqFAo1VdAnny+OfIXQBeEnK6tAzMUpwQ3HyS7OHcADSGJmYWfABEALbwANZZYABWavKpoPYgoPQwUK7ycOmeeARE-sQAdG1u8qWOzlXiiqwEMABiNel+6AAUfQOwFHwACkhwKhoAPF6NAHwAlH6bASDkbrXjre2jcehtLdODFOilXSBOEC63sCO1ACrYijAAykgEBh-KsANLoGAAD1gbHuWRg2HkCCwDUImwmcneMDm6HmtCy6zRSEuYM2oF2vn2pEO1ROzWux3Sl2u2PujwcIGxn3SE2IRlM5kiEjCMkuQTojBYMRkUVFEVYlyUKjUGjlMoVtm2oG5oz5AuSwui0k12rKXP6gx5Pz+gOB+qSQssxtiiqswSl8qNXrdytU6no6pN3C1OstH1GNoBQJgDsFKRFGpDZqAA)