### PR TITLE
Apply nicer default config in Playwright tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "e2e-employee-2": "testcafe 'chrome --start-fullscreen' src/e2e-test/specs/2_employee-2/*.spec.ts",
     "e2e-mobile": "testcafe 'chrome --start-fullscreen' src/e2e-test/specs/6_mobile/*.spec.ts",
     "e2e-messaging": "testcafe 'chrome --start-fullscreen' src/e2e-test/specs/7_messaging/*.spec.ts",
-    "e2e-playwright": "E2E_DEVELOPMENT=true jest --testTimeout 60000 --runInBand src/e2e-playwright/specs",
+    "e2e-playwright": "jest --runInBand src/e2e-playwright/specs",
     "e2e-ci": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/**/*.spec.ts -s takeOnFails=true --stop-on-first-fail",
     "e2e-ci-accessibility": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/**/*.spec.ts --fixture-meta subType=accessibility -s takeOnFails=true --stop-on-first-fail",
     "e2e-ci-citizen": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/specs/0_citizen/*.spec.ts -s takeOnFails=true --stop-on-first-fail",

--- a/frontend/src/e2e-playwright/browser.ts
+++ b/frontend/src/e2e-playwright/browser.ts
@@ -15,6 +15,7 @@ import config from 'e2e-test-common/config'
 let browser: Browser
 
 beforeAll(async () => {
+  jest.setTimeout(60000)
   browser = await playwright[config.playwright.browser].launch({
     headless: config.playwright.headless
   })
@@ -39,6 +40,7 @@ export async function newBrowserContext(
   options?: BrowserContextOptions
 ): Promise<BrowserContext> {
   const ctx = await browser.newContext(options)
+  ctx.setDefaultTimeout(config.playwright.ci ? 30_000 : 5_000)
   await ctx.addInitScript({ content: injected })
   return ctx
 }

--- a/frontend/src/e2e-playwright/browser.ts
+++ b/frontend/src/e2e-playwright/browser.ts
@@ -14,8 +14,10 @@ import config from 'e2e-test-common/config'
 
 let browser: Browser
 
+const DISABLE_JEST_TIMEOUT = 1_000_000_000 // 0 or Infinity unfortunately don't work
+
 beforeAll(async () => {
-  jest.setTimeout(60000)
+  jest.setTimeout(config.playwright.ci ? 60_000 : DISABLE_JEST_TIMEOUT)
   browser = await playwright[config.playwright.browser].launch({
     headless: config.playwright.headless
   })

--- a/frontend/src/e2e-playwright/utils/index.ts
+++ b/frontend/src/e2e-playwright/utils/index.ts
@@ -15,7 +15,7 @@ export async function delay(ms: number): Promise<void> {
   return new Promise<void>((resolve) => setTimeout(resolve, ms))
 }
 
-const WAIT_TIMEOUT_SECONDS = config.playwright.developmentMode ? 5 : 30
+const WAIT_TIMEOUT_SECONDS = config.playwright.ci ? 30 : 5
 const WAIT_LOOP_INTERVAL_MS = 100
 
 /**

--- a/frontend/src/e2e-test-common/config.ts
+++ b/frontend/src/e2e-test-common/config.ts
@@ -48,15 +48,15 @@ const unitSupervisorAad = '00000000-0000-0000-0004-000000000000'
 const staffAad = '00000000-0000-0000-0005-000000000000'
 const specialEducationTeacher = '00000000-0000-0000-0006-000000000000'
 
-const developmentMode = env('E2E_DEVELOPMENT', parseBoolean) ?? false
+const ci = env('CI', parseBoolean) ?? false
 
 const baseUrl = env('BASE_URL', (url) => url)
 const browserUrl = baseUrl ?? 'http://localhost:9099'
 
 const config = {
   playwright: {
-    developmentMode,
-    headless: env('HEADLESS', parseBoolean) ?? !developmentMode,
+    ci,
+    headless: env('HEADLESS', parseBoolean) ?? ci,
     browser:
       env('BROWSER', parseEnum(['chromium', 'firefox', 'webkit'] as const)) ??
       'chromium'


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- use "standard" CI env variable instead of custom E2E_DEVELOPMENT
- set jest timeout to 60s in all Playwright tests automatically on CI
- disable jest timeouts locally in Playwright tests
- set playwright timeout to 30s or 5s depending on mode. This matches
  the timeout used in our waitUntilX functions