### PR TITLE
[EVAKA-HOTFIX] Drop duplicate filename argument in licensing script

### DIFF
--- a/bin/add-license-headers.sh
+++ b/bin/add-license-headers.sh
@@ -45,6 +45,7 @@ function run_reuse() {
 
 function addheader() {
     local file="$1"
+    shift
     local cmd_args=("$@")
     run_reuse addheader --license "LGPL-2.1-or-later" --copyright "City of Espoo" --year "$REUSE_YEARS" "${cmd_args[@]}" "$file"
 }


### PR DESCRIPTION
#### Summary
- 024d6dc44ce134e548af40ab2ced99ff444e49b7 introduced a "regression" with the bash argument parsing that causes the filename argument to be given twice to reuse -> shift it away

#### Testing instructions

With `master` version of script, run:

```sh
touch file.txt
DEBUG=true ./bin/add-license-headers.sh
```

-> will show `file.txt file.txt` given as the last two args for `docker run`

Running with branch version gives the `file.txt` arg just once as it should.