### PR TITLE
EVAKA-HOTFIX: Mobile attendance list height

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/attendances/AttendancePageWrapper.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/AttendancePageWrapper.tsx
@@ -90,7 +90,7 @@ export default React.memo(function AttendancePageWrapper({
 
   useEffect(() => {
     loadDaycareAttendances(unitId)
-  }, [groupIdOrAll, unitId, currentPage])
+  }, [loadDaycareAttendances, groupIdOrAll, unitId, currentPage])
 
   const today = LocalDate.today()
   useEffect(() => {
@@ -115,7 +115,7 @@ export default React.memo(function AttendancePageWrapper({
       )
       setSearchResults(filteredData)
     }
-  }, [freeText])
+  }, [freeText, attendanceResponse])
 
   useEffect(() => {
     const selectedGroup =
@@ -130,7 +130,7 @@ export default React.memo(function AttendancePageWrapper({
     return () => {
       setSelectedGroup(undefined)
     }
-  }, [attendanceResponse])
+  }, [attendanceResponse, groupIdOrAll])
 
   const totalAttendances = attendanceResponse.isSuccess
     ? groupIdOrAll === 'all'

--- a/frontend/src/employee-mobile-frontend/components/attendances/AttendancePageWrapper.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/AttendancePageWrapper.tsx
@@ -292,7 +292,8 @@ export default React.memo(function AttendancePageWrapper({
           />
           <Tabs tabs={tabs} mobile />
 
-          <FullHeightContentArea
+          <ContentArea
+            fullHeight
             opaque={false}
             paddingVertical={'s'}
             paddingHorizontal={'zero'}
@@ -336,7 +337,7 @@ export default React.memo(function AttendancePageWrapper({
               />
               <Redirect to={`${path}/coming`} />
             </Switch>
-          </FullHeightContentArea>
+          </ContentArea>
           <BottomNavbar
             selected="child"
             staffCount={
@@ -373,10 +374,6 @@ const NoMarginTitle = styled(Title)`
     margin-left: ${defaultMargins.m};
     color: ${colors.greyscale.white};
   }
-`
-
-const FullHeightContentArea = styled(ContentArea)`
-  height: 100%;
 `
 
 const Bold = styled.div`


### PR DESCRIPTION
#### Summary

With a long child list, the last one was partially covered by the bottom navbar due to wrong `ContentArea` height.