### PR TITLE
Remove `jdbi.handle` and `jdbi.transaction` calls from integration tests

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/DuplicateApplicationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/DuplicateApplicationIntegrationTest.kt
@@ -29,33 +29,33 @@ class DuplicateApplicationIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     internal fun setUp() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
         }
     }
 
     @Test
     fun `no applications means no duplicates`() {
-        jdbi.handle { h -> assertFalse(duplicateApplicationExists(h, childId, guardianId, ApplicationType.DAYCARE)) }
+        db.transaction { tx -> assertFalse(duplicateApplicationExists(tx.handle, childId, guardianId, ApplicationType.DAYCARE)) }
     }
 
     @Test
     fun `duplicate is found`() {
         addDaycareApplication()
-        jdbi.handle { h -> assertTrue(duplicateApplicationExists(h, childId, guardianId, ApplicationType.DAYCARE)) }
+        db.transaction { tx -> assertTrue(duplicateApplicationExists(tx.handle, childId, guardianId, ApplicationType.DAYCARE)) }
     }
 
     @Test
     fun `application for a different child is not a duplicate`() {
         addDaycareApplication()
-        jdbi.handle { h -> assertFalse(duplicateApplicationExists(h, childId2, guardianId, ApplicationType.DAYCARE)) }
+        db.transaction { tx -> assertFalse(duplicateApplicationExists(tx.handle, childId2, guardianId, ApplicationType.DAYCARE)) }
     }
 
     @Test
     fun `application for a different type is not a duplicate`() {
         addDaycareApplication()
-        jdbi.handle { h -> assertFalse(duplicateApplicationExists(h, childId, guardianId, ApplicationType.PRESCHOOL)) }
+        db.transaction { tx -> assertFalse(duplicateApplicationExists(tx.handle, childId, guardianId, ApplicationType.PRESCHOOL)) }
     }
 
     @Test
@@ -63,19 +63,19 @@ class DuplicateApplicationIntegrationTest : FullApplicationTest() {
         addDaycareApplication(ApplicationStatus.ACTIVE)
         addDaycareApplication(ApplicationStatus.REJECTED)
         addDaycareApplication(ApplicationStatus.CANCELLED)
-        jdbi.handle { h -> assertFalse(duplicateApplicationExists(h, childId, guardianId, ApplicationType.DAYCARE)) }
+        db.transaction { tx -> assertFalse(duplicateApplicationExists(tx.handle, childId, guardianId, ApplicationType.DAYCARE)) }
     }
 
     private fun addDaycareApplication(status: ApplicationStatus = ApplicationStatus.SENT) {
-        jdbi.handle { h ->
+        db.transaction { tx ->
             val appId = insertTestApplication(
-                h = h,
+                h = tx.handle,
                 status = status,
                 childId = childId,
                 guardianId = guardianId
             )
             insertTestApplicationForm(
-                h = h,
+                h = tx.handle,
                 applicationId = appId,
                 document = DaycareFormV0.fromApplication2(validDaycareApplication)
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
@@ -33,13 +33,13 @@ class GetApplicationSummaryIntegrationTests : FullApplicationTest() {
 
     @BeforeEach
     private fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
 
-            createApplication(h = h, child = testChild_1, guardian = testAdult_1)
-            createApplication(h = h, child = testChild_2, guardian = testAdult_1, attachment = true)
-            createApplication(h = h, child = testChild_3, guardian = testAdult_1, urgent = true)
+            createApplication(h = tx.handle, child = testChild_1, guardian = testAdult_1)
+            createApplication(h = tx.handle, child = testChild_2, guardian = testAdult_1, attachment = true)
+            createApplication(h = tx.handle, child = testChild_3, guardian = testAdult_1, urgent = true)
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
@@ -30,9 +30,9 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     private fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
         }
     }
 
@@ -115,7 +115,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val assistanceActions = jdbi.handle { h -> getAssistanceActionsByChild(h, testChild_1.id) }
+        val assistanceActions = db.transaction { tx -> getAssistanceActionsByChild(tx.handle, testChild_1.id) }
         assertEquals(2, assistanceActions.size)
         assertTrue(assistanceActions.any { it.startDate == testDate(1) && it.endDate == testDate(15) })
         assertTrue(assistanceActions.any { it.startDate == testDate(16) && it.endDate == testDate(30) })
@@ -167,7 +167,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val assistanceActions = jdbi.handle { h -> getAssistanceActionsByChild(h, testChild_1.id) }
+        val assistanceActions = db.transaction { tx -> getAssistanceActionsByChild(tx.handle, testChild_1.id) }
         assertEquals(2, assistanceActions.size)
         assertTrue(assistanceActions.any { it.startDate == testDate(10) && it.endDate == testDate(19) })
         assertTrue(assistanceActions.any { it.startDate == testDate(20) && it.endDate == testDate(30) })
@@ -183,7 +183,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val assistanceActions = jdbi.handle { h -> getAssistanceActionsByChild(h, testChild_1.id) }
+        val assistanceActions = db.transaction { tx -> getAssistanceActionsByChild(tx.handle, testChild_1.id) }
         assertEquals(2, assistanceActions.size)
         assertTrue(assistanceActions.any { it.startDate == testDate(10) && it.endDate == testDate(10) })
         assertTrue(assistanceActions.any { it.startDate == testDate(11) && it.endDate == testDate(15) })
@@ -278,8 +278,8 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
     private fun testDate(day: Int) = LocalDate.of(2000, 1, day)
 
     private fun givenAssistanceAction(start: Int, end: Int, childId: UUID = testChild_1.id): UUID {
-        return jdbi.handle {
-            it.insertTestAssistanceAction(
+        return db.transaction {
+            it.handle.insertTestAssistanceAction(
                 DevAssistanceAction(
                     childId = childId,
                     startDate = testDate(start),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
@@ -30,9 +30,9 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     private fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
         }
     }
 
@@ -114,7 +114,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val assistanceNeeds = jdbi.handle { h -> getAssistanceNeedsByChild(h, testChild_1.id) }
+        val assistanceNeeds = db.transaction { tx -> getAssistanceNeedsByChild(tx.handle, testChild_1.id) }
         assertEquals(2, assistanceNeeds.size)
         assertTrue(assistanceNeeds.any { it.startDate == testDate(1) && it.endDate == testDate(15) })
         assertTrue(assistanceNeeds.any { it.startDate == testDate(16) && it.endDate == testDate(30) })
@@ -170,7 +170,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val assistanceNeeds = jdbi.handle { h -> getAssistanceNeedsByChild(h, testChild_1.id) }
+        val assistanceNeeds = db.transaction { tx -> getAssistanceNeedsByChild(tx.handle, testChild_1.id) }
         assertEquals(2, assistanceNeeds.size)
         assertTrue(assistanceNeeds.any { it.startDate == testDate(10) && it.endDate == testDate(19) })
         assertTrue(assistanceNeeds.any { it.startDate == testDate(20) && it.endDate == testDate(30) })
@@ -187,7 +187,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val assistanceNeeds = jdbi.handle { h -> getAssistanceNeedsByChild(h, testChild_1.id) }
+        val assistanceNeeds = db.transaction { tx -> getAssistanceNeedsByChild(tx.handle, testChild_1.id) }
         assertEquals(2, assistanceNeeds.size)
         assertTrue(assistanceNeeds.any { it.startDate == testDate(10) && it.endDate == testDate(10) })
         assertTrue(assistanceNeeds.any { it.startDate == testDate(11) && it.endDate == testDate(15) })
@@ -286,8 +286,8 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
     private fun testDate(day: Int) = LocalDate.of(2000, 1, day)
 
     private fun givenAssistanceNeed(start: Int, end: Int, childId: UUID = testChild_1.id): UUID {
-        return jdbi.handle {
-            it.insertTestAssistanceNeed(
+        return db.transaction {
+            it.handle.insertTestAssistanceNeed(
                 DevAssistanceNeed(
                     childId = childId,
                     startDate = testDate(start),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
@@ -16,7 +16,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.insertTestCareArea
@@ -89,10 +88,10 @@ class DaycareEditIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     private fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            h.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
-            h.insertTestDaycare(DevDaycare(id = testDaycare.id, areaId = testAreaId, name = testDaycare.name))
+        db.transaction { tx ->
+            tx.resetDatabase()
+            tx.handle.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
+            tx.handle.insertTestDaycare(DevDaycare(id = testDaycare.id, areaId = testAreaId, name = testDaycare.name))
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareGroupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareGroupIntegrationTest.kt
@@ -46,10 +46,10 @@ class DaycareGroupIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     protected fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            h.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
-            h.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
+        db.transaction { tx ->
+            tx.resetDatabase()
+            tx.handle.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
+            tx.handle.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
         }
     }
 
@@ -93,8 +93,8 @@ class DaycareGroupIntegrationTest : FullApplicationTest() {
             endDate = null,
             deletable = true
         )
-        jdbi.handle {
-            it.insertTestDaycareGroup(
+        db.transaction {
+            it.handle.insertTestDaycareGroup(
                 DevDaycareGroup(
                     id = group.id,
                     daycareId = group.daycareId,
@@ -105,11 +105,11 @@ class DaycareGroupIntegrationTest : FullApplicationTest() {
         }
         getAndAssertGroup(group)
 
-        jdbi.handle { h ->
-            h.insertTestPerson(DevPerson(testChild_1.id))
-            h.insertTestChild(DevChild(testChild_1.id))
+        db.transaction { tx ->
+            tx.handle.insertTestPerson(DevPerson(testChild_1.id))
+            tx.handle.insertTestChild(DevChild(testChild_1.id))
             insertTestBackupCare(
-                h,
+                tx.handle,
                 DevBackupCare(
                     childId = testChild_1.id,
                     groupId = group.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
@@ -31,9 +31,9 @@ class ChildrenControllerIntegrationTest : AbstractIntegrationTest() {
 
     @BeforeEach
     internal fun setUp() {
-        jdbi.handle { h ->
-            h.execute("INSERT INTO person (id, date_of_birth) VALUES ('$childId', '${LocalDate.now().minusYears(1)}')")
-            child = h.createChild(
+        db.transaction { tx ->
+            tx.handle.execute("INSERT INTO person (id, date_of_birth) VALUES ('$childId', '${LocalDate.now().minusYears(1)}')")
+            child = tx.handle.createChild(
                 Child(
                     id = childId,
                     additionalInformation = AdditionalInformation(
@@ -48,10 +48,10 @@ class ChildrenControllerIntegrationTest : AbstractIntegrationTest() {
 
     @AfterEach
     internal fun tearDown() {
-        jdbi.handle {
-            it.execute("DELETE FROM assistance_need")
-            it.execute("DELETE FROM service_need")
-            it.execute("DELETE FROM person WHERE id = '$childId'")
+        db.transaction {
+            it.handle.execute("DELETE FROM assistance_need")
+            it.handle.execute("DELETE FROM service_need")
+            it.handle.execute("DELETE FROM person WHERE id = '$childId'")
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -40,13 +40,13 @@ class UnitAclControllerIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     protected fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            admin = AuthenticatedUser.Employee(h.insertTestEmployee(DevEmployee(roles = setOf(UserRole.ADMIN))), roles = setOf(UserRole.ADMIN))
-            h.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
-            h.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
+        db.transaction { tx ->
+            tx.resetDatabase()
+            admin = AuthenticatedUser.Employee(tx.handle.insertTestEmployee(DevEmployee(roles = setOf(UserRole.ADMIN))), roles = setOf(UserRole.ADMIN))
+            tx.handle.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
+            tx.handle.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
             employee.also {
-                h.insertTestEmployee(DevEmployee(id = it.id, firstName = it.firstName, lastName = it.lastName, email = it.email))
+                tx.handle.insertTestEmployee(DevEmployee(id = it.id, firstName = it.firstName, lastName = it.lastName, email = it.email))
             }
         }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/CaretakerQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/CaretakerQueriesIntegrationTest.kt
@@ -30,15 +30,15 @@ class CaretakerQueriesIntegrationTest : PureJdbiTest() {
 
     @BeforeEach
     fun setup() {
-        jdbi.handle {
-            it.execute("INSERT INTO care_area (id, name, short_name) VALUES ('$careAreaId', 'foo', 'foo')")
-            it.execute("INSERT INTO daycare (id, name, care_area_id) VALUES ('$daycareId', 'foo', '$careAreaId')")
-            it.execute("INSERT INTO daycare (id, name, care_area_id) VALUES ('$daycareId2', 'empty daycare', '$careAreaId')")
+        db.transaction { tx ->
+            tx.handle.execute("INSERT INTO care_area (id, name, short_name) VALUES ('$careAreaId', 'foo', 'foo')")
+            tx.handle.execute("INSERT INTO daycare (id, name, care_area_id) VALUES ('$daycareId', 'foo', '$careAreaId')")
+            tx.handle.execute("INSERT INTO daycare (id, name, care_area_id) VALUES ('$daycareId2', 'empty daycare', '$careAreaId')")
 
-            it.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId1', 'foo', '$daycareId', '2000-01-01', '9999-01-01')")
-            it.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId2', 'bar', '$daycareId', '2000-01-01', '9999-01-01')")
-            it.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId3', 'baz', '$daycareId', '2000-01-01', '9999-01-01')")
-            it.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId4', 'empty', '$daycareId', '2000-01-01', '9999-01-01')")
+            tx.handle.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId1', 'foo', '$daycareId', '2000-01-01', '9999-01-01')")
+            tx.handle.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId2', 'bar', '$daycareId', '2000-01-01', '9999-01-01')")
+            tx.handle.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId3', 'baz', '$daycareId', '2000-01-01', '9999-01-01')")
+            tx.handle.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId4', 'empty', '$daycareId', '2000-01-01', '9999-01-01')")
 
             // date             01-01   02-02   02-06   03-02   03-04   05-06   09-04
             // g1               3       5       5       4       4       4       4
@@ -47,30 +47,30 @@ class CaretakerQueriesIntegrationTest : PureJdbiTest() {
             // g4               0       0       0       0       0       0       0
             // total            10      12      10      9       11      13      7
 
-            it.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 3, '2000-01-01', '2000-02-01')")
-            it.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 5, '2000-02-02', '2000-03-01')")
-            it.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 4, '2000-03-02', '9999-01-01')")
+            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 3, '2000-01-01', '2000-02-01')")
+            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 5, '2000-02-02', '2000-03-01')")
+            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 4, '2000-03-02', '9999-01-01')")
 
-            it.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 3, '2000-01-01', '2000-02-05')")
-            it.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 1, '2000-02-06', '2000-03-03')")
-            it.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 3, '2000-03-04', '9999-01-01')")
+            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 3, '2000-01-01', '2000-02-05')")
+            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 1, '2000-02-06', '2000-03-03')")
+            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 3, '2000-03-04', '9999-01-01')")
 
-            it.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId3', 4, '2000-01-01', '2000-05-05')")
-            it.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId3', 6, '2000-05-06', '2000-09-03')")
+            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId3', 4, '2000-01-01', '2000-05-05')")
+            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId3', 6, '2000-05-06', '2000-09-03')")
         }
     }
 
     @AfterEach
     fun tearDown() {
-        jdbi.handle {
-            it.execute("DELETE FROM daycare WHERE id IN ('$daycareId', '$daycareId2')")
-            it.execute("DELETE FROM care_area WHERE id = '$careAreaId'")
+        db.transaction { tx ->
+            tx.handle.execute("DELETE FROM daycare WHERE id IN ('$daycareId', '$daycareId2')")
+            tx.handle.execute("DELETE FROM care_area WHERE id = '$careAreaId'")
         }
     }
 
     @Test
-    fun `test getGroupStats`() = jdbi.handle { h ->
-        val groupStats = h.getGroupStats(daycareId, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
+    fun `test getGroupStats`() = db.transaction { tx ->
+        val groupStats = tx.handle.getGroupStats(daycareId, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
         assertEquals(4, groupStats.keys.size)
         assertEquals(Stats(3.0, 5.0), groupStats.get(groupId1))
         assertEquals(Stats(1.0, 3.0), groupStats.get(groupId2))
@@ -79,8 +79,8 @@ class CaretakerQueriesIntegrationTest : PureJdbiTest() {
     }
 
     @Test
-    fun `test getGroupStats with limited range`() = jdbi.handle { h ->
-        val groupStats = h.getGroupStats(daycareId, LocalDate.of(2000, 2, 3), LocalDate.of(2000, 4, 1))
+    fun `test getGroupStats with limited range`() = db.transaction { tx ->
+        val groupStats = tx.handle.getGroupStats(daycareId, LocalDate.of(2000, 2, 3), LocalDate.of(2000, 4, 1))
         assertEquals(4, groupStats.keys.size)
         assertEquals(Stats(4.0, 5.0), groupStats.get(groupId1))
         assertEquals(Stats(1.0, 3.0), groupStats.get(groupId2))
@@ -89,56 +89,56 @@ class CaretakerQueriesIntegrationTest : PureJdbiTest() {
     }
 
     @Test
-    fun `test getGroupStats with limited range 2`() = jdbi.handle { h ->
+    fun `test getGroupStats with limited range 2`() = db.transaction { tx ->
         val singleDate = LocalDate.of(2000, 2, 1)
-        val groupStats = h.getGroupStats(daycareId, singleDate, singleDate)
+        val groupStats = tx.handle.getGroupStats(daycareId, singleDate, singleDate)
         assertEquals(Stats(3.0, 3.0), groupStats.get(groupId1))
     }
 
     @Test
-    fun `test getGroupStats with limited range 3`() = jdbi.handle { h ->
+    fun `test getGroupStats with limited range 3`() = db.transaction { tx ->
         val singleDate = LocalDate.of(2000, 2, 2)
-        val groupStats = h.getGroupStats(daycareId, singleDate, singleDate)
+        val groupStats = tx.handle.getGroupStats(daycareId, singleDate, singleDate)
         assertEquals(Stats(5.0, 5.0), groupStats.get(groupId1))
     }
 
     @Test
-    fun `test getUnitStats`() = jdbi.handle { h ->
-        val unitStats = h.getUnitStats(daycareId, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
+    fun `test getUnitStats`() = db.transaction { tx ->
+        val unitStats = tx.handle.getUnitStats(daycareId, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
         assertEquals(Stats(9.0, 13.0), unitStats)
     }
 
     @Test
-    fun `test getUnitStats with no groups`() = jdbi.handle { h ->
-        val unitStats = h.getUnitStats(daycareId2, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
+    fun `test getUnitStats with no groups`() = db.transaction { tx ->
+        val unitStats = tx.handle.getUnitStats(daycareId2, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
         assertEquals(Stats(0.0, 0.0), unitStats)
     }
 
     @Test
-    fun `test getUnitStats with limited range 1`() = jdbi.handle { h ->
-        val unitStats = h.getUnitStats(daycareId, LocalDate.of(2000, 3, 1), LocalDate.of(2000, 3, 2))
+    fun `test getUnitStats with limited range 1`() = db.transaction { tx ->
+        val unitStats = tx.handle.getUnitStats(daycareId, LocalDate.of(2000, 3, 1), LocalDate.of(2000, 3, 2))
         assertEquals(Stats(9.0, 10.0), unitStats)
     }
 
     @Test
-    fun `test getUnitStats with limited range 2`() = jdbi.handle { h ->
-        val unitStats = h.getUnitStats(daycareId, LocalDate.of(2000, 3, 1), LocalDate.of(2000, 3, 1))
+    fun `test getUnitStats with limited range 2`() = db.transaction { tx ->
+        val unitStats = tx.handle.getUnitStats(daycareId, LocalDate.of(2000, 3, 1), LocalDate.of(2000, 3, 1))
         assertEquals(Stats(10.0, 10.0), unitStats)
     }
 
     @Test
-    fun `test getUnitStats with limited range 3`() = jdbi.handle { h ->
-        val unitStats = h.getUnitStats(daycareId, LocalDate.of(2000, 3, 2), LocalDate.of(2000, 3, 2))
+    fun `test getUnitStats with limited range 3`() = db.transaction { tx ->
+        val unitStats = tx.handle.getUnitStats(daycareId, LocalDate.of(2000, 3, 2), LocalDate.of(2000, 3, 2))
         assertEquals(Stats(9.0, 9.0), unitStats)
     }
 
     @Test
-    fun `test getUnitStats with long time range`() = jdbi.handle { h ->
-        assertDoesNotThrow { h.getUnitStats(daycareId, LocalDate.of(2005, 1, 1), LocalDate.of(2010, 1, 1)) }
+    fun `test getUnitStats with long time range`() = db.transaction { tx ->
+        assertDoesNotThrow { tx.handle.getUnitStats(daycareId, LocalDate.of(2005, 1, 1), LocalDate.of(2010, 1, 1)) }
     }
 
     @Test
-    fun `test getUnitStats with too long time range`() = jdbi.handle { h ->
-        assertThrows<BadRequest> { h.getUnitStats(daycareId, LocalDate.of(2005, 1, 1), LocalDate.of(2010, 1, 2)) }
+    fun `test getUnitStats with too long time range`() = db.transaction { tx ->
+        assertThrows<BadRequest> { tx.handle.getUnitStats(daycareId, LocalDate.of(2005, 1, 1), LocalDate.of(2010, 1, 2)) }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/ChildDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/ChildDAOIntegrationTest.kt
@@ -24,9 +24,9 @@ class ChildDAOIntegrationTest : AbstractIntegrationTest() {
 
     @BeforeEach
     internal fun setUp() {
-        jdbi.handle { h ->
-            h.execute("INSERT INTO person (id, date_of_birth) VALUES ('$childId', '${LocalDate.now().minusYears(1)}')")
-            child = h.createChild(
+        db.transaction { tx ->
+            tx.handle.execute("INSERT INTO person (id, date_of_birth) VALUES ('$childId', '${LocalDate.now().minusYears(1)}')")
+            child = tx.handle.createChild(
                 Child(
                     id = childId,
                     additionalInformation = AdditionalInformation(
@@ -41,12 +41,12 @@ class ChildDAOIntegrationTest : AbstractIntegrationTest() {
 
     @AfterEach
     internal fun tearDown() {
-        jdbi.handle { it.execute("DELETE FROM person WHERE id = '$childId'") }
+        db.transaction { it.execute("DELETE FROM person WHERE id = '$childId'") }
     }
 
     @Test
     fun `add and fetch child data`() {
-        val fetchedChild = jdbi.handle { it.getChild(childId) }
+        val fetchedChild = db.transaction { it.handle.getChild(childId) }
 
         assertEquals(child, fetchedChild)
     }
@@ -61,9 +61,9 @@ class ChildDAOIntegrationTest : AbstractIntegrationTest() {
             )
         )
 
-        jdbi.handle { it.updateChild(updated) }
+        db.transaction { it.handle.updateChild(updated) }
 
-        val actual = jdbi.handle { it.getChild(childId) }
+        val actual = db.transaction { it.handle.getChild(childId) }
         assertEquals(actual, updated)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/ClubTermQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/ClubTermQueriesIntegrationTest.kt
@@ -3,7 +3,6 @@ package fi.espoo.evaka.daycare.dao
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.daycare.getActiveClubTermAt
 import fi.espoo.evaka.daycare.getClubTerms
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -15,7 +14,7 @@ class ClubTermQueriesIntegrationTest : PureJdbiTest() {
 
     @BeforeEach
     internal fun setUp() {
-        jdbi.handle {
+        db.transaction {
             it.execute(
                 """INSERT INTO club_term (term, application_period) VALUES
                 ('[2020-08-13,2021-06-04]', '[2020-01-08,2020-01-20]'),
@@ -27,7 +26,7 @@ class ClubTermQueriesIntegrationTest : PureJdbiTest() {
 
     @AfterEach
     internal fun tearDown() {
-        jdbi.handle { it.execute("TRUNCATE TABLE club_term") }
+        db.transaction { it.execute("TRUNCATE TABLE club_term") }
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/PlacementQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/PlacementQueriesIntegrationTest.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getDaycarePlacements
 import fi.espoo.evaka.resetDatabase
-import fi.espoo.evaka.shared.db.handle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -27,10 +26,10 @@ class PlacementQueriesIntegrationTest : PureJdbiTest() {
     @BeforeEach
     fun setUp() {
         val legacyDataSql = this.javaClass.getResource("/legacy_db_data.sql").readText()
-        jdbi.handle {
-            resetDatabase(it)
-            it.execute(legacyDataSql)
-            it.execute(
+        db.transaction { tx ->
+            tx.resetDatabase()
+            tx.execute(legacyDataSql)
+            tx.execute(
                 // language=sql
                 """
                 INSERT INTO placement (id, type, child_id, unit_id, start_date, end_date)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
@@ -26,17 +26,17 @@ class CaretakerServiceIntegrationTest : PureJdbiTest() {
 
     @BeforeEach
     fun setup() {
-        jdbi.handle {
-            resetDatabase(it)
-            insertGeneralTestFixtures(it)
-            it.insertTestDaycareGroup(
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
+            tx.handle.insertTestDaycareGroup(
                 DevDaycareGroup(
                     id = groupId,
                     daycareId = daycareId,
                     startDate = groupStart
                 )
             )
-            it.execute(
+            tx.execute(
                 "INSERT INTO daycare_caretaker (group_id, start_date, amount) VALUES (?, ?, 3)",
                 groupId,
                 groupStart

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -66,10 +66,10 @@ class DecisionCreationIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     private fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
-            h.createUpdate(
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
+            tx.createUpdate(
                 // language=SQL
                 """
 UPDATE daycare SET

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
@@ -24,16 +24,16 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
 
     @BeforeEach
     private fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            storeDvvModificationToken(h, "100", "101", 0, 0)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            storeDvvModificationToken(tx.handle, "100", "101", 0, 0)
         }
     }
 
     @AfterEach
     private fun afterEach() {
-        jdbi.handle { h ->
-            deleteDvvModificationToken(h, "100")
+        db.transaction { tx ->
+            deleteDvvModificationToken(tx.handle, "100")
         }
     }
 
@@ -184,8 +184,8 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         restrictedDetailsEnabled = false
     )
 
-    private fun createTestPerson(devPerson: DevPerson): UUID = jdbi.handle { h ->
-        h.insertTestPerson(devPerson)
+    private fun createTestPerson(devPerson: DevPerson): UUID = db.transaction { tx ->
+        tx.handle.insertTestPerson(devPerson)
     }
 
     private fun createVtjPerson(person: DevPerson) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -82,12 +82,16 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        jdbi.handle(::insertGeneralTestFixtures)
+        db.transaction { tx ->
+            insertGeneralTestFixtures(tx.handle)
+        }
     }
 
     @AfterEach
     fun afterEach() {
-        jdbi.handle(::resetDatabase)
+        db.transaction { tx ->
+            tx.resetDatabase()
+        }
     }
 
     @Test
@@ -95,7 +99,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val placementPeriod = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertTrue(decisions.isEmpty())
@@ -107,7 +111,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycareNotInvoiced.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(0, decisions.size)
@@ -120,7 +124,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions[0].children.size)
@@ -133,7 +137,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions[0].children.size)
@@ -148,7 +152,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -160,12 +164,12 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val original = getAllFeeDecisions()
         assertEquals(1, original.size)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
         assertEquals(1, original.size)
@@ -190,13 +194,13 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        jdbi.handle { h -> upsertFeeDecisions2(h, listOf(oldDraft)) }
+        db.transaction { tx -> upsertFeeDecisions2(tx.handle, listOf(oldDraft)) }
 
         val placementPeriod = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
         assertEquals(2, result.size)
@@ -219,7 +223,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, PRESCHOOL, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
 
@@ -232,7 +236,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, PREPARATORY, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
 
@@ -245,7 +249,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, PRESCHOOL_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
 
@@ -260,7 +264,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, PREPARATORY_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
 
@@ -275,7 +279,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE_FIVE_YEAR_OLDS, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
 
@@ -290,7 +294,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE_PART_TIME_FIVE_YEAR_OLDS, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
 
@@ -305,7 +309,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val placementId = insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val original = getAllFeeDecisions()
         assertEquals(1, original.size)
@@ -313,7 +317,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
         val serviceNeed = snDaycareFullDayPartWeek25
         insertServiceNeed(placementId, placementPeriod.asFiniteDateRange()!!, serviceNeed.id)
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val updated = getAllFeeDecisions()
         assertEquals(1, updated.size)
@@ -326,7 +330,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val placementId = insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val original = getAllFeeDecisions()
         assertEquals(1, original.size)
@@ -335,7 +339,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val serviceNeedPeriod = FiniteDateRange(LocalDate.of(2019, 7, 1), LocalDate.of(2019, 12, 31))
         val serviceNeed = snDaycareFullDay25to35
         insertServiceNeed(placementId, serviceNeedPeriod, serviceNeed.id)
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val updated = getAllFeeDecisions()
         assertEquals(2, updated.size)
@@ -358,7 +362,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
         insertServiceNeed(placementId, serviceNeedPeriod, serviceNeed.id)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val original = getAllFeeDecisions()
         assertEquals(2, original.size)
@@ -371,9 +375,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
             assertEquals(serviceNeed.toFeeDecisionServiceNeed(), decision.children[0].serviceNeed)
         }
 
-        jdbi.handle { h ->
-            h.execute("DELETE FROM new_service_need WHERE placement_id = ?", placementId)
-            generator.handlePlacement(h, testChild_1.id, serviceNeedPeriod.asDateRange())
+        db.transaction { tx ->
+            tx.execute("DELETE FROM new_service_need WHERE placement_id = ?", placementId)
+            generator.handlePlacement(tx.handle, testChild_1.id, serviceNeedPeriod.asDateRange())
         }
 
         val updated = getAllFeeDecisions()
@@ -387,7 +391,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
 
-        jdbi.handle { generator.handleFeeAlterationChange(it, testChild_1.id, period) }
+        db.transaction { generator.handleFeeAlterationChange(it.handle, testChild_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(0, decisions.size)
@@ -397,9 +401,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     fun `new fee decisions are generated if children have no placements but there exists an sent decision for same head of family`() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions2(
-                h,
+                tx.handle,
                 listOf(
                     createFeeDecision2Fixture(
                         status = FeeDecisionStatus.SENT,
@@ -419,7 +423,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
         }
 
         val decisions = getAllFeeDecisions()
@@ -431,9 +435,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     @Test
     fun `new empty fee decision is generated if head of family has no children but there exists an sent decision for same head of family`() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions2(
-                h,
+                tx.handle,
                 listOf(
                     createFeeDecision2Fixture(
                         status = FeeDecisionStatus.SENT,
@@ -453,7 +457,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
         }
 
         val decisions = getAllFeeDecisions()
@@ -471,7 +475,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, PRESCHOOL_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -506,7 +510,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, PRESCHOOL_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -541,7 +545,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, PRESCHOOL_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -574,7 +578,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, PRESCHOOL_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -602,7 +606,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, PREPARATORY_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -637,7 +641,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, PREPARATORY_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -672,7 +676,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, PREPARATORY_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -705,7 +709,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, PREPARATORY_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -728,13 +732,13 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     fun `children over 18 years old are not included in families when determining base fee`() {
         val placementPeriod = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         val birthday = LocalDate.of(2001, 7, 1)
-        val childTurning18Id = jdbi.handle { it.insertTestPerson(DevPerson(dateOfBirth = birthday)) }
+        val childTurning18Id = db.transaction { it.handle.insertTestPerson(DevPerson(dateOfBirth = birthday)) }
 
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, childTurning18Id), placementPeriod)
         insertIncome(testAdult_1.id, 330000, placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -771,9 +775,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions2(
-                h,
+                tx.handle,
                 listOf(
                     createFeeDecision2Fixture(
                         status = FeeDecisionStatus.SENT,
@@ -793,7 +797,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
         }
 
         val decisions = getAllFeeDecisions()
@@ -806,9 +810,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions2(
-                h,
+                tx.handle,
                 listOf(
                     createFeeDecision2Fixture(
                         status = FeeDecisionStatus.SENT,
@@ -843,7 +847,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
         }
 
         val decisions = getAllFeeDecisions()
@@ -859,9 +863,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val serviceNeed = snDaycareFullDayPartWeek25
         val shorterPeriod = FiniteDateRange(period.start, period.start.plusDays(30))
         insertServiceNeed(placementId, shorterPeriod, serviceNeed.id)
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions2(
-                h,
+                tx.handle,
                 listOf(
                     createFeeDecision2Fixture(
                         status = FeeDecisionStatus.SENT,
@@ -881,7 +885,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
         }
 
         val decisions = getAllFeeDecisions()
@@ -928,9 +932,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val serviceNeed = snDaycareFullDayPartWeek25
         insertServiceNeed(placementId, olderPeriod.asFiniteDateRange()!!, serviceNeed.id)
         val newerPeriod = period.copy(start = olderPeriod.end!!.plusDays(1))
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions2(
-                h,
+                tx.handle,
                 listOf(
                     createFeeDecision2Fixture(
                         status = FeeDecisionStatus.SENT,
@@ -980,7 +984,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, newerPeriod)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, newerPeriod)
         }
 
         val decisions = getAllFeeDecisions()
@@ -1016,7 +1020,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, period.copy(start = period.start.plusMonths(1)), DAYCARE, testDaycare.id)
         insertPlacement(testChild_3.id, period.copy(start = period.start.plusMonths(2)), DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(3, decisions.size)
@@ -1111,7 +1115,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, period_2, DAYCARE, testDaycare.id)
         insertPlacement(testChild_3.id, period_3, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period_1.copy(end = period_3.end)) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period_1.copy(end = period_3.end)) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(3, decisions.size)
@@ -1175,7 +1179,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertPlacement(testChild_2.id, period, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1222,7 +1226,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, subPeriod_1)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1268,7 +1272,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, incomePeriod)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1290,7 +1294,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         }
 
         deleteIncomes()
-        jdbi.handle { generator.handleIncomeChange(it, testAdult_1.id, incomePeriod) }
+        db.transaction { generator.handleIncomeChange(it.handle, testAdult_1.id, incomePeriod) }
 
         val newDecisions = getAllFeeDecisions()
         assertEquals(1, newDecisions.size)
@@ -1321,7 +1325,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, subPeriod_1)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1359,7 +1363,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         }
 
         deleteIncomes()
-        jdbi.handle { generator.handleIncomeChange(it, testAdult_1.id, subPeriod_1) }
+        db.transaction { generator.handleIncomeChange(it.handle, testAdult_1.id, subPeriod_1) }
 
         val newDecisions = getAllFeeDecisions()
         assertEquals(1, newDecisions.size)
@@ -1392,7 +1396,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertIncome(testAdult_1.id, 310200, period)
         insertIncome(testAdult_2.id, 310200, period)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1440,7 +1444,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, period)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1485,7 +1489,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertFeeAlteration(testChild_1.id, 50.0, period)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1525,13 +1529,13 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        jdbi.handle { h -> upsertFeeDecisions2(h, listOf(sentDecision)) }
+        db.transaction { tx -> upsertFeeDecisions2(tx.handle, listOf(sentDecision)) }
 
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), originalPeriod)
         val newPeriod = originalPeriod.copy(end = originalPeriod.end!!.minusDays(7))
         insertPlacement(testChild_1.id, newPeriod, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, newPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, newPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1556,13 +1560,13 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        jdbi.handle { h -> upsertFeeDecisions2(h, listOf(sentDecision)) }
+        db.transaction { tx -> upsertFeeDecisions2(tx.handle, listOf(sentDecision)) }
 
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), originalPeriod)
         val newPeriod = originalPeriod.copy(end = originalPeriod.end!!.minusDays(7))
         insertPlacement(testChild_1.id, newPeriod, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, newPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, newPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1580,7 +1584,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val period = DateRange(LocalDate.of(2014, 6, 1), LocalDate.of(2015, 6, 1))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, period) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1602,9 +1606,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
             DAYCARE,
             testDaycare.id
         )
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions2(
-                h,
+                tx.handle,
                 listOf(
                     createFeeDecision2Fixture(
                         status = FeeDecisionStatus.SENT,
@@ -1624,7 +1628,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, familyPeriod)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, familyPeriod)
         }
 
         val decisions = getAllFeeDecisions()
@@ -1647,40 +1651,39 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     @Test
     fun `zero euro fee decisions get an updated draft when pricing changes`() {
         val period = DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31))
-        jdbi.handle { h ->
-            insertIncome(adultId = testAdult_1.id, amount = 0, period = period)
-            upsertFeeDecisions2(
-                h,
-                listOf(
-                    createFeeDecision2Fixture(
-                        status = FeeDecisionStatus.SENT,
-                        decisionType = FeeDecisionType.NORMAL,
-                        headOfFamilyId = testAdult_1.id,
-                        period = period,
-                        pricing = oldTestPricing,
-                        headOfFamilyIncome = DecisionIncome(
-                            effect = IncomeEffect.INCOME,
-                            data = mapOf(IncomeType.MAIN_INCOME to 0),
-                            total = 0,
-                            validFrom = period.start,
-                            validTo = period.end
-                        ),
-                        children = listOf(
-                            createFeeDecisionChildFixture(
-                                childId = testChild_1.id,
-                                dateOfBirth = testChild_1.dateOfBirth,
-                                placementUnitId = testDaycare.id,
-                                placementType = DAYCARE,
-                                serviceNeed = snDefaultDaycare.toFeeDecisionServiceNeed(),
-                                baseFee = 0,
-                                fee = 0
-                            )
-                        )
-                    )
+        insertIncome(adultId = testAdult_1.id, amount = 0, period = period)
+        createFeeDecision2Fixture(
+            status = FeeDecisionStatus.SENT,
+            decisionType = FeeDecisionType.NORMAL,
+            headOfFamilyId = testAdult_1.id,
+            period = period,
+            pricing = oldTestPricing,
+            headOfFamilyIncome = DecisionIncome(
+                effect = IncomeEffect.INCOME,
+                data = mapOf(IncomeType.MAIN_INCOME to 0),
+                total = 0,
+                validFrom = period.start,
+                validTo = period.end
+            ),
+            children = listOf(
+                createFeeDecisionChildFixture(
+                    childId = testChild_1.id,
+                    dateOfBirth = testChild_1.dateOfBirth,
+                    placementUnitId = testDaycare.id,
+                    placementType = DAYCARE,
+                    serviceNeed = snDefaultDaycare.toFeeDecisionServiceNeed(),
+                    baseFee = 0,
+                    fee = 0
                 )
             )
-
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+        ).let { fixture ->
+            db.transaction { tx ->
+                upsertFeeDecisions2(
+                    tx.handle,
+                    listOf(fixture)
+                )
+                generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
+            }
         }
 
         val decisions = getAllFeeDecisions()
@@ -1713,7 +1716,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
             testDaycare.id
         )
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val feeDecisions = getAllFeeDecisions()
         assertEquals(1, feeDecisions.size)
@@ -1749,9 +1752,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: UUID): UUID {
-        return jdbi.handle { h ->
+        return db.transaction { tx ->
             insertTestPlacement(
-                h,
+                tx.handle,
                 childId = childId,
                 unitId = daycareId,
                 startDate = period.start,
@@ -1762,16 +1765,16 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertFamilyRelations(headOfFamilyId: UUID, childIds: List<UUID>, period: DateRange) {
-        jdbi.handle { h ->
+        db.transaction { tx ->
             childIds.forEach { childId ->
-                insertTestParentship(h, headOfFamilyId, childId, startDate = period.start, endDate = period.end!!)
+                insertTestParentship(tx.handle, headOfFamilyId, childId, startDate = period.start, endDate = period.end!!)
             }
         }
     }
 
     private fun insertPartnership(adultId1: UUID, adultId2: UUID, period: DateRange) {
-        jdbi.handle { h ->
-            insertTestPartnership(h, adultId1, adultId2, startDate = period.start, endDate = period.end!!)
+        db.transaction { tx ->
+            insertTestPartnership(tx.handle, adultId1, adultId2, startDate = period.start, endDate = period.end!!)
         }
     }
 
@@ -1780,9 +1783,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         period: FiniteDateRange,
         optionId: UUID
     ) {
-        jdbi.handle { h ->
+        db.transaction { tx ->
             insertTestNewServiceNeed(
-                h,
+                tx.handle,
                 placementId,
                 period,
                 optionId
@@ -1791,9 +1794,9 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertIncome(adultId: UUID, amount: Int, period: DateRange) {
-        jdbi.handle { h ->
+        db.transaction { tx ->
             insertTestIncome(
-                h,
+                tx.handle,
                 objectMapper,
                 personId = adultId,
                 validFrom = period.start,
@@ -1805,15 +1808,15 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun deleteIncomes() {
-        jdbi.handle { h ->
-            h.createUpdate("DELETE FROM income").execute()
+        db.transaction { tx ->
+            tx.createUpdate("DELETE FROM income").execute()
         }
     }
 
     private fun insertFeeAlteration(childId: UUID, amount: Double, period: DateRange) {
-        jdbi.handle { h ->
+        db.transaction { tx ->
             insertTestFeeAlteration(
-                h,
+                tx.handle,
                 childId,
                 type = FeeAlteration.Type.DISCOUNT,
                 amount = amount,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
@@ -77,12 +77,16 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        jdbi.handle(::insertGeneralTestFixtures)
+        db.transaction { tx ->
+            insertGeneralTestFixtures(tx.handle)
+        }
     }
 
     @AfterEach
     fun afterEach() {
-        jdbi.handle(::resetDatabase)
+        db.transaction { tx ->
+            tx.resetDatabase()
+        }
     }
 
     @Test
@@ -90,7 +94,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val placementPeriod = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertTrue(decisions.isEmpty())
@@ -102,7 +106,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycareNotInvoiced.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(0, decisions.size)
@@ -115,7 +119,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions[0].parts.size)
@@ -128,7 +132,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions[0].parts.size)
@@ -143,7 +147,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -155,12 +159,12 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val original = getAllFeeDecisions()
         assertEquals(1, original.size)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
         assertEquals(1, original.size)
@@ -177,13 +181,13 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
             testAdult_1.id,
             listOf(createFeeDecisionPartFixture(testChild_2.id, LocalDate.of(2010, 1, 1), testDaycare.id))
         )
-        jdbi.handle { h -> upsertFeeDecisions(h, objectMapper, listOf(oldDraft)) }
+        db.transaction { tx -> upsertFeeDecisions(tx.handle, objectMapper, listOf(oldDraft)) }
 
         val placementPeriod = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
         assertEquals(2, result.size)
@@ -207,7 +211,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
         insertServiceNeed(testChild_1.id, listOf(placementPeriod to 30.0))
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
 
@@ -221,7 +225,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
         insertServiceNeed(testChild_1.id, listOf(placementPeriod to 30.0))
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
 
@@ -230,9 +234,9 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `fee decision placement infers FIVE_YEARS_OLD_DAYCARE from age correctly`() {
-        val fiveYearOld = jdbi.handle { h ->
-            val id = h.insertTestPerson(DevPerson(dateOfBirth = LocalDate.of(2014, 1, 1)))
-            h.insertTestChild(DevChild(id))
+        val fiveYearOld = db.transaction { tx ->
+            val id = tx.handle.insertTestPerson(DevPerson(dateOfBirth = LocalDate.of(2014, 1, 1)))
+            tx.handle.insertTestChild(DevChild(id))
             id
         }
 
@@ -241,7 +245,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertFamilyRelations(testAdult_1.id, listOf(fiveYearOld), placementPeriod)
         insertServiceNeed(fiveYearOld, listOf(placementPeriod to 30.0))
 
-        jdbi.handle { generator.handlePlacement(it, fiveYearOld, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, fiveYearOld, placementPeriod) }
 
         val result = getAllFeeDecisions()
 
@@ -287,7 +291,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
         insertServiceNeed(testChild_1.id, listOf(placementPeriod to 30.0))
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val result = getAllFeeDecisions()
 
@@ -316,7 +320,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val original = getAllFeeDecisions()
         assertEquals(1, original.size)
@@ -326,7 +330,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
         val serviceNeed = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31)) to 20.0
         insertServiceNeed(testChild_1.id, listOf(serviceNeed))
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, serviceNeed.first) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, serviceNeed.first) }
 
         val updated = getAllFeeDecisions()
         assertEquals(1, updated.size)
@@ -341,7 +345,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val original = getAllFeeDecisions()
         assertEquals(1, original.size)
@@ -351,7 +355,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
         val serviceNeed = DateRange(LocalDate.of(2019, 7, 1), null) to 20.0
         insertServiceNeed(testChild_1.id, listOf(serviceNeed))
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, serviceNeed.first) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, serviceNeed.first) }
 
         val updated = getAllFeeDecisions()
         assertEquals(2, updated.size)
@@ -371,7 +375,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
         insertServiceNeed(testChild_1.id, listOf(serviceNeed))
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, placementPeriod) }
 
         val original = getAllFeeDecisions()
         assertEquals(2, original.size)
@@ -382,12 +386,12 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
             assertEquals(listOf(ServiceNeed.LTE_25), parts.map { it.placement.serviceNeed })
         }
 
-        jdbi.handle { h ->
-            h.createUpdate("DELETE FROM service_need WHERE child_id = :childId")
+        db.transaction { tx ->
+            tx.createUpdate("DELETE FROM service_need WHERE child_id = :childId")
                 .bind("childId", testChild_1.id)
                 .execute()
 
-            generator.handlePlacement(h, testChild_1.id, serviceNeed.first)
+            generator.handlePlacement(tx.handle, testChild_1.id, serviceNeed.first)
         }
 
         val updated = getAllFeeDecisions()
@@ -400,7 +404,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     @Test
     fun `get pricing works when from is same as validFrom`() {
         val from = LocalDate.of(2000, 1, 1)
-        val result = jdbi.handle { getPricing(it, from) }
+        val result = db.transaction { getPricing(it.handle, from) }
 
         assertEquals(1, result.size)
         result[0].let { (period, pricing) ->
@@ -413,7 +417,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     @Test
     fun `get pricing works as expected when from is before any pricing configuration`() {
         val from = LocalDate.of(1990, 1, 1)
-        val result = jdbi.handle { getPricing(it, from) }
+        val result = db.transaction { getPricing(it.handle, from) }
 
         assertEquals(1, result.size)
         result[0].let { (period, pricing) ->
@@ -428,7 +432,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
 
-        jdbi.handle { generator.handleFeeAlterationChange(it, testChild_1.id, period) }
+        db.transaction { generator.handleFeeAlterationChange(it.handle, testChild_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(0, decisions.size)
@@ -438,9 +442,9 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     fun `new fee decisions are generated if children have no placements but there exists an sent decision for same head of family`() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions(
-                h,
+                tx.handle,
                 objectMapper,
                 listOf(
                     createFeeDecisionFixture(
@@ -459,7 +463,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
         }
 
         val decisions = getAllFeeDecisions()
@@ -471,9 +475,9 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     @Test
     fun `new empty fee decision is generated if head of family has no children but there exists an sent decision for same head of family`() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions(
-                h,
+                tx.handle,
                 objectMapper,
                 listOf(
                     createFeeDecisionFixture(
@@ -492,7 +496,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
         }
 
         val decisions = getAllFeeDecisions()
@@ -510,7 +514,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertServiceNeed(testChild_2.id, listOf(DateRange(placementPeriod.start, null) to 45.0))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -545,7 +549,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertServiceNeed(testChild_2.id, listOf(placementPeriod to 36.0))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -580,7 +584,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertServiceNeed(testChild_2.id, listOf(placementPeriod to 35.0))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -615,7 +619,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertServiceNeed(testChild_2.id, listOf(DateRange(placementPeriod.start, null) to 30.0))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -649,7 +653,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         )
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -690,7 +694,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         )
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -731,7 +735,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         )
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -772,7 +776,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         )
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -813,7 +817,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         )
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -836,13 +840,13 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     fun `children over 18 years old are not included in families when determining base fee`() {
         val placementPeriod = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         val birthday = LocalDate.of(2001, 7, 1)
-        val childTurning18Id = jdbi.handle { it.insertTestPerson(DevPerson(dateOfBirth = birthday)) }
+        val childTurning18Id = db.transaction { it.handle.insertTestPerson(DevPerson(dateOfBirth = birthday)) }
 
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, childTurning18Id), placementPeriod)
         insertIncome(testAdult_1.id, 330000, placementPeriod)
 
-        jdbi.handle { generator.handleServiceNeed(it, testChild_1.id, placementPeriod) }
+        db.transaction { generator.handleServiceNeed(it.handle, testChild_1.id, placementPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -879,9 +883,9 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions(
-                h,
+                tx.handle,
                 objectMapper,
                 listOf(
                     createFeeDecisionFixture(
@@ -901,7 +905,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
         }
 
         val decisions = getAllFeeDecisions()
@@ -914,9 +918,9 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions(
-                h,
+                tx.handle,
                 objectMapper,
                 listOf(
                     createFeeDecisionFixture(
@@ -950,7 +954,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
         }
 
         val decisions = getAllFeeDecisions()
@@ -965,9 +969,9 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         val shorterPeriod = period.copy(end = period.start.plusDays(30))
         insertServiceNeed(testChild_1.id, listOf(shorterPeriod to 20.0))
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions(
-                h,
+                tx.handle,
                 objectMapper,
                 listOf(
                     createFeeDecisionFixture(
@@ -987,7 +991,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
         }
 
         val decisions = getAllFeeDecisions()
@@ -1033,9 +1037,9 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val olderPeriod = period.copy(end = period.start.plusDays(30))
         insertServiceNeed(testChild_1.id, listOf(olderPeriod to 20.0))
         val newerPeriod = period.copy(start = olderPeriod.end!!.plusDays(1))
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions(
-                h,
+                tx.handle,
                 objectMapper,
                 listOf(
                     createFeeDecisionFixture(
@@ -1083,7 +1087,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, newerPeriod)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, newerPeriod)
         }
 
         val decisions = getAllFeeDecisions()
@@ -1119,7 +1123,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, period.copy(start = period.start.plusMonths(1)), DAYCARE, testDaycare.id)
         insertPlacement(testChild_3.id, period.copy(start = period.start.plusMonths(2)), DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(3, decisions.size)
@@ -1214,7 +1218,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, period_2, DAYCARE, testDaycare.id)
         insertPlacement(testChild_3.id, period_3, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period_1.copy(end = period_3.end)) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period_1.copy(end = period_3.end)) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(3, decisions.size)
@@ -1278,7 +1282,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertPlacement(testChild_2.id, period, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1325,7 +1329,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, subPeriod_1)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1371,7 +1375,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, incomePeriod)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1393,7 +1397,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         }
 
         deleteIncomes()
-        jdbi.handle { generator.handleIncomeChange(it, testAdult_1.id, incomePeriod) }
+        db.transaction { generator.handleIncomeChange(it.handle, testAdult_1.id, incomePeriod) }
 
         val newDecisions = getAllFeeDecisions()
         assertEquals(1, newDecisions.size)
@@ -1424,7 +1428,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, subPeriod_1)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1462,7 +1466,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         }
 
         deleteIncomes()
-        jdbi.handle { generator.handleIncomeChange(it, testAdult_1.id, subPeriod_1) }
+        db.transaction { generator.handleIncomeChange(it.handle, testAdult_1.id, subPeriod_1) }
 
         val newDecisions = getAllFeeDecisions()
         assertEquals(1, newDecisions.size)
@@ -1495,7 +1499,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertIncome(testAdult_1.id, 310200, period)
         insertIncome(testAdult_2.id, 310200, period)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1543,7 +1547,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, period)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1588,7 +1592,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertFeeAlteration(testChild_1.id, 50.0, period)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1626,13 +1630,13 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        jdbi.handle { h -> upsertFeeDecisions(h, objectMapper, listOf(sentDecision)) }
+        db.transaction { tx -> upsertFeeDecisions(tx.handle, objectMapper, listOf(sentDecision)) }
 
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), originalPeriod)
         val newPeriod = originalPeriod.copy(end = originalPeriod.end!!.minusDays(7))
         insertPlacement(testChild_1.id, newPeriod, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, newPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, newPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1655,13 +1659,13 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        jdbi.handle { h -> upsertFeeDecisions(h, objectMapper, listOf(sentDecision)) }
+        db.transaction { tx -> upsertFeeDecisions(tx.handle, objectMapper, listOf(sentDecision)) }
 
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), originalPeriod)
         val newPeriod = originalPeriod.copy(end = originalPeriod.end!!.minusDays(7))
         insertPlacement(testChild_1.id, newPeriod, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, newPeriod) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, newPeriod) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(2, decisions.size)
@@ -1679,7 +1683,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val period = DateRange(LocalDate.of(2014, 6, 1), LocalDate.of(2015, 6, 1))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
-        jdbi.handle { generator.handlePlacement(it, testChild_1.id, period) }
+        db.transaction { generator.handlePlacement(it.handle, testChild_1.id, period) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1701,9 +1705,9 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
             DAYCARE,
             testDaycare.id
         )
-        jdbi.handle { h ->
+        db.transaction { tx ->
             upsertFeeDecisions(
-                h,
+                tx.handle,
                 objectMapper,
                 listOf(
                     createFeeDecisionFixture(
@@ -1723,7 +1727,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            generator.handleFamilyUpdate(h, testAdult_1.id, familyPeriod)
+            generator.handleFamilyUpdate(tx.handle, testAdult_1.id, familyPeriod)
         }
 
         val decisions = getAllFeeDecisions()
@@ -1746,40 +1750,41 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     @Test
     fun `zero euro fee decisions get an updated draft when pricing changes`() {
         val period = DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31))
-        jdbi.handle { h ->
-            insertIncome(adultId = testAdult_1.id, amount = 0, period = period)
-            upsertFeeDecisions(
-                h,
-                objectMapper,
-                listOf(
-                    createFeeDecisionFixture(
-                        status = FeeDecisionStatus.SENT,
-                        decisionType = FeeDecisionType.NORMAL,
-                        headOfFamilyId = testAdult_1.id,
-                        period = period,
-                        pricing = oldTestPricing,
-                        headOfFamilyIncome = DecisionIncome(
-                            effect = IncomeEffect.INCOME,
-                            data = mapOf(IncomeType.MAIN_INCOME to 0),
-                            total = 0,
-                            validFrom = period.start,
-                            validTo = period.end
-                        ),
-                        parts = listOf(
-                            createFeeDecisionPartFixture(
-                                childId = testChild_1.id,
-                                dateOfBirth = testChild_1.dateOfBirth,
-                                daycareId = testDaycare.id,
-                                serviceNeed = ServiceNeed.MISSING,
-                                baseFee = 0,
-                                fee = 0
-                            )
-                        )
-                    )
+
+        insertIncome(adultId = testAdult_1.id, amount = 0, period = period)
+
+        createFeeDecisionFixture(
+            status = FeeDecisionStatus.SENT,
+            decisionType = FeeDecisionType.NORMAL,
+            headOfFamilyId = testAdult_1.id,
+            period = period,
+            pricing = oldTestPricing,
+            headOfFamilyIncome = DecisionIncome(
+                effect = IncomeEffect.INCOME,
+                data = mapOf(IncomeType.MAIN_INCOME to 0),
+                total = 0,
+                validFrom = period.start,
+                validTo = period.end
+            ),
+            parts = listOf(
+                createFeeDecisionPartFixture(
+                    childId = testChild_1.id,
+                    dateOfBirth = testChild_1.dateOfBirth,
+                    daycareId = testDaycare.id,
+                    serviceNeed = ServiceNeed.MISSING,
+                    baseFee = 0,
+                    fee = 0
                 )
             )
-
-            generator.handleFamilyUpdate(h, testAdult_1.id, period)
+        ).let { fixture ->
+            db.transaction { tx ->
+                upsertFeeDecisions(
+                    tx.handle,
+                    objectMapper,
+                    listOf(fixture)
+                )
+                generator.handleFamilyUpdate(tx.handle, testAdult_1.id, period)
+            }
         }
 
         val decisions = getAllFeeDecisions()
@@ -1808,7 +1813,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, period, DAYCARE, testVoucherDaycare.id)
         insertPlacement(testChild_3.id, period, DAYCARE, testDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val feeDecisions = getAllFeeDecisions()
         assertEquals(1, feeDecisions.size)
@@ -1858,7 +1863,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
             testDaycare.id
         )
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val feeDecisions = getAllFeeDecisions()
         assertEquals(1, feeDecisions.size)
@@ -1882,7 +1887,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
         insertPlacement(testChild_1.id, period, DAYCARE, testVoucherDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(2, voucherValueDecisions.size)
@@ -1916,7 +1921,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         val serviceNeedPeriod = period.copy(start = period.start.plusMonths(5))
         insertServiceNeed(testChild_2.id, listOf(serviceNeedPeriod to 25.0))
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(2, voucherValueDecisions.size)
@@ -1949,7 +1954,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, period, DAYCARE_FIVE_YEAR_OLDS, testVoucherDaycare.id)
         insertServiceNeed(testChild_2.id, listOf(period to 40.0))
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -1972,7 +1977,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, period, DAYCARE_PART_TIME_FIVE_YEAR_OLDS, testVoucherDaycare.id)
         insertServiceNeed(testChild_2.id, listOf(period to 25.0))
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -1995,7 +2000,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, period, PRESCHOOL, testVoucherDaycare.id)
         insertServiceNeed(testChild_2.id, listOf(period to 40.0))
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -2017,7 +2022,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertFamilyRelations(testAdult_1.id, listOf(testChild_2.id), period)
         insertPlacement(testChild_2.id, period, PREPARATORY, testVoucherDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -2039,7 +2044,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertFamilyRelations(testAdult_1.id, listOf(testChild_2.id), period)
         insertPlacement(testChild_2.id, period, DAYCARE, testVoucherDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -2062,7 +2067,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_2.id, period, DAYCARE, testVoucherDaycare.id)
         insertServiceNeed(testChild_2.id, listOf(period to 25.0))
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -2085,7 +2090,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         insertPlacement(testChild_1.id, period, DAYCARE, testVoucherDaycare.id)
         insertPlacement(testChild_2.id, period.copy(start = period.start.plusMonths(1)), DAYCARE, testVoucherDaycare.id)
 
-        jdbi.handle { generator.handleFamilyUpdate(it, testAdult_1.id, period) }
+        db.transaction { generator.handleFamilyUpdate(it.handle, testAdult_1.id, period) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
@@ -2122,9 +2127,9 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: UUID): UUID {
-        return jdbi.handle { h ->
+        return db.transaction { tx ->
             insertTestPlacement(
-                h,
+                tx.handle,
                 childId = childId,
                 unitId = daycareId,
                 startDate = period.start,
@@ -2135,16 +2140,16 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertFamilyRelations(headOfFamilyId: UUID, childIds: List<UUID>, period: DateRange) {
-        jdbi.handle { h ->
+        db.transaction { tx ->
             childIds.forEach { childId ->
-                insertTestParentship(h, headOfFamilyId, childId, startDate = period.start, endDate = period.end!!)
+                insertTestParentship(tx.handle, headOfFamilyId, childId, startDate = period.start, endDate = period.end!!)
             }
         }
     }
 
     private fun insertPartnership(adultId1: UUID, adultId2: UUID, period: DateRange) {
-        jdbi.handle { h ->
-            insertTestPartnership(h, adultId1, adultId2, startDate = period.start, endDate = period.end!!)
+        db.transaction { tx ->
+            insertTestPartnership(tx.handle, adultId1, adultId2, startDate = period.start, endDate = period.end!!)
         }
     }
 
@@ -2152,10 +2157,10 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         childId: UUID,
         hours: List<Pair<DateRange, Double>>
     ) {
-        jdbi.handle { h ->
+        db.transaction { tx ->
             hours.map {
                 insertTestServiceNeed(
-                    h,
+                    tx.handle,
                     childId,
                     startDate = it.first.start,
                     endDate = it.first.end,
@@ -2167,9 +2172,9 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertIncome(adultId: UUID, amount: Int, period: DateRange) {
-        jdbi.handle { h ->
+        db.transaction { tx ->
             insertTestIncome(
-                h,
+                tx.handle,
                 objectMapper,
                 personId = adultId,
                 validFrom = period.start,
@@ -2181,15 +2186,15 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun deleteIncomes() {
-        jdbi.handle { h ->
-            h.createUpdate("DELETE FROM income").execute()
+        db.transaction { tx ->
+            tx.createUpdate("DELETE FROM income").execute()
         }
     }
 
     private fun insertFeeAlteration(childId: UUID, amount: Double, period: DateRange) {
-        jdbi.handle { h ->
+        db.transaction { tx ->
             insertTestFeeAlteration(
-                h,
+                tx.handle,
                 childId,
                 type = FeeAlteration.Type.DISCOUNT,
                 amount = amount,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -127,7 +127,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         koskiTester.triggerUploads(today = preschoolTerm2019.end.plusDays(1))
         assertSingleStudyRight(version = 0)
 
-        jdbi.handle {
+        db.transaction {
             it.createUpdate("UPDATE placement SET end_date = :endDate WHERE id = :id")
                 .bind("id", placementId)
                 .bind("endDate", preschoolTerm2019.end.minusDays(1))
@@ -337,9 +337,9 @@ class KoskiIntegrationTest : FullApplicationTest() {
             TestCase(testPeriod(0L to 1L), AssistanceBasis.DEVELOPMENTAL_DISABILITY_1),
             TestCase(testPeriod(2L to 3L), AssistanceBasis.DEVELOPMENTAL_DISABILITY_2)
         )
-        jdbi.handle { h ->
+        db.transaction { tx ->
             testCases.forEach {
-                h.insertTestAssistanceNeed(
+                tx.handle.insertTestAssistanceNeed(
                     DevAssistanceNeed(
                         updatedBy = testDecisionMaker_1.id,
                         childId = testChild_1.id,
@@ -383,9 +383,9 @@ class KoskiIntegrationTest : FullApplicationTest() {
                 AssistanceActionType.SPECIAL_GROUP
             )
         )
-        jdbi.handle { h ->
+        db.transaction { tx ->
             testCases.forEach {
-                h.insertTestAssistanceAction(
+                tx.handle.insertTestAssistanceAction(
                     DevAssistanceAction(
                         updatedBy = testDecisionMaker_1.id,
                         childId = testChild_1.id,
@@ -603,8 +603,8 @@ class KoskiIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `a daycare with purchased provider type is marked as such in study rights`() {
-        val daycareId = jdbi.handle {
-            it.insertTestDaycare(
+        val daycareId = db.transaction {
+            it.handle.insertTestDaycare(
                 DevDaycare(areaId = testAreaId, providerType = ProviderType.PURCHASED)
             )
         }
@@ -619,8 +619,8 @@ class KoskiIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `a daycare with private provider type is marked as purchased in study rights`() {
-        val daycareId = jdbi.handle {
-            it.insertTestDaycare(
+        val daycareId = db.transaction {
+            it.handle.insertTestDaycare(
                 DevDaycare(areaId = testAreaId, providerType = ProviderType.PRIVATE)
             )
         }
@@ -755,8 +755,8 @@ class KoskiIntegrationTest : FullApplicationTest() {
         daycareId: UUID = testDaycare.id,
         period: FiniteDateRange = preschoolTerm2019,
         type: PlacementType = PlacementType.PRESCHOOL
-    ): UUID = jdbi.handle {
-        it.insertTestPlacement(
+    ): UUID = db.transaction {
+        it.handle.insertTestPlacement(
             DevPlacement(
                 childId = child.id,
                 unitId = daycareId,
@@ -768,11 +768,11 @@ class KoskiIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertAbsences(childId: UUID, absenceType: AbsenceType, vararg periods: FiniteDateRange) =
-        jdbi.transaction { h ->
+        db.transaction { tx ->
             for (period in periods) {
                 for (date in period.dates()) {
                     insertTestAbsence(
-                        h,
+                        tx.handle,
                         childId = childId,
                         careType = CareType.PRESCHOOL,
                         date = date,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/ConfirmedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/ConfirmedOccupancyTest.kt
@@ -28,7 +28,6 @@ import fi.espoo.evaka.testAreaId
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDaycare2
 import fi.espoo.evaka.testDecisionMaker_1
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -39,12 +38,16 @@ import java.util.UUID
 class ConfirmedOccupancyTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
-        jdbi.handle(::insertGeneralTestFixtures)
+        db.transaction { tx ->
+            insertGeneralTestFixtures(tx.handle)
+        }
     }
 
     @AfterEach
     fun afterEach() {
-        jdbi.handle(::resetDatabase)
+        db.transaction { tx ->
+            tx.resetDatabase()
+        }
     }
 
     private val defaultPeriod = FiniteDateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
@@ -61,7 +64,7 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in full time daycare without service need`() {
-        jdbi.handle(createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE))
+        db.transaction { it.createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE) }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -75,14 +78,20 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
     fun `occupancy group level calculation is correct for child over 3 years old in full time daycare without service need`() {
         val childId = UUID.randomUUID()
         val placementId = UUID.randomUUID()
-        jdbi.handle(createOccupancyTestFixture(childId, testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE, placementId = placementId))
+        db.transaction { it.createOccupancyTestFixture(childId, testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE, placementId = placementId) }
 
-        val groupId1 = jdbi.handle { it.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = LocalDate.of(2000, 1, 1))) }
-        jdbi.handle { h -> insertTestCaretakers(h, groupId1, amount = 2.0, startDate = LocalDate.of(2000, 1, 1)) }
-        jdbi.handle { h -> insertTestDaycareGroupPlacement(h, placementId, groupId1, startDate = defaultPeriod.start, endDate = defaultPeriod.end) }
+        val groupId1 = db.transaction { tx ->
+            tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = LocalDate.of(2000, 1, 1))).also {
+                insertTestCaretakers(tx.handle, it, amount = 2.0, startDate = LocalDate.of(2000, 1, 1))
+                insertTestDaycareGroupPlacement(tx.handle, placementId, it, startDate = defaultPeriod.start, endDate = defaultPeriod.end)
+            }
+        }
 
-        val groupId2 = jdbi.handle { it.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = LocalDate.of(2000, 1, 1))) }
-        jdbi.handle { h -> insertTestCaretakers(h, groupId2, amount = 1.0, startDate = LocalDate.of(2000, 1, 1)) }
+        val groupId2 = db.transaction { tx ->
+            tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = LocalDate.of(2000, 1, 1))).also {
+                insertTestCaretakers(tx.handle, it, amount = 1.0, startDate = LocalDate.of(2000, 1, 1))
+            }
+        }
 
         val result = fetchAndParseOccupancyByGroups(testDaycare.id, defaultPeriod)
 
@@ -113,7 +122,7 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child under 3 years old in full time daycare without service need`() {
-        jdbi.handle(createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE))
+        db.transaction { it.createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE) }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -125,15 +134,15 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in daycare with full time service need`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
                 placementType = PlacementType.DAYCARE,
                 hours = 30.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -145,15 +154,15 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in daycare with part time hours but no part time placement`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
                 placementType = PlacementType.DAYCARE,
                 hours = 25.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -165,15 +174,15 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in daycare with part time placement`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
                 placementType = PlacementType.DAYCARE_PART_TIME,
                 hours = 25.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -185,15 +194,15 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in preschool daycare with no daycare hours`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
                 placementType = PlacementType.PRESCHOOL_DAYCARE,
                 hours = 20.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -205,15 +214,15 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in preschool daycare with 20 daycare hours`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
                 placementType = PlacementType.PRESCHOOL_DAYCARE,
                 hours = 40.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -226,8 +235,8 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
     @Test
     fun `absences do not affect confirmed occupancy calculation`() {
         val childId = UUID.randomUUID()
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 childId = childId,
                 unitId = testDaycare.id,
                 period = defaultPeriod,
@@ -235,10 +244,9 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
                 placementType = PlacementType.PRESCHOOL_DAYCARE,
                 hours = 40.0
             )
-        )
-
-        jdbi.handle { h -> insertTestAbsence(h, childId = childId, date = defaultPeriod.start, careType = CareType.PRESCHOOL, absenceType = AbsenceType.SICKLEAVE) }
-        jdbi.handle { h -> insertTestAbsence(h, childId = childId, date = defaultPeriod.start, careType = CareType.PRESCHOOL_DAYCARE, absenceType = AbsenceType.SICKLEAVE) }
+            insertTestAbsence(it.handle, childId = childId, date = defaultPeriod.start, careType = CareType.PRESCHOOL, absenceType = AbsenceType.SICKLEAVE)
+            insertTestAbsence(it.handle, childId = childId, date = defaultPeriod.start, careType = CareType.PRESCHOOL_DAYCARE, absenceType = AbsenceType.SICKLEAVE)
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -251,8 +259,8 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
     @Test
     fun `backup care does not affect confirmed occupancy calculation`() {
         val childId = UUID.randomUUID()
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 childId = childId,
                 unitId = testDaycare.id,
                 period = defaultPeriod,
@@ -260,9 +268,8 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
                 placementType = PlacementType.PRESCHOOL_DAYCARE,
                 hours = 40.0
             )
-        )
-
-        jdbi.handle { h -> insertTestBackUpCare(h, childId, testDaycare2.id, defaultPeriod.start.plusDays(2), defaultPeriod.start.plusDays(5)) }
+            insertTestBackUpCare(it.handle, childId, testDaycare2.id, defaultPeriod.start.plusDays(2), defaultPeriod.start.plusDays(5))
+        }
 
         val resultOriginalUnit = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
         assertEquals(
@@ -279,15 +286,15 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in preschool daycare with 25 daycare hours`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
                 placementType = PlacementType.PRESCHOOL_DAYCARE,
                 hours = 45.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -299,8 +306,8 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in preparatory daycare without daycare hours`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
@@ -308,7 +315,7 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
                 hours = 25.0,
                 assistanceExtra = null
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -320,8 +327,8 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in preparatory daycare with 20 daycare hours`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
@@ -329,7 +336,7 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
                 hours = 45.0,
                 assistanceExtra = null
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -341,8 +348,8 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in preschool daycare with preparatory and 25 daycare hours`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
@@ -350,7 +357,7 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
                 hours = 50.0,
                 assistanceExtra = null
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -362,15 +369,15 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for 5-year-old child in daycare with part time hours`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2014, 1, 1),
                 placementType = PlacementType.DAYCARE,
                 hours = 20.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -385,15 +392,15 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for a child in full time 5-year-old daycare`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2014, 1, 1),
                 placementType = PlacementType.DAYCARE_FIVE_YEAR_OLDS,
                 hours = 25.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -407,15 +414,15 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for a child in part time 5-year-old daycare`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2014, 1, 1),
                 placementType = PlacementType.DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
                 hours = 20.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -429,15 +436,15 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child under 3 years old in daycare with part time placement`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2017, 1, 1),
                 placementType = PlacementType.DAYCARE_PART_TIME,
                 hours = 25.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -449,8 +456,8 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child over 3 years old in full time daycare with assistance extra`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
@@ -458,7 +465,7 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
                 hours = null,
                 assistanceExtra = 5.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -470,8 +477,8 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation is correct for child under 3 years old in full time daycare with assistance extra`() {
-        jdbi.handle(
-            createOccupancyTestFixture(
+        db.transaction {
+            it.createOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2017, 1, 1),
@@ -479,7 +486,7 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
                 hours = null,
                 assistanceExtra = 5.0
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -499,12 +506,11 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
             FiniteDateRange(LocalDate.of(2019, 9, 1), defaultPeriod.end)
         )
 
-        periods
-            .map { period ->
-                createOccupancyTestFixture(testDaycare.id, period, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE, 40.0)
+        db.transaction { tx ->
+            periods.forEach { period ->
+                tx.createOccupancyTestFixture(testDaycare.id, period, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE, 40.0)
             }
-            .let(::insertFixtures)
-            .let(jdbi::handle)
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -526,14 +532,14 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `confirmed occupancy calculation does not include placement plans`() {
-        jdbi.handle(
-            createPlanOccupancyTestFixture(
+        db.transaction {
+            it.createPlanOccupancyTestFixture(
                 unitId = testDaycare.id,
                 period = defaultPeriod,
                 dateOfBirth = LocalDate.of(2015, 1, 1),
                 placementType = PlacementType.DAYCARE
             )
-        )
+        }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
 
@@ -545,10 +551,10 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation includes caretakers if they exist and calculates a percentage`() {
-        jdbi.handle(createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE))
-        jdbi.handle { h ->
-            val groupId = h.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
-            insertTestCaretakers(h, groupId, amount = 1.0)
+        db.transaction {
+            it.createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE)
+            val groupId = it.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
+            insertTestCaretakers(it.handle, groupId, amount = 1.0)
         }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
@@ -561,12 +567,12 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation works with multiple groups and caretakers`() {
-        jdbi.handle(createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE))
-        jdbi.handle { h ->
-            val groupId_1 = h.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
-            insertTestCaretakers(h, groupId_1, amount = 1.0)
-            val groupId_2 = h.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
-            insertTestCaretakers(h, groupId_2, amount = 1.0)
+        db.transaction { tx ->
+            tx.createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE)
+            val groupId_1 = tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
+            insertTestCaretakers(tx.handle, groupId_1, amount = 1.0)
+            val groupId_2 = tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
+            insertTestCaretakers(tx.handle, groupId_2, amount = 1.0)
         }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
@@ -579,10 +585,10 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation does not break if caretaker amount is 0`() {
-        jdbi.handle(createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE))
-        jdbi.handle { h ->
-            val groupId = h.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
-            insertTestCaretakers(h, groupId, amount = 0.0)
+        db.transaction { tx ->
+            tx.createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE)
+            val groupId = tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
+            insertTestCaretakers(tx.handle, groupId, amount = 0.0)
         }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
@@ -595,12 +601,12 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation does not break if caretaker amount of one group is 0`() {
-        jdbi.handle(createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE))
-        jdbi.handle { h ->
-            val groupId_1 = h.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
-            insertTestCaretakers(h, groupId_1, amount = 1.0)
-            val groupId_2 = h.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
-            insertTestCaretakers(h, groupId_2, amount = 0.0)
+        db.transaction { tx ->
+            tx.createOccupancyTestFixture(testDaycare.id, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE)
+            val groupId_1 = tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
+            insertTestCaretakers(tx.handle, groupId_1, amount = 1.0)
+            val groupId_2 = tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, startDate = defaultPeriod.start))
+            insertTestCaretakers(tx.handle, groupId_2, amount = 0.0)
         }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
@@ -613,14 +619,17 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
 
     @Test
     fun `occupancy calculation uses same coefficient for all placements into FAMILY or GROUP_FAMILY units`() {
-        val unit = jdbi.handle { h ->
-            h.insertTestDaycare(DevDaycare(areaId = testAreaId, name = "Ryhmis", type = setOf(fi.espoo.evaka.daycare.CareType.GROUP_FAMILY)))
+        val unit = db.transaction { tx ->
+            tx.handle.insertTestDaycare(
+                DevDaycare(areaId = testAreaId, name = "Ryhmis", type = setOf(fi.espoo.evaka.daycare.CareType.GROUP_FAMILY))
+            ).also {
+                tx.createOccupancyTestFixture(it, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE)
+                tx.createOccupancyTestFixture(it, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE)
+                tx.createOccupancyTestFixture(it, defaultPeriod, LocalDate.of(2013, 1, 1), PlacementType.PRESCHOOL)
+                tx.createOccupancyTestFixture(it, defaultPeriod, LocalDate.of(2013, 1, 1), PlacementType.PRESCHOOL_DAYCARE)
+                tx.createOccupancyTestFixture(it, defaultPeriod, LocalDate.of(2014, 1, 1), PlacementType.PRESCHOOL)
+            }
         }
-        jdbi.handle(createOccupancyTestFixture(unit, defaultPeriod, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE))
-        jdbi.handle(createOccupancyTestFixture(unit, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE))
-        jdbi.handle(createOccupancyTestFixture(unit, defaultPeriod, LocalDate.of(2013, 1, 1), PlacementType.PRESCHOOL))
-        jdbi.handle(createOccupancyTestFixture(unit, defaultPeriod, LocalDate.of(2013, 1, 1), PlacementType.PRESCHOOL_DAYCARE))
-        jdbi.handle(createOccupancyTestFixture(unit, defaultPeriod, LocalDate.of(2014, 1, 1), PlacementType.PRESCHOOL))
 
         val result = fetchAndParseOccupancy(unit, defaultPeriod)
 
@@ -650,9 +659,5 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
         assertEquals(200, response.statusCode)
 
         return objectMapper.readValue(result.get())
-    }
-
-    private fun insertFixtures(fixtures: List<(Handle) -> Unit>) = { h: Handle ->
-        fixtures.forEach { it(h) }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTestUtils.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTestUtils.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.occupancy
 
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevAssistanceNeed
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevPerson
@@ -18,11 +19,10 @@ import fi.espoo.evaka.shared.dev.insertTestServiceNeed
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testDecisionMaker_1
-import org.jdbi.v3.core.Handle
 import java.time.LocalDate
 import java.util.UUID
 
-fun createOccupancyTestFixture(
+fun Database.Transaction.createOccupancyTestFixture(
     unitId: UUID,
     period: FiniteDateRange,
     dateOfBirth: LocalDate,
@@ -39,7 +39,7 @@ fun createOccupancyTestFixture(
     assistanceExtra
 )
 
-fun createOccupancyTestFixture(
+fun Database.Transaction.createOccupancyTestFixture(
     childId: UUID,
     unitId: UUID,
     period: FiniteDateRange,
@@ -48,11 +48,11 @@ fun createOccupancyTestFixture(
     hours: Double? = null,
     assistanceExtra: Double? = null,
     placementId: UUID = UUID.randomUUID()
-) = { h: Handle ->
-    h.insertTestPerson(DevPerson(id = childId, dateOfBirth = dateOfBirth))
-    h.insertTestChild(DevChild(id = childId))
+) {
+    handle.insertTestPerson(DevPerson(id = childId, dateOfBirth = dateOfBirth))
+    handle.insertTestChild(DevChild(id = childId))
     insertTestPlacement(
-        h,
+        handle,
         childId = childId,
         unitId = unitId,
         type = placementType,
@@ -62,7 +62,7 @@ fun createOccupancyTestFixture(
     )
     if (hours != null) {
         insertTestServiceNeed(
-            h,
+            handle,
             childId = childId,
             hoursPerWeek = hours,
             startDate = period.start,
@@ -71,7 +71,7 @@ fun createOccupancyTestFixture(
         )
     }
     if (assistanceExtra != null) {
-        h.insertTestAssistanceNeed(
+        handle.insertTestAssistanceNeed(
             DevAssistanceNeed(
                 childId = childId,
                 startDate = period.start,
@@ -83,7 +83,7 @@ fun createOccupancyTestFixture(
     }
 }
 
-fun createPlanOccupancyTestFixture(
+fun Database.Transaction.createPlanOccupancyTestFixture(
     unitId: UUID,
     period: FiniteDateRange,
     dateOfBirth: LocalDate,
@@ -102,7 +102,7 @@ fun createPlanOccupancyTestFixture(
     deletedPlacementPlan
 )
 
-fun createPlanOccupancyTestFixture(
+fun Database.Transaction.createPlanOccupancyTestFixture(
     childId: UUID,
     unitId: UUID,
     period: FiniteDateRange,
@@ -111,12 +111,12 @@ fun createPlanOccupancyTestFixture(
     assistanceExtra: Double? = null,
     preschoolDaycarePeriod: FiniteDateRange = period,
     deletedPlacementPlan: Boolean? = false
-) = { h: Handle ->
-    h.insertTestPerson(DevPerson(id = childId, dateOfBirth = dateOfBirth))
-    h.insertTestChild(DevChild(id = childId))
-    val applicationId = insertTestApplication(h, childId = childId, guardianId = testAdult_1.id)
+) {
+    handle.insertTestPerson(DevPerson(id = childId, dateOfBirth = dateOfBirth))
+    handle.insertTestChild(DevChild(id = childId))
+    val applicationId = insertTestApplication(handle, childId = childId, guardianId = testAdult_1.id)
     insertTestPlacementPlan(
-        h,
+        handle,
         applicationId = applicationId,
         unitId = unitId,
         type = placementType,
@@ -127,7 +127,7 @@ fun createPlanOccupancyTestFixture(
         deleted = deletedPlacementPlan
     )
     if (assistanceExtra != null) {
-        h.insertTestAssistanceNeed(
+        handle.insertTestAssistanceNeed(
             DevAssistanceNeed(
                 childId = childId,
                 startDate = period.start,
@@ -139,7 +139,7 @@ fun createPlanOccupancyTestFixture(
     }
 }
 
-fun createPreschoolPlanWithDistinctDaycareOccupancyTestFixture(
+fun Database.Transaction.createPreschoolPlanWithDistinctDaycareOccupancyTestFixture(
     unitId: UUID,
     period: FiniteDateRange,
     dateOfBirth: LocalDate,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerSearchIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerSearchIntegrationTest.kt
@@ -8,10 +8,8 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.AbstractIntegrationTest
 import fi.espoo.evaka.pis.DaycareRole
 import fi.espoo.evaka.pis.controllers.EmployeeController
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1
 import fi.espoo.evaka.unitSupervisorOfTestDaycare
@@ -29,10 +27,9 @@ class EmployeeControllerSearchIntegrationTest : AbstractIntegrationTest() {
     lateinit var controller: EmployeeController
 
     @BeforeEach
-    override fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
+    internal fun setUp() {
+        db.transaction { tx ->
+            insertGeneralTestFixtures(tx.handle)
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
@@ -30,12 +30,16 @@ import java.util.UUID
 class FamilyOverviewTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
-        jdbi.handle(::insertGeneralTestFixtures)
+        db.transaction { tx ->
+            insertGeneralTestFixtures(tx.handle)
+        }
     }
 
     @AfterEach
     fun afterEach() {
-        jdbi.handle(::resetDatabase)
+        db.transaction { tx ->
+            tx.resetDatabase()
+        }
     }
 
     @Test
@@ -124,16 +128,16 @@ class FamilyOverviewTest : FullApplicationTest() {
         val (from, to) = LocalDate.now().let {
             listOf(it.minusYears(1), it.plusYears(1))
         }
-        jdbi.handle { h -> h.createParentship(testChild_1.id, testAdult_1.id, from, to) }
+        db.transaction { it.handle.createParentship(testChild_1.id, testAdult_1.id, from, to) }
     }
 
     private fun createTestFixture1plus2() {
         val (from, to) = LocalDate.now().let {
             listOf(it.minusYears(1), it.plusYears(1))
         }
-        jdbi.handle { h ->
-            h.createParentship(testChild_1.id, testAdult_1.id, from, to)
-            h.createParentship(testChild_2.id, testAdult_1.id, from, to)
+        db.transaction {
+            it.handle.createParentship(testChild_1.id, testAdult_1.id, from, to)
+            it.handle.createParentship(testChild_2.id, testAdult_1.id, from, to)
         }
     }
 
@@ -141,10 +145,10 @@ class FamilyOverviewTest : FullApplicationTest() {
         val (from, to) = LocalDate.now().let {
             listOf(it.minusYears(1), it.plusYears(1))
         }
-        jdbi.handle { h ->
-            h.createParentship(testChild_1.id, testAdult_1.id, from, to)
-            h.createParentship(testChild_2.id, testAdult_1.id, from, to)
-            h.createPartnership(testAdult_1.id, testAdult_2.id, from, to)
+        db.transaction {
+            it.handle.createParentship(testChild_1.id, testAdult_1.id, from, to)
+            it.handle.createParentship(testChild_2.id, testAdult_1.id, from, to)
+            it.handle.createPartnership(testAdult_1.id, testAdult_2.id, from, to)
         }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -150,7 +150,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
         assertEquals(HttpStatus.OK, actual.statusCode)
 
-        val updated = jdbi.handle { it.getPersonById(person.id) }
+        val updated = db.read { it.handle.getPersonById(person.id) }
         assertEquals(contactInfo.email, updated?.email)
         assertEquals(contactInfo.invoicingStreetAddress, updated?.invoicingStreetAddress)
         assertEquals(contactInfo.invoicingPostalCode, updated?.invoicingPostalCode)
@@ -160,8 +160,8 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     private fun createPerson(): PersonDTO {
         val ssn = "140881-172X"
-        return jdbi.transaction {
-            it.createPerson(
+        return db.transaction {
+            it.handle.createPerson(
                 PersonIdentityRequest(
                     identity = ExternalIdentifier.SSN.getInstance(ssn),
                     firstName = "Matti",

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/FamilySchemaConstraintsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/FamilySchemaConstraintsIntegrationTest.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.util.UUID
@@ -25,11 +24,9 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val person2 = testPerson2()
         val startDate = LocalDate.now()
         val endDate = startDate.plusDays(200)
-        jdbi.transaction { h ->
-            val partnershipId = UUID.randomUUID()
-            createPartnerRecord(h, partnershipId, 1, person1.id, startDate, endDate)
-            createPartnerRecord(h, partnershipId, 2, person2.id, startDate, endDate)
-        }
+        val partnershipId = UUID.randomUUID()
+        createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate)
+        createPartnerRecord(partnershipId, 2, person2.id, startDate, endDate)
     }
 
     @Test
@@ -38,18 +35,16 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val person2 = testPerson2()
         val startDate1 = LocalDate.now()
         val endDate1 = startDate1.plusDays(200)
-        jdbi.transaction { h ->
-            val partnershipId = UUID.randomUUID()
-            createPartnerRecord(h, partnershipId, 1, person1.id, startDate1, endDate1)
-            createPartnerRecord(h, partnershipId, 2, person2.id, startDate1, endDate1)
+        UUID.randomUUID().let { partnershipId ->
+            createPartnerRecord(partnershipId, 1, person1.id, startDate1, endDate1)
+            createPartnerRecord(partnershipId, 2, person2.id, startDate1, endDate1)
         }
 
         val startDate2 = endDate1.plusDays(1)
         val endDate2 = startDate2.plusDays(200)
-        jdbi.transaction { h ->
-            val partnershipId = UUID.randomUUID()
-            createPartnerRecord(h, partnershipId, 1, person1.id, startDate2, endDate2)
-            createPartnerRecord(h, partnershipId, 2, person2.id, startDate2, endDate2)
+        UUID.randomUUID().let { partnershipId ->
+            createPartnerRecord(partnershipId, 1, person1.id, startDate2, endDate2)
+            createPartnerRecord(partnershipId, 2, person2.id, startDate2, endDate2)
         }
     }
 
@@ -59,21 +54,18 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val person2 = testPerson2()
         val startDate1 = LocalDate.now()
         val endDate1 = startDate1.plusDays(200)
-        jdbi.transaction { h ->
-            val partnershipId = UUID.randomUUID()
-            createPartnerRecord(h, partnershipId, 1, person1.id, startDate1, endDate1)
-            createPartnerRecord(h, partnershipId, 2, person2.id, startDate1, endDate1)
+        UUID.randomUUID().let { partnershipId ->
+            createPartnerRecord(partnershipId, 1, person1.id, startDate1, endDate1)
+            createPartnerRecord(partnershipId, 2, person2.id, startDate1, endDate1)
         }
 
         val startDate2 = endDate1.plusDays(0)
         val endDate2 = startDate2.plusDays(200)
 
         assertThatThrownBy {
-            jdbi.transaction { h ->
-                val partnershipId = UUID.randomUUID()
-                createPartnerRecord(h, partnershipId, 1, person1.id, startDate2, endDate2)
-                createPartnerRecord(h, partnershipId, 2, person2.id, startDate2, endDate2)
-            }
+            val partnershipId = UUID.randomUUID()
+            createPartnerRecord(partnershipId, 1, person1.id, startDate2, endDate2)
+            createPartnerRecord(partnershipId, 2, person2.id, startDate2, endDate2)
         }
     }
 
@@ -86,12 +78,10 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
 
         assertThatThrownBy {
-            jdbi.transaction { h ->
-                val partnershipId = UUID.randomUUID()
-                createPartnerRecord(h, partnershipId, 1, person1.id, startDate, endDate)
-                createPartnerRecord(h, partnershipId, 2, person2.id, startDate, endDate)
-                createPartnerRecord(h, partnershipId, 3, person3.id, startDate, endDate)
-            }
+            val partnershipId = UUID.randomUUID()
+            createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate)
+            createPartnerRecord(partnershipId, 2, person2.id, startDate, endDate)
+            createPartnerRecord(partnershipId, 3, person3.id, startDate, endDate)
         }
     }
 
@@ -104,12 +94,10 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
 
         assertThatThrownBy {
-            jdbi.transaction { h ->
-                val partnershipId = UUID.randomUUID()
-                createPartnerRecord(h, partnershipId, 0, person1.id, startDate, endDate)
-                createPartnerRecord(h, partnershipId, 1, person2.id, startDate, endDate)
-                createPartnerRecord(h, partnershipId, 2, person3.id, startDate, endDate)
-            }
+            val partnershipId = UUID.randomUUID()
+            createPartnerRecord(partnershipId, 0, person1.id, startDate, endDate)
+            createPartnerRecord(partnershipId, 1, person2.id, startDate, endDate)
+            createPartnerRecord(partnershipId, 2, person3.id, startDate, endDate)
         }
     }
 
@@ -122,12 +110,10 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
 
         assertThatThrownBy {
-            jdbi.transaction { h ->
-                val partnershipId = UUID.randomUUID()
-                createPartnerRecord(h, partnershipId, 1, person1.id, startDate, endDate)
-                createPartnerRecord(h, partnershipId, 2, person2.id, startDate, endDate)
-                createPartnerRecord(h, partnershipId, 2, person3.id, startDate, endDate)
-            }
+            val partnershipId = UUID.randomUUID()
+            createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate)
+            createPartnerRecord(partnershipId, 2, person2.id, startDate, endDate)
+            createPartnerRecord(partnershipId, 2, person3.id, startDate, endDate)
         }
     }
 
@@ -138,11 +124,9 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
 
         assertThatThrownBy {
-            jdbi.transaction { h ->
-                val partnershipId = UUID.randomUUID()
-                createPartnerRecord(h, partnershipId, 1, person1.id, startDate, endDate)
-                createPartnerRecord(h, partnershipId, 2, person1.id, startDate, endDate)
-            }
+            val partnershipId = UUID.randomUUID()
+            createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate)
+            createPartnerRecord(partnershipId, 2, person1.id, startDate, endDate)
         }
     }
 
@@ -155,11 +139,9 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate1.plusDays(200)
 
         assertThatThrownBy {
-            jdbi.transaction { h ->
-                val partnershipId = UUID.randomUUID()
-                createPartnerRecord(h, partnershipId, 1, person1.id, startDate1, endDate)
-                createPartnerRecord(h, partnershipId, 2, person2.id, startDate2, endDate)
-            }
+            val partnershipId = UUID.randomUUID()
+            createPartnerRecord(partnershipId, 1, person1.id, startDate1, endDate)
+            createPartnerRecord(partnershipId, 2, person2.id, startDate2, endDate)
         }
     }
 
@@ -172,11 +154,9 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate2 = endDate1.plusDays(1)
 
         assertThatThrownBy {
-            jdbi.transaction { h ->
-                val partnershipId = UUID.randomUUID()
-                createPartnerRecord(h, partnershipId, 1, person1.id, startDate, endDate1)
-                createPartnerRecord(h, partnershipId, 2, person2.id, startDate, endDate2)
-            }
+            val partnershipId = UUID.randomUUID()
+            createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate1)
+            createPartnerRecord(partnershipId, 2, person2.id, startDate, endDate2)
         }
     }
 
@@ -188,11 +168,9 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.minusDays(200)
 
         assertThatThrownBy {
-            jdbi.transaction { h ->
-                val partnershipId = UUID.randomUUID()
-                createPartnerRecord(h, partnershipId, 1, person1.id, startDate, endDate)
-                createPartnerRecord(h, partnershipId, 2, person2.id, startDate, endDate)
-            }
+            val partnershipId = UUID.randomUUID()
+            createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate)
+            createPartnerRecord(partnershipId, 2, person2.id, startDate, endDate)
         }
     }
 
@@ -250,7 +228,6 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
     }
 
     private fun createPartnerRecord(
-        h: Handle,
         partnershipId: UUID,
         indx: Int,
         personId: UUID,
@@ -264,21 +241,23 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
             VALUES (:partnershipId, :indx, :personId, :startDate, :endDate)
             """.trimIndent()
 
-        h.createUpdate(sql)
-            .bind("partnershipId", partnershipId)
-            .bind("indx", indx)
-            .bind("personId", personId)
-            .bind("startDate", startDate)
-            .bind("endDate", endDate)
-            .execute()
+        db.transaction { tx ->
+            tx.createUpdate(sql)
+                .bind("partnershipId", partnershipId)
+                .bind("indx", indx)
+                .bind("personId", personId)
+                .bind("startDate", startDate)
+                .bind("endDate", endDate)
+                .execute()
+        }
     }
 
     private fun createParentshipRecord(childId: UUID, parentId: UUID, startDate: LocalDate, endDate: LocalDate) =
-        jdbi.handle { h -> h.createParentship(childId, parentId, startDate, endDate) }
+        db.transaction { it.handle.createParentship(childId, parentId, startDate, endDate) }
 
     private fun createPerson(ssn: String, firstName: String): PersonDTO {
-        return jdbi.transaction {
-            it.createPerson(
+        return db.transaction {
+            it.handle.createPerson(
                 PersonIdentityRequest(
                     identity = ExternalIdentifier.SSN.getInstance(ssn),
                     firstName = firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PersonQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PersonQueriesIntegrationTest.kt
@@ -31,22 +31,22 @@ class PersonQueriesIntegrationTest : PureJdbiTest() {
     @BeforeEach
     fun setUp() {
         val legacyDataSql = this.javaClass.getResource("/legacy_db_data.sql").readText()
-        jdbi.handle {
-            resetDatabase(it)
+        db.transaction {
+            it.resetDatabase()
             it.execute(legacyDataSql)
         }
     }
 
     @Test
-    fun `creating an empty person sets their date of birth to current date`() = jdbi.handle { h ->
-        val identity: PersonDTO = h.createEmptyPerson()
+    fun `creating an empty person sets their date of birth to current date`() = db.transaction { tx ->
+        val identity: PersonDTO = tx.handle.createEmptyPerson()
         Assertions.assertEquals(identity.dateOfBirth, LocalDate.now())
     }
 
     @Test
-    fun `create person`() = jdbi.handle { h ->
+    fun `create person`() = db.transaction { tx ->
         val validSSN = "080512A918W"
-        val fetchedPerson = h.createPerson(
+        val fetchedPerson = tx.handle.createPerson(
             PersonIdentityRequest(
                 identity = ExternalIdentifier.SSN.getInstance(validSSN),
                 firstName = "Matti",

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/GuardianQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/GuardianQueriesIntegrationTest.kt
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.Test
 class GuardianQueriesIntegrationTest : FullApplicationTest() {
     @BeforeEach
     private fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -47,36 +47,38 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
     @BeforeEach
     internal fun setUp() {
         mergeService = MergeService(asyncJobRunnerMock)
-        jdbi.handle(::resetDatabase)
-        jdbi.handle(::insertGeneralTestFixtures)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
+        }
     }
 
     @Test
     fun `empty person can be deleted`() {
         val id = UUID.randomUUID()
-        jdbi.handle {
-            it.insertTestPerson(DevPerson(id = id))
-            it.insertTestChild(DevChild(id))
+        db.transaction {
+            it.handle.insertTestPerson(DevPerson(id = id))
+            it.handle.insertTestChild(DevChild(id))
         }
 
-        val countBefore = jdbi.handle { it.createQuery("SELECT 1 FROM person WHERE id = :id").bind("id", id).map { _, _ -> 1 }.list().size }
+        val countBefore = db.read { it.createQuery("SELECT 1 FROM person WHERE id = :id").bind("id", id).map { _, _ -> 1 }.list().size }
         assertEquals(1, countBefore)
 
         db.transaction {
             mergeService.deleteEmptyPerson(it, id)
         }
 
-        val countAfter = jdbi.handle { it.createQuery("SELECT 1 FROM person WHERE id = :id").bind("id", id).map { _, _ -> 1 }.list().size }
+        val countAfter = db.read { it.createQuery("SELECT 1 FROM person WHERE id = :id").bind("id", id).map { _, _ -> 1 }.list().size }
         assertEquals(0, countAfter)
     }
 
     @Test
     fun `cannot delete person with data - placement`() {
         val id = UUID.randomUUID()
-        jdbi.handle {
-            it.insertTestPerson(DevPerson(id = id))
-            it.insertTestChild(DevChild(id))
-            it.insertTestPlacement(
+        db.transaction {
+            it.handle.insertTestPerson(DevPerson(id = id))
+            it.handle.insertTestChild(DevChild(id))
+            it.handle.insertTestPlacement(
                 DevPlacement(
                     childId = id,
                     unitId = testDaycare.id
@@ -94,22 +96,22 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
         val childId = UUID.randomUUID()
         val validFrom = LocalDate.of(2010, 1, 1)
         val validTo = LocalDate.of(2020, 12, 30)
-        jdbi.handle {
-            it.insertTestPerson(DevPerson(id = childId))
-            it.insertTestPerson(DevPerson(id = adultId))
-            it.insertTestPerson(DevPerson(id = adultIdDuplicate))
-            insertTestParentship(it, headOfChild = adultId, childId = childId, startDate = LocalDate.of(2015, 1, 1), endDate = LocalDate.of(2030, 1, 1))
-            insertTestIncome(it, objectMapper, adultIdDuplicate, validFrom = validFrom, validTo = validTo)
+        db.transaction {
+            it.handle.insertTestPerson(DevPerson(id = childId))
+            it.handle.insertTestPerson(DevPerson(id = adultId))
+            it.handle.insertTestPerson(DevPerson(id = adultIdDuplicate))
+            insertTestParentship(it.handle, headOfChild = adultId, childId = childId, startDate = LocalDate.of(2015, 1, 1), endDate = LocalDate.of(2030, 1, 1))
+            insertTestIncome(it.handle, objectMapper, adultIdDuplicate, validFrom = validFrom, validTo = validTo)
         }
 
-        val countBefore = jdbi.handle { it.createQuery("SELECT 1 FROM income WHERE person_id = :id").bind("id", adultIdDuplicate).map { _, _ -> 1 }.list().size }
+        val countBefore = db.read { it.createQuery("SELECT 1 FROM income WHERE person_id = :id").bind("id", adultIdDuplicate).map { _, _ -> 1 }.list().size }
         assertEquals(1, countBefore)
 
         db.transaction {
             mergeService.mergePeople(it, adultId, adultIdDuplicate)
         }
 
-        val countAfter = jdbi.handle { it.createQuery("SELECT 1 FROM income WHERE person_id = :id").bind("id", adultId).map { _, _ -> 1 }.list().size }
+        val countAfter = db.read { it.createQuery("SELECT 1 FROM income WHERE person_id = :id").bind("id", adultId).map { _, _ -> 1 }.list().size }
         assertEquals(1, countAfter)
 
         verify(asyncJobRunnerMock).plan(
@@ -121,27 +123,27 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
     fun `merging child moves placements and service needs`() {
         val childId = UUID.randomUUID()
         val childIdDuplicate = UUID.randomUUID()
-        jdbi.handle {
-            it.insertTestPerson(DevPerson(id = childId))
-            it.insertTestPerson(DevPerson(id = childIdDuplicate))
-            it.insertTestChild(DevChild(childIdDuplicate))
+        db.transaction {
+            it.handle.insertTestPerson(DevPerson(id = childId))
+            it.handle.insertTestPerson(DevPerson(id = childIdDuplicate))
+            it.handle.insertTestChild(DevChild(childIdDuplicate))
         }
-        val employeeId = jdbi.handle { it.insertTestEmployee(DevEmployee()) }
+        val employeeId = db.transaction { it.handle.insertTestEmployee(DevEmployee()) }
         val from = LocalDate.of(2010, 1, 1)
         val to = LocalDate.of(2020, 12, 30)
-        jdbi.handle {
-            it.insertTestPlacement(DevPlacement(childId = childIdDuplicate, unitId = testDaycare.id, startDate = from, endDate = to))
-            insertTestServiceNeed(it, childIdDuplicate, startDate = from, endDate = to, updatedBy = employeeId)
+        db.transaction {
+            it.handle.insertTestPlacement(DevPlacement(childId = childIdDuplicate, unitId = testDaycare.id, startDate = from, endDate = to))
+            insertTestServiceNeed(it.handle, childIdDuplicate, startDate = from, endDate = to, updatedBy = employeeId)
         }
 
-        val countBefore = jdbi.handle { it.createQuery("SELECT 1 FROM placement WHERE child_id = :id").bind("id", childIdDuplicate).map { _, _ -> 1 }.list().size }
+        val countBefore = db.read { it.createQuery("SELECT 1 FROM placement WHERE child_id = :id").bind("id", childIdDuplicate).map { _, _ -> 1 }.list().size }
         assertEquals(1, countBefore)
 
         db.transaction {
             mergeService.mergePeople(it, childId, childIdDuplicate)
         }
 
-        val countAfter = jdbi.handle { it.createQuery("SELECT 1 FROM placement WHERE child_id = :id").bind("id", childId).map { _, _ -> 1 }.list().size }
+        val countAfter = db.read { it.createQuery("SELECT 1 FROM placement WHERE child_id = :id").bind("id", childId).map { _, _ -> 1 }.list().size }
         assertEquals(1, countAfter)
 
         verifyZeroInteractions(asyncJobRunnerMock)
@@ -152,17 +154,17 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
         val adultId = UUID.randomUUID()
         val childId = UUID.randomUUID()
         val childIdDuplicate = UUID.randomUUID()
-        jdbi.handle {
-            it.insertTestPerson(DevPerson(id = adultId))
-            it.insertTestPerson(DevPerson(id = childId))
-            it.insertTestChild(DevChild(childId))
-            it.insertTestPerson(DevPerson(id = childIdDuplicate))
-            it.insertTestChild(DevChild(childIdDuplicate))
-            insertTestParentship(it, headOfChild = adultId, childId = childId, startDate = LocalDate.of(2015, 1, 1), endDate = LocalDate.of(2030, 1, 1))
+        db.transaction {
+            it.handle.insertTestPerson(DevPerson(id = adultId))
+            it.handle.insertTestPerson(DevPerson(id = childId))
+            it.handle.insertTestChild(DevChild(childId))
+            it.handle.insertTestPerson(DevPerson(id = childIdDuplicate))
+            it.handle.insertTestChild(DevChild(childIdDuplicate))
+            insertTestParentship(it.handle, headOfChild = adultId, childId = childId, startDate = LocalDate.of(2015, 1, 1), endDate = LocalDate.of(2030, 1, 1))
         }
         val placementStart = LocalDate.of(2017, 1, 1)
         val placementEnd = LocalDate.of(2020, 12, 30)
-        jdbi.handle { it.insertTestPlacement(DevPlacement(childId = childIdDuplicate, unitId = testDaycare.id, startDate = placementStart, endDate = placementEnd)) }
+        db.transaction { it.handle.insertTestPlacement(DevPlacement(childId = childIdDuplicate, unitId = testDaycare.id, startDate = placementStart, endDate = placementEnd)) }
 
         db.transaction {
             mergeService.mergePeople(it, childId, childIdDuplicate)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -49,9 +49,9 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     internal fun setUp() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
         }
         service = VTJBatchRefreshService(
             fridgeFamilyService = fridgeFamilyService,
@@ -128,15 +128,15 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
             VALUES (:partnershipId, :index, :personId, :startDate, 'infinity')
             """.trimIndent()
         val partnershipId = UUID.randomUUID()
-        jdbi.handle { h ->
-            h.createUpdate(sql)
+        db.transaction { tx ->
+            tx.createUpdate(sql)
                 .bind("partnershipId", partnershipId)
                 .bind("index", 1)
                 .bind("personId", testAdult_1.id)
                 .bind("startDate", LocalDate.of(2000, 1, 1))
                 .execute()
 
-            h.createUpdate(sql)
+            tx.createUpdate(sql)
                 .bind("partnershipId", partnershipId)
                 .bind("index", 2)
                 .bind("personId", testAdult_2.id)
@@ -170,8 +170,8 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
             VALUES (:partnershipId, :index, :personId, :startDate, :endDate)
             """.trimIndent()
         val partnershipId = UUID.randomUUID()
-        jdbi.handle { h ->
-            h.createUpdate(sql)
+        db.transaction { tx ->
+            tx.createUpdate(sql)
                 .bind("partnershipId", partnershipId)
                 .bind("index", 1)
                 .bind("personId", testAdult_1.id)
@@ -179,7 +179,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
                 .bind("endDate", LocalDate.of(2010, 1, 1))
                 .execute()
 
-            h.createUpdate(sql)
+            tx.createUpdate(sql)
                 .bind("partnershipId", partnershipId)
                 .bind("index", 2)
                 .bind("personId", testAdult_2.id)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
@@ -36,7 +36,6 @@ import fi.espoo.evaka.testDecisionMaker_1
 import fi.espoo.evaka.testSvebiDaycare
 import fi.espoo.evaka.toDaycareFormAdult
 import fi.espoo.evaka.toDaycareFormChild
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -49,17 +48,16 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     private fun beforeEach() {
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
         }
     }
 
     @Test
-    fun testDaycareFullTime(): Unit = jdbi.handle { h ->
+    fun testDaycareFullTime() {
         val preferredStartDate = LocalDate.of(2020, 3, 17)
         val applicationId = insertInitialData(
-            h,
             status = ApplicationStatus.WAITING_PLACEMENT,
             type = ApplicationType.DAYCARE,
             preferredStartDate = preferredStartDate
@@ -71,7 +69,6 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
             period = FiniteDateRange(preferredStartDate, defaultEndDate)
         )
         createPlacementPlanAndAssert(
-            h,
             applicationId,
             PlacementType.DAYCARE,
             DaycarePlacementPlan(
@@ -82,10 +79,9 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
     }
 
     @Test
-    fun testDaycareFullTimeWithRestrictedDetails(): Unit = jdbi.handle { h ->
+    fun testDaycareFullTimeWithRestrictedDetails() {
         val preferredStartDate = LocalDate.of(2020, 3, 17)
         val applicationId = insertInitialData(
-            h,
             status = ApplicationStatus.WAITING_PLACEMENT,
             type = ApplicationType.DAYCARE,
             preferredStartDate = preferredStartDate,
@@ -99,7 +95,6 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
             guardianHasRestrictedDetails = true
         )
         createPlacementPlanAndAssert(
-            h,
             applicationId,
             PlacementType.DAYCARE,
             DaycarePlacementPlan(
@@ -110,10 +105,9 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
     }
 
     @Test
-    fun testDaycarePartTime(): Unit = jdbi.handle { h ->
+    fun testDaycarePartTime() {
         val preferredStartDate = LocalDate.of(2022, 11, 30)
         val applicationId = insertInitialData(
-            h,
             status = ApplicationStatus.WAITING_PLACEMENT,
             type = ApplicationType.DAYCARE,
             partTime = true,
@@ -126,7 +120,6 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
             period = FiniteDateRange(preferredStartDate, defaultEndDate)
         )
         createPlacementPlanAndAssert(
-            h,
             applicationId,
             PlacementType.DAYCARE_PART_TIME,
             DaycarePlacementPlan(
@@ -137,10 +130,9 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
     }
 
     @Test
-    fun testPreschoolOnly(): Unit = jdbi.handle { h ->
+    fun testPreschoolOnly() {
         val preferredStartDate = LocalDate.of(2023, 8, 1)
         val applicationId = insertInitialData(
-            h,
             status = ApplicationStatus.WAITING_PLACEMENT,
             type = ApplicationType.PRESCHOOL,
             preferredStartDate = preferredStartDate
@@ -152,7 +144,6 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
             period = FiniteDateRange(preferredStartDate, defaultEndDate)
         )
         createPlacementPlanAndAssert(
-            h,
             applicationId,
             PlacementType.PRESCHOOL,
             DaycarePlacementPlan(
@@ -163,10 +154,9 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
     }
 
     @Test
-    fun testPreschoolWithDaycare(): Unit = jdbi.handle { h ->
+    fun testPreschoolWithDaycare() {
         val preferredStartDate = LocalDate.of(2023, 8, 1)
         val applicationId = insertInitialData(
-            h,
             status = ApplicationStatus.WAITING_PLACEMENT,
             type = ApplicationType.PRESCHOOL,
             preschoolDaycare = true,
@@ -181,7 +171,6 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
             preschoolDaycarePeriod = FiniteDateRange(preferredStartDate, defaultDaycareEndDate)
         )
         createPlacementPlanAndAssert(
-            h,
             applicationId,
             PlacementType.PRESCHOOL_DAYCARE,
             DaycarePlacementPlan(
@@ -196,10 +185,9 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
     }
 
     @Test
-    fun testPreschoolWithSvebiDaycare(): Unit = jdbi.handle { h ->
+    fun testPreschoolWithSvebiDaycare() {
         val preferredStartDate = LocalDate.of(2023, 8, 1)
         val applicationId = insertInitialData(
-            h,
             status = ApplicationStatus.WAITING_PLACEMENT,
             type = ApplicationType.PRESCHOOL,
             preschoolDaycare = true,
@@ -216,7 +204,6 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
             preferredUnits = listOf(testSvebiDaycare)
         )
         createPlacementPlanAndAssert(
-            h,
             applicationId,
             PlacementType.PRESCHOOL_DAYCARE,
             DaycarePlacementPlan(
@@ -231,10 +218,9 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
     }
 
     @Test
-    fun testPreschoolWithPreparatory(): Unit = jdbi.handle { h ->
+    fun testPreschoolWithPreparatory() {
         val preferredStartDate = LocalDate.of(2023, 8, 1)
         val applicationId = insertInitialData(
-            h,
             status = ApplicationStatus.WAITING_PLACEMENT,
             type = ApplicationType.PRESCHOOL,
             preferredStartDate = preferredStartDate,
@@ -247,7 +233,6 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
             period = FiniteDateRange(preferredStartDate, defaultEndDate)
         )
         createPlacementPlanAndAssert(
-            h,
             applicationId,
             PlacementType.PREPARATORY,
             DaycarePlacementPlan(
@@ -259,14 +244,11 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
 
     @Test
     fun testEndpointSecurity() {
-        val applicationId = jdbi.handle { h ->
-            insertInitialData(
-                h,
-                status = ApplicationStatus.WAITING_PLACEMENT,
-                type = ApplicationType.DAYCARE,
-                preferredStartDate = LocalDate.of(2020, 3, 17)
-            )
-        }
+        val applicationId = insertInitialData(
+            status = ApplicationStatus.WAITING_PLACEMENT,
+            type = ApplicationType.DAYCARE,
+            preferredStartDate = LocalDate.of(2020, 3, 17)
+        )
         val invalidRoleLists = listOf(
             setOf(UserRole.UNIT_SUPERVISOR),
             setOf(UserRole.FINANCE_ADMIN),
@@ -330,7 +312,6 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
     }
 
     private fun createPlacementPlanAndAssert(
-        h: Handle,
         applicationId: UUID,
         type: PlacementType,
         proposal: DaycarePlacementPlan
@@ -341,50 +322,50 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
             .response()
         assertTrue(res.isSuccessful)
 
-        getPlacementPlanRowByApplication(h, applicationId).one().also {
-            assertEquals(type, it.type)
-            assertEquals(proposal.unitId, it.unitId)
-            assertEquals(proposal.period, it.period())
-            assertEquals(proposal.preschoolDaycarePeriod, it.preschoolDaycarePeriod())
-            assertEquals(false, it.deleted)
+        db.read { r ->
+            getPlacementPlanRowByApplication(r.handle, applicationId).one().also {
+                assertEquals(type, it.type)
+                assertEquals(proposal.unitId, it.unitId)
+                assertEquals(proposal.period, it.period())
+                assertEquals(proposal.preschoolDaycarePeriod, it.preschoolDaycarePeriod())
+                assertEquals(false, it.deleted)
+            }
+            assertEquals(ApplicationStatus.WAITING_DECISION, getApplicationStatus(r.handle, applicationId))
         }
-        assertEquals(ApplicationStatus.WAITING_DECISION, getApplicationStatus(h, applicationId))
     }
-}
-
-private fun insertInitialData(
-    h: Handle,
-    status: ApplicationStatus,
-    type: ApplicationType,
-    preferredStartDate: LocalDate,
-    adult: PersonData.Detailed = testAdult_1,
-    child: PersonData.Detailed = testChild_1,
-    partTime: Boolean = false,
-    preschoolDaycare: Boolean = false,
-    preferredUnits: List<UnitData.Detailed> = listOf(testDaycare, testDaycare2),
-    preparatory: Boolean = false
-): UUID {
-    val applicationId = insertTestApplication(
-        h,
-        status = status,
-        guardianId = adult.id,
-        childId = child.id
-    )
-    val careDetails = if (preparatory) CareDetails(preparatory = true) else CareDetails()
-    insertTestApplicationForm(
-        h, applicationId,
-        DaycareFormV0(
-            type = type,
-            partTime = partTime,
-            connectedDaycare = preschoolDaycare,
-            serviceStart = "08:00".takeIf { preschoolDaycare },
-            serviceEnd = "16:00".takeIf { preschoolDaycare },
-            child = child.toDaycareFormChild(),
-            guardian = adult.toDaycareFormAdult(adult.restrictedDetailsEnabled),
-            apply = Apply(preferredUnits = preferredUnits.map { it.id }),
-            preferredStartDate = preferredStartDate,
-            careDetails = careDetails
+    private fun insertInitialData(
+        status: ApplicationStatus,
+        type: ApplicationType,
+        preferredStartDate: LocalDate,
+        adult: PersonData.Detailed = testAdult_1,
+        child: PersonData.Detailed = testChild_1,
+        partTime: Boolean = false,
+        preschoolDaycare: Boolean = false,
+        preferredUnits: List<UnitData.Detailed> = listOf(testDaycare, testDaycare2),
+        preparatory: Boolean = false
+    ): UUID = db.transaction { tx ->
+        val applicationId = insertTestApplication(
+            tx.handle,
+            status = status,
+            guardianId = adult.id,
+            childId = child.id
         )
-    )
-    return applicationId
+        val careDetails = if (preparatory) CareDetails(preparatory = true) else CareDetails()
+        insertTestApplicationForm(
+            tx.handle, applicationId,
+            DaycareFormV0(
+                type = type,
+                partTime = partTime,
+                connectedDaycare = preschoolDaycare,
+                serviceStart = "08:00".takeIf { preschoolDaycare },
+                serviceEnd = "16:00".takeIf { preschoolDaycare },
+                child = child.toDaycareFormChild(),
+                guardian = adult.toDaycareFormAdult(adult.restrictedDetailsEnabled),
+                apply = Apply(preferredUnits = preferredUnits.map { it.id }),
+                preferredStartDate = preferredStartDate,
+                careDetails = careDetails
+            )
+        )
+        applicationId
+    }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
@@ -33,12 +33,16 @@ import java.util.UUID
 class InvoicingReportTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
-        jdbi.handle(::insertGeneralTestFixtures)
+        db.transaction { tx ->
+            insertGeneralTestFixtures(tx.handle)
+        }
     }
 
     @AfterEach
     fun afterEach() {
-        jdbi.handle(::resetDatabase)
+        db.transaction { tx ->
+            tx.resetDatabase()
+        }
     }
 
     @Test
@@ -107,9 +111,9 @@ class InvoicingReportTest : FullApplicationTest() {
     )
 
     private fun insertInvoices(date: LocalDate) {
-        jdbi.handle { h ->
-            upsertInvoices(h, testInvoices)
-            h.createUpdate(
+        db.transaction {
+            upsertInvoices(it.handle, testInvoices)
+            it.createUpdate(
                 """
                 UPDATE invoice SET sent_at = :sentAt
                 """.trimIndent()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
@@ -25,12 +25,16 @@ class ReportSmokeTests : FullApplicationTest() {
 
     @BeforeAll
     fun beforeEach() {
-        jdbi.handle(::insertGeneralTestFixtures)
+        db.transaction { tx ->
+            insertGeneralTestFixtures(tx.handle)
+        }
     }
 
     @AfterAll
     fun afterEach() {
-        jdbi.handle(::resetDatabase)
+        db.transaction { tx ->
+            tx.resetDatabase()
+        }
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
@@ -26,12 +26,16 @@ import java.util.UUID
 class StartingPlacementsReportTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
-        jdbi.handle(::insertGeneralTestFixtures)
+        db.transaction { tx ->
+            insertGeneralTestFixtures(tx.handle)
+        }
     }
 
     @AfterEach
     fun afterEach() {
-        jdbi.handle(::resetDatabase)
+        db.transaction { tx ->
+            tx.resetDatabase()
+        }
     }
 
     @Test
@@ -122,9 +126,9 @@ class StartingPlacementsReportTest : FullApplicationTest() {
     }
 
     private fun insertPlacement(childId: UUID, startDate: LocalDate, endDate: LocalDate = startDate.plusYears(1)) =
-        jdbi.handle { h ->
+        db.transaction { tx ->
             insertTestPlacement(
-                h,
+                tx.handle,
                 childId = childId,
                 unitId = testDaycare.id,
                 startDate = startDate,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -94,7 +94,7 @@ class AclIntegrationTest : PureJdbiTest() {
 
     @BeforeEach
     fun beforeEach() {
-        jdbi.handle { it.execute("TRUNCATE daycare_acl") }
+        db.transaction { it.execute("TRUNCATE daycare_acl") }
     }
 
     @ParameterizedTest(name = "{0}")
@@ -131,7 +131,7 @@ class AclIntegrationTest : PureJdbiTest() {
         assertEquals(negativeAclRoles, acl.getRolesForUnitGroup(user, groupId))
         assertEquals(negativeAclRoles, acl.getRolesForDailyNote(user, noteId))
 
-        jdbi.handle { it.insertDaycareAclRow(daycareId, employeeId, role) }
+        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, role) }
 
         assertEquals(positiveAclAuth, acl.getAuthorizedDaycares(user))
         assertEquals(positiveAclAuth, acl.getAuthorizedUnits(user))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -35,12 +35,16 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        jdbi.handle(::insertGeneralTestFixtures)
+        db.transaction { tx ->
+            insertGeneralTestFixtures(tx.handle)
+        }
     }
 
     @AfterEach
     fun afterEach() {
-        jdbi.handle(::resetDatabase)
+        db.transaction { tx ->
+            tx.resetDatabase()
+        }
         mockEndpoint.cleanUp()
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/service/PersonStorageServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/service/PersonStorageServiceIntegrationTest.kt
@@ -25,9 +25,9 @@ class PersonStorageServiceIntegrationTest : PureJdbiTest() {
     @BeforeEach
     private fun beforeEach() {
         service = PersonStorageService()
-        jdbi.handle { h ->
-            resetDatabase(h)
-            insertGeneralTestFixtures(h)
+        db.transaction { tx ->
+            tx.resetDatabase()
+            insertGeneralTestFixtures(tx.handle)
         }
     }
 


### PR DESCRIPTION
#### Summary

Use `db.transaction` and `db.read` instead of `jdbi.handle` and `jdbi.transaction`. Quite a few tests had to be refactored to avoid nested transactions or changes not visible outside of transactions.

This paves way for removing `jdbi.Handle` usage elsewhere.
