### PR TITLE
Move test data creation to `Database.Transaction` extension functions

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -27,7 +27,6 @@ import fi.espoo.evaka.invoicing.domain.VoucherValue
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -45,7 +44,6 @@ import fi.espoo.evaka.shared.dev.insertTestPricing
 import fi.espoo.evaka.shared.dev.insertTestVoucherValue
 import fi.espoo.evaka.shared.dev.updateDaycareAcl
 import fi.espoo.evaka.shared.domain.DateRange
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.bindKotlin
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -371,10 +369,10 @@ val allChildren = setOf(
 val allBasicChildren = allChildren.map { PersonData.Basic(it.id, it.dateOfBirth, it.firstName, it.lastName, it.ssn) }
 val allDaycares = setOf(testDaycare, testDaycare2)
 
-fun insertGeneralTestFixtures(h: Handle) {
-    insertTestVardaOrganizer(h)
-    h.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
-    h.insertTestCareArea(
+fun Database.Transaction.insertGeneralTestFixtures() {
+    insertTestVardaOrganizer()
+    handle.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
+    handle.insertTestCareArea(
         DevCareArea(
             id = testArea2Id,
             name = testDaycare2.areaName,
@@ -382,7 +380,7 @@ fun insertGeneralTestFixtures(h: Handle) {
             areaCode = testArea2Code
         )
     )
-    h.insertTestCareArea(
+    handle.insertTestCareArea(
         DevCareArea(
             id = svebiTestId,
             name = testSvebiDaycare.areaName,
@@ -390,7 +388,7 @@ fun insertGeneralTestFixtures(h: Handle) {
             areaCode = svebiTestCode
         )
     )
-    h.insertTestDaycare(
+    handle.insertTestDaycare(
         DevDaycare(
             areaId = svebiTestId,
             id = testSvebiDaycare.id,
@@ -398,7 +396,7 @@ fun insertGeneralTestFixtures(h: Handle) {
             language = Language.sv
         )
     )
-    h.insertTestDaycare(
+    handle.insertTestDaycare(
         DevDaycare(
             areaId = testAreaId,
             id = testDaycare.id,
@@ -406,8 +404,8 @@ fun insertGeneralTestFixtures(h: Handle) {
             ophOrganizerOid = defaultMunicipalOrganizerOid
         )
     )
-    h.insertTestDaycare(DevDaycare(areaId = testArea2Id, id = testDaycare2.id, name = testDaycare2.name))
-    h.insertTestDaycare(
+    handle.insertTestDaycare(DevDaycare(areaId = testArea2Id, id = testDaycare2.id, name = testDaycare2.name))
+    handle.insertTestDaycare(
         DevDaycare(
             areaId = testArea2Id,
             id = testDaycareNotInvoiced.id,
@@ -415,7 +413,7 @@ fun insertGeneralTestFixtures(h: Handle) {
             invoicedByMunicipality = testDaycareNotInvoiced.invoicedByMunicipality
         )
     )
-    h.insertTestDaycare(
+    handle.insertTestDaycare(
         DevDaycare(
             areaId = testAreaId,
             id = testPurchasedDaycare.id,
@@ -425,7 +423,7 @@ fun insertGeneralTestFixtures(h: Handle) {
             invoicedByMunicipality = false
         )
     )
-    h.insertTestDaycare(
+    handle.insertTestDaycare(
         DevDaycare(
             areaId = testVoucherDaycare.areaId,
             id = testVoucherDaycare.id,
@@ -435,7 +433,7 @@ fun insertGeneralTestFixtures(h: Handle) {
             invoicedByMunicipality = false
         )
     )
-    h.insertTestDaycare(
+    handle.insertTestDaycare(
         DevDaycare(
             areaId = testVoucherDaycare2.areaId,
             id = testVoucherDaycare2.id,
@@ -446,12 +444,12 @@ fun insertGeneralTestFixtures(h: Handle) {
         )
     )
 
-    h.insertTestDaycare(testClub)
-    h.insertTestDaycare(testGhostUnitDaycare)
-    h.insertTestDaycare(testRoundTheClockDaycare)
+    handle.insertTestDaycare(testClub)
+    handle.insertTestDaycare(testGhostUnitDaycare)
+    handle.insertTestDaycare(testRoundTheClockDaycare)
 
     testDecisionMaker_1.let {
-        h.insertTestEmployee(
+        handle.insertTestEmployee(
             DevEmployee(
                 id = it.id,
                 firstName = it.firstName,
@@ -462,7 +460,7 @@ fun insertGeneralTestFixtures(h: Handle) {
     }
 
     testDecisionMaker_2.let {
-        h.insertTestEmployee(
+        handle.insertTestEmployee(
             DevEmployee(
                 id = it.id,
                 firstName = it.firstName,
@@ -472,7 +470,7 @@ fun insertGeneralTestFixtures(h: Handle) {
     }
 
     unitSupervisorOfTestDaycare.let {
-        h.insertTestEmployee(
+        handle.insertTestEmployee(
             DevEmployee(
                 id = it.id,
                 firstName = it.firstName,
@@ -481,7 +479,7 @@ fun insertGeneralTestFixtures(h: Handle) {
             )
         )
         updateDaycareAcl(
-            h,
+            handle,
             testDaycare.id,
             unitSupervisorExternalId,
             UserRole.UNIT_SUPERVISOR
@@ -489,7 +487,7 @@ fun insertGeneralTestFixtures(h: Handle) {
     }
 
     allAdults.forEach {
-        h.insertTestPerson(
+        handle.insertTestPerson(
             DevPerson(
                 id = it.id,
                 dateOfBirth = it.dateOfBirth,
@@ -506,7 +504,7 @@ fun insertGeneralTestFixtures(h: Handle) {
     }
 
     allChildren.forEach {
-        h.insertTestPerson(
+        handle.insertTestPerson(
             DevPerson(
                 id = it.id,
                 dateOfBirth = it.dateOfBirth,
@@ -518,10 +516,10 @@ fun insertGeneralTestFixtures(h: Handle) {
                 postOffice = it.postOffice ?: ""
             )
         )
-        h.insertTestChild(DevChild(id = it.id))
+        handle.insertTestChild(DevChild(id = it.id))
     }
 
-    h.insertTestPricing(
+    handle.insertTestPricing(
         DevPricing(
             id = UUID.randomUUID(),
             validFrom = LocalDate.of(2000, 1, 1),
@@ -537,21 +535,18 @@ fun insertGeneralTestFixtures(h: Handle) {
         )
     )
 
-    h.insertTestVoucherValue(
+    handle.insertTestVoucherValue(
         VoucherValue(id = UUID.randomUUID(), validity = DateRange(LocalDate.of(2000, 1, 1), null), voucherValue = 87000)
     )
 
-    h.insertPreschoolTerms()
+    insertPreschoolTerms()
 
-    h.insertServiceNeedOptions()
+    insertServiceNeedOptions()
 }
 
 fun Database.Transaction.resetDatabase() = execute("SELECT reset_database()")
-fun resetDatabase(h: Handle) {
-    h.transaction { it.execute("SELECT reset_database()") }
-}
 
-fun Handle.insertPreschoolTerms() {
+fun Database.Transaction.insertPreschoolTerms() {
     //language=SQL
     val sql =
         """
@@ -595,7 +590,7 @@ VALUES (
     createUpdate(sql).execute()
 }
 
-fun Handle.insertServiceNeedOptions() {
+fun Database.Transaction.insertServiceNeedOptions() {
     val batch = prepareBatch(
         // language=sql
         """
@@ -609,7 +604,7 @@ VALUES (:id, :name, :validPlacementType, :defaultOption, :feeCoefficient, :vouch
     batch.execute()
 }
 
-fun insertTestVardaOrganizer(h: Handle) {
+fun Database.Transaction.insertTestVardaOrganizer() {
     //language=SQL
     val sql =
         """
@@ -617,7 +612,7 @@ fun insertTestVardaOrganizer(h: Handle) {
             VALUES (:organizer, :email, :phone, :varda_organizer_id, :varda_organizer_oid, :url, :municipality_code)
         """.trimIndent()
 
-    h.createUpdate(sql)
+    createUpdate(sql)
         .bindMap(
             mapOf(
                 "organizer" to "Espoo",
@@ -631,8 +626,7 @@ fun insertTestVardaOrganizer(h: Handle) {
         ).execute()
 }
 
-fun insertApplication(
-    h: Handle,
+fun Database.Transaction.insertApplication(
     guardian: PersonData.Detailed = testAdult_5,
     child: PersonData.Detailed = testChild_6,
     appliedType: PlacementType = PlacementType.PRESCHOOL_DAYCARE,
@@ -645,7 +639,7 @@ fun insertApplication(
     guardianEmail: String = "abc@espoo.fi"
 ): ApplicationDetails {
     insertTestApplication(
-        h = h,
+        h = handle,
         id = applicationId,
         sentDate = null,
         dueDate = null,
@@ -735,7 +729,7 @@ fun insertApplication(
         attachments = listOf()
     )
     insertTestApplicationForm(
-        h = h,
+        h = handle,
         applicationId = applicationId,
         document = DaycareFormV0.fromApplication2(application)
     )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -371,8 +371,8 @@ val allDaycares = setOf(testDaycare, testDaycare2)
 
 fun Database.Transaction.insertGeneralTestFixtures() {
     insertTestVardaOrganizer()
-    handle.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
-    handle.insertTestCareArea(
+    insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
+    insertTestCareArea(
         DevCareArea(
             id = testArea2Id,
             name = testDaycare2.areaName,
@@ -380,7 +380,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
             areaCode = testArea2Code
         )
     )
-    handle.insertTestCareArea(
+    insertTestCareArea(
         DevCareArea(
             id = svebiTestId,
             name = testSvebiDaycare.areaName,
@@ -388,7 +388,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
             areaCode = svebiTestCode
         )
     )
-    handle.insertTestDaycare(
+    insertTestDaycare(
         DevDaycare(
             areaId = svebiTestId,
             id = testSvebiDaycare.id,
@@ -396,7 +396,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
             language = Language.sv
         )
     )
-    handle.insertTestDaycare(
+    insertTestDaycare(
         DevDaycare(
             areaId = testAreaId,
             id = testDaycare.id,
@@ -404,8 +404,8 @@ fun Database.Transaction.insertGeneralTestFixtures() {
             ophOrganizerOid = defaultMunicipalOrganizerOid
         )
     )
-    handle.insertTestDaycare(DevDaycare(areaId = testArea2Id, id = testDaycare2.id, name = testDaycare2.name))
-    handle.insertTestDaycare(
+    insertTestDaycare(DevDaycare(areaId = testArea2Id, id = testDaycare2.id, name = testDaycare2.name))
+    insertTestDaycare(
         DevDaycare(
             areaId = testArea2Id,
             id = testDaycareNotInvoiced.id,
@@ -413,7 +413,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
             invoicedByMunicipality = testDaycareNotInvoiced.invoicedByMunicipality
         )
     )
-    handle.insertTestDaycare(
+    insertTestDaycare(
         DevDaycare(
             areaId = testAreaId,
             id = testPurchasedDaycare.id,
@@ -423,7 +423,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
             invoicedByMunicipality = false
         )
     )
-    handle.insertTestDaycare(
+    insertTestDaycare(
         DevDaycare(
             areaId = testVoucherDaycare.areaId,
             id = testVoucherDaycare.id,
@@ -433,7 +433,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
             invoicedByMunicipality = false
         )
     )
-    handle.insertTestDaycare(
+    insertTestDaycare(
         DevDaycare(
             areaId = testVoucherDaycare2.areaId,
             id = testVoucherDaycare2.id,
@@ -444,12 +444,12 @@ fun Database.Transaction.insertGeneralTestFixtures() {
         )
     )
 
-    handle.insertTestDaycare(testClub)
-    handle.insertTestDaycare(testGhostUnitDaycare)
-    handle.insertTestDaycare(testRoundTheClockDaycare)
+    insertTestDaycare(testClub)
+    insertTestDaycare(testGhostUnitDaycare)
+    insertTestDaycare(testRoundTheClockDaycare)
 
     testDecisionMaker_1.let {
-        handle.insertTestEmployee(
+        insertTestEmployee(
             DevEmployee(
                 id = it.id,
                 firstName = it.firstName,
@@ -460,7 +460,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
     }
 
     testDecisionMaker_2.let {
-        handle.insertTestEmployee(
+        insertTestEmployee(
             DevEmployee(
                 id = it.id,
                 firstName = it.firstName,
@@ -470,7 +470,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
     }
 
     unitSupervisorOfTestDaycare.let {
-        handle.insertTestEmployee(
+        insertTestEmployee(
             DevEmployee(
                 id = it.id,
                 firstName = it.firstName,
@@ -479,7 +479,6 @@ fun Database.Transaction.insertGeneralTestFixtures() {
             )
         )
         updateDaycareAcl(
-            handle,
             testDaycare.id,
             unitSupervisorExternalId,
             UserRole.UNIT_SUPERVISOR
@@ -487,7 +486,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
     }
 
     allAdults.forEach {
-        handle.insertTestPerson(
+        insertTestPerson(
             DevPerson(
                 id = it.id,
                 dateOfBirth = it.dateOfBirth,
@@ -504,7 +503,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
     }
 
     allChildren.forEach {
-        handle.insertTestPerson(
+        insertTestPerson(
             DevPerson(
                 id = it.id,
                 dateOfBirth = it.dateOfBirth,
@@ -516,10 +515,10 @@ fun Database.Transaction.insertGeneralTestFixtures() {
                 postOffice = it.postOffice ?: ""
             )
         )
-        handle.insertTestChild(DevChild(id = it.id))
+        insertTestChild(DevChild(id = it.id))
     }
 
-    handle.insertTestPricing(
+    insertTestPricing(
         DevPricing(
             id = UUID.randomUUID(),
             validFrom = LocalDate.of(2000, 1, 1),
@@ -535,7 +534,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
         )
     )
 
-    handle.insertTestVoucherValue(
+    insertTestVoucherValue(
         VoucherValue(id = UUID.randomUUID(), validity = DateRange(LocalDate.of(2000, 1, 1), null), voucherValue = 87000)
     )
 
@@ -639,7 +638,6 @@ fun Database.Transaction.insertApplication(
     guardianEmail: String = "abc@espoo.fi"
 ): ApplicationDetails {
     insertTestApplication(
-        h = handle,
         id = applicationId,
         sentDate = null,
         dueDate = null,
@@ -729,7 +727,6 @@ fun Database.Transaction.insertApplication(
         attachments = listOf()
     )
     insertTestApplicationForm(
-        h = handle,
         applicationId = applicationId,
         document = DaycareFormV0.fromApplication2(application)
     )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
@@ -31,7 +31,6 @@ import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testSvebiDaycare
 import fi.espoo.evaka.testVoucherDaycare
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -79,14 +78,12 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     @Test
     fun `email is sent after end user sends application`() {
         val applicationId = db.transaction { tx ->
-            insertTestApplication(
-                h = tx.handle,
+            tx.insertTestApplication(
                 childId = testChild_1.id,
                 guardianId = guardian.id,
                 status = ApplicationStatus.CREATED
             ).also { id ->
-                insertTestApplicationForm(
-                    h = tx.handle,
+                tx.insertTestApplicationForm(
                     applicationId = id,
                     document = validDaycareForm.copy(
                         guardian = guardianAsDaycareAdult,
@@ -103,9 +100,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
             .response()
 
         assertEquals(204, res.statusCode)
-        db.read { tx ->
-            assertApplicationIsSent(tx.handle, applicationId)
-        }
+        assertApplicationIsSent(applicationId)
 
         assertEquals(1, asyncJobRunner.getPendingJobCount())
         asyncJobRunner.runPendingJobsSync()
@@ -122,14 +117,12 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     @Test
     fun `swedish email is sent after end user sends application to svebi daycare`() {
         val applicationId = db.transaction { tx ->
-            insertTestApplication(
-                h = tx.handle,
+            tx.insertTestApplication(
                 childId = testChild_1.id,
                 guardianId = guardian.id,
                 status = ApplicationStatus.CREATED
             ).also { id ->
-                insertTestApplicationForm(
-                    h = tx.handle,
+                tx.insertTestApplicationForm(
                     applicationId = id,
                     document = validDaycareForm.copy(
                         guardian = guardianAsDaycareAdult,
@@ -147,7 +140,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
 
         assertEquals(204, res.statusCode)
 
-        db.read { tx -> assertApplicationIsSent(tx.handle, applicationId) }
+        assertApplicationIsSent(applicationId)
         asyncJobRunner.runPendingJobsSync(1)
 
         val sentMails = MockEmailClient.emails
@@ -162,15 +155,13 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     @Test
     fun `email is sent after service worker sends application`() {
         val applicationId = db.transaction { tx ->
-            insertTestApplication(
-                h = tx.handle,
+            tx.insertTestApplication(
                 childId = testChild_1.id,
                 guardianId = guardian.id,
                 status = ApplicationStatus.CREATED,
                 hideFromGuardian = false
             ).also { id ->
-                insertTestApplicationForm(
-                    h = tx.handle,
+                tx.insertTestApplicationForm(
                     applicationId = id,
                     document = validDaycareForm.copy(
                         guardian = guardianAsDaycareAdult,
@@ -186,7 +177,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
             .response()
 
         assertEquals(204, res.statusCode)
-        db.read { tx -> assertApplicationIsSent(tx.handle, applicationId) }
+        assertApplicationIsSent(applicationId)
         assertEquals(1, asyncJobRunner.getPendingJobCount())
 
         asyncJobRunner.runPendingJobsSync(1)
@@ -203,14 +194,12 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     @Test
     fun `email is sent after sending club application`() {
         val applicationId = db.transaction { tx ->
-            insertTestApplication(
-                h = tx.handle,
+            tx.insertTestApplication(
                 childId = testChild_1.id,
                 guardianId = guardian.id,
                 status = ApplicationStatus.CREATED
             ).also { id ->
-                insertTestClubApplicationForm(
-                    h = tx.handle,
+                tx.insertTestClubApplicationForm(
                     applicationId = id,
                     document = validClubForm
                 )
@@ -222,7 +211,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
             .response()
 
         assertEquals(204, res.statusCode)
-        db.read { tx -> assertApplicationIsSent(tx.handle, applicationId) }
+        assertApplicationIsSent(applicationId)
 
         asyncJobRunner.runPendingJobsSync(1)
         assertEquals(0, asyncJobRunner.getPendingJobCount())
@@ -238,47 +227,44 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `email is sent after sending preschool application`() {
-        jdbi.handle { h ->
-            val applicationId = UUID.randomUUID()
-            insertApplication(
-                h,
+        val applicationId = UUID.randomUUID()
+        db.transaction { tx ->
+            tx.insertApplication(
                 guardian = guardian,
                 appliedType = PlacementType.PRESCHOOL,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 13)
             )
-
-            val (_, res, _) = http.post("/citizen/applications/$applicationId/actions/send-application")
-                .asUser(endUser)
-                .response()
-
-            assertEquals(204, res.statusCode)
-            assertApplicationIsSent(h, applicationId)
-
-            asyncJobRunner.runPendingJobsSync(1)
-            assertEquals(0, asyncJobRunner.getPendingJobCount())
-
-            val sentMails = MockEmailClient.emails
-
-            assertEquals(1, sentMails.size)
-
-            val sentMail = sentMails.first()
-            assertEquals(guardian.id.toString(), sentMail.traceId)
-            assertEquals("Olemme vastaanottaneet hakemuksenne", sentMail.subject)
         }
+
+        val (_, res, _) = http.post("/citizen/applications/$applicationId/actions/send-application")
+            .asUser(endUser)
+            .response()
+
+        assertEquals(204, res.statusCode)
+        assertApplicationIsSent(applicationId)
+
+        asyncJobRunner.runPendingJobsSync(1)
+        assertEquals(0, asyncJobRunner.getPendingJobCount())
+
+        val sentMails = MockEmailClient.emails
+
+        assertEquals(1, sentMails.size)
+
+        val sentMail = sentMails.first()
+        assertEquals(guardian.id.toString(), sentMail.traceId)
+        assertEquals("Olemme vastaanottaneet hakemuksenne", sentMail.subject)
     }
 
     @Test
     fun `email is not sent when provider type of preferred unit is private voucher`() {
         val applicationId = db.transaction { tx ->
-            insertTestApplication(
-                h = tx.handle,
+            tx.insertTestApplication(
                 childId = testChild_1.id,
                 guardianId = guardian.id,
                 status = ApplicationStatus.CREATED
             ).also { id ->
-                insertTestApplicationForm(
-                    h = tx.handle,
+                tx.insertTestApplicationForm(
                     applicationId = id,
                     document = validDaycareForm.copy(
                         guardian = guardianAsDaycareAdult,
@@ -295,7 +281,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
             .response()
 
         assertEquals(204, res.statusCode)
-        db.read { tx -> assertApplicationIsSent(tx.handle, applicationId) }
+        assertApplicationIsSent(applicationId)
         assertEquals(0, asyncJobRunner.getPendingJobCount())
         assertEquals(0, MockEmailClient.emails.size)
     }
@@ -303,15 +289,13 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     @Test
     fun `email is not sent when service workers sends hidden application`() {
         val applicationId = db.transaction { tx ->
-            insertTestApplication(
-                h = tx.handle,
+            tx.insertTestApplication(
                 childId = testChild_1.id,
                 guardianId = guardian.id,
                 status = ApplicationStatus.CREATED,
                 hideFromGuardian = true
             ).also { id ->
-                insertTestApplicationForm(
-                    h = tx.handle,
+                tx.insertTestApplicationForm(
                     applicationId = id,
                     document = validDaycareForm.copy(
                         guardian = guardianAsDaycareAdult,
@@ -327,7 +311,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
             .response()
 
         assertEquals(204, res.statusCode)
-        db.read { tx -> assertApplicationIsSent(tx.handle, applicationId) }
+        assertApplicationIsSent(applicationId)
         assertEquals(0, asyncJobRunner.getPendingJobCount())
 
         val sentMails = MockEmailClient.emails
@@ -337,14 +321,12 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     @Test
     fun `email is not sent to invalid email`() {
         val applicationId = db.transaction { tx ->
-            insertTestApplication(
-                h = tx.handle,
+            tx.insertTestApplication(
                 childId = testChild_1.id,
                 guardianId = testAdult_1.id,
                 status = ApplicationStatus.CREATED
             ).also { id ->
-                insertTestApplicationForm(
-                    h = tx.handle,
+                tx.insertTestApplicationForm(
                     applicationId = id,
                     document = validDaycareForm.copy(
                         guardian = guardianAsDaycareAdult.copy(email = "not@valid"),
@@ -361,7 +343,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
             .response()
 
         assertEquals(204, res.statusCode)
-        db.read { tx -> assertApplicationIsSent(tx.handle, applicationId) }
+        assertApplicationIsSent(applicationId)
         assertEquals(1, asyncJobRunner.getPendingJobCount())
 
         asyncJobRunner.runPendingJobsSync()
@@ -374,15 +356,13 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     fun `application keeps its manually set sent date after it is sent`() {
         val manuallySetSentDate = LocalDate.of(2020, 1, 1)
         val applicationId = db.transaction { tx ->
-            insertTestApplication(
-                h = tx.handle,
+            tx.insertTestApplication(
                 childId = testChild_1.id,
                 guardianId = testAdult_1.id,
                 status = ApplicationStatus.CREATED,
                 sentDate = manuallySetSentDate
             ).also { id ->
-                insertTestApplicationForm(
-                    h = tx.handle,
+                tx.insertTestApplicationForm(
                     applicationId = id,
                     document = validDaycareForm
                 )
@@ -394,12 +374,12 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
             .response()
 
         assertEquals(204, res.statusCode)
-        db.read { tx -> assertApplicationIsSent(tx.handle, applicationId) }
+        assertApplicationIsSent(applicationId)
         assertEquals(1, asyncJobRunner.getPendingJobCount())
 
         asyncJobRunner.runPendingJobsSync()
 
-        val result = db.read { tx -> fetchApplicationDetails(tx.handle, applicationId) }
+        val result = db.read { r -> fetchApplicationDetails(r.handle, applicationId) }
         assertEquals(manuallySetSentDate, result?.sentDate)
     }
 
@@ -443,7 +423,9 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
         assert(email.textBody.contains(expectedTextPart, true))
     }
 
-    private fun assertApplicationIsSent(h: Handle, applicationId: UUID) {
-        assertEquals(ApplicationStatus.SENT, fetchApplicationDetails(h, applicationId)!!.status)
+    private fun assertApplicationIsSent(applicationId: UUID) {
+        db.read {
+            assertEquals(ApplicationStatus.SENT, fetchApplicationDetails(it.handle, applicationId)!!.status)
+        }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
@@ -71,7 +71,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
         MockEmailClient.emails.clear()
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -53,7 +53,6 @@ import fi.espoo.evaka.testChild_7
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDaycare2
 import fi.espoo.evaka.testDecisionMaker_1
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -96,7 +95,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         MockEvakaMessageClient.clearMessages()
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 
@@ -104,8 +103,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `sendApplication - preschool has due date same as sent date`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.PRESCHOOL,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 13)
@@ -130,8 +128,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `sendApplication - daycare has due date after 4 months if not urgent`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.DAYCARE,
                 urgent = false,
                 applicationId = applicationId,
@@ -164,8 +161,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `sendApplication - daycare has due date after 2 weeks if urgent and has attachments`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 guardian = testAdult_1,
                 appliedType = PlacementType.DAYCARE,
                 urgent = true,
@@ -197,8 +193,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `sendApplication - urgent daycare application gets due date from first received attachment`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 guardian = testAdult_1,
                 appliedType = PlacementType.DAYCARE,
                 urgent = true,
@@ -238,8 +233,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `sendApplication - daycare has not due date if a transfer application`() {
         db.transaction { tx ->
             // given
-            val draft = insertApplication(
-                tx.handle,
+            val draft = tx.insertApplication(
                 appliedType = PlacementType.DAYCARE,
                 urgent = false,
                 applicationId = applicationId,
@@ -270,8 +264,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement without otherInfo - status is changed and checkedByAdmin defaults true`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 hasAdditionalInfo = false,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -294,8 +287,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement with otherInfo - status is changed and checkedByAdmin defaults false`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 hasAdditionalInfo = true,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -317,8 +309,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement - guardian contact details are updated`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.DAYCARE,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -341,8 +332,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement - empty application guardian email does not wipe out person email`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                h = tx.handle,
+            tx.insertApplication(
                 guardian = testAdult_6,
                 appliedType = PlacementType.DAYCARE,
                 applicationId = applicationId,
@@ -367,8 +357,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `moveToWaitingPlacement - child is upserted with diet and allergies`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.DAYCARE,
                 hasAdditionalInfo = true,
                 applicationId = applicationId
@@ -391,8 +380,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `setVerified and setUnverified - changes checkedByAdmin`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 hasAdditionalInfo = true,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -426,7 +414,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `cancelApplication from SENT - status is changed`() {
         db.transaction { tx ->
             // given
-            insertApplication(tx.handle, applicationId = applicationId, preferredStartDate = LocalDate.of(2020, 8, 1))
+            tx.insertApplication(applicationId = applicationId, preferredStartDate = LocalDate.of(2020, 8, 1))
             service.sendApplication(tx, serviceWorker, applicationId)
         }
         db.transaction { tx ->
@@ -444,7 +432,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `cancelApplication from WAITING_PLACEMENT - status is changed`() {
         db.transaction { tx ->
             // given
-            insertApplication(tx.handle, applicationId = applicationId, preferredStartDate = LocalDate.of(2020, 8, 1))
+            tx.insertApplication(applicationId = applicationId, preferredStartDate = LocalDate.of(2020, 8, 1))
             service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
         }
@@ -463,7 +451,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `returnToSent - status is changed`() {
         db.transaction { tx ->
             // given
-            insertApplication(tx.handle, applicationId = applicationId, preferredStartDate = LocalDate.of(2020, 8, 1))
+            tx.insertApplication(applicationId = applicationId, preferredStartDate = LocalDate.of(2020, 8, 1))
             service.sendApplication(tx, serviceWorker, applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
         }
@@ -482,8 +470,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `createPlacementPlan - daycare`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.DAYCARE,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -541,8 +528,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `createPlacementPlan - daycare part-time`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.DAYCARE_PART_TIME,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -600,8 +586,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `createPlacementPlan - preschool`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.PRESCHOOL,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 13)
@@ -675,8 +660,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `createPlacementPlan - preschool with daycare`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.PRESCHOOL_DAYCARE,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -751,8 +735,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `cancelPlacementPlan - removes placement plan and decision drafts and changes status`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.PRESCHOOL_DAYCARE,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -846,8 +829,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     ) {
         // given
         db.transaction { tx ->
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.PRESCHOOL,
                 guardian = applier,
                 child = child,
@@ -911,8 +893,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `sendPlacementProposal - updates status`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.PRESCHOOL_DAYCARE,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -946,8 +927,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `withdrawPlacementProposal - updates status`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.PRESCHOOL_DAYCARE,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -984,8 +964,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `acceptPlacementProposal - sends decisions and updates status`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle, appliedType = PlacementType.PRESCHOOL_DAYCARE,
+            tx.insertApplication(
+                appliedType = PlacementType.PRESCHOOL_DAYCARE,
                 child = testChild_2,
                 guardian = testAdult_1,
                 applicationId = applicationId,
@@ -1039,8 +1019,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `acceptPlacementProposal - if no decisions are marked for sending do nothing`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle, appliedType = PlacementType.PRESCHOOL_DAYCARE,
+            tx.insertApplication(
+                appliedType = PlacementType.PRESCHOOL_DAYCARE,
                 child = testChild_2,
                 guardian = testAdult_1, applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
@@ -1106,8 +1086,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `acceptPlacementProposal - throws if some application is pending response`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.PRESCHOOL,
                 child = testChild_2,
                 guardian = testAdult_1, applicationId = applicationId,
@@ -1136,8 +1115,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     fun `acceptPlacementProposal - throws if some application has been rejected`() {
         db.transaction { tx ->
             // given
-            insertApplication(
-                tx.handle,
+            tx.insertApplication(
                 appliedType = PlacementType.PRESCHOOL,
                 child = testChild_2,
                 guardian = testAdult_1, applicationId = applicationId,
@@ -1171,17 +1149,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `reject preschool decision rejects preschool daycare decision too`() {
-        db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
-        }
+        // given
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.rejectDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id
+                getDecision(tx, DecisionType.PRESCHOOL).id
             )
         }
         db.read { tx ->
@@ -1189,10 +1166,10 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val application = fetchApplicationDetails(tx.handle, applicationId)!!
             assertEquals(ApplicationStatus.REJECTED, application.status)
 
-            with(getDecision(tx.handle, DecisionType.PRESCHOOL)) {
+            with(getDecision(tx, DecisionType.PRESCHOOL)) {
                 assertEquals(DecisionStatus.REJECTED, status)
             }
-            with(getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE)) {
+            with(getDecision(tx, DecisionType.PRESCHOOL_DAYCARE)) {
                 assertEquals(DecisionStatus.REJECTED, status)
             }
 
@@ -1206,24 +1183,23 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `accept preschool and reject preschool daycare`() {
-        db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
-        }
+        // given
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
             service.rejectDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE).id
+                getDecision(tx, DecisionType.PRESCHOOL_DAYCARE).id
             )
         }
         db.read { tx ->
@@ -1231,10 +1207,10 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val application = fetchApplicationDetails(tx.handle, applicationId)!!
             assertEquals(ApplicationStatus.ACTIVE, application.status)
 
-            with(getDecision(tx.handle, DecisionType.PRESCHOOL)) {
+            with(getDecision(tx, DecisionType.PRESCHOOL)) {
                 assertEquals(DecisionStatus.ACCEPTED, status)
             }
-            with(getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE)) {
+            with(getDecision(tx, DecisionType.PRESCHOOL_DAYCARE)) {
                 assertEquals(DecisionStatus.REJECTED, status)
             }
 
@@ -1253,17 +1229,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `accept preschool application with maxFeeAccepted - new income has been created`() {
-        db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
-        }
+        // given
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1293,15 +1268,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = null
             )
             upsertIncome(tx.handle, mapper, earlierIndefinite, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1332,15 +1308,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = mainPeriod.start.plusMonths(5)
             )
             upsertIncome(tx.handle, mapper, earlierIncome, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1371,15 +1348,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = null
             )
             upsertIncome(tx.handle, mapper, laterIndefiniteIncome, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1410,15 +1388,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = mainPeriod.start.minusMonths(5)
             )
             upsertIncome(tx.handle, mapper, earlierIncome, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1451,15 +1430,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = mainPeriod.start.plusMonths(6)
             )
             upsertIncome(tx.handle, mapper, laterIncome, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1490,15 +1470,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = null
             )
             upsertIncome(tx.handle, mapper, earlierIndefinite, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx, preferredStartDate = null)
         }
+        workflowForPreschoolDaycareDecisions(preferredStartDate = null)
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1527,15 +1508,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = null
             )
             upsertIncome(tx.handle, mapper, sameDayIncomeIndefinite, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1565,15 +1547,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = mainPeriod.start.plusMonths(5)
             )
             upsertIncome(tx.handle, mapper, sameDayIncome, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1604,15 +1587,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = null
             )
             upsertIncome(tx.handle, mapper, dayBeforeIncomeIndefinite, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1644,15 +1628,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = null
             )
             upsertIncome(tx.handle, mapper, nextDayIncomeIndefinite, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1683,15 +1668,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = mainPeriod.start.plusMonths(5)
             )
             upsertIncome(tx.handle, mapper, incomeDayBefore, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1722,15 +1708,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = mainPeriod.start
             )
             upsertIncome(tx.handle, mapper, earlierIncomeEndingOnSameDay, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1761,15 +1748,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = mainPeriod.start.plusDays(1)
             )
             upsertIncome(tx.handle, mapper, earlierIncomeEndingOnNextDay, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1800,15 +1788,16 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 validTo = mainPeriod.start.minusDays(1)
             )
             upsertIncome(tx.handle, mapper, earlierIncomeEndingOnDayBefore, financeUser.id)
-            workflowForPreschoolDaycareDecisions(tx)
         }
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1826,10 +1815,9 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `enduser can accept and reject own decisions`() {
-        db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
-        }
+        // given
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             val user = AuthenticatedUser.Citizen(testAdult_5.id)
@@ -1837,7 +1825,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 tx,
                 user,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start,
                 isEnduser = true
             )
@@ -1845,7 +1833,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 tx,
                 user,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE).id,
+                getDecision(tx, DecisionType.PRESCHOOL_DAYCARE).id,
                 isEnduser = true
             )
 
@@ -1857,10 +1845,9 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `enduser can not accept decision of someone else`() {
-        db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
-        }
+        // given
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             val user = AuthenticatedUser.Citizen(testAdult_1.id)
             // when
@@ -1869,7 +1856,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                     tx,
                     user,
                     applicationId,
-                    getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                    getDecision(tx, DecisionType.PRESCHOOL).id,
                     mainPeriod.start,
                     isEnduser = true
                 )
@@ -1879,10 +1866,9 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `enduser can not reject decision of someone else`() {
-        db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
-        }
+        // given
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             val user = AuthenticatedUser.Citizen(testAdult_1.id)
@@ -1891,7 +1877,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                     tx,
                     user,
                     applicationId,
-                    getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                    getDecision(tx, DecisionType.PRESCHOOL).id,
                     isEnduser = true
                 )
             }
@@ -1900,24 +1886,23 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `accept preschool and accept preschool daycare`() {
-        db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
-        }
+        // given
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE).id,
+                getDecision(tx, DecisionType.PRESCHOOL_DAYCARE).id,
                 connectedPeriod.start
             )
         }
@@ -1926,10 +1911,10 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val application = fetchApplicationDetails(tx.handle, applicationId)!!
             assertEquals(ApplicationStatus.ACTIVE, application.status)
 
-            with(getDecision(tx.handle, DecisionType.PRESCHOOL)) {
+            with(getDecision(tx, DecisionType.PRESCHOOL)) {
                 assertEquals(DecisionStatus.ACCEPTED, status)
             }
-            with(getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE)) {
+            with(getDecision(tx, DecisionType.PRESCHOOL_DAYCARE)) {
                 assertEquals(DecisionStatus.ACCEPTED, status)
             }
 
@@ -1951,10 +1936,9 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `accept preschool daycare first throws`() {
-        db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
-        }
+        // given
+        workflowForPreschoolDaycareDecisions()
+
         db.transaction { tx ->
             // when / then
             assertThrows<BadRequest> {
@@ -1962,7 +1946,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                     tx,
                     serviceWorker,
                     applicationId,
-                    getDecision(tx.handle, DecisionType.PRESCHOOL_DAYCARE).id,
+                    getDecision(tx, DecisionType.PRESCHOOL_DAYCARE).id,
                     mainPeriod.start
                 )
             }
@@ -1971,14 +1955,14 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `accepting already accepted decision throws`() {
+        // given
+        workflowForPreschoolDaycareDecisions()
         db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -1989,7 +1973,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                     tx,
                     serviceWorker,
                     applicationId,
-                    getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                    getDecision(tx, DecisionType.PRESCHOOL).id,
                     mainPeriod.start
                 )
             }
@@ -1998,14 +1982,14 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `accepting already rejected decision throws`() {
+        // given
+        workflowForPreschoolDaycareDecisions()
         db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
             service.rejectDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id
+                getDecision(tx, DecisionType.PRESCHOOL).id
             )
         }
         db.transaction { tx ->
@@ -2015,7 +1999,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                     tx,
                     serviceWorker,
                     applicationId,
-                    getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                    getDecision(tx, DecisionType.PRESCHOOL).id,
                     mainPeriod.start
                 )
             }
@@ -2024,14 +2008,14 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `rejecting already accepted decision throws`() {
+        // given
+        workflowForPreschoolDaycareDecisions()
         db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
             service.acceptDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id,
+                getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
             )
         }
@@ -2042,7 +2026,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                     tx,
                     serviceWorker,
                     applicationId,
-                    getDecision(tx.handle, DecisionType.PRESCHOOL).id
+                    getDecision(tx, DecisionType.PRESCHOOL).id
                 )
             }
         }
@@ -2050,14 +2034,14 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `rejecting already rejected decision throws`() {
+        // given
+        workflowForPreschoolDaycareDecisions()
         db.transaction { tx ->
-            // given
-            workflowForPreschoolDaycareDecisions(tx)
             service.rejectDecision(
                 tx,
                 serviceWorker,
                 applicationId,
-                getDecision(tx.handle, DecisionType.PRESCHOOL).id
+                getDecision(tx, DecisionType.PRESCHOOL).id
             )
         }
         db.transaction { tx ->
@@ -2067,36 +2051,37 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                     tx,
                     serviceWorker,
                     applicationId,
-                    getDecision(tx.handle, DecisionType.PRESCHOOL).id
+                    getDecision(tx, DecisionType.PRESCHOOL).id
                 )
             }
         }
     }
 
-    private fun getDecision(h: Handle, type: DecisionType): Decision =
-        getDecisionsByApplication(h, applicationId, AclAuthorization.All).first { it.type == type }
+    private fun getDecision(r: Database.Read, type: DecisionType): Decision =
+        getDecisionsByApplication(r.handle, applicationId, AclAuthorization.All).first { it.type == type }
 
-    private fun workflowForPreschoolDaycareDecisions(tx: Database.Transaction, preferredStartDate: LocalDate? = LocalDate.of(2020, 8, 1)) {
-        insertApplication(
-            tx.handle,
-            guardian = testAdult_5,
-            maxFeeAccepted = true,
-            appliedType = PlacementType.PRESCHOOL_DAYCARE,
-            applicationId = applicationId,
-            preferredStartDate = preferredStartDate
-        )
-        service.sendApplication(tx, serviceWorker, applicationId)
-        service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
-        service.createPlacementPlan(
-            tx,
-            serviceWorker,
-            applicationId,
-            DaycarePlacementPlan(
-                unitId = testDaycare.id,
-                period = mainPeriod,
-                preschoolDaycarePeriod = connectedPeriod
+    private fun workflowForPreschoolDaycareDecisions(preferredStartDate: LocalDate? = LocalDate.of(2020, 8, 1)) {
+        db.transaction { tx ->
+            tx.insertApplication(
+                guardian = testAdult_5,
+                maxFeeAccepted = true,
+                appliedType = PlacementType.PRESCHOOL_DAYCARE,
+                applicationId = applicationId,
+                preferredStartDate = preferredStartDate
             )
-        )
-        service.sendDecisionsWithoutProposal(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.createPlacementPlan(
+                tx,
+                serviceWorker,
+                applicationId,
+                DaycarePlacementPlan(
+                    unitId = testDaycare.id,
+                    period = mainPeriod,
+                    preschoolDaycarePeriod = connectedPeriod
+                )
+            )
+            service.sendDecisionsWithoutProposal(tx, serviceWorker, applicationId)
+        }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -239,7 +239,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            tx.handle.insertTestPlacement(
+            tx.insertTestPlacement(
                 DevPlacement(
                     childId = draft.childId,
                     unitId = testDaycare2.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
@@ -34,7 +34,7 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
@@ -145,9 +145,9 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
         dueDate: LocalDate,
         urgent: Boolean
     ): ApplicationDetails = db.transaction { tx ->
-        val applicationId = insertTestApplication(tx.handle, status = ApplicationStatus.SENT, sentDate = sentDate, dueDate = dueDate, childId = testChild_1.id, guardianId = testAdult_1.id)
+        val applicationId = tx.insertTestApplication(status = ApplicationStatus.SENT, sentDate = sentDate, dueDate = dueDate, childId = testChild_1.id, guardianId = testAdult_1.id)
         val validDaycareForm = DaycareFormV0.fromApplication2(validDaycareApplication)
-        insertTestApplicationForm(tx.handle, applicationId, validDaycareForm.copy(urgent = urgent))
+        tx.insertTestApplicationForm(applicationId, validDaycareForm.copy(urgent = urgent))
         fetchApplicationDetails(tx.handle, applicationId)!!
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/DuplicateApplicationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/DuplicateApplicationIntegrationTest.kt
@@ -68,14 +68,12 @@ class DuplicateApplicationIntegrationTest : FullApplicationTest() {
 
     private fun addDaycareApplication(status: ApplicationStatus = ApplicationStatus.SENT) {
         db.transaction { tx ->
-            val appId = insertTestApplication(
-                h = tx.handle,
+            val appId = tx.insertTestApplication(
                 status = status,
                 childId = childId,
                 guardianId = guardianId
             )
-            insertTestApplicationForm(
-                h = tx.handle,
+            tx.insertTestApplicationForm(
                 applicationId = appId,
                 document = DaycareFormV0.fromApplication2(validDaycareApplication)
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/DuplicateApplicationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/DuplicateApplicationIntegrationTest.kt
@@ -31,7 +31,7 @@ class DuplicateApplicationIntegrationTest : FullApplicationTest() {
     internal fun setUp() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -58,14 +58,13 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
-            tx.handle.insertTestEmployee(
+            tx.insertTestEmployee(
                 DevEmployee(
                     id = testRoundTheClockDaycareSupervisor.id,
                     externalId = testRoundTheClockDaycareSupervisorExternalId
                 )
             )
-            updateDaycareAcl(
-                tx.handle,
+            tx.updateDaycareAcl(
                 testRoundTheClockDaycare.id!!,
                 testRoundTheClockDaycareSupervisorExternalId,
                 UserRole.UNIT_SUPERVISOR
@@ -82,12 +81,11 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
     @Test
     fun `application found returns 200`() {
         val applicationId = db.transaction { tx ->
-            insertTestApplication(h = tx.handle, childId = testChild_1.id, guardianId = testAdult_1.id)
+            tx.insertTestApplication(childId = testChild_1.id, guardianId = testAdult_1.id)
         }
 
         db.transaction { tx ->
-            insertTestApplicationForm(
-                h = tx.handle,
+            tx.insertTestApplicationForm(
                 applicationId = applicationId,
                 document = validDaycareForm.copy(
                     apply = validDaycareForm.apply.copy(
@@ -120,7 +118,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
     @Test
     fun `restricted child address is hidden`() {
         val childId = db.transaction {
-            it.handle.insertTestPerson(
+            it.insertTestPerson(
                 DevPerson(
                     restrictedDetailsEnabled = true
                 )
@@ -128,12 +126,11 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
         }
 
         val applicationId = db.transaction { tx ->
-            insertTestApplication(h = tx.handle, childId = childId, guardianId = testAdult_1.id)
+            tx.insertTestApplication(childId = childId, guardianId = testAdult_1.id)
         }
 
         db.transaction { tx ->
-            insertTestApplicationForm(
-                h = tx.handle,
+            tx.insertTestApplicationForm(
                 applicationId = applicationId,
                 document = validDaycareForm.copy(
                     child = validDaycareForm.child.copy(
@@ -161,7 +158,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
     @Test
     fun `restricted guardian address is hidden`() {
         val guardianId = db.transaction {
-            it.handle.insertTestPerson(
+            it.insertTestPerson(
                 DevPerson(
                     restrictedDetailsEnabled = true
                 )
@@ -169,12 +166,11 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
         }
 
         val applicationId = db.transaction { tx ->
-            insertTestApplication(h = tx.handle, childId = testChild_1.id, guardianId = guardianId)
+            tx.insertTestApplication(childId = testChild_1.id, guardianId = guardianId)
         }
 
         db.transaction { tx ->
-            insertTestApplicationForm(
-                h = tx.handle,
+            tx.insertTestApplicationForm(
                 applicationId = applicationId,
                 document = validDaycareForm.copy(
                     guardian = validDaycareForm.guardian.copy(
@@ -203,14 +199,14 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
     fun `old drafts are removed`() {
         val (old, id1, id2) = db.transaction { tx ->
             listOf(
-                insertTestApplication(h = tx.handle, childId = testChild_1.id, guardianId = testAdult_1.id, status = ApplicationStatus.CREATED),
-                insertTestApplication(h = tx.handle, childId = testChild_2.id, guardianId = testAdult_1.id, status = ApplicationStatus.CREATED),
-                insertTestApplication(h = tx.handle, childId = testChild_3.id, guardianId = testAdult_1.id)
+                tx.insertTestApplication(childId = testChild_1.id, guardianId = testAdult_1.id, status = ApplicationStatus.CREATED),
+                tx.insertTestApplication(childId = testChild_2.id, guardianId = testAdult_1.id, status = ApplicationStatus.CREATED),
+                tx.insertTestApplication(childId = testChild_3.id, guardianId = testAdult_1.id)
             )
         }
 
         db.transaction { tx ->
-            tx.handle.createUpdate("""update application set created = :createdAt where id = :applicationId""")
+            tx.createUpdate("""update application set created = :createdAt where id = :applicationId""")
                 .bind("applicationId", old)
                 .bind("createdAt", Instant.parse("2020-01-01T00:00:00Z"))
                 .execute()
@@ -297,14 +293,12 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
 
     private fun createPlacementProposalWithAttachments(unitId: UUID): UUID {
         val applicationId = db.transaction { tx ->
-            val applicationId = insertTestApplication(
-                tx.handle,
+            val applicationId = tx.insertTestApplication(
                 childId = testChild_1.id,
                 guardianId = endUser.id,
                 status = ApplicationStatus.CREATED
             )
-            insertTestApplicationForm(
-                h = tx.handle,
+            tx.insertTestApplicationForm(
                 applicationId = applicationId,
                 document = DaycareFormV0.fromApplication2(validDaycareApplication)
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -57,7 +57,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             tx.handle.insertTestEmployee(
                 DevEmployee(
                     id = testRoundTheClockDaycareSupervisor.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
@@ -35,7 +35,7 @@ class GetApplicationSummaryIntegrationTests : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
 
             createApplication(h = tx.handle, child = testChild_1, guardian = testAdult_1)
             createApplication(h = tx.handle, child = testChild_2, guardian = testAdult_1, attachment = true)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.test.validDaycareApplication
@@ -23,7 +22,6 @@ import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
 import fi.espoo.evaka.testChild_3
 import fi.espoo.evaka.testDecisionMaker_1
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,11 +34,10 @@ class GetApplicationSummaryIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
-
-            createApplication(h = tx.handle, child = testChild_1, guardian = testAdult_1)
-            createApplication(h = tx.handle, child = testChild_2, guardian = testAdult_1, attachment = true)
-            createApplication(h = tx.handle, child = testChild_3, guardian = testAdult_1, urgent = true)
         }
+        createApplication(child = testChild_1, guardian = testAdult_1)
+        createApplication(child = testChild_2, guardian = testAdult_1, attachment = true)
+        createApplication(child = testChild_3, guardian = testAdult_1, urgent = true)
     }
 
     @Test
@@ -71,11 +68,13 @@ class GetApplicationSummaryIntegrationTests : FullApplicationTest() {
         return result.get()
     }
 
-    private fun createApplication(h: Handle, child: PersonData.Detailed, guardian: PersonData.Detailed, attachment: Boolean = false, urgent: Boolean = false) {
-        val applicationId = insertTestApplication(h, childId = child.id, guardianId = guardian.id)
-
-        val form = DaycareFormV0.fromApplication2(validDaycareApplication.copy(childId = child.id, guardianId = guardian.id)).copy(urgent = urgent)
-        insertTestApplicationForm(h, applicationId, form)
+    private fun createApplication(child: PersonData.Detailed, guardian: PersonData.Detailed, attachment: Boolean = false, urgent: Boolean = false) {
+        val applicationId = db.transaction { tx ->
+            tx.insertTestApplication(childId = child.id, guardianId = guardian.id).also { id ->
+                val form = DaycareFormV0.fromApplication2(validDaycareApplication.copy(childId = child.id, guardianId = guardian.id)).copy(urgent = urgent)
+                tx.insertTestApplicationForm(id, form)
+            }
+        }
 
         if (attachment) {
             uploadAttachment(applicationId, AuthenticatedUser.Citizen(guardian.id))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -48,7 +48,7 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
     internal fun setUp() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
 
             insertTestApplication(
                 h = tx.handle,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -50,15 +50,13 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
 
-            insertTestApplication(
-                h = tx.handle,
+            tx.insertTestApplication(
                 id = applicationId,
                 status = ApplicationStatus.WAITING_CONFIRMATION,
                 childId = childId,
                 guardianId = guardianId
             )
-            insertTestApplicationForm(
-                h = tx.handle,
+            tx.insertTestApplicationForm(
                 applicationId = applicationId,
                 document = DaycareFormV0.fromApplication2(validDaycareApplication)
             )
@@ -153,7 +151,7 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
 
     private fun createPendingDecision(sentDate: LocalDate, resolved: Instant?, pendingDecisionEmailSent: Instant?, pendingDecisionEmailsSentCount: Int, type: DecisionType = DecisionType.DAYCARE) {
         db.transaction { tx ->
-            tx.handle.insertTestDecision(
+            tx.insertTestDecision(
                 TestDecision(
                     applicationId = applicationId,
                     status = DecisionStatus.PENDING,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
@@ -32,7 +32,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
@@ -279,7 +279,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
 
     private fun givenAssistanceAction(start: Int, end: Int, childId: UUID = testChild_1.id): UUID {
         return db.transaction {
-            it.handle.insertTestAssistanceAction(
+            it.insertTestAssistanceAction(
                 DevAssistanceAction(
                     childId = childId,
                     startDate = testDate(start),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
@@ -32,7 +32,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
@@ -287,7 +287,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
 
     private fun givenAssistanceNeed(start: Int, end: Int, childId: UUID = testChild_1.id): UUID {
         return db.transaction {
-            it.handle.insertTestAssistanceNeed(
+            it.insertTestAssistanceNeed(
                 DevAssistanceNeed(
                     childId = childId,
                     startDate = testDate(start),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsControllerIntegrationTest.kt
@@ -26,10 +26,10 @@ class AttachmentsControllerIntegrationTest : FullApplicationTest() {
     @BeforeEach
     protected fun beforeEach() {
         db.transaction {
-            resetDatabase(it.handle)
-            insertGeneralTestFixtures(it.handle)
-            user = AuthenticatedUser.Citizen(testAdult_5.id)
+            it.resetDatabase()
+            it.insertGeneralTestFixtures()
         }
+        user = AuthenticatedUser.Citizen(testAdult_5.id)
     }
 
     @AfterEach
@@ -43,7 +43,7 @@ class AttachmentsControllerIntegrationTest : FullApplicationTest() {
     fun `Enduser can upload attachments up to the limit`() {
         val maxAttachments = env.getProperty("fi.espoo.evaka.maxAttachmentsPerUser")!!.toInt()
         db.transaction {
-            insertApplication(it.handle, applicationId = applicationId, guardian = testAdult_5, status = ApplicationStatus.CREATED)
+            it.insertApplication(applicationId = applicationId, guardian = testAdult_5, status = ApplicationStatus.CREATED)
         }
         for (i in 1..maxAttachments) {
             Assertions.assertTrue(uploadAttachment(applicationId, user))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
@@ -50,7 +50,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
         db.transaction { tx ->
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
-            tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id, name = groupName))
+            tx.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id, name = groupName))
             tx.createMobileDeviceToUnit(userId, testDaycare.id)
         }
     }
@@ -322,8 +322,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
     fun `post full day absence - happy case when coming to preschool`() {
         // previous day attendance should have no effect
         db.transaction {
-            insertTestChildAttendance(
-                h = it.handle,
+            it.insertTestChildAttendance(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 arrived = ZonedDateTime.now(europeHelsinki).minusDays(1).minusHours(1).toInstant(),
@@ -437,8 +436,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
 
     private fun givenChildPlacement(placementType: PlacementType) {
         db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 id = daycarePlacementId,
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
@@ -446,8 +444,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
                 endDate = placementEnd,
                 type = placementType
             )
-            insertTestDaycareGroupPlacement(
-                h = tx.handle,
+            tx.insertTestDaycareGroupPlacement(
                 daycarePlacementId = daycarePlacementId,
                 groupId = groupId,
                 startDate = placementStart,
@@ -463,8 +460,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
 
     private fun givenChildPresent(arrived: LocalTime = roundedTimeNow().minusHours(1)) {
         db.transaction {
-            insertTestChildAttendance(
-                h = it.handle,
+            it.insertTestChildAttendance(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 arrived = ZonedDateTime.of(LocalDate.now(europeHelsinki).atTime(arrived), europeHelsinki).toInstant(),
@@ -480,8 +476,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
         departed: LocalTime = roundedTimeNow().minusMinutes(10)
     ) {
         db.transaction {
-            insertTestChildAttendance(
-                h = it.handle,
+            it.insertTestChildAttendance(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 arrived = ZonedDateTime.of(LocalDate.now(europeHelsinki).atTime(arrived), europeHelsinki).toInstant(),
@@ -495,7 +490,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
     private fun givenChildAbsent(absentFrom: List<CareType>, absenceType: AbsenceType) {
         absentFrom.forEach { careType ->
             db.transaction {
-                insertTestAbsence(h = it.handle, childId = testChild_1.id, absenceType = absenceType, careType = careType, date = LocalDate.now())
+                it.insertTestAbsence(childId = testChild_1.id, absenceType = absenceType, careType = careType, date = LocalDate.now())
             }
         }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
@@ -49,7 +49,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id, name = groupName))
             tx.createMobileDeviceToUnit(userId, testDaycare.id)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
@@ -36,9 +36,8 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest() {
         db.transaction { tx ->
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
-            tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id))
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id))
+            tx.insertTestPlacement(
                 id = daycarePlacementId,
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
@@ -46,8 +45,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest() {
                 endDate = placementEnd,
                 type = PlacementType.PRESCHOOL_DAYCARE
             )
-            insertTestDaycareGroupPlacement(
-                h = tx.handle,
+            tx.insertTestDaycareGroupPlacement(
                 daycarePlacementId = daycarePlacementId,
                 groupId = groupId,
                 startDate = placementStart,
@@ -65,8 +63,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest() {
         ).toInstant()
 
         db.transaction {
-            insertTestChildAttendance(
-                h = it.handle,
+            it.insertTestChildAttendance(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 arrived = arrived,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
@@ -35,7 +35,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id))
             insertTestPlacement(
                 h = tx.handle,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
@@ -54,10 +54,9 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
         db.transaction { tx ->
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
-            tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id, name = groupName))
-            tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = groupId2, daycareId = testDaycare2.id, name = groupName))
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id, name = groupName))
+            tx.insertTestDaycareGroup(DevDaycareGroup(id = groupId2, daycareId = testDaycare2.id, name = groupName))
+            tx.insertTestPlacement(
                 id = daycarePlacementId,
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
@@ -65,8 +64,7 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
                 endDate = placementEnd,
                 type = PlacementType.PRESCHOOL_DAYCARE
             )
-            insertTestDaycareGroupPlacement(
-                h = tx.handle,
+            tx.insertTestDaycareGroupPlacement(
                 daycarePlacementId = daycarePlacementId,
                 groupId = groupId,
                 startDate = placementStart,
@@ -88,8 +86,7 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
     @Test
     fun `child is coming`() {
         db.transaction {
-            insertTestChildAttendance(
-                h = it.handle,
+            it.insertTestChildAttendance(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 arrived = OffsetDateTime.now().minusDays(1).minusHours(8).toInstant(),
@@ -106,8 +103,7 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
     @Test
     fun `child is in backup care in another unit`() {
         db.transaction {
-            insertTestBackUpCare(
-                h = it.handle,
+            it.insertTestBackUpCare(
                 childId = testChild_1.id,
                 unitId = testDaycare2.id,
                 groupId = groupId2,
@@ -122,8 +118,7 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
     @Test
     fun `child is in backup care in same another unit`() {
         db.transaction {
-            insertTestBackUpCare(
-                h = it.handle,
+            it.insertTestBackUpCare(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 groupId = groupId,
@@ -142,8 +137,7 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
     fun `child is present`() {
         val arrived = OffsetDateTime.now().minusHours(3).toInstant()
         db.transaction {
-            insertTestChildAttendance(
-                h = it.handle,
+            it.insertTestChildAttendance(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 arrived = arrived,
@@ -164,8 +158,7 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
         val arrived = OffsetDateTime.now().minusHours(3).toInstant()
         val departed = OffsetDateTime.now().minusMinutes(1).toInstant()
         db.transaction {
-            insertTestChildAttendance(
-                h = it.handle,
+            it.insertTestChildAttendance(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 arrived = arrived,
@@ -184,15 +177,13 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
     @Test
     fun `child is absent`() {
         db.transaction {
-            insertTestAbsence(
-                h = it.handle,
+            it.insertTestAbsence(
                 childId = testChild_1.id,
                 careType = CareType.PRESCHOOL,
                 date = LocalDate.now(),
                 absenceType = AbsenceType.SICKLEAVE
             )
-            insertTestAbsence(
-                h = it.handle,
+            it.insertTestAbsence(
                 childId = testChild_1.id,
                 careType = CareType.PRESCHOOL_DAYCARE,
                 date = LocalDate.now(),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
@@ -53,7 +53,7 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id, name = groupName))
             tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = groupId2, daycareId = testDaycare2.id, name = groupName))
             insertTestPlacement(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
@@ -60,7 +59,7 @@ class BackupCareIntegrationTest : FullApplicationTest() {
             .response()
         Assertions.assertTrue(res.isSuccessful)
         db.read { r ->
-            getBackupCareRowsByChild(r.handle, testChild_1.id).one().also {
+            r.getBackupCareRowsByChild(testChild_1.id).one().also {
                 Assertions.assertEquals(id, it.id)
                 Assertions.assertEquals(testChild_1.id, it.childId)
                 Assertions.assertEquals(testDaycare.id, it.unitId)
@@ -192,7 +191,7 @@ class BackupCareIntegrationTest : FullApplicationTest() {
         val id = result.get().id
 
         db.read { r ->
-            getBackupCareRowById(r.handle, id).one().also {
+            r.getBackupCareRowById(id).one().also {
                 Assertions.assertEquals(id, it.id)
                 Assertions.assertEquals(childId, it.childId)
                 Assertions.assertEquals(unitId, it.unitId)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
@@ -43,7 +43,7 @@ class BackupCareIntegrationTest : FullApplicationTest() {
 
     @Test
     fun testUpdate() {
-        val groupId = db.transaction { tx -> tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id)) }
+        val groupId = db.transaction { tx -> tx.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id)) }
         val period = FiniteDateRange(LocalDate.of(2020, 7, 1), LocalDate.of(2020, 7, 31))
         val id = createBackupCareAndAssert(period = period)
         val changedPeriod = period.copy(end = LocalDate.of(2020, 7, 7))
@@ -91,7 +91,7 @@ class BackupCareIntegrationTest : FullApplicationTest() {
     @Test
     fun testChildBackupCare() {
         val groupName = "Test Group"
-        val groupId = db.transaction { it.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, name = groupName)) }
+        val groupId = db.transaction { it.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, name = groupName)) }
         val id = createBackupCareAndAssert(groupId = groupId)
         val (_, res, result) = http.get("/children/${testChild_1.id}/backup-cares")
             .asUser(serviceWorker)
@@ -124,11 +124,10 @@ class BackupCareIntegrationTest : FullApplicationTest() {
         val period = FiniteDateRange(LocalDate.of(2020, 7, 1), LocalDate.of(2020, 7, 31))
         val serviceNeedPeriod = FiniteDateRange(LocalDate.of(2020, 7, 3), period.end)
         val groupId = db.transaction { tx ->
-            tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, name = groupName))
+            tx.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, name = groupName))
         }
         db.transaction { tx ->
-            insertTestServiceNeed(
-                tx.handle,
+            tx.insertTestServiceNeed(
                 childId = testChild_1.id,
                 startDate = serviceNeedPeriod.start,
                 endDate = serviceNeedPeriod.end,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
@@ -37,7 +37,7 @@ class BackupCareIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
@@ -90,8 +90,8 @@ class DaycareEditIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            tx.handle.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
-            tx.handle.insertTestDaycare(DevDaycare(id = testDaycare.id, areaId = testAreaId, name = testDaycare.name))
+            tx.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
+            tx.insertTestDaycare(DevDaycare(id = testDaycare.id, areaId = testAreaId, name = testDaycare.name))
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareGroupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareGroupIntegrationTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevBackupCare
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevChild
@@ -48,8 +47,8 @@ class DaycareGroupIntegrationTest : FullApplicationTest() {
     protected fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            tx.handle.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
-            tx.handle.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
+            tx.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
+            tx.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
         }
     }
 
@@ -94,7 +93,7 @@ class DaycareGroupIntegrationTest : FullApplicationTest() {
             deletable = true
         )
         db.transaction {
-            it.handle.insertTestDaycareGroup(
+            it.insertTestDaycareGroup(
                 DevDaycareGroup(
                     id = group.id,
                     daycareId = group.daycareId,
@@ -106,10 +105,9 @@ class DaycareGroupIntegrationTest : FullApplicationTest() {
         getAndAssertGroup(group)
 
         db.transaction { tx ->
-            tx.handle.insertTestPerson(DevPerson(testChild_1.id))
-            tx.handle.insertTestChild(DevChild(testChild_1.id))
-            insertTestBackupCare(
-                tx.handle,
+            tx.insertTestPerson(DevPerson(testChild_1.id))
+            tx.insertTestChild(DevChild(testChild_1.id))
+            tx.insertTestBackupCare(
                 DevBackupCare(
                     childId = testChild_1.id,
                     groupId = group.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -42,11 +42,11 @@ class UnitAclControllerIntegrationTest : FullApplicationTest() {
     protected fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            admin = AuthenticatedUser.Employee(tx.handle.insertTestEmployee(DevEmployee(roles = setOf(UserRole.ADMIN))), roles = setOf(UserRole.ADMIN))
-            tx.handle.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
-            tx.handle.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
+            admin = AuthenticatedUser.Employee(tx.insertTestEmployee(DevEmployee(roles = setOf(UserRole.ADMIN))), roles = setOf(UserRole.ADMIN))
+            tx.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
+            tx.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
             employee.also {
-                tx.handle.insertTestEmployee(DevEmployee(id = it.id, firstName = it.firstName, lastName = it.lastName, email = it.email))
+                tx.insertTestEmployee(DevEmployee(id = it.id, firstName = it.firstName, lastName = it.lastName, email = it.email))
             }
         }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.shared.auth.DaycareAclRow
 import fi.espoo.evaka.shared.auth.DaycareAclRowEmployee
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevEmployee

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
@@ -49,7 +49,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
     @BeforeEach
     private fun prepare() {
         db.transaction {
-            insertGeneralTestFixtures(it.handle)
+            it.insertGeneralTestFixtures()
             it.handle.insertTestPerson(DevPerson(id = testUserId))
             it.handle.insertTestEmployee(DevEmployee(id = testUserId))
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
@@ -50,8 +50,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
     private fun prepare() {
         db.transaction {
             it.insertGeneralTestFixtures()
-            it.handle.insertTestPerson(DevPerson(id = testUserId))
-            it.handle.insertTestEmployee(DevEmployee(id = testUserId))
+            it.insertTestPerson(DevPerson(id = testUserId))
+            it.insertTestEmployee(DevEmployee(id = testUserId))
         }
         insertDaycareGroup()
     }
@@ -374,8 +374,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
         val childId2 = UUID.randomUUID()
         insertGroupPlacement(childId, LocalDate.of(2013, 1, 1), PlacementType.PRESCHOOL_DAYCARE)
         db.transaction {
-            it.handle.insertTestPerson(DevPerson(id = childId2, dateOfBirth = LocalDate.of(2013, 1, 1)))
-            it.handle.insertTestChild(DevChild(childId2))
+            it.insertTestPerson(DevPerson(id = childId2, dateOfBirth = LocalDate.of(2013, 1, 1)))
+            it.insertTestChild(DevChild(childId2))
         }
 
         val absenceDate = placementEnd
@@ -413,20 +413,18 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
     @Test
     fun `backup care children are returned with correct care types`() {
         db.transaction {
-            it.handle.insertTestPerson(DevPerson(id = childId, dateOfBirth = LocalDate.of(2013, 1, 1)))
-            it.handle.insertTestChild(DevChild(childId))
+            it.insertTestPerson(DevPerson(id = childId, dateOfBirth = LocalDate.of(2013, 1, 1)))
+            it.insertTestChild(DevChild(childId))
         }
         db.transaction { tx ->
-            insertTestPlacement(
-                tx.handle,
+            tx.insertTestPlacement(
                 childId = childId,
                 unitId = daycareId,
                 startDate = placementStart,
                 endDate = placementEnd,
                 type = PlacementType.PRESCHOOL_DAYCARE
             )
-            insertTestBackupCare(
-                tx.handle,
+            tx.insertTestBackupCare(
                 DevBackupCare(
                     childId = childId,
                     unitId = daycareId,
@@ -479,7 +477,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
 
     private fun insertDaycareGroup() {
         db.transaction {
-            it.handle.insertTestDaycareGroup(
+            it.insertTestDaycareGroup(
                 DevDaycareGroup(daycareId = daycareId, id = groupId, name = groupName, startDate = placementStart)
             )
         }
@@ -492,9 +490,9 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
         placementPeriod: FiniteDateRange = FiniteDateRange(placementStart, placementEnd)
     ) {
         db.transaction {
-            it.handle.insertTestPerson(DevPerson(id = childId, dateOfBirth = dob))
-            it.handle.insertTestChild(DevChild(childId))
-            val daycarePlacementId = it.handle.insertTestPlacement(
+            it.insertTestPerson(DevPerson(id = childId, dateOfBirth = dob))
+            it.insertTestChild(DevChild(childId))
+            val daycarePlacementId = it.insertTestPlacement(
                 DevPlacement(
                     childId = childId,
                     unitId = daycareId,
@@ -503,8 +501,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
                     endDate = placementPeriod.end
                 )
             )
-            insertTestDaycareGroupPlacement(
-                h = it.handle, daycarePlacementId = daycarePlacementId, groupId = groupId,
+            it.insertTestDaycareGroupPlacement(
+                daycarePlacementId = daycarePlacementId, groupId = groupId,
                 startDate = placementPeriod.start, endDate = placementPeriod.end
             )
         }
@@ -520,7 +518,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
     private fun insertGroupPlacements(children: List<ChildSeed>, placementType: PlacementType) {
         children.forEach {
             db.transaction { tx ->
-                tx.handle.insertTestPerson(
+                tx.insertTestPerson(
                     DevPerson(
                         id = it.id,
                         firstName = it.firstName,
@@ -528,8 +526,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
                         dateOfBirth = it.dob
                     )
                 )
-                tx.handle.insertTestChild(DevChild(it.id))
-                val daycarePlacementId = tx.handle.insertTestPlacement(
+                tx.insertTestChild(DevChild(it.id))
+                val daycarePlacementId = tx.insertTestPlacement(
                     DevPlacement(
                         childId = it.id,
                         unitId = daycareId,
@@ -538,8 +536,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
                         endDate = placementEnd
                     )
                 )
-                insertTestDaycareGroupPlacement(
-                    h = tx.handle, daycarePlacementId = daycarePlacementId, groupId = groupId,
+                tx.insertTestDaycareGroupPlacement(
+                    daycarePlacementId = daycarePlacementId, groupId = groupId,
                     startDate = placementStart, endDate = placementEnd
                 )
             }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.daycare.service
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.testDaycare

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
@@ -28,7 +28,7 @@ class CaretakerServiceIntegrationTest : PureJdbiTest() {
     fun setup() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             tx.handle.insertTestDaycareGroup(
                 DevDaycareGroup(
                     id = groupId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
@@ -29,7 +29,7 @@ class CaretakerServiceIntegrationTest : PureJdbiTest() {
         db.transaction { tx ->
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
-            tx.handle.insertTestDaycareGroup(
+            tx.insertTestDaycareGroup(
                 DevDaycareGroup(
                     id = groupId,
                     daycareId = daycareId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
@@ -36,9 +36,9 @@ class StaffAttendanceServiceIntegrationTest : AbstractIntegrationTest() {
     protected fun insertDaycareGroup() {
         db.transaction { tx ->
             tx.resetDatabase()
-            tx.handle.insertTestCareArea(DevCareArea(id = areaId))
-            tx.handle.insertTestDaycare(DevDaycare(areaId = areaId, id = daycareId))
-            tx.handle.insertTestDaycareGroup(
+            tx.insertTestCareArea(DevCareArea(id = areaId))
+            tx.insertTestDaycare(DevDaycare(areaId = areaId, id = daycareId))
+            tx.insertTestDaycareGroup(
                 DevDaycareGroup(daycareId = daycareId, id = groupId, name = groupName, startDate = groupStartDate)
             )
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -68,7 +68,7 @@ class DecisionCreationIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             tx.createUpdate(
                 // language=SQL
                 """

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -26,7 +26,6 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
@@ -93,13 +92,10 @@ WHERE id = :unitId
             LocalDate.of(2020, 3, 17),
             LocalDate.of(2023, 7, 31)
         )
-        val applicationId = db.transaction {
-            insertInitialData(
-                it,
-                type = PlacementType.DAYCARE,
-                period = period
-            )
-        }
+        val applicationId = insertInitialData(
+            type = PlacementType.DAYCARE,
+            period = period
+        )
         checkDecisionDrafts(
             applicationId,
             decisions = listOf(
@@ -131,13 +127,10 @@ WHERE id = :unitId
             LocalDate.of(2020, 3, 18),
             LocalDate.of(2023, 7, 29)
         )
-        val applicationId = db.transaction {
-            insertInitialData(
-                it,
-                type = PlacementType.DAYCARE_PART_TIME,
-                period = period
-            )
-        }
+        val applicationId = insertInitialData(
+            type = PlacementType.DAYCARE_PART_TIME,
+            period = period
+        )
         checkDecisionDrafts(
             applicationId,
             decisions = listOf(
@@ -169,13 +162,10 @@ WHERE id = :unitId
             LocalDate.of(2020, 8, 15),
             LocalDate.of(2021, 5, 31)
         )
-        val applicationId = db.transaction {
-            insertInitialData(
-                it,
-                type = PlacementType.PRESCHOOL,
-                period = period
-            )
-        }
+        val applicationId = insertInitialData(
+            type = PlacementType.PRESCHOOL,
+            period = period
+        )
         checkDecisionDrafts(
             applicationId,
             decisions = listOf(
@@ -219,15 +209,12 @@ WHERE id = :unitId
             LocalDate.of(2020, 8, 1),
             LocalDate.of(2021, 7, 31)
         )
-        val applicationId = db.transaction {
-            insertInitialData(
-                it,
-                type = PlacementType.PRESCHOOL_DAYCARE,
-                period = period,
-                preschoolDaycarePeriod = preschoolDaycarePeriod,
-                preparatoryEducation = false
-            )
-        }
+        val applicationId = insertInitialData(
+            type = PlacementType.PRESCHOOL_DAYCARE,
+            period = period,
+            preschoolDaycarePeriod = preschoolDaycarePeriod,
+            preparatoryEducation = false
+        )
         checkDecisionDrafts(
             applicationId,
             decisions = listOf(
@@ -275,15 +262,12 @@ WHERE id = :unitId
             LocalDate.of(2020, 8, 1),
             LocalDate.of(2021, 7, 31)
         )
-        val applicationId = db.transaction {
-            insertInitialData(
-                it,
-                type = PlacementType.PRESCHOOL_DAYCARE,
-                period = period,
-                preschoolDaycarePeriod = preschoolDaycarePeriod,
-                preparatoryEducation = true
-            )
-        }
+        val applicationId = insertInitialData(
+            type = PlacementType.PRESCHOOL_DAYCARE,
+            period = period,
+            preschoolDaycarePeriod = preschoolDaycarePeriod,
+            preparatoryEducation = true
+        )
         checkDecisionDrafts(
             applicationId,
             decisions = listOf(
@@ -399,13 +383,10 @@ WHERE id = :unitId
             LocalDate.of(2020, 3, 17),
             LocalDate.of(2023, 7, 31)
         )
-        val applicationId = db.transaction {
-            insertInitialData(
-                it,
-                type = PlacementType.DAYCARE,
-                period = period
-            )
-        }
+        val applicationId = insertInitialData(
+            type = PlacementType.DAYCARE,
+            period = period
+        )
         val invalidRoleLists = listOf(
             setOf(UserRole.UNIT_SUPERVISOR),
             setOf(UserRole.FINANCE_ADMIN),
@@ -421,7 +402,6 @@ WHERE id = :unitId
     }
 
     private fun insertInitialData(
-        tx: Database.Transaction,
         type: PlacementType,
         unit: UnitData.Detailed = testDaycare,
         adult: PersonData.Detailed = testAdult_5,
@@ -429,16 +409,15 @@ WHERE id = :unitId
         period: FiniteDateRange,
         preschoolDaycarePeriod: FiniteDateRange? = null,
         preparatoryEducation: Boolean = false
-    ): UUID {
-        val applicationId = insertTestApplication(
-            tx.handle,
+    ): UUID = db.transaction { tx ->
+        val applicationId = tx.insertTestApplication(
             status = ApplicationStatus.WAITING_PLACEMENT,
             guardianId = adult.id,
             childId = child.id
         )
         val preschoolDaycare = type == PlacementType.PRESCHOOL_DAYCARE
-        insertTestApplicationForm(
-            tx.handle, applicationId,
+        tx.insertTestApplicationForm(
+            applicationId,
             DaycareFormV0(
                 type = type.toApplicationType(),
                 partTime = type == PlacementType.DAYCARE_PART_TIME,
@@ -464,6 +443,6 @@ WHERE id = :unitId
             )
         )
 
-        return applicationId
+        applicationId
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
@@ -40,7 +40,6 @@ import fi.espoo.evaka.testDecisionMaker_1
 import fi.espoo.evaka.toApplicationType
 import fi.espoo.evaka.toDaycareFormAdult
 import fi.espoo.evaka.toDaycareFormChild
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -83,14 +82,11 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
             LocalDate.of(2019, 5, 1),
             LocalDate.of(2019, 7, 1)
         )
-        val ids = db.transaction { tx ->
-            insertInitialData(
-                tx.handle,
-                status = ApplicationStatus.WAITING_CONFIRMATION,
-                type = PlacementType.DAYCARE,
-                period = period
-            )
-        }
+        val ids = insertInitialData(
+            status = ApplicationStatus.WAITING_CONFIRMATION,
+            type = PlacementType.DAYCARE,
+            period = period
+        )
         val user = if (test.isServiceWorker) serviceWorker else endUser
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
@@ -119,14 +115,11 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
             LocalDate.of(2019, 5, 18),
             LocalDate.of(2019, 7, 1)
         )
-        val ids = db.transaction { tx ->
-            insertInitialData(
-                tx.handle,
-                status = ApplicationStatus.WAITING_CONFIRMATION,
-                type = PlacementType.DAYCARE_PART_TIME,
-                period = period
-            )
-        }
+        val ids = insertInitialData(
+            status = ApplicationStatus.WAITING_CONFIRMATION,
+            type = PlacementType.DAYCARE_PART_TIME,
+            period = period
+        )
         val user = if (test.isServiceWorker) serviceWorker else endUser
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
@@ -157,14 +150,11 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
             LocalDate.of(2020, 8, 15),
             LocalDate.of(2021, 5, 31)
         )
-        val ids = db.transaction { tx ->
-            insertInitialData(
-                tx.handle,
-                status = ApplicationStatus.WAITING_CONFIRMATION,
-                type = PlacementType.PRESCHOOL,
-                period = period
-            )
-        }
+        val ids = insertInitialData(
+            status = ApplicationStatus.WAITING_CONFIRMATION,
+            type = PlacementType.PRESCHOOL,
+            period = period
+        )
         val user = if (test.isServiceWorker) serviceWorker else endUser
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
@@ -199,15 +189,12 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
             LocalDate.of(2020, 8, 1),
             LocalDate.of(2021, 7, 31)
         )
-        val ids = db.transaction { tx ->
-            insertInitialData(
-                tx.handle,
-                status = ApplicationStatus.WAITING_CONFIRMATION,
-                type = PlacementType.PRESCHOOL_DAYCARE,
-                period = period,
-                preschoolDaycarePeriod = preschoolDaycarePeriod
-            )
-        }
+        val ids = insertInitialData(
+            status = ApplicationStatus.WAITING_CONFIRMATION,
+            type = PlacementType.PRESCHOOL_DAYCARE,
+            period = period,
+            preschoolDaycarePeriod = preschoolDaycarePeriod
+        )
         val user = if (test.isServiceWorker) serviceWorker else endUser
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
@@ -253,15 +240,12 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
             LocalDate.of(2020, 8, 1),
             LocalDate.of(2021, 7, 31)
         )
-        val ids = db.transaction { tx ->
-            insertInitialData(
-                tx.handle,
-                status = ApplicationStatus.WAITING_CONFIRMATION,
-                type = PlacementType.PREPARATORY_DAYCARE,
-                period = period,
-                preschoolDaycarePeriod = preschoolDaycarePeriod
-            )
-        }
+        val ids = insertInitialData(
+            status = ApplicationStatus.WAITING_CONFIRMATION,
+            type = PlacementType.PREPARATORY_DAYCARE,
+            period = period,
+            preschoolDaycarePeriod = preschoolDaycarePeriod
+        )
         val user = if (test.isServiceWorker) serviceWorker else endUser
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
@@ -306,16 +290,13 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
             LocalDate.of(2020, 8, 1),
             LocalDate.of(2021, 7, 31)
         )
-        val ids = db.transaction { tx ->
-            insertInitialData(
-                tx.handle,
-                status = ApplicationStatus.WAITING_CONFIRMATION,
-                type = PlacementType.PRESCHOOL_DAYCARE,
-                period = period,
-                preschoolDaycarePeriod = preschoolDaycarePeriod,
-                preschoolDaycareWithoutPreschool = true
-            )
-        }
+        val ids = insertInitialData(
+            status = ApplicationStatus.WAITING_CONFIRMATION,
+            type = PlacementType.PRESCHOOL_DAYCARE,
+            period = period,
+            preschoolDaycarePeriod = preschoolDaycarePeriod,
+            preschoolDaycareWithoutPreschool = true
+        )
         val user = if (test.isServiceWorker) serviceWorker else endUser
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.preschoolDaycareId!!, preschoolDaycarePeriod.start)
@@ -379,7 +360,6 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertInitialData(
-        h: Handle,
         status: ApplicationStatus,
         type: PlacementType,
         unit: UnitData.Detailed = testDaycare,
@@ -388,17 +368,16 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         period: FiniteDateRange,
         preschoolDaycarePeriod: FiniteDateRange? = null,
         preschoolDaycareWithoutPreschool: Boolean = false
-    ): DataIdentifiers {
-        insertTestApplication(
-            h,
+    ): DataIdentifiers = db.transaction { tx ->
+        tx.insertTestApplication(
             id = applicationId,
             status = status,
             guardianId = adult.id,
             childId = child.id
         )
         val preschoolDaycare = type in listOf(PlacementType.PRESCHOOL_DAYCARE, PlacementType.PREPARATORY_DAYCARE)
-        insertTestApplicationForm(
-            h, applicationId,
+        tx.insertTestApplicationForm(
+            applicationId,
             DaycareFormV0(
                 type = type.toApplicationType(),
                 partTime = type == PlacementType.DAYCARE_PART_TIME,
@@ -412,8 +391,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
                 preferredStartDate = period.start
             )
         )
-        insertTestPlacementPlan(
-            h,
+        tx.insertTestPlacementPlan(
             applicationId = applicationId,
             unitId = unit.id,
             type = type,
@@ -424,7 +402,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         )
         val primaryId =
             if (preschoolDaycareWithoutPreschool) null
-            else h.insertTestDecision(
+            else tx.insertTestDecision(
                 TestDecision(
                     createdBy = testDecisionMaker_1.id,
                     unitId = unit.id,
@@ -443,7 +421,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
                 )
             )
         val preschoolDaycareId = preschoolDaycarePeriod?.let {
-            h.insertTestDecision(
+            tx.insertTestDecision(
                 TestDecision(
                     createdBy = testDecisionMaker_1.id,
                     unitId = unit.id,
@@ -454,7 +432,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
                 )
             )
         }
-        return DataIdentifiers(applicationId, primaryId, preschoolDaycareId)
+        DataIdentifiers(applicationId, primaryId, preschoolDaycareId)
     }
 }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
@@ -64,7 +64,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
@@ -21,7 +21,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
@@ -91,8 +90,8 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
             db.read { r ->
-                assertEquals(ApplicationStatus.ACTIVE, getApplicationStatus(r.handle, ids.applicationId))
-                getPlacementRowsByChild(r.handle, testChild_1.id).one().also {
+                assertEquals(ApplicationStatus.ACTIVE, r.getApplicationStatus(ids.applicationId))
+                r.getPlacementRowsByChild(testChild_1.id).one().also {
                     assertEquals(PlacementType.DAYCARE, it.type)
                     assertEquals(testDaycare.id, it.unitId)
                     assertEquals(period, it.period())
@@ -101,11 +100,11 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         } else {
             rejectDecisionAndAssert(user, applicationId, ids.primaryId!!)
             db.read { r ->
-                assertEquals(ApplicationStatus.REJECTED, getApplicationStatus(r.handle, ids.applicationId))
-                assertTrue(getPlacementRowsByChild(r.handle, testChild_1.id).list().isEmpty())
+                assertEquals(ApplicationStatus.REJECTED, r.getApplicationStatus(ids.applicationId))
+                assertTrue(r.getPlacementRowsByChild(testChild_1.id).list().isEmpty())
             }
         }
-        db.read { r -> assertTrue(getPlacementPlanRowByApplication(r.handle, ids.applicationId).one().deleted) }
+        db.read { r -> assertTrue(r.getPlacementPlanRowByApplication(ids.applicationId).one().deleted) }
     }
 
     @ParameterizedTest(name = "{0}")
@@ -124,8 +123,8 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
             db.read { r ->
-                assertEquals(ApplicationStatus.ACTIVE, getApplicationStatus(r.handle, ids.applicationId))
-                getPlacementRowsByChild(r.handle, testChild_1.id).one().also {
+                assertEquals(ApplicationStatus.ACTIVE, r.getApplicationStatus(ids.applicationId))
+                r.getPlacementRowsByChild(testChild_1.id).one().also {
                     assertEquals(PlacementType.DAYCARE_PART_TIME, it.type)
                     assertEquals(testDaycare.id, it.unitId)
                     assertEquals(period, it.period())
@@ -134,12 +133,12 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         } else {
             rejectDecisionAndAssert(user, applicationId, ids.primaryId!!)
             db.read {
-                assertEquals(ApplicationStatus.REJECTED, getApplicationStatus(it.handle, ids.applicationId))
-                assertTrue(getPlacementRowsByChild(it.handle, testChild_1.id).list().isEmpty())
+                assertEquals(ApplicationStatus.REJECTED, it.getApplicationStatus(ids.applicationId))
+                assertTrue(it.getPlacementRowsByChild(testChild_1.id).list().isEmpty())
             }
         }
         db.read {
-            assertTrue(getPlacementPlanRowByApplication(it.handle, ids.applicationId).one().deleted)
+            assertTrue(it.getPlacementPlanRowByApplication(ids.applicationId).one().deleted)
         }
     }
 
@@ -159,8 +158,8 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
             db.read { r ->
-                assertEquals(ApplicationStatus.ACTIVE, getApplicationStatus(r.handle, ids.applicationId))
-                getPlacementRowsByChild(r.handle, testChild_1.id).one().also {
+                assertEquals(ApplicationStatus.ACTIVE, r.getApplicationStatus(ids.applicationId))
+                r.getPlacementRowsByChild(testChild_1.id).one().also {
                     assertEquals(PlacementType.PRESCHOOL, it.type)
                     assertEquals(testDaycare.id, it.unitId)
                     assertEquals(period, it.period())
@@ -169,12 +168,12 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         } else {
             rejectDecisionAndAssert(user, applicationId, ids.primaryId!!)
             db.read {
-                assertEquals(ApplicationStatus.REJECTED, getApplicationStatus(it.handle, ids.applicationId))
-                assertTrue(getPlacementRowsByChild(it.handle, testChild_1.id).list().isEmpty())
+                assertEquals(ApplicationStatus.REJECTED, it.getApplicationStatus(ids.applicationId))
+                assertTrue(it.getPlacementRowsByChild(testChild_1.id).list().isEmpty())
             }
         }
         db.read {
-            assertTrue(getPlacementPlanRowByApplication(it.handle, ids.applicationId).one().deleted)
+            assertTrue(it.getPlacementPlanRowByApplication(ids.applicationId).one().deleted)
         }
     }
 
@@ -199,8 +198,8 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
             db.read { r ->
-                assertEquals(ApplicationStatus.ACTIVE, getApplicationStatus(r.handle, ids.applicationId))
-                getPlacementRowsByChild(r.handle, testChild_1.id).one().also {
+                assertEquals(ApplicationStatus.ACTIVE, r.getApplicationStatus(ids.applicationId))
+                r.getPlacementRowsByChild(testChild_1.id).one().also {
                     assertEquals(PlacementType.PRESCHOOL, it.type)
                     assertEquals(testDaycare.id, it.unitId)
                     assertEquals(period, it.period())
@@ -208,7 +207,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
             }
             acceptDecisionAndAssert(user, applicationId, ids.preschoolDaycareId!!, preschoolDaycarePeriod.start)
             db.read { r ->
-                getPlacementRowsByChild(r.handle, testChild_1.id).list().also {
+                r.getPlacementRowsByChild(testChild_1.id).list().also {
                     assertEquals(2, it.size)
                     assertEquals(PlacementType.PRESCHOOL_DAYCARE, it[0].type)
                     assertEquals(testDaycare.id, it[0].unitId)
@@ -217,14 +216,14 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
                     assertEquals(testDaycare.id, it[1].unitId)
                     assertEquals(FiniteDateRange(period.end.plusDays(1), preschoolDaycarePeriod.end), it[1].period())
                 }
-                assertTrue(getPlacementPlanRowByApplication(r.handle, ids.applicationId).one().deleted)
+                assertTrue(r.getPlacementPlanRowByApplication(ids.applicationId).one().deleted)
             }
         } else {
             rejectDecisionAndAssert(user, applicationId, ids.primaryId!!)
             db.read {
-                assertEquals(ApplicationStatus.REJECTED, getApplicationStatus(it.handle, ids.applicationId))
-                assertTrue(getPlacementRowsByChild(it.handle, testChild_1.id).list().isEmpty())
-                assertTrue(getDecisionRowsByApplication(it.handle, ids.applicationId).all { it.status == DecisionStatus.REJECTED })
+                assertEquals(ApplicationStatus.REJECTED, it.getApplicationStatus(ids.applicationId))
+                assertTrue(it.getPlacementRowsByChild(testChild_1.id).list().isEmpty())
+                assertTrue(it.getDecisionRowsByApplication(ids.applicationId).all { it.status == DecisionStatus.REJECTED })
             }
         }
     }
@@ -250,8 +249,8 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
             db.read { r ->
-                assertEquals(ApplicationStatus.ACTIVE, getApplicationStatus(r.handle, ids.applicationId))
-                getPlacementRowsByChild(r.handle, testChild_1.id).one().also {
+                assertEquals(ApplicationStatus.ACTIVE, r.getApplicationStatus(ids.applicationId))
+                r.getPlacementRowsByChild(testChild_1.id).one().also {
                     assertEquals(PlacementType.PREPARATORY, it.type)
                     assertEquals(testDaycare.id, it.unitId)
                     assertEquals(period, it.period())
@@ -259,7 +258,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
             }
             acceptDecisionAndAssert(user, applicationId, ids.preschoolDaycareId!!, preschoolDaycarePeriod.start)
             db.read { r ->
-                getPlacementRowsByChild(r.handle, testChild_1.id).list().also {
+                r.getPlacementRowsByChild(testChild_1.id).list().also {
                     assertEquals(2, it.size)
                     assertEquals(PlacementType.PREPARATORY_DAYCARE, it[0].type)
                     assertEquals(testDaycare.id, it[0].unitId)
@@ -272,9 +271,9 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         } else {
             rejectDecisionAndAssert(user, applicationId, ids.primaryId!!)
             db.read { r ->
-                assertEquals(ApplicationStatus.REJECTED, getApplicationStatus(r.handle, ids.applicationId))
-                assertTrue(getPlacementRowsByChild(r.handle, testChild_1.id).list().isEmpty())
-                assertTrue(getDecisionRowsByApplication(r.handle, ids.applicationId).all { it.status == DecisionStatus.REJECTED })
+                assertEquals(ApplicationStatus.REJECTED, r.getApplicationStatus(ids.applicationId))
+                assertTrue(r.getPlacementRowsByChild(testChild_1.id).list().isEmpty())
+                assertTrue(r.getDecisionRowsByApplication(ids.applicationId).all { it.status == DecisionStatus.REJECTED })
             }
         }
     }
@@ -301,8 +300,8 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         if (test.isAccept) {
             acceptDecisionAndAssert(user, applicationId, ids.preschoolDaycareId!!, preschoolDaycarePeriod.start)
             db.read { r ->
-                assertEquals(ApplicationStatus.ACTIVE, getApplicationStatus(r.handle, ids.applicationId))
-                getPlacementRowsByChild(r.handle, testChild_1.id).list().also {
+                assertEquals(ApplicationStatus.ACTIVE, r.getApplicationStatus(ids.applicationId))
+                r.getPlacementRowsByChild(testChild_1.id).list().also {
                     assertEquals(PlacementType.PRESCHOOL_DAYCARE, it[0].type)
                     assertEquals(testDaycare.id, it[0].unitId)
                     assertEquals(preschoolDaycarePeriod.copy(end = period.end), it[0].period())
@@ -314,9 +313,9 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         } else {
             rejectDecisionAndAssert(user, applicationId, ids.preschoolDaycareId!!)
             db.read { r ->
-                assertEquals(ApplicationStatus.REJECTED, getApplicationStatus(r.handle, ids.applicationId))
-                assertTrue(getPlacementRowsByChild(r.handle, testChild_1.id).list().isEmpty())
-                assertTrue(getDecisionRowsByApplication(r.handle, ids.applicationId).all { it.status == DecisionStatus.REJECTED })
+                assertEquals(ApplicationStatus.REJECTED, r.getApplicationStatus(ids.applicationId))
+                assertTrue(r.getPlacementRowsByChild(testChild_1.id).list().isEmpty())
+                assertTrue(r.getDecisionRowsByApplication(ids.applicationId).all { it.status == DecisionStatus.REJECTED })
             }
         }
     }
@@ -331,7 +330,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         assertTrue(res.isSuccessful)
 
         db.read { r ->
-            getDecisionRowById(r.handle, decisionId).one().also {
+            r.getDecisionRowById(decisionId).one().also {
                 assertEquals(DecisionStatus.ACCEPTED, it.status)
                 assertNotNull(it.resolved)
                 assertEquals(requestedStartDate, it.requestedStartDate)
@@ -350,7 +349,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         assertTrue(res.isSuccessful)
 
         db.read { r ->
-            getDecisionRowById(r.handle, decisionId).one().also {
+            r.getDecisionRowById(decisionId).one().also {
                 assertEquals(DecisionStatus.REJECTED, it.status)
                 assertNotNull(it.resolved)
                 assertNull(it.requestedStartDate)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
@@ -154,7 +154,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         // until token is 0 and then it will return ajanTasalla=true
         // So if the paging works correctly there should Math.abs(original_token) + 1 identical records
         db.transaction {
-            resetDatabase(it.handle)
+            it.resetDatabase()
             storeDvvModificationToken(it.handle, "10000", "-2", 0, 0)
         }
         try {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
@@ -185,7 +185,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     )
 
     private fun createTestPerson(devPerson: DevPerson): UUID = db.transaction { tx ->
-        tx.handle.insertTestPerson(devPerson)
+        tx.insertTestPerson(devPerson)
     }
 
     private fun createVtjPerson(person: DevPerson) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeAlterationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeAlterationIntegrationTest.kt
@@ -39,7 +39,7 @@ class FeeAlterationIntegrationTest : FullApplicationTest() {
     @BeforeEach
     fun setup() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -188,7 +188,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/IncomeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/IncomeIntegrationTest.kt
@@ -49,7 +49,7 @@ class IncomeIntegrationTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -47,7 +47,6 @@ import fi.espoo.evaka.testChild_2
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1
 import org.assertj.core.api.Assertions.assertThat
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -743,7 +742,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     @Test
     fun `createAllDraftInvoices works with one decision`() {
         val decision = testDecisions.find { it.status == FeeDecisionStatus.SENT }!!
-        db.transaction { tx -> insertDecisions(tx.handle, listOf(decision)) }
+        insertDecisions(listOf(decision))
 
         val (_, response, _) = http.post("/invoices/create-drafts")
             .asUser(testUser)
@@ -770,7 +769,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     @Test
     fun `createAllDraftInvoices works with two decisions`() {
         val testDecisions2 = testDecisions.filter { it.status == FeeDecisionStatus.SENT }.take(2)
-        db.transaction { tx -> insertDecisions(tx.handle, testDecisions2) }
+        insertDecisions(testDecisions2)
 
         val (_, response, _) = http.post("/invoices/create-drafts")
             .asUser(testUser)
@@ -797,7 +796,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     @Test
     fun `createAllDraftInvoices is idempotent`() {
         val decisions = listOf(testDecisions.find { it.status == FeeDecisionStatus.SENT }!!)
-        db.transaction { tx -> insertDecisions(tx.handle, decisions) }
+        insertDecisions(decisions)
 
         for (i in 1..4) {
             val (_, response, _) = http.post("/invoices/create-drafts")
@@ -826,7 +825,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     @Test
     fun `createAllDraftInvoices generates no drafts from already invoiced decisions`() {
         val decisions = listOf(testDecisions.find { it.status == FeeDecisionStatus.SENT }!!)
-        db.transaction { tx -> insertDecisions(tx.handle, decisions) }
+        insertDecisions(decisions)
 
         val (_, response1, _) = http.post("/invoices/create-drafts")
             .asUser(testUser)
@@ -863,7 +862,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     @Test
     fun `createAllDraftInvoices overrides drafts`() {
         val decisions = listOf(testDecisions.find { it.status == FeeDecisionStatus.SENT }!!).take(1)
-        db.transaction { tx -> insertDecisions(tx.handle, decisions) }
+        insertDecisions(decisions)
 
         val (_, response1, _) = http.post("/invoices/create-drafts")
             .asUser(testUser)
@@ -1025,11 +1024,11 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun insertDecisions(h: Handle, decisions: List<FeeDecision>) {
-        upsertFeeDecisions(h, objectMapper, decisions)
+    private fun insertDecisions(decisions: List<FeeDecision>) = db.transaction { tx ->
+        upsertFeeDecisions(tx.handle, objectMapper, decisions)
         decisions.forEach { decision ->
             decision.parts.forEach { part ->
-                h.insertTestPlacement(
+                tx.insertTestPlacement(
                     DevPlacement(
                         childId = part.child.id,
                         unitId = part.placement.unit,
@@ -1037,8 +1036,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
                         endDate = decision.validTo!!
                     )
                 )
-                insertTestParentship(
-                    h,
+                tx.insertTestParentship(
                     headOfChild = decision.headOfFamily.id,
                     childId = part.child.id,
                     startDate = decision.validFrom,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -150,7 +150,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -48,7 +48,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        db.transaction { insertGeneralTestFixtures(it.handle) }
+        db.transaction { it.insertGeneralTestFixtures() }
         db.transaction {
             insertTestParentship(
                 it.handle,
@@ -62,7 +62,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest() {
 
     @AfterEach
     fun afterEach() {
-        db.transaction { resetDatabase(it.handle) }
+        db.transaction { it.resetDatabase() }
     }
 
     private val startDate = LocalDate.now().minusMonths(1)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -48,10 +48,9 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        db.transaction { it.insertGeneralTestFixtures() }
         db.transaction {
-            insertTestParentship(
-                it.handle,
+            it.insertGeneralTestFixtures()
+            it.insertTestParentship(
                 headOfChild = testAdult_1.id,
                 childId = testChild_1.id,
                 startDate = testChild_1.dateOfBirth,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeAlterationQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeAlterationQueriesTest.kt
@@ -25,7 +25,7 @@ class FeeAlterationQueriesTest : PureJdbiTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
@@ -95,7 +95,7 @@ class FeeDecisionQueriesTest : PureJdbiTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueriesTest.kt
@@ -52,7 +52,7 @@ class InvoiceQueriesTest : PureJdbiTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -732,7 +732,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     fun `children over 18 years old are not included in families when determining base fee`() {
         val placementPeriod = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         val birthday = LocalDate.of(2001, 7, 1)
-        val childTurning18Id = db.transaction { it.handle.insertTestPerson(DevPerson(dateOfBirth = birthday)) }
+        val childTurning18Id = db.transaction { it.insertTestPerson(DevPerson(dateOfBirth = birthday)) }
 
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, childTurning18Id), placementPeriod)
@@ -1753,8 +1753,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
     private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: UUID): UUID {
         return db.transaction { tx ->
-            insertTestPlacement(
-                tx.handle,
+            tx.insertTestPlacement(
                 childId = childId,
                 unitId = daycareId,
                 startDate = period.start,
@@ -1767,14 +1766,14 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     private fun insertFamilyRelations(headOfFamilyId: UUID, childIds: List<UUID>, period: DateRange) {
         db.transaction { tx ->
             childIds.forEach { childId ->
-                insertTestParentship(tx.handle, headOfFamilyId, childId, startDate = period.start, endDate = period.end!!)
+                tx.insertTestParentship(headOfFamilyId, childId, startDate = period.start, endDate = period.end!!)
             }
         }
     }
 
     private fun insertPartnership(adultId1: UUID, adultId2: UUID, period: DateRange) {
         db.transaction { tx ->
-            insertTestPartnership(tx.handle, adultId1, adultId2, startDate = period.start, endDate = period.end!!)
+            tx.insertTestPartnership(adultId1, adultId2, startDate = period.start, endDate = period.end!!)
         }
     }
 
@@ -1784,8 +1783,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         optionId: UUID
     ) {
         db.transaction { tx ->
-            insertTestNewServiceNeed(
-                tx.handle,
+            tx.insertTestNewServiceNeed(
                 placementId,
                 period,
                 optionId
@@ -1795,8 +1793,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
     private fun insertIncome(adultId: UUID, amount: Int, period: DateRange) {
         db.transaction { tx ->
-            insertTestIncome(
-                tx.handle,
+            tx.insertTestIncome(
                 objectMapper,
                 personId = adultId,
                 validFrom = period.start,
@@ -1815,8 +1812,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
     private fun insertFeeAlteration(childId: UUID, amount: Double, period: DateRange) {
         db.transaction { tx ->
-            insertTestFeeAlteration(
-                tx.handle,
+            tx.insertTestFeeAlteration(
                 childId,
                 type = FeeAlteration.Type.DISCOUNT,
                 amount = amount,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -83,7 +83,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
@@ -786,7 +786,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     fun `children over 18 years old are not included in families when determining base fee`() {
         val placementPeriod = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         val birthday = LocalDate.of(2001, 7, 1)
-        val childTurning18Id = db.transaction { it.handle.insertTestPerson(DevPerson(dateOfBirth = birthday)) }
+        val childTurning18Id = db.transaction { it.insertTestPerson(DevPerson(dateOfBirth = birthday)) }
 
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, childTurning18Id), placementPeriod)
@@ -2074,8 +2074,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
     private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: UUID): UUID {
         return db.transaction { tx ->
-            insertTestPlacement(
-                tx.handle,
+            tx.insertTestPlacement(
                 childId = childId,
                 unitId = daycareId,
                 startDate = period.start,
@@ -2088,14 +2087,14 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     private fun insertFamilyRelations(headOfFamilyId: UUID, childIds: List<UUID>, period: DateRange) {
         db.transaction { tx ->
             childIds.forEach { childId ->
-                insertTestParentship(tx.handle, headOfFamilyId, childId, startDate = period.start, endDate = period.end!!)
+                tx.insertTestParentship(headOfFamilyId, childId, startDate = period.start, endDate = period.end!!)
             }
         }
     }
 
     private fun insertPartnership(adultId1: UUID, adultId2: UUID, period: DateRange) {
         db.transaction { tx ->
-            insertTestPartnership(tx.handle, adultId1, adultId2, startDate = period.start, endDate = period.end!!)
+            tx.insertTestPartnership(adultId1, adultId2, startDate = period.start, endDate = period.end!!)
         }
     }
 
@@ -2105,8 +2104,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     ) {
         db.transaction { tx ->
             hours.map {
-                insertTestServiceNeed(
-                    tx.handle,
+                tx.insertTestServiceNeed(
                     childId,
                     startDate = it.first.start,
                     endDate = it.first.end,
@@ -2119,8 +2117,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
     private fun insertIncome(adultId: UUID, amount: Int, period: DateRange) {
         db.transaction { tx ->
-            insertTestIncome(
-                tx.handle,
+            tx.insertTestIncome(
                 objectMapper,
                 personId = adultId,
                 validFrom = period.start,
@@ -2139,8 +2136,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
     private fun insertFeeAlteration(childId: UUID, amount: Double, period: DateRange) {
         db.transaction { tx ->
-            insertTestFeeAlteration(
-                tx.handle,
+            tx.insertTestFeeAlteration(
                 childId,
                 type = FeeAlteration.Type.DISCOUNT,
                 amount = amount,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
@@ -76,7 +76,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -43,7 +43,6 @@ import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDaycare2
 import fi.espoo.evaka.testDecisionMaker_1
 import fi.espoo.evaka.testRoundTheClockDaycare
-import org.jdbi.v3.core.Handle
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -397,15 +396,12 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx ->
-            insertDecisionsAndPlacements(
-                tx.handle,
-                listOf(
-                    decision.copy(validTo = period.start.plusDays(7)),
-                    decision.copy(id = UUID.randomUUID(), validFrom = period.start.plusDays(8))
-                )
+        insertDecisionsAndPlacements(
+            listOf(
+                decision.copy(validTo = period.start.plusDays(7)),
+                decision.copy(id = UUID.randomUUID(), validFrom = period.start.plusDays(8))
             )
-        }
+        )
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -453,15 +449,12 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx ->
-            insertDecisionsAndPlacements(
-                tx.handle,
-                listOf(
-                    decision.copy(validTo = period.start.plusDays(7)),
-                    decision.copy(id = UUID.randomUUID(), validFrom = period.start.plusDays(8))
-                )
+        insertDecisionsAndPlacements(
+            listOf(
+                decision.copy(validTo = period.start.plusDays(7)),
+                decision.copy(id = UUID.randomUUID(), validFrom = period.start.plusDays(8))
             )
-        }
+        )
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -509,27 +502,24 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx ->
-            insertDecisionsAndPlacements(
-                tx.handle,
-                listOf(
-                    decision.copy(validTo = period.start.plusDays(7)),
-                    decision.copy(
-                        id = UUID.randomUUID(),
-                        validFrom = period.start.plusDays(8),
-                        familySize = decision.familySize + 1,
-                        parts = decision.parts + createFeeDecisionPartFixture(
-                            childId = testChild_2.id,
-                            dateOfBirth = testChild_2.dateOfBirth,
-                            daycareId = testDaycare.id,
-                            baseFee = 28900,
-                            siblingDiscount = 50,
-                            fee = 14500
-                        )
+        insertDecisionsAndPlacements(
+            listOf(
+                decision.copy(validTo = period.start.plusDays(7)),
+                decision.copy(
+                    id = UUID.randomUUID(),
+                    validFrom = period.start.plusDays(8),
+                    familySize = decision.familySize + 1,
+                    parts = decision.parts + createFeeDecisionPartFixture(
+                        childId = testChild_2.id,
+                        dateOfBirth = testChild_2.dateOfBirth,
+                        daycareId = testDaycare.id,
+                        baseFee = 28900,
+                        siblingDiscount = 50,
+                        fee = 14500
                     )
                 )
             )
-        }
+        )
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -594,7 +584,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, decisions) }
+        insertDecisionsAndPlacements(decisions)
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -666,7 +656,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, decisions) }
+        insertDecisionsAndPlacements(decisions)
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -738,7 +728,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, decisions) }
+        insertDecisionsAndPlacements(decisions)
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -794,19 +784,16 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx ->
-            insertDecisionsAndPlacements(
-                tx.handle,
-                listOf(
-                    decision.copy(validTo = period.start.plusDays(7)),
-                    decision.copy(
-                        id = UUID.randomUUID(),
-                        validFrom = period.start.plusDays(8),
-                        parts = listOf(decision.parts[0], decision.parts[1].copy(fee = 10000))
-                    )
+        insertDecisionsAndPlacements(
+            listOf(
+                decision.copy(validTo = period.start.plusDays(7)),
+                decision.copy(
+                    id = UUID.randomUUID(),
+                    validFrom = period.start.plusDays(8),
+                    parts = listOf(decision.parts[0], decision.parts[1].copy(fee = 10000))
                 )
             )
-        }
+        )
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -868,7 +855,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -929,7 +916,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -992,7 +979,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -1041,8 +1028,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
             )
         )
         db.transaction { tx ->
-            insertTestPlacement(
-                tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 startDate = period.start,
@@ -1096,8 +1082,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
             )
         )
         db.transaction { tx ->
-            insertTestPlacement(
-                tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 startDate = placementPeriod.start,
@@ -1575,7 +1560,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -1604,7 +1589,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -1642,7 +1627,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -1680,7 +1665,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -1718,7 +1703,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -1756,7 +1741,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -1811,7 +1796,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, decisions) }
+        insertDecisionsAndPlacements(decisions)
 
         db.transaction { createAllDraftInvoices(it.handle, objectMapper, period) }
 
@@ -1858,7 +1843,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
         db.transaction { tx ->
             absenceService.upsertAbsences(
                 tx,
@@ -1915,7 +1900,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
         db.transaction { tx ->
             absenceService.upsertAbsences(
                 tx,
@@ -1972,7 +1957,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 )
             )
         )
-        db.transaction { tx -> insertDecisionsAndPlacements(tx.handle, listOf(decision)) }
+        insertDecisionsAndPlacements(listOf(decision))
         db.transaction { tx ->
             absenceService.upsertAbsences(
                 tx,
@@ -2236,10 +2221,9 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
             db.transaction { tx -> upsertFeeDecisions(tx.handle, objectMapper, listOf(decision)) }
 
             val placementId = db.transaction(insertPlacement(child.id, period))
-            val groupId = db.transaction { it.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id)) }
+            val groupId = db.transaction { it.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id)) }
             db.transaction { tx ->
-                insertTestDaycareGroupPlacement(
-                    tx.handle,
+                tx.insertTestDaycareGroupPlacement(
                     daycarePlacementId = placementId,
                     groupId = groupId,
                     startDate = period.start,
@@ -2262,12 +2246,11 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
             }
         }
 
-    private fun insertDecisionsAndPlacements(h: Handle, feeDecisions: List<FeeDecision>) {
-        upsertFeeDecisions(h, objectMapper, feeDecisions)
+    private fun insertDecisionsAndPlacements(feeDecisions: List<FeeDecision>) = db.transaction { tx ->
+        upsertFeeDecisions(tx.handle, objectMapper, feeDecisions)
         feeDecisions.forEach { decision ->
             decision.parts.forEach { part ->
-                insertTestPlacement(
-                    h,
+                tx.insertTestPlacement(
                     childId = part.child.id,
                     unitId = part.placement.unit,
                     startDate = decision.validFrom,
@@ -2286,8 +2269,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertPlacement(childId: UUID, period: DateRange, type: PlacementType = PlacementType.DAYCARE) = { tx: Database.Transaction ->
-        insertTestPlacement(
-            tx.handle,
+        tx.insertTestPlacement(
             childId = childId,
             unitId = testDaycare.id,
             startDate = period.start,
@@ -2297,8 +2279,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertChildParentRelation(headOfFamilyId: UUID, childId: UUID, period: DateRange) = { tx: Database.Transaction ->
-        insertTestParentship(
-            tx.handle,
+        tx.insertTestParentship(
             headOfFamilyId,
             childId,
             startDate = period.start,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -64,7 +64,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             tx.execute(
                 "INSERT INTO holiday (date) VALUES (?), (?), (?), (?), (?), (?)",
                 LocalDate.of(2019, 1, 1),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -69,7 +69,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             tx.setUnitOids()
         }
         koskiServer.clearData()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -18,7 +18,6 @@ import fi.espoo.evaka.preschoolTerm2019
 import fi.espoo.evaka.preschoolTerm2020
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.dev.DevAssistanceAction
 import fi.espoo.evaka.shared.dev.DevAssistanceNeed
@@ -339,7 +338,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         )
         db.transaction { tx ->
             testCases.forEach {
-                tx.handle.insertTestAssistanceNeed(
+                tx.insertTestAssistanceNeed(
                     DevAssistanceNeed(
                         updatedBy = testDecisionMaker_1.id,
                         childId = testChild_1.id,
@@ -385,7 +384,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         )
         db.transaction { tx ->
             testCases.forEach {
-                tx.handle.insertTestAssistanceAction(
+                tx.insertTestAssistanceAction(
                     DevAssistanceAction(
                         updatedBy = testDecisionMaker_1.id,
                         childId = testChild_1.id,
@@ -604,7 +603,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
     @Test
     fun `a daycare with purchased provider type is marked as such in study rights`() {
         val daycareId = db.transaction {
-            it.handle.insertTestDaycare(
+            it.insertTestDaycare(
                 DevDaycare(areaId = testAreaId, providerType = ProviderType.PURCHASED)
             )
         }
@@ -620,7 +619,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
     @Test
     fun `a daycare with private provider type is marked as purchased in study rights`() {
         val daycareId = db.transaction {
-            it.handle.insertTestDaycare(
+            it.insertTestDaycare(
                 DevDaycare(areaId = testAreaId, providerType = ProviderType.PRIVATE)
             )
         }
@@ -756,7 +755,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         period: FiniteDateRange = preschoolTerm2019,
         type: PlacementType = PlacementType.PRESCHOOL
     ): UUID = db.transaction {
-        it.handle.insertTestPlacement(
+        it.insertTestPlacement(
             DevPlacement(
                 childId = child.id,
                 unitId = daycareId,
@@ -771,8 +770,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         db.transaction { tx ->
             for (period in periods) {
                 for (date in period.dates()) {
-                    insertTestAbsence(
-                        tx.handle,
+                    tx.insertTestAbsence(
                         childId = childId,
                         careType = CareType.PRESCHOOL,
                         date = date,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
@@ -45,7 +45,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             tx.setUnitOids()
         }
         koskiServer.clearData()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
@@ -54,7 +54,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
     @Test
     fun `simple preschool placement in 2019`() {
         db.transaction {
-            it.handle.insertTestPlacement(
+            it.insertTestPlacement(
                 DevPlacement(
                     childId = testChild_1.id,
                     unitId = testDaycare.id,
@@ -152,7 +152,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
     @Test
     fun `child with two preschool placements in the past`() {
         db.transaction {
-            it.handle.insertTestPlacement(
+            it.insertTestPlacement(
                 DevPlacement(
                     childId = testChild_1.id,
                     unitId = testDaycare.id,
@@ -161,7 +161,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
                     type = PlacementType.PRESCHOOL
                 )
             )
-            it.handle.insertTestPlacement(
+            it.insertTestPlacement(
                 DevPlacement(
                     childId = testChild_1.id,
                     unitId = testDaycare2.id,
@@ -357,7 +357,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
                     endDate = LocalDate.of(2019, 5, 31),
                     type = PlacementType.PRESCHOOL
                 )
-            ).forEach { tx.handle.insertTestPlacement(it) }
+            ).forEach { tx.insertTestPlacement(it) }
         }
 
         koskiTester.triggerUploads(today = preschoolTerm2019.end.plusDays(1))
@@ -602,7 +602,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
     @Test
     fun `simple preparatory education placement in the past`() {
         db.transaction {
-            it.handle.insertTestPlacement(
+            it.insertTestPlacement(
                 DevPlacement(
                     childId = testChild_1.id,
                     unitId = testDaycare.id,
@@ -745,7 +745,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
     @Test
     fun `deleting all placements voids the study right`() {
         val placementId = db.transaction {
-            it.handle.insertTestPlacement(
+            it.insertTestPlacement(
                 DevPlacement(
                     childId = testChild_1.id,
                     unitId = testDaycare.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
@@ -105,7 +105,7 @@ class BulletinIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
 
             tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id, name = groupName))
             tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = secondGroupId, daycareId = secondUnitId, name = secondGroupName))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
@@ -83,7 +83,7 @@ class BulletinIntegrationTest : FullApplicationTest() {
     """.trimIndent()
 
     private fun insertChildToGroup(tx: Database.Transaction, childId: UUID, guardianId: UUID, groupId: UUID, unitId: UUID) {
-        val daycarePlacementId = tx.handle.insertTestPlacement(
+        val daycarePlacementId = tx.insertTestPlacement(
             DevPlacement(
                 childId = childId,
                 unitId = unitId,
@@ -91,8 +91,7 @@ class BulletinIntegrationTest : FullApplicationTest() {
                 endDate = placementEnd
             )
         )
-        insertTestDaycareGroupPlacement(
-            h = tx.handle,
+        tx.insertTestDaycareGroupPlacement(
             daycarePlacementId = daycarePlacementId,
             groupId = groupId,
             startDate = placementStart,
@@ -107,8 +106,8 @@ class BulletinIntegrationTest : FullApplicationTest() {
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
 
-            tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id, name = groupName))
-            tx.handle.insertTestDaycareGroup(DevDaycareGroup(id = secondGroupId, daycareId = secondUnitId, name = secondGroupName))
+            tx.insertTestDaycareGroup(DevDaycareGroup(id = groupId, daycareId = testDaycare.id, name = groupName))
+            tx.insertTestDaycareGroup(DevDaycareGroup(id = secondGroupId, daycareId = secondUnitId, name = secondGroupName))
 
             insertChildToGroup(tx, childId, guardianPerson.id, groupId, unitId)
             insertChildToGroup(tx, testChild_3.id, testAdult_3.id, secondGroupId, secondUnitId)
@@ -116,14 +115,14 @@ class BulletinIntegrationTest : FullApplicationTest() {
 
             tx.handle.createParentship(testChild_3.id, testAdult_2.id, placementStart, placementEnd)
 
-            tx.handle.insertTestEmployee(
+            tx.insertTestEmployee(
                 DevEmployee(
                     id = supervisorId,
                     firstName = "Elina",
                     lastName = "Esimies"
                 )
             )
-            tx.handle.insertTestEmployee(
+            tx.insertTestEmployee(
                 DevEmployee(
                     id = staffId
                 )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/ConfirmedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/ConfirmedOccupancyTest.kt
@@ -39,7 +39,7 @@ class ConfirmedOccupancyTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTestUtils.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTestUtils.kt
@@ -49,10 +49,9 @@ fun Database.Transaction.createOccupancyTestFixture(
     assistanceExtra: Double? = null,
     placementId: UUID = UUID.randomUUID()
 ) {
-    handle.insertTestPerson(DevPerson(id = childId, dateOfBirth = dateOfBirth))
-    handle.insertTestChild(DevChild(id = childId))
+    insertTestPerson(DevPerson(id = childId, dateOfBirth = dateOfBirth))
+    insertTestChild(DevChild(id = childId))
     insertTestPlacement(
-        handle,
         childId = childId,
         unitId = unitId,
         type = placementType,
@@ -62,7 +61,6 @@ fun Database.Transaction.createOccupancyTestFixture(
     )
     if (hours != null) {
         insertTestServiceNeed(
-            handle,
             childId = childId,
             hoursPerWeek = hours,
             startDate = period.start,
@@ -71,7 +69,7 @@ fun Database.Transaction.createOccupancyTestFixture(
         )
     }
     if (assistanceExtra != null) {
-        handle.insertTestAssistanceNeed(
+        insertTestAssistanceNeed(
             DevAssistanceNeed(
                 childId = childId,
                 startDate = period.start,
@@ -112,11 +110,10 @@ fun Database.Transaction.createPlanOccupancyTestFixture(
     preschoolDaycarePeriod: FiniteDateRange = period,
     deletedPlacementPlan: Boolean? = false
 ) {
-    handle.insertTestPerson(DevPerson(id = childId, dateOfBirth = dateOfBirth))
-    handle.insertTestChild(DevChild(id = childId))
-    val applicationId = insertTestApplication(handle, childId = childId, guardianId = testAdult_1.id)
+    insertTestPerson(DevPerson(id = childId, dateOfBirth = dateOfBirth))
+    insertTestChild(DevChild(id = childId))
+    val applicationId = insertTestApplication(childId = childId, guardianId = testAdult_1.id)
     insertTestPlacementPlan(
-        handle,
         applicationId = applicationId,
         unitId = unitId,
         type = placementType,
@@ -127,7 +124,7 @@ fun Database.Transaction.createPlanOccupancyTestFixture(
         deleted = deletedPlacementPlan
     )
     if (assistanceExtra != null) {
-        handle.insertTestAssistanceNeed(
+        insertTestAssistanceNeed(
             DevAssistanceNeed(
                 childId = childId,
                 startDate = period.start,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/PlannedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/PlannedOccupancyTest.kt
@@ -38,7 +38,7 @@ class PlannedOccupancyTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/PlannedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/PlannedOccupancyTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -294,9 +293,8 @@ class PlannedOccupancyTest : FullApplicationTest() {
                 LocalDate.of(2015, 1, 1),
                 PlacementType.DAYCARE_PART_TIME
             )
-            val applicationId = insertTestApplication(tx.handle, childId = childId, guardianId = testAdult_1.id)
-            insertTestPlacementPlan(
-                tx.handle,
+            val applicationId = tx.insertTestApplication(childId = childId, guardianId = testAdult_1.id)
+            tx.insertTestPlacementPlan(
                 applicationId = applicationId,
                 unitId = testDaycare.id,
                 type = PlacementType.DAYCARE,
@@ -334,9 +332,8 @@ class PlannedOccupancyTest : FullApplicationTest() {
                 LocalDate.of(2015, 1, 1),
                 PlacementType.DAYCARE
             )
-            val applicationId = insertTestApplication(tx.handle, childId = childId, guardianId = testAdult_1.id)
-            insertTestPlacementPlan(
-                tx.handle,
+            val applicationId = tx.insertTestApplication(childId = childId, guardianId = testAdult_1.id)
+            tx.insertTestPlacementPlan(
                 applicationId = applicationId,
                 unitId = testDaycare.id,
                 type = PlacementType.DAYCARE_PART_TIME,
@@ -369,7 +366,7 @@ class PlannedOccupancyTest : FullApplicationTest() {
         val daycareId2 = UUID.randomUUID()
 
         db.transaction { tx ->
-            tx.handle.insertTestDaycare(DevDaycare(id = daycareId2, areaId = testDaycare.areaId, name = "foo"))
+            tx.insertTestDaycare(DevDaycare(id = daycareId2, areaId = testDaycare.areaId, name = "foo"))
 
             tx.createPlanOccupancyTestFixture(
                 childId,
@@ -379,7 +376,7 @@ class PlannedOccupancyTest : FullApplicationTest() {
                 PlacementType.DAYCARE_PART_TIME
             )
 
-            tx.handle.insertTestPlacement(DevPlacement(type = PlacementType.DAYCARE, childId = childId, unitId = daycareId1, startDate = defaultPeriod.start, endDate = defaultPeriod.end))
+            tx.insertTestPlacement(DevPlacement(type = PlacementType.DAYCARE, childId = childId, unitId = daycareId1, startDate = defaultPeriod.start, endDate = defaultPeriod.end))
         }
 
         val result1 = fetchAndParseOccupancy(daycareId1, defaultPeriod)
@@ -417,9 +414,8 @@ class PlannedOccupancyTest : FullApplicationTest() {
                 LocalDate.of(2015, 1, 1),
                 PlacementType.DAYCARE
             )
-            val applicationId = insertTestApplication(tx.handle, childId = childId, guardianId = testAdult_1.id)
-            insertTestPlacementPlan(
-                tx.handle,
+            val applicationId = tx.insertTestApplication(childId = childId, guardianId = testAdult_1.id)
+            tx.insertTestPlacementPlan(
                 applicationId = applicationId,
                 unitId = testDaycare.id,
                 type = PlacementType.DAYCARE_PART_TIME,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealizedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealizedOccupancyTest.kt
@@ -39,7 +39,7 @@ class RealizedOccupancyTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, id = groupId))
             insertTestCaretakers(tx.handle, groupId = groupId, amount = 3.0, startDate = LocalDate.of(2019, 1, 1))
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealizedOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealizedOccupancyTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestAbsence
 import fi.espoo.evaka.shared.dev.insertTestBackUpCare
@@ -40,8 +39,8 @@ class RealizedOccupancyTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.insertGeneralTestFixtures()
-            tx.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, id = groupId))
-            insertTestCaretakers(tx.handle, groupId = groupId, amount = 3.0, startDate = LocalDate.of(2019, 1, 1))
+            tx.insertTestDaycareGroup(DevDaycareGroup(daycareId = testDaycare.id, id = groupId))
+            tx.insertTestCaretakers(groupId = groupId, amount = 3.0, startDate = LocalDate.of(2019, 1, 1))
         }
     }
 
@@ -87,9 +86,9 @@ class RealizedOccupancyTest : FullApplicationTest() {
         val placementId = UUID.randomUUID()
         db.transaction { tx ->
             tx.createOccupancyTestFixture(childId, testDaycare.id, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE, placementId = placementId)
-            insertTestStaffAttendance(tx.handle, groupId = groupId, count = 1.0, date = day1)
-            insertTestStaffAttendance(tx.handle, groupId = groupId, count = 2.0, date = day2)
-            insertTestDaycareGroupPlacement(tx.handle, placementId, groupId, startDate = defaultPeriod.start, endDate = defaultPeriod.end)
+            tx.insertTestStaffAttendance(groupId = groupId, count = 1.0, date = day1)
+            tx.insertTestStaffAttendance(groupId = groupId, count = 2.0, date = day2)
+            tx.insertTestDaycareGroupPlacement(placementId, groupId, startDate = defaultPeriod.start, endDate = defaultPeriod.end)
         }
 
         val result = fetchAndParseOccupancyByGroups(testDaycare.id, defaultPeriod)
@@ -118,7 +117,7 @@ class RealizedOccupancyTest : FullApplicationTest() {
         val normalPlacementChild2 = UUID.randomUUID()
         db.transaction { tx ->
             tx.createOccupancyTestFixture(backupCareChild, testDaycare.id, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE)
-            insertTestBackUpCare(tx.handle, backupCareChild, testDaycare2.id, day2, day2)
+            tx.insertTestBackUpCare(backupCareChild, testDaycare2.id, day2, day2)
 
             tx.createOccupancyTestFixture(normalPlacementChild1, testDaycare2.id, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE)
             tx.createOccupancyTestFixture(normalPlacementChild2, testDaycare2.id, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE)
@@ -148,8 +147,8 @@ class RealizedOccupancyTest : FullApplicationTest() {
         val childId = UUID.randomUUID()
         db.transaction { tx ->
             tx.createOccupancyTestFixture(childId, testDaycare.id, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE)
-            insertTestBackUpCare(tx.handle, childId, testDaycare2.id, day1, day2)
-            insertTestAbsence(tx.handle, childId = childId, date = day2, careType = CareType.DAYCARE, absenceType = AbsenceType.SICKLEAVE)
+            tx.insertTestBackUpCare(childId, testDaycare2.id, day1, day2)
+            tx.insertTestAbsence(childId = childId, date = day2, careType = CareType.DAYCARE, absenceType = AbsenceType.SICKLEAVE)
         }
 
         val resultBackupUnit = fetchAndParseOccupancy(testDaycare2.id, defaultPeriod)
@@ -167,7 +166,7 @@ class RealizedOccupancyTest : FullApplicationTest() {
         val childId = UUID.randomUUID()
         db.transaction { tx ->
             tx.createOccupancyTestFixture(childId, testDaycare.id, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE)
-            insertTestAbsence(tx.handle, childId = childId, date = LocalDate.of(2019, 1, 2), careType = CareType.DAYCARE)
+            tx.insertTestAbsence(childId = childId, date = LocalDate.of(2019, 1, 2), careType = CareType.DAYCARE)
         }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
@@ -186,7 +185,7 @@ class RealizedOccupancyTest : FullApplicationTest() {
         val childId = UUID.randomUUID()
         db.transaction { tx ->
             tx.createOccupancyTestFixture(childId, testDaycare.id, defaultPeriod, LocalDate.of(2017, 1, 1), PlacementType.DAYCARE)
-            insertTestAbsence(tx.handle, childId = childId, date = LocalDate.of(2019, 1, 2), careType = CareType.DAYCARE, absenceType = AbsenceType.PRESENCE)
+            tx.insertTestAbsence(childId = childId, date = LocalDate.of(2019, 1, 2), careType = CareType.DAYCARE, absenceType = AbsenceType.PRESENCE)
         }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
@@ -200,8 +199,8 @@ class RealizedOccupancyTest : FullApplicationTest() {
     @Test
     fun `caretaker count is based on attendance`() {
         db.transaction { tx ->
-            insertTestStaffAttendance(tx.handle, groupId = groupId, date = LocalDate.of(2019, 1, 1), count = 2.0)
-            insertTestStaffAttendance(tx.handle, groupId = groupId, date = LocalDate.of(2019, 1, 2), count = 1.5)
+            tx.insertTestStaffAttendance(groupId = groupId, date = LocalDate.of(2019, 1, 1), count = 2.0)
+            tx.insertTestStaffAttendance(groupId = groupId, date = LocalDate.of(2019, 1, 2), count = 1.5)
         }
 
         val result = fetchAndParseOccupancy(testDaycare.id, defaultPeriod)
@@ -234,7 +233,7 @@ class RealizedOccupancyTest : FullApplicationTest() {
             tx.createOccupancyTestFixture(testDaycare.id, period, LocalDate.of(2015, 1, 1), PlacementType.DAYCARE)
             generateSequence(period.start) { date -> date.plusDays(1) }
                 .takeWhile { date -> date <= LocalDate.now() }
-                .forEach { date -> insertTestStaffAttendance(tx.handle, groupId = groupId, date = date, count = 1.0) }
+                .forEach { date -> tx.insertTestStaffAttendance(groupId = groupId, date = date, count = 1.0) }
         }
 
         val result = fetchAndParseOccupancy(testDaycare.id, period)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -33,7 +33,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         db.transaction { tx ->
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
-            updateDaycareAclWithEmployee(tx.handle, testUnitId, user.id, UserRole.UNIT_SUPERVISOR)
+            tx.updateDaycareAclWithEmployee(testUnitId, user.id, UserRole.UNIT_SUPERVISOR)
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -32,7 +32,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             updateDaycareAclWithEmployee(tx.handle, testUnitId, user.id, UserRole.UNIT_SUPERVISOR)
         }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
@@ -33,8 +33,8 @@ class SystemIdentityControllerTest : FullApplicationTest() {
     @BeforeEach
     protected fun beforeEach() {
         db.transaction { it.resetDatabase() }
-        areaId = db.transaction { it.handle.insertTestCareArea(DevCareArea()) }
-        unitId = db.transaction { it.handle.insertTestDaycare(DevDaycare(areaId = areaId)) }
+        areaId = db.transaction { it.insertTestCareArea(DevCareArea()) }
+        unitId = db.transaction { it.insertTestDaycare(DevDaycare(areaId = areaId)) }
     }
 
     @Test
@@ -59,7 +59,7 @@ class SystemIdentityControllerTest : FullApplicationTest() {
     }
 
     private fun Database.Transaction.insertTestDevice(longTermToken: UUID? = null, deleted: Boolean = false): UUID {
-        val id = handle.insertTestEmployee(DevEmployee())
+        val id = insertTestEmployee(DevEmployee())
         insertTestMobileDevice(
             DevMobileDevice(
                 id = id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerSearchIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerSearchIntegrationTest.kt
@@ -29,7 +29,7 @@ class EmployeeControllerSearchIntegrationTest : AbstractIntegrationTest() {
     @BeforeEach
     internal fun setUp() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
@@ -31,7 +31,7 @@ class FamilyOverviewTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/GuardianQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/GuardianQueriesIntegrationTest.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/GuardianQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/GuardianQueriesIntegrationTest.kt
@@ -22,7 +22,7 @@ class GuardianQueriesIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -49,7 +49,7 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
         mergeService = MergeService(asyncJobRunnerMock)
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -16,7 +16,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.VTJRefresh
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -51,7 +51,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
     internal fun setUp() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
         service = VTJBatchRefreshService(
             fridgeFamilyService = fridgeFamilyService,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/FiveYearOldDaycarePlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/FiveYearOldDaycarePlacementsIntegrationTest.kt
@@ -22,7 +22,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction {
             it.resetDatabase()
-            insertGeneralTestFixtures(it.handle)
+            it.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
@@ -47,7 +47,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
     fun setUp() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             insertTestPlacement(
                 h = tx.handle,
                 childId = childId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
@@ -48,16 +48,15 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
         db.transaction { tx ->
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = childId,
                 unitId = daycareId,
                 startDate = placementStart,
                 endDate = placementEnd
             )
-            tx.handle.insertTestDaycareGroup(testDaycareGroup)
+            tx.insertTestDaycareGroup(testDaycareGroup)
             testPlacement = tx.getDaycarePlacements(daycareId, null, null, null).first()
-            updateDaycareAclWithEmployee(tx.handle, daycareId, unitSupervisor.id, UserRole.UNIT_SUPERVISOR)
+            tx.updateDaycareAclWithEmployee(daycareId, unitSupervisor.id, UserRole.UNIT_SUPERVISOR)
         }
     }
 
@@ -390,8 +389,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
     @Test
     fun `unit supervisor sees placements to her unit only`() {
         val allowedId = db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = childId,
                 unitId = daycareId,
                 startDate = LocalDate.now(),
@@ -400,8 +398,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
         }
 
         val restrictedId = db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = childId,
                 unitId = testDaycare2.id,
                 startDate = LocalDate.now().minusDays(2),
@@ -429,8 +426,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
         val newEnd = placementEnd.minusDays(2)
         val allowedId = testPlacement.id
         val restrictedId = db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = childId,
                 unitId = testDaycare2.id,
                 startDate = placementEnd.plusDays(1),
@@ -465,8 +461,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
         val newEnd = placementEnd.plusDays(1)
         val allowedId = testPlacement.id
         db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = childId,
                 unitId = testDaycare2.id,
                 startDate = newEnd,
@@ -490,14 +485,13 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
     fun `unit supervisor can modify placement if it overlaps with another that supervisor has the rights to`() {
         val newEnd = placementEnd.plusDays(1)
         val secondPlacement = db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = childId,
                 unitId = testDaycare2.id,
                 startDate = newEnd,
                 endDate = newEnd.plusMonths(2)
             ).also {
-                updateDaycareAclWithEmployee(tx.handle, testDaycare2.id, unitSupervisor.id, UserRole.UNIT_SUPERVISOR)
+                tx.updateDaycareAclWithEmployee(testDaycare2.id, unitSupervisor.id, UserRole.UNIT_SUPERVISOR)
             }
         }
 
@@ -525,7 +519,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
     @Test
     fun `staff can't modify placements`() {
         db.transaction { tx ->
-            updateDaycareAclWithEmployee(tx.handle, daycareId, staff.id, UserRole.STAFF)
+            tx.updateDaycareAclWithEmployee(daycareId, staff.id, UserRole.STAFF)
         }
         val newStart = placementStart.plusDays(1)
         val newEnd = placementEnd.minusDays(2)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
@@ -50,7 +50,7 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
@@ -344,15 +344,14 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
         preferredUnits: List<UnitData.Detailed> = listOf(testDaycare, testDaycare2),
         preparatory: Boolean = false
     ): UUID = db.transaction { tx ->
-        val applicationId = insertTestApplication(
-            tx.handle,
+        val applicationId = tx.insertTestApplication(
             status = status,
             guardianId = adult.id,
             childId = child.id
         )
         val careDetails = if (preparatory) CareDetails(preparatory = true) else CareDetails()
-        insertTestApplicationForm(
-            tx.handle, applicationId,
+        tx.insertTestApplicationForm(
+            applicationId,
             DaycareFormV0(
                 type = type,
                 partTime = partTime,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
@@ -21,7 +21,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -323,14 +322,14 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
         assertTrue(res.isSuccessful)
 
         db.read { r ->
-            getPlacementPlanRowByApplication(r.handle, applicationId).one().also {
+            r.getPlacementPlanRowByApplication(applicationId).one().also {
                 assertEquals(type, it.type)
                 assertEquals(proposal.unitId, it.unitId)
                 assertEquals(proposal.period, it.period())
                 assertEquals(proposal.preschoolDaycarePeriod, it.preschoolDaycarePeriod())
                 assertEquals(false, it.deleted)
             }
-            assertEquals(ApplicationStatus.WAITING_DECISION, getApplicationStatus(r.handle, applicationId))
+            assertEquals(ApplicationStatus.WAITING_DECISION, r.getApplicationStatus(applicationId))
         }
     }
     private fun insertInitialData(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
@@ -51,13 +51,13 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             it.insertGeneralTestFixtures()
         }
         db.transaction {
-            groupId1 = it.handle.insertTestDaycareGroup(
+            groupId1 = it.insertTestDaycareGroup(
                 DevDaycareGroup(
                     daycareId = unitId,
                     startDate = placementStart
                 )
             )
-            groupId2 = it.handle.insertTestDaycareGroup(
+            groupId2 = it.insertTestDaycareGroup(
                 DevDaycareGroup(
                     daycareId = unitId,
                     startDate = placementStart
@@ -73,8 +73,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
             daycarePlacementId = oldPlacement.id
 
-            groupPlacementId = insertTestDaycareGroupPlacement(
-                it.handle,
+            groupPlacementId = it.insertTestDaycareGroupPlacement(
                 daycarePlacementId = daycarePlacementId,
                 groupId = groupId1,
                 startDate = placementStart,
@@ -476,10 +475,9 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
                 LocalDate.of(year, month, 20)
             )
         }.first()
-        val groupId = db.transaction { it.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = unitId)) }
+        val groupId = db.transaction { it.insertTestDaycareGroup(DevDaycareGroup(daycareId = unitId)) }
         db.transaction {
-            insertTestDaycareGroupPlacement(
-                it.handle,
+            it.insertTestDaycareGroupPlacement(
                 groupId = groupId,
                 daycarePlacementId = oldPlacement.id,
                 startDate = oldPlacement.startDate,
@@ -512,10 +510,9 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
                 LocalDate.of(year, month, 30)
             )
         }.first()
-        val groupId = db.transaction { it.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = unitId)) }
+        val groupId = db.transaction { it.insertTestDaycareGroup(DevDaycareGroup(daycareId = unitId)) }
         db.transaction {
-            insertTestDaycareGroupPlacement(
-                it.handle,
+            it.insertTestDaycareGroupPlacement(
                 groupId = groupId,
                 daycarePlacementId = oldPlacement.id,
                 startDate = oldPlacement.startDate,
@@ -563,10 +560,9 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
                 LocalDate.of(year, month, 30)
             )
         }.first()
-        val groupId = db.transaction { it.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = unitId)) }
+        val groupId = db.transaction { it.insertTestDaycareGroup(DevDaycareGroup(daycareId = unitId)) }
         db.transaction {
-            insertTestDaycareGroupPlacement(
-                it.handle,
+            it.insertTestDaycareGroupPlacement(
                 groupId = groupId,
                 daycarePlacementId = oldPlacement.id,
                 startDate = oldPlacement.startDate,
@@ -706,8 +702,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
         val daycarePlacementType = PlacementType.DAYCARE
 
         db.transaction {
-            insertTestPlacement(
-                it.handle,
+            it.insertTestPlacement(
                 id = daycarePlacementId,
                 childId = testChild_2.id,
                 unitId = testDaycare2.id,
@@ -762,8 +757,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
         val daycarePlacementType = PlacementType.DAYCARE
 
         db.transaction {
-            insertTestPlacement(
-                it.handle,
+            it.insertTestPlacement(
                 id = daycarePlacementId,
                 childId = testChild_2.id,
                 unitId = testDaycare2.id,
@@ -784,8 +778,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
 
         db.transaction { tx ->
             groupPlacementDays.forEachIndexed { index, (startDate, endDate) ->
-                insertTestDaycareGroupPlacement(
-                    tx.handle,
+                tx.insertTestDaycareGroupPlacement(
                     id = groupPlacementIds[index],
                     groupId = groupId1,
                     daycarePlacementId = daycarePlacementId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
@@ -48,7 +48,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
     internal fun setUp() {
         db.transaction {
             it.resetDatabase()
-            insertGeneralTestFixtures(it.handle)
+            it.insertGeneralTestFixtures()
         }
         db.transaction {
             groupId1 = it.handle.insertTestDaycareGroup(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReportTest.kt
@@ -41,8 +41,8 @@ class DuplicatePeopleReportTest : FullApplicationTest() {
         )
         val personWithoutSsn = personWithSsn.copy(id = UUID.randomUUID(), ssn = null)
         db.transaction {
-            it.handle.insertTestPerson(personWithSsn)
-            it.handle.insertTestPerson(personWithoutSsn)
+            it.insertTestPerson(personWithSsn)
+            it.insertTestPerson(personWithoutSsn)
         }
 
         val (_, _, result) = http.get("/reports/duplicate-people")
@@ -68,8 +68,8 @@ class DuplicatePeopleReportTest : FullApplicationTest() {
         val personWithoutSsn =
             personWithSsn.copy(id = UUID.randomUUID(), firstName = firstName.split(" ")[0], ssn = null)
         db.transaction {
-            it.handle.insertTestPerson(personWithSsn)
-            it.handle.insertTestPerson(personWithoutSsn)
+            it.insertTestPerson(personWithSsn)
+            it.insertTestPerson(personWithoutSsn)
         }
 
         val (_, _, result) = http.get("/reports/duplicate-people")
@@ -95,8 +95,8 @@ class DuplicatePeopleReportTest : FullApplicationTest() {
         val personWithoutSsn =
             personWithSsn.copy(id = UUID.randomUUID(), ssn = null, dateOfBirth = dateOfBirth.plusDays(1))
         db.transaction {
-            it.handle.insertTestPerson(personWithSsn)
-            it.handle.insertTestPerson(personWithoutSsn)
+            it.insertTestPerson(personWithSsn)
+            it.insertTestPerson(personWithoutSsn)
         }
 
         val (_, _, result) = http.get("/reports/duplicate-people")
@@ -121,8 +121,8 @@ class DuplicatePeopleReportTest : FullApplicationTest() {
         val ssn2 = "010170-1124"
         val personWithSsn2 = personWithSsn1.copy(id = UUID.randomUUID(), ssn = ssn2)
         db.transaction {
-            it.handle.insertTestPerson(personWithSsn1)
-            it.handle.insertTestPerson(personWithSsn2)
+            it.insertTestPerson(personWithSsn1)
+            it.insertTestPerson(personWithSsn2)
         }
 
         val (_, _, result) = http.get("/reports/duplicate-people")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
@@ -34,7 +34,7 @@ class InvoicingReportTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
@@ -26,7 +26,7 @@ class ReportSmokeTests : FullApplicationTest() {
     @BeforeAll
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.testAreaId
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.AfterAll

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
@@ -49,7 +49,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        db.transaction { insertGeneralTestFixtures(it.handle) }
+        db.transaction { it.insertGeneralTestFixtures() }
     }
 
     @AfterEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -48,7 +48,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        db.transaction { insertGeneralTestFixtures(it.handle) }
+        db.transaction { it.insertGeneralTestFixtures() }
     }
 
     @AfterEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
@@ -27,7 +27,7 @@ class StartingPlacementsReportTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
@@ -127,8 +126,7 @@ class StartingPlacementsReportTest : FullApplicationTest() {
 
     private fun insertPlacement(childId: UUID, startDate: LocalDate, endDate: LocalDate = startDate.plusYears(1)) =
         db.transaction { tx ->
-            insertTestPlacement(
-                tx.handle,
+            tx.insertTestPlacement(
                 childId = childId,
                 unitId = testDaycare.id,
                 startDate = startDate,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
@@ -37,7 +37,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
             insertTestPlacement(
                 tx.handle,
                 childId = testChild_1.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
@@ -38,8 +38,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
         db.transaction { tx ->
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
-            insertTestPlacement(
-                tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 startDate = LocalDate.now().minusDays(1),
@@ -399,8 +398,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
 
     private fun givenServiceNeed(start: Int, end: Int?, childId: UUID = testChild_1.id): UUID {
         return db.transaction { tx ->
-            insertTestServiceNeed(
-                h = tx.handle,
+            tx.insertTestServiceNeed(
                 childId = childId,
                 startDate = testDate(start),
                 endDate = if (end == null) null else testDate(end),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -52,15 +52,15 @@ class AclIntegrationTest : PureJdbiTest() {
     @BeforeAll
     fun before() {
         db.transaction {
-            employeeId = it.handle.insertTestEmployee(DevEmployee())
-            val areaId = it.handle.insertTestCareArea(DevCareArea(name = "Test area"))
-            daycareId = it.handle.insertTestDaycare(DevDaycare(areaId = areaId))
-            groupId = it.handle.insertTestDaycareGroup(DevDaycareGroup(daycareId = daycareId))
-            val guardianId = it.handle.insertTestPerson(DevPerson())
-            childId = it.handle.insertTestPerson(DevPerson())
-            it.handle.insertTestChild(DevChild(id = childId))
-            applicationId = insertTestApplication(it.handle, childId = childId, guardianId = guardianId)
-            decisionId = it.handle.insertTestDecision(
+            employeeId = it.insertTestEmployee(DevEmployee())
+            val areaId = it.insertTestCareArea(DevCareArea(name = "Test area"))
+            daycareId = it.insertTestDaycare(DevDaycare(areaId = areaId))
+            groupId = it.insertTestDaycareGroup(DevDaycareGroup(daycareId = daycareId))
+            val guardianId = it.insertTestPerson(DevPerson())
+            childId = it.insertTestPerson(DevPerson())
+            it.insertTestChild(DevChild(id = childId))
+            applicationId = it.insertTestApplication(childId = childId, guardianId = guardianId)
+            decisionId = it.insertTestDecision(
                 TestDecision(
                     createdBy = employeeId,
                     unitId = daycareId,
@@ -70,8 +70,8 @@ class AclIntegrationTest : PureJdbiTest() {
                     endDate = LocalDate.of(2100, 1, 1)
                 )
             )
-            placementId = insertTestPlacement(it.handle, childId = childId, unitId = daycareId)
-            mobileId = it.handle.insertTestEmployee(DevEmployee())
+            placementId = it.insertTestPlacement(childId = childId, unitId = daycareId)
+            mobileId = it.insertTestEmployee(DevEmployee())
             noteId = it.createDaycareDailyNote(
                 DaycareDailyNote(
                     id = null,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -17,8 +17,8 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
 import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.dev.runDevScript
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
@@ -70,9 +70,9 @@ fun getTestDataSource(): TestDataSource = synchronized(globalLock) {
                 .run {
                     migrate()
                 }
-            Jdbi.create(it).handle { h ->
-                h.runDevScript("reset-database.sql")
-                h.resetDatabase()
+            Database(Jdbi.create(it)).transaction { tx ->
+                tx.runDevScript("reset-database.sql")
+                tx.resetDatabase()
             }
         }
     ).also {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
@@ -58,7 +58,7 @@ class ScheduledOperationControllerIntegrationTest : FullApplicationTest() {
     private fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 
@@ -69,10 +69,10 @@ class ScheduledOperationControllerIntegrationTest : FullApplicationTest() {
         val user = AuthenticatedUser.Citizen(testAdult_5.id)
 
         db.transaction { tx ->
-            insertApplication(tx.handle, guardian = testAdult_5, applicationId = id_to_be_deleted)
+            tx.insertApplication(guardian = testAdult_5, applicationId = id_to_be_deleted)
             setApplicationCreatedDate(tx, id_to_be_deleted, LocalDate.now().minusDays(32))
 
-            insertApplication(tx.handle, guardian = testAdult_5, applicationId = id_not_to_be_deleted)
+            tx.insertApplication(guardian = testAdult_5, applicationId = id_not_to_be_deleted)
             setApplicationCreatedDate(tx, id_not_to_be_deleted, LocalDate.now().minusDays(31))
         }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
@@ -380,15 +380,13 @@ class ScheduledOperationControllerIntegrationTest : FullApplicationTest() {
         status: ApplicationStatus = ApplicationStatus.SENT
     ): UUID {
         return db.transaction { tx ->
-            val applicationId = insertTestApplication(
-                h = tx.handle,
+            val applicationId = tx.insertTestApplication(
                 status = status,
                 childId = childId,
                 guardianId = testAdult_1.id,
                 transferApplication = true
             )
-            insertTestApplicationForm(
-                h = tx.handle,
+            tx.insertTestApplicationForm(
                 applicationId = applicationId,
                 document = DaycareFormV0.fromApplication2(validDaycareApplication).copy(
                     type = type,
@@ -407,14 +405,12 @@ class ScheduledOperationControllerIntegrationTest : FullApplicationTest() {
         childId: UUID = testChild_1.id
     ): UUID {
         return db.transaction { tx ->
-            val applicationId = insertTestApplication(
-                h = tx.handle,
+            val applicationId = tx.insertTestApplication(
                 status = ApplicationStatus.SENT,
                 childId = childId,
                 guardianId = testAdult_1.id
             )
-            insertTestApplicationForm(
-                h = tx.handle,
+            tx.insertTestApplicationForm(
                 applicationId = applicationId,
                 document = DaycareFormV0.fromApplication2(validDaycareApplication).let { form ->
                     form.copy(
@@ -430,8 +426,7 @@ class ScheduledOperationControllerIntegrationTest : FullApplicationTest() {
 
     private fun createPlacement(type: PlacementType, dateRange: FiniteDateRange, childId: UUID = testChild_1.id) {
         db.transaction {
-            insertTestPlacement(
-                it.handle,
+            it.insertTestPlacement(
                 childId = childId,
                 type = type,
                 startDate = dateRange.start,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
@@ -25,7 +25,7 @@ class TimeIntegrationTest : PureJdbiTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
@@ -64,8 +64,8 @@ class TimeIntegrationTest : PureJdbiTest() {
         var secondUnitId: UUID? = null
         var thirdUnitId: UUID? = null
         db.transaction { tx ->
-            secondUnitId = tx.handle.insertTestDaycare(DevDaycare(areaId = testAreaId, name = "second round the clock unit"))
-            thirdUnitId = tx.handle.insertTestDaycare(DevDaycare(areaId = testAreaId, name = "third round the clock unit"))
+            secondUnitId = tx.insertTestDaycare(DevDaycare(areaId = testAreaId, name = "second round the clock unit"))
+            thirdUnitId = tx.insertTestDaycare(DevDaycare(areaId = testAreaId, name = "third round the clock unit"))
             tx.createUpdate("UPDATE daycare SET operation_days = '{1, 2, 3, 4, 5, 6, 7}' WHERE id = ANY(:ids)")
                 .bind("ids", arrayOf(secondUnitId, thirdUnitId))
                 .execute()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
@@ -8,14 +8,14 @@ import fi.espoo.evaka.application.ApplicationStatus
 import fi.espoo.evaka.decision.DecisionStatus
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-fun getApplicationStatus(h: Handle, applicationId: UUID): ApplicationStatus = h.createQuery(
+fun Database.Read.getApplicationStatus(applicationId: UUID): ApplicationStatus = createQuery(
     // language=SQL
     """
 SELECT status
@@ -45,12 +45,12 @@ data class DecisionTableRow(
     fun period() = FiniteDateRange(startDate, endDate)
 }
 
-fun getDecisionRowsByApplication(h: Handle, applicationId: UUID) = h.createQuery(
+fun Database.Read.getDecisionRowsByApplication(applicationId: UUID) = createQuery(
     // language=SQL
     "SELECT * FROM decision WHERE application_id = :applicationId ORDER BY type"
 ).bind("applicationId", applicationId).mapTo<DecisionTableRow>()
 
-fun getDecisionRowById(h: Handle, id: UUID) = h.createQuery(
+fun Database.Read.getDecisionRowById(id: UUID) = createQuery(
     // language=SQL
     "SELECT * FROM decision WHERE id = :id"
 ).bind("id", id).mapTo<DecisionTableRow>()
@@ -66,7 +66,7 @@ data class PlacementTableRow(
     fun period() = FiniteDateRange(startDate, endDate)
 }
 
-fun getPlacementRowsByChild(h: Handle, childId: UUID) = h.createQuery(
+fun Database.Read.getPlacementRowsByChild(childId: UUID) = createQuery(
     // language=SQL
     "SELECT * FROM placement WHERE child_id = :childId ORDER BY start_date"
 ).bind("childId", childId).mapTo<PlacementTableRow>()
@@ -92,7 +92,7 @@ data class PlacementPlanTableRow(
         ) else null
 }
 
-fun getPlacementPlanRowByApplication(h: Handle, applicationId: UUID) = h.createQuery(
+fun Database.Read.getPlacementPlanRowByApplication(applicationId: UUID) = createQuery(
     // language=SQL
     "SELECT * FROM placement_plan WHERE application_id = :applicationId"
 ).bind("applicationId", applicationId).mapTo<PlacementPlanTableRow>()
@@ -108,12 +108,12 @@ data class BackupCareTableRow(
     fun period() = FiniteDateRange(startDate, endDate)
 }
 
-fun getBackupCareRowById(h: Handle, id: UUID) = h.createQuery(
+fun Database.Read.getBackupCareRowById(id: UUID) = createQuery(
     // language=SQL
     "SELECT * FROM backup_care WHERE id = :id"
 ).bind("id", id).mapTo<BackupCareTableRow>()
 
-fun getBackupCareRowsByChild(h: Handle, childId: UUID) = h.createQuery(
+fun Database.Read.getBackupCareRowsByChild(childId: UUID) = createQuery(
     // language=SQL
     "SELECT * FROM backup_care WHERE child_id = :childId ORDER BY start_date"
 ).bind("childId", childId).mapTo<BackupCareTableRow>()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaChildrenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaChildrenIntegrationTest.kt
@@ -40,7 +40,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
         insertTestVardaUnit(db, testDaycare.id)
         uploadChildren()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaChildrenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaChildrenIntegrationTest.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestChild
@@ -54,8 +53,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
         val child = testChild_1
         val daycare = testDaycare
         db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = child.id,
                 unitId = daycare.id,
                 startDate = LocalDate.now().minusMonths(1),
@@ -84,8 +82,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
         val testOrganizationOid = defaultMunicipalOrganizerOid
         val daycareId = testDaycare.id
         db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = daycareId,
                 startDate = LocalDate.now().minusMonths(1),
@@ -112,8 +109,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
         val daycareId = testPurchasedDaycare.id
         insertTestVardaUnit(db, daycareId)
         db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = daycareId,
                 startDate = LocalDate.now().minusMonths(1),
@@ -137,8 +133,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
     @Test
     fun `child before varda begin date is not uploaded to Varda`() {
         db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 startDate = getVardaMinDate().minusDays(5),
@@ -152,8 +147,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
     @Test
     fun `child is uploaded despite daycare itself is not sent to varda`() {
         db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = testDaycare2.id,
                 startDate = LocalDate.now().minusMonths(2),
@@ -172,8 +166,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
                 .bind("id", daycareId)
                 .execute()
 
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = daycareId,
                 startDate = LocalDate.now().minusMonths(2),
@@ -187,8 +180,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
     @Test
     fun `child already in database is not sent to Varda`() {
         db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 startDate = LocalDate.now().minusMonths(2),
@@ -209,8 +201,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
                 .bind("id", testDaycare.id)
                 .execute()
 
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 startDate = LocalDate.now().minusMonths(2),
@@ -227,8 +218,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
     @Test
     fun `updating daycare organizer oid yields new varda_child`() {
         db.transaction { tx ->
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = testChild_1.id,
                 unitId = testDaycare.id,
                 startDate = LocalDate.now().minusMonths(2),
@@ -255,7 +245,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
         val child = namelessChild
         val daycare = testDaycare
         db.transaction { tx ->
-            tx.handle.insertTestPerson(
+            tx.insertTestPerson(
                 DevPerson(
                     id = child.id,
                     dateOfBirth = child.dateOfBirth,
@@ -267,10 +257,9 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
                     postOffice = child.postOffice ?: ""
                 )
             )
-            tx.handle.insertTestChild(DevChild(id = child.id))
+            tx.insertTestChild(DevChild(id = child.id))
 
-            insertTestPlacement(
-                h = tx.handle,
+            tx.insertTestPlacement(
                 childId = child.id,
                 unitId = daycare.id,
                 startDate = LocalDate.now().minusMonths(1),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -955,8 +955,7 @@ internal fun insertServiceNeed(
     hours: Double = 40.0
 ): UUID {
     return db.transaction {
-        insertTestServiceNeed(
-            it.handle,
+        it.insertTestServiceNeed(
             childId,
             testDecisionMaker_1.id,
             startDate = period.start,
@@ -996,9 +995,9 @@ fun insertDecisionWithApplication(
     sentDate: LocalDate = LocalDate.of(2019, 1, 1),
     decisionStatus: DecisionStatus = DecisionStatus.ACCEPTED
 ): UUID = db.transaction {
-    val applicationId = insertTestApplication(it.handle, childId = child.id, guardianId = testAdult_1.id, sentDate = sentDate)
-    insertTestApplicationForm(
-        it.handle, applicationId,
+    val applicationId = it.insertTestApplication(childId = child.id, guardianId = testAdult_1.id, sentDate = sentDate)
+    it.insertTestApplicationForm(
+        applicationId,
         DaycareFormV0(
             type = ApplicationType.DAYCARE,
             partTime = false,
@@ -1024,15 +1023,14 @@ fun insertDecisionWithApplication(
         resolvedBy = testDecisionMaker_1.id,
         resolved = Instant.now()
     )
-    it.handle.insertTestDecision(acceptedDecision)
+    it.insertTestDecision(acceptedDecision)
 }
 
 fun insertPlacementWithDecision(db: Database.Connection, child: PersonData.Detailed, unitId: UUID, period: FiniteDateRange): Pair<UUID, UUID> {
     val decisionId = insertDecisionWithApplication(db, child = child, period = period, unitId = unitId)
     insertServiceNeed(db, child.id, period)
     return db.transaction {
-        val placementId = insertTestPlacement(
-            h = it.handle,
+        val placementId = it.insertTestPlacement(
             childId = child.id,
             unitId = unitId,
             startDate = period.start,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -57,7 +57,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        db.transaction { insertGeneralTestFixtures(it.handle) }
+        db.transaction { it.insertGeneralTestFixtures() }
     }
 
     @AfterEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -65,7 +65,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
     @BeforeEach
     fun beforeEach() {
-        db.transaction { insertGeneralTestFixtures(it.handle) }
+        db.transaction { it.insertGeneralTestFixtures() }
         insertVardaUnit(db)
         mockEndpoint.cleanUp()
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -670,8 +670,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
         insertDecisionWithApplication(db, child, period, unitId = daycareId)
         insertServiceNeed(db, child.id, period)
         db.transaction {
-            insertTestPlacement(
-                h = it.handle,
+            it.insertTestPlacement(
                 childId = child.id,
                 unitId = daycareId,
                 startDate = period.start,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaOrganizerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaOrganizerIntegrationTest.kt
@@ -28,7 +28,7 @@ class VardaOrganizerIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
         mockEndpoint.cleanUp()
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -36,7 +36,7 @@ class VardaPlacementsIntegrationTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.PlacementType.DAYCARE
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.testChild_1
@@ -460,8 +459,7 @@ internal fun insertPlacement(
     unitId: UUID = testDaycare.id
 ): UUID {
     return db.transaction {
-        insertTestPlacement(
-            it.handle,
+        it.insertTestPlacement(
             childId = childId,
             type = type,
             startDate = period.start,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
@@ -34,7 +34,7 @@ class VardaUnitIntegrationTest : FullApplicationTest() {
             tx.handle.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
             tx.handle.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
             tx.handle.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare2.id, name = testDaycare2.name))
-            insertTestVardaOrganizer(tx.handle)
+            tx.insertTestVardaOrganizer()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
@@ -31,9 +31,9 @@ class VardaUnitIntegrationTest : FullApplicationTest() {
     fun beforeEach() {
         db.transaction { tx ->
             tx.resetDatabase()
-            tx.handle.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
-            tx.handle.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
-            tx.handle.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare2.id, name = testDaycare2.name))
+            tx.insertTestCareArea(DevCareArea(id = testAreaId, name = testDaycare.areaName, areaCode = testAreaCode))
+            tx.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare.id, name = testDaycare.name))
+            tx.insertTestDaycare(DevDaycare(areaId = testAreaId, id = testDaycare2.id, name = testDaycare2.name))
             tx.insertTestVardaOrganizer()
         }
     }
@@ -50,7 +50,7 @@ class VardaUnitIntegrationTest : FullApplicationTest() {
         assertEquals(2, getVardaUnits(db).size)
 
         db.transaction {
-            it.handle.insertTestDaycare(
+            it.insertTestDaycare(
                 DevDaycare(
                     areaId = testAreaId,
                     id = testPurchasedDaycare.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/service/PersonStorageServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/service/PersonStorageServiceIntegrationTest.kt
@@ -27,7 +27,7 @@ class PersonStorageServiceIntegrationTest : PureJdbiTest() {
         service = PersonStorageService()
         db.transaction { tx ->
             tx.resetDatabase()
-            insertGeneralTestFixtures(tx.handle)
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/service/PersonStorageServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/service/PersonStorageServiceIntegrationTest.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.service.getGuardianChildIds
 import fi.espoo.evaka.resetDatabase
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.vtjclient.dto.NativeLanguage
 import fi.espoo.evaka.vtjclient.dto.PersonDataSource
 import fi.espoo.evaka.vtjclient.dto.VtjPersonDTO

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/DevDataInitializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/DevDataInitializer.kt
@@ -14,9 +14,9 @@ import org.springframework.stereotype.Component
 @Profile("local")
 class DevDataInitializer(jdbi: Jdbi) {
     init {
-        jdbi.transaction { h ->
-            h.runDevScript("reset-database.sql")
-            h.ensureDevData()
+        Database(jdbi).transaction { tx ->
+            tx.runDevScript("reset-database.sql")
+            tx.ensureDevData()
         }
     }
 }


### PR DESCRIPTION
#### Summary

The beef is in 
* `service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt`
* `service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt`
* `service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt`

The rest is just updating the tests and test related code to call the functions in the new way.