### PR TITLE
EVAKA-4176 occupancy and raw report with new service needs

### DIFF
--- a/frontend/src/employee-frontend/api/reports.ts
+++ b/frontend/src/employee-frontend/api/reports.ts
@@ -268,7 +268,8 @@ export interface OccupancyReportFilters {
 }
 
 export async function getOccupanciesReport(
-  filters: OccupancyReportFilters
+  filters: OccupancyReportFilters,
+  useNewServiceNeeds: boolean
 ): Promise<Result<OccupancyReportRow[]>> {
   return client
     .get<JsonOf<OccupancyReportRow[]>>(
@@ -276,7 +277,8 @@ export async function getOccupanciesReport(
       {
         params: {
           ...filters,
-          type: filters.type.split('_')[1]
+          type: filters.type.split('_')[1],
+          useNewServiceNeeds
         }
       }
     )

--- a/frontend/src/employee-frontend/api/reports.ts
+++ b/frontend/src/employee-frontend/api/reports.ts
@@ -52,13 +52,15 @@ export async function getApplicationsReport(
 }
 
 export async function getRawReport(
-  filters: PeriodFilters
+  filters: PeriodFilters,
+  useNewServiceNeeds: boolean
 ): Promise<Result<RawReportRow[]>> {
   return client
     .get<JsonOf<RawReportRow[]>>('/reports/raw', {
       params: {
         from: filters.from.formatIso(),
-        to: filters.to.formatIso()
+        to: filters.to.formatIso(),
+        useNewServiceNeeds
       }
     })
     .then((res) =>

--- a/frontend/src/employee-frontend/components/reports/Occupancies.tsx
+++ b/frontend/src/employee-frontend/components/reports/Occupancies.tsx
@@ -11,6 +11,7 @@ import { Container, ContentArea } from 'lib-components/layout/Container'
 import Loader from 'lib-components/atoms/Loader'
 import Title from 'lib-components/atoms/Title'
 import { Th, Tr, Td, Thead, Tbody } from 'lib-components/layout/Table'
+import Checkbox from 'lib-components/atoms/form/Checkbox'
 import { reactSelectStyles } from '../../components/common/Select'
 import { Translations, useTranslation } from '../../state/i18n'
 import { Loading, Result, Success } from 'lib-common/api'
@@ -36,6 +37,7 @@ import {
   TableScrollable
 } from '../../components/reports/common'
 import { FlexRow } from '../../components/common/styled/containers'
+import { RequireRole } from '../../utils/roles'
 
 const StyledTd = styled(Td)`
   white-space: nowrap;
@@ -207,6 +209,7 @@ function Occupancies() {
     type: 'UNIT_CONFIRMED'
   })
   const [usedValues, setUsedValues] = useState<ValueOnReport>('percentage')
+  const [useNewServiceNeeds, setUseNewServiceNeeds] = useState(false)
 
   useEffect(() => {
     void getAreas().then((res) => res.isSuccess && setAreas(res.value))
@@ -216,8 +219,8 @@ function Occupancies() {
     if (filters.careAreaId == '') return
 
     setRows(Loading.of())
-    void getOccupanciesReport(filters).then(setRows)
-  }, [filters])
+    void getOccupanciesReport(filters, useNewServiceNeeds).then(setRows)
+  }, [filters, useNewServiceNeeds])
 
   const dates = getDisplayDates(filters.year, filters.month, filters.type)
   const displayCells: string[][] = rows
@@ -369,6 +372,15 @@ function Occupancies() {
             />
           </Wrapper>
         </FilterRow>
+        <RequireRole oneOf={['ADMIN']}>
+          <FilterRow>
+            <Checkbox
+              label="Käytä uusia palveluntarpeita"
+              checked={useNewServiceNeeds}
+              onChange={setUseNewServiceNeeds}
+            />
+          </FilterRow>
+        </RequireRole>
         {rows.isLoading && <Loader />}
         {rows.isFailure && <span>{i18n.common.loadingFailed}</span>}
         {rows.isSuccess && filters.careAreaId != '' && (

--- a/frontend/src/employee-frontend/components/reports/Raw.tsx
+++ b/frontend/src/employee-frontend/components/reports/Raw.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import Loader from 'lib-components/atoms/Loader'
 import Title from 'lib-components/atoms/Title'
+import Checkbox from 'lib-components/atoms/form/Checkbox'
 import { useTranslation } from '../../state/i18n'
 import { Loading, Result } from 'lib-common/api'
 import { RawReportRow } from '../../types/reports'
@@ -16,6 +17,7 @@ import { DatePickerDeprecated } from 'lib-components/molecules/DatePickerDepreca
 import LocalDate from 'lib-common/local-date'
 import { FlexRow } from '../../components/common/styled/containers'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
+import { RequireRole } from '../../utils/roles'
 
 function Raw() {
   const { i18n } = useTranslation()
@@ -26,13 +28,14 @@ function Raw() {
   })
   const invertedRange = filters.to.isBefore(filters.from)
   const tooLongRange = filters.to.isAfter(filters.from.addDays(7))
+  const [useNewServiceNeeds, setUseNewServiceNeeds] = useState(false)
 
   useEffect(() => {
     setRows(Loading.of())
     if (!invertedRange && !tooLongRange) {
-      void getRawReport(filters).then(setRows)
+      void getRawReport(filters, useNewServiceNeeds).then(setRows)
     }
-  }, [filters])
+  }, [filters, invertedRange, tooLongRange, useNewServiceNeeds])
 
   const mapYesNo = (value: boolean | null | undefined) => {
     if (value === true) {
@@ -74,6 +77,16 @@ function Raw() {
             />
           </FlexRow>
         </FilterRow>
+
+        <RequireRole oneOf={['ADMIN']}>
+          <FilterRow>
+            <Checkbox
+              label="Käytä uusia palveluntarpeita"
+              checked={useNewServiceNeeds}
+              onChange={setUseNewServiceNeeds}
+            />
+          </FilterRow>
+        </RequireRole>
 
         {invertedRange ? (
           <span>Virheellinen aikaväli</span>
@@ -144,7 +157,6 @@ function Raw() {
                     { label: 'Osapäiväinen', key: 'partDay' },
                     { label: 'Osaviikkoinen', key: 'partWeek' },
                     { label: 'Vuorohoito', key: 'shiftCare' },
-                    { label: 'Valmistava', key: 'preparatory' },
                     { label: 'Tunteja viikossa', key: 'hoursPerWeek' },
                     { label: 'Tuentarve', key: 'hasAssistanceNeed' },
                     { label: 'Tuentarpeen kerroin', key: 'capacityFactor' },

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -225,7 +225,11 @@ enum class AbsenceType {
     TEMPORARY_VISITOR,
     PARENTLEAVE,
     FORCE_MAJEURE,
-    PRESENCE
+    PRESENCE;
+
+    companion object {
+        val nonAbsences = setOf(PRESENCE, PLANNED_ABSENCE)
+    }
 }
 
 data class AbsencePlacement(

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
@@ -8,6 +8,8 @@ import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.util.UUID
 
+const val youngChildOccupancyCoefficient = "1.75"
+
 enum class OccupancyType {
     PLANNED,
     CONFIRMED,
@@ -152,8 +154,8 @@ private fun coefficients(excludeAbsent: Boolean, includeGroups: Boolean) =
             WHEN age IS NULL THEN 0.0
             WHEN placement_type IS NULL THEN 0.0
             ${if (excludeAbsent) "WHEN absent THEN 0.0" else ""}
-            WHEN is_family_unit THEN 1.75
-            WHEN age < 3 THEN 1.75
+            WHEN is_family_unit THEN $youngChildOccupancyCoefficient
+            WHEN age < 3 THEN $youngChildOccupancyCoefficient
             WHEN placement_type = 'DAYCARE_PART_TIME_FIVE_YEAR_OLDS' AND COALESCE(hours, 0.0) <= 20.0 THEN 0.5
             WHEN placement_type IN ('DAYCARE_FIVE_YEAR_OLDS', 'DAYCARE_PART_TIME_FIVE_YEAR_OLDS') AND hours <= 20 THEN 0.5
             WHEN placement_type IN ('DAYCARE_PART_TIME', 'TEMPORARY_DAYCARE_PART_DAY') THEN 0.54
@@ -208,8 +210,8 @@ private val plannedCoefficients =
         updated,
         coalesce(assistance_coefficient, 1.0) * (CASE
             WHEN age IS NULL THEN 0.0
-            WHEN is_family_unit THEN 1.75
-            WHEN age < 3 THEN 1.75
+            WHEN is_family_unit THEN $youngChildOccupancyCoefficient
+            WHEN age < 3 THEN $youngChildOccupancyCoefficient
             WHEN placement_type = 'DAYCARE_PART_TIME' AND (term_start_year - birth_year) = 5 THEN 0.5
             WHEN placement_type = 'DAYCARE_PART_TIME' THEN 0.54
             WHEN placement_type = 'PRESCHOOL' THEN 0.5

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.occupancy.OccupancyType
 import fi.espoo.evaka.occupancy.getSql
+import fi.espoo.evaka.occupancy.youngChildOccupancyCoefficient
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -456,8 +457,8 @@ WHERE sn.placement_id = ANY(:placementIds)
             ?: error("No date of birth found for child ${placement.childId}")
 
         val serviceNeedCoefficient = when {
-            placement.familyUnitPlacement -> BigDecimal("1.75")
-            date < dateOfBirth.plusYears(3) -> BigDecimal("1.75")
+            placement.familyUnitPlacement -> BigDecimal(youngChildOccupancyCoefficient)
+            date < dateOfBirth.plusYears(3) -> BigDecimal(youngChildOccupancyCoefficient)
             else -> serviceNeedCoefficients[placement.id]
                 ?.let { placementServiceNeeds ->
                     placementServiceNeeds.find { it.period.includes(date) }?.occupancyCoefficient

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -5,18 +5,25 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.occupancy.OccupancyType
 import fi.espoo.evaka.occupancy.getSql
+import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
+import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import org.jdbi.v3.core.kotlin.mapTo
+import org.jdbi.v3.core.mapper.Nested
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.LocalDate
 import java.util.UUID
 
@@ -29,7 +36,8 @@ class OccupancyReportController {
         @RequestParam type: OccupancyType,
         @RequestParam careAreaId: UUID,
         @RequestParam year: Int,
-        @RequestParam month: Int
+        @RequestParam month: Int,
+        @RequestParam(required = false) useNewServiceNeeds: Boolean? = false
     ): ResponseEntity<List<OccupancyUnitReportResultRow>> {
         Audit.OccupancyReportRead.log(targetId = careAreaId)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.DIRECTOR)
@@ -37,46 +45,52 @@ class OccupancyReportController {
         val to = from.plusMonths(1).minusDays(1)
 
         val occupancies = db.read {
-            it.calculateOccupancyUnitReport(
-                careAreaId,
-                FiniteDateRange(from, to),
-                type
-            )
-        }
-
-        val result = occupancies
-            .groupBy(
-                { UnitKey(it.unitId, it.unitName) },
-                {
-                    OccupancyReportRowGroupedValuesDaily(
-                        date = it.date,
-                        sum = it.sum,
-                        headcount = it.headcount,
-                        caretakers = it.caretakers,
-                        percentage = it.percentage
-                    )
-                }
-            )
-            .entries
-            .map { entry ->
-                OccupancyUnitReportResultRow(
-                    unitId = entry.key.unitId,
-                    unitName = entry.key.unitName,
-                    occupancies = entry.value.associateBy(
-                        { it.date },
+            if (useNewServiceNeeds == true)
+                it.calculateOccupancyUnitReportV2(
+                    LocalDate.now(),
+                    careAreaId,
+                    FiniteDateRange(from, to),
+                    type
+                )
+            else
+                it.calculateOccupancyUnitReport(
+                    careAreaId,
+                    FiniteDateRange(from, to),
+                    type
+                )
+                    .groupBy(
+                        { UnitKey(it.unitId, it.unitName) },
                         {
-                            OccupancyReportRowGroupedValues(
+                            OccupancyReportRowGroupedValuesDaily(
+                                date = it.date,
                                 sum = it.sum,
                                 headcount = it.headcount,
                                 caretakers = it.caretakers,
                                 percentage = it.percentage
                             )
                         }
-                    ).toSortedMap()
-                )
-            }.sortedBy { it.unitName }
+                    )
+                    .entries
+                    .map { entry ->
+                        OccupancyUnitReportResultRow(
+                            unitId = entry.key.unitId,
+                            unitName = entry.key.unitName,
+                            occupancies = entry.value.associateBy(
+                                { it.date },
+                                {
+                                    OccupancyReportRowGroupedValues(
+                                        sum = it.sum,
+                                        headcount = it.headcount,
+                                        caretakers = it.caretakers,
+                                        percentage = it.percentage
+                                    )
+                                }
+                            ).toSortedMap()
+                        )
+                    }.sortedBy { it.unitName }
+        }
 
-        return ResponseEntity.ok(result)
+        return ResponseEntity.ok(occupancies)
     }
 
     @GetMapping("/reports/occupancy-by-group")
@@ -272,4 +286,224 @@ private fun Database.Read.calculateOccupancyGroupReport(
         .list()
         .filter { (isOperationDay, _) -> isOperationDay }
         .map { (_, reportRow) -> reportRow }
+}
+
+private data class Caretakers(
+    @Nested
+    val unit: UnitKey,
+    val date: LocalDate,
+    val caretakerCount: BigDecimal
+)
+
+private data class Placement(
+    val id: UUID,
+    val childId: UUID,
+    val unitId: UUID,
+    val type: PlacementType,
+    val familyUnitPlacement: Boolean,
+    val period: FiniteDateRange
+)
+
+private data class Child(
+    val id: UUID,
+    val dateOfBirth: LocalDate
+)
+
+private data class ServiceNeed(
+    val placementId: UUID,
+    val occupancyCoefficient: BigDecimal,
+    val period: FiniteDateRange
+)
+
+private data class AssistanceNeed(
+    val childId: UUID,
+    val capacityFactor: BigDecimal,
+    val period: FiniteDateRange
+)
+
+private data class Absence(
+    val childId: UUID,
+    val date: LocalDate
+)
+
+private fun Database.Read.calculateOccupancyUnitReportV2(
+    today: LocalDate,
+    areaId: UUID,
+    queryPeriod: FiniteDateRange,
+    type: OccupancyType
+): List<OccupancyUnitReportResultRow> {
+    val period =
+        if (type == OccupancyType.REALIZED) queryPeriod.copy(end = minOf(queryPeriod.end, today))
+        else queryPeriod
+
+    if (period.start.plusDays(50) < period.end) {
+        throw BadRequest("Date range ${period.start} - ${period.end} is too long. Maximum range is 50 days.")
+    }
+
+    val caretakers =
+        if (type == OccupancyType.REALIZED)
+            this.createQuery(
+                """
+SELECT u.id AS unit_id, u.name AS unit_name, t::date AS date, coalesce(sum(s.count), 0.0) AS caretaker_count
+FROM generate_series(:start, :end, '1 day') t
+CROSS JOIN daycare_group g
+JOIN daycare u ON g.daycare_id = u.id AND u.care_area_id = :areaId AND t BETWEEN g.start_date AND g.end_date AND NOT 'CLUB'::care_types = ANY(u.type)
+LEFT JOIN staff_attendance s ON g.id = s.group_id AND t = s.date
+LEFT JOIN holiday h ON t = h.date AND NOT u.operation_days @> ARRAY[1, 2, 3, 4, 5, 6, 7]
+WHERE date_part('isodow', t) = ANY(u.operation_days) AND h.date IS NULL
+GROUP BY u.id, t
+"""
+            )
+                .bind("areaId", areaId)
+                .bind("start", period.start)
+                .bind("end", period.end)
+                .mapTo<Caretakers>()
+                .groupBy { it.unit }
+        else
+            this.createQuery(
+                """
+SELECT u.id AS unit_id, u.name AS unit_name, t::date AS date, coalesce(sum(c.amount), 0.0) AS caretaker_count
+FROM generate_series(:start, :end, '1 day') t
+CROSS JOIN daycare_group g
+JOIN daycare u ON g.daycare_id = u.id AND u.care_area_id = :areaId AND t BETWEEN g.start_date AND g.end_date AND NOT 'CLUB'::care_types = ANY(u.type)
+LEFT JOIN daycare_caretaker c ON g.id = c.group_id AND t BETWEEN c.start_date AND c.end_date
+LEFT JOIN holiday h ON t = h.date AND NOT u.operation_days @> ARRAY[1, 2, 3, 4, 5, 6, 7]
+WHERE date_part('isodow', t) = ANY(u.operation_days) AND h.date IS NULL
+GROUP BY u.id, t
+"""
+            )
+                .bind("areaId", areaId)
+                .bind("start", period.start)
+                .bind("end", period.end)
+                .mapTo<Caretakers>()
+                .groupBy { it.unit }
+
+    val placements = this.createQuery(
+        """
+SELECT p.id, p.child_id, p.unit_id, p.type, u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] AS family_unit_placement, daterange(p.start_date, p.end_date, '[]') AS period
+FROM placement p
+JOIN daycare u ON p.unit_id = u.id AND u.care_area_id = :areaId
+WHERE daterange(p.start_date, p.end_date, '[]') && :period
+"""
+    )
+        .bind("areaId", areaId)
+        .bind("period", period)
+        .mapTo<Placement>()
+
+    val placementPlans =
+        if (type == OccupancyType.PLANNED)
+            this.createQuery(
+                """
+SELECT p.id, a.child_id, p.unit_id, p.type, u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] AS family_unit_placement, daterange(p.start_date, p.end_date, '[]') AS period
+FROM placement_plan p
+JOIN application a ON p.application_id = a.id
+JOIN daycare u ON p.unit_id = u.id AND u.care_area_id = :areaId
+WHERE NOT p.deleted AND daterange(p.start_date, p.end_date, '[]') && :period
+"""
+            )
+                .bind("areaId", areaId)
+                .bind("period", period)
+                .mapTo<Placement>()
+        else
+            listOf()
+
+    val childIds = (placements.map { it.childId } + placementPlans.map { it.childId }).toTypedArray()
+    val childBirthdays = this.createQuery("SELECT id, date_of_birth FROM person WHERE id = ANY(:childIds)")
+        .bind("childIds", childIds)
+        .mapTo<Child>()
+        .map { it.id to it.dateOfBirth }
+        .toMap()
+
+    val serviceNeedCoefficients = this.createQuery(
+        """
+SELECT sn.placement_id, sno.occupancy_coefficient, daterange(sn.start_date, sn.end_date, '[]') AS period
+FROM new_service_need sn
+JOIN service_need_option sno ON sn.option_id = sno.id
+WHERE sn.placement_id = ANY(:placementIds)
+"""
+    )
+        .bind("placementIds", placements.map { it.id }.toList().toTypedArray())
+        .mapTo<ServiceNeed>()
+        .groupBy { it.placementId }
+
+    val defaultServiceNeedCoefficients = this.createQuery("SELECT occupancy_coefficient, valid_placement_type FROM service_need_option WHERE default_option")
+        .map { row -> row.mapColumn<PlacementType>("valid_placement_type") to row.mapColumn<BigDecimal>("occupancy_coefficient") }
+        .toMap()
+
+    val assistanceNeedCoefficients = this.createQuery("SELECT child_id, capacity_factor, daterange(start_date, end_date, '[]') AS period FROM assistance_need WHERE child_id = ANY(:childIds)")
+        .bind("childIds", childIds)
+        .mapTo<AssistanceNeed>()
+        .groupBy { it.childId }
+
+    val absences =
+        if (type == OccupancyType.REALIZED)
+            this.createQuery("SELECT child_id, date FROM absence WHERE child_id = ANY(:childIds) AND :period @> date AND NOT absence_type = ANY(:nonAbsences)")
+                .bind("childIds", childIds)
+                .bind("period", period)
+                .bind("nonAbsences", AbsenceType.nonAbsences.toTypedArray())
+                .mapTo<Absence>()
+                .groupBy { it.childId }
+        else
+            mapOf()
+
+    fun getCoefficient(date: LocalDate, placement: Placement): BigDecimal {
+        val assistanceCoefficient = assistanceNeedCoefficients[placement.childId]
+            ?.find { it.period.includes(date) }
+            ?.capacityFactor
+            ?: BigDecimal.ONE
+
+        val dateOfBirth = childBirthdays[placement.childId]
+            ?: error("No date of birth found for child ${placement.childId}")
+
+        val serviceNeedCoefficient = when {
+            placement.familyUnitPlacement -> BigDecimal("1.75")
+            date < dateOfBirth.plusYears(3) -> BigDecimal("1.75")
+            else -> serviceNeedCoefficients[placement.id]
+                ?.let { placementServiceNeeds ->
+                    placementServiceNeeds.find { it.period.includes(date) }?.occupancyCoefficient
+                }
+                ?: defaultServiceNeedCoefficients[placement.type]
+                ?: error("No default service need found for placement type ${placement.type}")
+        }
+
+        return assistanceCoefficient * serviceNeedCoefficient
+    }
+
+    val placementsAndPlans = (placements + placementPlans).groupBy { it.unitId }
+
+    return caretakers
+        .map { (unit, values) ->
+            val occupancies = values
+                .associate { (_, date, caretakers) ->
+                    val unitPlacementsOnDate = (placementsAndPlans[unit.unitId] ?: listOf())
+                        .filter { it.period.includes(date) }
+                        .filterNot { absences[it.childId]?.any { absence -> absence.date == date } ?: false }
+
+                    val sum = unitPlacementsOnDate
+                        .groupBy { it.childId }
+                        .mapNotNull { (_, placements) -> placements.map { getCoefficient(date, it) }.maxOrNull() }
+                        .fold(BigDecimal.ZERO) { sum, value -> sum + value }
+
+                    val percentage =
+                        if (caretakers.compareTo(BigDecimal.ZERO) == 0) null
+                        else sum
+                            .divide(caretakers * BigDecimal(7), 10, RoundingMode.HALF_UP)
+                            .times(BigDecimal(100))
+                            .setScale(1, RoundingMode.HALF_UP)
+
+                    date to OccupancyReportRowGroupedValues(
+                        sum = sum.toDouble(),
+                        headcount = unitPlacementsOnDate.size,
+                        percentage = percentage?.toDouble(),
+                        caretakers = caretakers.toDouble().takeUnless { it == 0.0 }
+                    )
+                }
+
+            OccupancyUnitReportResultRow(
+                unitId = unit.unitId,
+                unitName = unit.unitName,
+                occupancies = occupancies
+            )
+        }
+        .sortedBy { it.unitName }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.daycare.service.AbsenceType
+import fi.espoo.evaka.occupancy.youngChildOccupancyCoefficient
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -144,8 +145,8 @@ private fun Database.Read.getRawRows(from: LocalDate, to: LocalDate): List<RawRe
                 coalesce(capacity_factor, 1.0) * (CASE
                     WHEN age IS NULL THEN 0.0
                     WHEN placement_type IS NULL THEN 0.0
-                    WHEN is_family_unit THEN 1.75
-                    WHEN age < 3 THEN 1.75
+                    WHEN is_family_unit THEN $youngChildOccupancyCoefficient
+                    WHEN age < 3 THEN $youngChildOccupancyCoefficient
                     WHEN placement_type = 'DAYCARE_PART_TIME_FIVE_YEAR_OLDS' AND COALESCE(hours_per_week, 0.0) <= 20.0 THEN 0.5
                     WHEN placement_type = 'DAYCARE_PART_TIME' AND (term_start_year - birth_year) = 5 AND COALESCE(hours_per_week, 0.0) <= 20.0 THEN 0.5
                     WHEN placement_type IN ('DAYCARE_FIVE_YEAR_OLDS', 'DAYCARE_PART_TIME_FIVE_YEAR_OLDS') AND hours_per_week <= 20 THEN 0.5
@@ -241,8 +242,8 @@ SELECT
     an IS NOT NULL as has_assistance_need,
     coalesce(an.capacity_factor, 1.0) as capacity_factor,
     coalesce(capacity_factor, 1.0) * (CASE
-        WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN 1.75
-        WHEN date_part('year', age(t::date, p.date_of_birth)) < 3 THEN 1.75
+        WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN $youngChildOccupancyCoefficient
+        WHEN date_part('year', age(t::date, p.date_of_birth)) < 3 THEN $youngChildOccupancyCoefficient
         ELSE coalesce(sno.occupancy_coefficient, default_sno.occupancy_coefficient)
     END) AS capacity,
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -30,14 +30,20 @@ class RawReportController {
         db: Database,
         user: AuthenticatedUser,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
-        @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
+        @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+        @RequestParam("useNewServiceNeeds", required = false) useNewServiceNeeds: Boolean?
     ): ResponseEntity<List<RawReportRow>> {
         Audit.RawReportRead.log()
         user.requireOneOfRoles(UserRole.DIRECTOR, UserRole.ADMIN)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
         if (to.isAfter(from.plusDays(7))) throw BadRequest("Time range too long")
 
-        return db.read { it.getRawRows(from, to) }.let(::ok)
+        return db.read {
+            if (useNewServiceNeeds == true)
+                it.getRawRowsWithNewServiceNeeds(from, to)
+            else
+                it.getRawRows(from, to)
+        }.let(::ok)
     }
 }
 
@@ -157,6 +163,112 @@ private fun Database.Read.getRawRows(from: LocalDate, to: LocalDate): List<RawRe
             FROM data
             order by child_id, day;
         """.trimIndent()
+
+    @Suppress("UNCHECKED_CAST")
+    return createQuery(sql)
+        .bind("start_date", from)
+        .bind("end_date", to)
+        .map { rs, _ ->
+            RawReportRow(
+                day = rs.getDate("day").toLocalDate(),
+                childId = rs.getUUID("child_id"),
+                dateOfBirth = rs.getDate("date_of_birth").toLocalDate(),
+                age = rs.getInt("age"),
+                language = rs.getString("language"),
+                postOffice = rs.getString("post_office"),
+                placementType = rs.getEnum("placement_type"),
+                unitId = rs.getUUID("unit_id"),
+                unitName = rs.getString("unit_name"),
+                careArea = rs.getString("care_area"),
+                unitType = (rs.getArray("unit_type").array as Array<out Any>).map { it.toString() }.toSet().let(::getPrimaryUnitType),
+                unitProviderType = rs.getString("unit_provider_type"),
+                daycareGroupId = rs.getNullableUUID("daycare_group_id"),
+                groupName = rs.getString("group_name"),
+                caretakersPlanned = rs.getBigDecimal("caretakers_planned")?.toDouble(),
+                caretakersRealized = rs.getBigDecimal("caretakers_realized")?.toDouble(),
+                backupUnitId = rs.getNullableUUID("backup_unit_id"),
+                backupGroupId = rs.getNullableUUID("backup_group_id"),
+                hasServiceNeed = rs.getBoolean("has_service_need"),
+                partDay = rs.getBoolean("part_day"),
+                partWeek = rs.getBoolean("part_week"),
+                shiftCare = rs.getBoolean("shift_care"),
+                hoursPerWeek = rs.getDouble("hours_per_week"),
+                hasAssistanceNeed = rs.getBoolean("has_assistance_need"),
+                capacityFactor = rs.getBigDecimal("capacity_factor").toDouble(),
+                capacity = rs.getBigDecimal("capacity").toDouble(),
+                absencePaid = rs.getString("absence_paid")?.let { AbsenceType.valueOf(it) },
+                absenceFree = rs.getString("absence_free")?.let { AbsenceType.valueOf(it) }
+            )
+        }
+        .toList()
+}
+
+private fun Database.Read.getRawRowsWithNewServiceNeeds(from: LocalDate, to: LocalDate): List<RawReportRow> {
+    // language=sql
+    val sql =
+        """
+SELECT
+    t::date as day,
+    p.id as child_id,
+    p.date_of_birth,
+    date_part('year', p.date_of_birth) as birth_year,
+    date_part('year', age(t::date, p.date_of_birth)) as age,
+    p.language,
+    p.post_office,
+
+    pl.type as placement_type,
+
+    pl.unit_id,
+    u.name as unit_name,
+    ca.name AS care_area,
+    u.type as unit_type,
+    u.provider_type as unit_provider_type,
+
+    dgp.daycare_group_id,
+    dg.name as group_name,
+    dc.amount as caretakers_planned,
+    sa.count as caretakers_realized,
+
+    bc.unit_id as backup_unit_id,
+    bc.group_id as backup_group_id,
+
+    sn IS NOT NULL AS has_service_need,
+    sno.part_day,
+    sno.part_week,
+    sn.shift_care,
+    sno.daycare_hours_per_week AS hours_per_week,
+
+    an IS NOT NULL as has_assistance_need,
+    coalesce(an.capacity_factor, 1.0) as capacity_factor,
+    coalesce(capacity_factor, 1.0) * (CASE
+        WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN 1.75
+        WHEN date_part('year', age(t::date, p.date_of_birth)) < 3 THEN 1.75
+        ELSE coalesce(sno.occupancy_coefficient, default_sno.occupancy_coefficient)
+    END) AS capacity,
+
+    ab1.absence_type as absence_paid,
+    ab2.absence_type as absence_free
+FROM generate_series(:start_date, :end_date, '1 day') t
+JOIN placement pl ON daterange(pl.start_date, pl.end_date, '[]') @> t::date
+JOIN daycare u on u.id = pl.unit_id
+JOIN care_area ca ON ca.id = u.care_area_id
+JOIN person p ON p.id = pl.child_id
+LEFT JOIN daycare_group_placement dgp on pl.id = dgp.daycare_placement_id AND daterange(dgp.start_date, dgp.end_date, '[]') @> t::date
+LEFT JOIN daycare_group dg on dg.id = dgp.daycare_group_id
+LEFT JOIN daycare_caretaker dc on dg.id = dc.group_id AND daterange(dc.start_date, dc.end_date, '[]') @> t::date
+LEFT JOIN staff_attendance sa on dg.id = sa.group_id AND sa.date = t::date
+LEFT JOIN backup_care bc on bc.child_id = p.id AND daterange(bc.start_date, bc.end_date, '[]') @> t::date
+LEFT JOIN daycare bcu on bc.unit_id = bcu.id
+LEFT JOIN new_service_need sn on sn.placement_id = pl.id AND daterange(sn.start_date, sn.end_date, '[]') @> t::date
+LEFT JOIN service_need_option sno on sn.option_id = sno.id
+LEFT JOIN service_need_option default_sno on pl.type = default_sno.valid_placement_type AND default_sno.default_option
+LEFT JOIN assistance_need an on an.child_id = p.id AND daterange(an.start_date, an.end_date, '[]') @> t::date
+LEFT JOIN absence ab1 on ab1.child_id = p.id and ab1.date = t::date and ab1.absence_type != 'PRESENCE' AND ab1.care_type IN ('DAYCARE', 'PRESCHOOL_DAYCARE')
+LEFT JOIN absence ab2 on ab2.child_id = p.id and ab2.date = t::date and ab2.absence_type != 'PRESENCE' AND ab2.care_type NOT IN ('DAYCARE', 'PRESCHOOL_DAYCARE')
+LEFT JOIN holiday ON t = holiday.date AND NOT (u.operation_days @> ARRAY[1, 2, 3, 4, 5, 6, 7] OR bcu.operation_days @> ARRAY[1, 2, 3, 4, 5, 6, 7])
+WHERE (date_part('isodow', t) = ANY(u.operation_days) OR date_part('isodow', t) = ANY(bcu.operation_days)) AND holiday.date IS NULL
+ORDER BY p.id, t
+"""
 
     @Suppress("UNCHECKED_CAST")
     return createQuery(sql)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add toggles for using new service needs to occupancy and raw reports. Implement the occupancy report with most of the computations done in kotlin code to make the implementation easier to read. If the performance hit is too big, revert back to the single database query.

The group occupancy reports are not implemented yet because they take a bit more work to implement and it's good to test the performance part first.