### PR TITLE
[EVAKA-HOTFIX] Harden SAML configuration for replay attacks, audience confusion

### DIFF
--- a/apigw/src/shared/auth/ad-saml.ts
+++ b/apigw/src/shared/auth/ad-saml.ts
@@ -101,20 +101,19 @@ export default function createAdStrategy(): SamlStrategy | DevPassportStrategy {
     if (!adConfig) throw Error('Missing AD SAML configuration')
     return new SamlStrategy(
       {
+        acceptedClockSkewMs: 0,
+        audience: adConfig.issuer,
         callbackUrl: adConfig.callbackUrl,
-        entryPoint: adConfig.entryPointUrl,
-        logoutUrl: adConfig.logoutUrl,
-        issuer: adConfig.issuer,
         cert: adConfig.publicCert.map(
           (certificateName) => certificates[certificateName]
         ),
-        privateCert: readFileSync(adConfig.privateCert, {
-          encoding: 'utf8'
-        }),
-        identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
         disableRequestedAuthnContext: true,
-        signatureAlgorithm: 'sha256',
-        acceptedClockSkewMs: 0
+        entryPoint: adConfig.entryPointUrl,
+        identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+        issuer: adConfig.issuer,
+        logoutUrl: adConfig.logoutUrl,
+        privateCert: readFileSync(adConfig.privateCert, { encoding: 'utf8' }),
+        signatureAlgorithm: 'sha256'
       },
       (profile: Profile, done: VerifiedCallback) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apigw/src/shared/auth/ad-saml.ts
+++ b/apigw/src/shared/auth/ad-saml.ts
@@ -114,7 +114,7 @@ export default function createAdStrategy(): SamlStrategy | DevPassportStrategy {
         identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
         disableRequestedAuthnContext: true,
         signatureAlgorithm: 'sha256',
-        acceptedClockSkewMs: -1
+        acceptedClockSkewMs: 0
       },
       (profile: Profile, done: VerifiedCallback) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apigw/src/shared/auth/keycloak-saml.ts
+++ b/apigw/src/shared/auth/keycloak-saml.ts
@@ -22,15 +22,16 @@ export default function createKeycloakSamlStrategy(): SamlStrategy {
   })
   return new SamlStrategy(
     {
-      issuer: 'evaka',
-      callbackUrl: evakaSamlConfig.callbackUrl,
-      entryPoint: evakaSamlConfig.entryPoint,
-      logoutUrl: evakaSamlConfig.entryPoint,
       acceptedClockSkewMs: 0,
+      audience: evakaSamlConfig.issuer,
+      callbackUrl: evakaSamlConfig.callbackUrl,
       cert: publicCert,
-      privateCert: privateCert,
       decryptionPvk: privateCert,
+      entryPoint: evakaSamlConfig.entryPoint,
       identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+      issuer: 'evaka',
+      logoutUrl: evakaSamlConfig.entryPoint,
+      privateCert: privateCert,
       signatureAlgorithm: 'sha256'
     },
     (profile: Profile, done: VerifiedCallback) => {

--- a/apigw/src/shared/auth/keycloak-saml.ts
+++ b/apigw/src/shared/auth/keycloak-saml.ts
@@ -26,7 +26,7 @@ export default function createKeycloakSamlStrategy(): SamlStrategy {
       callbackUrl: evakaSamlConfig.callbackUrl,
       entryPoint: evakaSamlConfig.entryPoint,
       logoutUrl: evakaSamlConfig.entryPoint,
-      acceptedClockSkewMs: -1,
+      acceptedClockSkewMs: 0,
       cert: publicCert,
       privateCert: privateCert,
       decryptionPvk: privateCert,

--- a/apigw/src/shared/auth/suomi-fi-saml.ts
+++ b/apigw/src/shared/auth/suomi-fi-saml.ts
@@ -78,7 +78,7 @@ export default function createSuomiFiStrategy(): Strategy | DummyStrategy {
         identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
         disableRequestedAuthnContext: true,
         signatureAlgorithm: 'sha256',
-        acceptedClockSkewMs: -1
+        acceptedClockSkewMs: 0
       },
       (profile: Profile, done: VerifiedCallback) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apigw/src/shared/auth/suomi-fi-saml.ts
+++ b/apigw/src/shared/auth/suomi-fi-saml.ts
@@ -66,19 +66,20 @@ export default function createSuomiFiStrategy(): Strategy | DummyStrategy {
     })
     return new Strategy(
       {
+        acceptedClockSkewMs: 0,
+        audience: sfiConfig.issuer,
         callbackUrl: sfiConfig.callbackUrl,
-        entryPoint: sfiConfig.entryPoint,
-        logoutUrl: sfiConfig.logoutUrl,
-        issuer: sfiConfig.issuer,
         cert: sfiConfig.publicCert.map(
           (certificateName) => certificates[certificateName]
         ),
-        privateCert: privateCert,
         decryptionPvk: privateCert,
-        identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
         disableRequestedAuthnContext: true,
-        signatureAlgorithm: 'sha256',
-        acceptedClockSkewMs: 0
+        entryPoint: sfiConfig.entryPoint,
+        identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+        issuer: sfiConfig.issuer,
+        logoutUrl: sfiConfig.logoutUrl,
+        privateCert: privateCert,
+        signatureAlgorithm: 'sha256'
       },
       (profile: Profile, done: VerifiedCallback) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -193,6 +193,13 @@ export const evakaSamlConfig = evakaCallbackUrl
             'http://localhost:8080/auth/realms/evaka/protocol/saml'
           )
       ),
+      issuer: required(
+        process.env.EVAKA_SAML_ISSUER ??
+          ifNodeEnv(
+            ['local', 'test'],
+            'http://localhost:8080/auth/realms/evaka'
+          )
+      ),
       publicCert: required(
         process.env.EVAKA_SAML_PUBLIC_CERT ??
           ifNodeEnv(['local', 'test'], 'config/test-cert/keycloak-local.pem')


### PR DESCRIPTION
#### Summary
This is part 2 of the SAML configuration hardenings/fixes as reported by a white hat. SLO fixes are in progress in #738 and `InResponseTo` checking will follow later.

- APIGW: Enable SAML audience checking
    - Audience checking for SAML responses is one way to prevent attackers from reusing e.g. login responses intended for another SP (from a trusted IdP) to log into eVaka
        - Without audience checking, eVaka would only check that the message came from a trusted IdP and would allow login/logout -> any user that can log in the IdP (AD mainly, in this case) can log into eVaka even if the IdP wouldn't permit it (e.g. missing AD role to access eVaka)
    - Add new configuration for "eVaka SAML" (i.e. Keycloak), `EVAKA_SAML_ISSUER` for use as the expected audience (same for Suomi.fi and AD but they already have equivalent configs exposed)
- APIGW: Enable notOnOrAfter SAML validation
    - This limits replay attack feasibility by enabling the SAML `notOnOrAfter` checks in `passport-saml` meaning that responses are only valid as long as described by themselves in the aforementioned property
    - The value -1 for `acceptedClockSkewMs` disables this check completely, meaning that SAML responses can be replayed indefinitely (or at least while the certificates in them are valid)

#### Dependencies
- https://github.com/espoon-voltti/evaka-infra/pull/401