### PR TITLE
Move domain queries under `Database` wrapper, part 2

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -322,7 +322,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         }
         db.read { tx ->
             // then
-            val guardian = tx.handle.getPersonById(testAdult_5.id)!!
+            val guardian = tx.getPersonById(testAdult_5.id)!!
             assertEquals("abc@espoo.fi", guardian.email)
             assertEquals("0501234567", guardian.phone)
         }
@@ -347,7 +347,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         }
         db.read { tx ->
             // then
-            val guardian = tx.handle.getPersonById(testAdult_6.id)!!
+            val guardian = tx.getPersonById(testAdult_6.id)!!
             assertEquals(testAdult_6.email, guardian.email)
             assertEquals("0501234567", guardian.phone)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -370,7 +370,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         }
         db.read { tx ->
             // then
-            val childDetails = tx.handle.getChild(testChild_6.id)!!.additionalInformation
+            val childDetails = tx.getChild(testChild_6.id)!!.additionalInformation
             assertEquals("diet", childDetails.diet)
             assertEquals("allergies", childDetails.allergies)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -1077,7 +1077,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val placementPlan = tx.getPlacementPlan(applicationId)
             assertNotNull(placementPlan)
 
-            val placements = tx.handle.getPlacementsForChild(testChild_2.id)
+            val placements = tx.getPlacementsForChild(testChild_2.id)
             assertEquals(0, placements.size)
         }
     }
@@ -1176,7 +1176,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val placementPlan = tx.getPlacementPlan(applicationId)
             assertNull(placementPlan)
 
-            val placements = tx.handle.getPlacementsForChild(testChild_6.id)
+            val placements = tx.getPlacementsForChild(testChild_6.id)
             assertEquals(0, placements.size)
         }
     }
@@ -1217,7 +1217,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val placementPlan = tx.getPlacementPlan(applicationId)
             assertNull(placementPlan)
 
-            val placements = tx.handle.getPlacementsForChild(testChild_6.id)
+            val placements = tx.getPlacementsForChild(testChild_6.id)
             assertEquals(1, placements.size)
             with(placements.first()) {
                 assertEquals(mainPeriod.start, startDate)
@@ -1921,7 +1921,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val placementPlan = tx.getPlacementPlan(applicationId)
             assertNull(placementPlan)
 
-            val placements = tx.handle.getPlacementsForChild(testChild_6.id)
+            val placements = tx.getPlacementsForChild(testChild_6.id)
             assertEquals(2, placements.size)
             with(placements.first { it.type == PlacementType.PRESCHOOL_DAYCARE }) {
                 assertEquals(connectedPeriod.start, startDate)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -495,7 +495,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_DECISION, application.status)
 
-            val placementPlan = getPlacementPlan(tx.handle, applicationId)!!
+            val placementPlan = tx.getPlacementPlan(applicationId)!!
             assertEquals(
                 PlacementPlan(
                     id = placementPlan.id,
@@ -553,7 +553,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_DECISION, application.status)
 
-            val placementPlan = getPlacementPlan(tx.handle, applicationId)!!
+            val placementPlan = tx.getPlacementPlan(applicationId)!!
             assertEquals(
                 PlacementPlan(
                     id = placementPlan.id,
@@ -611,7 +611,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_DECISION, application.status)
 
-            val placementPlan = getPlacementPlan(tx.handle, applicationId)!!
+            val placementPlan = tx.getPlacementPlan(applicationId)!!
             assertEquals(
                 PlacementPlan(
                     id = placementPlan.id,
@@ -686,7 +686,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_DECISION, application.status)
 
-            val placementPlan = getPlacementPlan(tx.handle, applicationId)!!
+            val placementPlan = tx.getPlacementPlan(applicationId)!!
             assertEquals(
                 PlacementPlan(
                     id = placementPlan.id,
@@ -762,7 +762,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_PLACEMENT, application.status)
 
-            val placementPlan = getPlacementPlan(tx.handle, applicationId)
+            val placementPlan = tx.getPlacementPlan(applicationId)
             assertEquals(null, placementPlan)
 
             val decisionDrafts = tx.fetchDecisionDrafts(applicationId)
@@ -1074,7 +1074,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val messages = MockEvakaMessageClient.getMessages()
             assertEquals(0, messages.size)
 
-            val placementPlan = getPlacementPlan(tx.handle, applicationId)
+            val placementPlan = tx.getPlacementPlan(applicationId)
             assertNotNull(placementPlan)
 
             val placements = tx.handle.getPlacementsForChild(testChild_2.id)
@@ -1173,7 +1173,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 assertEquals(DecisionStatus.REJECTED, status)
             }
 
-            val placementPlan = getPlacementPlan(tx.handle, applicationId)
+            val placementPlan = tx.getPlacementPlan(applicationId)
             assertNull(placementPlan)
 
             val placements = tx.handle.getPlacementsForChild(testChild_6.id)
@@ -1214,7 +1214,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 assertEquals(DecisionStatus.REJECTED, status)
             }
 
-            val placementPlan = getPlacementPlan(tx.handle, applicationId)
+            val placementPlan = tx.getPlacementPlan(applicationId)
             assertNull(placementPlan)
 
             val placements = tx.handle.getPlacementsForChild(testChild_6.id)
@@ -1918,7 +1918,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
                 assertEquals(DecisionStatus.ACCEPTED, status)
             }
 
-            val placementPlan = getPlacementPlan(tx.handle, applicationId)
+            val placementPlan = tx.getPlacementPlan(applicationId)
             assertNull(placementPlan)
 
             val placements = tx.handle.getPlacementsForChild(testChild_6.id)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -214,7 +213,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
 
         db.transaction { tx ->
             val data =
-                tx.handle.createQuery("""select id from application""")
+                tx.createQuery("""select id from application""")
                     .mapTo<UUID>()
                     .toList()
 
@@ -229,7 +228,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
 
         db.transaction { tx ->
             val data =
-                tx.handle.createQuery("""select id from application""")
+                tx.createQuery("""select id from application""")
                     .mapTo<UUID>()
                     .toSet()
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
@@ -33,7 +33,7 @@ class ChildrenControllerIntegrationTest : AbstractIntegrationTest() {
     internal fun setUp() {
         db.transaction { tx ->
             tx.handle.execute("INSERT INTO person (id, date_of_birth) VALUES ('$childId', '${LocalDate.now().minusYears(1)}')")
-            child = tx.handle.createChild(
+            child = tx.createChild(
                 Child(
                     id = childId,
                     additionalInformation = AdditionalInformation(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.daycare.AbstractIntegrationTest
 import fi.espoo.evaka.daycare.createChild
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.Forbidden
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -32,7 +31,7 @@ class ChildrenControllerIntegrationTest : AbstractIntegrationTest() {
     @BeforeEach
     internal fun setUp() {
         db.transaction { tx ->
-            tx.handle.execute("INSERT INTO person (id, date_of_birth) VALUES ('$childId', '${LocalDate.now().minusYears(1)}')")
+            tx.execute("INSERT INTO person (id, date_of_birth) VALUES ('$childId', '${LocalDate.now().minusYears(1)}')")
             child = tx.createChild(
                 Child(
                     id = childId,
@@ -49,9 +48,9 @@ class ChildrenControllerIntegrationTest : AbstractIntegrationTest() {
     @AfterEach
     internal fun tearDown() {
         db.transaction {
-            it.handle.execute("DELETE FROM assistance_need")
-            it.handle.execute("DELETE FROM service_need")
-            it.handle.execute("DELETE FROM person WHERE id = '$childId'")
+            it.execute("DELETE FROM assistance_need")
+            it.execute("DELETE FROM service_need")
+            it.execute("DELETE FROM person WHERE id = '$childId'")
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/CaretakerQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/CaretakerQueriesIntegrationTest.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.daycare.getGroupStats
 import fi.espoo.evaka.daycare.getUnitStats
 import fi.espoo.evaka.daycare.service.Stats
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
@@ -31,14 +30,14 @@ class CaretakerQueriesIntegrationTest : PureJdbiTest() {
     @BeforeEach
     fun setup() {
         db.transaction { tx ->
-            tx.handle.execute("INSERT INTO care_area (id, name, short_name) VALUES ('$careAreaId', 'foo', 'foo')")
-            tx.handle.execute("INSERT INTO daycare (id, name, care_area_id) VALUES ('$daycareId', 'foo', '$careAreaId')")
-            tx.handle.execute("INSERT INTO daycare (id, name, care_area_id) VALUES ('$daycareId2', 'empty daycare', '$careAreaId')")
+            tx.execute("INSERT INTO care_area (id, name, short_name) VALUES ('$careAreaId', 'foo', 'foo')")
+            tx.execute("INSERT INTO daycare (id, name, care_area_id) VALUES ('$daycareId', 'foo', '$careAreaId')")
+            tx.execute("INSERT INTO daycare (id, name, care_area_id) VALUES ('$daycareId2', 'empty daycare', '$careAreaId')")
 
-            tx.handle.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId1', 'foo', '$daycareId', '2000-01-01', '9999-01-01')")
-            tx.handle.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId2', 'bar', '$daycareId', '2000-01-01', '9999-01-01')")
-            tx.handle.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId3', 'baz', '$daycareId', '2000-01-01', '9999-01-01')")
-            tx.handle.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId4', 'empty', '$daycareId', '2000-01-01', '9999-01-01')")
+            tx.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId1', 'foo', '$daycareId', '2000-01-01', '9999-01-01')")
+            tx.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId2', 'bar', '$daycareId', '2000-01-01', '9999-01-01')")
+            tx.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId3', 'baz', '$daycareId', '2000-01-01', '9999-01-01')")
+            tx.execute("INSERT INTO daycare_group (id, name, daycare_id, start_date, end_date) VALUES ('$groupId4', 'empty', '$daycareId', '2000-01-01', '9999-01-01')")
 
             // date             01-01   02-02   02-06   03-02   03-04   05-06   09-04
             // g1               3       5       5       4       4       4       4
@@ -47,24 +46,24 @@ class CaretakerQueriesIntegrationTest : PureJdbiTest() {
             // g4               0       0       0       0       0       0       0
             // total            10      12      10      9       11      13      7
 
-            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 3, '2000-01-01', '2000-02-01')")
-            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 5, '2000-02-02', '2000-03-01')")
-            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 4, '2000-03-02', '9999-01-01')")
+            tx.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 3, '2000-01-01', '2000-02-01')")
+            tx.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 5, '2000-02-02', '2000-03-01')")
+            tx.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId1', 4, '2000-03-02', '9999-01-01')")
 
-            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 3, '2000-01-01', '2000-02-05')")
-            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 1, '2000-02-06', '2000-03-03')")
-            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 3, '2000-03-04', '9999-01-01')")
+            tx.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 3, '2000-01-01', '2000-02-05')")
+            tx.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 1, '2000-02-06', '2000-03-03')")
+            tx.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId2', 3, '2000-03-04', '9999-01-01')")
 
-            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId3', 4, '2000-01-01', '2000-05-05')")
-            tx.handle.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId3', 6, '2000-05-06', '2000-09-03')")
+            tx.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId3', 4, '2000-01-01', '2000-05-05')")
+            tx.execute("INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES ('$groupId3', 6, '2000-05-06', '2000-09-03')")
         }
     }
 
     @AfterEach
     fun tearDown() {
         db.transaction { tx ->
-            tx.handle.execute("DELETE FROM daycare WHERE id IN ('$daycareId', '$daycareId2')")
-            tx.handle.execute("DELETE FROM care_area WHERE id = '$careAreaId'")
+            tx.execute("DELETE FROM daycare WHERE id IN ('$daycareId', '$daycareId2')")
+            tx.execute("DELETE FROM care_area WHERE id = '$careAreaId'")
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/CaretakerQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/CaretakerQueriesIntegrationTest.kt
@@ -70,7 +70,7 @@ class CaretakerQueriesIntegrationTest : PureJdbiTest() {
 
     @Test
     fun `test getGroupStats`() = db.transaction { tx ->
-        val groupStats = tx.handle.getGroupStats(daycareId, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
+        val groupStats = tx.getGroupStats(daycareId, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
         assertEquals(4, groupStats.keys.size)
         assertEquals(Stats(3.0, 5.0), groupStats.get(groupId1))
         assertEquals(Stats(1.0, 3.0), groupStats.get(groupId2))
@@ -80,7 +80,7 @@ class CaretakerQueriesIntegrationTest : PureJdbiTest() {
 
     @Test
     fun `test getGroupStats with limited range`() = db.transaction { tx ->
-        val groupStats = tx.handle.getGroupStats(daycareId, LocalDate.of(2000, 2, 3), LocalDate.of(2000, 4, 1))
+        val groupStats = tx.getGroupStats(daycareId, LocalDate.of(2000, 2, 3), LocalDate.of(2000, 4, 1))
         assertEquals(4, groupStats.keys.size)
         assertEquals(Stats(4.0, 5.0), groupStats.get(groupId1))
         assertEquals(Stats(1.0, 3.0), groupStats.get(groupId2))
@@ -91,54 +91,54 @@ class CaretakerQueriesIntegrationTest : PureJdbiTest() {
     @Test
     fun `test getGroupStats with limited range 2`() = db.transaction { tx ->
         val singleDate = LocalDate.of(2000, 2, 1)
-        val groupStats = tx.handle.getGroupStats(daycareId, singleDate, singleDate)
+        val groupStats = tx.getGroupStats(daycareId, singleDate, singleDate)
         assertEquals(Stats(3.0, 3.0), groupStats.get(groupId1))
     }
 
     @Test
     fun `test getGroupStats with limited range 3`() = db.transaction { tx ->
         val singleDate = LocalDate.of(2000, 2, 2)
-        val groupStats = tx.handle.getGroupStats(daycareId, singleDate, singleDate)
+        val groupStats = tx.getGroupStats(daycareId, singleDate, singleDate)
         assertEquals(Stats(5.0, 5.0), groupStats.get(groupId1))
     }
 
     @Test
     fun `test getUnitStats`() = db.transaction { tx ->
-        val unitStats = tx.handle.getUnitStats(daycareId, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
+        val unitStats = tx.getUnitStats(daycareId, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
         assertEquals(Stats(9.0, 13.0), unitStats)
     }
 
     @Test
     fun `test getUnitStats with no groups`() = db.transaction { tx ->
-        val unitStats = tx.handle.getUnitStats(daycareId2, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
+        val unitStats = tx.getUnitStats(daycareId2, LocalDate.of(2000, 1, 1), LocalDate.of(2000, 6, 1))
         assertEquals(Stats(0.0, 0.0), unitStats)
     }
 
     @Test
     fun `test getUnitStats with limited range 1`() = db.transaction { tx ->
-        val unitStats = tx.handle.getUnitStats(daycareId, LocalDate.of(2000, 3, 1), LocalDate.of(2000, 3, 2))
+        val unitStats = tx.getUnitStats(daycareId, LocalDate.of(2000, 3, 1), LocalDate.of(2000, 3, 2))
         assertEquals(Stats(9.0, 10.0), unitStats)
     }
 
     @Test
     fun `test getUnitStats with limited range 2`() = db.transaction { tx ->
-        val unitStats = tx.handle.getUnitStats(daycareId, LocalDate.of(2000, 3, 1), LocalDate.of(2000, 3, 1))
+        val unitStats = tx.getUnitStats(daycareId, LocalDate.of(2000, 3, 1), LocalDate.of(2000, 3, 1))
         assertEquals(Stats(10.0, 10.0), unitStats)
     }
 
     @Test
     fun `test getUnitStats with limited range 3`() = db.transaction { tx ->
-        val unitStats = tx.handle.getUnitStats(daycareId, LocalDate.of(2000, 3, 2), LocalDate.of(2000, 3, 2))
+        val unitStats = tx.getUnitStats(daycareId, LocalDate.of(2000, 3, 2), LocalDate.of(2000, 3, 2))
         assertEquals(Stats(9.0, 9.0), unitStats)
     }
 
     @Test
     fun `test getUnitStats with long time range`() = db.transaction { tx ->
-        assertDoesNotThrow { tx.handle.getUnitStats(daycareId, LocalDate.of(2005, 1, 1), LocalDate.of(2010, 1, 1)) }
+        assertDoesNotThrow { tx.getUnitStats(daycareId, LocalDate.of(2005, 1, 1), LocalDate.of(2010, 1, 1)) }
     }
 
     @Test
     fun `test getUnitStats with too long time range`() = db.transaction { tx ->
-        assertThrows<BadRequest> { tx.handle.getUnitStats(daycareId, LocalDate.of(2005, 1, 1), LocalDate.of(2010, 1, 2)) }
+        assertThrows<BadRequest> { tx.getUnitStats(daycareId, LocalDate.of(2005, 1, 1), LocalDate.of(2010, 1, 2)) }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/ChildDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/ChildDAOIntegrationTest.kt
@@ -26,7 +26,7 @@ class ChildDAOIntegrationTest : AbstractIntegrationTest() {
     internal fun setUp() {
         db.transaction { tx ->
             tx.handle.execute("INSERT INTO person (id, date_of_birth) VALUES ('$childId', '${LocalDate.now().minusYears(1)}')")
-            child = tx.handle.createChild(
+            child = tx.createChild(
                 Child(
                     id = childId,
                     additionalInformation = AdditionalInformation(
@@ -46,7 +46,7 @@ class ChildDAOIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `add and fetch child data`() {
-        val fetchedChild = db.transaction { it.handle.getChild(childId) }
+        val fetchedChild = db.transaction { it.getChild(childId) }
 
         assertEquals(child, fetchedChild)
     }
@@ -61,9 +61,9 @@ class ChildDAOIntegrationTest : AbstractIntegrationTest() {
             )
         )
 
-        db.transaction { it.handle.updateChild(updated) }
+        db.transaction { it.updateChild(updated) }
 
-        val actual = db.transaction { it.handle.getChild(childId) }
+        val actual = db.transaction { it.getChild(childId) }
         assertEquals(actual, updated)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/ChildDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/ChildDAOIntegrationTest.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.daycare.controllers.Child
 import fi.espoo.evaka.daycare.createChild
 import fi.espoo.evaka.daycare.getChild
 import fi.espoo.evaka.daycare.updateChild
-import fi.espoo.evaka.shared.db.handle
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -25,7 +24,7 @@ class ChildDAOIntegrationTest : AbstractIntegrationTest() {
     @BeforeEach
     internal fun setUp() {
         db.transaction { tx ->
-            tx.handle.execute("INSERT INTO person (id, date_of_birth) VALUES ('$childId', '${LocalDate.now().minusYears(1)}')")
+            tx.execute("INSERT INTO person (id, date_of_birth) VALUES ('$childId', '${LocalDate.now().minusYears(1)}')")
             child = tx.createChild(
                 Child(
                     id = childId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/LocationServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/LocationServiceIntegrationTest.kt
@@ -99,8 +99,8 @@ class LocationServiceIntegrationTest : PureJdbiTest() {
     }
 
     private fun createDaycare(location: Location, openingDate: LocalDate? = null, closingDate: LocalDate? = null): UUID = db.transaction { tx ->
-        val id = tx.handle.createDaycare(location.care_area_id, location.name)
-        tx.handle.updateDaycare(
+        val id = tx.createDaycare(location.care_area_id, location.name)
+        tx.updateDaycare(
             id,
             DaycareFields(
                 name = location.name,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/LocationServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/LocationServiceIntegrationTest.kt
@@ -23,7 +23,6 @@ import fi.espoo.evaka.daycare.domain.ProviderType.MUNICIPAL
 import fi.espoo.evaka.daycare.domain.ProviderType.MUNICIPAL_SCHOOL
 import fi.espoo.evaka.daycare.domain.ProviderType.PRIVATE
 import fi.espoo.evaka.daycare.updateDaycare
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import org.assertj.core.api.Assertions.assertThat
@@ -65,7 +64,7 @@ class LocationServiceIntegrationTest : PureJdbiTest() {
         )
         val prepPreschoolId = createDaycare(prepPreschool)
 
-        val areas = db.transaction { it.handle.getAreas().filter { area -> area.id == areaId } }
+        val areas = db.transaction { it.getAreas().filter { area -> area.id == areaId } }
         assertThat(areas).size().isEqualTo(1)
         val locationResults = areas.first().locations
 
@@ -88,7 +87,7 @@ class LocationServiceIntegrationTest : PureJdbiTest() {
         val preschool1 = createDaycare(createGenericUnit(areaId = areaId), openingDate = LocalDate.now().minusYears(1), closingDate = LocalDate.now().plusMonths(1))
         val preschool2 = createDaycare(createGenericUnit(areaId = areaId), openingDate = LocalDate.now().plusYears(1), closingDate = LocalDate.now().plusYears(2))
 
-        val areas = db.transaction { it.handle.getAreas().filter { area -> area.id == areaId } }
+        val areas = db.transaction { it.getAreas().filter { area -> area.id == areaId } }
         assertThat(areas).size().isEqualTo(1)
         val locationResults = areas.first().locations
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
@@ -6,7 +6,6 @@ package fi.espoo.evaka.daycare.service
 
 import fi.espoo.evaka.daycare.AbstractIntegrationTest
 import fi.espoo.evaka.resetDatabase
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevDaycareGroup

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
@@ -60,7 +60,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     fun `person date of death`() {
         createTestPerson(testPerson.copy(ssn = "010180-999A"))
         dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("010180-999A"))
-        assertEquals(LocalDate.parse("2019-07-30"), db.read { it.handle.getPersonBySSN("010180-999A") }?.dateOfDeath)
+        assertEquals(LocalDate.parse("2019-07-30"), db.read { it.getPersonBySSN("010180-999A") }?.dateOfDeath)
         assertEquals(0, DvvIntegrationTestPersonService.getSsnUpdateCount("010180-999A"))
     }
 
@@ -68,7 +68,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     fun `person restricted details started`() {
         createTestPerson(testPerson.copy(ssn = "020180-999Y"))
         dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("020180-999Y"))
-        val modifiedPerson = db.read { it.handle.getPersonBySSN("020180-999Y") }!!
+        val modifiedPerson = db.read { it.getPersonBySSN("020180-999Y") }!!
         assertEquals(true, modifiedPerson.restrictedDetailsEnabled)
         assertEquals("", modifiedPerson.streetAddress)
         assertEquals("", modifiedPerson.postalCode)
@@ -80,7 +80,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     fun `person restricted details ended and address is set`() {
         createTestPerson(testPerson.copy(ssn = "030180-999L", restrictedDetailsEnabled = true, streetAddress = "", postalCode = "", postOffice = ""))
         dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("030180-999L"))
-        val modifiedPerson = db.read { it.handle.getPersonBySSN("030180-999L") }!!
+        val modifiedPerson = db.read { it.getPersonBySSN("030180-999L") }!!
         assertEquals(false, modifiedPerson.restrictedDetailsEnabled)
         assertEquals(LocalDate.parse("2030-01-01"), modifiedPerson.restrictedDetailsEndDate)
         assertEquals("Vanhakatu 10h5 3", modifiedPerson.streetAddress)
@@ -93,7 +93,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
     fun `person address change`() {
         createTestPerson(testPerson.copy(ssn = "040180-9998"))
         dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("040180-9998"))
-        val modifiedPerson = db.read { it.handle.getPersonBySSN("040180-9998") }!!
+        val modifiedPerson = db.read { it.getPersonBySSN("040180-9998") }!!
         assertEquals("Uusitie 17 A 2", modifiedPerson.streetAddress)
         assertEquals("02940", modifiedPerson.postalCode)
         assertEquals("ESPOO", modifiedPerson.postOffice)
@@ -106,8 +106,8 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         val testId = createTestPerson(testPerson.copy(ssn = "010181-999K"))
         // Should update SSN from 010181-999K to 010181-999C
         dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("010181-999K"))
-        assertEquals(testId, db.read { it.handle.getPersonBySSN("010281-999C") }?.id)
-        assertEquals(null, db.read { it.handle.getPersonBySSN("010281-999K") })
+        assertEquals(testId, db.read { it.getPersonBySSN("010281-999C") }?.id)
+        assertEquals(null, db.read { it.getPersonBySSN("010281-999K") })
         assertEquals(0, DvvIntegrationTestPersonService.getSsnUpdateCount("010281-999K"))
         assertEquals(0, DvvIntegrationTestPersonService.getSsnUpdateCount("010281-999C"))
     }
@@ -124,13 +124,13 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createVtjPerson(caretaker)
 
         dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("050180-999W"))
-        val dvvCustodian = db.read { it.handle.getPersonBySSN("050118A999W") }!!
+        val dvvCustodian = db.read { it.getPersonBySSN("050118A999W") }!!
         assertEquals("Harri", dvvCustodian.firstName)
         assertEquals("Huollettava", dvvCustodian.lastName)
         assertTrue(
             db.read { tx ->
                 tx.getChildGuardians(dvvCustodian.id)
-                    .map { tx.handle.getPersonById(it) }.filterNotNull()
+                    .map { tx.getPersonById(it) }.filterNotNull()
                     .any() { guardian -> guardian.identity.toString() == caretaker.ssn }
             }
         )
@@ -149,14 +149,14 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createVtjPerson(caretaker)
 
         dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("060118A999J"))
-        val dvvCaretaker = db.read { it.handle.getPersonBySSN("060180-999J") }!!
+        val dvvCaretaker = db.read { it.getPersonBySSN("060180-999J") }!!
         assertEquals("Harri", dvvCaretaker.firstName)
         assertEquals("Huoltaja", dvvCaretaker.lastName)
 
         assertTrue(
             db.read { tx ->
                 tx.getGuardianChildIds(dvvCaretaker.id)
-                    .map { tx.handle.getPersonById(it) }.filterNotNull()
+                    .map { tx.getPersonById(it) }.filterNotNull()
                     .any() { child -> child.identity.toString() == custodian.ssn }
             }
         )
@@ -176,14 +176,14 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createVtjPerson(caretaker)
 
         dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("yksinhuoltaja-muutos"))
-        val dvvCaretaker = db.read { it.handle.getPersonBySSN(caretaker.ssn!!) }!!
+        val dvvCaretaker = db.read { it.getPersonBySSN(caretaker.ssn!!) }!!
         assertEquals("Harri", dvvCaretaker.firstName)
         assertEquals("Huoltaja", dvvCaretaker.lastName)
 
         assertTrue(
             db.read { tx ->
                 tx.getGuardianChildIds(dvvCaretaker.id)
-                    .map { tx.handle.getPersonById(it) }.filterNotNull()
+                    .map { tx.getPersonById(it) }.filterNotNull()
                     .any() { child -> child.identity.toString() == custodian.ssn }
             }
         )
@@ -202,7 +202,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
         createVtjPerson(personWithNewName)
 
         dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf(SSN))
-        val updatedPerson = db.read { it.handle.getPersonBySSN(SSN) }!!
+        val updatedPerson = db.read { it.getPersonBySSN(SSN) }!!
         assertEquals("Urkki", updatedPerson.firstName)
         assertEquals("Uusinimi", updatedPerson.lastName)
     }
@@ -222,7 +222,7 @@ class DvvModificationsServiceIntegrationTest : DvvModificationsServiceIntegratio
             assertEquals(3, dvvModificationsService.updatePersonsFromDvv(dbInstance(), listOf("010180-999A")))
             db.read {
                 assertEquals("1", it.getNextDvvModificationToken())
-                assertEquals(LocalDate.parse("2019-07-30"), it.handle.getPersonBySSN("010180-999A")?.dateOfDeath)
+                assertEquals(LocalDate.parse("2019-07-30"), it.getPersonBySSN("010180-999A")?.dateOfDeath)
             }
         } finally {
             db.transaction {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeAlterationQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeAlterationQueriesTest.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.FeeAlteration
 import fi.espoo.evaka.resetDatabase
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.testDecisionMaker_1
 import org.junit.jupiter.api.AfterEach
@@ -54,7 +53,7 @@ class FeeAlterationQueriesTest : PureJdbiTest() {
         db.transaction { tx ->
             tx.upsertFeeAlteration(testFeeAlteration)
 
-            val result = tx.handle.createQuery("SELECT * FROM fee_alteration")
+            val result = tx.createQuery("SELECT * FROM fee_alteration")
                 .map(toFeeAlteration)
                 .list()
 
@@ -67,7 +66,7 @@ class FeeAlterationQueriesTest : PureJdbiTest() {
         db.transaction { tx ->
             tx.upsertFeeAlteration(testFeeAlteration)
 
-            val result = tx.handle.createQuery("SELECT * FROM fee_alteration")
+            val result = tx.createQuery("SELECT * FROM fee_alteration")
                 .map(toFeeAlteration)
                 .list()
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueriesTest.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.invoicing.domain.IncomeType
 import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.config.defaultObjectMapper
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
 import org.jdbi.v3.core.kotlin.mapTo
@@ -55,7 +54,7 @@ class IncomeQueriesTest : PureJdbiTest() {
         db.transaction { tx ->
             tx.upsertIncome(mapper, testIncome, userId)
 
-            val result = tx.handle.createQuery("SELECT id FROM income")
+            val result = tx.createQuery("SELECT id FROM income")
                 .mapTo<UUID>()
                 .toList()
 
@@ -68,7 +67,7 @@ class IncomeQueriesTest : PureJdbiTest() {
         db.transaction { tx ->
             tx.upsertIncome(mapper, testIncome, userId)
 
-            val result = tx.handle.createQuery("SELECT updated_at FROM income")
+            val result = tx.createQuery("SELECT updated_at FROM income")
                 .mapTo<Instant>()
                 .toList()
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -27,7 +27,6 @@ import fi.espoo.evaka.invoicing.domain.Product
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -18,7 +18,6 @@ import fi.espoo.evaka.preschoolTerm2019
 import fi.espoo.evaka.preschoolTerm2020
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.dev.DevAssistanceAction
 import fi.espoo.evaka.shared.dev.DevAssistanceNeed
 import fi.espoo.evaka.shared.dev.DevDaycare

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
@@ -127,9 +127,9 @@ class BulletinIntegrationTest : FullApplicationTest() {
                     id = staffId
                 )
             )
-            tx.handle.insertDaycareAclRow(unitId, supervisorId, UserRole.UNIT_SUPERVISOR)
-            tx.handle.insertDaycareAclRow(unitId, staffId, UserRole.STAFF)
-            tx.handle.insertDaycareAclRow(secondUnitId, supervisorId, UserRole.UNIT_SUPERVISOR)
+            tx.insertDaycareAclRow(unitId, supervisorId, UserRole.UNIT_SUPERVISOR)
+            tx.insertDaycareAclRow(unitId, staffId, UserRole.STAFF)
+            tx.insertDaycareAclRow(secondUnitId, supervisorId, UserRole.UNIT_SUPERVISOR)
         }
         MockEmailClient.emails.clear()
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/BulletinIntegrationTest.kt
@@ -113,7 +113,7 @@ class BulletinIntegrationTest : FullApplicationTest() {
             insertChildToGroup(tx, testChild_3.id, testAdult_3.id, secondGroupId, secondUnitId)
             insertChildToGroup(tx, testChild_4.id, testAdult_4.id, secondGroupId, secondUnitId)
 
-            tx.handle.createParentship(testChild_3.id, testAdult_2.id, placementStart, placementEnd)
+            tx.createParentship(testChild_3.id, testAdult_2.id, placementStart, placementEnd)
 
             tx.insertTestEmployee(
                 DevEmployee(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
@@ -128,7 +128,7 @@ class FamilyOverviewTest : FullApplicationTest() {
         val (from, to) = LocalDate.now().let {
             listOf(it.minusYears(1), it.plusYears(1))
         }
-        db.transaction { it.handle.createParentship(testChild_1.id, testAdult_1.id, from, to) }
+        db.transaction { it.createParentship(testChild_1.id, testAdult_1.id, from, to) }
     }
 
     private fun createTestFixture1plus2() {
@@ -136,8 +136,8 @@ class FamilyOverviewTest : FullApplicationTest() {
             listOf(it.minusYears(1), it.plusYears(1))
         }
         db.transaction {
-            it.handle.createParentship(testChild_1.id, testAdult_1.id, from, to)
-            it.handle.createParentship(testChild_2.id, testAdult_1.id, from, to)
+            it.createParentship(testChild_1.id, testAdult_1.id, from, to)
+            it.createParentship(testChild_2.id, testAdult_1.id, from, to)
         }
     }
 
@@ -146,8 +146,8 @@ class FamilyOverviewTest : FullApplicationTest() {
             listOf(it.minusYears(1), it.plusYears(1))
         }
         db.transaction {
-            it.handle.createParentship(testChild_1.id, testAdult_1.id, from, to)
-            it.handle.createParentship(testChild_2.id, testAdult_1.id, from, to)
+            it.createParentship(testChild_1.id, testAdult_1.id, from, to)
+            it.createParentship(testChild_2.id, testAdult_1.id, from, to)
             it.handle.createPartnership(testAdult_1.id, testAdult_2.id, from, to)
         }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChild_1
@@ -148,7 +147,7 @@ class FamilyOverviewTest : FullApplicationTest() {
         db.transaction {
             it.createParentship(testChild_1.id, testAdult_1.id, from, to)
             it.createParentship(testChild_2.id, testAdult_1.id, from, to)
-            it.handle.createPartnership(testAdult_1.id, testAdult_2.id, from, to)
+            it.createPartnership(testAdult_1.id, testAdult_2.id, from, to)
         }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.pis.service.PersonJSON
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Forbidden
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.pis.service.PersonJSON
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Forbidden
@@ -214,7 +213,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
     }
 
     private fun createPerson(ssn: String, firstName: String): PersonJSON = db.transaction { tx ->
-        tx.handle.createPerson(
+        tx.createPerson(
             PersonIdentityRequest(
                 identity = ExternalIdentifier.SSN.getInstance(ssn),
                 firstName = firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
@@ -95,8 +95,8 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val adult = testPerson1()
         val child = testPerson2()
         val parentship = db.transaction { tx ->
-            tx.handle.createParentship(child.id, adult.id, child.dateOfBirth.plusDays(500), child.dateOfBirth.plusDays(700))
-            tx.handle.createParentship(child.id, adult.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
+            tx.createParentship(child.id, adult.id, child.dateOfBirth.plusDays(500), child.dateOfBirth.plusDays(700))
+            tx.createParentship(child.id, adult.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
         }
         val newStartDate = child.dateOfBirth.plusDays(100)
         val newEndDate = child.dateOfBirth.plusDays(300)
@@ -134,16 +134,16 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val adult = testPerson1()
         val child = testPerson2()
         val parentship = db.transaction { tx ->
-            tx.handle.createParentship(child.id, adult.id, child.dateOfBirth, child.dateOfBirth.plusDays(100)).also {
-                tx.handle.createParentship(child.id, adult.id, child.dateOfBirth.plusDays(200), child.dateOfBirth.plusDays(300))
-                assertEquals(2, tx.handle.getParentships(headOfChildId = adult.id, childId = null).size)
+            tx.createParentship(child.id, adult.id, child.dateOfBirth, child.dateOfBirth.plusDays(100)).also {
+                tx.createParentship(child.id, adult.id, child.dateOfBirth.plusDays(200), child.dateOfBirth.plusDays(300))
+                assertEquals(2, tx.getParentships(headOfChildId = adult.id, childId = null).size)
             }
         }
 
         val delResponse = controller.deleteParentship(db, user, parentship.id)
         assertEquals(HttpStatus.NO_CONTENT, delResponse.statusCode)
         db.read { r ->
-            assertEquals(1, r.handle.getParentships(headOfChildId = adult.id, childId = null).size)
+            assertEquals(1, r.getParentships(headOfChildId = adult.id, childId = null).size)
         }
     }
 
@@ -151,9 +151,9 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val adult = testPerson1()
         val child = testPerson2()
         val parentship = db.transaction { tx ->
-            tx.handle.createParentship(child.id, adult.id, child.dateOfBirth, child.dateOfBirth.plusDays(100)).also {
-                tx.handle.createParentship(child.id, adult.id, child.dateOfBirth.plusDays(200), child.dateOfBirth.plusDays(300))
-                assertEquals(2, tx.handle.getParentships(headOfChildId = adult.id, childId = null).size)
+            tx.createParentship(child.id, adult.id, child.dateOfBirth, child.dateOfBirth.plusDays(100)).also {
+                tx.createParentship(child.id, adult.id, child.dateOfBirth.plusDays(200), child.dateOfBirth.plusDays(300))
+                assertEquals(2, tx.getParentships(headOfChildId = adult.id, childId = null).size)
             }
         }
         assertThrows<Forbidden> { controller.deleteParentship(db, user, parentship.id) }
@@ -165,7 +165,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val parent = testPerson1()
         val child = testPerson2()
         db.transaction { tx ->
-            tx.handle.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
+            tx.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
         }
         assertThrows<Forbidden> { controller.getParentships(db, user, headOfChildId = parent.id) }
     }
@@ -176,7 +176,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val parent = testPerson1()
         val child = testPerson2()
         val parentship = db.transaction { tx ->
-            tx.handle.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
+            tx.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
         }
         val newStartDate = child.dateOfBirth.plusDays(100)
         val newEndDate = child.dateOfBirth.plusDays(300)
@@ -190,7 +190,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val parent = testPerson1()
         val child = testPerson2()
         val parentship = db.transaction { tx ->
-            tx.handle.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
+            tx.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
         }
         assertThrows<Forbidden> { controller.deleteParentship(db, user, parentship.id) }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
@@ -92,16 +92,16 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val partnership1 = db.transaction { tx ->
-            tx.handle.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(100)).also {
-                tx.handle.createPartnership(adult1.id, adult2.id, LocalDate.now().plusDays(200), LocalDate.now().plusDays(300))
-                assertEquals(2, tx.handle.getPartnershipsForPerson(adult1.id).size)
+            tx.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(100)).also {
+                tx.createPartnership(adult1.id, adult2.id, LocalDate.now().plusDays(200), LocalDate.now().plusDays(300))
+                assertEquals(2, tx.getPartnershipsForPerson(adult1.id).size)
             }
         }
 
         val delResponse = controller.deletePartnership(db, user, partnership1.id)
         assertEquals(HttpStatus.NO_CONTENT, delResponse.statusCode)
         db.read { r ->
-            assertEquals(1, r.handle.getPartnershipsForPerson(adult1.id).size)
+            assertEquals(1, r.getPartnershipsForPerson(adult1.id).size)
         }
     }
 
@@ -124,8 +124,8 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val partnership1 = db.transaction { tx ->
-            tx.handle.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200)).also {
-                tx.handle.createPartnership(adult1.id, adult2.id, LocalDate.now().plusDays(500), LocalDate.now().plusDays(700))
+            tx.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200)).also {
+                tx.createPartnership(adult1.id, adult2.id, LocalDate.now().plusDays(500), LocalDate.now().plusDays(700))
             }
         }
 
@@ -153,8 +153,8 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val partnership1 = db.transaction { tx ->
-            tx.handle.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200)).also {
-                tx.handle.createPartnership(adult1.id, adult2.id, LocalDate.now().plusDays(500), LocalDate.now().plusDays(700))
+            tx.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200)).also {
+                tx.createPartnership(adult1.id, adult2.id, LocalDate.now().plusDays(500), LocalDate.now().plusDays(700))
             }
         }
 
@@ -172,7 +172,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         db.transaction { tx ->
-            tx.handle.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
+            tx.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
         }
 
         assertThrows<Forbidden> {
@@ -200,7 +200,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val partnership = db.transaction { tx ->
-            tx.handle.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
+            tx.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
         }
 
         val requestBody = PartnershipsController.PartnershipUpdateRequest(LocalDate.now(), LocalDate.now().plusDays(999))
@@ -215,7 +215,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val adult1 = testPerson1()
         val adult2 = testPerson2()
         val partnership = db.transaction { tx ->
-            tx.handle.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
+            tx.createPartnership(adult1.id, adult2.id, LocalDate.now(), LocalDate.now().plusDays(200))
         }
 
         assertThrows<Forbidden> {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.pis.service.PersonJSON
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.Forbidden
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.pis.service.PersonJSON
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.Forbidden
@@ -224,7 +223,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
     }
 
     private fun createPerson(ssn: String, firstName: String): PersonJSON = db.transaction { tx ->
-        tx.handle.createPerson(
+        tx.createPerson(
             PersonIdentityRequest(
                 identity = ExternalIdentifier.SSN.getInstance(ssn),
                 firstName = firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Forbidden
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -150,7 +149,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
         assertEquals(HttpStatus.OK, actual.statusCode)
 
-        val updated = db.read { it.handle.getPersonById(person.id) }
+        val updated = db.read { it.getPersonById(person.id) }
         assertEquals(contactInfo.email, updated?.email)
         assertEquals(contactInfo.invoicingStreetAddress, updated?.invoicingStreetAddress)
         assertEquals(contactInfo.invoicingPostalCode, updated?.invoicingPostalCode)
@@ -161,7 +160,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
     private fun createPerson(): PersonDTO {
         val ssn = "140881-172X"
         return db.transaction {
-            it.handle.createPerson(
+            it.createPerson(
                 PersonIdentityRequest(
                     identity = ExternalIdentifier.SSN.getInstance(ssn),
                     firstName = "Matti",

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.db.transaction
 import fi.espoo.evaka.shared.domain.Forbidden
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/FamilySchemaConstraintsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/FamilySchemaConstraintsIntegrationTest.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.pis.createParentship
 import fi.espoo.evaka.pis.createPerson
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -257,7 +256,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
 
     private fun createPerson(ssn: String, firstName: String): PersonDTO {
         return db.transaction {
-            it.handle.createPerson(
+            it.createPerson(
                 PersonIdentityRequest(
                     identity = ExternalIdentifier.SSN.getInstance(ssn),
                     firstName = firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/FamilySchemaConstraintsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/FamilySchemaConstraintsIntegrationTest.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.pis.createParentship
 import fi.espoo.evaka.pis.createPerson
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
-import fi.espoo.evaka.shared.db.transaction
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.time.LocalDate

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/FamilySchemaConstraintsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/FamilySchemaConstraintsIntegrationTest.kt
@@ -253,7 +253,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
     }
 
     private fun createParentshipRecord(childId: UUID, parentId: UUID, startDate: LocalDate, endDate: LocalDate) =
-        db.transaction { it.handle.createParentship(childId, parentId, startDate, endDate) }
+        db.transaction { it.createParentship(childId, parentId, startDate, endDate) }
 
     private fun createPerson(ssn: String, firstName: String): PersonDTO {
         return db.transaction {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/ParentshipDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/ParentshipDAOIntegrationTest.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.pis.getPersonBySSN
 import fi.espoo.evaka.pis.service.Parentship
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.pis.service.PersonJSON
-import fi.espoo.evaka.shared.db.transaction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/ParentshipDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/ParentshipDAOIntegrationTest.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.pis.getPersonBySSN
 import fi.espoo.evaka.pis.service.Parentship
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
 import fi.espoo.evaka.pis.service.PersonJSON
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -102,7 +101,7 @@ class ParentshipDAOIntegrationTest : AbstractIntegrationTest() {
     }
 
     private fun createPerson(ssn: String, firstName: String): PersonJSON = db.transaction {
-        it.handle.getPersonBySSN(ssn) ?: it.handle.createPerson(
+        it.getPersonBySSN(ssn) ?: it.createPerson(
             PersonIdentityRequest(
                 identity = ExternalIdentifier.SSN.getInstance(ssn),
                 firstName = firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/ParentshipDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/ParentshipDAOIntegrationTest.kt
@@ -28,7 +28,7 @@ class ParentshipDAOIntegrationTest : AbstractIntegrationTest() {
         val startDate = LocalDate.now()
         val endDate = startDate.plusDays(100)
         val parentship = db.transaction { tx ->
-            tx.handle.createParentship(child.id, parent.id, startDate, endDate)
+            tx.createParentship(child.id, parent.id, startDate, endDate)
         }
         assertNotNull(parentship.id)
         assertEquals(child, parentship.child)
@@ -45,12 +45,12 @@ class ParentshipDAOIntegrationTest : AbstractIntegrationTest() {
 
         listOf(testPerson4(), testPerson5(), testPerson6()).map {
             db.transaction { tx ->
-                tx.handle.createParentship(it.id, parent.id, startDate, endDate)
+                tx.createParentship(it.id, parent.id, startDate, endDate)
             }
         }
 
         val fetchedRelations = db.read { r ->
-            r.handle.getParentships(headOfChildId = parent.id, childId = null)
+            r.getParentships(headOfChildId = parent.id, childId = null)
         }
         assertEquals(3, fetchedRelations.size)
     }
@@ -66,18 +66,18 @@ class ParentshipDAOIntegrationTest : AbstractIntegrationTest() {
             val startDate = now.plusDays(index * 51.toLong())
             val endDate = startDate.plusDays((index + 1) * 50.toLong())
             db.transaction { tx ->
-                tx.handle.createParentship(child.id, parent.id, startDate, endDate)
+                tx.createParentship(child.id, parent.id, startDate, endDate)
             }
         }
 
         db.read { r ->
-            val fetchedRelationsByChild = r.handle.getParentships(headOfChildId = null, childId = child.id)
+            val fetchedRelationsByChild = r.getParentships(headOfChildId = null, childId = child.id)
             assertEquals(2, fetchedRelationsByChild.size)
 
-            val fetchedRelationsByParent1 = r.handle.getParentships(headOfChildId = adult1.id, childId = child.id)
+            val fetchedRelationsByParent1 = r.getParentships(headOfChildId = adult1.id, childId = child.id)
             assertEquals(1, fetchedRelationsByParent1.size)
 
-            val fetchedRelationsByParent2 = r.handle.getParentships(headOfChildId = adult2.id, childId = child.id)
+            val fetchedRelationsByParent2 = r.getParentships(headOfChildId = adult2.id, childId = child.id)
             assertEquals(1, fetchedRelationsByParent2.size)
         }
     }
@@ -89,15 +89,15 @@ class ParentshipDAOIntegrationTest : AbstractIntegrationTest() {
         val startDate = LocalDate.now()
         val endDate = startDate.plusDays(100)
         db.transaction { tx ->
-            val parentship = tx.handle.createParentship(child.id, adult.id, startDate, endDate)
+            val parentship = tx.createParentship(child.id, adult.id, startDate, endDate)
 
-            assertEquals(setOf(parentship), tx.handle.getParentships(headOfChildId = adult.id, childId = child.id).toHashSet())
-            assertEquals(setOf(parentship), tx.handle.getParentships(headOfChildId = adult.id, childId = null).toHashSet())
-            assertEquals(setOf(parentship), tx.handle.getParentships(headOfChildId = null, childId = child.id).toHashSet())
+            assertEquals(setOf(parentship), tx.getParentships(headOfChildId = adult.id, childId = child.id).toHashSet())
+            assertEquals(setOf(parentship), tx.getParentships(headOfChildId = adult.id, childId = null).toHashSet())
+            assertEquals(setOf(parentship), tx.getParentships(headOfChildId = null, childId = child.id).toHashSet())
 
-            assertEquals(emptySet<Parentship>(), tx.handle.getParentships(headOfChildId = child.id, childId = adult.id).toHashSet())
-            assertEquals(emptySet<Parentship>(), tx.handle.getParentships(headOfChildId = child.id, childId = null).toHashSet())
-            assertEquals(emptySet<Parentship>(), tx.handle.getParentships(headOfChildId = null, childId = adult.id).toHashSet())
+            assertEquals(emptySet<Parentship>(), tx.getParentships(headOfChildId = child.id, childId = adult.id).toHashSet())
+            assertEquals(emptySet<Parentship>(), tx.getParentships(headOfChildId = child.id, childId = null).toHashSet())
+            assertEquals(emptySet<Parentship>(), tx.getParentships(headOfChildId = null, childId = adult.id).toHashSet())
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PartnershipDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PartnershipDAOIntegrationTest.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.pis.createPerson
 import fi.espoo.evaka.pis.getPartnershipsForPerson
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.db.transaction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -73,7 +72,7 @@ class PartnershipDAOIntegrationTest : AbstractIntegrationTest() {
 
     private fun createPerson(ssn: String, firstName: String): PersonDTO =
         db.transaction {
-            it.handle.createPerson(
+            it.createPerson(
                 PersonIdentityRequest(
                     identity = ExternalIdentifier.SSN.getInstance(ssn),
                     firstName = firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PartnershipDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PartnershipDAOIntegrationTest.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.pis.createPerson
 import fi.espoo.evaka.pis.getPartnershipsForPerson
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
-import fi.espoo.evaka.shared.db.transaction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PartnershipDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PartnershipDAOIntegrationTest.kt
@@ -26,7 +26,7 @@ class PartnershipDAOIntegrationTest : AbstractIntegrationTest() {
         val startDate = LocalDate.now()
         val endDate = startDate.plusDays(100)
         val partnership = db.transaction { tx ->
-            tx.handle.createPartnership(person1.id, person2.id, startDate, endDate)
+            tx.createPartnership(person1.id, person2.id, startDate, endDate)
         }
         assertNotNull(partnership.id)
         assertEquals(2, partnership.partners.size)
@@ -40,16 +40,16 @@ class PartnershipDAOIntegrationTest : AbstractIntegrationTest() {
         val person2 = testPerson2()
         val person3 = testPerson3()
 
-        val partnership1 = db.transaction { it.handle.createPartnership(person1.id, person2.id, LocalDate.now(), LocalDate.now().plusDays(200)) }
-        val partnership2 = db.transaction { it.handle.createPartnership(person2.id, person3.id, LocalDate.now().plusDays(300), LocalDate.now().plusDays(400)) }
+        val partnership1 = db.transaction { it.createPartnership(person1.id, person2.id, LocalDate.now(), LocalDate.now().plusDays(200)) }
+        val partnership2 = db.transaction { it.createPartnership(person2.id, person3.id, LocalDate.now().plusDays(300), LocalDate.now().plusDays(400)) }
 
-        val person1Partnerships = db.read { it.handle.getPartnershipsForPerson(person1.id) }
+        val person1Partnerships = db.read { it.getPartnershipsForPerson(person1.id) }
         assertEquals(listOf(partnership1), person1Partnerships)
 
-        val person2Partnerships = db.read { it.handle.getPartnershipsForPerson(person2.id) }
+        val person2Partnerships = db.read { it.getPartnershipsForPerson(person2.id) }
         assertEquals(listOf(partnership1, partnership2), person2Partnerships)
 
-        val person3Partnerships = db.read { it.handle.getPartnershipsForPerson(person3.id) }
+        val person3Partnerships = db.read { it.getPartnershipsForPerson(person3.id) }
         assertEquals(listOf(partnership2), person3Partnerships)
     }
 
@@ -58,13 +58,13 @@ class PartnershipDAOIntegrationTest : AbstractIntegrationTest() {
         val person1 = testPerson1()
         val person2 = testPerson2()
         val startDate = LocalDate.now()
-        val partnership = db.transaction { it.handle.createPartnership(person1.id, person2.id, startDate, endDate = null) }
+        val partnership = db.transaction { it.createPartnership(person1.id, person2.id, startDate, endDate = null) }
         assertNotNull(partnership.id)
         assertEquals(2, partnership.partners.size)
         assertEquals(startDate, partnership.startDate)
         assertEquals(null, partnership.endDate)
 
-        val fetched = db.read { it.handle.getPartnershipsForPerson(person1.id).first() }
+        val fetched = db.read { it.getPartnershipsForPerson(person1.id).first() }
         assertEquals(partnership.id, fetched.id)
         assertEquals(2, fetched.partners.size)
         assertEquals(startDate, fetched.startDate)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/ParentshipServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/ParentshipServiceIntegrationTest.kt
@@ -47,7 +47,7 @@ class ParentshipServiceIntegrationTest : AbstractIntegrationTest() {
 
     private fun createPerson(ssn: String, firstName: String): PersonDTO {
         return db.transaction {
-            it.handle.createPerson(
+            it.createPerson(
                 PersonIdentityRequest(
                     identity = ExternalIdentifier.SSN.getInstance(ssn),
                     firstName = firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/ParentshipServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/ParentshipServiceIntegrationTest.kt
@@ -35,11 +35,11 @@ class ParentshipServiceIntegrationTest : AbstractIntegrationTest() {
 
             parentshipService.createParentship(tx, child.id, parent2.id, startDate2, endDate2)
 
-            val headsByChild = tx.handle.getParentships(headOfChildId = null, childId = child.id)
+            val headsByChild = tx.getParentships(headOfChildId = null, childId = child.id)
 
             assertEquals(2, headsByChild.size)
 
-            val childByHeads = headsByChild.map { tx.handle.getParentships(headOfChildId = it.headOfChildId, childId = null) }
+            val childByHeads = headsByChild.map { tx.getParentships(headOfChildId = it.headOfChildId, childId = null) }
 
             assertEquals(2, childByHeads.size)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/PartnershipServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/PartnershipServiceIntegrationTest.kt
@@ -37,7 +37,7 @@ class PartnershipServiceIntegrationTest : AbstractIntegrationTest() {
 
     private fun createPerson(ssn: String, firstName: String): PersonDTO {
         return db.transaction {
-            it.handle.createPerson(
+            it.createPerson(
                 PersonIdentityRequest(
                     identity = ExternalIdentifier.SSN.getInstance(ssn),
                     firstName = firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/FiveYearOldDaycarePlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/FiveYearOldDaycarePlacementsIntegrationTest.kt
@@ -105,7 +105,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest() {
             it.updatePlacement(oldPlacement.id, originalStartDate, newEndDate)
         }
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }.sortedBy { it.startDate }
+        val placements = db.read { it.getPlacementsForChild(childId) }.sortedBy { it.startDate }
         assertEquals(2, placements.size)
         placements.first().let { placement ->
             assertEquals(PlacementType.DAYCARE, placement.type)
@@ -140,7 +140,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest() {
             it.updatePlacement(oldPlacement.id, originalStartDate, newEndDate)
         }
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }.sortedBy { it.startDate }
+        val placements = db.read { it.getPlacementsForChild(childId) }.sortedBy { it.startDate }
         assertEquals(2, placements.size)
         placements.first().let { placement ->
             assertEquals(PlacementType.DAYCARE_FIVE_YEAR_OLDS, placement.type)
@@ -175,7 +175,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest() {
             it.updatePlacement(oldPlacement.id, newStartDate, originalEndDate)
         }
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }.sortedBy { it.startDate }
+        val placements = db.read { it.getPlacementsForChild(childId) }.sortedBy { it.startDate }
         assertEquals(2, placements.size)
         placements.first().let { placement ->
             assertEquals(PlacementType.DAYCARE_FIVE_YEAR_OLDS, placement.type)
@@ -210,7 +210,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest() {
             it.updatePlacement(oldPlacement.id, newStartDate, originalEndDate)
         }
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }.sortedBy { it.startDate }
+        val placements = db.read { it.getPlacementsForChild(childId) }.sortedBy { it.startDate }
         assertEquals(2, placements.size)
         placements.first().let { placement ->
             assertEquals(PlacementType.DAYCARE, placement.type)
@@ -246,7 +246,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest() {
             it.updatePlacement(oldPlacement.id, newStartDate, newEndDate)
         }
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }.sortedBy { it.startDate }
+        val placements = db.read { it.getPlacementsForChild(childId) }.sortedBy { it.startDate }
         assertEquals(1, placements.size)
         placements.first().let { placement ->
             assertEquals(PlacementType.DAYCARE_FIVE_YEAR_OLDS, placement.type)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestPlacement
@@ -368,7 +367,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
     @Test
     fun `deleting group placement works`() {
         val groupPlacementId = db.transaction { tx ->
-            tx.handle.createGroupPlacement(testPlacement.id, groupId, placementStart, placementEnd).id!!
+            tx.createGroupPlacement(testPlacement.id, groupId, placementStart, placementEnd).id!!
         }
 
         val (_, res, _) = http.delete("/placements/${testPlacement.id}/group-placements/$groupPlacementId")
@@ -450,7 +449,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
         org.junit.jupiter.api.Assertions.assertEquals(204, allowed.statusCode)
 
         db.read { r ->
-            val updated = r.handle.getPlacementsForChild(childId).find { it.id == allowedId }!!
+            val updated = r.getPlacementsForChild(childId).find { it.id == allowedId }!!
             org.junit.jupiter.api.Assertions.assertEquals(newStart, updated.startDate)
             org.junit.jupiter.api.Assertions.assertEquals(newEnd, updated.endDate)
         }
@@ -507,7 +506,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
         org.junit.jupiter.api.Assertions.assertEquals(204, res.statusCode)
 
         val placements = db.read { r ->
-            r.handle.getPlacementsForChild(childId)
+            r.getPlacementsForChild(childId)
         }
         val first = placements.find { it.id == testPlacement.id }!!
         val second = placements.find { it.id == secondPlacement }!!
@@ -536,7 +535,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
     @Test
     fun `service worker cannot remove placements`() {
         val groupPlacementId = db.transaction { tx ->
-            tx.handle.createGroupPlacement(testPlacement.id, groupId, placementStart, placementEnd).id!!
+            tx.createGroupPlacement(testPlacement.id, groupId, placementStart, placementEnd).id!!
         }
 
         val (_, res, _) = http.delete("/placements/${testPlacement.id}/group-placements/$groupPlacementId")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
@@ -64,7 +64,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            oldPlacement = it.handle.insertPlacement(
+            oldPlacement = it.insertPlacement(
                 PlacementType.PRESCHOOL,
                 childId,
                 unitId,
@@ -100,7 +100,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(2, placements.size)
         assertTrue(placements.containsAll(listOf(oldPlacement, newPlacement)))
@@ -124,7 +124,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(newPlacements, placements)
     }
@@ -147,7 +147,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(2, placements.size)
         assertTrue(placements.contains(newPlacement))
@@ -173,7 +173,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val originalPlacements = db.read { it.handle.getPlacementsForChild(childId) }
+        val originalPlacements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(2, originalPlacements.size)
         assertTrue(originalPlacements.containsAll(listOf(oldPlacement, newPlacement)))
@@ -181,7 +181,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
         val newStart = oldPlacement.endDate.minusDays(5)
         db.transaction { it.updatePlacement(newPlacement.id, newStart, newPlacement.endDate) }
 
-        val newPlacements = db.read { it.handle.getPlacementsForChild(childId) }
+        val newPlacements = db.read { it.getPlacementsForChild(childId) }
         val old = newPlacements.find { it.id == oldPlacement.id }!!
         val updated = newPlacements.find { it.id == newPlacement.id }!!
 
@@ -210,7 +210,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(2, placements.size)
         assertTrue(placements.contains(newPlacement))
@@ -241,7 +241,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(3, placements.size)
         assertTrue(placements.contains(newPlacement))
@@ -279,7 +279,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(1, placements.size)
         assertEquals(listOf(newPlacement), placements)
@@ -303,7 +303,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(2, placements.size)
         assertTrue(placements.contains(newPlacement))
@@ -334,7 +334,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(1, placements.size)
         assertTrue(placements.contains(newPlacement))
@@ -358,7 +358,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(1, placements.size)
         assertTrue(placements.contains(newPlacement))
@@ -382,7 +382,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(2, placements.size)
         assertTrue(placements.contains(newPlacement))
@@ -423,7 +423,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }.first()
 
-        val placements = db.read { it.handle.getPlacementsForChild(childId) }
+        val placements = db.read { it.getPlacementsForChild(childId) }
 
         assertEquals(3, placements.size)
         assertTrue(placements.contains(newPlacement))
@@ -458,7 +458,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
 
         db.transaction { it.updatePlacement(oldPlacement.id, oldPlacement.startDate, LocalDate.of(year, month, 19)) }
 
-        val updated = db.read { it.handle.getPlacement(oldPlacement.id) }
+        val updated = db.read { it.getPlacement(oldPlacement.id) }
         val expected = oldPlacement.copy(endDate = LocalDate.of(year, month, 19))
         assertEquals(expected, updated)
     }
@@ -615,7 +615,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             it.updatePlacement(oldPlacement.id, oldPlacement.startDate, LocalDate.of(year, month, 21))
         }
 
-        val updated = db.read { it.handle.getPlacement(oldPlacement.id) }
+        val updated = db.read { it.getPlacement(oldPlacement.id) }
         val expected = oldPlacement.copy(endDate = LocalDate.of(year, month, 21))
         assertEquals(expected, updated)
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
@@ -162,7 +162,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
                 value = value,
                 coPayment = coPayment
             )
-            it.handle.upsertValueDecisions(objectMapper, listOf(decision))
+            it.upsertValueDecisions(objectMapper, listOf(decision))
 
             sendVoucherValueDecisions(
                 tx = it,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -310,7 +310,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
                 value = value,
                 coPayment = coPayment
             )
-            it.handle.upsertValueDecisions(objectMapper, listOf(decision))
+            it.upsertValueDecisions(objectMapper, listOf(decision))
 
             sendVoucherValueDecisions(
                 tx = it,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
 import fi.espoo.evaka.testChild_1
@@ -118,7 +117,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val serviceNeeds = db.transaction { tx -> getServiceNeedsByChild(tx.handle, testChild_1.id) }
+        val serviceNeeds = db.transaction { tx -> tx.getServiceNeedsByChild(testChild_1.id) }
         assertEquals(2, serviceNeeds.size)
         assertTrue(serviceNeeds.any { it.startDate == testDate(1) && it.endDate == testDate(15) })
         assertTrue(serviceNeeds.any { it.startDate == testDate(16) && it.endDate == testDate(30) })
@@ -187,7 +186,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val serviceNeeds = db.transaction { tx -> getServiceNeedsByChild(tx.handle, testChild_1.id) }
+        val serviceNeeds = db.transaction { tx -> tx.getServiceNeedsByChild(testChild_1.id) }
         assertEquals(2, serviceNeeds.size)
         assertTrue(serviceNeeds.any { it.startDate == testDate(10) && it.endDate == testDate(19) })
         assertTrue(serviceNeeds.any { it.startDate == testDate(20) && it.endDate == testDate(30) })
@@ -204,7 +203,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val serviceNeeds = db.transaction { tx -> getServiceNeedsByChild(tx.handle, testChild_1.id) }
+        val serviceNeeds = db.transaction { tx -> tx.getServiceNeedsByChild(testChild_1.id) }
         assertEquals(2, serviceNeeds.size)
         assertTrue(serviceNeeds.any { it.startDate == testDate(10) && it.endDate == testDate(19) })
         assertTrue(serviceNeeds.any { it.startDate == testDate(20) && it.endDate == testDate(30) })
@@ -221,7 +220,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val serviceNeeds = db.transaction { tx -> getServiceNeedsByChild(tx.handle, testChild_1.id) }
+        val serviceNeeds = db.transaction { tx -> tx.getServiceNeedsByChild(testChild_1.id) }
         assertEquals(2, serviceNeeds.size)
         assertTrue(serviceNeeds.any { it.startDate == testDate(10) && it.endDate == testDate(10) })
         assertTrue(serviceNeeds.any { it.startDate == testDate(11) && it.endDate == testDate(15) })
@@ -238,7 +237,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
             )
         )
 
-        val serviceNeeds = db.transaction { tx -> getServiceNeedsByChild(tx.handle, testChild_1.id) }
+        val serviceNeeds = db.transaction { tx -> tx.getServiceNeedsByChild(testChild_1.id) }
         assertEquals(2, serviceNeeds.size)
         assertTrue(serviceNeeds.any { it.startDate == testDate(10) && it.endDate == testDate(10) })
         assertTrue(serviceNeeds.any { it.startDate == testDate(11) && it.endDate == testDate(15) })
@@ -345,7 +344,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
         givenServiceNeed(startDate, null, testChild_1.id)
 
         val results = db.transaction { tx ->
-            getServiceNeedsByChildDuringPeriod(tx.handle, testChild_1.id, testDate(startDate), testDate(startDate + 5))
+            tx.getServiceNeedsByChildDuringPeriod(testChild_1.id, testDate(startDate), testDate(startDate + 5))
         }
         assertEquals(1, results.size)
 
@@ -361,7 +360,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
         givenServiceNeed(startDate, endDate, testChild_1.id)
 
         val results = db.transaction { tx ->
-            getServiceNeedsByChildDuringPeriod(tx.handle, testChild_1.id, testDate(startDate), null)
+            tx.getServiceNeedsByChildDuringPeriod(testChild_1.id, testDate(startDate), null)
         }
         assertEquals(1, results.size)
 
@@ -375,7 +374,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
         val startDate = 5
         givenServiceNeed(startDate, null, testChild_1.id)
 
-        val results = db.transaction { tx -> getServiceNeedsByChildDuringPeriod(tx.handle, testChild_1.id, testDate(startDate), null) }
+        val results = db.transaction { tx -> tx.getServiceNeedsByChildDuringPeriod(testChild_1.id, testDate(startDate), null) }
         assertEquals(1, results.size)
 
         val serviceNeed = results[0]
@@ -389,7 +388,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
         givenServiceNeed(startDate, null, testChild_1.id)
 
         val results = db.transaction { tx ->
-            getServiceNeedsByChildDuringPeriod(tx.handle, testChild_1.id, testDate(1), testDate(4))
+            tx.getServiceNeedsByChildDuringPeriod(testChild_1.id, testDate(1), testDate(4))
         }
         assertEquals(0, results.size)
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
 import fi.espoo.evaka.messaging.daycarydailynote.createDaycareDailyNote
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -131,7 +130,7 @@ class AclIntegrationTest : PureJdbiTest() {
         assertEquals(negativeAclRoles, acl.getRolesForUnitGroup(user, groupId))
         assertEquals(negativeAclRoles, acl.getRolesForDailyNote(user, noteId))
 
-        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, role) }
+        db.transaction { it.insertDaycareAclRow(daycareId, employeeId, role) }
 
         assertEquals(positiveAclAuth, acl.getAuthorizedDaycares(user))
         assertEquals(positiveAclAuth, acl.getAuthorizedUnits(user))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationControllerIntegrationTest.kt
@@ -354,7 +354,7 @@ class ScheduledOperationControllerIntegrationTest : FullApplicationTest() {
                     sleepingNote = null
                 )
             )
-            it.handle.insertPlacement(
+            it.insertPlacement(
                 type = PlacementType.DAYCARE,
                 childId = testChild_1.id,
                 unitId = testDaycare.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.shared.domain
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
-import fi.espoo.evaka.shared.db.handle
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.testAreaId
@@ -38,7 +37,7 @@ class TimeIntegrationTest : PureJdbiTest() {
 
     @Test
     fun `operational days with no holidays or round the clock units in database`() {
-        val result = db.transaction { operationalDays(it.handle, 2020, Month.JANUARY) }
+        val result = db.transaction { it.operationalDays(2020, Month.JANUARY) }
 
         assertEquals(january2020Weekdays, result.generalCase)
         assertEquals(january2020Weekdays, result.forUnit(testDaycare.id))
@@ -52,7 +51,7 @@ class TimeIntegrationTest : PureJdbiTest() {
                 .execute()
         }
 
-        val result = db.transaction { operationalDays(it.handle, 2020, Month.JANUARY) }
+        val result = db.transaction { it.operationalDays(2020, Month.JANUARY) }
 
         assertEquals(january2020Weekdays, result.generalCase)
         assertEquals(january2020Weekdays, result.forUnit(testDaycare2.id))
@@ -71,7 +70,7 @@ class TimeIntegrationTest : PureJdbiTest() {
                 .execute()
         }
 
-        val result = db.transaction { operationalDays(it.handle, 2020, Month.JANUARY) }
+        val result = db.transaction { it.operationalDays(2020, Month.JANUARY) }
 
         assertEquals(january2020Weekdays, result.generalCase)
         assertEquals(january2020Weekdays, result.forUnit(testDaycare.id))
@@ -88,7 +87,7 @@ class TimeIntegrationTest : PureJdbiTest() {
                 .execute()
         }
 
-        val result = db.transaction { operationalDays(it.handle, 2020, Month.JANUARY) }
+        val result = db.transaction { it.operationalDays(2020, Month.JANUARY) }
 
         val weekdaysWithoutHolidays = january2020Weekdays.filter { it != newYear }
         assertEquals(weekdaysWithoutHolidays, result.generalCase)
@@ -106,7 +105,7 @@ class TimeIntegrationTest : PureJdbiTest() {
                 .execute()
         }
 
-        val result = db.transaction { operationalDays(it.handle, 2020, Month.JANUARY) }
+        val result = db.transaction { it.operationalDays(2020, Month.JANUARY) }
 
         val weekdaysWithoutHolidays = january2020Weekdays.filter { it != newYear && it != epiphany }
         assertEquals(weekdaysWithoutHolidays, result.generalCase)
@@ -122,7 +121,7 @@ class TimeIntegrationTest : PureJdbiTest() {
                 .execute()
         }
 
-        val result = db.transaction { operationalDays(it.handle, 2020, Month.JANUARY) }
+        val result = db.transaction { it.operationalDays(2020, Month.JANUARY) }
 
         assertEquals(january2020Weekdays, result.generalCase)
         assertEquals(january2020Weekdays, result.forUnit(testDaycare.id))
@@ -143,7 +142,7 @@ class TimeIntegrationTest : PureJdbiTest() {
                 .execute()
         }
 
-        val result = db.transaction { operationalDays(it.handle, 2020, Month.JANUARY) }
+        val result = db.transaction { it.operationalDays(2020, Month.JANUARY) }
 
         val weekdaysWithoutHolidays = january2020Weekdays.filter { it != newYear && it != epiphany }
         assertEquals(weekdaysWithoutHolidays, result.generalCase)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -408,7 +408,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         val beforeDelete = getVardaDecisions()
         assertEquals(1, beforeDelete.size)
 
-        db.transaction { deleteServiceNeed(it.handle, serviceNeedId) }
+        db.transaction { it.deleteServiceNeed(serviceNeedId) }
         updateDecisions(db, vardaClient)
         val result = getVardaDecisions()
         assertEquals(0, result.size)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -726,7 +726,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
         val newStart = period.start.minusMonths(1)
         val newEnd = period.end.plusMonths(1)
-        db.transaction { it.handle.updatePlacementStartAndEndDate(placementId, newStart, newEnd) }
+        db.transaction { it.updatePlacementStartAndEndDate(placementId, newStart, newEnd) }
         updateDecisions(db, vardaClient)
 
         val vardaDecisions = mockEndpoint.decisions
@@ -752,7 +752,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
         assertEquals(1, placements.size)
 
         db.transaction {
-            it.handle.updatePlacementStartAndEndDate(placementId, period.start.plusMonths(1), period.end.minusMonths(1))
+            it.updatePlacementStartAndEndDate(placementId, period.start.plusMonths(1), period.end.minusMonths(1))
         }
         updateDecisions(db, vardaClient)
         assertEquals(0, getVardaPlacements(db).size)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -744,7 +744,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             )
         }
 
-        it.handle.upsertValueDecisions(objectMapper, voucherValueDecisions)
+        it.upsertValueDecisions(objectMapper, voucherValueDecisions)
         voucherValueDecisions
     }
 
@@ -765,6 +765,6 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             .response()
         assertEquals(204, response.statusCode)
         asyncJobRunner.runPendingJobsSync()
-        return db.read { it.handle.getValueDecisionsByIds(objectMapper, listOf(this.id)) }.first()
+        return db.read { it.getValueDecisionsByIds(objectMapper, listOf(this.id)) }.first()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -133,7 +133,7 @@ class ApplicationControllerV2(
                             ExternalIdentifier.SSN.getInstance(body.guardianSsn)
                         )?.id ?: throw BadRequest("Could not find the guardian with ssn ${body.guardianSsn}")
                     else if (body.guardianToBeCreated != null)
-                        tx.handle.createPerson(body.guardianToBeCreated)
+                        tx.createPerson(body.guardianToBeCreated)
                     else
                         throw BadRequest("Could not find guardian info from paper application request for ${body.childId}")
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -332,7 +332,7 @@ class ApplicationControllerV2(
             val application = tx.fetchApplicationDetails(applicationId)
                 ?: throw NotFound("Application $applicationId not found")
 
-            val placementUnitName = getPlacementPlanUnitName(tx.handle, applicationId)
+            val placementUnitName = tx.getPlacementPlanUnitName(applicationId)
 
             val decisionDrafts = tx.fetchDecisionDrafts(applicationId)
             val unit = decisionDraftService.getDecisionUnit(tx, decisionDrafts[0].unitId)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationDetailsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationDetailsService.kt
@@ -30,15 +30,15 @@ fun Database.Read.applicationFlags(
 ): ApplicationFlags {
     return when (formType) {
         ApplicationType.CLUB -> ApplicationFlags(
-            isTransferApplication = handle.getPlacementsForChildDuring(childId, startDate, null)
+            isTransferApplication = getPlacementsForChildDuring(childId, startDate, null)
                 .any { it.type == PlacementType.CLUB }
         )
         ApplicationType.DAYCARE -> ApplicationFlags(
-            isTransferApplication = handle.getPlacementsForChildDuring(childId, startDate, null)
+            isTransferApplication = getPlacementsForChildDuring(childId, startDate, null)
                 .any { listOf(PlacementType.DAYCARE, PlacementType.DAYCARE_PART_TIME).contains(it.type) }
         )
         ApplicationType.PRESCHOOL -> {
-            val existingPlacements = handle.getPlacementsForChildDuring(childId, startDate, null)
+            val existingPlacements = getPlacementsForChildDuring(childId, startDate, null)
                 .filter {
                     listOf(
                         PlacementType.PRESCHOOL,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -169,7 +169,7 @@ class ApplicationStateService(
             )
         }
 
-        tx.handle.upsertChild(
+        tx.upsertChild(
             Child(
                 id = application.childId,
                 additionalInformation = AdditionalInformation(

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -298,9 +298,9 @@ class ApplicationStateService(
             if (rejectReason == PlacementPlanRejectReason.OTHER && rejectOtherReason.isNullOrBlank())
                 throw BadRequest("Must describe other reason for rejecting")
 
-            updatePlacementPlanUnitConfirmation(tx.handle, applicationId, status, rejectReason, rejectOtherReason)
+            tx.updatePlacementPlanUnitConfirmation(applicationId, status, rejectReason, rejectOtherReason)
         } else {
-            updatePlacementPlanUnitConfirmation(tx.handle, applicationId, status, null, null)
+            tx.updatePlacementPlanUnitConfirmation(applicationId, status, null, null)
         }
     }
 
@@ -377,7 +377,7 @@ class ApplicationStateService(
             )
         }
 
-        val plan = getPlacementPlan(tx.handle, applicationId)
+        val plan = tx.getPlacementPlan(applicationId)
             ?: throw IllegalStateException("Application $applicationId has no placement plan")
 
         // everything validated now!

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -129,7 +129,7 @@ class ApplicationStateService(
 
         if (!application.hideFromGuardian && application.type == ApplicationType.DAYCARE) {
             val preferredUnit =
-                tx.handle.getDaycare(application.form.preferences.preferredUnits.first().id)!! // should never be null after validation
+                tx.getDaycare(application.form.preferences.preferredUnits.first().id)!! // should never be null after validation
 
             if (preferredUnit.providerType != ProviderType.PRIVATE_SERVICE_VOUCHER) {
                 asyncJobRunner.plan(tx, listOf(SendApplicationEmail(application.guardianId, preferredUnit.language, ApplicationType.DAYCARE)))
@@ -557,7 +557,7 @@ class ApplicationStateService(
         if (unitIds.isEmpty()) {
             throw BadRequest("Must have at least one preferred unit")
         } else {
-            val daycares = tx.handle.getUnitApplyPeriods(unitIds.toSet())
+            val daycares = tx.getUnitApplyPeriods(unitIds.toSet())
             if (daycares.size < unitIds.toSet().size) {
                 throw BadRequest("Some unit was not found")
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -113,14 +113,14 @@ class ApplicationStateService(
         )
         tx.updateApplicationDates(application.id, sentDate, dueDate)
 
-        tx.handle.getPersonById(application.guardianId)?.let {
+        tx.getPersonById(application.guardianId)?.let {
             val email = if (!application.form.guardian.email.isNullOrBlank()) {
                 application.form.guardian.email
             } else {
                 it.email
             }
 
-            tx.handle.updatePersonBasicContactInfo(
+            tx.updatePersonBasicContactInfo(
                 id = application.guardianId,
                 email = email ?: "",
                 phone = application.form.guardian.phoneNumber
@@ -155,14 +155,14 @@ class ApplicationStateService(
         val application = getApplication(tx, applicationId)
         verifyStatus(application, SENT)
 
-        tx.handle.getPersonById(application.guardianId)?.let {
+        tx.getPersonById(application.guardianId)?.let {
             val email = if (!application.form.guardian.email.isNullOrBlank()) {
                 application.form.guardian.email
             } else {
                 it.email
             }
 
-            tx.handle.updatePersonBasicContactInfo(
+            tx.updatePersonBasicContactInfo(
                 id = application.guardianId,
                 email = email ?: "",
                 phone = application.form.guardian.phoneNumber

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -74,7 +74,7 @@ GROUP BY application.guardian_id
 
             var createdJobCount = 0
             pendingGuardianDecisions.forEach { pendingDecision ->
-                tx.handle.getPersonById(pendingDecision.guardianId)?.let { guardian ->
+                tx.getPersonById(pendingDecision.guardianId)?.let { guardian ->
                     if (!guardian.email.isNullOrBlank()) {
                         asyncJobRunner.plan(
                             tx,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/SendApplicationReceivedEmailAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/SendApplicationReceivedEmailAsyncJobs.kt
@@ -24,7 +24,7 @@ class SendApplicationReceivedEmailAsyncJobs(
     }
 
     private fun runSendApplicationEmail(db: Database, msg: SendApplicationEmail) {
-        val guardian = db.read { it.handle.getPersonById(msg.guardianId) }
+        val guardian = db.read { it.getPersonById(msg.guardianId) }
             ?: throw Exception("Didn't find guardian when sending application email (guardianId: ${msg.guardianId})")
 
         if (!guardian.email.isNullOrBlank()) {

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -90,8 +90,8 @@ class ChildAttendanceController(
         }
 
         val result = db.transaction {
-            if (it.handle.employeePinIsCorrect(staffId, pin)) {
-                it.handle.resetEmployeePinFailureCount(staffId)
+            if (it.employeePinIsCorrect(staffId, pin)) {
+                it.resetEmployeePinFailureCount(staffId)
                 it.getChildSensitiveInfo(childId)?.let {
                     ChildResult(
                         status = ChildResultStatus.SUCCESS,
@@ -99,7 +99,7 @@ class ChildAttendanceController(
                     )
                 } ?: ChildResult(status = ChildResultStatus.NOT_FOUND)
             } else {
-                if (it.handle.updateEmployeePinFailureCountAndCheckIfLocked(staffId)) {
+                if (it.updateEmployeePinFailureCountAndCheckIfLocked(staffId)) {
                     ChildResult(status = ChildResultStatus.PIN_LOCKED, child = null)
                 } else {
                     ChildResult(status = ChildResultStatus.WRONG_PIN, child = null)

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -359,7 +359,7 @@ fun Database.Transaction.deleteCurrentDayAbsences(childId: UUID) {
 }
 
 fun Database.Read.getChildSensitiveInfo(childId: UUID): ChildSensitiveInformation? {
-    val person = handle.getPersonById(childId)
+    val person = getPersonById(childId)
     val placementTypes = handle.getPlacementsForChild(childId).map { it.type }
     val child = getChild(childId)
     val backupPickups = getBackupPickupsForChild(childId)

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -361,7 +361,7 @@ fun Database.Transaction.deleteCurrentDayAbsences(childId: UUID) {
 fun Database.Read.getChildSensitiveInfo(childId: UUID): ChildSensitiveInformation? {
     val person = handle.getPersonById(childId)
     val placementTypes = handle.getPlacementsForChild(childId).map { it.type }
-    val child = handle.getChild(childId)
+    val child = getChild(childId)
     val backupPickups = getBackupPickupsForChild(childId)
     val familyContacts = fetchFamilyContacts(childId)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -360,7 +360,7 @@ fun Database.Transaction.deleteCurrentDayAbsences(childId: UUID) {
 
 fun Database.Read.getChildSensitiveInfo(childId: UUID): ChildSensitiveInformation? {
     val person = getPersonById(childId)
-    val placementTypes = handle.getPlacementsForChild(childId).map { it.type }
+    val placementTypes = getPlacementsForChild(childId).map { it.type }
     val child = getChild(childId)
     val backupPickups = getBackupPickupsForChild(childId)
     val familyContacts = fetchFamilyContacts(childId)

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -32,7 +32,7 @@ class BackupCareController(private val acl: AccessControlList) {
         @PathVariable("childId") childId: UUID
     ): ResponseEntity<ChildBackupCaresResponse> {
         acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
-        val backupCares = db.read { it.handle.getBackupCaresForChild(childId) }
+        val backupCares = db.read { it.getBackupCaresForChild(childId) }
         return ResponseEntity.ok(ChildBackupCaresResponse(backupCares))
     }
 
@@ -45,7 +45,7 @@ class BackupCareController(private val acl: AccessControlList) {
     ): ResponseEntity<BackupCareCreateResponse> {
         acl.getRolesForChild(user, childId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         try {
-            val id = db.transaction { it.handle.createBackupCare(childId, body) }
+            val id = db.transaction { it.createBackupCare(childId, body) }
             return ResponseEntity.ok(BackupCareCreateResponse(id))
         } catch (e: JdbiException) {
             throw mapPSQLException(e)
@@ -61,7 +61,7 @@ class BackupCareController(private val acl: AccessControlList) {
     ): ResponseEntity<Unit> {
         acl.getRolesForBackupCare(user, backupCareId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
         try {
-            db.transaction { it.handle.updateBackupCare(backupCareId, body.period, body.groupId) }
+            db.transaction { it.updateBackupCare(backupCareId, body.period, body.groupId) }
             return ResponseEntity.noContent().build()
         } catch (e: JdbiException) {
             throw mapPSQLException(e)
@@ -75,7 +75,7 @@ class BackupCareController(private val acl: AccessControlList) {
         @PathVariable("id") backupCareId: UUID
     ): ResponseEntity<Unit> {
         acl.getRolesForBackupCare(user, backupCareId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
-        db.transaction { it.handle.deleteBackupCare(backupCareId) }
+        db.transaction { it.deleteBackupCare(backupCareId) }
         return ResponseEntity.noContent().build()
     }
 
@@ -89,7 +89,7 @@ class BackupCareController(private val acl: AccessControlList) {
     ): ResponseEntity<UnitBackupCaresResponse> {
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF)
-        val backupCares = db.read { it.handle.getBackupCaresForDaycare(daycareId, FiniteDateRange(startDate, endDate)) }
+        val backupCares = db.read { it.getBackupCaresForDaycare(daycareId, FiniteDateRange(startDate, endDate)) }
         return ResponseEntity.ok(UnitBackupCaresResponse(backupCares))
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareQueries.kt
@@ -4,13 +4,13 @@
 
 package fi.espoo.evaka.backupcare
 
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.domain.FiniteDateRange
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import java.util.UUID
 
-fun Handle.getBackupCaresForChild(childId: UUID): List<ChildBackupCare> = createQuery(
+fun Database.Read.getBackupCaresForChild(childId: UUID): List<ChildBackupCare> = createQuery(
     // language=SQL
     """
 SELECT
@@ -32,7 +32,7 @@ WHERE child_id = :childId
     .mapTo<ChildBackupCare>()
     .list()
 
-fun Handle.getBackupCaresForDaycare(daycareId: UUID, period: FiniteDateRange): List<UnitBackupCare> = createQuery(
+fun Database.Read.getBackupCaresForDaycare(daycareId: UUID, period: FiniteDateRange): List<UnitBackupCare> = createQuery(
     // language=SQL
     """
 SELECT
@@ -73,7 +73,7 @@ AND daterange(backup_care.start_date, backup_care.end_date, '[]') && :period
     .mapTo<UnitBackupCare>()
     .list()
 
-fun Handle.createBackupCare(childId: UUID, backupCare: NewBackupCare): UUID = createUpdate(
+fun Database.Transaction.createBackupCare(childId: UUID, backupCare: NewBackupCare): UUID = createUpdate(
     // language=SQL
     """
 INSERT INTO backup_care (child_id, unit_id, group_id, start_date, end_date)
@@ -90,7 +90,7 @@ RETURNING id
     .mapTo<UUID>()
     .one()
 
-fun Handle.updateBackupCare(id: UUID, period: FiniteDateRange, groupId: UUID?) = createUpdate(
+fun Database.Transaction.updateBackupCare(id: UUID, period: FiniteDateRange, groupId: UUID?) = createUpdate(
     // language=SQL
     """
 UPDATE backup_care
@@ -107,7 +107,7 @@ WHERE id = :id
     .bindNullable("groupId", groupId)
     .execute()
 
-fun Handle.deleteBackupCare(id: UUID) = createUpdate(
+fun Database.Transaction.deleteBackupCare(id: UUID) = createUpdate(
     // language=SQL
     """
 DELETE FROM backup_care

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/CaretakerQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/CaretakerQueries.kt
@@ -5,14 +5,14 @@
 package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.daycare.service.Stats
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.mapper.Nested
 import java.time.LocalDate
 import java.util.UUID
 
-fun Handle.initCaretakers(groupId: UUID, startDate: LocalDate, amount: Double) {
+fun Database.Transaction.initCaretakers(groupId: UUID, startDate: LocalDate, amount: Double) {
     // language=SQL
     val sql = "INSERT INTO daycare_caretaker (group_id, start_date, amount) VALUES (:groupId, :startDate, :amount)"
 
@@ -23,7 +23,7 @@ fun Handle.initCaretakers(groupId: UUID, startDate: LocalDate, amount: Double) {
         .execute()
 }
 
-fun Handle.getUnitStats(unitId: UUID, startDate: LocalDate, endDate: LocalDate): Stats {
+fun Database.Read.getUnitStats(unitId: UUID, startDate: LocalDate, endDate: LocalDate): Stats {
     if (startDate.isBefore(endDate.minusYears(5))) {
         throw BadRequest("Too long time range")
     }
@@ -53,7 +53,7 @@ fun Handle.getUnitStats(unitId: UUID, startDate: LocalDate, endDate: LocalDate):
         .first()
 }
 
-fun Handle.getGroupStats(unitId: UUID, startDate: LocalDate, endDate: LocalDate): Map<UUID, Stats> {
+fun Database.Read.getGroupStats(unitId: UUID, startDate: LocalDate, endDate: LocalDate): Map<UUID, Stats> {
     // language=SQL
     val sql =
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/ChildQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/ChildQueries.kt
@@ -5,11 +5,11 @@
 package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.daycare.controllers.Child
-import org.jdbi.v3.core.Handle
+import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.kotlin.mapTo
 import java.util.UUID
 
-fun Handle.getChild(id: UUID): Child? {
+fun Database.Read.getChild(id: UUID): Child? {
     // language=SQL
     val sql = "SELECT * FROM child WHERE id = :id"
 
@@ -19,7 +19,7 @@ fun Handle.getChild(id: UUID): Child? {
         .firstOrNull()
 }
 
-fun Handle.createChild(child: Child): Child {
+fun Database.Transaction.createChild(child: Child): Child {
     // language=SQL
     val sql =
         "INSERT INTO child (id, allergies, diet, additionalinfo, medication) VALUES (:id, :allergies, :diet, :additionalInfo, :medication) RETURNING *"
@@ -34,7 +34,7 @@ fun Handle.createChild(child: Child): Child {
         .first()
 }
 
-fun Handle.upsertChild(child: Child) {
+fun Database.Transaction.upsertChild(child: Child) {
     // language=SQL
     val sql =
         """
@@ -49,7 +49,7 @@ fun Handle.upsertChild(child: Child) {
         .execute()
 }
 
-fun Handle.updateChild(child: Child) {
+fun Database.Transaction.updateChild(child: Child) {
     // language=SQL
     val sql = "UPDATE child SET allergies = :allergies, diet = :diet, additionalinfo = :additionalInfo, preferred_name = :preferredName, medication = :medication WHERE id = :id"
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
@@ -47,7 +47,7 @@ class ChildController(private val acl: AccessControlList) {
 }
 
 fun Database.Read.getAdditionalInformation(childId: UUID): AdditionalInformation {
-    val child = handle.getChild(childId)
+    val child = getChild(childId)
     return if (child != null) {
         AdditionalInformation(
             allergies = child.additionalInformation.allergies,
@@ -60,11 +60,11 @@ fun Database.Read.getAdditionalInformation(childId: UUID): AdditionalInformation
 }
 
 fun Database.Transaction.upsertAdditionalInformation(childId: UUID, data: AdditionalInformation) {
-    val child = handle.getChild(childId)
+    val child = getChild(childId)
     if (child != null) {
-        handle.updateChild(child.copy(additionalInformation = data))
+        updateChild(child.copy(additionalInformation = data))
     } else {
-        handle.createChild(
+        createChild(
             Child(
                 id = childId,
                 additionalInformation = data

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -53,7 +53,7 @@ class DaycareController(
     fun getDaycares(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<Daycare>> {
         Audit.UnitSearch.log()
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
-        return ResponseEntity.ok(db.read { it.handle.getDaycares(acl.getAuthorizedDaycares(user)) })
+        return ResponseEntity.ok(db.read { it.getDaycares(acl.getAuthorizedDaycares(user)) })
     }
 
     @GetMapping("/{daycareId}")
@@ -65,7 +65,7 @@ class DaycareController(
         Audit.UnitRead.log(targetId = daycareId)
         val currentUserRoles = acl.getRolesForUnit(user, daycareId)
         currentUserRoles.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
-        return db.read { it.handle.getDaycare(daycareId) }
+        return db.read { it.getDaycare(daycareId) }
             ?.let { ResponseEntity.ok(DaycareResponse(it, currentUserRoles.roles)) } ?: ResponseEntity.notFound()
             .build()
     }
@@ -155,7 +155,7 @@ class DaycareController(
             .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
 
         return db.read {
-            val daycareStub = it.handle.getDaycareStub(daycareId)
+            val daycareStub = it.getDaycareStub(daycareId)
             ok(
                 CaretakersResponse(
                     caretakers = caretakerService.getCaretakers(it, groupId),
@@ -268,9 +268,9 @@ class DaycareController(
         fields.validate()
         return ResponseEntity.ok(
             db.transaction {
-                it.handle.updateDaycareManager(daycareId, fields.unitManager)
-                it.handle.updateDaycare(daycareId, fields)
-                it.handle.getDaycare(daycareId)!!
+                it.updateDaycareManager(daycareId, fields.unitManager)
+                it.updateDaycare(daycareId, fields)
+                it.getDaycare(daycareId)!!
             }
         )
     }
@@ -287,9 +287,9 @@ class DaycareController(
         return ResponseEntity.ok(
             CreateDaycareResponse(
                 db.transaction {
-                    val id = it.handle.createDaycare(fields.areaId, fields.name)
-                    it.handle.updateDaycareManager(id, fields.unitManager)
-                    it.handle.updateDaycare(id, fields)
+                    val id = it.createDaycare(fields.areaId, fields.name)
+                    it.updateDaycareManager(id, fields.unitManager)
+                    it.updateDaycare(id, fields)
                     id
                 }
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -123,7 +123,7 @@ class DaycareController(
         acl.getRolesForUnitGroup(user, groupId)
             .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
-        db.transaction { it.handle.updateGroup(groupId, body.name, body.startDate, body.endDate) }
+        db.transaction { it.updateGroup(groupId, body.name, body.startDate, body.endDate) }
 
         return noContent()
     }
@@ -160,7 +160,7 @@ class DaycareController(
                 CaretakersResponse(
                     caretakers = caretakerService.getCaretakers(it, groupId),
                     unitName = daycareStub?.name ?: "",
-                    groupName = it.handle.getDaycareGroup(groupId)?.name ?: ""
+                    groupName = it.getDaycareGroup(groupId)?.name ?: ""
                 )
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -40,7 +40,7 @@ class LocationController {
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
         @RequestParam shiftCare: Boolean?
     ): ResponseEntity<List<PublicUnit>> {
-        val units = db.read { it.handle.getApplicationUnits(type, date, shiftCare, onlyApplicable = user.isEndUser) }
+        val units = db.read { it.getApplicationUnits(type, date, shiftCare, onlyApplicable = user.isEndUser) }
         return ResponseEntity.ok(units)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -19,7 +19,6 @@ import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
@@ -68,7 +67,7 @@ class LocationController {
     @GetMapping("/filters/units")
     fun getUnits(db: Database.Connection, @RequestParam type: UnitTypeFilter, @RequestParam area: String?): ResponseEntity<List<UnitStub>> {
         val areas = area?.split(",") ?: listOf()
-        val units = db.read { it.handle.getUnits(areas, type) }
+        val units = db.read { it.getUnits(areas, type) }
         return ResponseEntity.ok(units)
     }
 }
@@ -103,7 +102,7 @@ data class AreaJSON(
     val shortName: String
 )
 
-fun Handle.getAreas(): List<CareArea> = createQuery(
+fun Database.Read.getAreas(): List<CareArea> = createQuery(
     // language=sql
     """
 SELECT
@@ -148,7 +147,7 @@ enum class UnitTypeFilter {
     ALL, CLUB, DAYCARE, PRESCHOOL
 }
 
-fun Handle.getUnits(areaShortNames: Collection<String>, type: UnitTypeFilter): List<UnitStub> = createQuery(
+fun Database.Read.getUnits(areaShortNames: Collection<String>, type: UnitTypeFilter): List<UnitStub> = createQuery(
     // language=SQL
     """
 SELECT unit.id, unit.name

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
@@ -32,7 +32,7 @@ class UnitAclController(private val acl: AccessControlList) {
         Audit.UnitAclRead.log()
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
-        val acls = db.read { it.handle.getDaycareAclRows(daycareId) }
+        val acls = db.read { it.getDaycareAclRows(daycareId) }
         return ResponseEntity.ok(DaycareAclResponse(acls))
     }
 
@@ -46,7 +46,7 @@ class UnitAclController(private val acl: AccessControlList) {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(UserRole.ADMIN)
-        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, UserRole.UNIT_SUPERVISOR) }
+        db.transaction { it.insertDaycareAclRow(daycareId, employeeId, UserRole.UNIT_SUPERVISOR) }
         return ResponseEntity.noContent().build()
     }
 
@@ -61,7 +61,7 @@ class UnitAclController(private val acl: AccessControlList) {
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(UserRole.ADMIN)
 
-        db.transaction { it.handle.deleteDaycareAclRow(daycareId, employeeId, UserRole.UNIT_SUPERVISOR) }
+        db.transaction { it.deleteDaycareAclRow(daycareId, employeeId, UserRole.UNIT_SUPERVISOR) }
         return ResponseEntity.noContent().build()
     }
 
@@ -75,7 +75,7 @@ class UnitAclController(private val acl: AccessControlList) {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(UserRole.ADMIN)
-        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, UserRole.SPECIAL_EDUCATION_TEACHER) }
+        db.transaction { it.insertDaycareAclRow(daycareId, employeeId, UserRole.SPECIAL_EDUCATION_TEACHER) }
         return ResponseEntity.noContent().build()
     }
 
@@ -89,7 +89,7 @@ class UnitAclController(private val acl: AccessControlList) {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(UserRole.ADMIN)
-        db.transaction { it.handle.deleteDaycareAclRow(daycareId, employeeId, UserRole.SPECIAL_EDUCATION_TEACHER) }
+        db.transaction { it.deleteDaycareAclRow(daycareId, employeeId, UserRole.SPECIAL_EDUCATION_TEACHER) }
         return ResponseEntity.noContent().build()
     }
 
@@ -103,7 +103,7 @@ class UnitAclController(private val acl: AccessControlList) {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
-        db.transaction { it.handle.insertDaycareAclRow(daycareId, employeeId, UserRole.STAFF) }
+        db.transaction { it.insertDaycareAclRow(daycareId, employeeId, UserRole.STAFF) }
         return ResponseEntity.noContent().build()
     }
 
@@ -118,7 +118,7 @@ class UnitAclController(private val acl: AccessControlList) {
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
-        db.transaction { it.handle.deleteDaycareAclRow(daycareId, employeeId, UserRole.STAFF) }
+        db.transaction { it.deleteDaycareAclRow(daycareId, employeeId, UserRole.STAFF) }
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -100,7 +100,7 @@ class AbsenceService {
         val absenceList = tx.getAbsencesByChildByRange(childId, period)
         val backupCareList = tx.getBackupCaresAffectingChild(childId, period)
         val child =
-            tx.handle.getPersonById(childId) ?: throw BadRequest("Error: Could not find child with id: $childId")
+            tx.getPersonById(childId) ?: throw BadRequest("Error: Could not find child with id: $childId")
         return AbsenceChildMinimal(
             id = child.id,
             firstName = child.firstName ?: "",

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -28,7 +28,7 @@ class AbsenceService {
         val endDate = startDate.with(lastDayOfMonth())
         val period = FiniteDateRange(startDate, endDate)
 
-        val daycare = tx.handle.getDaycare(tx.getDaycareIdByGroup(groupId)) ?: throw BadRequest("Couldn't find daycare with group with id $groupId")
+        val daycare = tx.getDaycare(tx.getDaycareIdByGroup(groupId)) ?: throw BadRequest("Couldn't find daycare with group with id $groupId")
         val groupName = tx.getGroupName(groupId) ?: throw BadRequest("Couldn't find group with id $groupId")
         val placementList = tx.getPlacementsByRange(groupId, period)
         val absenceList = tx.getAbsencesByRange(groupId, period)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -43,7 +43,7 @@ class DaycareService {
         name: String,
         startDate: LocalDate,
         initialCaretakers: Double
-    ): DaycareGroup = tx.handle.createDaycareGroup(daycareId, name, startDate).also {
+    ): DaycareGroup = tx.createDaycareGroup(daycareId, name, startDate).also {
         tx.initCaretakers(it.id, it.startDate, initialCaretakers)
     }
 
@@ -57,7 +57,7 @@ class DaycareService {
 
         if (!isEmpty) throw Conflict("Cannot delete group which has children placed in it")
 
-        tx.handle.deleteDaycareGroup(groupId)
+        tx.deleteDaycareGroup(groupId)
     } catch (e: UnableToExecuteStatementException) {
         throw e.psqlCause()?.takeIf { it.sqlState == PSQLState.FOREIGN_KEY_VIOLATION.state }
             ?.let { Conflict("Cannot delete group which is still referred to from other data") }
@@ -67,7 +67,7 @@ class DaycareService {
     fun getDaycareGroups(tx: Database.Read, daycareId: UUID, startDate: LocalDate?, endDate: LocalDate?): List<DaycareGroup> {
         if (!tx.handle.isValidDaycareId(daycareId)) throw NotFound("No daycare found with id $daycareId")
 
-        return tx.handle.getDaycareGroups(daycareId, startDate, endDate)
+        return tx.getDaycareGroups(daycareId, startDate, endDate)
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -30,10 +30,10 @@ class DaycareService {
         startDate: LocalDate,
         endDate: LocalDate
     ): DaycareCapacityStats {
-        val unitStats = tx.handle.getUnitStats(daycareId, startDate, endDate)
+        val unitStats = tx.getUnitStats(daycareId, startDate, endDate)
         return DaycareCapacityStats(
             unitTotalCaretakers = unitStats,
-            groupCaretakers = tx.handle.getGroupStats(daycareId, startDate, endDate)
+            groupCaretakers = tx.getGroupStats(daycareId, startDate, endDate)
         )
     }
 
@@ -44,7 +44,7 @@ class DaycareService {
         startDate: LocalDate,
         initialCaretakers: Double
     ): DaycareGroup = tx.handle.createDaycareGroup(daycareId, name, startDate).also {
-        tx.handle.initCaretakers(it.id, it.startDate, initialCaretakers)
+        tx.initCaretakers(it.id, it.startDate, initialCaretakers)
     }
 
     fun deleteGroup(tx: Database.Transaction, daycareId: UUID, groupId: UUID) = try {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -65,7 +65,7 @@ class DaycareService {
     }
 
     fun getDaycareGroups(tx: Database.Read, daycareId: UUID, startDate: LocalDate?, endDate: LocalDate?): List<DaycareGroup> {
-        if (!tx.handle.isValidDaycareId(daycareId)) throw NotFound("No daycare found with id $daycareId")
+        if (!tx.isValidDaycareId(daycareId)) throw NotFound("No daycare found with id $daycareId")
 
         return tx.getDaycareGroups(daycareId, startDate, endDate)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionDraftService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionDraftService.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 @Service
 class DecisionDraftService {
     fun createDecisionDrafts(tx: Database.Transaction, user: AuthenticatedUser, application: ApplicationDetails) {
-        val placementPlan = getPlacementPlan(tx.handle, application.id)
+        val placementPlan = tx.getPlacementPlan(application.id)
             ?: throw NotFound("Application ${application.id} has no placement")
 
         val drafts: List<DecisionDraft> = when (placementPlan.type) {

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -175,7 +175,7 @@ class DecisionService(
 
         val currentVtjGuardianIds = personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, decision.childId).map { person -> person.id }
 
-        val applicationGuardian = tx.handle.getPersonById(application.guardianId)
+        val applicationGuardian = tx.getPersonById(application.guardianId)
             ?: error("Guardian not found with id: ${application.guardianId}")
 
         if (currentVtjGuardianIds.contains(applicationGuardian.id)) {
@@ -188,7 +188,7 @@ class DecisionService(
             !decision.otherGuardianDocumentUri.isNullOrBlank() &&
             !applicationGuardian.restrictedDetailsEnabled
         ) {
-            val otherGuardian = tx.handle.getPersonById(application.otherGuardianId)
+            val otherGuardian = tx.getPersonById(application.otherGuardianId)
                 ?: error("Other guardian not found with id: ${application.otherGuardianId}")
 
             if (currentVtjGuardianIds.contains(application.otherGuardianId)) {
@@ -255,7 +255,7 @@ class DecisionService(
     }
 
     private fun calculateDecisionFileName(tx: Database.Read, decision: Decision, lang: String): String {
-        val child = tx.handle.getPersonById(decision.childId)
+        val child = tx.getPersonById(decision.childId)
         val childName = "${child?.firstName}_${child?.lastName}"
         val prefix = getLocalizedFilename(decision.type, lang)
         return "${prefix}_$childName.pdf".replace(" ", "_")

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -74,7 +74,7 @@ class DecisionService(
             ?: error("Guardian not found with id: ${application.guardianId}")
         val child = personService.getUpToDatePerson(tx, user, application.childId)
             ?: error("Child not found with id: ${application.childId}")
-        val unitManager = tx.handle.getUnitManager(decision.unit.id)
+        val unitManager = tx.getUnitManager(decision.unit.id)
             ?: throw NotFound("Daycare manager not found with daycare id: ${decision.unit.id}.")
         val guardianDecisionURI = createAndUploadDecision(
             decision, application, guardian, child, decisionLanguage, unitManager

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsService.kt
@@ -96,7 +96,7 @@ class DvvModificationsService(
     }
 
     private fun handleDeath(db: Database, ssn: String, deathDvvInfoGroup: DeathDvvInfoGroup) = db.transaction { tx ->
-        tx.handle.getPersonBySSN(ssn)?.let {
+        tx.getPersonBySSN(ssn)?.let {
             val dateOfDeath = deathDvvInfoGroup.kuolinpv?.asLocalDate() ?: LocalDate.now()
             logger.info("Dvv modification for ${it.id}: marking dead since $dateOfDeath")
             tx.updatePersonFromVtj(it.copy(dateOfDeath = dateOfDeath))
@@ -108,7 +108,7 @@ class DvvModificationsService(
         ssn: String,
         restrictedInfoDvvInfoGroup: RestrictedInfoDvvInfoGroup
     ) = db.transaction { tx ->
-        tx.handle.getPersonBySSN(ssn)?.let {
+        tx.getPersonBySSN(ssn)?.let {
             logger.info("Dvv modification for ${it.id}: restricted ${restrictedInfoDvvInfoGroup.turvakieltoAktiivinen}")
             tx.updatePersonFromVtj(
                 it.copy(
@@ -124,9 +124,9 @@ class DvvModificationsService(
 
     private fun handleSsnDvvInfoGroup(db: Database, ssn: String, ssnDvvInfoGroup: SsnDvvInfoGroup) =
         db.transaction { tx ->
-            tx.handle.getPersonBySSN(ssn)?.let {
+            tx.getPersonBySSN(ssn)?.let {
                 logger.info("Dvv modification for ${it.id}: ssn change")
-                tx.handle.addSSNToPerson(it.id, ssnDvvInfoGroup.aktiivinenHenkilotunnus)
+                tx.addSSNToPerson(it.id, ssnDvvInfoGroup.aktiivinenHenkilotunnus)
             }
         }
 
@@ -134,7 +134,7 @@ class DvvModificationsService(
     // TURVAKIELTO=false and MUUTETTU if restrictions are lifted (MUUTETTU is the "new" address)
     private fun handleAddressDvvInfoGroup(db: Database, ssn: String, addressDvvInfoGroup: AddressDvvInfoGroup) =
         db.transaction { tx ->
-            tx.handle.getPersonBySSN(ssn)?.let {
+            tx.getPersonBySSN(ssn)?.let {
                 if (addressDvvInfoGroup.muutosattribuutti.equals("LISATTY") || (
                     addressDvvInfoGroup.muutosattribuutti.equals("MUUTETTU") && it.streetAddress.isNullOrEmpty()
                     )
@@ -157,7 +157,7 @@ class DvvModificationsService(
         residenceCodeDvvInfoGroup: ResidenceCodeDvvInfoGroup
     ) = db.transaction { tx ->
         if (residenceCodeDvvInfoGroup.muutosattribuutti.equals("LISATTY")) {
-            tx.handle.getPersonBySSN(ssn)?.let {
+            tx.getPersonBySSN(ssn)?.let {
                 logger.info("Dvv modification for ${it.id}: residence code change")
                 tx.updatePersonFromVtj(
                     it.copy(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -56,7 +56,6 @@ import fi.espoo.evaka.shared.domain.mergePeriods
 import fi.espoo.evaka.shared.domain.minEndDate
 import fi.espoo.evaka.shared.domain.orMax
 import mu.KotlinLogging
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Component
@@ -217,7 +216,7 @@ private fun Database.Transaction.handleValueDecisionChanges(
 ) {
     val familySize = 1 + (partner?.let { 1 } ?: 0) + allChildren.size
     val prices = getPricing(from)
-    val voucherValues = handle.getVoucherValues(from)
+    val voucherValues = getVoucherValues(from)
     val incomes = getIncomesFrom(objectMapper, listOfNotNull(headOfFamily.id, partner?.id), from)
     val feeAlterations =
         getFeeAlterationsFrom(listOf(child.id), from) + addECHAFeeAlterations(listOf(child), incomes)
@@ -760,7 +759,7 @@ internal fun <Decision : FinanceDecision<Decision>> updateDecisionEndDatesAndMer
     return Pair(updatedActives, filteredDrafts)
 }
 
-private fun Handle.getVoucherValues(from: LocalDate): List<Pair<DateRange, Int>> {
+private fun Database.Read.getVoucherValues(from: LocalDate): List<Pair<DateRange, Int>> {
     // language=sql
     val sql = "SELECT * FROM voucher_value WHERE validity && daterange(:from, null, '[]')"
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -559,7 +559,7 @@ private fun Database.Read.getPaidPlacements(
         val placements = getActivePaidPlacements(child.id, from)
         if (placements.isEmpty()) return@map child to listOf<Pair<DateRange, PermanentPlacementWithHours>>()
 
-        val serviceNeeds = getServiceNeedsByChildDuringPeriod(handle, child.id, from, null)
+        val serviceNeeds = getServiceNeedsByChildDuringPeriod(child.id, from, null)
         val placementsWithServiceNeeds = addServiceNeedsToPlacements(placements, serviceNeeds)
 
         child to placementsWithServiceNeeds

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -490,7 +490,7 @@ private fun Database.Read.findFamiliesByChild(childId: UUID, period: DateRange):
     val parentRelations = getParentships(null, childId, includeConflicts = false, period = period)
 
     return parentRelations.flatMap {
-        val fridgePartners = handle.getPartnersForPerson(it.headOfChildId, includeConflicts = false, period = period)
+        val fridgePartners = getPartnersForPerson(it.headOfChildId, includeConflicts = false, period = period)
         val fridgeChildren = getParentships(it.headOfChildId, null, includeConflicts = false, period = period)
         generateFamilyCompositions(
             it.headOfChild.id,
@@ -503,12 +503,12 @@ private fun Database.Read.findFamiliesByChild(childId: UUID, period: DateRange):
 
 private fun Database.Read.findFamiliesByHeadOfFamily(headOfFamilyId: UUID, period: DateRange): List<FridgeFamily> {
     val childRelations = getParentships(headOfFamilyId, null, includeConflicts = false, period = period)
-    val partners = handle.getPartnersForPerson(headOfFamilyId, includeConflicts = false, period = period)
+    val partners = getPartnersForPerson(headOfFamilyId, includeConflicts = false, period = period)
     return generateFamilyCompositions(headOfFamilyId, partners, childRelations, period)
 }
 
 private fun Database.Read.findFamiliesByPartner(personId: UUID, period: DateRange): List<FridgeFamily> {
-    val possibleHeadsOfFamily = handle.getPartnersForPerson(personId, includeConflicts = false, period = period)
+    val possibleHeadsOfFamily = getPartnersForPerson(personId, includeConflicts = false, period = period)
     return possibleHeadsOfFamily.flatMap { findFamiliesByHeadOfFamily(it.person.id, period) }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -240,11 +240,11 @@ private fun Database.Transaction.handleValueDecisionChanges(
             serviceVoucherUnits
         )
 
-    handle.lockValueDecisionsForChild(child.id)
+    lockValueDecisionsForChild(child.id)
 
     val existingDrafts =
-        handle.findValueDecisionsForChild(objectMapper, child.id, null, listOf(VoucherValueDecisionStatus.DRAFT))
-    val activeDecisions = handle.findValueDecisionsForChild(
+        findValueDecisionsForChild(objectMapper, child.id, null, listOf(VoucherValueDecisionStatus.DRAFT))
+    val activeDecisions = findValueDecisionsForChild(
         objectMapper,
         child.id,
         null,
@@ -256,8 +256,8 @@ private fun Database.Transaction.handleValueDecisionChanges(
     )
 
     val updatedDecisions = updateExistingDecisions(from, newDrafts, existingDrafts, activeDecisions)
-    handle.deleteValueDecisions(existingDrafts.map { it.id })
-    handle.upsertValueDecisions(objectMapper, updatedDecisions)
+    deleteValueDecisions(existingDrafts.map { it.id })
+    upsertValueDecisions(objectMapper, updatedDecisions)
 }
 
 internal fun addECHAFeeAlterations(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -487,11 +487,11 @@ private fun Database.Read.getServiceVoucherUnits(): List<UUID> {
 }
 
 private fun Database.Read.findFamiliesByChild(childId: UUID, period: DateRange): List<FridgeFamily> {
-    val parentRelations = handle.getParentships(null, childId, includeConflicts = false, period = period)
+    val parentRelations = getParentships(null, childId, includeConflicts = false, period = period)
 
     return parentRelations.flatMap {
         val fridgePartners = handle.getPartnersForPerson(it.headOfChildId, includeConflicts = false, period = period)
-        val fridgeChildren = handle.getParentships(it.headOfChildId, null, includeConflicts = false, period = period)
+        val fridgeChildren = getParentships(it.headOfChildId, null, includeConflicts = false, period = period)
         generateFamilyCompositions(
             it.headOfChild.id,
             fridgePartners,
@@ -502,7 +502,7 @@ private fun Database.Read.findFamiliesByChild(childId: UUID, period: DateRange):
 }
 
 private fun Database.Read.findFamiliesByHeadOfFamily(headOfFamilyId: UUID, period: DateRange): List<FridgeFamily> {
-    val childRelations = handle.getParentships(headOfFamilyId, null, includeConflicts = false, period = period)
+    val childRelations = getParentships(headOfFamilyId, null, includeConflicts = false, period = period)
     val partners = handle.getPartnersForPerson(headOfFamilyId, includeConflicts = false, period = period)
     return generateFamilyCompositions(headOfFamilyId, partners, childRelations, period)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -55,7 +55,7 @@ fun Database.Transaction.createAllDraftInvoices(objectMapper: ObjectMapper, peri
     val unhandledDecisions = effectiveDecisions.filterNot { invoicedHeadsOfFamily.contains(it.key) }
     val unhandledPlacements = placements.filterNot { invoicedHeadsOfFamily.contains(it.key) }
     val daycareCodes = getDaycareCodes()
-    val operationalDays = operationalDays(handle, period.start.year, period.start.month)
+    val operationalDays = operationalDays(period.start.year, period.start.month)
 
     val absences: List<AbsenceStub> = getAbsenceStubs(period, listOf(CareType.DAYCARE, CareType.PRESCHOOL_DAYCARE))
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
@@ -51,11 +51,11 @@ class VoucherValueDecisionService(
 
         val pdf = generatePdf(decision)
         val key = uploadPdf(decision.id, pdf)
-        tx.handle.updateVoucherValueDecisionDocumentKey(decision.id, key)
+        tx.updateVoucherValueDecisionDocumentKey(decision.id, key)
     }
 
     fun getDecisionPdf(tx: Database.Read, decisionId: UUID): Pair<String, ByteArray> {
-        val key = tx.handle.getVoucherValueDecisionDocumentKey(decisionId)
+        val key = tx.getVoucherValueDecisionDocumentKey(decisionId)
             ?: throw NotFound("No voucher value decision found with ID ($decisionId)")
         return key to s3Client.getPdf(bucket, key)
     }
@@ -121,9 +121,9 @@ AND placements.combined_range << daterange(:now, null)
 """
         ).bind("now", now).mapTo<UUID>().toList()
 
-        tx.handle.lockValueDecisions(decisionIds)
+        tx.lockValueDecisions(decisionIds)
 
-        tx.handle
+        tx
             .getValueDecisionsByIds(objectMapper, decisionIds)
             .forEach { decision ->
                 val mergedPlacementPeriods = tx
@@ -162,7 +162,7 @@ ORDER BY start_date ASC
     }
 
     private fun getDecision(tx: Database.Read, decisionId: UUID): VoucherValueDecisionDetailed =
-        tx.handle.getVoucherValueDecision(objectMapper, decisionId)
+        tx.getVoucherValueDecision(objectMapper, decisionId)
             ?: error("No voucher value decision found with ID ($decisionId)")
 
     private val key = { id: UUID -> "value_decision_$id.pdf" }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/ParentshipQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/ParentshipQueries.kt
@@ -6,18 +6,18 @@ package fi.espoo.evaka.pis
 
 import fi.espoo.evaka.pis.service.Parentship
 import fi.espoo.evaka.pis.service.PersonJSON
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.statement.StatementContext
 import java.sql.ResultSet
 import java.time.LocalDate
 import java.util.UUID
 
-fun Handle.getParentship(id: UUID): Parentship? {
+fun Database.Read.getParentship(id: UUID): Parentship? {
     // language=SQL
     val sql =
         """
@@ -37,7 +37,7 @@ fun Handle.getParentship(id: UUID): Parentship? {
         .firstOrNull()
 }
 
-fun Handle.getParentships(
+fun Database.Read.getParentships(
     headOfChildId: UUID?,
     childId: UUID?,
     includeConflicts: Boolean = false,
@@ -71,7 +71,7 @@ fun Handle.getParentships(
         .toList()
 }
 
-fun Handle.createParentship(
+fun Database.Transaction.createParentship(
     childId: UUID,
     headOfChildId: UUID,
     startDate: LocalDate,
@@ -105,7 +105,7 @@ fun Handle.createParentship(
         .first()
 }
 
-fun Handle.updateParentshipDuration(id: UUID, startDate: LocalDate, endDate: LocalDate): Boolean {
+fun Database.Transaction.updateParentshipDuration(id: UUID, startDate: LocalDate, endDate: LocalDate): Boolean {
     // language=sql
     val sql = "UPDATE fridge_child SET start_date = :startDate, end_date = :endDate WHERE id = :id"
 
@@ -116,7 +116,7 @@ fun Handle.updateParentshipDuration(id: UUID, startDate: LocalDate, endDate: Loc
         .execute() > 0
 }
 
-fun Handle.retryParentship(id: UUID) {
+fun Database.Transaction.retryParentship(id: UUID) {
     // language=SQL
     val sql = "UPDATE fridge_child SET conflict = false WHERE id = :id"
     createUpdate(sql)
@@ -124,7 +124,7 @@ fun Handle.retryParentship(id: UUID) {
         .execute()
 }
 
-fun Handle.deleteParentship(id: UUID): Boolean {
+fun Database.Transaction.deleteParentship(id: UUID): Boolean {
     // language=SQL
     val sql = "DELETE FROM fridge_child WHERE id = :id RETURNING id"
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PartnershipQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PartnershipQueries.kt
@@ -6,18 +6,18 @@ package fi.espoo.evaka.pis
 
 import fi.espoo.evaka.pis.service.Partner
 import fi.espoo.evaka.pis.service.Partnership
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.PGConstants
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.DateRange
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.statement.StatementContext
 import java.sql.ResultSet
 import java.time.LocalDate
 import java.util.UUID
 
-fun Handle.getPartnership(id: UUID): Partnership? {
+fun Database.Read.getPartnership(id: UUID): Partnership? {
     // language=SQL
     val sql =
         """
@@ -41,7 +41,7 @@ fun Handle.getPartnership(id: UUID): Partnership? {
         .firstOrNull()
 }
 
-fun Handle.getPartnershipsForPerson(personId: UUID, includeConflicts: Boolean = false): List<Partnership> {
+fun Database.Read.getPartnershipsForPerson(personId: UUID, includeConflicts: Boolean = false): List<Partnership> {
     // language=SQL
     val sql =
         """
@@ -67,7 +67,7 @@ fun Handle.getPartnershipsForPerson(personId: UUID, includeConflicts: Boolean = 
         .toList()
 }
 
-fun Handle.getPartnersForPerson(personId: UUID, includeConflicts: Boolean, period: DateRange? = null): List<Partner> {
+fun Database.Read.getPartnersForPerson(personId: UUID, includeConflicts: Boolean, period: DateRange? = null): List<Partner> {
     // language=SQL
     val sql =
         """
@@ -91,7 +91,7 @@ fun Handle.getPartnersForPerson(personId: UUID, includeConflicts: Boolean, perio
         .toList()
 }
 
-fun Handle.createPartnership(
+fun Database.Transaction.createPartnership(
     personId1: UUID,
     personId2: UUID,
     startDate: LocalDate,
@@ -132,7 +132,7 @@ fun Handle.createPartnership(
         .first()
 }
 
-fun Handle.updatePartnershipDuration(id: UUID, startDate: LocalDate, endDate: LocalDate?): Boolean {
+fun Database.Transaction.updatePartnershipDuration(id: UUID, startDate: LocalDate, endDate: LocalDate?): Boolean {
     // language=SQL
     val sql =
         """
@@ -149,7 +149,7 @@ fun Handle.updatePartnershipDuration(id: UUID, startDate: LocalDate, endDate: Lo
         .firstOrNull() != null
 }
 
-fun Handle.retryPartnership(id: UUID) {
+fun Database.Transaction.retryPartnership(id: UUID) {
     // language=SQL
     val sql = "UPDATE fridge_partner SET conflict = false WHERE partnership_id = :id"
 
@@ -158,7 +158,7 @@ fun Handle.retryPartnership(id: UUID) {
         .execute()
 }
 
-fun Handle.deletePartnership(id: UUID): Boolean {
+fun Database.Transaction.deletePartnership(id: UUID): Boolean {
     // language=SQL
     val sql = "DELETE FROM fridge_partner WHERE partnership_id = :id RETURNING partnership_id"
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonQueries.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.pis.service.PersonPatch
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.freeTextSearchQuery
 import fi.espoo.evaka.shared.db.getUUID
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.statement.StatementContext
@@ -23,7 +22,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-fun Handle.getPersonById(id: UUID): PersonDTO? {
+fun Database.Read.getPersonById(id: UUID): PersonDTO? {
     // language=SQL
     val sql = "SELECT * FROM person WHERE id = :id"
 
@@ -37,7 +36,7 @@ fun Database.Transaction.lockPersonBySSN(ssn: String): PersonDTO? = createQuery(
     "SELECT * FROM person WHERE social_security_number = :ssn FOR UPDATE"
 ).bind("ssn", ssn).map(toPersonDTO).firstOrNull()
 
-fun Handle.getPersonBySSN(ssn: String): PersonDTO? {
+fun Database.Read.getPersonBySSN(ssn: String): PersonDTO? {
     // language=SQL
     val sql = "SELECT * FROM person WHERE social_security_number = :ssn"
 
@@ -50,7 +49,7 @@ fun Handle.getPersonBySSN(ssn: String): PersonDTO? {
 private val personSortColumns =
     listOf("first_name", "last_name", "date_of_birth", "street_address", "social_security_number")
 
-fun Handle.searchPeople(searchTerms: String, sortColumns: String, sortDirection: String): List<PersonDTO> {
+fun Database.Read.searchPeople(searchTerms: String, sortColumns: String, sortDirection: String): List<PersonDTO> {
     if (searchTerms.isBlank()) return listOf()
 
     val direction = if (sortDirection.equals("DESC", ignoreCase = true)) "DESC" else "ASC"
@@ -73,7 +72,7 @@ fun Handle.searchPeople(searchTerms: String, sortColumns: String, sortDirection:
         .toList()
 }
 
-fun Handle.createPerson(person: PersonIdentityRequest): PersonDTO {
+fun Database.Transaction.createPerson(person: PersonIdentityRequest): PersonDTO {
     // language=SQL
     val sql =
         """
@@ -93,7 +92,7 @@ fun Handle.createPerson(person: PersonIdentityRequest): PersonDTO {
         .first()
 }
 
-fun Handle.createPerson(person: CreatePersonBody): UUID {
+fun Database.Transaction.createPerson(person: CreatePersonBody): UUID {
     // language=SQL
     val sql =
         """
@@ -108,7 +107,7 @@ fun Handle.createPerson(person: CreatePersonBody): UUID {
         .first()
 }
 
-fun Handle.createEmptyPerson(): PersonDTO {
+fun Database.Transaction.createEmptyPerson(): PersonDTO {
     // language=SQL
     val sql =
         """
@@ -198,7 +197,7 @@ fun Database.Transaction.updatePersonFromVtj(person: PersonDTO): PersonDTO {
         .first()
 }
 
-fun Handle.updatePersonBasicContactInfo(id: UUID, email: String, phone: String): Boolean {
+fun Database.Transaction.updatePersonBasicContactInfo(id: UUID, email: String, phone: String): Boolean {
     // language=SQL
     val sql =
         """
@@ -217,7 +216,7 @@ fun Handle.updatePersonBasicContactInfo(id: UUID, email: String, phone: String):
         .firstOrNull() != null
 }
 
-fun Handle.updatePersonContactInfo(id: UUID, contactInfo: ContactInfo): Boolean {
+fun Database.Transaction.updatePersonContactInfo(id: UUID, contactInfo: ContactInfo): Boolean {
     // language=SQL
     val sql =
         """
@@ -241,7 +240,7 @@ fun Handle.updatePersonContactInfo(id: UUID, contactInfo: ContactInfo): Boolean 
         .firstOrNull() != null
 }
 
-fun Handle.updatePersonDetails(id: UUID, patch: PersonPatch): Boolean {
+fun Database.Transaction.updatePersonDetails(id: UUID, patch: PersonPatch): Boolean {
     // language=SQL
     val sql =
         """
@@ -270,7 +269,7 @@ fun Handle.updatePersonDetails(id: UUID, patch: PersonPatch): Boolean {
         .firstOrNull() != null
 }
 
-fun Handle.addSSNToPerson(id: UUID, ssn: String) {
+fun Database.Transaction.addSSNToPerson(id: UUID, ssn: String) {
     // language=SQL
     val sql = "UPDATE person SET social_security_number = :ssn WHERE id = :id"
 
@@ -280,7 +279,7 @@ fun Handle.addSSNToPerson(id: UUID, ssn: String) {
         .execute()
 }
 
-fun Handle.getDeceasedPeople(since: LocalDate): List<PersonDTO> {
+fun Database.Read.getDeceasedPeople(since: LocalDate): List<PersonDTO> {
     // language=SQL
     val sql = "SELECT * FROM person WHERE date_of_death >= :since"
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
@@ -30,7 +30,7 @@ class SystemIdentityController {
         Audit.PersonCreate.log()
         user.assertSystemInternalUser()
         return db.transaction { tx ->
-            tx.handle.getPersonBySSN(person.socialSecurityNumber) ?: tx.handle.createPerson(
+            tx.getPersonBySSN(person.socialSecurityNumber) ?: tx.createPerson(
                 fi.espoo.evaka.pis.service.PersonIdentityRequest(
                     identity = ExternalIdentifier.SSN.getInstance(person.socialSecurityNumber),
                     firstName = person.firstName,

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
@@ -54,7 +54,7 @@ class SystemIdentityController {
         return db.transaction {
             it.getEmployeeUserByExternalId(employee.externalId)
                 ?: EmployeeUser(
-                    id = it.handle.createEmployee(employee.toNewEmployee()).id,
+                    id = it.createEmployee(employee.toNewEmployee()).id,
                     firstName = employee.firstName,
                     lastName = employee.lastName,
                     globalRoles = emptySet(),

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
@@ -39,14 +39,14 @@ class EmployeeController {
     fun getEmployees(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<Employee>> {
         Audit.EmployeesRead.log()
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
-        return ResponseEntity.ok(db.read { it.handle.getEmployees() }.sortedBy { it.email })
+        return ResponseEntity.ok(db.read { it.getEmployees() }.sortedBy { it.email })
     }
 
     @GetMapping("/finance-decision-handler")
     fun getFinanceDecisionHandlers(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<Employee>> {
         Audit.EmployeesRead.log()
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
-        return ResponseEntity.ok(db.read { it.handle.getFinanceDecisionHandlers() }.sortedBy { it.email })
+        return ResponseEntity.ok(db.read { it.getFinanceDecisionHandlers() }.sortedBy { it.email })
     }
 
     @GetMapping("/{id}")
@@ -62,7 +62,7 @@ class EmployeeController {
                 UserRole.DIRECTOR
             )
         }
-        return db.read { it.handle.getEmployee(id) }?.let { ResponseEntity.ok().body(it) }
+        return db.read { it.getEmployee(id) }?.let { ResponseEntity.ok().body(it) }
             ?: ResponseEntity.notFound().build()
     }
 
@@ -70,14 +70,14 @@ class EmployeeController {
     fun createEmployee(db: Database.Connection, user: AuthenticatedUser, @RequestBody employee: NewEmployee): ResponseEntity<Employee> {
         Audit.EmployeeCreate.log(targetId = employee.externalId)
         user.requireOneOfRoles(UserRole.ADMIN)
-        return ResponseEntity.ok().body(db.transaction { it.handle.createEmployee(employee) })
+        return ResponseEntity.ok().body(db.transaction { it.createEmployee(employee) })
     }
 
     @DeleteMapping("/{id}")
     fun deleteEmployee(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Unit> {
         Audit.EmployeeDelete.log(targetId = id)
         user.requireOneOfRoles(UserRole.ADMIN)
-        db.transaction { it.handle.deleteEmployee(id) }
+        db.transaction { it.deleteEmployee(id) }
         return ResponseEntity.ok().build()
     }
 
@@ -104,7 +104,7 @@ class EmployeeController {
     ): Boolean {
         Audit.PinCodeLockedRead.log(targetId = user.id)
         return db.read { tx ->
-            tx.handle.isPinLocked(user.id)
+            tx.isPinLocked(user.id)
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -73,7 +73,7 @@ class ParentshipController(
         )
 
         return db.read {
-            it.handle.getParentships(
+            it.getParentships(
                 headOfChildId = headOfChildId,
                 childId = childId,
                 includeConflicts = true
@@ -92,7 +92,7 @@ class ParentshipController(
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
         return db.read {
-            it.handle.getParentship(id)
+            it.getParentship(id)
         }
             ?.let { ResponseEntity.ok().body(it) }
             ?: ResponseEntity.notFound().build()
@@ -149,7 +149,7 @@ class ParentshipController(
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
 
         db.transaction {
-            if (it.handle.getParentship(id)?.conflict == false) {
+            if (it.getParentship(id)?.conflict == false) {
                 user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
             }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
@@ -65,7 +65,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
         Audit.PartnerShipsRead.log(targetId = personId)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
-        return db.read { it.handle.getPartnershipsForPerson(personId, includeConflicts = true) }
+        return db.read { it.getPartnershipsForPerson(personId, includeConflicts = true) }
             .let { ResponseEntity.ok().body(it) }
     }
 
@@ -78,7 +78,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
         Audit.PartnerShipsRead.log(targetId = partnershipId)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
-        return db.read { it.handle.getPartnership(partnershipId) }
+        return db.read { it.getPartnership(partnershipId) }
             ?.let { ResponseEntity.ok().body(it) }
             ?: ResponseEntity.notFound().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -50,7 +50,7 @@ class PersonController(
     fun createEmpty(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<PersonIdentityResponseJSON> {
         Audit.PersonCreate.log()
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.ADMIN)
-        return db.transaction { it.handle.createEmptyPerson() }
+        return db.transaction { it.createEmptyPerson() }
             .let { ResponseEntity.ok().body(PersonIdentityResponseJSON.from(it)) }
     }
 
@@ -115,7 +115,7 @@ class PersonController(
         return ResponseEntity.ok()
             .body(
                 db.read {
-                    it.handle.searchPeople(
+                    it.searchPeople(
                         searchTerm,
                         orderBy,
                         sortDirection
@@ -133,7 +133,7 @@ class PersonController(
     ): ResponseEntity<ContactInfo> {
         Audit.PersonContactInfoUpdate.log(targetId = personId)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
-        return if (db.transaction { it.handle.updatePersonContactInfo(personId, contactInfo) }) {
+        return if (db.transaction { it.updatePersonContactInfo(personId, contactInfo) }) {
             ResponseEntity.ok().body(contactInfo)
         } else {
             ResponseEntity.notFound().build()
@@ -225,7 +225,7 @@ class PersonController(
 
         return ResponseEntity.ok()
             .body(
-                db.read { it.handle.getDeceasedPeople(sinceDate) }.map { personDTO -> PersonJSON.from(personDTO) }
+                db.read { it.getDeceasedPeople(sinceDate) }.map { personDTO -> PersonJSON.from(personDTO) }
             )
     }
 
@@ -252,7 +252,7 @@ class PersonController(
     ): ResponseEntity<UUID> {
         Audit.PersonCreate.log()
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN)
-        return db.transaction { it.handle.createPerson(body) }
+        return db.transaction { it.createPerson(body) }
             .let { ResponseEntity.ok(it) }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -198,7 +198,7 @@ class FamilyInitializerService(
     private fun createPartnership(tx: Database.Transaction, personId1: UUID, personId2: UUID) {
         val startDate = LocalDate.now()
         val alreadyExists =
-            tx.handle.getPartnershipsForPerson(personId = personId1, includeConflicts = true)
+            tx.getPartnershipsForPerson(personId = personId1, includeConflicts = true)
                 .any { partnership ->
                     partnership.partners.any { partner -> partner.id == personId2 } &&
                         (partnership.startDate.isBefore(startDate) || partnership.startDate.isEqual(startDate)) &&
@@ -209,7 +209,7 @@ class FamilyInitializerService(
         } else {
             try {
                 tx.subTransaction {
-                    tx.handle.createPartnership(
+                    tx.createPartnership(
                         personId1 = personId1,
                         personId2 = personId2,
                         startDate = startDate,
@@ -222,7 +222,7 @@ class FamilyInitializerService(
                     PSQLState.UNIQUE_VIOLATION.state, PSQLState.EXCLUSION_VIOLATION.state -> {
                         val constraint = e.psqlCause()?.serverErrorMessage?.constraint ?: "-"
                         logger.warn("Creating conflict partnership between $personId1 and $personId2 (conflicting constraint is $constraint)")
-                        tx.handle.createPartnership(
+                        tx.createPartnership(
                             personId1 = personId1,
                             personId2 = personId2,
                             startDate = startDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -147,7 +147,7 @@ class FamilyInitializerService(
 
     private fun createParentship(tx: Database.Transaction, childId: UUID, headOfChildId: UUID) {
         val startDate = LocalDate.now()
-        val alreadyExists = tx.handle.getParentships(
+        val alreadyExists = tx.getParentships(
             headOfChildId = headOfChildId,
             childId = childId,
             includeConflicts = true
@@ -168,7 +168,7 @@ class FamilyInitializerService(
             }
             try {
                 tx.subTransaction {
-                    tx.handle.createParentship(
+                    tx.createParentship(
                         childId = childId,
                         headOfChildId = headOfChildId,
                         startDate = startDate,
@@ -181,7 +181,7 @@ class FamilyInitializerService(
                     PSQLState.UNIQUE_VIOLATION.state, PSQLState.EXCLUSION_VIOLATION.state -> {
                         val constraint = e.psqlCause()?.serverErrorMessage?.constraint ?: "-"
                         logger.warn("Creating conflict parentship between $headOfChildId and $childId (conflicting constraint is $constraint)")
-                        tx.handle.createParentship(
+                        tx.createParentship(
                             childId = childId,
                             headOfChildId = headOfChildId,
                             startDate = startDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -117,7 +117,7 @@ class FamilyInitializerService(
             otherGuardianId != null &&
             personService.personsLiveInTheSameAddress(tx, headOfFamilyId, otherGuardianId)
         ) {
-            (tx.handle.getPersonById(otherGuardianId)?.identity as? SSN)?.ssn
+            (tx.getPersonById(otherGuardianId)?.identity as? SSN)?.ssn
         } else {
             application.form.otherPartner?.socialSecurityNumber
         }
@@ -159,7 +159,7 @@ class FamilyInitializerService(
         if (alreadyExists) {
             logger.debug("Similar parentship already exists between $headOfChildId and $childId")
         } else {
-            val child = tx.handle.getPersonById(childId)
+            val child = tx.getPersonById(childId)
                 ?: error("Couldn't find child ($childId) to create parentship")
             val endDate = child.dateOfBirth.plusYears(18).minusDays(1)
             if (startDate > endDate) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/ParentshipService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/ParentshipService.kt
@@ -32,7 +32,7 @@ class ParentshipService(private val asyncJobRunner: AsyncJobRunner) {
         startDate: LocalDate,
         endDate: LocalDate
     ): Parentship {
-        tx.handle.getPersonById(childId)?.let { child -> validateDates(child.dateOfBirth, startDate, endDate) }
+        tx.getPersonById(childId)?.let { child -> validateDates(child.dateOfBirth, startDate, endDate) }
         return try {
             tx.createParentship(childId, headOfChildId, startDate, endDate, false)
                 .also { tx.sendFamilyUpdatedMessage(headOfChildId, startDate, endDate) }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/ParentshipService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/ParentshipService.kt
@@ -34,7 +34,7 @@ class ParentshipService(private val asyncJobRunner: AsyncJobRunner) {
     ): Parentship {
         tx.handle.getPersonById(childId)?.let { child -> validateDates(child.dateOfBirth, startDate, endDate) }
         return try {
-            tx.handle.createParentship(childId, headOfChildId, startDate, endDate, false)
+            tx.createParentship(childId, headOfChildId, startDate, endDate, false)
                 .also { tx.sendFamilyUpdatedMessage(headOfChildId, startDate, endDate) }
         } catch (e: Exception) {
             throw mapPSQLException(e)
@@ -42,10 +42,10 @@ class ParentshipService(private val asyncJobRunner: AsyncJobRunner) {
     }
 
     fun updateParentshipDuration(tx: Database.Transaction, id: UUID, startDate: LocalDate, endDate: LocalDate): Parentship {
-        val oldParentship = tx.handle.getParentship(id) ?: throw NotFound("No parentship found with id $id")
+        val oldParentship = tx.getParentship(id) ?: throw NotFound("No parentship found with id $id")
         validateDates(oldParentship.child.dateOfBirth, startDate, endDate)
         try {
-            val success = tx.handle.updateParentshipDuration(id, startDate, endDate)
+            val success = tx.updateParentshipDuration(id, startDate, endDate)
             if (!success) throw NotFound("No parentship found with id $id")
         } catch (e: Exception) {
             throw mapPSQLException(e)
@@ -62,10 +62,10 @@ class ParentshipService(private val asyncJobRunner: AsyncJobRunner) {
 
     fun retryParentship(tx: Database.Transaction, id: UUID) {
         try {
-            tx.handle.getParentship(id)
+            tx.getParentship(id)
                 ?.takeIf { it.conflict }
                 ?.let {
-                    tx.handle.retryParentship(it.id)
+                    tx.retryParentship(it.id)
                     tx.sendFamilyUpdatedMessage(
                         adultId = it.headOfChildId,
                         startDate = it.startDate,
@@ -78,8 +78,8 @@ class ParentshipService(private val asyncJobRunner: AsyncJobRunner) {
     }
 
     fun deleteParentship(tx: Database.Transaction, id: UUID) {
-        val parentship = tx.handle.getParentship(id)
-        val success = tx.handle.deleteParentship(id)
+        val parentship = tx.getParentship(id)
+        val success = tx.deleteParentship(id)
         if (parentship == null || !success) throw NotFound("No parentship found with id $id")
 
         with(parentship) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PartnershipService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PartnershipService.kt
@@ -27,7 +27,7 @@ class PartnershipService {
         endDate: LocalDate?
     ): Partnership {
         return try {
-            tx.handle.createPartnership(personId1, personId2, startDate, endDate)
+            tx.createPartnership(personId1, personId2, startDate, endDate)
         } catch (e: UnableToExecuteStatementException) {
             throw mapPSQLException(e)
         }
@@ -39,10 +39,10 @@ class PartnershipService {
         startDate: LocalDate,
         endDate: LocalDate?
     ): Partnership {
-        val partnership = tx.handle.getPartnership(partnershipId)
+        val partnership = tx.getPartnership(partnershipId)
             ?: throw NotFound("No partnership found with id $partnershipId")
         try {
-            val success = tx.handle.updatePartnershipDuration(partnershipId, startDate, endDate)
+            val success = tx.updatePartnershipDuration(partnershipId, startDate, endDate)
             if (!success) throw NotFound("No partnership found with id $partnershipId")
         } catch (e: Exception) {
             throw mapPSQLException(e)
@@ -53,17 +53,17 @@ class PartnershipService {
 
     fun retryPartnership(tx: Database.Transaction, partnershipId: UUID): Partnership? {
         return try {
-            tx.handle.getPartnership(partnershipId)
+            tx.getPartnership(partnershipId)
                 ?.takeIf { it.conflict }
-                ?.also { tx.handle.retryPartnership(partnershipId) }
+                ?.also { tx.retryPartnership(partnershipId) }
         } catch (e: Exception) {
             throw mapPSQLException(e)
         }
     }
 
     fun deletePartnership(tx: Database.Transaction, partnershipId: UUID): Partnership? {
-        return tx.handle.getPartnership(partnershipId)?.also {
-            tx.handle.deletePartnership(partnershipId)
+        return tx.getPartnership(partnershipId)?.also {
+            tx.deletePartnership(partnershipId)
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -173,7 +173,7 @@ class PlacementController(
             .requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
 
         db.transaction { tx ->
-            val (childId, startDate, endDate) = tx.handle.cancelPlacement(placementId)
+            val (childId, startDate, endDate) = tx.cancelPlacement(placementId)
             asyncJobRunner.plan(tx, listOf(NotifyPlacementPlanApplied(childId, startDate, endDate)))
         }
 
@@ -193,7 +193,7 @@ class PlacementController(
             .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
         return db.transaction { tx ->
-            tx.createGroupPlacement(
+            tx.checkAndCreateGroupPlacement(
                 daycarePlacementId = placementId,
                 groupId = body.groupId,
                 startDate = body.startDate,
@@ -215,7 +215,7 @@ class PlacementController(
         acl.getRolesForPlacement(user, daycarePlacementId)
             .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
 
-        val success = db.transaction { it.handle.deleteGroupPlacement(groupPlacementId) }
+        val success = db.transaction { it.deleteGroupPlacement(groupPlacementId) }
         if (!success) throw NotFound("Group placement not found")
         return noContent()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -92,7 +92,7 @@ class PlacementController(
         acl.getRolesForUnit(user, daycareId)
             .requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
 
-        return db.read { getPlacementPlans(it.handle, daycareId, startDate, endDate) }.let(::ok)
+        return db.read { it.getPlacementPlans(daycareId, startDate, endDate) }.let(::ok)
     }
 
     @PostMapping

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -108,8 +108,8 @@ class PlacementController(
         if (body.startDate > body.endDate) throw BadRequest("Placement start date cannot be after the end date")
 
         db.transaction { tx ->
-            if (tx.handle.getChild(body.childId) == null) {
-                tx.handle.createChild(
+            if (tx.getChild(body.childId) == null) {
+                tx.createChild(
                     Child(
                         id = body.childId,
                         additionalInformation = AdditionalInformation()

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -31,9 +31,9 @@ class PlacementPlanService(
 
         val type = derivePlacementType(application)
         val form = application.form
-        val child = getPlacementDraftChild(tx.handle, application.childId)
+        val child = tx.getPlacementDraftChild(application.childId)
             ?: throw NotFound("Cannot find child with id ${application.childId} to application ${application.id}")
-        val guardianHasRestrictedDetails = getGuardiansRestrictedStatus(tx.handle, application.guardianId)
+        val guardianHasRestrictedDetails = tx.getGuardiansRestrictedStatus(application.guardianId)
             ?: throw NotFound("Cannot find guardian with id ${application.guardianId} to application ${application.id}")
         val preferredUnits = form.preferences.preferredUnits.map {
             PlacementDraftUnit(
@@ -102,10 +102,10 @@ class PlacementPlanService(
     }
 
     fun softDeleteUnusedPlacementPlanByApplication(tx: Database.Transaction, applicationId: UUID) =
-        softDeletePlacementPlanIfUnused(tx.handle, applicationId)
+        tx.softDeletePlacementPlanIfUnused(applicationId)
 
     fun createPlacementPlan(tx: Database.Transaction, application: ApplicationDetails, placementPlan: DaycarePlacementPlan) =
-        createPlacementPlan(tx.handle, application.id, derivePlacementType(application), placementPlan)
+        tx.createPlacementPlan(application.id, derivePlacementType(application), placementPlan)
 
     fun applyPlacementPlan(
         tx: Database.Transaction,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -41,7 +41,7 @@ class PlacementPlanService(
                 name = it.name
             )
         }
-        val placements = tx.handle.getPlacementDraftPlacements(application.childId)
+        val placements = tx.getPlacementDraftPlacements(application.childId)
 
         val startDate = form.preferences.preferredStartDate!!
 

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -308,7 +308,7 @@ private fun handleFiveYearOldDaycare(tx: Database.Transaction, childId: UUID, ty
         else -> return listOf(FiniteDateRange(startDate, endDate) to type)
     }
 
-    val child = tx.handle.getPersonById(childId) ?: error("Child not found ($childId)")
+    val child = tx.getPersonById(childId) ?: error("Child not found ($childId)")
     val fiveYearOldTermStart = LocalDate.of(child.dateOfBirth.plusYears(5).year, 8, 1)
     val fiveYearOldTermEnd = fiveYearOldTermStart.plusYears(1).minusDays(1)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -94,7 +94,7 @@ fun Database.Transaction.createGroupPlacement(
     if (startDate.isBefore(daycarePlacement.startDate) || endDate.isAfter(daycarePlacement.endDate))
         throw BadRequest("Group placement must be within the daycare placement")
 
-    val group = handle.getDaycareGroup(groupId)
+    val group = getDaycareGroup(groupId)
         ?: throw NotFound("Group $groupId does not exist")
     if (group.startDate.isAfter(startDate) || (group.endDate != null && group.endDate.isBefore(endDate)))
         throw BadRequest("Group is not active for the full duration")

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
@@ -144,8 +144,7 @@ fun Database.Transaction.deleteServiceNeed(id: UUID): ServiceNeed {
             (SELECT concat_ws(' ', first_name, last_name) FROM employee WHERE id = service_need.updated_by) AS updated_by_name
     """.trimMargin()
 
-    return h
-        .createQuery(sql)
+    return createQuery(sql)
         .bind("id", id)
         .mapTo(ServiceNeed::class.java)
         .firstOrNull() ?: throw NotFound("Service need $id not found")

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
@@ -5,13 +5,13 @@
 package fi.espoo.evaka.serviceneed
 
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.NotFound
-import org.jdbi.v3.core.Handle
 import java.time.LocalDate
 import java.util.UUID
 
-fun insertServiceNeed(h: Handle, user: AuthenticatedUser, childId: UUID, data: ServiceNeedRequest): ServiceNeed {
+fun Database.Transaction.insertServiceNeed(user: AuthenticatedUser, childId: UUID, data: ServiceNeedRequest): ServiceNeed {
     //language=sql
     val sql =
         """
@@ -40,8 +40,7 @@ fun insertServiceNeed(h: Handle, user: AuthenticatedUser, childId: UUID, data: S
             (SELECT concat_ws(' ', first_name, last_name) FROM employee WHERE id = :updatedBy) AS updated_by_name
         """.trimIndent()
 
-    return h
-        .createQuery(sql)
+    return createQuery(sql)
         .bind("childId", childId)
         .bind("startDate", data.startDate)
         .bind("endDate", data.endDate)
@@ -54,7 +53,7 @@ fun insertServiceNeed(h: Handle, user: AuthenticatedUser, childId: UUID, data: S
         .first()
 }
 
-fun getServiceNeedsByChild(h: Handle, childId: UUID): List<ServiceNeed> {
+fun Database.Read.getServiceNeedsByChild(childId: UUID): List<ServiceNeed> {
     //language=sql
     val sql =
         """
@@ -64,13 +63,13 @@ fun getServiceNeedsByChild(h: Handle, childId: UUID): List<ServiceNeed> {
         WHERE child_id = :childId 
         ORDER BY start_date DESC
         """.trimIndent()
-    return h.createQuery(sql)
+    return createQuery(sql)
         .bind("childId", childId)
         .mapTo(ServiceNeed::class.java)
         .list()
 }
 
-fun getServiceNeedsByChildDuringPeriod(h: Handle, childId: UUID, startDate: LocalDate, endDate: LocalDate?): List<ServiceNeed> {
+fun Database.Read.getServiceNeedsByChildDuringPeriod(childId: UUID, startDate: LocalDate, endDate: LocalDate?): List<ServiceNeed> {
     //language=sql
     val sql =
         """
@@ -80,14 +79,14 @@ fun getServiceNeedsByChildDuringPeriod(h: Handle, childId: UUID, startDate: Loca
         WHERE child_id = :childId AND daterange(start_date, end_date, '[]') && :period
         ORDER BY start_date DESC 
         """.trimIndent()
-    return h.createQuery(sql)
+    return createQuery(sql)
         .bind("childId", childId)
         .bind("period", DateRange(startDate, endDate))
         .mapTo(ServiceNeed::class.java)
         .list()
 }
 
-fun updateServiceNeed(h: Handle, user: AuthenticatedUser, id: UUID, data: ServiceNeedRequest): ServiceNeed {
+fun Database.Transaction.updateServiceNeed(user: AuthenticatedUser, id: UUID, data: ServiceNeedRequest): ServiceNeed {
     //language=sql
     val sql =
         """
@@ -105,7 +104,7 @@ fun updateServiceNeed(h: Handle, user: AuthenticatedUser, id: UUID, data: Servic
             (SELECT concat_ws(' ', first_name, last_name) FROM employee WHERE id = :updatedBy) AS updated_by_name
         """.trimIndent()
 
-    return h.createQuery(sql)
+    return createQuery(sql)
         .bind("id", id)
         .bind("startDate", data.startDate)
         .bind("endDate", data.endDate)
@@ -118,7 +117,7 @@ fun updateServiceNeed(h: Handle, user: AuthenticatedUser, id: UUID, data: Servic
         .firstOrNull() ?: throw NotFound("Service need $id not found")
 }
 
-fun shortenOverlappingServiceNeed(h: Handle, user: AuthenticatedUser, childId: UUID, startDate: LocalDate, endDate: LocalDate?) {
+fun Database.Transaction.shortenOverlappingServiceNeed(user: AuthenticatedUser, childId: UUID, startDate: LocalDate, endDate: LocalDate?) {
     //language=sql
     val sql =
         """
@@ -128,7 +127,7 @@ fun shortenOverlappingServiceNeed(h: Handle, user: AuthenticatedUser, childId: U
         RETURNING *
         """.trimIndent()
 
-    h.createUpdate(sql)
+    createUpdate(sql)
         .bind("childId", childId)
         .bind("startDate", startDate)
         .bind("endDate", endDate)
@@ -136,7 +135,7 @@ fun shortenOverlappingServiceNeed(h: Handle, user: AuthenticatedUser, childId: U
         .execute()
 }
 
-fun deleteServiceNeed(h: Handle, id: UUID): ServiceNeed {
+fun Database.Transaction.deleteServiceNeed(id: UUID): ServiceNeed {
     //language=sql
     val sql =
         """DELETE FROM service_need WHERE id = :id

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedService.kt
@@ -18,8 +18,8 @@ class ServiceNeedService(private val asyncJobRunner: AsyncJobRunner) {
     fun createServiceNeed(db: Database.Connection, user: AuthenticatedUser, childId: UUID, data: ServiceNeedRequest): ServiceNeed {
         try {
             return db.transaction { tx ->
-                shortenOverlappingServiceNeed(tx.handle, user, childId, data.startDate, data.endDate)
-                insertServiceNeed(tx.handle, user, childId, data).also {
+                tx.shortenOverlappingServiceNeed(user, childId, data.startDate, data.endDate)
+                tx.insertServiceNeed(user, childId, data).also {
                     tx.notifyServiceNeedUpdated(it)
                 }
             }.also {
@@ -31,13 +31,13 @@ class ServiceNeedService(private val asyncJobRunner: AsyncJobRunner) {
     }
 
     fun getServiceNeedsByChildId(db: Database.Connection, childId: UUID): List<ServiceNeed> {
-        return db.read { tx -> getServiceNeedsByChild(tx.handle, childId) }
+        return db.read { tx -> tx.getServiceNeedsByChild(childId) }
     }
 
     fun updateServiceNeed(db: Database.Connection, user: AuthenticatedUser, id: UUID, data: ServiceNeedRequest): ServiceNeed {
         try {
             return db.transaction { tx ->
-                updateServiceNeed(tx.handle, user, id, data).also {
+                tx.updateServiceNeed(user, id, data).also {
                     tx.notifyServiceNeedUpdated(it)
                 }
             }.also {
@@ -50,7 +50,7 @@ class ServiceNeedService(private val asyncJobRunner: AsyncJobRunner) {
 
     fun deleteServiceNeed(db: Database.Connection, id: UUID) {
         db.transaction { tx ->
-            deleteServiceNeed(tx.handle, id).also {
+            tx.deleteServiceNeed(id).also {
                 tx.notifyServiceNeedUpdated(it)
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AclQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AclQueries.kt
@@ -4,7 +4,7 @@
 
 package fi.espoo.evaka.shared.auth
 
-import org.jdbi.v3.core.Handle
+import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.mapper.Nested
 import java.util.UUID
@@ -17,7 +17,7 @@ data class DaycareAclRow(
 
 data class DaycareAclRowEmployee(val id: UUID, val firstName: String, val lastName: String, val email: String?)
 
-fun Handle.getDaycareAclRows(daycareId: UUID): List<DaycareAclRow> = createQuery(
+fun Database.Read.getDaycareAclRows(daycareId: UUID): List<DaycareAclRow> = createQuery(
     // language=SQL
     """
 SELECT id, first_name, last_name, email, role
@@ -30,7 +30,7 @@ WHERE daycare_id = :daycareId
     .mapTo<DaycareAclRow>()
     .toList()
 
-fun Handle.insertDaycareAclRow(
+fun Database.Transaction.insertDaycareAclRow(
     daycareId: UUID,
     employeeId: UUID,
     role: UserRole
@@ -47,7 +47,7 @@ ON CONFLICT (daycare_id, employee_id) DO UPDATE SET role = excluded.role
     .bind("role", role)
     .execute()
 
-fun Handle.deleteDaycareAclRow(
+fun Database.Transaction.deleteDaycareAclRow(
     daycareId: UUID,
     employeeId: UUID,
     role: UserRole

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/ActuatorConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/ActuatorConfig.kt
@@ -4,7 +4,7 @@
 
 package fi.espoo.evaka.shared.config
 
-import fi.espoo.evaka.shared.db.handle
+import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.JdbiException
 import org.jdbi.v3.core.kotlin.mapTo
@@ -28,7 +28,7 @@ class ActuatorConfig {
 class DatabaseHealthIndicator(private val jdbi: Jdbi) : AbstractHealthIndicator() {
     override fun doHealthCheck(builder: Health.Builder) {
         try {
-            jdbi.handle { h -> h.createQuery("SELECT 1").mapTo<Int>().first() }
+            Database(jdbi).read { tx -> tx.createQuery("SELECT 1").mapTo<Int>().first() }
             builder.up()
         } catch (e: JdbiException) {
             builder.down(e)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
@@ -98,7 +98,7 @@ class Database(private val jdbi: Jdbi) {
         fun <T> transaction(f: (db: Transaction) -> T): T {
             threadId.assertCurrentThread()
             check(!handle.isInTransaction) { "Already in a transaction" }
-            return handle.transaction { f(Transaction(it)) }
+            return handle.inTransaction<T, Exception> { f(Transaction(it)) }
         }
 
         fun isConnected(): Boolean = connected.get()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import fi.espoo.evaka.invoicing.domain.FeeDecision2
-import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.generic.GenericType
 import org.jdbi.v3.core.kotlin.KotlinPlugin
@@ -26,41 +25,6 @@ import org.jdbi.v3.json.Json
 import org.jdbi.v3.postgres.PostgresPlugin
 import java.sql.ResultSet
 import java.util.UUID
-
-/**
- * Starts a transaction, runs the given function, and commits or rolls back the transaction depending on whether
- * the function threw an exception or not.
- *
- * Same as Handle.inTransaction, but works better with Kotlin.
- *
- * @see org.jdbi.v3.core.Handle.inTransaction
- */
-inline fun <T> Handle.transaction(crossinline f: (Handle) -> T): T {
-    return this.inTransaction<T, Exception> { f(it) }
-}
-
-/**
- * Opens a database connection, runs the given function, and closes the connection.
- *
- * Same as Jdbi.withHandle, but works better with Kotlin.
- *
- * @see org.jdbi.v3.core.Jdbi.withHandle
- */
-inline fun <T> Jdbi.handle(crossinline f: (Handle) -> T): T {
-    return this.open().use { f(it) }
-}
-
-/**
- * Starts a transaction, runs the given function, and commits or rolls back the transaction depending on whether
- * the function threw an exception or not.
- *
- * Same as Jdbi.inTransaction, but works better with Kotlin.
- *
- * @see org.jdbi.v3.core.Jdbi.inTransaction
- */
-inline fun <T> Jdbi.transaction(crossinline f: (Handle) -> T): T {
-    return this.open().use { h -> h.inTransaction<T, Exception> { f(it) } }
-}
 
 private inline fun <reified T> Jdbi.register(columnMapper: ColumnMapper<T>) {
     registerColumnMapper(T::class.java, columnMapper)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -199,7 +199,7 @@ class DevApi(
     @DeleteMapping("/daycare-groups/{id}")
     fun removeDaycareGroup(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
         db.transaction { tx ->
-            tx.handle.deleteDaycareGroup(id)
+            tx.deleteDaycareGroup(id)
         }
         return ResponseEntity.ok().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -347,7 +347,7 @@ class DevApi(
         db: Database,
         @RequestBody decisions: List<VoucherValueDecision>
     ): ResponseEntity<Unit> {
-        db.transaction { tx -> tx.handle.upsertValueDecisions(objectMapper, decisions) }
+        db.transaction { tx -> tx.upsertValueDecisions(objectMapper, decisions) }
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -472,7 +472,7 @@ DELETE FROM attachment USING ApplicationsDeleted WHERE application_id = Applicat
 
     @GetMapping("/employee")
     fun getEmployees(db: Database): ResponseEntity<List<Employee>> {
-        return ResponseEntity.ok(db.read { it.handle.getEmployees() })
+        return ResponseEntity.ok(db.read { it.getEmployees() })
     }
 
     @PostMapping("/employee")
@@ -488,7 +488,7 @@ DELETE FROM attachment USING ApplicationsDeleted WHERE application_id = Applicat
 
     @DeleteMapping("/employee/external-id/{externalId}")
     fun deleteEmployeeByExternalId(db: Database, @PathVariable externalId: ExternalId): ResponseEntity<Unit> {
-        db.transaction { it.handle.deleteEmployeeByExternalId(externalId) }
+        db.transaction { it.deleteEmployeeByExternalId(externalId) }
         return ResponseEntity.ok().build()
     }
 
@@ -516,7 +516,7 @@ RETURNING id
 
     @DeleteMapping("/employee/roles/external-id/{externalId}")
     fun deleteEmployeeRolesByExternalId(db: Database, @PathVariable externalId: ExternalId): ResponseEntity<Unit> {
-        db.transaction { it.handle.deleteEmployeeRolesByExternalId(externalId) }
+        db.transaction { it.deleteEmployeeRolesByExternalId(externalId) }
         return ResponseEntity.ok().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -392,7 +392,7 @@ RETURNING id
     fun upsertPerson(db: Database, @RequestBody body: DevPerson): ResponseEntity<PersonDTO> {
         if (body.ssn == null) throw BadRequest("SSN is required for using this endpoint")
         return db.transaction { tx ->
-            val person = tx.handle.getPersonBySSN(body.ssn)
+            val person = tx.getPersonBySSN(body.ssn)
             val personDTO = body.toPersonDTO()
 
             if (person != null) {

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -70,8 +70,8 @@ class UnitsView(private val acl: AccessControlList) {
             val backupCares = it.getBackupCaresForDaycare(unitId, period)
             val missingGroupPlacements = it.handle.getMissingGroupPlacements(unitId)
             val caretakers = Caretakers(
-                unitCaretakers = it.handle.getUnitStats(unitId, from, to),
-                groupCaretakers = it.handle.getGroupStats(unitId, from, to)
+                unitCaretakers = it.getUnitStats(unitId, from, to),
+                groupCaretakers = it.getGroupStats(unitId, from, to)
             )
 
             val basicData = UnitDataResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -65,7 +65,7 @@ class UnitsView(private val acl: AccessControlList) {
 
         val period = FiniteDateRange(from, to)
         val unitData = db.read {
-            val groups = it.handle.getDaycareGroups(unitId, from, to)
+            val groups = it.getDaycareGroups(unitId, from, to)
             val placements = it.getDetailedDaycarePlacements(unitId, null, from, to).toList()
             val backupCares = it.getBackupCaresForDaycare(unitId, period)
             val missingGroupPlacements = it.handle.getMissingGroupPlacements(unitId)

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -67,7 +67,7 @@ class UnitsView(private val acl: AccessControlList) {
         val unitData = db.read {
             val groups = it.handle.getDaycareGroups(unitId, from, to)
             val placements = it.getDetailedDaycarePlacements(unitId, null, from, to).toList()
-            val backupCares = it.handle.getBackupCaresForDaycare(unitId, period)
+            val backupCares = it.getBackupCaresForDaycare(unitId, period)
             val missingGroupPlacements = it.handle.getMissingGroupPlacements(unitId)
             val caretakers = Caretakers(
                 unitCaretakers = it.handle.getUnitStats(unitId, from, to),

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -68,7 +68,7 @@ class UnitsView(private val acl: AccessControlList) {
             val groups = it.getDaycareGroups(unitId, from, to)
             val placements = it.getDetailedDaycarePlacements(unitId, null, from, to).toList()
             val backupCares = it.getBackupCaresForDaycare(unitId, period)
-            val missingGroupPlacements = it.handle.getMissingGroupPlacements(unitId)
+            val missingGroupPlacements = it.getMissingGroupPlacements(unitId)
             val caretakers = Caretakers(
                 unitCaretakers = it.getUnitStats(unitId, from, to),
                 groupCaretakers = it.getGroupStats(unitId, from, to)

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -85,8 +85,8 @@ class UnitsView(private val acl: AccessControlList) {
             if (currentUserRoles.hasOneOfRoles(*detailedDataRoles)) {
                 val unitOccupancies = getUnitOccupancies(it, unitId, period)
                 val groupOccupancies = getGroupOccupancies(it, unitId, period)
-                val placementProposals = getPlacementPlans(it.handle, unitId, null, null, listOf(ApplicationStatus.WAITING_UNIT_CONFIRMATION))
-                val placementPlans = getPlacementPlans(it.handle, unitId, null, null, listOf(ApplicationStatus.WAITING_CONFIRMATION, ApplicationStatus.WAITING_MAILING))
+                val placementProposals = it.getPlacementPlans(unitId, null, null, listOf(ApplicationStatus.WAITING_UNIT_CONFIRMATION))
+                val placementPlans = it.getPlacementPlans(unitId, null, null, listOf(ApplicationStatus.WAITING_CONFIRMATION, ApplicationStatus.WAITING_MAILING))
                 val applications = it.getApplicationUnitSummaries(unitId)
 
                 basicData.copy(

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -41,7 +41,7 @@ class VtjController(
             throw Forbidden("Query not allowed")
         }
 
-        return db.read { it.handle.getPersonById(personId) }?.let { person ->
+        return db.read { it.getPersonById(personId) }?.let { person ->
             when (person.identity) {
                 is ExternalIdentifier.NoID -> CitizenUserDetails.from(person)
                 is ExternalIdentifier.SSN -> personService.getPersonWithDependants(user, person.identity)


### PR DESCRIPTION
#### Summary

This PR finishes the refactoring.

- Move all the queries left as extension functions under `Database.Read` or `Database.Transaction`
- Remove `jdbi.handle`, `jdbi.transaction`, `Handle.transaction` helpers (no longer used)

