### PR TITLE
Confirm when navigating away from unsaved PIN

### DIFF
--- a/frontend/src/employee-frontend/components/employee/EmployeePinCodePage.tsx
+++ b/frontend/src/employee-frontend/components/employee/EmployeePinCodePage.tsx
@@ -25,6 +25,7 @@ export default React.memo(function EmployeePinCodePage() {
   const [pin, setPin] = useState<string>('')
   const [error, setError] = useState<boolean>(false)
   const [pinLocked, setPinLocked] = useState<Result<boolean>>()
+  const [dirty, setDirty] = useState<boolean>(false)
 
   useEffect(() => {
     void isPinCodeLocked().then(setPinLocked)
@@ -54,10 +55,14 @@ export default React.memo(function EmployeePinCodePage() {
       setError(false)
     }
     setPin(pin)
+    setDirty(true)
   }
 
   function savePinCode() {
-    return updatePinCode(pin).then(isPinCodeLocked).then(setPinLocked)
+    return updatePinCode(pin)
+      .then(() => setDirty(false))
+      .then(isPinCodeLocked)
+      .then(setPinLocked)
   }
 
   function getInputInfo(): InputInfo | undefined {
@@ -73,6 +78,22 @@ export default React.memo(function EmployeePinCodePage() {
         }
       : undefined
   }
+
+  const beforeUnloadHandler = (e: BeforeUnloadEvent) => {
+    if (dirty) {
+      e.preventDefault()
+      e.returnValue = i18n.pinCode.unsavedDataWarning
+      return i18n.pinCode.unsavedDataWarning
+    }
+    return
+  }
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', beforeUnloadHandler)
+    return () => {
+      window.removeEventListener('beforeunload', beforeUnloadHandler)
+    }
+  }, [beforeUnloadHandler])
 
   return (
     <Container>

--- a/frontend/src/employee-frontend/components/employee/EmployeePinCodePage.tsx
+++ b/frontend/src/employee-frontend/components/employee/EmployeePinCodePage.tsx
@@ -19,6 +19,7 @@ import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
 import { Result } from '../../../lib-common/api'
 import { AlertBox } from '../../../lib-components/molecules/MessageBoxes'
+import { Prompt } from 'react-router-dom'
 
 export default React.memo(function EmployeePinCodePage() {
   const { i18n } = useTranslation()
@@ -55,7 +56,7 @@ export default React.memo(function EmployeePinCodePage() {
       setError(false)
     }
     setPin(pin)
-    setDirty(true)
+    setDirty(pin.length > 0)
   }
 
   function savePinCode() {
@@ -81,6 +82,7 @@ export default React.memo(function EmployeePinCodePage() {
 
   const beforeUnloadHandler = (e: BeforeUnloadEvent) => {
     if (dirty) {
+      // Support different browsers: https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event
       e.preventDefault()
       e.returnValue = i18n.pinCode.unsavedDataWarning
       return i18n.pinCode.unsavedDataWarning
@@ -97,6 +99,8 @@ export default React.memo(function EmployeePinCodePage() {
 
   return (
     <Container>
+      <Prompt when={dirty} message={i18n.pinCode.unsavedDataWarning} />
+
       <Gap size={'L'} />
       <ContentArea opaque>
         <Title>{i18n.pinCode.title}</Title>

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2367,7 +2367,7 @@ export const fi = {
     lockedLong:
       'PIN-koodi on syötetty eVaka-mobiilissa 5 kertaa väärin, ja koodi on lukittu. Ole hyvä ja vaihda tilalle uusi PIN-koodi.',
     link: 'eVaka-mobiilin PIN-koodi',
-    unsavedDataWarning: 'Et ole tallettanut PIN koodia'
+    unsavedDataWarning: 'Et ole tallentanut PIN-koodia'
   },
   employees: {
     title: 'Käyttäjät',

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2366,7 +2366,8 @@ export const fi = {
     locked: 'PIN-koodi on lukittu, vaihda se uuteen',
     lockedLong:
       'PIN-koodi on syötetty eVaka-mobiilissa 5 kertaa väärin, ja koodi on lukittu. Ole hyvä ja vaihda tilalle uusi PIN-koodi.',
-    link: 'eVaka-mobiilin PIN-koodi'
+    link: 'eVaka-mobiilin PIN-koodi',
+    unsavedDataWarning: 'Et ole tallettanut PIN koodia'
   },
   employees: {
     title: 'Käyttäjät',


### PR DESCRIPTION
#### Summary
Confirm when navigating away from unsaved PIN:
- If tab is closed or back button pressed, use browser beforeunload support (https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)
- If clicking another link, use react routed DOM support

Tested on latest chrome and firefox. On playwright chromium the popup disappears immediately.

The two cases shown on chrome and firefox:

<img width="1019" alt="Screenshot 2021-05-06 at 8 53 28" src="https://user-images.githubusercontent.com/158767/117284426-799f0680-ae6f-11eb-82fd-af6960403dec.png">
<img width="1051" alt="Screenshot 2021-05-06 at 9 02 10" src="https://user-images.githubusercontent.com/158767/117284436-7c99f700-ae6f-11eb-8bb8-f0f76ff882b6.png">
<img width="817" alt="Screenshot 2021-05-06 at 13 22 50" src="https://user-images.githubusercontent.com/158767/117284444-7e63ba80-ae6f-11eb-9683-19e8c33ecd9e.png">
<img width="1115" alt="Screenshot 2021-05-06 at 13 23 18" src="https://user-images.githubusercontent.com/158767/117284451-802d7e00-ae6f-11eb-99f6-59b2e60beeeb.png">

