### PR TITLE
EVAKA-4176: splitting placements splits service needs

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
@@ -186,7 +186,16 @@ function PlacementRow({ placement, onRefreshNeeded, checkOverlaps }: Props) {
               'UNIT_SUPERVISOR'
             ]}
             onDelete={() => setConfirmingDelete(true)}
-            deletableFor={['ADMIN', 'SERVICE_WORKER', 'FINANCE_ADMIN']}
+            deletableFor={
+              placement.startDate.isAfter(LocalDate.today())
+                ? [
+                    'ADMIN',
+                    'SERVICE_WORKER',
+                    'FINANCE_ADMIN',
+                    'UNIT_SUPERVISOR'
+                  ]
+                : ['ADMIN', 'SERVICE_WORKER', 'FINANCE_ADMIN']
+            }
             dataQaDelete="btn-remove-placement"
             warning={
               missingServiceNeedDays > 0

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -64,7 +64,7 @@ class PlacementController(
             childId != null -> acl.getRolesForChild(user, childId)
             else -> throw BadRequest("daycareId or childId is required")
         }
-        roles.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
+        roles.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
         val auth = acl.getAuthorizedDaycares(user)
         val authorizedDaycares = auth.ids ?: emptySet()
 
@@ -90,7 +90,7 @@ class PlacementController(
     ): ResponseEntity<List<PlacementPlanDetails>> {
         Audit.PlacementPlanSearch.log(targetId = daycareId)
         acl.getRolesForUnit(user, daycareId)
-            .requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
 
         return db.read { it.getPlacementPlans(daycareId, startDate, endDate) }.let(::ok)
     }
@@ -103,7 +103,7 @@ class PlacementController(
     ): ResponseEntity<Unit> {
         Audit.PlacementCreate.log(targetId = body.childId, objectId = body.unitId)
         acl.getRolesForUnit(user, body.unitId)
-            .requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
 
         if (body.startDate > body.endDate) throw BadRequest("Placement start date cannot be after the end date")
 
@@ -141,7 +141,7 @@ class PlacementController(
     ): ResponseEntity<Unit> {
         Audit.PlacementUpdate.log(targetId = placementId)
         acl.getRolesForPlacement(user, placementId)
-            .requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
 
         val aclAuth = acl.getAuthorizedDaycares(user)
         db.transaction { tx ->
@@ -170,7 +170,7 @@ class PlacementController(
     ): ResponseEntity<Unit> {
         Audit.PlacementCancel.log(targetId = placementId)
         acl.getRolesForPlacement(user, placementId)
-            .requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
+            .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
 
         db.transaction { tx ->
             val (childId, startDate, endDate) = tx.cancelPlacement(placementId)

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -151,13 +151,22 @@ fun Database.Transaction.cancelPlacement(id: UUID): Triple<UUID, LocalDate, Loca
     createUpdate(
         //language=SQL
         """DELETE FROM daycare_group_placement WHERE daycare_placement_id = :id""".trimIndent()
-    ).bind("id", id)
+    )
+        .bind("id", id)
+        .execute()
+
+    createUpdate(
+        //language=SQL
+        """DELETE FROM new_service_need WHERE placement_id = :id""".trimIndent()
+    )
+        .bind("id", id)
         .execute()
 
     return createUpdate(
         //language=SQL
         """DELETE FROM placement WHERE id = :id RETURNING child_id, start_date, end_date""".trimIndent()
-    ).bind("id", id)
+    )
+        .bind("id", id)
         .executeAndReturnGeneratedKeys()
         .mapTo<QueryResult>()
         .findFirst()

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -221,8 +221,8 @@ private fun Database.Transaction.splitPlacementWithGap(
     gapStartInclusive: LocalDate,
     gapEndInclusive: LocalDate
 ) {
-    clearNewServiceNeedsFromPeriod(this, placement.id, FiniteDateRange(gapStartInclusive, gapEndInclusive))
-    movePlacementEndDateEarlier(placement, gapStartInclusive.minusDays(1))
+    movePlacementEndDateEarlier(placement, newEndDate = gapStartInclusive.minusDays(1))
+
     insertPlacement(
         type = placement.type,
         childId = placement.childId,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.getDaycareGroup
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.serviceneednew.NewServiceNeed
+import fi.espoo.evaka.serviceneednew.clearNewServiceNeedsFromPeriod
 import fi.espoo.evaka.serviceneednew.getServiceNeedsByChild
 import fi.espoo.evaka.serviceneednew.getServiceNeedsByUnit
 import fi.espoo.evaka.shared.auth.AclAuthorization
@@ -49,9 +50,15 @@ fun Database.Transaction.updatePlacement(
     if (endDate.isBefore(startDate)) throw BadRequest("Inverted time range")
 
     val old = getPlacement(id) ?: throw NotFound("Placement $id not found")
-    if (startDate.isAfter(old.startDate)) clearGroupPlacementsBefore(id, startDate)
-    if (endDate.isBefore(old.endDate)) clearGroupPlacementsAfter(id, endDate)
-    clearOldPlacements(old.childId, startDate, endDate, id, aclAuth)
+    if (startDate.isAfter(old.startDate)) {
+        clearGroupPlacementsBefore(id, startDate)
+        clearNewServiceNeedsFromPeriod(this, old.id, FiniteDateRange(old.startDate, startDate.minusDays(1)))
+    }
+    if (endDate.isBefore(old.endDate)) {
+        clearGroupPlacementsAfter(id, endDate)
+        clearNewServiceNeedsFromPeriod(this, old.id, FiniteDateRange(endDate.plusDays(1), old.endDate))
+    }
+    clearOldPlacements(childId = old.childId, from = startDate, to = endDate, excludePlacement = id, aclAuth = aclAuth)
 
     try {
         val placementTypePeriods = handleFiveYearOldDaycare(this, old.childId, old.type, startDate, endDate)
@@ -154,11 +161,11 @@ fun Database.Transaction.transferGroup(daycarePlacementId: UUID, groupPlacementI
     createGroupPlacement(daycarePlacementId, groupId, startDate, groupPlacement.endDate)
 }
 
-private fun Database.Transaction.clearOldPlacements(childId: UUID, from: LocalDate, to: LocalDate, modifiedId: UUID? = null, aclAuth: AclAuthorization = AclAuthorization.All) {
+private fun Database.Transaction.clearOldPlacements(childId: UUID, from: LocalDate, to: LocalDate, excludePlacement: UUID? = null, aclAuth: AclAuthorization = AclAuthorization.All) {
     if (from.isAfter(to)) throw IllegalArgumentException("inverted range")
 
     getPlacementsForChildDuring(childId, from, to)
-        .filter { placement -> if (modifiedId != null) placement.id != modifiedId else true }
+        .filter { placement -> if (excludePlacement != null) placement.id != excludePlacement else true }
         .forEach { old ->
             if (old.endDate.isBefore(from) || old.startDate.isAfter(to)) {
                 throw Error("bug discovered: query returned non-overlapping placement")
@@ -197,6 +204,7 @@ private fun Database.Transaction.movePlacementStartDateLater(placement: Placemen
     if (newStartDate.isBefore(placement.startDate)) throw IllegalArgumentException("Use this method only for shortening placement")
 
     clearGroupPlacementsBefore(placement.id, newStartDate)
+    clearNewServiceNeedsFromPeriod(this, placement.id, FiniteDateRange(placement.startDate, newStartDate.minusDays(1)))
     updatePlacementStartDate(placement.id, newStartDate)
 }
 
@@ -204,6 +212,7 @@ private fun Database.Transaction.movePlacementEndDateEarlier(placement: Placemen
     if (newEndDate.isAfter(placement.endDate)) throw IllegalArgumentException("Use this method only for shortening placement")
 
     clearGroupPlacementsAfter(placement.id, newEndDate)
+    clearNewServiceNeedsFromPeriod(this, placement.id, FiniteDateRange(newEndDate.plusDays(1), placement.endDate))
     updatePlacementEndDate(placement.id, newEndDate)
 }
 
@@ -212,6 +221,7 @@ private fun Database.Transaction.splitPlacementWithGap(
     gapStartInclusive: LocalDate,
     gapEndInclusive: LocalDate
 ) {
+    clearNewServiceNeedsFromPeriod(this, placement.id, FiniteDateRange(gapStartInclusive, gapEndInclusive))
     movePlacementEndDateEarlier(placement, gapStartInclusive.minusDays(1))
     insertPlacement(
         type = placement.type,

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneednew/NewServiceNeed.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneednew/NewServiceNeed.kt
@@ -146,7 +146,7 @@ fun updateNewServiceNeed(
     )
 }
 
-private fun clearNewServiceNeedsFromPeriod(tx: Database.Transaction, placementId: UUID, periodToClear: FiniteDateRange, excluding: UUID? = null) {
+fun clearNewServiceNeedsFromPeriod(tx: Database.Transaction, placementId: UUID, periodToClear: FiniteDateRange, excluding: UUID? = null) {
     tx.getOverlappingServiceNeeds(placementId, periodToClear.start, periodToClear.end, excluding).forEach { old ->
         val oldPeriod = FiniteDateRange(old.startDate, old.endDate)
         when {


### PR DESCRIPTION
#### Summary
Service needs are split the same way as group placements. If a placement is created inside another, both service needs and group placements are shortened. Later it would be nice to copy them to the new placement inserted at the end, but this is a rare use-case and not trivial to implement so I left that out.

Unit supervisors may also now delete placements from their units which have not yet started.