### PR TITLE
EVAKA-FIX: remove attachments if irrelevant

### DIFF
--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -324,13 +324,14 @@ const ApplicationsList = React.memo(function Applications({
           {application.urgent && (
             <RoundIcon content="!" color={colors.accents.red} size="s" />
           )}
-          {application.attachmentCount > 0 && (
-            <RoundIcon
-              content={faPaperclip}
-              color={colors.accents.violet}
-              size="s"
-            />
-          )}
+          {(application.urgent || application.extendedCare) &&
+            application.attachmentCount > 0 && (
+              <RoundIcon
+                content={faPaperclip}
+                color={colors.accents.violet}
+                size="s"
+              />
+            )}
         </FixedSpaceRow>
       </Td>
       <Td>

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
@@ -15,7 +15,7 @@ import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
-import fi.espoo.evaka.test.validDaycareApplication
+import fi.espoo.evaka.test.getValidDaycareApplication
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDecisionMaker_1
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 class ApplicationUpdateIntegrationTest : FullApplicationTest() {
+    private val citizen = AuthenticatedUser.Citizen(testAdult_1.id)
     private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach
@@ -139,13 +140,142 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
         assertEquals(manuallySetDueDate, afterSendingAttachment?.dueDate)
     }
 
+    @Test
+    fun `when urgency is cancelled by citizen, relevant attachments are deleted`() {
+        // given
+        val sentDate = LocalDate.of(2021, 1, 1)
+        val originalDueDate = LocalDate.of(2021, 5, 1)
+        val application = insertSentApplication(sentDate, originalDueDate, true, shiftCare = true)
+        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.URGENCY)
+        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.EXTENDED_CARE)
+
+        val beforeClearingUrgency = db.transaction { it.fetchApplicationDetails(application.id) }
+        assertEquals(true, beforeClearingUrgency!!.form.preferences.urgent)
+        assertEquals(2, beforeClearingUrgency!!.attachments.size)
+
+        // when
+        val updatedApplication =
+            application.copy(form = application.form.copy(preferences = application.form.preferences.copy(urgent = false)))
+        val (_, res, _) = http.put("/citizen/applications/${application.id}")
+            .jsonBody(objectMapper.writeValueAsString(ApplicationFormUpdate.from(updatedApplication.form)))
+            .asUser(citizen)
+            .responseString()
+
+        assertEquals(204, res.statusCode)
+
+        // then
+        val afterClearingUrgency = db.transaction { it.fetchApplicationDetails(application.id) }
+        assertEquals(false, afterClearingUrgency!!.form.preferences.urgent)
+        assertEquals(0, afterClearingUrgency!!.attachments.filter { it.type === AttachmentType.URGENCY }.size)
+        assertEquals(1, afterClearingUrgency!!.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
+    }
+
+    @Test
+    fun `when urgency is cancelled by service worker, relevant attachments are deleted`() {
+        // given
+        val sentDate = LocalDate.of(2021, 1, 1)
+        val originalDueDate = LocalDate.of(2021, 5, 1)
+        val application = insertSentApplication(sentDate, originalDueDate, urgent = true, shiftCare = true)
+        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.URGENCY)
+        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.EXTENDED_CARE)
+
+        val beforeClearingUrgency = db.transaction { it.fetchApplicationDetails(application.id) }
+        assertEquals(true, beforeClearingUrgency!!.form.preferences.urgent)
+        assertEquals(2, beforeClearingUrgency!!.attachments.size)
+
+        // when
+        val updatedApplication =
+            application.copy(form = application.form.copy(preferences = application.form.preferences.copy(urgent = false)))
+        val (_, res, _) = http.put("/v2/applications/${application.id}")
+            .jsonBody(objectMapper.writeValueAsString(ApplicationUpdate(form = ApplicationFormUpdate.from(updatedApplication.form))))
+            .asUser(serviceWorker)
+            .responseString()
+
+        assertEquals(204, res.statusCode)
+
+        // then
+        val afterClearingUrgency = db.transaction { it.fetchApplicationDetails(application.id) }
+        assertEquals(false, afterClearingUrgency!!.form.preferences.urgent)
+        assertEquals(0, afterClearingUrgency!!.attachments.filter { it.type === AttachmentType.URGENCY }.size)
+        assertEquals(1, afterClearingUrgency!!.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
+    }
+
+    @Test
+    fun `when extended care is cancelled by citizen, relevant attachments are deleted`() {
+        // given
+        val sentDate = LocalDate.of(2021, 1, 1)
+        val originalDueDate = LocalDate.of(2021, 5, 1)
+        val application = insertSentApplication(sentDate, originalDueDate, urgent = true, shiftCare = true)
+        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.URGENCY)
+        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.EXTENDED_CARE)
+
+        val beforeClearingShiftCare = db.transaction { it.fetchApplicationDetails(application.id) }
+        assertEquals(true, beforeClearingShiftCare!!.form.preferences.urgent)
+        assertEquals(2, beforeClearingShiftCare!!.attachments.size)
+
+        // when
+        val updatedApplication =
+            application.copy(
+                form = application.form.copy(
+                    preferences = application.form.preferences.copy(serviceNeed = application.form.preferences.serviceNeed!!.copy(shiftCare = false))
+                )
+            )
+        val (_, res, _) = http.put("/citizen/applications/${application.id}")
+            .jsonBody(objectMapper.writeValueAsString(ApplicationFormUpdate.from(updatedApplication.form)))
+            .asUser(citizen)
+            .responseString()
+
+        assertEquals(204, res.statusCode)
+
+        // then
+        val afterClearingShiftCare = db.transaction { it.fetchApplicationDetails(application.id) }
+        assertEquals(false, afterClearingShiftCare!!.form.preferences.serviceNeed!!.shiftCare)
+        assertEquals(1, afterClearingShiftCare!!.attachments.filter { it.type === AttachmentType.URGENCY }.size)
+        assertEquals(0, afterClearingShiftCare!!.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
+    }
+
+    @Test
+    fun `when extended care is cancelled by service worker, relevant attachments are deleted`() {
+        // given
+        val sentDate = LocalDate.of(2021, 1, 1)
+        val originalDueDate = LocalDate.of(2021, 5, 1)
+        val application = insertSentApplication(sentDate, originalDueDate, urgent = true, shiftCare = true)
+        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.URGENCY)
+        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.EXTENDED_CARE)
+
+        val beforeClearingShiftCare = db.transaction { it.fetchApplicationDetails(application.id) }
+        assertEquals(true, beforeClearingShiftCare!!.form.preferences.serviceNeed!!.shiftCare)
+        assertEquals(2, beforeClearingShiftCare!!.attachments.size)
+
+        // when
+        val updatedApplication =
+            application.copy(
+                form = application.form.copy(
+                    preferences = application.form.preferences.copy(serviceNeed = application.form.preferences.serviceNeed!!.copy(shiftCare = false))
+                )
+            )
+        val (_, res, _) = http.put("/v2/applications/${application.id}")
+            .jsonBody(objectMapper.writeValueAsString(ApplicationUpdate(form = ApplicationFormUpdate.from(updatedApplication.form))))
+            .asUser(serviceWorker)
+            .responseString()
+
+        assertEquals(204, res.statusCode)
+
+        // then
+        val afterClearingShiftCare = db.transaction { it.fetchApplicationDetails(application.id) }
+        assertEquals(false, afterClearingShiftCare!!.form.preferences.serviceNeed!!.shiftCare)
+        assertEquals(1, afterClearingShiftCare!!.attachments.filter { it.type === AttachmentType.URGENCY }.size)
+        assertEquals(0, afterClearingShiftCare!!.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
+    }
+
     private fun insertSentApplication(
         sentDate: LocalDate,
         dueDate: LocalDate,
-        urgent: Boolean
+        urgent: Boolean,
+        shiftCare: Boolean = false
     ): ApplicationDetails = db.transaction { tx ->
         val applicationId = tx.insertTestApplication(status = ApplicationStatus.SENT, sentDate = sentDate, dueDate = dueDate, childId = testChild_1.id, guardianId = testAdult_1.id)
-        val validDaycareForm = DaycareFormV0.fromApplication2(validDaycareApplication)
+        val validDaycareForm = DaycareFormV0.fromApplication2(getValidDaycareApplication(shiftCare = shiftCare))
         tx.insertTestApplicationForm(applicationId, validDaycareForm.copy(urgent = urgent))
         tx.fetchApplicationDetails(applicationId)!!
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
@@ -146,8 +146,8 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
         val sentDate = LocalDate.of(2021, 1, 1)
         val originalDueDate = LocalDate.of(2021, 5, 1)
         val application = insertSentApplication(sentDate, originalDueDate, true, shiftCare = true)
-        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.URGENCY)
-        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.EXTENDED_CARE)
+        uploadAttachment(applicationId = application.id, user = citizen, type = AttachmentType.URGENCY)
+        uploadAttachment(applicationId = application.id, user = citizen, type = AttachmentType.EXTENDED_CARE)
 
         val beforeClearingUrgency = db.transaction { it.fetchApplicationDetails(application.id) }
         assertEquals(true, beforeClearingUrgency!!.form.preferences.urgent)
@@ -206,8 +206,8 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
         val sentDate = LocalDate.of(2021, 1, 1)
         val originalDueDate = LocalDate.of(2021, 5, 1)
         val application = insertSentApplication(sentDate, originalDueDate, urgent = true, shiftCare = true)
-        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.URGENCY)
-        uploadAttachment(applicationId = application.id, user = serviceWorker, type = AttachmentType.EXTENDED_CARE)
+        uploadAttachment(applicationId = application.id, user = citizen, type = AttachmentType.URGENCY)
+        uploadAttachment(applicationId = application.id, user = citizen, type = AttachmentType.EXTENDED_CARE)
 
         val beforeClearingShiftCare = db.transaction { it.fetchApplicationDetails(application.id) }
         assertEquals(true, beforeClearingShiftCare!!.form.preferences.urgent)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
@@ -36,7 +36,7 @@ class GetApplicationSummaryIntegrationTests : FullApplicationTest() {
             tx.insertGeneralTestFixtures()
         }
         createApplication(child = testChild_1, guardian = testAdult_1)
-        createApplication(child = testChild_2, guardian = testAdult_1, attachment = true)
+        createApplication(child = testChild_2, guardian = testAdult_1, extendedCare = true, attachment = true)
         createApplication(child = testChild_3, guardian = testAdult_1, urgent = true)
     }
 
@@ -68,10 +68,10 @@ class GetApplicationSummaryIntegrationTests : FullApplicationTest() {
         return result.get()
     }
 
-    private fun createApplication(child: PersonData.Detailed, guardian: PersonData.Detailed, attachment: Boolean = false, urgent: Boolean = false) {
+    private fun createApplication(child: PersonData.Detailed, guardian: PersonData.Detailed, attachment: Boolean = false, urgent: Boolean = false, extendedCare: Boolean = false) {
         val applicationId = db.transaction { tx ->
             tx.insertTestApplication(childId = child.id, guardianId = guardian.id).also { id ->
-                val form = DaycareFormV0.fromApplication2(validDaycareApplication.copy(childId = child.id, guardianId = guardian.id)).copy(urgent = urgent)
+                val form = DaycareFormV0.fromApplication2(validDaycareApplication.copy(childId = child.id, guardianId = guardian.id)).copy(urgent = urgent).copy(extendedCare = extendedCare)
                 tx.insertTestApplicationForm(id, form)
             }
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestData.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestData.kt
@@ -26,12 +26,14 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-val validDaycareApplication = applicationDetails(
-    PreferredUnit(
-        id = testDaycare.id,
-        name = testDaycare.name
-    )
+val defaultPreferredUnit = PreferredUnit(
+    id = testDaycare.id,
+    name = testDaycare.name
 )
+
+fun getValidDaycareApplication(preferredUnit: PreferredUnit = defaultPreferredUnit, shiftCare: Boolean = false) = applicationDetails(preferredUnit, shiftCare = shiftCare)
+
+val validDaycareApplication = getValidDaycareApplication()
 
 val validVoucherApplication =
     applicationDetails(
@@ -41,7 +43,7 @@ val validVoucherApplication =
         )
     )
 
-private fun applicationDetails(vararg preferredUnits: PreferredUnit) = ApplicationDetails(
+private fun applicationDetails(vararg preferredUnits: PreferredUnit, shiftCare: Boolean = false) = ApplicationDetails(
     id = UUID.randomUUID(),
     type = ApplicationType.DAYCARE,
     status = ApplicationStatus.WAITING_DECISION,
@@ -109,7 +111,7 @@ private fun applicationDetails(vararg preferredUnits: PreferredUnit) = Applicati
             serviceNeed = ServiceNeed(
                 startTime = "08:00",
                 endTime = "17:00",
-                shiftCare = false,
+                shiftCare = shiftCare,
                 partTime = false
             ),
             siblingBasis = null,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -293,7 +293,7 @@ class ApplicationControllerV2(
         Audit.ApplicationUpdate.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
-        db.transaction { applicationStateService.updateApplicationContentsServiceWorker(it, user, applicationId, application) }
+        db.transaction { applicationStateService.updateApplicationContentsServiceWorker(it, user, applicationId, application, user.id) }
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -200,7 +200,7 @@ fun Database.Read.fetchApplicationSummaries(
                 ApplicationBasis.EXTENDED_CARE -> "(f.document ->> 'extendedCare')::boolean = true"
                 ApplicationBasis.DUPLICATE_APPLICATION -> "array_length(duplicates.duplicate_application_ids, 1) > 0"
                 ApplicationBasis.URGENT -> "(f.document ->> 'urgent')::boolean = true"
-                ApplicationBasis.HAS_ATTACHMENTS -> "array_length(attachments.attachment_ids, 1) > 0"
+                ApplicationBasis.HAS_ATTACHMENTS -> "((f.document ->> 'urgent')::boolean = true OR (f.document ->> 'extendedCare')::boolean = true) AND array_length(attachments.attachment_ids, 1) > 0"
             }
         }.joinToString("\nAND ") else null,
         if (type != ApplicationTypeToggle.ALL) "f.document ->> 'type' = :documentType" else null,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.application.ApplicationStatus.WAITING_DECISION
 import fi.espoo.evaka.application.ApplicationStatus.WAITING_MAILING
 import fi.espoo.evaka.application.ApplicationStatus.WAITING_PLACEMENT
 import fi.espoo.evaka.application.ApplicationStatus.WAITING_UNIT_CONFIRMATION
+import fi.espoo.evaka.attachment.deleteAttachmentsByApplicationAndType
 import fi.espoo.evaka.daycare.controllers.AdditionalInformation
 import fi.espoo.evaka.daycare.controllers.Child
 import fi.espoo.evaka.daycare.domain.Language
@@ -49,6 +50,7 @@ import fi.espoo.evaka.placement.PlacementPlanService
 import fi.espoo.evaka.placement.deletePlacementPlans
 import fi.espoo.evaka.placement.getPlacementPlan
 import fi.espoo.evaka.placement.updatePlacementPlanUnitConfirmation
+import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.InitializeFamilyFromApplication
 import fi.espoo.evaka.shared.async.NotifyIncomeUpdated
@@ -67,6 +69,7 @@ import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.utils.europeHelsinki
 import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
+import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.UUID
@@ -81,7 +84,9 @@ class ApplicationStateService(
     private val decisionDraftService: DecisionDraftService,
     private val personService: PersonService,
     private val asyncJobRunner: AsyncJobRunner,
-    private val mapper: ObjectMapper
+    private val mapper: ObjectMapper,
+    private val documentClient: DocumentService,
+    private val env: Environment
 ) {
     // STATE TRANSITIONS
 
@@ -445,6 +450,17 @@ class ApplicationStateService(
 
         val updatedForm = original.form.update(update)
 
+        val filesBucket = env.getProperty("fi.espoo.voltti.document.bucket.attachments")!!
+        if (!updatedForm.preferences.urgent) {
+            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.URGENCY)
+            deleted.forEach { documentClient.delete(filesBucket, "$it") }
+        }
+
+        if (updatedForm.preferences.serviceNeed?.shiftCare != true) {
+            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.EXTENDED_CARE)
+            deleted.forEach { documentClient.delete(filesBucket, "$it") }
+        }
+
         if (asDraft) {
             if (original.status !== CREATED) throw BadRequest("Cannot save as draft, application already sent")
         } else {
@@ -470,6 +486,17 @@ class ApplicationStateService(
 
         val updatedForm = original.form.update(update.form)
         validateApplication(tx, original.type, updatedForm, strict = false)
+
+        val filesBucket = env.getProperty("fi.espoo.voltti.document.bucket.attachments")!!
+        if (!updatedForm.preferences.urgent) {
+            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.URGENCY)
+            deleted.forEach { documentClient.delete(filesBucket, "$it") }
+        }
+
+        if (updatedForm.preferences.serviceNeed?.shiftCare != true) {
+            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.EXTENDED_CARE)
+            deleted.forEach { documentClient.delete(filesBucket, "$it") }
+        }
 
         tx.updateApplicationContents(original, updatedForm, manuallySetDueDate = update.dueDate)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -452,12 +452,12 @@ class ApplicationStateService(
 
         val filesBucket = env.getProperty("fi.espoo.voltti.document.bucket.attachments")!!
         if (!updatedForm.preferences.urgent) {
-            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.URGENCY)
+            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.URGENCY, user.id)
             deleted.forEach { documentClient.delete(filesBucket, "$it") }
         }
 
         if (updatedForm.preferences.serviceNeed?.shiftCare != true) {
-            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.EXTENDED_CARE)
+            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.EXTENDED_CARE, user.id)
             deleted.forEach { documentClient.delete(filesBucket, "$it") }
         }
 
@@ -480,7 +480,7 @@ class ApplicationStateService(
         return getApplication(tx, applicationId)
     }
 
-    fun updateApplicationContentsServiceWorker(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID, update: ApplicationUpdate) {
+    fun updateApplicationContentsServiceWorker(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID, update: ApplicationUpdate, userId: UUID) {
         val original = tx.fetchApplicationDetails(applicationId)
             ?: throw NotFound("Application $applicationId was not found")
 
@@ -489,12 +489,12 @@ class ApplicationStateService(
 
         val filesBucket = env.getProperty("fi.espoo.voltti.document.bucket.attachments")!!
         if (!updatedForm.preferences.urgent) {
-            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.URGENCY)
+            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.URGENCY, userId)
             deleted.forEach { documentClient.delete(filesBucket, "$it") }
         }
 
         if (updatedForm.preferences.serviceNeed?.shiftCare != true) {
-            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.EXTENDED_CARE)
+            val deleted = tx.deleteAttachmentsByApplicationAndType(applicationId, AttachmentType.EXTENDED_CARE, userId)
             deleted.forEach { documentClient.delete(filesBucket, "$it") }
         }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
@@ -80,3 +80,11 @@ fun Database.Transaction.deleteAttachment(id: UUID) {
         .bind("id", id)
         .execute()
 }
+
+fun Database.Transaction.deleteAttachmentsByApplicationAndType(applicationId: UUID, type: AttachmentType): List<UUID> {
+    return this.createQuery("DELETE FROM attachment WHERE application_id = :applicationId AND type = :type RETURNING id")
+        .bind("applicationId", applicationId)
+        .bind("type", type)
+        .mapTo<UUID>()
+        .toList()
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
@@ -81,10 +81,19 @@ fun Database.Transaction.deleteAttachment(id: UUID) {
         .execute()
 }
 
-fun Database.Transaction.deleteAttachmentsByApplicationAndType(applicationId: UUID, type: AttachmentType): List<UUID> {
-    return this.createQuery("DELETE FROM attachment WHERE application_id = :applicationId AND type = :type RETURNING id")
+fun Database.Transaction.deleteAttachmentsByApplicationAndType(applicationId: UUID, type: AttachmentType, userId: UUID): List<UUID> {
+    return this.createQuery(
+        """
+            DELETE FROM attachment 
+            WHERE application_id = :applicationId 
+            AND type = :type 
+            AND (uploaded_by_employee = :userId OR uploaded_by_person = :userId)
+            RETURNING id
+        """.trimIndent()
+    )
         .bind("applicationId", applicationId)
         .bind("type", type)
+        .bind("userId", userId)
         .mapTo<UUID>()
         .toList()
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

When `extendedCare` or `urgency` is cancelled when updating application, remove corresponding attachments that were uploaded by the same user