### PR TITLE
EVAKA-FIX updated lodash to fix CVE-2021-23337

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "lib-components": "link:src/lib-components",
     "lib-customizations": "link:src/lib-customizations",
     "lib-icons": "link:src/lib-icons",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "polished": "^4.1.0",
     "react": "^17.0.1",
     "react-autosize-textarea": "^7.0.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9261,7 +9261,7 @@ __metadata:
     lib-components: "link:src/lib-components"
     lib-customizations: "link:src/lib-customizations"
     lib-icons: "link:src/lib-icons"
-    lodash: ^4.17.15
+    lodash: ^4.17.21
     make-error-cause: ^2.3.0
     parcel-bundler: ^1.12.4
     playwright: ^1.9.2


### PR DESCRIPTION
#### Summary
Dependabot had an alert about this.