### PR TITLE
Customizable colors POC

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -21,64 +21,68 @@ import requireAuth from './auth/requireAuth'
 import MessagesPage from './messages/MessagesPage'
 import { featureFlags } from './config'
 import { HeaderContextProvider } from './messages/state'
+import { ThemeProvider } from 'styled-components'
+import { theme } from 'lib-customizations/common'
 
 export default function App() {
   return (
     <BrowserRouter basename="/">
-      <Authentication>
-        <Localization>
-          <OverlayContextProvider>
-            <HeaderContextProvider>
-              <Header />
-              <main>
-                <Switch>
-                  <Route exact path="/" component={MapView} />
-                  <Route
-                    exact
-                    path="/applications"
-                    component={requireAuth(Applications)}
-                  />
-                  <Route
-                    exact
-                    path="/applications/new/:childId"
-                    component={requireAuth(ApplicationCreation)}
-                  />
-                  <Route
-                    exact
-                    path="/applications/:applicationId"
-                    component={requireAuth(ApplicationReadView)}
-                  />
-                  <Route
-                    exact
-                    path="/applications/:applicationId/edit"
-                    component={requireAuth(ApplicationEditor)}
-                  />
-                  <Route
-                    exact
-                    path="/decisions"
-                    component={requireAuth(Decisions)}
-                  />
-                  <Route
-                    exact
-                    path="/decisions/by-application/:applicationId"
-                    component={requireAuth(DecisionResponseList)}
-                  />
-                  {featureFlags.messaging && (
+      <ThemeProvider theme={theme}>
+        <Authentication>
+          <Localization>
+            <OverlayContextProvider>
+              <HeaderContextProvider>
+                <Header />
+                <main>
+                  <Switch>
+                    <Route exact path="/" component={MapView} />
                     <Route
                       exact
-                      path="/messages"
-                      component={requireAuth(MessagesPage, false)}
+                      path="/applications"
+                      component={requireAuth(Applications)}
                     />
-                  )}
-                  <Route path="/" component={RedirectToMap} />
-                </Switch>
-              </main>
-              <GlobalInfoDialog />
-              <GlobalErrorDialog />
-            </HeaderContextProvider>
-          </OverlayContextProvider>
-        </Localization>
-      </Authentication>
+                    <Route
+                      exact
+                      path="/applications/new/:childId"
+                      component={requireAuth(ApplicationCreation)}
+                    />
+                    <Route
+                      exact
+                      path="/applications/:applicationId"
+                      component={requireAuth(ApplicationReadView)}
+                    />
+                    <Route
+                      exact
+                      path="/applications/:applicationId/edit"
+                      component={requireAuth(ApplicationEditor)}
+                    />
+                    <Route
+                      exact
+                      path="/decisions"
+                      component={requireAuth(Decisions)}
+                    />
+                    <Route
+                      exact
+                      path="/decisions/by-application/:applicationId"
+                      component={requireAuth(DecisionResponseList)}
+                    />
+                    {featureFlags.messaging && (
+                      <Route
+                        exact
+                        path="/messages"
+                        component={requireAuth(MessagesPage, false)}
+                      />
+                    )}
+                    <Route path="/" component={RedirectToMap} />
+                  </Switch>
+                </main>
+                <GlobalInfoDialog />
+                <GlobalErrorDialog />
+              </HeaderContextProvider>
+            </OverlayContextProvider>
+          </Localization>
+        </Authentication>
+      </ThemeProvider>
     </BrowserRouter>
   )
 }

--- a/frontend/src/citizen-frontend/header/Header.tsx
+++ b/frontend/src/citizen-frontend/header/Header.tsx
@@ -4,7 +4,7 @@
 
 import React, { useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
-import colors from 'lib-components/colors'
+import colors from 'lib-customizations/common'
 import { desktopMin } from 'lib-components/breakpoints'
 import EspooLogo from './EspooLogo'
 import EvakaLogo from './EvakaLogo'

--- a/frontend/src/citizen-frontend/styled.d.ts
+++ b/frontend/src/citizen-frontend/styled.d.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import 'styled-components'
+import { Theme } from 'lib-common/theme'
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface DefaultTheme extends Theme {}
+}

--- a/frontend/src/employee-frontend/state/StateProvider.tsx
+++ b/frontend/src/employee-frontend/state/StateProvider.tsx
@@ -19,6 +19,8 @@ import {
 } from '../state/placementdraft'
 import { DecisionDraftContextProvider } from '../state/decision'
 import { TitleContextProvider } from '../state/title'
+import { ThemeProvider } from 'styled-components'
+import { theme } from 'lib-customizations/common'
 
 const StateProvider = React.memo(function StateProvider({
   children
@@ -40,7 +42,9 @@ const StateProvider = React.memo(function StateProvider({
                           <PDUnitsContextProvider>
                             <TitleContextProvider>
                               <ApplicationUIContextProvider>
-                                {children}
+                                <ThemeProvider theme={theme}>
+                                  {children}
+                                </ThemeProvider>
                               </ApplicationUIContextProvider>
                             </TitleContextProvider>
                           </PDUnitsContextProvider>

--- a/frontend/src/employee-frontend/styled.d.ts
+++ b/frontend/src/employee-frontend/styled.d.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import 'styled-components'
+import { Theme } from 'lib-common/theme'
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface DefaultTheme extends Theme {}
+}

--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -29,6 +29,8 @@ import StaffPage from './components/staff/StaffPage'
 import PinLogin from './components/attendances/child-info/PinLogin'
 import { NavItem } from './components/common/BottomNavbar'
 import { History } from 'history'
+import { ThemeProvider } from 'styled-components'
+import { theme } from 'lib-customizations/common'
 
 export type RouteParams = { unitId: string; groupId: string }
 type RouteProps = RouteComponentProps<RouteParams>
@@ -47,59 +49,61 @@ export default function App() {
     >
       <I18nContextProvider>
         <AttendanceUIContextProvider>
-          <Router basename="/employee/mobile">
-            <Switch>
-              <Route exact path="/landing" component={MobileLander} />
-              <Route exact path="/pairing" component={PairingWizard} />
-              <Route
-                path="/units/:unitId/attendance/:groupId"
-                render={({ match, history }: RouteProps) => {
-                  const Component = ensureAuthenticated(AttendancePageWrapper)
-                  return (
-                    <Component
-                      onNavigate={navBarNavigate(match.params, history)}
-                    />
-                  )
-                }}
-              />
-              <Route
-                path="/units/:unitId/groups/:groupId/childattendance/:childId/markpresent"
-                component={ensureAuthenticated(MarkPresent)}
-              />
-              <Route
-                path="/units/:unitId/groups/:groupId/childattendance/:childId/markabsent"
-                component={ensureAuthenticated(MarkAbsent)}
-              />
-              <Route
-                path="/units/:unitId/groups/:groupId/childattendance/:childId/markdeparted"
-                component={ensureAuthenticated(MarkDeparted)}
-              />
-              <Route
-                path="/units/:unitId/groups/:groupId/childattendance/:childId/note"
-                component={ensureAuthenticated(DailyNoteEditor)}
-              />
-              <Route
-                path="/units/:unitId/groups/:groupId/childattendance/:childId/pin"
-                component={ensureAuthenticated(PinLogin)}
-              />
-              <Route
-                path="/units/:unitId/groups/:groupId/childattendance/:childId"
-                component={ensureAuthenticated(AttendanceChildPage)}
-              />
-              <Route
-                path="/units/:unitId/staff/:groupId"
-                render={({ match, history }: RouteProps) => {
-                  const Component = ensureAuthenticated(StaffPage)
-                  return (
-                    <Component
-                      onNavigate={navBarNavigate(match.params, history)}
-                    />
-                  )
-                }}
-              />
-              <Route component={RedirectToMainPage} />
-            </Switch>
-          </Router>
+          <ThemeProvider theme={theme}>
+            <Router basename="/employee/mobile">
+              <Switch>
+                <Route exact path="/landing" component={MobileLander} />
+                <Route exact path="/pairing" component={PairingWizard} />
+                <Route
+                  path="/units/:unitId/attendance/:groupId"
+                  render={({ match, history }: RouteProps) => {
+                    const Component = ensureAuthenticated(AttendancePageWrapper)
+                    return (
+                      <Component
+                        onNavigate={navBarNavigate(match.params, history)}
+                      />
+                    )
+                  }}
+                />
+                <Route
+                  path="/units/:unitId/groups/:groupId/childattendance/:childId/markpresent"
+                  component={ensureAuthenticated(MarkPresent)}
+                />
+                <Route
+                  path="/units/:unitId/groups/:groupId/childattendance/:childId/markabsent"
+                  component={ensureAuthenticated(MarkAbsent)}
+                />
+                <Route
+                  path="/units/:unitId/groups/:groupId/childattendance/:childId/markdeparted"
+                  component={ensureAuthenticated(MarkDeparted)}
+                />
+                <Route
+                  path="/units/:unitId/groups/:groupId/childattendance/:childId/note"
+                  component={ensureAuthenticated(DailyNoteEditor)}
+                />
+                <Route
+                  path="/units/:unitId/groups/:groupId/childattendance/:childId/pin"
+                  component={ensureAuthenticated(PinLogin)}
+                />
+                <Route
+                  path="/units/:unitId/groups/:groupId/childattendance/:childId"
+                  component={ensureAuthenticated(AttendanceChildPage)}
+                />
+                <Route
+                  path="/units/:unitId/staff/:groupId"
+                  render={({ match, history }: RouteProps) => {
+                    const Component = ensureAuthenticated(StaffPage)
+                    return (
+                      <Component
+                        onNavigate={navBarNavigate(match.params, history)}
+                      />
+                    )
+                  }}
+                />
+                <Route component={RedirectToMainPage} />
+              </Switch>
+            </Router>
+          </ThemeProvider>
         </AttendanceUIContextProvider>
       </I18nContextProvider>
     </UserContextProvider>

--- a/frontend/src/employee-mobile-frontend/styled.d.ts
+++ b/frontend/src/employee-mobile-frontend/styled.d.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import 'styled-components'
+import { Theme } from 'lib-common/theme'
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface DefaultTheme extends Theme {}
+}

--- a/frontend/src/employee-mobile-frontend/tsconfig.json
+++ b/frontend/src/employee-mobile-frontend/tsconfig.json
@@ -10,6 +10,7 @@
   "references": [
     { "path": "../lib-common" },
     { "path": "../lib-components" },
+    { "path": "../lib-customizations" },
     { "path": "../lib-icons" }
   ]
 }

--- a/frontend/src/lib-common/theme.ts
+++ b/frontend/src/lib-common/theme.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+export interface Theme {
+  colors: {
+    espooBrandColors: {
+      espooBlue: string
+      espooTurquoise: string
+      espooTurquoiseLight: string
+    }
+    blueColors: {
+      dark: string
+      medium: string
+      primary: string
+      primaryHover: string
+      primaryActive: string
+      light: string
+      lighter: string
+    }
+    greyscale: {
+      darkest: string
+      dark: string
+      medium: string
+      lighter: string
+      lightest: string
+      white: string
+    }
+    accentColors: {
+      orange: string
+      orangeDark: string
+      green: string
+      greenDark: string
+      water: string
+      yellow: string
+      red: string
+      petrol: string
+      emerald: string
+      violet: string
+    }
+  }
+}

--- a/frontend/src/lib-common/theme.ts
+++ b/frontend/src/lib-common/theme.ts
@@ -4,12 +4,12 @@
 
 export interface Theme {
   colors: {
-    espooBrandColors: {
-      espooBlue: string
-      espooTurquoise: string
-      espooTurquoiseLight: string
+    brand: {
+      primary: string
+      secondary: string
+      secondaryLight: string
     }
-    blueColors: {
+    main: {
       dark: string
       medium: string
       primary: string
@@ -26,7 +26,7 @@ export interface Theme {
       lightest: string
       white: string
     }
-    accentColors: {
+    accents: {
       orange: string
       orangeDark: string
       green: string

--- a/frontend/src/lib-common/themes/espoo-theme.ts
+++ b/frontend/src/lib-common/themes/espoo-theme.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Theme } from 'lib-common/theme'
+
+const espooBrandColors = {
+  espooBlue: '#0050bb',
+  espooTurquoise: '#249fff',
+  espooTurquoiseLight: '#e9f5ff'
+}
+
+const blueColors = {
+  dark: '#013c8c',
+  medium: '#0050bb',
+  primary: '#3273c9',
+  light: '#99b9e4',
+  lighter: '#dce5f2'
+}
+
+const greyscale = {
+  darkest: '#0f0f0f',
+  dark: '#6e6e6e',
+  medium: '#b1b1b1',
+
+  lighter: '#d8d8d8',
+  lightest: '#f5f5f5',
+  white: '#ffffff'
+}
+
+const accentColors = {
+  orange: '#ff7300',
+  orangeDark: '#b85300',
+  green: '#c6db00',
+  greenDark: '#6e7a00',
+  water: '#9fc1d3',
+  yellow: '#ffce00',
+  red: '#db0c41',
+  petrol: '#1f6390',
+  emerald: '#038572',
+  violet: '#9d55c3'
+}
+
+const theme: Theme = {
+  colors: {
+    espooBrandColors,
+    blueColors: {
+      ...blueColors,
+      primaryHover: blueColors.medium,
+      primaryActive: blueColors.dark
+    },
+    greyscale,
+    accentColors
+  }
+}
+
+export default theme

--- a/frontend/src/lib-common/themes/espoo-theme.ts
+++ b/frontend/src/lib-common/themes/espoo-theme.ts
@@ -43,14 +43,18 @@ const accentColors = {
 
 const theme: Theme = {
   colors: {
-    espooBrandColors,
-    blueColors: {
+    brand: {
+      primary: espooBrandColors.espooBlue,
+      secondary: espooBrandColors.espooTurquoise,
+      secondaryLight: espooBrandColors.espooTurquoiseLight
+    },
+    main: {
       ...blueColors,
       primaryHover: blueColors.medium,
       primaryActive: blueColors.dark
     },
     greyscale,
-    accentColors
+    accents: accentColors
   }
 }
 

--- a/frontend/src/lib-components/.storybook/preview.jsx
+++ b/frontend/src/lib-components/.storybook/preview.jsx
@@ -9,11 +9,15 @@ import { addDecorator, addParameters } from '@storybook/react'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 
 import '../../citizen-frontend/index.css'
+import { ThemeProvider } from 'styled-components'
+import theme from 'lib-common/themes/espoo-theme'
 
 const storyWrapper = (story) => (
-  <Container>
-    <ContentArea opaque>{story()}</ContentArea>
-  </Container>
+  <ThemeProvider theme={theme}>
+    <Container>
+        <ContentArea opaque>{story()}</ContentArea>
+    </Container>
+  </ThemeProvider>
 )
 
 addParameters({

--- a/frontend/src/lib-components/atoms/RoundIcon.stories.tsx
+++ b/frontend/src/lib-components/atoms/RoundIcon.stories.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -15,7 +15,6 @@ import {
   fasExclamationTriangle,
   faEuroSign
 } from 'lib-icons'
-import colors from '../colors'
 import { defaultMargins } from '../white-space'
 import { FixedSpaceRow } from '../layout/flex-helpers'
 import RoundIcon from './RoundIcon'
@@ -33,77 +32,103 @@ const ColItem = styled.div`
 const onClick = action('clicked')
 
 storiesOf('evaka/atoms/RoundIcon', module)
-  .add('default', () => (
-    <div>
-      <FixedSpaceRow spacing="L">
-        <ColItem>
-          <span>s</span>
-          <RoundIcon content={fasInfo} color={colors.accents.water} size="s" />
-        </ColItem>
-        <ColItem>
-          <span>m</span>
-          <RoundIcon
-            content={faExclamation}
-            color={colors.accents.orange}
-            size="m"
-          />
-        </ColItem>
-        <ColItem>
-          <span>m (text)</span>
-          <RoundIcon content="T" color={colors.accents.emerald} size="m" />
-        </ColItem>
-        <ColItem>
-          <span>L</span>
-          <RoundIcon content={faPlus} color={colors.primary} size="L" />
-        </ColItem>
-        <ColItem>
-          <span>XL</span>
-          <RoundIcon content={faCheck} color={colors.accents.green} size="XL" />
-        </ColItem>
-      </FixedSpaceRow>
-      <p>Note 1: use solid icons for size s, light otherwise</p>
-      <p>
-        Note 2: xs not included here, use solid icon with font-size 16px and
-        pre-included background, e.g. fasExclamationTriangle{' '}
-        <FontAwesomeIcon
-          icon={fasExclamationTriangle}
-          color={colors.accents.orange}
-          style={{ fontSize: '16px' }}
-        />
-      </p>
-    </div>
-  ))
-  .add('as filters', () => (
-    <div>
-      <FixedSpaceRow spacing="xs">
-        <RoundIcon
-          content="T"
-          color={colors.accents.emerald}
-          size="m"
-          onClick={onClick}
-          active={false}
-        />
-        <RoundIcon
-          content="2"
-          color={colors.primary}
-          size="m"
-          onClick={onClick}
-          active={true}
-        />
-        <RoundIcon
-          content={fasInfo}
-          color={colors.accents.violet}
-          size="m"
-          onClick={onClick}
-          active={false}
-        />
-        <RoundIcon
-          content={faEuroSign}
-          color={colors.accents.petrol}
-          size="m"
-          onClick={onClick}
-          active={true}
-        />
-      </FixedSpaceRow>
-    </div>
-  ))
+  .add('default', () =>
+    React.createElement(() => {
+      const theme = useTheme()
+      return (
+        <div>
+          <FixedSpaceRow spacing="L">
+            <ColItem>
+              <span>s</span>
+              <RoundIcon
+                content={fasInfo}
+                color={theme.colors.accents.water}
+                size="s"
+              />
+            </ColItem>
+            <ColItem>
+              <span>m</span>
+              <RoundIcon
+                content={faExclamation}
+                color={theme.colors.accents.orange}
+                size="m"
+              />
+            </ColItem>
+            <ColItem>
+              <span>m (text)</span>
+              <RoundIcon
+                content="T"
+                color={theme.colors.accents.emerald}
+                size="m"
+              />
+            </ColItem>
+            <ColItem>
+              <span>L</span>
+              <RoundIcon
+                content={faPlus}
+                color={theme.colors.main.primary}
+                size="L"
+              />
+            </ColItem>
+            <ColItem>
+              <span>XL</span>
+              <RoundIcon
+                content={faCheck}
+                color={theme.colors.accents.green}
+                size="XL"
+              />
+            </ColItem>
+          </FixedSpaceRow>
+          <p>Note 1: use solid icons for size s, light otherwise</p>
+          <p>
+            Note 2: xs not included here, use solid icon with font-size 16px and
+            pre-included background, e.g. fasExclamationTriangle{' '}
+            <FontAwesomeIcon
+              icon={fasExclamationTriangle}
+              color={theme.colors.accents.orange}
+              style={{ fontSize: '16px' }}
+            />
+          </p>
+        </div>
+      )
+    })
+  )
+  .add('as filters', () =>
+    React.createElement(() => {
+      const theme = useTheme()
+      return (
+        <div>
+          <FixedSpaceRow spacing="xs">
+            <RoundIcon
+              content="T"
+              color={theme.colors.accents.emerald}
+              size="m"
+              onClick={onClick}
+              active={false}
+            />
+            <RoundIcon
+              content="2"
+              color={theme.colors.main.primary}
+              size="m"
+              onClick={onClick}
+              active={true}
+            />
+            <RoundIcon
+              content={fasInfo}
+              color={theme.colors.accents.violet}
+              size="m"
+              onClick={onClick}
+              active={false}
+            />
+            <RoundIcon
+              content={faEuroSign}
+              color={theme.colors.accents.petrol}
+              size="m"
+              onClick={onClick}
+              active={true}
+            />
+          </FixedSpaceRow>
+        </div>
+      )
+    })
+  )

--- a/frontend/src/lib-components/colors.stories.tsx
+++ b/frontend/src/lib-components/colors.stories.tsx
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 import { storiesOf } from '@storybook/react'
-import colors from './colors'
 import { H2, H3, Label } from './typography'
 import { Gap } from './white-space'
 import { FixedSpaceColumn, FixedSpaceRow } from './layout/flex-helpers'
@@ -30,111 +29,132 @@ function Col({ children }: { children: React.ReactNode }) {
   return <FixedSpaceColumn alignItems="center">{children}</FixedSpaceColumn>
 }
 
-storiesOf('evaka/Colors', module).add('default', () => (
-  <div>
-    <H2>Brand Colors</H2>
-    <H3>Espoo</H3>
-    <Row>
-      <Col>
-        <ColorCircle color={colors.brandEspoo.espooBlue} />
-        <Label>blue</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.brandEspoo.espooTurquoise} />
-        <Label>turquoise</Label>
-      </Col>
-    </Row>
+storiesOf('evaka/Colors', module).add('default', () =>
+  React.createElement(() => {
+    const theme = useTheme()
+    return (
+      <div>
+        <H2>Brand Colors</H2>
+        <H3>Espoo</H3>
+        <Row>
+          <Col>
+            <ColorCircle color={theme.colors.brand.primary} />
+            <Label>primary</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.brand.secondary} />
+            <Label>secondary</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.brand.secondaryLight} />
+            <Label>secondary light</Label>
+          </Col>
+        </Row>
 
-    <Gap />
+        <Gap />
 
-    <H2>Evaka Colors</H2>
+        <H2>Evaka Colors</H2>
 
-    <H3>Blues</H3>
-    <Row>
-      <Col>
-        <ColorCircle color={colors.blues.dark} />
-        <Label>dark</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.blues.medium} />
-        <Label>medium</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.blues.primary} />
-        <Label>primary</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.blues.light} />
-        <Label>light</Label>
-      </Col>
-    </Row>
+        <H3>Main</H3>
+        <Row>
+          <Col>
+            <ColorCircle color={theme.colors.main.dark} />
+            <Label>dark</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.main.medium} />
+            <Label>medium</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.main.primary} />
+            <Label>primary</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.main.light} />
+            <Label>light</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.main.lighter} />
+            <Label>lighter</Label>
+          </Col>
+        </Row>
 
-    <Gap />
+        <Gap />
 
-    <H3>Greyscale</H3>
-    <Row>
-      <Col>
-        <ColorCircle color={colors.greyscale.darkest} />
-        <Label>darkest</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.greyscale.dark} />
-        <Label>dark</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.greyscale.medium} />
-        <Label>medium</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.greyscale.lighter} />
-        <Label>lighter</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.greyscale.lightest} />
-        <Label>lightest</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.greyscale.white} bordered />
-        <Label>white</Label>
-      </Col>
-    </Row>
+        <H3>Greyscale</H3>
+        <Row>
+          <Col>
+            <ColorCircle color={theme.colors.greyscale.darkest} />
+            <Label>darkest</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.greyscale.dark} />
+            <Label>dark</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.greyscale.medium} />
+            <Label>medium</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.greyscale.lighter} />
+            <Label>lighter</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.greyscale.lightest} />
+            <Label>lightest</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.greyscale.white} bordered />
+            <Label>white</Label>
+          </Col>
+        </Row>
 
-    <Gap />
+        <Gap />
 
-    <H3>Accents</H3>
-    <Row>
-      <Col>
-        <ColorCircle color={colors.accents.orange} />
-        <Label>orange</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.accents.green} />
-        <Label>green</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.accents.water} />
-        <Label>water</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.accents.yellow} />
-        <Label>yellow</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.accents.red} />
-        <Label>red</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.accents.petrol} />
-        <Label>petrol</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.accents.emerald} />
-        <Label>emerald</Label>
-      </Col>
-      <Col>
-        <ColorCircle color={colors.accents.violet} />
-        <Label>violet</Label>
-      </Col>
-    </Row>
-  </div>
-))
+        <H3>Accents</H3>
+        <Row>
+          <Col>
+            <ColorCircle color={theme.colors.accents.orange} />
+            <Label>orange</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.accents.orangeDark} />
+            <Label>orange dark</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.accents.green} />
+            <Label>green</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.accents.greenDark} />
+            <Label>green dark</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.accents.water} />
+            <Label>water</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.accents.yellow} />
+            <Label>yellow</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.accents.red} />
+            <Label>red</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.accents.petrol} />
+            <Label>petrol</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.accents.emerald} />
+            <Label>emerald</Label>
+          </Col>
+          <Col>
+            <ColorCircle color={theme.colors.accents.violet} />
+            <Label>violet</Label>
+          </Col>
+        </Row>
+      </div>
+    )
+  })
+)

--- a/frontend/src/lib-components/colors.ts
+++ b/frontend/src/lib-components/colors.ts
@@ -2,12 +2,20 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+/**
+ * @deprecated frontends: use espooBrandColors from lib-customizations/common.
+ *             lib-components: use styled components theme
+ */
 export const espooBrandColors = {
   espooBlue: '#0050bb',
   espooTurquoise: '#249fff',
   espooTurquoiseLight: '#e9f5ff'
 }
 
+/**
+ * @deprecated frontends: use blueColors from lib-customizations/common.
+ *             lib-components: use styled components theme
+ */
 export const blueColors = {
   dark: '#013c8c',
   medium: '#0050bb',
@@ -16,6 +24,10 @@ export const blueColors = {
   lighter: '#dce5f2'
 }
 
+/**
+ * @deprecated frontends: use greyscale from lib-customizations/common.
+ *             lib-components: use styled components theme
+ */
 export const greyscale = {
   darkest: '#0f0f0f',
   dark: '#6e6e6e',
@@ -26,6 +38,10 @@ export const greyscale = {
   white: '#ffffff'
 }
 
+/**
+ * @deprecated frontends: use accentColors from lib-customizations/common.
+ *             lib-components: use styled components theme
+ */
 export const accentColors = {
   orange: '#ff7300',
   orangeDark: '#b85300',
@@ -39,6 +55,10 @@ export const accentColors = {
   violet: '#9d55c3'
 }
 
+/**
+ * @deprecated frontends: use default export from lib-customizations/common.
+ *             lib-components: use styled components theme
+ */
 const colors = {
   brandEspoo: espooBrandColors,
   blues: blueColors,
@@ -49,6 +69,10 @@ const colors = {
   accents: accentColors
 }
 
+/**
+ * @deprecated frontends: use absenceColours from lib-customizations/common.
+ *             lib-components: use styled components theme
+ */
 export const absenceColours = {
   UNKNOWN_ABSENCE: colors.accents.green,
   OTHER_ABSENCE: colors.blues.dark,

--- a/frontend/src/lib-components/styled.d.ts
+++ b/frontend/src/lib-components/styled.d.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import 'styled-components'
+import { Theme } from 'lib-common/theme'
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface DefaultTheme extends Theme {}
+}

--- a/frontend/src/lib-components/typography.ts
+++ b/frontend/src/lib-components/typography.ts
@@ -4,7 +4,6 @@
 
 import styled from 'styled-components'
 
-import { blueColors, greyscale } from 'lib-components/colors'
 import { defaultMargins } from 'lib-components/white-space'
 
 import { BaseProps } from './utils'
@@ -20,8 +19,10 @@ type HeadingProps = BaseProps & {
 }
 
 export const H1 = styled.h1<HeadingProps>`
-  color: ${(p) =>
-    p.primary || p.primary === undefined ? blueColors.dark : greyscale.dark};
+  color: ${({ theme: { colors }, ...p }) =>
+    p.primary || p.primary === undefined
+      ? colors.main.dark
+      : colors.greyscale.dark};
   font-size: ${(p) => (p.smaller ? '24px' : '36px')};
   font-family: Montserrat, sans-serif;
   font-weight: ${(p) => (p.bold ? 600 : 200)};
@@ -38,7 +39,8 @@ export const H1 = styled.h1<HeadingProps>`
 `
 
 export const H2 = styled.h2<HeadingProps>`
-  color: ${(p) => (p.primary ? blueColors.dark : greyscale.dark)};
+  color: ${({ theme: { colors }, ...p }) =>
+    p.primary ? colors.main.dark : colors.greyscale.dark};
   font-size: ${(p) => (p.smaller ? '20px' : '24px')};
   font-family: Montserrat, sans-serif;
   font-weight: ${(p) => (p.bold ? 600 : 300)};
@@ -54,7 +56,8 @@ export const H2 = styled.h2<HeadingProps>`
 `
 
 export const H3 = styled.h3<HeadingProps>`
-  color: ${(p) => (p.primary ? blueColors.dark : greyscale.dark)};
+  color: ${({ theme: { colors }, ...p }) =>
+    p.primary ? colors.main.dark : colors.greyscale.dark};
   font-size: ${(p) => (p.smaller ? '18px' : '20px')};
   font-family: Montserrat, sans-serif;
   font-weight: ${(p) => (p.bold ? 600 : 'normal')};
@@ -64,7 +67,8 @@ export const H3 = styled.h3<HeadingProps>`
 `
 
 export const H4 = styled.h4<HeadingProps>`
-  color: ${(p) => (p.primary ? blueColors.dark : greyscale.dark)};
+  color: ${({ theme: { colors }, ...p }) =>
+    p.primary ? colors.main.dark : colors.greyscale.dark};
   font-size: ${(p) => (p.smaller ? '16px' : '18px')};
   font-family: Montserrat, sans-serif;
   font-weight: ${(p) => (p.bold ? 600 : 'normal')};
@@ -74,7 +78,8 @@ export const H4 = styled.h4<HeadingProps>`
 `
 
 export const H5 = styled.h4<HeadingProps>`
-  color: ${(p) => (p.primary ? blueColors.dark : greyscale.dark)};
+  color: ${({ theme: { colors }, ...p }) =>
+    p.primary ? colors.main.dark : colors.greyscale.dark};
   font-size: ${(p) => (p.smaller ? '14px' : '16px')};
   font-family: Montserrat, sans-serif;
   font-weight: ${(p) => (p.bold ? 600 : 'normal')};
@@ -109,7 +114,7 @@ export const P = styled.p<ParagraphProps>`
   }
 
   a {
-    color: ${blueColors.primary};
+    color: ${({ theme: { colors } }) => colors.main.primary};
     text-decoration: none;
   }
 
@@ -118,5 +123,5 @@ export const P = styled.p<ParagraphProps>`
   }
 `
 export const Dimmed = styled.span`
-  color: ${greyscale.dark};
+  color: ${({ theme: { colors } }) => colors.greyscale.dark};
 `

--- a/frontend/src/lib-customizations/common.tsx
+++ b/frontend/src/lib-customizations/common.tsx
@@ -1,0 +1,47 @@
+{
+  /*
+SPDX-FileCopyrightText: 2017-2021 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+*/
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import customizations from '@evaka/customizations/common'
+import type { CommonCustomizations } from './types'
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const { theme }: CommonCustomizations = customizations
+
+export { theme }
+
+// mimic lib-components/colors api:
+
+export const {
+  colors: { espooBrandColors, blueColors, greyscale, accentColors }
+} = theme
+
+const colors = {
+  brandEspoo: espooBrandColors,
+  blues: blueColors,
+  primary: blueColors.primary,
+  primaryHover: blueColors.medium,
+  primaryActive: blueColors.dark,
+  greyscale: greyscale,
+  accents: accentColors
+}
+
+export const absenceColours = {
+  UNKNOWN_ABSENCE: colors.accents.green,
+  OTHER_ABSENCE: colors.blues.dark,
+  SICKLEAVE: colors.accents.violet,
+  PLANNED_ABSENCE: colors.blues.light,
+  PARENTLEAVE: colors.blues.primary,
+  FORCE_MAJEURE: colors.accents.red,
+  TEMPORARY_RELOCATION: colors.accents.orange,
+  TEMPORARY_VISITOR: colors.accents.yellow,
+  PRESENCE: colors.greyscale.white
+}
+
+export default colors

--- a/frontend/src/lib-customizations/common.tsx
+++ b/frontend/src/lib-customizations/common.tsx
@@ -18,8 +18,14 @@ export { theme }
 
 // mimic lib-components/colors api:
 
+export const espooBrandColors = {
+  espooBlue: theme.colors.brand.primary,
+  espooTurquoise: theme.colors.brand.secondary,
+  espooTurquoiseLight: theme.colors.brand.secondaryLight
+}
+
 export const {
-  colors: { espooBrandColors, blueColors, greyscale, accentColors }
+  colors: { main: blueColors, greyscale, accents: accentColors }
 } = theme
 
 const colors = {

--- a/frontend/src/lib-customizations/espoo/common.tsx
+++ b/frontend/src/lib-customizations/espoo/common.tsx
@@ -1,0 +1,16 @@
+{
+  /*
+SPDX-FileCopyrightText: 2017-2021 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+*/
+}
+
+import { CommonCustomizations } from 'lib-customizations/types'
+import theme from 'lib-common/themes/espoo-theme'
+
+const customizations: CommonCustomizations = {
+  theme
+}
+
+export default customizations

--- a/frontend/src/lib-customizations/tsconfig.json
+++ b/frontend/src/lib-customizations/tsconfig.json
@@ -8,6 +8,7 @@
     "suppressImplicitAnyIndexErrors": true
   },
   "references": [
+    { "path": "../lib-common" },
     { "path": "../lib-components" }
   ]
 }

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import type { LatLngExpression } from 'leaflet'
+import { Theme } from 'lib-common/theme'
 import {
   Lang as LangCitizen,
   Translations as TranslationsCitizen
@@ -18,6 +19,10 @@ type DeepPartial<T> = {
     : T[P] extends Readonly<infer U>[]
     ? Readonly<DeepPartial<U>>[]
     : DeepPartial<T[P]>
+}
+
+export interface CommonCustomizations {
+  theme: Theme
 }
 
 export interface CitizenCustomizations {


### PR DESCRIPTION
#### Summary

Frontend styles needs to be customized for other installations. This first part takes care of component colors:

1. Introduced styled components theme into `lib-customizations` based on `lib-components/colors.ts` (which is now deprecated)
2. Added `ThemeProvider` for every app (citizen, employee, employee-mobile) that uses new theme from `lib-customizations`
3. Added examples how to refactor modules to support colors from `lib-customizations`:
    - lib-components needs to be changed to use styled components theme: https://github.com/espoon-voltti/evaka/commit/d102e44bd127217d41b029c59f212fab6d2eae06
    - other modules require only simple import change for now: https://github.com/espoon-voltti/evaka/commit/81338816af68f3cf98ceaa356ca940c9598bddba

I can finish step 3 if this POC is accepted.