### PR TITLE
EVAKA-HOTFIX fix unit caretaker stats query

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/CaretakerQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/CaretakerQueries.kt
@@ -35,7 +35,7 @@ fun Database.Read.getUnitStats(unitId: UUID, startDate: LocalDate, endDate: Loca
             select t, sum(ct.amount) as total
             from generate_series(:startDate::date, :endDate::date, '1 day') t
             left outer join daycare_caretaker ct on daterange(ct.start_date, ct.end_date, '[]') @> t::date
-            left outer join daycare_group dg on ct.group_id = dg.id
+            left outer join daycare_group dg on ct.group_id = dg.id and daterange(dg.start_date, dg.end_date, '[]') @> t::date
             where dg.daycare_id = :unitId
             group by t
         )


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The query would previously include caretakers from groups that have already ended as long as there was no ending date for the group caretaker amount.

