### PR TITLE
EVAKA-HOTFIX make SimpleSelect arrow click-through

### DIFF
--- a/frontend/src/lib-components/atoms/form/SimpleSelect.tsx
+++ b/frontend/src/lib-components/atoms/form/SimpleSelect.tsx
@@ -78,6 +78,7 @@ const StyledSelect = styled.select`
 `
 
 const Icon = styled(FontAwesomeIcon)`
+  pointer-events: none;
   position: absolute;
   right: 8px;
   top: 12px;


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The arrow icon would previously prevent the option list from opening.

