### PR TITLE
APIGW: Don't require SFI configs when disabled

### DIFF
--- a/apigw/src/shared/__tests__/saml-slo.ts
+++ b/apigw/src/shared/__tests__/saml-slo.ts
@@ -31,6 +31,8 @@ const mockUser: AuthenticatedUser = {
 // See also:
 // https://wiki.shibboleth.net/confluence/display/IDP30/LogoutConfiguration#LogoutConfiguration-Overview
 // https://simplesamlphp.org/docs/stable/simplesamlphp-idp-more#section_1
+if (!sfiConfig)
+  throw new Error('sfiConfig must be defined for these tests to run')
 const SAML_SP_DOMAIN = new URL(sfiConfig.callbackUrl).origin
 const IDP_ENTRY_POINT_URL = sfiConfig.entryPoint
 

--- a/apigw/src/shared/auth/suomi-fi-saml.ts
+++ b/apigw/src/shared/auth/suomi-fi-saml.ts
@@ -57,6 +57,7 @@ async function verifyProfile(profile: SuomiFiProfile): Promise<SamlUser> {
 
 export function createSamlConfig(redisClient?: RedisClient): SamlConfig {
   if (sfiMock) return {}
+  if (!sfiConfig) throw new Error('Missing Suomi.fi SAML configuration')
   const publicCert = Array.isArray(sfiConfig.publicCert)
     ? sfiConfig.publicCert.map(
         (certificateName) => certificates[certificateName]

--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -190,20 +190,22 @@ const sfiEntryPointUrl =
 const sfiLogoutUrl = process.env.SFI_SAML_LOGOUT_URL ?? sfiEntryPointUrl
 const sfiIssuer = process.env.SFI_SAML_ISSUER ?? 'evaka-local'
 
-export const sfiConfig: EvakaSamlConfig = {
-  callbackUrl: required(sfiCallbackUrl),
-  entryPoint: required(sfiEntryPointUrl),
-  logoutUrl: required(sfiLogoutUrl),
-  issuer: required(sfiIssuer),
-  publicCert: required(
-    envArray('SFI_SAML_PUBLIC_CERT', parseEnum(certificateNames)) ??
-      ifNodeEnv(['local', 'test'], 'config/test-cert/slo-test-idp-cert.pem')
-  ),
-  privateCert: required(
-    process.env.SFI_SAML_PRIVATE_CERT ??
-      ifNodeEnv(['local', 'test'], 'config/test-cert/saml-private.pem')
-  )
-}
+export const sfiConfig: EvakaSamlConfig | undefined = sfiCallbackUrl
+  ? {
+      callbackUrl: required(sfiCallbackUrl),
+      entryPoint: required(sfiEntryPointUrl),
+      logoutUrl: required(sfiLogoutUrl),
+      issuer: required(sfiIssuer),
+      publicCert: required(
+        envArray('SFI_SAML_PUBLIC_CERT', parseEnum(certificateNames)) ??
+          ifNodeEnv(['local', 'test'], 'config/test-cert/slo-test-idp-cert.pem')
+      ),
+      privateCert: required(
+        process.env.SFI_SAML_PRIVATE_CERT ??
+          ifNodeEnv(['local', 'test'], 'config/test-cert/saml-private.pem')
+      )
+    }
+  : undefined
 
 const evakaCallbackUrl =
   process.env.EVAKA_SAML_CALLBACK_URL ??


### PR DESCRIPTION
#### Summary

Fixes internal-gw regression introduced in #738

- evaka-internal-gw won't have the required Suomi.fi configs set -> revert the changes introduced in 6a62fcd6b85550b4bf0669cb76ac404ea92b1f8f and don't required other SFI configs to be set when callback URL isn't set (baseline for all SAML configs)