### PR TITLE
Log remaining attempts in AsyncJobRunner

### DIFF
--- a/message-service/src/main/kotlin/fi/espoo/evaka/msg/async/AsyncJob.kt
+++ b/message-service/src/main/kotlin/fi/espoo/evaka/msg/async/AsyncJob.kt
@@ -30,4 +30,4 @@ data class JobParams<T : AsyncJobPayload>(
     val runAt: Instant = Instant.now()
 )
 
-data class ClaimedJobRef(val jobId: UUID, val jobType: AsyncJobType, val txId: Long)
+data class ClaimedJobRef(val jobId: UUID, val jobType: AsyncJobType, val txId: Long, val remainingAttempts: Int)

--- a/message-service/src/main/kotlin/fi/espoo/evaka/msg/async/AsyncJobQueries.kt
+++ b/message-service/src/main/kotlin/fi/espoo/evaka/msg/async/AsyncJobQueries.kt
@@ -63,7 +63,7 @@ SET
   claimed_at = now(),
   claimed_by = txid_current()
 WHERE id = (SELECT id FROM claimed_job)
-RETURNING id AS jobId, type AS jobType, txid_current() AS txId
+RETURNING id AS jobId, type AS jobType, txid_current() AS txId, retry_count AS remainingAttempts
 """
     ).bind("jobTypes", jobTypes.toTypedArray())
         .executeAndReturnGeneratedKeys()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -166,4 +166,4 @@ data class JobParams<T : AsyncJobPayload>(
     val runAt: HelsinkiDateTime
 )
 
-data class ClaimedJobRef(val jobId: UUID, val jobType: AsyncJobType, val txId: Long)
+data class ClaimedJobRef(val jobId: UUID, val jobType: AsyncJobType, val txId: Long, val remainingAttempts: Int)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueries.kt
@@ -67,7 +67,7 @@ SET
   claimed_at = now(),
   claimed_by = txid_current()
 WHERE id = (SELECT id FROM claimed_job)
-RETURNING id AS jobId, type AS jobType, txid_current() AS txId
+RETURNING id AS jobId, type AS jobType, txid_current() AS txId, retry_count AS remainingAttempts
 """
     ).bind("jobTypes", jobTypes.toTypedArray())
         .executeAndReturnGeneratedKeys()


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This information is now logged in log messages via ClaimedJobRef.toString, and separately in log message metadata.