### PR TITLE
[EVAKA-HOTFIX] Fix FileUpload allowing downloads for unfinished uploads

### DIFF
--- a/frontend/src/lib-components/molecules/FileUpload.tsx
+++ b/frontend/src/lib-components/molecules/FileUpload.tsx
@@ -31,7 +31,16 @@ interface FileObject extends Attachment {
   key: number
   file: File | undefined
   error: FileUploadError | undefined
+  /**
+   * Percentage of upload done.
+   * NOTE: 100 does not mean the file upload has finished processing,
+   * check "uploaded" truthyness instead.
+   */
   progress: number
+  /**
+   * Marker to separate transfer and processing readiness
+   */
+  uploaded: boolean
 }
 
 interface FileUploadI18n {
@@ -201,7 +210,8 @@ const attachmentToFile = (attachment: Attachment): FileObject => {
     name: attachment.name,
     contentType: attachment.contentType,
     progress: 100,
-    error: undefined
+    error: undefined,
+    uploaded: true
   }
 }
 
@@ -221,7 +231,7 @@ const fileIcon = (file: FileObject): IconDefinition => {
   }
 }
 
-const inProgress = (file: FileObject): boolean => file.progress !== 100
+const inProgress = (file: FileObject): boolean => file.uploaded === false
 
 export default React.memo(function FileUpload({
   i18n,
@@ -303,6 +313,7 @@ export default React.memo(function FileUpload({
       name: file.name,
       contentType: file.type,
       progress: 0,
+      uploaded: false,
       error
     }
 
@@ -325,6 +336,7 @@ export default React.memo(function FileUpload({
           {
             ...fileObject,
             progress: 100,
+            uploaded: true,
             id: result.value
           },
           fileObject.id


### PR DESCRIPTION
#### Summary

- `FileUpload` creates a pseudo-ID for new files for use in state comparisons until the actual file ID is received from `onUpload`
- Internally, `FileUpload` decides whether to show a progress bar and span instead of a download link based on the status of the upload process -> if `progress === 100` but the `FileObject` had not yet received its proper ID, users could attempt file download using the pseudo-ID, which would result in errors
- Instead of relying on a (rounded!) progress state, use a separate `uploaded` flag on `FileObject`s to signify that all of the upload processing is complete -- not just the data transfer
    - `progress` is still useful for visualization purposes
- Unfortunately I couldn't figure out a sensible way to regression test this as the bug relies on either:
    1. Specific timings where the user clicks the shown link when progress is rounded up to 100% but the upload processing hasn't finished
    2. Having control over the upload progression to force 100% progress without actually completing (+ we don't really have a test setup for _components_ yet, and the meaningful part is the incorrectly shown link)