### PR TITLE
EVAKA-4190 Forbid access to inactive accounts

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -104,6 +104,18 @@ class MessageAccountQueriesTest : PureJdbiTest() {
     }
 
     @Test
+    fun `employee has no access to inactive accounts`() {
+        val groupAccountName = "Test Daycare - Testiläiset"
+        assertEquals(2, db.read { it.getMessageAccountsForUser(employee) }.size)
+
+        db.transaction { it.deactivateEmployeeMessageAccount(employeeId) }
+
+        val accounts = db.transaction { it.getMessageAccountsForUser(employee) }
+        assertEquals(1, accounts.size)
+        assertEquals(1, accounts.filter { it.name == groupAccountName }.size)
+    }
+
+    @Test
     fun `unread counts`() {
         val accounts = db.read { it.getAuthorizedMessageAccountsForUser(employee) }
         assertEquals(0, accounts.first().unreadCount)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -7,6 +7,9 @@ package fi.espoo.evaka.messaging
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.messaging.message.MessageAccount
 import fi.espoo.evaka.messaging.message.MessageType
+import fi.espoo.evaka.messaging.message.createMessageAccountForDaycareGroup
+import fi.espoo.evaka.messaging.message.createMessageAccountForPerson
+import fi.espoo.evaka.messaging.message.deactivateEmployeeMessageAccount
 import fi.espoo.evaka.messaging.message.getAuthorizedMessageAccountsForUser
 import fi.espoo.evaka.messaging.message.getMessageAccountsForUser
 import fi.espoo.evaka.messaging.message.getUnreadMessagesCount
@@ -14,6 +17,7 @@ import fi.espoo.evaka.messaging.message.insertMessage
 import fi.espoo.evaka.messaging.message.insertMessageContent
 import fi.espoo.evaka.messaging.message.insertRecipients
 import fi.espoo.evaka.messaging.message.insertThread
+import fi.espoo.evaka.messaging.message.upsertMessageAccountForEmployee
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -46,20 +50,20 @@ class MessageAccountQueriesTest : PureJdbiTest() {
     internal fun setUp() {
         db.transaction {
             it.insertTestPerson(DevPerson(id = personId, firstName = "Firstname", lastName = "Person"))
-            it.execute("INSERT INTO message_account (person_id) VALUES ('$personId')")
+            it.createMessageAccountForPerson(personId)
 
             it.insertTestEmployee(DevEmployee(id = employeeId, firstName = "Firstname", lastName = "Employee"))
-            it.execute("INSERT INTO message_account (employee_id) VALUES ('$employeeId')")
+            it.upsertMessageAccountForEmployee(employeeId)
 
             val randomUuid = it.insertTestEmployee(DevEmployee(firstName = "Random", lastName = "Employee"))
-            it.execute("INSERT INTO message_account (employee_id) VALUES ('$randomUuid')")
+            it.upsertMessageAccountForEmployee(randomUuid)
 
             it.insertTestEmployee(DevEmployee(firstName = "Random", lastName = "Employee without account"))
 
             val areaId = it.insertTestCareArea(DevCareArea())
             val daycareId = it.insertTestDaycare(DevDaycare(areaId = areaId))
             val groupId = it.insertTestDaycareGroup(DevDaycareGroup(daycareId = daycareId))
-            it.execute("INSERT INTO message_account (daycare_group_id) VALUES ('$groupId')")
+            it.createMessageAccountForDaycareGroup(groupId)
             it.insertDaycareAclRow(daycareId, employeeId, UserRole.UNIT_SUPERVISOR)
         }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -13,7 +13,9 @@ import fi.espoo.evaka.messaging.message.MessageControllerCitizen
 import fi.espoo.evaka.messaging.message.MessageThread
 import fi.espoo.evaka.messaging.message.MessageType
 import fi.espoo.evaka.messaging.message.SentMessage
+import fi.espoo.evaka.messaging.message.createMessageAccountForPerson
 import fi.espoo.evaka.messaging.message.getMessageAccountsForUser
+import fi.espoo.evaka.messaging.message.upsertMessageAccountForEmployee
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.Paged
@@ -55,7 +57,7 @@ class MessageIntegrationTest : FullApplicationTest() {
         db.transaction { tx ->
             listOf(testAdult_1, testAdult_2, testAdult_3, testAdult_4).forEach {
                 tx.insertTestPerson(DevPerson(id = it.id, firstName = it.firstName, lastName = it.lastName))
-                tx.execute("INSERT INTO message_account (person_id) VALUES ('${it.id}')")
+                tx.createMessageAccountForPerson(it.id)
             }
 
             // person 1 and 2 are guardians of child 1
@@ -76,7 +78,7 @@ class MessageIntegrationTest : FullApplicationTest() {
 
             tx.insertTestEmployee(DevEmployee(id = employee1Id, firstName = "Firstname", lastName = "Employee"))
             tx.insertTestEmployee(DevEmployee(id = employee2Id, firstName = "Firstname", lastName = "Employee Two"))
-            tx.execute("INSERT INTO message_account (employee_id) VALUES ('$employee1Id'), ('$employee2Id')")
+            listOf(employee1Id, employee2Id).forEach { tx.upsertMessageAccountForEmployee(it) }
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.messaging
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.messaging.message.MessageAccount
 import fi.espoo.evaka.messaging.message.MessageType
+import fi.espoo.evaka.messaging.message.createMessageAccountForPerson
 import fi.espoo.evaka.messaging.message.getMessageAccountsForUser
 import fi.espoo.evaka.messaging.message.getMessagesReceivedByAccount
 import fi.espoo.evaka.messaging.message.getMessagesSentByAccount
@@ -16,6 +17,7 @@ import fi.espoo.evaka.messaging.message.insertMessage
 import fi.espoo.evaka.messaging.message.insertMessageContent
 import fi.espoo.evaka.messaging.message.insertRecipients
 import fi.espoo.evaka.messaging.message.insertThread
+import fi.espoo.evaka.messaging.message.upsertMessageAccountForEmployee
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.dev.DevEmployee
@@ -38,15 +40,14 @@ class MessageQueriesTest : PureJdbiTest() {
 
     @BeforeEach
     internal fun setUp() {
-        db.transaction {
-            it.insertTestPerson(DevPerson(id = person1Id, firstName = "Firstname", lastName = "Person"))
+        db.transaction { tx ->
+            tx.insertTestPerson(DevPerson(id = person1Id, firstName = "Firstname", lastName = "Person"))
+            tx.insertTestPerson(DevPerson(id = person2Id, firstName = "Firstname", lastName = "Person Two"))
+            listOf(person1Id, person2Id).forEach { tx.createMessageAccountForPerson(it) }
 
-            it.insertTestPerson(DevPerson(id = person2Id, firstName = "Firstname", lastName = "Person Two"))
-            it.execute("INSERT INTO message_account (person_id) VALUES ('$person1Id'), ('$person2Id')")
-
-            it.insertTestEmployee(DevEmployee(id = employee1Id, firstName = "Firstname", lastName = "Employee"))
-            it.insertTestEmployee(DevEmployee(id = employee2Id, firstName = "Firstname", lastName = "Employee Two"))
-            it.execute("INSERT INTO message_account (employee_id) VALUES ('$employee1Id'), ('$employee2Id')")
+            tx.insertTestEmployee(DevEmployee(id = employee1Id, firstName = "Firstname", lastName = "Employee"))
+            tx.insertTestEmployee(DevEmployee(id = employee2Id, firstName = "Firstname", lastName = "Employee Two"))
+            listOf(employee1Id, employee2Id).forEach { tx.upsertMessageAccountForEmployee(it) }
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
@@ -19,8 +19,8 @@ FROM message_account acc
     LEFT JOIN daycare_group dg ON acc.daycare_group_id = dg.id
     LEFT JOIN daycare dc ON dc.id = dg.daycare_id
     LEFT JOIN daycare_acl acl ON acl.daycare_id = dg.daycare_id
-WHERE acc.employee_id = :userId
-   OR acl.employee_id = :userId
+WHERE (acc.employee_id = :userId OR acl.employee_id = :userId)
+  AND acc.active
     """.trimIndent()
 
     // language=SQL
@@ -29,6 +29,7 @@ SELECT acc.id, name_view.account_name AS name
 FROM message_account acc
     JOIN message_account_name_view name_view ON name_view.id = acc.id
 WHERE acc.person_id = :userId
+  AND acc.active
     """.trimIndent()
 
     return this.createQuery(if (user.isEndUser) citizenSql else employeeSql)


### PR DESCRIPTION
#### Summary

- Don't allow an employee or person to access an inactive message account.
- This doesn't currently affect message sending, because person accounts are never inactive, and citizens cannot yet send messages to employees.
