### PR TITLE
EVAKA-4190 Move messages when merging persons

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/MergeService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/MergeService.kt
@@ -78,6 +78,10 @@ class MergeService(private val asyncJobRunner: AsyncJobRunner) {
             UPDATE invoice_row SET child = :id_master WHERE child = :id_duplicate;
             UPDATE placement SET child_id = :id_master WHERE child_id = :id_duplicate;
             UPDATE service_need SET child_id = :id_master WHERE child_id = :id_duplicate;
+            
+            UPDATE message SET sender_id = (SELECT id FROM message_account WHERE person_id = :id_master) WHERE sender_id = (SELECT id FROM message_account WHERE person_id = :id_duplicate);
+            UPDATE message_content SET author_id = (SELECT id FROM message_account WHERE person_id = :id_master) WHERE author_id = (SELECT id FROM message_account WHERE person_id = :id_duplicate);
+            UPDATE message_recipients SET recipient_id = (SELECT id FROM message_account WHERE person_id = :id_master) WHERE recipient_id = (SELECT id FROM message_account WHERE person_id = :id_duplicate);
             """.trimIndent()
         tx.createUpdate(updateSQL)
             .bind("id_master", master)
@@ -113,6 +117,7 @@ class MergeService(private val asyncJobRunner: AsyncJobRunner) {
         // language=sql
         val sql2 =
             """
+            DELETE FROM message_account WHERE person_id = :id;
             DELETE FROM child WHERE id = :id;
             DELETE FROM person WHERE id = :id;
             """.trimIndent()

--- a/service/src/main/resources/db/migration/R__ensure_empty_person_function.sql
+++ b/service/src/main/resources/db/migration/R__ensure_empty_person_function.sql
@@ -20,7 +20,10 @@ BEGIN
         (SELECT count(*) FROM invoice WHERE head_of_family = $1) > 0 OR
         (SELECT count(*) FROM invoice_row WHERE child = $1) > 0 OR
         (SELECT count(*) FROM placement WHERE child_id = $1) > 0 OR
-        (SELECT count(*) FROM service_need WHERE child_id = $1) > 0
+        (SELECT count(*) FROM service_need WHERE child_id = $1) > 0 OR
+        (SELECT count(*) FROM message WHERE sender_id = (SELECT id FROM message_account WHERE person_id = $1)) > 0 OR
+        (SELECT count(*) FROM message_content WHERE author_id = (SELECT id FROM message_account WHERE person_id = $1)) > 0 OR
+        (SELECT count(*) FROM message_recipients WHERE recipient_id = (SELECT id FROM message_account WHERE person_id = $1)) > 0
     ) THEN RAISE EXCEPTION 'Person still has references.';
     END IF;
 END;


### PR DESCRIPTION
#### Summary

When to persons are merged, move the duplicate person's sent and received messages to the master person's message account.
