### PR TITLE
Show all matching units in map search input dropdown

### DIFF
--- a/frontend/src/citizen-frontend/map/SearchInput.tsx
+++ b/frontend/src/citizen-frontend/map/SearchInput.tsx
@@ -67,7 +67,6 @@ export default React.memo(function SearchInput({
       .filter((u) =>
         u.name.toLowerCase().includes(debouncedInputString.toLowerCase())
       )
-      .slice(0, 5)
       .map<MapAddress>((u) => ({
         unit: {
           id: u.id,


### PR DESCRIPTION
#### Summary

Show all matching units instead of the first five in map search input dropdown.