### PR TITLE
EVAKA-4176 new service needs and Varda

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -29,10 +29,12 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.dev.insertTestNewServiceNeed
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.snDaycareFullDay35
+import fi.espoo.evaka.snDefaultDaycare
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChildWithNamelessGuardian
@@ -671,13 +673,18 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
         daycareId: UUID = testDaycare.id
     ) {
         insertDecisionWithApplication(db, child, period, unitId = daycareId)
-        insertServiceNeed(db, child.id, period)
         db.transaction {
-            it.insertTestPlacement(
+            val placementId = it.insertTestPlacement(
                 childId = child.id,
                 unitId = daycareId,
                 startDate = period.start,
                 endDate = period.end
+            )
+            it.insertTestNewServiceNeed(
+                confirmedBy = testDecisionMaker_1.id,
+                placementId = placementId,
+                period = period,
+                optionId = snDefaultDaycare.id
             )
         }
     }

--- a/service/src/main/resources/db/scripts/fee-decision-migration.sql
+++ b/service/src/main/resources/db/scripts/fee-decision-migration.sql
@@ -21,6 +21,8 @@ SELECT
     placement_unit,
     (CASE
         WHEN placement_type = 'FIVE_YEARS_OLD_DAYCARE' THEN 'DAYCARE_FIVE_YEAR_OLDS'::placement_type
+        WHEN placement_type = 'PRESCHOOL_WITH_DAYCARE' THEN 'PRESCHOOL_DAYCARE'::placement_type
+        WHEN placement_type = 'PREPARATORY_WITH_DAYCARE' THEN 'PREPARATORY_DAYCARE'::placement_type
         ELSE placement_type::placement_type
     END),
     (CASE


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Use new service needs in Varda integration. Also, fix fee decision migration for preschool and preparatory children.

