### PR TITLE
EVAKA-4190 Initial draft view implementation

### DIFF
--- a/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
+++ b/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
@@ -5,11 +5,11 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { ReactNode, useState } from 'react'
 import styled from 'styled-components'
-import { greyscale } from '../../../lib-components/colors'
 import { defaultMargins } from '../../../lib-components/white-space'
+import colors from '../../../lib-customizations/common'
 import { faChevronDown, faChevronUp } from '../../../lib-icons'
 import MessageBox, { MessageBoxRow } from './MessageBox'
-import { GroupMessageAccount } from './types'
+import { GroupMessageAccount, messageBoxes } from './types'
 import { AccountView } from './types-view'
 
 const AccountContainer = styled.div`
@@ -43,7 +43,7 @@ function CollapsibleRow({
         <FontAwesomeIcon
           icon={expanded ? faChevronUp : faChevronDown}
           size="xs"
-          color={greyscale.darkest}
+          color={colors.greyscale.darkest}
         />
       </CollapseToggle>
       <Content visible={expanded}>{children}</Content>
@@ -76,18 +76,15 @@ export default function GroupMessageAccountList({
           startCollapsed={i > 0}
           title={acc.daycareGroup.name}
         >
-          <MessageBox
-            account={acc}
-            activeView={activeView}
-            setView={setView}
-            view="RECEIVED"
-          />
-          <MessageBox
-            account={acc}
-            activeView={activeView}
-            setView={setView}
-            view="SENT"
-          />
+          {messageBoxes.map((view) => (
+            <MessageBox
+              key={view}
+              view={view}
+              account={acc}
+              activeView={activeView}
+              setView={setView}
+            />
+          ))}
         </CollapsibleRow>
       ))}
     </CollapsibleMessageBoxesContainer>

--- a/frontend/src/employee-frontend/components/messages/MessageDrafts.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageDrafts.tsx
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Result } from 'lib-common/api'
+import Loader from 'lib-components/atoms/Loader'
+import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
+import React from 'react'
+import {
+  MessageRow,
+  Participants,
+  ParticipantsAndPreview,
+  SentAt,
+  Title,
+  Truncated,
+  TypeAndDate
+} from './MessageComponents'
+import { MessageTypeChip } from './MessageTypeChip'
+import { DraftContent } from './types'
+
+function DraftContent({ draft }: { draft: DraftContent }) {
+  return (
+    <MessageRow>
+      <ParticipantsAndPreview>
+        <Participants>{draft.recipientNames?.join(', ') ?? '–'}</Participants>
+        <Truncated>
+          <Title>{draft.title}</Title>
+          {' - '}
+          {draft.content}
+        </Truncated>
+      </ParticipantsAndPreview>
+      <TypeAndDate>
+        <MessageTypeChip type={draft.type ?? 'MESSAGE'} />
+        <SentAt sentAt={draft.created} />
+      </TypeAndDate>
+    </MessageRow>
+  )
+}
+
+interface Props {
+  drafts: Result<DraftContent[]>
+}
+
+export function MessageDrafts({ drafts }: Props) {
+  return drafts.mapAll({
+    loading() {
+      return <Loader />
+    },
+    failure() {
+      return <ErrorSegment />
+    },
+    success(data) {
+      return (
+        <>
+          {data.map((draft) => (
+            <DraftContent key={draft.id} draft={draft} />
+          ))}
+        </>
+      )
+    }
+  })
+}

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -119,9 +119,10 @@ export default React.memo(function MessagesPage() {
           setView={setView}
           showEditor={() => setShowEditor(true)}
         />
-        {view && (view.view === 'RECEIVED' || view.view === 'SENT') && (
-          <MessageList {...view} />
-        )}
+        {view &&
+          (view.view === 'RECEIVED' ||
+            view.view === 'SENT' ||
+            view.view === 'DRAFTS') && <MessageList {...view} />}
         {view && view.view === 'RECEIVERS' && selectedReceivers && (
           <ReceiverSelection
             selectedReceivers={selectedReceivers}

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -6,29 +6,29 @@ import { Result } from 'lib-common/api'
 import Button from 'lib-components/atoms/buttons/Button'
 import Loader from 'lib-components/atoms/Loader'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
-import colors, { espooBrandColors, greyscale } from 'lib-components/colors'
 import { defaultMargins } from 'lib-components/white-space'
 import { sortBy, uniqBy } from 'lodash'
 import React, { useState } from 'react'
 import styled from 'styled-components'
+import colors from '../../../lib-customizations/common'
 import { useTranslation } from '../../state/i18n'
 import Select, { SelectOptionProps } from '../common/Select'
 import GroupMessageAccountList from './GroupMessageAccountList'
 import MessageBox from './MessageBox'
-import { isGroupMessageAccount, MessageAccount } from './types'
+import { isGroupMessageAccount, MessageAccount, messageBoxes } from './types'
 import { AccountView } from './types-view'
 
 const AccountSection = styled.section`
   padding: 12px 0;
 
   & + & {
-    border-top: 1px dashed ${greyscale.dark};
+    border-top: 1px dashed ${colors.greyscale.dark};
   }
 `
 
 const AccountHeader = styled.div`
   padding: 12px ${defaultMargins.m};
-  color: ${greyscale.dark};
+  color: ${colors.greyscale.dark};
   font-family: 'Montserrat', sans-serif;
   font-size: 20px;
   font-weight: 600;
@@ -77,18 +77,15 @@ function Accounts(props: AccountsParams) {
       {personalAccount && (
         <AccountSection>
           <AccountHeader>{i18n.messages.sidePanel.ownMessages}</AccountHeader>
-          <MessageBox
-            view="RECEIVED"
-            account={personalAccount}
-            activeView={props.view}
-            setView={props.setView}
-          />
-          <MessageBox
-            view="SENT"
-            account={personalAccount}
-            activeView={props.view}
-            setView={props.setView}
-          />
+          {messageBoxes.map((view) => (
+            <MessageBox
+              key={view}
+              view={view}
+              account={personalAccount}
+              activeView={props.view}
+              setView={props.setView}
+            />
+          ))}
         </AccountSection>
       )}
 
@@ -168,7 +165,7 @@ export const Received = styled.div<{ active: boolean }>`
   padding: 12px ${defaultMargins.m};
   font-weight: ${(p) => (p.active ? '600;' : 'unset')}
   background-color: ${(p) =>
-    p.active ? espooBrandColors.espooTurquoiseLight : 'unset'}
+    p.active ? colors.brandEspoo.espooTurquoiseLight : 'unset'}
 `
 
 const Container = styled.div`

--- a/frontend/src/employee-frontend/components/messages/api.ts
+++ b/frontend/src/employee-frontend/components/messages/api.ts
@@ -7,9 +7,11 @@ import { JsonOf } from 'lib-common/json'
 import { client } from '../../api/client'
 import { UUID } from '../../types'
 import {
+  deserializeDraftContent,
   deserializeMessageThread,
   deserializeReceiverChild,
   deserializeSentMessage,
+  DraftContent,
   IdAndName,
   MessageAccount,
   MessageBody,
@@ -17,7 +19,8 @@ import {
   MessageType,
   ReceiverGroup,
   ReceiverTriplet,
-  SentMessage
+  SentMessage,
+  UpsertableDraftContent
 } from './types'
 
 export async function deleteDraftBulletin(id: UUID): Promise<void> {
@@ -128,6 +131,43 @@ export async function getSentMessages(
         data: data.data.map(deserializeSentMessage)
       })
     )
+    .catch((e) => Failure.fromError(e))
+}
+
+export async function getMessageDrafts(
+  accountId: UUID
+): Promise<Result<DraftContent[]>> {
+  return client
+    .get<JsonOf<DraftContent[]>>(`/messages/${accountId}/drafts`)
+    .then(({ data }) => Success.of(data.map(deserializeDraftContent)))
+    .catch((e) => Failure.fromError(e))
+}
+
+export async function initDraft(accountId: UUID): Promise<Result<UUID>> {
+  return client
+    .post<UUID>(`/messages/${accountId}/drafts`)
+    .then(({ data }) => Success.of(data))
+    .catch((e) => Failure.fromError(e))
+}
+
+export async function saveDraft(
+  accountId: UUID,
+  draftId: UUID,
+  content: UpsertableDraftContent
+): Promise<Result<void>> {
+  return client
+    .put(`/messages/${accountId}/drafts/${draftId}`, content)
+    .then(() => Success.of(undefined))
+    .catch((e) => Failure.fromError(e))
+}
+
+export async function deleteDraft(
+  accountId: UUID,
+  draftId: UUID
+): Promise<Result<void>> {
+  return client
+    .delete(`/messages/${accountId}/drafts/${draftId}`)
+    .then(() => Success.of(undefined))
     .catch((e) => Failure.fromError(e))
 }
 

--- a/frontend/src/employee-frontend/components/messages/types-view.d.ts
+++ b/frontend/src/employee-frontend/components/messages/types-view.d.ts
@@ -4,7 +4,7 @@
 
 import { MessageAccount } from './types'
 
-export type View = 'RECEIVED' | 'SENT' | 'RECEIVERS'
+export type View = 'RECEIVED' | 'SENT' | 'RECEIVERS' | 'DRAFTS'
 
 export interface AccountView {
   account: MessageAccount

--- a/frontend/src/employee-frontend/components/messages/types.ts
+++ b/frontend/src/employee-frontend/components/messages/types.ts
@@ -5,6 +5,7 @@
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from '../../types'
+import { View } from './types-view'
 
 export type Recipient = {
   personId: string
@@ -50,6 +51,8 @@ export interface ReceiverTriplet {
   personId?: UUID
 }
 
+export const messageBoxes: View[] = ['RECEIVED', 'SENT', 'DRAFTS']
+
 export interface BaseMessageAccount {
   id: UUID
   name: string
@@ -87,6 +90,21 @@ export interface MessageBody {
   senderAccountId: UUID
   recipientAccountIds: UUID[]
 }
+
+export type UpsertableDraftContent = Partial<MessageBody> & {
+  recipientNames?: string[]
+}
+export interface DraftContent extends UpsertableDraftContent {
+  id: UUID
+  created: Date
+}
+export const deserializeDraftContent = ({
+  created,
+  ...rest
+}: JsonOf<DraftContent>): DraftContent => ({
+  ...rest,
+  created: new Date(created)
+})
 
 export type MessageType = 'MESSAGE' | 'BULLETIN'
 

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2318,7 +2318,7 @@ export const fi = {
       names: {
         RECEIVED: 'Saapuneet',
         SENT: 'Lähetetyt',
-        DRAFT: 'Luonnokset'
+        DRAFTS: 'Luonnokset'
       },
       receivers: 'Vastaanottajat',
       newBulletin: 'Uusi viesti'

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/DraftContent.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/DraftContent.kt
@@ -4,10 +4,23 @@
 
 package fi.espoo.evaka.messaging.message
 
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.util.UUID
 
 data class DraftContent(
+    val id: UUID,
+    val created: HelsinkiDateTime,
+    val type: MessageType? = null,
     val title: String? = null,
     val content: String? = null,
-    val recipients: Set<UUID>? = null,
+    val recipientAccountIds: Set<UUID>? = null,
+    val recipientNames: List<String>? = null,
+)
+
+data class UpsertableDraftContent(
+    val type: MessageType? = null,
+    val title: String? = null,
+    val content: String? = null,
+    val recipientAccountIds: Set<UUID>? = null,
+    val recipientNames: List<String>? = null,
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/DraftQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/DraftQueries.kt
@@ -27,23 +27,27 @@ fun Database.Transaction.initDraft(accountId: UUID): UUID {
         .one()
 }
 
-fun Database.Transaction.upsertDraft(accountId: UUID, id: UUID, draft: DraftContent) {
+fun Database.Transaction.upsertDraft(accountId: UUID, id: UUID, draft: UpsertableDraftContent) {
     this.createUpdate(
         """
-        INSERT INTO message_draft (id, account_id, title, content, recipients)
-        VALUES (:id, :accountId, :title, :content, :recipients)
+        INSERT INTO message_draft (id, account_id, title, content, type, recipient_account_ids, recipient_names)
+        VALUES (:id, :accountId, :title, :content, :type, :recipientIds, :recipientNames)
         ON CONFLICT (id)
         DO UPDATE SET
              title = excluded.title,
              content = excluded.content,
-             recipients = excluded.recipients
+             type = excluded.type,
+             recipient_account_ids = excluded.recipient_account_ids,
+             recipient_names = excluded.recipient_names
         """.trimIndent()
     )
         .bind("accountId", accountId)
         .bind("id", id)
+        .bindNullable("type", draft.type)
         .bindNullable("title", draft.title)
         .bindNullable("content", draft.content)
-        .bindNullable("recipients", draft.recipients?.toTypedArray())
+        .bindNullable("recipientIds", draft.recipientAccountIds?.toTypedArray())
+        .bindNullable("recipientNames", draft.recipientNames?.toTypedArray())
         .execute()
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/DraftQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/DraftQueries.kt
@@ -10,7 +10,7 @@ import org.jdbi.v3.core.kotlin.mapTo
 import java.util.UUID
 
 fun Database.Read.getDrafts(accountId: UUID): List<DraftContent> {
-    return this.createQuery("SELECT * FROM message_draft WHERE account_id = :accountId")
+    return this.createQuery("SELECT * FROM message_draft WHERE account_id = :accountId ORDER BY created DESC")
         .bind("accountId", accountId)
         .mapTo<DraftContent>()
         .list()

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageController.kt
@@ -145,7 +145,7 @@ class MessageController(
         user: AuthenticatedUser,
         @PathVariable accountId: UUID,
         @PathVariable draftId: UUID,
-        @RequestBody content: DraftContent,
+        @RequestBody content: UpsertableDraftContent,
     ) {
         Audit.MessagingUpdateDraft.log(accountId, draftId)
         authorizeAllowedMessagingRoles(user)

--- a/service/src/main/resources/db/migration/V88__draft_type_and_recipients.sql
+++ b/service/src/main/resources/db/migration/V88__draft_type_and_recipients.sql
@@ -1,0 +1,6 @@
+ALTER TABLE message_draft
+    RENAME recipients TO recipient_account_ids;
+
+ALTER TABLE message_draft
+    ADD COLUMN recipient_names text[],
+    ADD COLUMN type message_type;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -85,3 +85,4 @@ V84__create_message_accounts.sql
 V85__message_draft_table.sql
 V86__add_invoice_created_at.sql
 V87__drop_service_need_option_id_from_fee_decision.sql
+V88__draft_type_and_recipients.sql


### PR DESCRIPTION
#### Summary

- Add drafts message box to accounts view
- Implement simple list view for drafts
- Separate displayable draft content from upsertable draft content
- Add missing message type to draft content
- Add recipient names to draft content for display purposes. The frontend can decide on the content and group the recipients eg. `["Hippiäiset", "Joni Juntunen"]` or `["Aallonhuipun päiväkoti"]`.