### PR TITLE
Take screenshots after failed Playwright tests

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,7 +13,7 @@ test-results
 junit.xml
 .DS_Store
 .vscode
-e2e-test/screenshots/
+screenshots/
 .yalc
 yalc.lock
 **/storybook-build/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -124,6 +124,8 @@
     "html-webpack-plugin": "^5.3.1",
     "husky": "^5.0.9",
     "jest": "^26.6.3",
+    "jest-circus": "^26.6.3",
+    "jest-environment-node": "^26.6.2",
     "jest-junit": "^12.0.0",
     "make-error-cause": "^2.3.0",
     "parcel-bundler": "^1.12.4",
@@ -137,6 +139,7 @@
     "testcafe-reporter-junit": "3.0.2",
     "ts-jest": "^26.5.4",
     "ts-loader": "^8.0.18",
+    "ts-node": "^9.1.1",
     "tsconfig-paths-webpack-plugin": "^3.5.1",
     "typescript": "^4.1.3",
     "webpack": "^5.27.1",
@@ -183,26 +186,22 @@
     "trailingComma": "none"
   },
   "jest": {
-    "preset": "ts-jest",
+    "testRunner": "jest-circus/runner",
+    "projects": [
+      "./src/citizen-frontend",
+      "./src/e2e-playwright",
+      "./src/employee-frontend",
+      "./src/lib-common"
+    ],
     "reporters": [
       "default",
       "jest-junit"
     ],
-    "testEnvironment": "node",
     "modulePathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/dist/",
-      "<rootDir>/src/e2e-test"
+      "<rootDir>/node_modules/"
     ],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png)$": "<rootDir>/assetsTransformer.js",
-      "^e2e-playwright/(.*)$": "<rootDir>/src/e2e-playwright/$1",
-      "^e2e-test-common/(.*)$": "<rootDir>/src/e2e-test-common/$1"
-    },
-    "globals": {
-      "ts-jest": {
-        "isolatedModules": true
-      }
+      "\\.(jpg|jpeg|png)$": "<rootDir>/assetsTransformer.js"
     }
   },
   "jest-junit": {

--- a/frontend/src/citizen-frontend/jest.config.ts
+++ b/frontend/src/citizen-frontend/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
+  displayName: 'citizen-frontend',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRunner: 'jest-circus/runner'
+}
+export default config

--- a/frontend/src/e2e-playwright/jest-environment.js
+++ b/frontend/src/e2e-playwright/jest-environment.js
@@ -1,0 +1,24 @@
+/* eslint-disable
+  @typescript-eslint/no-unsafe-member-access,
+  @typescript-eslint/no-unsafe-assignment,
+  @typescript-eslint/no-unsafe-call,
+  @typescript-eslint/no-var-requires,
+  no-undef
+*/
+const NodeEnvironment = require('jest-environment-node')
+
+class PlaywrightEnvironment extends NodeEnvironment {
+  async handleTestEvent(event, _state) {
+    if (event.name === 'test_fn_failure') {
+      /** @type {string} **/
+      const parentName = event.test.parent.name.replace(/\W/g, '-')
+      /** @type {string} **/
+      const specName = event.test.name.replace(/\W/g, '-')
+
+      const namePrefix = `${parentName}_${specName}`
+      await this.global.evaka?.takeScreenshots(namePrefix)
+    }
+  }
+}
+
+module.exports = PlaywrightEnvironment

--- a/frontend/src/e2e-playwright/jest.config.ts
+++ b/frontend/src/e2e-playwright/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from '@jest/types'
 const config: Config.InitialOptions = {
   displayName: 'e2e-playwright',
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: './jest-environment',
   testRunner: 'jest-circus/runner',
   moduleNameMapper: {
     '^e2e-playwright/(.*)$': '<rootDir>/$1'

--- a/frontend/src/e2e-playwright/jest.config.ts
+++ b/frontend/src/e2e-playwright/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
+  displayName: 'e2e-playwright',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRunner: 'jest-circus/runner',
+  moduleNameMapper: {
+    '^e2e-playwright/(.*)$': '<rootDir>/$1'
+  }
+}
+export default config

--- a/frontend/src/employee-frontend/jest.config.ts
+++ b/frontend/src/employee-frontend/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
+  displayName: 'employee-frontend',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRunner: 'jest-circus/runner'
+}
+export default config

--- a/frontend/src/lib-common/jest.config.ts
+++ b/frontend/src/lib-common/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
+  displayName: 'lib-common',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRunner: 'jest-circus/runner'
+}
+export default config

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5062,6 +5062,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 81b3b40b1529c4fbf75b12f7c3e6fb2dcce9e78072063babc169de9b4f40777788f3d2b04380f659ef676a756e03ccfbfe78adf4477353bda906295fa69dab89
+  languageName: node
+  linkType: hard
+
 "argparse@npm:^1.0.7":
   version: 1.0.10
   resolution: "argparse@npm:1.0.10"
@@ -7473,6 +7480,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: babd307893abfb26d77ae11cb9d6b6cfa6d18c9cee435cf70b5a3fb44aa8d90c9ec26ea89cbb16e0a94b8d34f5fcaee164b90ed526cdd3158955673ab9652d01
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -8251,7 +8265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^4.0.2":
+"diff@npm:^4.0.1, diff@npm:^4.0.2":
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: 81b5cd7ddde6f0ba2a532d434cfdca365aedd6cc62bb133e851e66e071d40382a30924a07c1034bd3d5a2e332146f64514b73c06fe2ebc0490a67f0c98da79fb
@@ -9264,6 +9278,8 @@ __metadata:
     html-webpack-plugin: ^5.3.1
     husky: ^5.0.9
     jest: ^26.6.3
+    jest-circus: ^26.6.3
+    jest-environment-node: ^26.6.2
     jest-junit: ^12.0.0
     leaflet: ^1.7.1
     leaflet.markercluster: ^1.5.0
@@ -9303,6 +9319,7 @@ __metadata:
     testcafe-reporter-junit: 3.0.2
     ts-jest: ^26.5.4
     ts-loader: ^8.0.18
+    ts-node: ^9.1.1
     tsconfig-paths-webpack-plugin: ^3.5.1
     tslib: ^2.1.0
     typescript: ^4.1.3
@@ -12109,6 +12126,35 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-circus@npm:^26.6.3":
+  version: 26.6.3
+  resolution: "jest-circus@npm:26.6.3"
+  dependencies:
+    "@babel/traverse": ^7.1.0
+    "@jest/environment": ^26.6.2
+    "@jest/test-result": ^26.6.2
+    "@jest/types": ^26.6.2
+    "@types/babel__traverse": ^7.0.4
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    dedent: ^0.7.0
+    expect: ^26.6.2
+    is-generator-fn: ^2.0.0
+    jest-each: ^26.6.2
+    jest-matcher-utils: ^26.6.2
+    jest-message-util: ^26.6.2
+    jest-runner: ^26.6.3
+    jest-runtime: ^26.6.3
+    jest-snapshot: ^26.6.2
+    jest-util: ^26.6.2
+    pretty-format: ^26.6.2
+    stack-utils: ^2.0.2
+    throat: ^5.0.0
+  checksum: 8ef70b1ccd0837d19131889fcf4e7ed4d6f051a9140be71eb3536dd98d80ab4ab31dd5d445300f08f6e8d0bd6588e77159d53ea4fda808c5e55eb464755d1837
+  languageName: node
+  linkType: hard
+
 "jest-cli@npm:^26.6.3":
   version: 26.6.3
   resolution: "jest-cli@npm:26.6.3"
@@ -13271,7 +13317,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"make-error@npm:1.x, make-error@npm:^1.3.5":
+"make-error@npm:1.x, make-error@npm:^1.1.1, make-error@npm:^1.3.5":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: 2c780bab8409b865e8ee86697c599a2bf2765ec64d21eb67ccda27050e039f983feacad05a0d43aba3c966ea03d305d2612e94fec45474bcbc61181f57c5bb88
@@ -18304,7 +18350,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.6, source-map-support@npm:~0.5.10, source-map-support@npm:~0.5.12, source-map-support@npm:~0.5.19":
+"source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.17, source-map-support@npm:^0.5.6, source-map-support@npm:~0.5.10, source-map-support@npm:~0.5.12, source-map-support@npm:~0.5.19":
   version: 0.5.19
   resolution: "source-map-support@npm:0.5.19"
   dependencies:
@@ -19712,6 +19758,27 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^9.1.1":
+  version: 9.1.1
+  resolution: "ts-node@npm:9.1.1"
+  dependencies:
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    source-map-support: ^0.5.17
+    yn: 3.1.1
+  peerDependencies:
+    typescript: ">=2.7"
+  bin:
+    ts-node: dist/bin.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: a90db4a342872cd0e7a80babdfcb15d2f7c06e700d735003098f7cc79db575c3380580c58a19ae0d0eaab553af083651d4237060c92170e6f8ac4e64693113ea
+  languageName: node
+  linkType: hard
+
 "ts-pnp@npm:^1.1.6":
   version: 1.2.0
   resolution: "ts-pnp@npm:1.2.0"
@@ -21062,6 +21129,13 @@ typescript@^4.1.3:
     buffer-crc32: ~0.2.3
     fd-slicer: ~1.1.0
   checksum: 6d0c4e72706ec2df6ea842d09c792e7b34badc5db3d8a893e0c70d0e464c9bf82bac4b1690f3515b5e1d96b72fceb6cc4dd96465426077ba6dddc54e7dd4d517
+  languageName: node
+  linkType: hard
+
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: bff63b80568d80c711670935427494dde47cdf97e8b04196b140ce0af519c81c5ee857eddad0caa8b422dd65aea0157bbfaacbb1546bebba623f0f383d5d9ae5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

* split global jest config into separate "projects" so we can customize the configuration just for tests under src/e2e-playwright
* use jest-circus test runner, which has support for various lifecycle hooks
* implement a simple custom jest environment, which allows us to run code after a failing test
* expose screenshot function from `browser.ts` to the jest environment through a nodejs global object
* take screenshots after failed Playwright tests from all browser contexts and pages

