### PR TITLE
EVAKA-HOTFIX decision response when waiting for mailing

### DIFF
--- a/frontend/src/employee-frontend/components/application-page/ApplicationDecisionsSection.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationDecisionsSection.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import { faFilePdf, faGavel, fasExclamationTriangle } from 'lib-icons'
+import { ApplicationStatus } from 'lib-common/api-types/application/enums'
 import { Label } from 'lib-components/typography'
 import CollapsibleSection from 'lib-components/molecules/CollapsibleSection'
 import ListGrid from 'lib-components/layout/ListGrid'
@@ -19,7 +20,8 @@ import {
 import DecisionResponse from '../../components/application-page/DecisionResponse'
 import { UUID } from '../../types'
 
-const isPending = (decision: Decision) => decision.status === 'PENDING'
+const isPending = (decision: Decision, applicationStatus: ApplicationStatus) =>
+  decision.status === 'PENDING' && applicationStatus !== 'WAITING_MAILING'
 
 const isBlocked = (decisions: Decision[], decision: Decision) =>
   ['PRESCHOOL_DAYCARE'].includes(decision.type) &&
@@ -37,12 +39,14 @@ type Props = {
   applicationId: UUID
   decisions: Decision[]
   reloadApplication: () => void
+  applicationStatus: ApplicationStatus
 }
 
 export default React.memo(function ApplicationDecisionsSection({
   applicationId,
   decisions,
-  reloadApplication
+  reloadApplication,
+  applicationStatus
 }: Props) {
   const { i18n } = useTranslation()
 
@@ -95,7 +99,7 @@ export default React.memo(function ApplicationDecisionsSection({
                 {decision.unit.name}
               </Link>
 
-              {isPending(decision) && (
+              {isPending(decision, applicationStatus) && (
                 <>
                   <Label>{i18n.application.decisions.response.label}</Label>
 

--- a/frontend/src/employee-frontend/components/application-page/ApplicationReadView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationReadView.tsx
@@ -535,6 +535,7 @@ function ApplicationReadView({
         applicationId={application.application.id}
         decisions={decisions}
         reloadApplication={reloadApplication}
+        applicationStatus={application.application.status}
       />
 
       <ApplicationStatusSection application={application.application} />


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Hide decision response component when application is waiting for mailing, back end won't let user confirm or reject the decisions anyway.

