### PR TITLE
EVAKA-4190 Save message draft state automatically

### DIFF
--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react-router-dom'
 import ChildInformation from './/components/ChildInformation'
 import StateProvider from './/state/StateProvider'
-import { MessagesPageContextProvider } from './components/messages/MessagesPageContext'
 import PersonProfile from './components/PersonProfile'
 import ErrorMessage from './components/common/ErrorMessage'
 import UnitPage from './components/UnitPage'
@@ -327,14 +326,12 @@ export default function App() {
               />
             )}
             {featureFlags.messaging && (
-              <MessagesPageContextProvider>
-                <RouteWithTitle
-                  exact
-                  path="/messages"
-                  component={ensureAuthenticated(MessagesPage)}
-                  title={i18n.titles.messages}
-                />
-              </MessagesPageContextProvider>
+              <RouteWithTitle
+                exact
+                path="/messages"
+                component={ensureAuthenticated(MessagesPage)}
+                title={i18n.titles.messages}
+              />
             )}
             <RouteWithTitle
               exact

--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-router-dom'
 import ChildInformation from './/components/ChildInformation'
 import StateProvider from './/state/StateProvider'
+import { MessagesPageContextProvider } from './components/messages/MessagesPageContext'
 import PersonProfile from './components/PersonProfile'
 import ErrorMessage from './components/common/ErrorMessage'
 import UnitPage from './components/UnitPage'
@@ -326,12 +327,14 @@ export default function App() {
               />
             )}
             {featureFlags.messaging && (
-              <RouteWithTitle
-                exact
-                path="/messages"
-                component={ensureAuthenticated(MessagesPage)}
-                title={i18n.titles.messages}
-              />
+              <MessagesPageContextProvider>
+                <RouteWithTitle
+                  exact
+                  path="/messages"
+                  component={ensureAuthenticated(MessagesPage)}
+                  title={i18n.titles.messages}
+                />
+              </MessagesPageContextProvider>
             )}
             <RouteWithTitle
               exact

--- a/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
+++ b/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
@@ -9,8 +9,8 @@ import { defaultMargins } from '../../../lib-components/white-space'
 import colors from '../../../lib-customizations/common'
 import { faChevronDown, faChevronUp } from '../../../lib-icons'
 import MessageBox, { MessageBoxRow } from './MessageBox'
-import { GroupMessageAccount, messageBoxes } from './types'
-import { AccountView } from './types-view'
+import { GroupMessageAccount } from './types'
+import { AccountView, messageBoxes } from './types-view'
 
 const AccountContainer = styled.div`
   margin: 12px 0;

--- a/frontend/src/employee-frontend/components/messages/MessageDrafts.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageDrafts.tsx
@@ -5,7 +5,7 @@
 import { Result } from 'lib-common/api'
 import Loader from 'lib-components/atoms/Loader'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
-import React from 'react'
+import React, { useContext } from 'react'
 import {
   MessageRow,
   Participants,
@@ -15,12 +15,18 @@ import {
   Truncated,
   TypeAndDate
 } from './MessageComponents'
+import { MessagesPageContext } from './MessagesPageContext'
 import { MessageTypeChip } from './MessageTypeChip'
 import { DraftContent } from './types'
 
-function DraftContent({ draft }: { draft: DraftContent }) {
+interface RowProps {
+  draft: DraftContent
+}
+
+function DraftRow({ draft }: RowProps) {
+  const { setSelectedDraft } = useContext(MessagesPageContext)
   return (
-    <MessageRow>
+    <MessageRow onClick={() => setSelectedDraft(draft)}>
       <ParticipantsAndPreview>
         <Participants>{draft.recipientNames?.join(', ') ?? '–'}</Participants>
         <Truncated>
@@ -53,7 +59,7 @@ export function MessageDrafts({ drafts }: Props) {
       return (
         <>
           {data.map((draft) => (
-            <DraftContent key={draft.id} draft={draft} />
+            <DraftRow key={draft.id} draft={draft} />
           ))}
         </>
       )

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -13,7 +13,7 @@ import { Label } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faTimes, faTrash } from 'lib-icons'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import Select from '../../components/common/Select'
 import { useTranslation } from '../../state/i18n'
@@ -64,7 +64,7 @@ interface Props {
     messageBody: MessageBody,
     draftId: string | undefined
   ) => void
-  onClose: () => void
+  onClose: (didChanges: boolean) => void
   onDiscard: (accountId: UUID, draftId?: UUID) => void
   draftContent?: DraftContent
 }
@@ -174,11 +174,16 @@ export default React.memo(function MessageEditor({
     messageBody.title ||
     i18n.messages.messageEditor.newMessage
 
+  const onCloseHandler = useCallback(() => onClose(!!draftSaveResult), [
+    draftSaveResult,
+    onClose
+  ])
+
   return (
     <Container>
       <TopBar>
         <span>{title}</span>
-        <IconButton icon={faTimes} onClick={onClose} white />
+        <IconButton icon={faTimes} onClick={onCloseHandler} white />
       </TopBar>
       <FormArea>
         <div>
@@ -187,9 +192,7 @@ export default React.memo(function MessageEditor({
         </div>
         <Select
           options={accountOptions}
-          onChange={(selected) =>
-            selected ? setSelectedAccount(selected as Option) : null
-          }
+          onChange={(selected) => setSelectedAccount(selected as Option)}
           data-qa="select-sender"
         />
         <div>
@@ -275,18 +278,14 @@ export default React.memo(function MessageEditor({
         <Gap size={'s'} />
         <BottomRow>
           <InlineButton
-            onClick={() => {
-              onDiscard(selectedAccount.value, draftId)
-            }}
+            onClick={() => onDiscard(selectedAccount.value, draftId)}
             text={i18n.messages.messageEditor.deleteDraft}
             icon={faTrash}
           />
           <Button
             text={i18n.messages.messageEditor.send}
             primary
-            onClick={() => {
-              onSend(selectedAccount.value, messageBody, draftId)
-            }}
+            onClick={() => onSend(selectedAccount.value, messageBody, draftId)}
             data-qa="send-message-btn"
           />
         </BottomRow>

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -52,8 +52,8 @@ type Option = {
 }
 
 interface Props {
-  defaultAccountSelection: Option
-  accountOptions: Option[]
+  defaultSender: Option
+  senderOptions: Option[]
   selectedReceivers: SelectorNode
   receiverOptions: Option[]
   setSelectedReceivers: React.Dispatch<
@@ -70,8 +70,8 @@ interface Props {
 }
 
 export default React.memo(function MessageEditor({
-  defaultAccountSelection,
-  accountOptions,
+  defaultSender,
+  senderOptions,
   selectedReceivers,
   receiverOptions,
   setSelectedReceivers,
@@ -88,9 +88,7 @@ export default React.memo(function MessageEditor({
   const [selectedReceiverOptions, setSelectedReceiverOptions] = useState<
     Option[]
   >(getSelected(selectedReceivers))
-  const [selectedAccount, setSelectedAccount] = useState<Option>(
-    defaultAccountSelection
-  )
+  const [sender, setSender] = useState<Option>(defaultSender)
   const [messageBody, setMessageBody] = useState<MessageBody>(
     draftContentToInitialState(draftContent)
   )
@@ -107,9 +105,9 @@ export default React.memo(function MessageEditor({
   // initialize draft when requested
   useEffect(() => {
     if (newDraftRequested && !draftId) {
-      initDraft(selectedAccount.value)
+      initDraft(sender.value)
     }
-  }, [draftId, newDraftRequested, initDraft, selectedAccount.value])
+  }, [draftId, newDraftRequested, initDraft, sender.value])
 
   // save draft on input change or ask for a new draft to be initialized
   const debouncedMessageBody = useDebounce(messageBody, 2000)
@@ -123,15 +121,9 @@ export default React.memo(function MessageEditor({
     if (!draftId) {
       setNewDraftRequested(true)
     } else {
-      saveDraft(selectedAccount.value, draftId, debouncedMessageBody)
+      saveDraft(sender.value, draftId, debouncedMessageBody)
     }
-  }, [
-    draftId,
-    debouncedMessageBody,
-    saveDraft,
-    selectedAccount.value,
-    contentTouched
-  ])
+  }, [draftId, debouncedMessageBody, saveDraft, sender.value, contentTouched])
 
   useEffect(() => {
     if (selectorChange) {
@@ -191,8 +183,9 @@ export default React.memo(function MessageEditor({
           <div>{i18n.messages.messageEditor.sender}</div>
         </div>
         <Select
-          options={accountOptions}
-          onChange={(selected) => setSelectedAccount(selected as Option)}
+          options={senderOptions}
+          onChange={(selected) => setSender(selected as Option)}
+          value={sender}
           data-qa="select-sender"
         />
         <div>
@@ -278,14 +271,14 @@ export default React.memo(function MessageEditor({
         <Gap size={'s'} />
         <BottomRow>
           <InlineButton
-            onClick={() => onDiscard(selectedAccount.value, draftId)}
+            onClick={() => onDiscard(sender.value, draftId)}
             text={i18n.messages.messageEditor.deleteDraft}
             icon={faTrash}
           />
           <Button
             text={i18n.messages.messageEditor.send}
             primary
-            onClick={() => onSend(selectedAccount.value, messageBody, draftId)}
+            onClick={() => onSend(sender.value, messageBody, draftId)}
             data-qa="send-message-btn"
           />
         </BottomRow>

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -34,18 +34,22 @@ type Message = UpsertableDraftContent & {
   recipientAccountIds: UUID[]
 }
 
+const emptyMessage = {
+  content: '',
+  recipientIds: [],
+  recipientNames: [],
+  recipientAccountIds: [],
+  title: '',
+  type: 'MESSAGE' as const
+}
+
 const getInitialMessage = (
   draft: DraftContent | undefined,
   senderId: UUID
-): Message => ({
-  senderId,
-  content: draft?.content ?? '',
-  recipientIds: draft?.recipientIds ?? [],
-  recipientNames: draft?.recipientNames ?? [],
-  recipientAccountIds: [],
-  title: draft?.title ?? '',
-  type: draft?.type ?? 'MESSAGE'
-})
+): Message =>
+  draft
+    ? { ...draft, senderId, recipientAccountIds: [] }
+    : { senderId, ...emptyMessage }
 
 const areRequiredFieldsFilledForMessage = (msg: Message): boolean =>
   !!(msg.recipientAccountIds?.length && msg.type && msg.content && msg.title)

--- a/frontend/src/employee-frontend/components/messages/MessageList.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageList.tsx
@@ -2,113 +2,46 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Loading, Paged, Result } from 'lib-common/api'
-import { useRestApi } from 'lib-common/utils/useRestApi'
 import { ContentArea } from 'lib-components/layout/Container'
 import Pagination from 'lib-components/Pagination'
 import { H1, H2 } from 'lib-components/typography'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useContext, useEffect } from 'react'
 import styled from 'styled-components'
-import { UUID } from '../../../lib-common/types'
 import { useTranslation } from '../../state/i18n'
-import {
-  getMessageDrafts,
-  getReceivedMessages,
-  getSentMessages,
-  markThreadRead
-} from './api'
+import { markThreadRead } from './api'
 import { MessageDrafts } from './MessageDrafts'
+import { MessagesPageContext } from './MessagesPageContext'
 import { ReceivedMessages } from './ReceivedMessages'
 import { SentMessages } from './SentMessages'
 import { SingleThreadView } from './SingleThreadView'
-import { DraftContent, MessageThread, SentMessage } from './types'
+import { MessageThread } from './types'
 import { AccountView } from './types-view'
-
-const PAGE_SIZE = 20
 
 const MessagesContainer = styled(ContentArea)`
   overflow: hidden;
   flex-grow: 1;
 `
 
-const markMessagesReadIfThreadIdMatches = (id: UUID) => (t: MessageThread) =>
-  t.id === id
-    ? {
-        ...t,
-        messages: t.messages.map((m) => ({
-          ...m,
-          readAt: m.readAt ?? new Date()
-        }))
-      }
-    : t
-
 export default React.memo(function MessagesList({
   account,
   view
 }: AccountView) {
   const { i18n } = useTranslation()
+  const {
+    receivedMessages,
+    sentMessages,
+    messageDrafts,
+    page,
+    setPage,
+    pages,
+    selectedThread,
+    setSelectedThread,
+    refreshMessages
+  } = useContext(MessagesPageContext)
 
-  const [page, setPage] = useState<number>(1)
-  const [pages, setPages] = useState<number>()
-  const [receivedMessages, setReceivedMessages] = useState<
-    Result<MessageThread[]>
-  >(Loading.of())
-  const [messageDrafts, setMessageDrafts] = useState<Result<DraftContent[]>>(
-    Loading.of()
-  )
-  const [selectedThread, setSelectedThread] = useState<MessageThread>()
-  const [sentMessages, setSentMessages] = useState<Result<SentMessage[]>>(
-    Loading.of()
-  )
-
-  const setReceivedMessagesResult = useCallback(
-    (result: Result<Paged<MessageThread>>) => {
-      setReceivedMessages(result.map((r) => r.data))
-      if (result.isSuccess) {
-        setPages(result.value.pages)
-      }
-    },
-    []
-  )
-  const loadReceivedMessages = useRestApi(
-    getReceivedMessages,
-    setReceivedMessagesResult
-  )
-
-  const loadMessageDrafts = useRestApi(getMessageDrafts, setMessageDrafts)
-
-  const setSentMessagesResult = useCallback(
-    (result: Result<Paged<SentMessage>>) => {
-      setSentMessages(result.map((r) => r.data))
-      if (result.isSuccess) {
-        setPages(result.value.pages)
-      }
-    },
-    []
-  )
-  const loadSentMessages = useRestApi(getSentMessages, setSentMessagesResult)
-
-  // reset view and load messages if account, view or page changes
   useEffect(() => {
     setSelectedThread(undefined)
-    switch (view) {
-      case 'RECEIVED':
-        loadReceivedMessages(account.id, page, PAGE_SIZE)
-        break
-      case 'SENT':
-        loadSentMessages(account.id, page, PAGE_SIZE)
-        break
-      case 'DRAFTS':
-        loadMessageDrafts(account.id)
-    }
-  }, [
-    account.id,
-    view,
-    page,
-    loadReceivedMessages,
-    loadSentMessages,
-    loadMessageDrafts
-  ])
+  }, [account.id, setSelectedThread, view])
 
   const onSelectThread = useCallback(
     (thread: MessageThread) => {
@@ -116,15 +49,12 @@ export default React.memo(function MessagesList({
 
       const hasUnreadMessages = thread.messages.some((m) => !m.readAt)
       if (hasUnreadMessages) {
-        setReceivedMessages((prev) =>
-          prev.map((t: MessageThread[]) =>
-            t.map(markMessagesReadIfThreadIdMatches(thread.id))
-          )
+        void markThreadRead(account.id, thread.id).then(() =>
+          refreshMessages(account.id)
         )
-        void markThreadRead(account.id, thread.id)
       }
     },
-    [account.id]
+    [account.id, refreshMessages, setSelectedThread]
   )
 
   if (selectedThread) {

--- a/frontend/src/employee-frontend/components/messages/MessageList.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageList.tsx
@@ -69,7 +69,7 @@ export default React.memo(function MessagesList({
   return (
     <MessagesContainer opaque>
       <H1>{i18n.messages.messageList.titles[view]}</H1>
-      {!account.personal && <H2>{account.name}</H2>}
+      {account.type !== 'PERSONAL' && <H2>{account.name}</H2>}
       {view === 'RECEIVED' && (
         <ReceivedMessages
           messages={receivedMessages}

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -128,11 +128,8 @@ function MessagesPage() {
         )}
         {showEditor && accounts.isSuccess && selectedReceivers && view && (
           <MessageEditor
-            defaultAccountSelection={{
-              value: view.account.id,
-              label: view.account.id
-            }}
-            accountOptions={accounts.value.map(({ name, id }) => ({
+            defaultSender={{ value: view.account.id, label: view.account.name }}
+            senderOptions={accounts.value.map(({ name, id }) => ({
               value: id,
               label: name
             }))}

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -2,12 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import ReceiverSelection from 'employee-frontend/components/messages/ReceiverSelection'
-import {
-  deselectAll,
-  getReceiverOptions,
-  SelectorNode
-} from 'employee-frontend/components/messages/SelectorNode'
 import { Loading, Result } from 'lib-common/api'
 import { UUID } from 'lib-common/types'
 import { useRestApi } from 'lib-common/utils/useRestApi'
@@ -22,6 +16,8 @@ import {
   MessagesPageContext,
   MessagesPageContextProvider
 } from './MessagesPageContext'
+import ReceiverSelection from './ReceiverSelection'
+import { deselectAll, SelectorNode } from './SelectorNode'
 import Sidebar from './Sidebar'
 import { MessageAccount, MessageBody } from './types'
 
@@ -46,7 +42,7 @@ function MessagesPage() {
 
   const [showEditor, setShowEditor] = useState<boolean>(false)
   const hideEditor = () => {
-    selectedReceivers && setSelectedReceivers(deselectAll(selectedReceivers))
+    setSelectedReceivers((old) => (old ? deselectAll(old) : old))
     setShowEditor(false)
     setSelectedDraft(undefined)
   }
@@ -133,9 +129,7 @@ function MessagesPage() {
               value: id,
               label: name
             }))}
-            selectedReceivers={selectedReceivers}
-            receiverOptions={getReceiverOptions(selectedReceivers)}
-            setSelectedReceivers={setSelectedReceivers}
+            availableReceivers={selectedReceivers}
             onSend={onSend}
             onDiscard={onDiscard}
             onClose={onHide}

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -18,7 +18,10 @@ import styled from 'styled-components'
 import { deleteDraft, getMessagingAccounts, postMessage } from './api'
 import MessageEditor from './MessageEditor'
 import MessageList from './MessageList'
-import { MessagesPageContext } from './MessagesPageContext'
+import {
+  MessagesPageContext,
+  MessagesPageContextProvider
+} from './MessagesPageContext'
 import Sidebar from './Sidebar'
 import { MessageAccount, MessageBody } from './types'
 
@@ -26,7 +29,7 @@ const PanelContainer = styled.div`
   display: flex;
 `
 
-export default React.memo(function MessagesPage() {
+function MessagesPage() {
   const {
     selectedDraft,
     setSelectedDraft,
@@ -145,4 +148,12 @@ export default React.memo(function MessagesPage() {
       </PanelContainer>
     </Container>
   )
-})
+}
+
+export default function MessagesPageWrapper() {
+  return (
+    <MessagesPageContextProvider>
+      <MessagesPage />
+    </MessagesPageContextProvider>
+  )
+}

--- a/frontend/src/employee-frontend/components/messages/MessagesPageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPageContext.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useMemo, useState } from 'react'
+import { DraftContent } from './types'
+import { AccountView } from './types-view'
+
+export interface MessagesPageState {
+  selectedDraft: DraftContent | undefined
+  setSelectedDraft: (draft: DraftContent | undefined) => void
+  view: AccountView | undefined
+  setView: (view: AccountView) => void
+}
+
+const defaultState: MessagesPageState = {
+  selectedDraft: undefined,
+  setSelectedDraft: () => undefined,
+  view: undefined,
+  setView: () => undefined
+}
+
+export const MessagesPageContext = createContext<MessagesPageState>(
+  defaultState
+)
+
+export const MessagesPageContextProvider = React.memo(
+  function MessagesPageContextProvider({
+    children
+  }: {
+    children: JSX.Element
+  }) {
+    const [selectedDraft, setSelectedDraft] = useState(
+      defaultState.selectedDraft
+    )
+    const [view, setView] = useState<AccountView>()
+
+    const value = useMemo(
+      () => ({
+        selectedDraft,
+        setSelectedDraft,
+        view,
+        setView
+      }),
+      [selectedDraft, view]
+    )
+
+    return (
+      <MessagesPageContext.Provider value={value}>
+        {children}
+      </MessagesPageContext.Provider>
+    )
+  }
+)

--- a/frontend/src/employee-frontend/components/messages/MessagesPageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPageContext.tsx
@@ -1,19 +1,51 @@
-import React, { createContext, useMemo, useState } from 'react'
-import { DraftContent } from './types'
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
+import { Loading, Paged, Result } from '../../../lib-common/api'
+import { useRestApi } from '../../../lib-common/utils/useRestApi'
+import { UUID } from '../../types'
+import { getMessageDrafts, getReceivedMessages, getSentMessages } from './api'
+import { DraftContent, MessageThread, SentMessage } from './types'
 import { AccountView } from './types-view'
+
+const PAGE_SIZE = 20
 
 export interface MessagesPageState {
   selectedDraft: DraftContent | undefined
   setSelectedDraft: (draft: DraftContent | undefined) => void
   view: AccountView | undefined
   setView: (view: AccountView) => void
+  page: number
+  setPage: (page: number) => void
+  pages: number | undefined
+  setPages: (pages: number) => void
+  receivedMessages: Result<MessageThread[]>
+  sentMessages: Result<SentMessage[]>
+  messageDrafts: Result<DraftContent[]>
+  selectedThread: MessageThread | undefined
+  setSelectedThread: (thread: MessageThread | undefined) => void
+  refreshMessages: (account?: UUID) => void
 }
 
 const defaultState: MessagesPageState = {
   selectedDraft: undefined,
   setSelectedDraft: () => undefined,
   view: undefined,
-  setView: () => undefined
+  setView: () => undefined,
+  page: 1,
+  setPage: () => undefined,
+  pages: undefined,
+  setPages: () => undefined,
+  receivedMessages: Loading.of(),
+  sentMessages: Loading.of(),
+  messageDrafts: Loading.of(),
+  selectedThread: undefined,
+  setSelectedThread: () => undefined,
+  refreshMessages: () => undefined
 }
 
 export const MessagesPageContext = createContext<MessagesPageState>(
@@ -31,14 +63,103 @@ export const MessagesPageContextProvider = React.memo(
     )
     const [view, setView] = useState<AccountView>()
 
+    const [selectedThread, setSelectedThread] = useState<MessageThread>()
+
+    const [page, setPage] = useState<number>(1)
+    const [pages, setPages] = useState<number>()
+    const [receivedMessages, setReceivedMessages] = useState<
+      Result<MessageThread[]>
+    >(Loading.of())
+    const [messageDrafts, setMessageDrafts] = useState<Result<DraftContent[]>>(
+      Loading.of()
+    )
+    const [sentMessages, setSentMessages] = useState<Result<SentMessage[]>>(
+      Loading.of()
+    )
+
+    const setReceivedMessagesResult = useCallback(
+      (result: Result<Paged<MessageThread>>) => {
+        setReceivedMessages(result.map((r) => r.data))
+        if (result.isSuccess) {
+          setPages(result.value.pages)
+        }
+      },
+      []
+    )
+    const loadReceivedMessages = useRestApi(
+      getReceivedMessages,
+      setReceivedMessagesResult
+    )
+
+    const loadMessageDrafts = useRestApi(getMessageDrafts, setMessageDrafts)
+
+    const setSentMessagesResult = useCallback(
+      (result: Result<Paged<SentMessage>>) => {
+        setSentMessages(result.map((r) => r.data))
+        if (result.isSuccess) {
+          setPages(result.value.pages)
+        }
+      },
+      []
+    )
+    const loadSentMessages = useRestApi(getSentMessages, setSentMessagesResult)
+
+    // load messages if account, view or page changes
+    const loadMessages = useCallback(() => {
+      if (!view) {
+        return
+      }
+      switch (view.view) {
+        case 'RECEIVED':
+          loadReceivedMessages(view.account.id, page, PAGE_SIZE)
+          break
+        case 'SENT':
+          loadSentMessages(view.account.id, page, PAGE_SIZE)
+          break
+        case 'DRAFTS':
+          loadMessageDrafts(view.account.id)
+      }
+    }, [loadMessageDrafts, loadReceivedMessages, loadSentMessages, page, view])
+
+    useEffect(loadMessages, [loadMessages])
+
+    const refreshMessages = useMemo(
+      () => (accountId?: UUID) => {
+        if (!accountId || view?.account.id === accountId) {
+          loadMessages()
+        }
+      },
+      [loadMessages, view]
+    )
+
     const value = useMemo(
       () => ({
         selectedDraft,
         setSelectedDraft,
         view,
-        setView
+        setView,
+        page,
+        setPage,
+        pages,
+        setPages,
+        receivedMessages,
+        sentMessages,
+        messageDrafts,
+        selectedThread,
+        setSelectedThread,
+        refreshMessages
       }),
-      [selectedDraft, view]
+      [
+        messageDrafts,
+        page,
+        pages,
+        receivedMessages,
+        refreshMessages,
+        selectedDraft,
+        selectedThread,
+        sentMessages,
+        view
+      ]
     )
 
     return (

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -22,11 +22,11 @@ import GroupMessageAccountList from './GroupMessageAccountList'
 import MessageBox from './MessageBox'
 import {
   isGroupMessageAccount,
+  isPersonalMessageAccount,
   MessageAccount,
-  messageBoxes,
   ReceiverGroup
 } from './types'
-import { AccountView } from './types-view'
+import { AccountView, messageBoxes } from './types-view'
 
 const AccountSection = styled.section`
   padding: 12px 0;
@@ -64,7 +64,7 @@ function Accounts({
   accountView
 }: AccountsParams) {
   const { i18n } = useTranslation()
-  const personalAccount = accounts.find((a) => a.personal)
+  const personalAccount = accounts.find(isPersonalMessageAccount)
   const groupAccounts = accounts.filter(isGroupMessageAccount)
 
   const unitOptions = sortBy(

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -79,11 +79,14 @@ function Accounts({
   )
   const unitSelectionEnabled = unitOptions.length > 1
 
-  const [selectedUnit, setSelectedUnit] = useState<SelectOptionProps>(
-    unitOptions[0]
-  )
+  const [selectedUnit, setSelectedUnit] = useState<
+    SelectOptionProps | undefined
+  >(unitOptions[0])
 
   useEffect(() => {
+    if (!selectedUnit) {
+      return
+    }
     const { label: unitName, value: unitId } = selectedUnit
     void getReceivers(unitId).then((result: Result<ReceiverGroup[]>) => {
       if (result.isSuccess)
@@ -93,12 +96,14 @@ function Accounts({
     })
   }, [selectedUnit, setSelectedReceivers])
 
-  const visibleGroupAccounts = sortBy(
-    groupAccounts.filter(
-      (acc) => acc.daycareGroup.unitId === selectedUnit.value
-    ),
-    (val) => val.daycareGroup.name
-  )
+  const visibleGroupAccounts = selectedUnit
+    ? sortBy(
+        groupAccounts.filter(
+          (acc) => acc.daycareGroup.unitId === selectedUnit.value
+        ),
+        (val) => val.daycareGroup.name
+      )
+    : []
 
   return (
     <>

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -13,20 +13,21 @@ import Loader from 'lib-components/atoms/Loader'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import { defaultMargins } from 'lib-components/white-space'
 import { sortBy, uniqBy } from 'lodash'
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import colors from '../../../lib-customizations/common'
 import { useTranslation } from '../../state/i18n'
 import Select, { SelectOptionProps } from '../common/Select'
 import GroupMessageAccountList from './GroupMessageAccountList'
 import MessageBox from './MessageBox'
+import { MessagesPageContext } from './MessagesPageContext'
 import {
   isGroupMessageAccount,
   isPersonalMessageAccount,
   MessageAccount,
   ReceiverGroup
 } from './types'
-import { AccountView, messageBoxes } from './types-view'
+import { messageBoxes } from './types-view'
 
 const AccountSection = styled.section`
   padding: 12px 0;
@@ -50,20 +51,17 @@ const UnitSelection = styled.div`
 
 interface AccountsParams {
   accounts: MessageAccount[]
-  setView: (view: AccountView) => void
   setSelectedReceivers: React.Dispatch<
     React.SetStateAction<SelectorNode | undefined>
   >
-  accountView: AccountView | undefined
 }
 
-function Accounts({
-  accounts,
-  setView,
-  setSelectedReceivers,
-  accountView
-}: AccountsParams) {
+function Accounts({ accounts, setSelectedReceivers }: AccountsParams) {
   const { i18n } = useTranslation()
+  const { setSelectedAccount, selectedAccount: accountView } = useContext(
+    MessagesPageContext
+  )
+
   const personalAccount = accounts.find(isPersonalMessageAccount)
   const groupAccounts = accounts.filter(isGroupMessageAccount)
 
@@ -116,7 +114,7 @@ function Accounts({
               view={view}
               account={personalAccount}
               activeView={accountView}
-              setView={setView}
+              setView={setSelectedAccount}
             />
           ))}
         </AccountSection>
@@ -141,7 +139,7 @@ function Accounts({
           <GroupMessageAccountList
             accounts={visibleGroupAccounts}
             activeView={accountView}
-            setView={setView}
+            setView={setSelectedAccount}
           />
         </AccountSection>
       )}
@@ -150,9 +148,6 @@ function Accounts({
 }
 
 interface Props {
-  accounts: Result<MessageAccount[]>
-  view: AccountView | undefined
-  setView: (view: AccountView) => void
   setSelectedReceivers: React.Dispatch<
     React.SetStateAction<SelectorNode | undefined>
   >
@@ -160,13 +155,13 @@ interface Props {
 }
 
 export default React.memo(function Sidebar({
-  accounts,
-  setView,
   setSelectedReceivers,
-  showEditor,
-  view
+  showEditor
 }: Props) {
   const { i18n } = useTranslation()
+  const { accounts, selectedAccount, setSelectedAccount } = useContext(
+    MessagesPageContext
+  )
 
   return (
     <Container>
@@ -181,16 +176,17 @@ export default React.memo(function Sidebar({
           return (
             <Accounts
               accounts={accounts}
-              accountView={view}
-              setView={setView}
               setSelectedReceivers={setSelectedReceivers}
             />
           )
         }
       })}
       <Received
-        active={!!view && view.view === 'RECEIVERS'}
-        onClick={() => view && setView({ ...view, view: 'RECEIVERS' })}
+        active={selectedAccount?.view === 'RECEIVERS'}
+        onClick={() =>
+          selectedAccount &&
+          setSelectedAccount({ ...selectedAccount, view: 'RECEIVERS' })
+        }
       >
         {i18n.messages.receiverSelection.title}
       </Received>

--- a/frontend/src/employee-frontend/components/messages/api.ts
+++ b/frontend/src/employee-frontend/components/messages/api.ts
@@ -12,53 +12,14 @@ import {
   deserializeReceiverChild,
   deserializeSentMessage,
   DraftContent,
-  IdAndName,
   MessageAccount,
   MessageBody,
   MessageThread,
   MessageType,
   ReceiverGroup,
-  ReceiverTriplet,
   SentMessage,
   UpsertableDraftContent
 } from './types'
-
-export async function deleteDraftBulletin(id: UUID): Promise<void> {
-  return client.delete(`/bulletins/${id}`)
-}
-
-export async function updateDraftBulletin(
-  id: UUID,
-  receivers: ReceiverTriplet[] | null,
-  title: string,
-  content: string,
-  sender: string
-): Promise<void> {
-  return client.put(`/bulletins/${id}`, {
-    receivers,
-    title,
-    content,
-    sender
-  })
-}
-
-export async function sendBulletin(id: UUID): Promise<void> {
-  return client.post(`/bulletins/${id}/send`)
-}
-
-export async function getUnits(): Promise<Result<IdAndName[]>> {
-  return client
-    .get<JsonOf<IdAndName[]>>('/daycares')
-    .then((res) => Success.of(res.data.map(({ id, name }) => ({ id, name }))))
-    .catch((e) => Failure.fromError(e))
-}
-
-export async function getGroups(unitId: UUID): Promise<Result<IdAndName[]>> {
-  return client
-    .get<JsonOf<IdAndName[]>>(`/daycares/${unitId}/groups`)
-    .then((res) => Success.of(res.data.map(({ id, name }) => ({ id, name }))))
-    .catch((e) => Failure.fromError(e))
-}
 
 export async function getReceivers(
   unitId: UUID
@@ -75,17 +36,6 @@ export async function getReceivers(
         }))
       )
     )
-    .catch((e) => Failure.fromError(e))
-}
-
-export async function getSenderOptions(
-  unitId: UUID
-): Promise<Result<string[]>> {
-  return client
-    .get<JsonOf<string[]>>('/bulletins/sender-options', {
-      params: { unitId }
-    })
-    .then((res) => Success.of(res.data))
     .catch((e) => Failure.fromError(e))
 }
 

--- a/frontend/src/employee-frontend/components/messages/api.ts
+++ b/frontend/src/employee-frontend/components/messages/api.ts
@@ -100,11 +100,17 @@ export async function initDraft(accountId: UUID): Promise<Result<UUID>> {
     .catch((e) => Failure.fromError(e))
 }
 
-export async function saveDraft(
-  accountId: UUID,
-  draftId: UUID,
+export interface SaveDraftParams {
+  accountId: UUID
+  draftId: UUID
   content: UpsertableDraftContent
-): Promise<Result<void>> {
+}
+
+export async function saveDraft({
+  accountId,
+  draftId,
+  content
+}: SaveDraftParams): Promise<Result<void>> {
   return client
     .put(`/messages/${accountId}/drafts/${draftId}`, content)
     .then(() => Success.of(undefined))

--- a/frontend/src/employee-frontend/components/messages/types-view.ts
+++ b/frontend/src/employee-frontend/components/messages/types-view.ts
@@ -10,3 +10,5 @@ export interface AccountView {
   account: MessageAccount
   view: View
 }
+
+export const messageBoxes: View[] = ['RECEIVED', 'SENT', 'DRAFTS']

--- a/frontend/src/employee-frontend/components/messages/types.ts
+++ b/frontend/src/employee-frontend/components/messages/types.ts
@@ -5,7 +5,6 @@
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from '../../types'
-import { View } from './types-view'
 
 export type Recipient = {
   personId: string
@@ -14,11 +13,6 @@ export type Recipient = {
   guardian: boolean
   headOfChild: boolean
   blocklisted: boolean
-}
-
-export type IdAndName = {
-  id: UUID
-  name: string
 }
 
 export interface ReceiverChild {
@@ -45,32 +39,35 @@ export const deserializeReceiverChild = (
   ...json,
   childDateOfBirth: LocalDate.parseIso(json.childDateOfBirth)
 })
-export interface ReceiverTriplet {
-  unitId: UUID
-  groupId?: UUID
-  personId?: UUID
-}
-
-export const messageBoxes: View[] = ['RECEIVED', 'SENT', 'DRAFTS']
 
 export interface BaseMessageAccount {
   id: UUID
   name: string
 }
-export interface MessageAccount extends BaseMessageAccount {
-  personal: boolean
-  daycareGroup?: {
+interface AccountWithUnreadCount extends BaseMessageAccount {
+  unreadCount: number
+}
+export interface PersonalMessageAccount extends AccountWithUnreadCount {
+  type: 'PERSONAL'
+}
+export interface GroupMessageAccount extends AccountWithUnreadCount {
+  type: 'GROUP'
+  daycareGroup: {
     id: UUID
     name: string
     unitId: UUID
     unitName: string
   }
-  unreadCount: number
 }
-export type GroupMessageAccount = Required<MessageAccount>
+export type MessageAccount = PersonalMessageAccount | GroupMessageAccount
+
 export const isGroupMessageAccount = (
   acc: MessageAccount
-): acc is GroupMessageAccount => !!acc.daycareGroup
+): acc is GroupMessageAccount => acc.type === 'GROUP'
+
+export const isPersonalMessageAccount = (
+  acc: MessageAccount
+): acc is PersonalMessageAccount => acc.type === 'PERSONAL'
 
 export interface Message {
   id: UUID

--- a/frontend/src/employee-frontend/components/messages/types.ts
+++ b/frontend/src/employee-frontend/components/messages/types.ts
@@ -90,8 +90,12 @@ export interface MessageBody {
   recipientAccountIds: UUID[]
 }
 
-export type UpsertableDraftContent = Partial<MessageBody> & {
-  recipientNames?: string[]
+export interface UpsertableDraftContent {
+  title: string
+  content: string
+  type: MessageType
+  recipientIds: UUID[]
+  recipientNames: string[]
 }
 export interface DraftContent extends UpsertableDraftContent {
   id: UUID

--- a/frontend/src/employee-frontend/components/messages/useDraft.ts
+++ b/frontend/src/employee-frontend/components/messages/useDraft.ts
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { useCallback, useEffect, useState } from 'react'
+import { Result } from '../../../lib-common/api'
+import { UUID } from '../../../lib-common/types'
+import { useRestApi } from '../../../lib-common/utils/useRestApi'
+import * as api from './api'
+import { SaveDraftParams } from './api'
+import { useDebouncedCallback } from '../../../lib-common/utils/useDebouncedCallback'
+import { UpsertableDraftContent } from './types'
+
+type InitState = 'uninitialized' | 'initializing' | 'initialized'
+type SaveState = 'clean' | 'dirty' | 'saving'
+
+export type Draft = UpsertableDraftContent & { accountId: UUID }
+
+const draftToSaveParams = ({ accountId, ...content }: Draft, id: string) => ({
+  content,
+  accountId,
+  draftId: id
+})
+
+export function useDraft(
+  initialId: UUID | undefined
+): {
+  draftId: string | undefined
+  saveDraft: () => void
+  wasModified: boolean
+  state: 'clean' | 'dirty' | 'saving'
+  setDraft: (draft: Draft) => void
+} {
+  const [initState, setInitState] = useState<InitState>(
+    initialId ? 'initialized' : 'uninitialized'
+  )
+  const [saveState, setSaveState] = useState<SaveState>('clean')
+  const [id, setId] = useState<UUID | undefined>(initialId)
+  const [draft, setDraft] = useState<Draft>()
+  const [wasModified, setWasModified] = useState(false)
+
+  const initDraft = useRestApi(api.initDraft, (res: Result<UUID>) => {
+    if (res.isSuccess) {
+      setInitState('initialized')
+      setId(res.value)
+    }
+  })
+  // initialize draft when needed
+  useEffect(() => {
+    if (!id && saveState === 'dirty' && initState !== 'initializing' && draft) {
+      initDraft(draft.accountId)
+      setInitState('initializing')
+    }
+  }, [id, initDraft, draft, saveState, initState])
+
+  const save = useRestApi(api.saveDraft, (res: Result<void>) => {
+    if (res.isSuccess) {
+      setWasModified(true)
+      setSaveState('clean')
+    }
+  })
+  const saveNow = useCallback(
+    (params: SaveDraftParams) => {
+      setSaveState('saving')
+      save(params)
+    },
+    [save]
+  )
+  const debouncedSave = useDebouncedCallback(saveNow, 2000)
+
+  // save dirty draft with debounce
+  useEffect(() => {
+    if (id && draft && saveState === 'dirty') {
+      debouncedSave(draftToSaveParams(draft, id))
+    }
+  }, [draft, id, debouncedSave, saveState])
+
+  const saveDraftCallback = useCallback(() => {
+    if (id && draft) {
+      saveNow(draftToSaveParams(draft, id))
+    }
+  }, [draft, id, saveNow])
+
+  const setDraftCallback = useCallback((draft: Draft) => {
+    setDraft(draft)
+    setSaveState('dirty')
+  }, [])
+
+  return {
+    draftId: id,
+    state: saveState,
+    setDraft: setDraftCallback,
+    saveDraft: saveDraftCallback,
+    wasModified
+  }
+}

--- a/frontend/src/lib-common/utils/useDebouncedCallback.ts
+++ b/frontend/src/lib-common/utils/useDebouncedCallback.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { useRef, useCallback } from 'react'
+
+export function useDebouncedCallback<
+  T extends (...args: never[]) => ReturnType<T>
+>(fn: T, delay: number): (...args: Parameters<T>) => void {
+  // ref stores the timeout between renders and prevents re-renders on changes
+  const timeout = useRef<ReturnType<typeof setTimeout>>()
+
+  return useCallback(
+    (...args) => {
+      const functionToBeExecutedLater = () => {
+        if (timeout.current) {
+          clearTimeout(timeout.current)
+        }
+        fn(...args)
+      }
+
+      if (timeout.current) {
+        clearTimeout(timeout.current)
+      }
+      timeout.current = setTimeout(functionToBeExecutedLater, delay)
+    },
+    [fn, delay]
+  )
+}

--- a/frontend/src/lib-common/utils/useRestApi.ts
+++ b/frontend/src/lib-common/utils/useRestApi.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import {
   ApiFunction,
   ApiResultOf,
@@ -17,11 +17,13 @@ export function useRestApi<F extends ApiFunction>(
   setState: (result: Result<ApiResultOf<F>>) => void
 ): (...args: Parameters<F>) => void {
   const [api] = useState(() => withStaleCancellation(f))
+  const mountedRef = useRef(true)
+
   return useCallback(
     (...args: Parameters<F>) => {
       setState(Loading.of())
       void api(...args).then((result) => {
-        if (isCancelled(result)) return
+        if (!mountedRef.current || isCancelled(result)) return
         setState(result)
       })
     },

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2327,7 +2327,7 @@ export const fi = {
       titles: {
         RECEIVED: 'Saapuneet viestit',
         SENT: 'Lähetetyt viestit',
-        DRAFT: 'Luonnokset'
+        DRAFTS: 'Luonnokset'
       }
     },
     types: {

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2342,7 +2342,7 @@ export const fi = {
       confirmText: 'Lähetä viesti valituille'
     },
     messageEditor: {
-      newBulletin: 'Uusi viesti',
+      newMessage: 'Uusi viesti',
       to: {
         label: 'Vastaanottaja',
         placeholder: 'Valitse ryhmä',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/DraftQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/DraftQueriesTest.kt
@@ -50,25 +50,18 @@ class DraftQueriesTest : PureJdbiTest() {
 
         val id = db.transaction { it.initDraft(accountId) }
 
-        val emptyContent = UpsertableDraftContent()
-        assertContent(emptyContent)
-
-        upsert(id, emptyContent)
-        assertContent(emptyContent)
-
-        val partialContent = UpsertableDraftContent(title = "Foo", content = null, recipientAccountIds = recipients)
-        upsert(id, partialContent)
-        assertContent(partialContent)
-
         val fullContent = UpsertableDraftContent(
             type = type,
             title = title,
             content = content,
-            recipientAccountIds = recipients,
+            recipientIds = recipients,
             recipientNames = recipientNames
         )
         upsert(id, fullContent)
         assertContent(fullContent)
+
+        upsert(id, fullContent.copy(title = "Dogs"))
+        assertContent(fullContent.copy(title = "Dogs"))
 
         db.transaction { it.deleteDraft(accountId, id) }
         assertEquals(0, db.read { it.getDrafts(accountId) }.size)
@@ -82,7 +75,7 @@ class DraftQueriesTest : PureJdbiTest() {
         assertEquals(expected.title, actual.title)
         assertEquals(expected.type, actual.type)
         assertEquals(expected.content, actual.content)
-        assertEquals(expected.recipientAccountIds, actual.recipientAccountIds)
+        assertEquals(expected.recipientIds, actual.recipientIds)
         assertEquals(expected.recipientNames, actual.recipientNames)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.messaging
 
 import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.messaging.message.AccountType
 import fi.espoo.evaka.messaging.message.MessageAccount
 import fi.espoo.evaka.messaging.message.MessageType
 import fi.espoo.evaka.messaging.message.createMessageAccountForDaycareGroup
@@ -92,13 +93,13 @@ class MessageAccountQueriesTest : PureJdbiTest() {
 
         val accounts2 = db.read { it.getAuthorizedMessageAccountsForEmployee(employee) }
         assertEquals(2, accounts2.size)
-        val personalAccount = accounts2.find { it.personal } ?: throw Error("Personal account not found")
+        val personalAccount = accounts2.find { it.type === AccountType.PERSONAL } ?: throw Error("Personal account not found")
         assertEquals(personalAccountName, personalAccount.name)
-        assertEquals(true, personalAccount.personal)
+        assertEquals(AccountType.PERSONAL, personalAccount.type)
         assertNull(personalAccount.daycareGroup)
         val groupAccount = accounts2.find { it.daycareGroup != null } ?: throw Error("Group account not found")
         assertEquals(groupAccountName, groupAccount.name)
-        assertEquals(false, groupAccount.personal)
+        assertEquals(AccountType.GROUP, groupAccount.type)
         assertEquals("Test Daycare", groupAccount.daycareGroup?.unitName)
         assertEquals("Testiläiset", groupAccount.daycareGroup?.name)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/DraftContent.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/DraftContent.kt
@@ -10,17 +10,17 @@ import java.util.UUID
 data class DraftContent(
     val id: UUID,
     val created: HelsinkiDateTime,
-    val type: MessageType? = null,
-    val title: String? = null,
-    val content: String? = null,
-    val recipientAccountIds: Set<UUID>? = null,
-    val recipientNames: List<String>? = null,
+    val type: MessageType,
+    val title: String,
+    val content: String,
+    val recipientIds: Set<UUID>,
+    val recipientNames: List<String>,
 )
 
 data class UpsertableDraftContent(
-    val type: MessageType? = null,
-    val title: String? = null,
-    val content: String? = null,
-    val recipientAccountIds: Set<UUID>? = null,
-    val recipientNames: List<String>? = null,
+    val type: MessageType,
+    val title: String,
+    val content: String,
+    val recipientIds: Set<UUID>,
+    val recipientNames: List<String>,
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/DraftQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/DraftQueries.kt
@@ -34,6 +34,7 @@ fun Database.Transaction.upsertDraft(accountId: UUID, id: UUID, draft: Upsertabl
         VALUES (:id, :accountId, :title, :content, :type, :recipientIds, :recipientNames)
         ON CONFLICT (id)
         DO UPDATE SET
+             account_id = excluded.account_id,
              title = excluded.title,
              content = excluded.content,
              type = excluded.type,
@@ -41,8 +42,8 @@ fun Database.Transaction.upsertDraft(accountId: UUID, id: UUID, draft: Upsertabl
              recipient_names = excluded.recipient_names
         """.trimIndent()
     )
-        .bind("accountId", accountId)
         .bind("id", id)
+        .bind("accountId", accountId)
         .bindNullable("type", draft.type)
         .bindNullable("title", draft.title)
         .bindNullable("content", draft.content)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
@@ -67,12 +67,17 @@ data class Group(
     val unitName: String,
 )
 
+enum class AccountType {
+    PERSONAL,
+    GROUP
+}
+
 data class AuthorizedMessageAccount(
     val id: UUID,
     val name: String,
     @Nested("group_")
     val daycareGroup: Group?,
-    val personal: Boolean,
+    val type: AccountType,
     val unreadCount: Int
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
@@ -61,9 +61,9 @@ fun Database.Read.getAuthorizedMessageAccountsForEmployee(user: AuthenticatedUse
 SELECT acc.id,
        name_view.account_name AS name,
        CASE
-           WHEN acc.daycare_group_id IS NOT NULL THEN FALSE
-           ELSE TRUE
-       END                    AS personal,
+           WHEN acc.daycare_group_id IS NOT NULL THEN 'group'
+           ELSE 'personal'
+       END                    AS type,
        dg.id                  AS group_id,
        dg.name                AS group_name,
        dc.id                  AS group_unitId,
@@ -77,7 +77,7 @@ FROM message_account acc
     LEFT JOIN daycare_acl acl ON acl.daycare_id = dg.daycare_id
 WHERE acc.employee_id = :userId
    OR acl.employee_id = :userId
-GROUP BY acc.id, account_name, personal, group_id, group_name, group_unitId, group_unitName
+GROUP BY acc.id, account_name, type, group_id, group_name, group_unitId, group_unitName
     """.trimIndent()
 
     return this.createQuery(employeeSql)

--- a/service/src/main/resources/db/migration/V91__message_draft_non_nullable.sql
+++ b/service/src/main/resources/db/migration/V91__message_draft_non_nullable.sql
@@ -1,0 +1,20 @@
+ALTER TABLE message_draft RENAME COLUMN recipient_account_ids TO recipient_ids;
+UPDATE message_draft SET recipient_ids = '{}' WHERE recipient_ids IS NULL;
+ALTER TABLE message_draft ALTER COLUMN recipient_ids SET DEFAULT '{}';
+ALTER TABLE message_draft ALTER COLUMN recipient_ids SET NOT NULL;
+
+UPDATE message_draft SET recipient_names = '{}' WHERE recipient_names IS NULL;
+ALTER TABLE message_draft ALTER COLUMN recipient_names SET DEFAULT '{}';
+ALTER TABLE message_draft ALTER COLUMN recipient_names SET NOT NULL;
+
+UPDATE message_draft SET title = '' WHERE title IS NULL;
+ALTER TABLE message_draft ALTER COLUMN title SET DEFAULT '';
+ALTER TABLE message_draft ALTER COLUMN title SET NOT NULL;
+
+UPDATE message_draft SET content = '' WHERE content IS NULL;
+ALTER TABLE message_draft ALTER COLUMN content SET DEFAULT '';
+ALTER TABLE message_draft ALTER COLUMN content SET NOT NULL;
+
+UPDATE message_draft SET type = 'MESSAGE' WHERE type IS NULL;
+ALTER TABLE message_draft ALTER COLUMN type SET DEFAULT 'MESSAGE';
+ALTER TABLE message_draft ALTER COLUMN type SET NOT NULL;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -88,3 +88,4 @@ V87__drop_service_need_option_id_from_fee_decision.sql
 V88__draft_type_and_recipients.sql
 V89__message_account_null_foreign_keys.sql
 V90__message_recipients_notification_sent_at.sql
+V91__message_draft_non_nullable.sql


### PR DESCRIPTION
#### Summary

- Save message content as draft
- Open draft from the draft section
- Discard draft after message is sent or when manually discarded
- Move message state to context as it is needed to be refreshed from multiple places
- Fix pre-selection of sender and recipients
- Refactor message editor logic
  - Handle receiver selection internally within the editor. Previously the receiver selection was passed from the outside and updated from within the editor creating a two-way data flow. Now the editor just gets the initial state and handles it from there by itself.
- Make all fields of draft content required.

