### PR TITLE
Use a top-level spinner for /auth/status loading status

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { ReactNode, useContext } from 'react'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
 import { Localization } from './localization'
 import Header from './header/Header'
@@ -23,6 +23,8 @@ import { featureFlags } from './config'
 import { HeaderContextProvider } from './messages/state'
 import { ThemeProvider } from 'styled-components'
 import { theme } from 'lib-customizations/common'
+import { AuthContext } from 'citizen-frontend/auth/state'
+import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
 
 export default function App() {
   return (
@@ -33,7 +35,7 @@ export default function App() {
             <OverlayContextProvider>
               <HeaderContextProvider>
                 <Header />
-                <main>
+                <Main>
                   <Switch>
                     <Route exact path="/" component={MapView} />
                     <Route
@@ -75,7 +77,7 @@ export default function App() {
                     )}
                     <Route path="/" component={RedirectToMap} />
                   </Switch>
-                </main>
+                </Main>
                 <GlobalInfoDialog />
                 <GlobalErrorDialog />
               </HeaderContextProvider>
@@ -85,6 +87,11 @@ export default function App() {
       </ThemeProvider>
     </BrowserRouter>
   )
+}
+
+function Main({ children }: { children: ReactNode }) {
+  const { loading: authStatusLoading } = useContext(AuthContext)
+  return <main>{authStatusLoading ? <SpinnerSegment /> : children}</main>
 }
 
 function RedirectToMap() {

--- a/frontend/src/citizen-frontend/auth/requireAuth.tsx
+++ b/frontend/src/citizen-frontend/auth/requireAuth.tsx
@@ -6,7 +6,6 @@ import React, { useContext } from 'react'
 import { AuthContext } from '../auth/state'
 import { RouteComponentProps } from 'react-router'
 import { Redirect } from 'react-router-dom'
-import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
 import { getWeakLoginUri, getLoginUri } from 'citizen-frontend/header/const'
 
 function refreshRedirect(uri: string) {
@@ -19,7 +18,7 @@ export default function requireAuth<T>(
   requireStrong = true
 ) {
   return function WithRequireAuth(props: RouteComponentProps<T>) {
-    const { user, loading } = useContext(AuthContext)
+    const { user } = useContext(AuthContext)
 
     return user ? (
       requireStrong && user.userType === 'CITIZEN_WEAK' ? (
@@ -27,8 +26,6 @@ export default function requireAuth<T>(
       ) : (
         <WrappedComponent {...props} />
       )
-    ) : loading ? (
-      <SpinnerSegment />
     ) : requireStrong ? (
       <Redirect to={'/'} />
     ) : (


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- /auth/status can sometimes take a long time, and we want the user to know we're still loading something
- move spinner from requireAuth up in the component hierarchy
- map doesn't use requireAuth but now gets the spinner, so the user sees a spinner if the first load after login takes a while