### PR TITLE
EVAKA-4190 Save and show textual recipient names with message

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -178,8 +178,19 @@ export default React.memo(function MessageEditor({
 
   const sendEnabled = areRequiredFieldsFilledForMessage(message)
   const sendHandler = useCallback(() => {
-    const { senderId, content, title, type, recipientAccountIds } = message
-    onSend(senderId, { content, title, type, recipientAccountIds }, draftId)
+    const {
+      senderId,
+      content,
+      title,
+      type,
+      recipientAccountIds,
+      recipientNames
+    } = message
+    onSend(
+      senderId,
+      { content, title, type, recipientAccountIds, recipientNames },
+      draftId
+    )
   }, [onSend, message, draftId])
 
   const onCloseHandler = useCallback(() => {

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -69,12 +69,7 @@ function MessagesPage() {
     draftId?: UUID
   ) => {
     // TODO state and error handling
-    void postMessage(accountId, {
-      title: messageBody.title,
-      content: messageBody.content,
-      type: messageBody.type,
-      recipientAccountIds: messageBody.recipientAccountIds
-    })
+    void postMessage(accountId, messageBody)
       .then(() => {
         if (draftId) {
           void deleteDraft(accountId, draftId)

--- a/frontend/src/employee-frontend/components/messages/SentMessages.tsx
+++ b/frontend/src/employee-frontend/components/messages/SentMessages.tsx
@@ -33,9 +33,7 @@ function SentMessage({ message: message }: { message: SentMessage }) {
   return (
     <MessageRow onClick={() => setExpanded(!expanded)}>
       <ParticipantsAndPreview>
-        <Participants>
-          {message.recipients.map(({ name }) => name).join(', ')}
-        </Participants>
+        <Participants>{message.recipientNames.join(', ')}</Participants>
         <MessageContent expanded={expanded}>
           <Title>{message.threadTitle}</Title>
           {' - '}

--- a/frontend/src/employee-frontend/components/messages/types.ts
+++ b/frontend/src/employee-frontend/components/messages/types.ts
@@ -69,22 +69,14 @@ export const isPersonalMessageAccount = (
   acc: MessageAccount
 ): acc is PersonalMessageAccount => acc.type === 'PERSONAL'
 
-export interface Message {
-  id: UUID
-  senderId: UUID
-  senderName: string
-  sentAt: Date
-  readAt: Date | null
-  title: string
-  content: string
-  receivers: UUID[]
-}
+export type MessageType = 'MESSAGE' | 'BULLETIN'
 
 export interface MessageBody {
   title: string
   content: string
   type: MessageType
   recipientAccountIds: UUID[]
+  recipientNames: string[]
 }
 
 export interface UpsertableDraftContent {
@@ -106,14 +98,13 @@ export const deserializeDraftContent = ({
   created: new Date(created)
 })
 
-export type MessageType = 'MESSAGE' | 'BULLETIN'
-
 export interface SentMessage {
   id: UUID
   type: MessageType
   threadTitle: string
   content: string
   recipients: BaseMessageAccount[]
+  recipientNames: string[]
   sentAt: Date
 }
 export const deserializeSentMessage = ({
@@ -124,6 +115,14 @@ export const deserializeSentMessage = ({
   sentAt: new Date(sentAt)
 })
 
+export interface Message {
+  id: UUID
+  senderId: UUID
+  senderName: string
+  sentAt: Date
+  readAt: Date | null
+  content: string
+}
 export interface MessageThread {
   id: UUID
   type: MessageType

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountIntegrationTest.kt
@@ -78,7 +78,8 @@ class MessageAccountIntegrationTest : PureJdbiTest() {
                 content = "Juhannus tulee kohta",
                 type = MessageType.MESSAGE,
                 sender = groupAccount,
-                recipientGroups = setOf(setOf(receiverAccount.id))
+                recipientGroups = setOf(setOf(receiverAccount.id)),
+                recipientNames = listOf(receiverAccount.name)
             )
         }
         assertEquals(MessageAccountState.ACTIVE, getMessageAccountState(groupAccount.id))
@@ -116,7 +117,8 @@ class MessageAccountIntegrationTest : PureJdbiTest() {
                 content = "Juhannus tulee kohta",
                 type = MessageType.MESSAGE,
                 sender = senderAccount,
-                recipientGroups = setOf(setOf(groupAccount.id))
+                recipientGroups = setOf(setOf(groupAccount.id)),
+                recipientNames = listOf(groupAccount.name)
             )
         }
         assertEquals(MessageAccountState.ACTIVE, getMessageAccountState(groupAccount.id))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -123,12 +123,12 @@ class MessageAccountQueriesTest : PureJdbiTest() {
 
         val employeeAccount = MessageAccount(accounts.first().id, "foo")
         db.transaction { tx ->
-            val allAccounts = tx.createQuery("SELECT id from message_account").mapTo<UUID>().toSet()
+            val allAccounts = tx.createQuery("SELECT id, account_name as name from message_account_name_view").mapTo<MessageAccount>().list()
 
             val contentId = tx.insertMessageContent("content", employeeAccount)
             val threadId = tx.insertThread(MessageType.MESSAGE, "title")
-            val messageId = tx.insertMessage(contentId, threadId, employeeAccount)
-            tx.insertRecipients(allAccounts, messageId)
+            val messageId = tx.insertMessage(contentId, threadId, employeeAccount, allAccounts.map { it.name })
+            tx.insertRecipients(allAccounts.map { it.id }.toSet(), messageId)
         }
 
         assertEquals(2, db.read { it.getUnreadMessagesCount(accounts.map { acc -> acc.id }.toSet()) })

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -110,7 +110,7 @@ class MessageIntegrationTest : FullApplicationTest() {
             message = "Juhannus tulee pian",
             messageType = MessageType.MESSAGE,
             sender = employee1Account.id,
-            recipients = setOf(person1Account.id, person2Account.id),
+            recipients = listOf(person1Account, person2Account),
             user = employee1,
         )
 
@@ -266,12 +266,13 @@ class MessageIntegrationTest : FullApplicationTest() {
         // when a new thread is created to several recipients who do not all have common children
         val title = "Thread splitting"
         val content = "This message is sent to several participants and split to threads"
+        val recipients = listOf(person1Account, person2Account, person3Account, person4Account)
         postNewThread(
             title = title,
             message = content,
             messageType = MessageType.MESSAGE,
             sender = employee1Account.id,
-            recipients = listOf(person1Account, person2Account, person3Account, person4Account).map { it.id }.toSet(),
+            recipients = recipients,
             user = employee1
         )
 
@@ -353,7 +354,7 @@ class MessageIntegrationTest : FullApplicationTest() {
             message = "Juhannus tulee pian",
             messageType = MessageType.BULLETIN,
             sender = employee1Account.id,
-            recipients = setOf(person1Account.id),
+            recipients = listOf(person1Account),
             user = employee1,
         )
 
@@ -413,7 +414,7 @@ class MessageIntegrationTest : FullApplicationTest() {
             message = "m1",
             messageType = MessageType.MESSAGE,
             sender = employee1Account.id,
-            recipients = setOf(person1Account.id, person2Account.id),
+            recipients = listOf(person1Account, person2Account),
             user = employee1,
         )
 
@@ -450,16 +451,17 @@ class MessageIntegrationTest : FullApplicationTest() {
         message: String,
         messageType: MessageType,
         sender: UUID,
-        recipients: Set<UUID>,
+        recipients: List<MessageAccount>,
         user: AuthenticatedUser.Employee,
     ) = http.post("/messages/$sender")
         .jsonBody(
             objectMapper.writeValueAsString(
                 MessageController.PostMessageBody(
-                    title,
-                    message,
-                    messageType,
-                    recipientAccountIds = recipients
+                    title = title,
+                    content = message,
+                    type = messageType,
+                    recipientNames = recipients.map { it.name },
+                    recipientAccountIds = recipients.map { it.id }.toSet()
                 )
             )
         )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.github.kittinunf.fuel.core.isSuccessful
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.emailclient.MockEmail
 import fi.espoo.evaka.emailclient.MockEmailClient
+import fi.espoo.evaka.messaging.message.MessageAccount
 import fi.espoo.evaka.messaging.message.MessageController
 import fi.espoo.evaka.messaging.message.MessageType
 import fi.espoo.evaka.messaging.message.createMessageAccountForPerson
@@ -73,7 +74,7 @@ class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest() {
             message = "Juhannus tulee pian",
             messageType = MessageType.MESSAGE,
             sender = employeeAccount.id,
-            recipients = personAccounts.map { it.id }.toSet(),
+            recipients = personAccounts,
             user = employee,
         )
         asyncJobRunner.runPendingJobsSync()
@@ -92,7 +93,7 @@ class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest() {
         message: String,
         messageType: MessageType,
         sender: UUID,
-        recipients: Set<UUID>,
+        recipients: List<MessageAccount>,
         user: AuthenticatedUser.Employee,
     ) {
         val (_, response) = http.post("/messages/$sender")
@@ -102,7 +103,8 @@ class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest() {
                         title,
                         message,
                         messageType,
-                        recipientAccountIds = recipients
+                        recipientAccountIds = recipients.map { it.id }.toSet(),
+                        recipientNames = recipients.map { it.name },
                     )
                 )
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
@@ -33,6 +33,7 @@ data class SentMessage(
     val type: MessageType,
     @Json
     val recipients: Set<MessageAccount>,
+    val recipientNames: List<String>,
 )
 
 enum class MessageType {

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
@@ -86,6 +86,19 @@ GROUP BY acc.id, account_name, type, group_id, group_name, group_unitId, group_u
         .toSet()
 }
 
+fun Database.Read.getAccountNames(ids: Set<UUID>): List<String> {
+    val sql = """
+        SELECT account_name
+        FROM message_account_name_view
+        WHERE id = ANY(:ids)
+    """.trimIndent()
+
+    return this.createQuery(sql)
+        .bind("ids", ids.toTypedArray())
+        .mapTo<String>()
+        .list()
+}
+
 fun Database.Transaction.createMessageAccountForDaycareGroup(daycareGroupId: UUID) {
     // language=SQL
     val sql = """

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageController.kt
@@ -82,6 +82,7 @@ class MessageController(
         val content: String,
         val type: MessageType,
         val recipientAccountIds: Set<UUID>,
+        val recipientNames: List<String>,
     )
 
     @PostMapping("/{accountId}")
@@ -105,7 +106,8 @@ class MessageController(
                 content = body.content,
                 sender = sender,
                 type = body.type,
-                recipientGroups = groupedRecipients
+                recipientNames = body.recipientNames,
+                recipientGroups = groupedRecipients,
             )
         }
     }

--- a/service/src/main/resources/db/migration/V93__message_recipient_names.sql
+++ b/service/src/main/resources/db/migration/V93__message_recipient_names.sql
@@ -1,0 +1,1 @@
+ALTER TABLE message ADD COLUMN recipient_names text[] DEFAULT '{}' NOT NULL;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -90,3 +90,4 @@ V89__message_account_null_foreign_keys.sql
 V90__message_recipients_notification_sent_at.sql
 V91__message_draft_non_nullable.sql
 V92__add_missing_foreign_keys_referencing_person.sql
+V93__message_recipient_names.sql


### PR DESCRIPTION
#### Summary

Save textual recipient name with message. Eg. `Aallonhuipun päiväkoti` or `Ryhmä 1, Karhula Veera` instead of `Karhula Viljami, Karhula Jami, Karhula Mukkelis-Makkelis, Karhula Veera`