### PR TITLE
EVAKA-4190 Page layout fixes

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -192,7 +192,7 @@ export default React.memo(function MessageEditor({
   return (
     <Container>
       <TopBar>
-        <span>{title}</span>
+        <Title>{title}</Title>
         <IconButton icon={faTimes} onClick={onCloseHandler} white />
       </TopBar>
       <FormArea>
@@ -298,6 +298,13 @@ const TopBar = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: ${defaultMargins.m};
+`
+
+const Title = styled.span`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: ${defaultMargins.s};
 `
 
 const FormArea = styled.div`

--- a/frontend/src/employee-frontend/components/messages/MessageList.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageList.tsx
@@ -18,7 +18,7 @@ import { MessageThread } from './types'
 import { AccountView } from './types-view'
 
 const MessagesContainer = styled(ContentArea)`
-  overflow: hidden;
+  overflow-y: auto;
   flex-grow: 1;
 `
 

--- a/frontend/src/employee-frontend/components/messages/MessageList.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageList.tsx
@@ -19,7 +19,7 @@ import { AccountView } from './types-view'
 
 const MessagesContainer = styled(ContentArea)`
   overflow-y: auto;
-  flex-grow: 1;
+  flex: 1;
 `
 
 export default React.memo(function MessagesList({

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -4,9 +4,9 @@
 
 import { UUID } from 'lib-common/types'
 import Container from 'lib-components/layout/Container'
-import { Gap } from 'lib-components/white-space'
 import React, { useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
+import { defaultMargins } from '../../../lib-components/white-space'
 import { deleteDraft, postMessage } from './api'
 import MessageEditor from './MessageEditor'
 import MessageList from './MessageList'
@@ -19,7 +19,19 @@ import { deselectAll, SelectorNode } from './SelectorNode'
 import Sidebar from './Sidebar'
 import { MessageBody } from './types'
 
+// TODO is fixed header height possible?
+// If not, replace with a stretching flex container with scrollable children
+const approximatedHeaderHeight = `164px`
+const MessagesPageContainer = styled(Container)`
+  height: calc(100vh - ${approximatedHeaderHeight});
+`
+
 const PanelContainer = styled.div`
+  position: absolute;
+  top: ${defaultMargins.L};
+  right: 0;
+  bottom: 0;
+  left: 0;
   display: flex;
 `
 
@@ -103,8 +115,7 @@ function MessagesPage() {
   }
 
   return (
-    <Container>
-      <Gap size="L" />
+    <MessagesPageContainer>
       <PanelContainer>
         <Sidebar
           setSelectedReceivers={setSelectedReceivers}
@@ -142,7 +153,7 @@ function MessagesPage() {
             />
           )}
       </PanelContainer>
-    </Container>
+    </MessagesPageContainer>
   )
 }
 

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -29,6 +29,25 @@ import {
 } from './types'
 import { messageBoxes } from './types-view'
 
+const Container = styled.div`
+  width: 260px;
+  display: flex;
+  flex-direction: column;
+  margin-right: ${defaultMargins.m};
+  & > div {
+    background-color: ${colors.greyscale.white};
+  }
+`
+const AccountContainer = styled.div`
+  flex: 1;
+  overflow-y: auto;
+`
+const ButtonContainer = styled.div`
+  flex: 0 1 auto;
+  margin-top: ${defaultMargins.s};
+  padding: 12px ${defaultMargins.m};
+`
+
 const AccountSection = styled.section`
   padding: 12px 0;
 
@@ -47,6 +66,14 @@ const AccountHeader = styled.div`
 
 const UnitSelection = styled.div`
   padding: 0 ${defaultMargins.s};
+`
+
+const Receivers = styled.div<{ active: boolean }>`
+  cursor: pointer;
+  padding: 12px ${defaultMargins.m};
+  font-weight: ${(p) => (p.active ? '600;' : 'unset')}
+  background-color: ${(p) =>
+    p.active ? colors.brandEspoo.espooTurquoiseLight : 'unset'}
 `
 
 interface AccountsParams {
@@ -165,54 +192,41 @@ export default React.memo(function Sidebar({
 
   return (
     <Container>
-      {accounts.mapAll({
-        loading() {
-          return <Loader />
-        },
-        failure() {
-          return <ErrorSegment />
-        },
-        success(accounts) {
-          return (
-            <Accounts
-              accounts={accounts}
-              setSelectedReceivers={setSelectedReceivers}
-            />
-          )
-        }
-      })}
-      <Received
-        active={selectedAccount?.view === 'RECEIVERS'}
-        onClick={() =>
-          selectedAccount &&
-          setSelectedAccount({ ...selectedAccount, view: 'RECEIVERS' })
-        }
-      >
-        {i18n.messages.receiverSelection.title}
-      </Received>
-      <Button
-        text={i18n.messages.messageBoxes.newBulletin}
-        onClick={showEditor}
-        data-qa="new-message-btn"
-      />
+      <AccountContainer>
+        {accounts.mapAll({
+          loading() {
+            return <Loader />
+          },
+          failure() {
+            return <ErrorSegment />
+          },
+          success(accounts) {
+            return (
+              <Accounts
+                accounts={accounts}
+                setSelectedReceivers={setSelectedReceivers}
+              />
+            )
+          }
+        })}
+        <Receivers
+          active={selectedAccount?.view === 'RECEIVERS'}
+          onClick={() =>
+            selectedAccount &&
+            setSelectedAccount({ ...selectedAccount, view: 'RECEIVERS' })
+          }
+        >
+          {i18n.messages.receiverSelection.title}
+        </Receivers>
+      </AccountContainer>
+      <ButtonContainer>
+        <Button
+          primary
+          text={i18n.messages.messageBoxes.newMessage}
+          onClick={showEditor}
+          data-qa="new-message-btn"
+        />
+      </ButtonContainer>
     </Container>
   )
 })
-
-export const Received = styled.div<{ active: boolean }>`
-  cursor: pointer;
-  padding: 12px ${defaultMargins.m};
-  font-weight: ${(p) => (p.active ? '600;' : 'unset')}
-  background-color: ${(p) =>
-    p.active ? colors.brandEspoo.espooTurquoiseLight : 'unset'}
-`
-
-const Container = styled.div`
-  width: 20%;
-  min-width: 20%;
-  max-width: 20%;
-  min-height: 500px;
-  background-color: ${colors.greyscale.white};
-  overflow-y: auto;
-  margin-right: ${defaultMargins.m};
-`

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -30,7 +30,7 @@ import {
 import { messageBoxes } from './types-view'
 
 const Container = styled.div`
-  width: 260px;
+  flex: 0 1 260px;
   display: flex;
   flex-direction: column;
   margin-right: ${defaultMargins.m};

--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -77,6 +77,7 @@ function Message({
 }
 
 const ThreadContainer = styled.div`
+  flex: 1;
   display: flex;
   flex-direction: column;
 `

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2322,7 +2322,7 @@ export const fi = {
         DRAFTS: 'Luonnokset'
       },
       receivers: 'Vastaanottajat',
-      newBulletin: 'Uusi viesti'
+      newMessage: 'Uusi viesti'
     },
     messageList: {
       titles: {


### PR DESCRIPTION
#### Summary

- Keep message title in its container
- Make messages page occupy the full page height. Currently it is implemented by setting a fixed height to the page container, which is sub-optimal.
- Make accounts panel and message list scrollable.
- "Sticky" new message button
- Add a gap between accounts and new message button