### PR TITLE
Assistance action options to database

### DIFF
--- a/frontend/src/employee-frontend/api/child/assistance-actions.ts
+++ b/frontend/src/employee-frontend/api/child/assistance-actions.ts
@@ -6,7 +6,7 @@ import { UUID } from '../../types'
 import { Failure, Result, Success } from 'lib-common/api'
 import {
   AssistanceAction,
-  AssistanceActionType,
+  AssistanceActionOption,
   AssistanceMeasure
 } from '../../types/child'
 import { client } from '../../api/client'
@@ -16,7 +16,7 @@ import LocalDate from 'lib-common/local-date'
 export interface AssistanceActionRequest {
   startDate: LocalDate
   endDate: LocalDate
-  actions: AssistanceActionType[]
+  actions: string[]
   otherAction: string
   measures: AssistanceMeasure[]
 }
@@ -92,5 +92,14 @@ export async function removeAssistanceAction(
   return client
     .delete(`/assistance-actions/${assistanceActionId}`)
     .then(() => Success.of(null))
+    .catch((e) => Failure.fromError(e))
+}
+
+export async function getAssistanceActionOptions(): Promise<
+  Result<AssistanceActionOption[]>
+> {
+  return client
+    .get<JsonOf<AssistanceActionOption[]>>('/assistance-action-options')
+    .then((res) => Success.of(res.data))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
@@ -36,7 +36,7 @@ import {
   createAssistanceAction,
   updateAssistanceAction
 } from '../../../api/child/assistance-actions'
-import { assistanceMeasures } from 'lib-customizations/employee'
+import { assistanceMeasures, featureFlags } from 'lib-customizations/employee'
 
 const CheckboxRow = styled.div`
   display: flex;
@@ -48,6 +48,7 @@ interface FormState {
   startDate: LocalDate
   endDate: LocalDate
   actions: Set<string>
+  otherSelected: boolean
   otherAction: string
   measures: Set<AssistanceMeasure>
 }
@@ -106,11 +107,13 @@ function AssistanceActionForm(props: Props) {
           startDate: LocalDate.today(),
           endDate: LocalDate.today(),
           actions: new Set(),
+          otherSelected: false,
           otherAction: '',
           measures: new Set()
         }
       : {
-          ...props.assistanceAction
+          ...props.assistanceAction,
+          otherSelected: props.assistanceAction.otherAction !== ''
         }
   const [form, setForm] = useState<FormState>(initialFormState)
 
@@ -257,20 +260,37 @@ function AssistanceActionForm(props: Props) {
                     />
                   </CheckboxRow>
                 ))}
-                {props.assistanceActionOptions.some(
-                  (option) => option.isOther && form.actions.has(option.value)
-                ) && (
-                  <InputField
-                    value={form.otherAction}
-                    onChange={(value) =>
-                      updateFormState({ otherAction: value })
-                    }
-                    placeholder={
-                      i18n.childInformation.assistanceAction.fields
-                        .otherActionPlaceholder
-                    }
-                  />
-                )}
+                {featureFlags.assistanceActionOtherEnabled ? (
+                  <>
+                    <CheckboxRow>
+                      <Checkbox
+                        label={
+                          i18n.childInformation.assistanceAction.fields
+                            .actionTypes.OTHER
+                        }
+                        checked={form.otherSelected}
+                        onChange={(value) => {
+                          updateFormState({
+                            otherSelected: value,
+                            otherAction: ''
+                          })
+                        }}
+                      />
+                    </CheckboxRow>
+                    {form.otherSelected && (
+                      <InputField
+                        value={form.otherAction}
+                        onChange={(value) =>
+                          updateFormState({ otherAction: value })
+                        }
+                        placeholder={
+                          i18n.childInformation.assistanceAction.fields
+                            .otherActionPlaceholder
+                        }
+                      />
+                    )}
+                  </>
+                ) : null}
               </div>
             ),
             valueWidth: '100%'

--- a/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
@@ -14,7 +14,7 @@ import InputField from 'lib-components/atoms/form/InputField'
 import InfoBall from '../../../components/common/InfoBall'
 import {
   AssistanceAction,
-  AssistanceActionType,
+  AssistanceActionOption,
   AssistanceMeasure
 } from '../../../types/child'
 import { UUID } from '../../../types'
@@ -26,7 +26,6 @@ import {
   isDateRangeInverted
 } from '../../../utils/validation/validations'
 import LabelValueList from '../../../components/common/LabelValueList'
-import { ASSISTANCE_ACTION_TYPE_LIST } from '../../../constants'
 import FormActions from '../../../components/common/FormActions'
 import { ChildContext } from '../../../state'
 import { DateRange, rangeContainsDate } from '../../../utils/date'
@@ -48,13 +47,14 @@ const CheckboxRow = styled.div`
 interface FormState {
   startDate: LocalDate
   endDate: LocalDate
-  actions: Set<AssistanceActionType>
+  actions: Set<string>
   otherAction: string
   measures: Set<AssistanceMeasure>
 }
 
 interface CommonProps {
   onReload: () => undefined | void
+  assistanceActionOptions: AssistanceActionOption[]
 }
 
 interface CreateProps extends CommonProps {
@@ -243,34 +243,23 @@ function AssistanceActionForm(props: Props) {
             label: i18n.childInformation.assistanceAction.fields.actions,
             value: (
               <div>
-                {ASSISTANCE_ACTION_TYPE_LIST.map((action) => (
-                  <CheckboxRow key={action}>
+                {props.assistanceActionOptions.map((option) => (
+                  <CheckboxRow key={option.value}>
                     <Checkbox
-                      label={
-                        i18n.childInformation.assistanceAction.fields
-                          .actionTypes[action]
-                      }
-                      checked={form.actions.has(action)}
+                      label={option.nameFi}
+                      checked={form.actions.has(option.value)}
                       onChange={(value) => {
                         const actions = new Set([...form.actions])
-                        if (value) actions.add(action)
-                        else actions.delete(action)
+                        if (value) actions.add(option.value)
+                        else actions.delete(option.value)
                         updateFormState({ actions: actions })
                       }}
                     />
-                    {i18n.childInformation.assistanceAction.fields.actionTypes[
-                      `${action}_INFO`
-                    ] && (
-                      <InfoBall
-                        text={String(
-                          i18n.childInformation.assistanceAction.fields
-                            .actionTypes[`${action}_INFO`]
-                        )}
-                      />
-                    )}
                   </CheckboxRow>
                 ))}
-                {form.actions.has('OTHER') && (
+                {props.assistanceActionOptions.some(
+                  (option) => option.isOther && form.actions.has(option.value)
+                ) && (
                   <InputField
                     value={form.otherAction}
                     onChange={(value) =>

--- a/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionRow.tsx
@@ -4,7 +4,7 @@
 
 import React, { MutableRefObject, useContext, useRef, useState } from 'react'
 import { useTranslation } from '../../../state/i18n'
-import { AssistanceAction } from '../../../types/child'
+import { AssistanceAction, AssistanceActionOption } from '../../../types/child'
 import { UIContext } from '../../../state/ui'
 import AssistanceActionForm from '../../../components/child-information/assistance-action/AssistanceActionForm'
 import { faQuestion } from 'lib-icons'
@@ -13,7 +13,6 @@ import { isActiveDateRange } from '../../../utils/date'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
 
 import LabelValueList from '../../../components/common/LabelValueList'
-import { ASSISTANCE_ACTION_TYPE_LIST } from '../../../constants'
 import Toolbar from '../../../components/common/Toolbar'
 import { scrollToRef } from '../../../utils'
 import { removeAssistanceAction } from '../../../api/child/assistance-actions'
@@ -22,12 +21,14 @@ import { assistanceMeasures } from 'lib-customizations/employee'
 export interface Props {
   assistanceAction: AssistanceAction
   onReload: () => undefined | void
+  assistanceActionOptions: AssistanceActionOption[]
   refSectionTop: MutableRefObject<HTMLElement | null>
 }
 
 function AssistanceActionRow({
   assistanceAction,
   onReload,
+  assistanceActionOptions,
   refSectionTop
 }: Props) {
   const { i18n } = useTranslation()
@@ -94,6 +95,7 @@ function AssistanceActionRow({
             <AssistanceActionForm
               assistanceAction={assistanceAction}
               onReload={onReload}
+              assistanceActionOptions={assistanceActionOptions}
             />
           </div>
         ) : (
@@ -108,27 +110,16 @@ function AssistanceActionRow({
                 label: i18n.childInformation.assistanceAction.fields.actions,
                 value: (
                   <ul>
-                    {ASSISTANCE_ACTION_TYPE_LIST.filter(
-                      (action) => action != 'OTHER'
-                    ).map(
-                      (action) =>
-                        assistanceAction.actions.has(action) && (
-                          <li key={action}>
-                            {
-                              i18n.childInformation.assistanceAction.fields
-                                .actionTypes[action]
-                            }
+                    {assistanceActionOptions.map(
+                      (option) =>
+                        assistanceAction.actions.has(option.value) && (
+                          <li key={option.value}>
+                            {option.nameFi}
+                            {option.isOther
+                              ? `: ${assistanceAction.otherAction}`
+                              : null}
                           </li>
                         )
-                    )}
-                    {assistanceAction.actions.has('OTHER') && (
-                      <li>
-                        {
-                          i18n.childInformation.assistanceAction.fields
-                            .actionTypes.OTHER
-                        }
-                        : {assistanceAction.otherAction}
-                      </li>
                     )}
                   </ul>
                 )

--- a/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionRow.tsx
@@ -16,7 +16,7 @@ import LabelValueList from '../../../components/common/LabelValueList'
 import Toolbar from '../../../components/common/Toolbar'
 import { scrollToRef } from '../../../utils'
 import { removeAssistanceAction } from '../../../api/child/assistance-actions'
-import { assistanceMeasures } from 'lib-customizations/employee'
+import { assistanceMeasures, featureFlags } from 'lib-customizations/employee'
 
 export interface Props {
   assistanceAction: AssistanceAction
@@ -113,14 +113,19 @@ function AssistanceActionRow({
                     {assistanceActionOptions.map(
                       (option) =>
                         assistanceAction.actions.has(option.value) && (
-                          <li key={option.value}>
-                            {option.nameFi}
-                            {option.isOther
-                              ? `: ${assistanceAction.otherAction}`
-                              : null}
-                          </li>
+                          <li key={option.value}>{option.nameFi}</li>
                         )
                     )}
+                    {featureFlags.assistanceActionOtherEnabled &&
+                    assistanceAction.otherAction !== '' ? (
+                      <li>
+                        {
+                          i18n.childInformation.assistanceAction.fields
+                            .actionTypes.OTHER
+                        }
+                        : {assistanceAction.otherAction}
+                      </li>
+                    ) : null}
                   </ul>
                 )
               },

--- a/frontend/src/employee-frontend/constants.ts
+++ b/frontend/src/employee-frontend/constants.ts
@@ -4,7 +4,7 @@
 
 import LocalDate from 'lib-common/local-date'
 import { UUID } from './types'
-import { AssistanceActionType, AssistanceBasis } from './types/child'
+import { AssistanceBasis } from './types/child'
 
 export const DATE_FORMAT_DEFAULT = 'dd.MM.yyyy'
 export const DATE_FORMAT_DATE_TIME = 'dd.MM.yyyy HH:mm'
@@ -83,17 +83,5 @@ export const ASSISTANCE_BASIS_LIST: AssistanceBasis[] = [
   'LONG_TERM_CONDITION',
   'REGULATION_SKILL_CHALLENGE',
   'DISABILITY',
-  'OTHER'
-]
-
-export const ASSISTANCE_ACTION_TYPE_LIST: AssistanceActionType[] = [
-  'ASSISTANCE_SERVICE_CHILD',
-  'ASSISTANCE_SERVICE_UNIT',
-  'SMALLER_GROUP',
-  'SPECIAL_GROUP',
-  'PERVASIVE_VEO_SUPPORT',
-  'RESOURCE_PERSON',
-  'RATIO_DECREASE',
-  'PERIODICAL_VEO_SUPPORT',
   'OTHER'
 ]

--- a/frontend/src/employee-frontend/types/child.ts
+++ b/frontend/src/employee-frontend/types/child.ts
@@ -51,17 +51,6 @@ export interface AssistanceNeed {
   otherBasis: string
 }
 
-export type AssistanceActionType =
-  | 'ASSISTANCE_SERVICE_CHILD'
-  | 'ASSISTANCE_SERVICE_UNIT'
-  | 'SMALLER_GROUP'
-  | 'SPECIAL_GROUP'
-  | 'PERVASIVE_VEO_SUPPORT'
-  | 'RESOURCE_PERSON'
-  | 'RATIO_DECREASE'
-  | 'PERIODICAL_VEO_SUPPORT'
-  | 'OTHER'
-
 export type { AssistanceMeasure }
 
 export interface AssistanceAction {
@@ -69,9 +58,15 @@ export interface AssistanceAction {
   childId: UUID
   startDate: LocalDate
   endDate: LocalDate
-  actions: Set<AssistanceActionType>
+  actions: Set<string>
   otherAction: string
   measures: Set<AssistanceMeasure>
+}
+
+export interface AssistanceActionOption {
+  value: string
+  nameFi: string
+  isOther: boolean
 }
 
 export interface AdditionalInformation {

--- a/frontend/src/employee-frontend/types/child.ts
+++ b/frontend/src/employee-frontend/types/child.ts
@@ -66,7 +66,6 @@ export interface AssistanceAction {
 export interface AssistanceActionOption {
   value: string
   nameFi: string
-  isOther: boolean
 }
 
 export interface AdditionalInformation {

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -5,5 +5,6 @@
 export default {
   daycareApplicationServiceNeedOptionsEnabled: false,
   urgencyAttachmentsEnabled: true,
-  preschoolEnabled: true
+  preschoolEnabled: true,
+  assistanceActionOtherEnabled: true
 }

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -64,6 +64,7 @@ interface FeatureFlags {
   daycareApplicationServiceNeedOptionsEnabled: boolean
   urgencyAttachmentsEnabled: boolean
   preschoolEnabled: boolean
+  assistanceActionOtherEnabled: boolean
 }
 
 export interface EmployeeCustomizations {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -542,6 +542,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
     insertClubTerms()
 
     insertServiceNeedOptions()
+    insertAssistanceActionOptions()
 }
 
 fun Database.Transaction.resetDatabase() = execute("SELECT reset_database()")
@@ -615,6 +616,24 @@ VALUES (:id, :name, :validPlacementType, :defaultOption, :feeCoefficient, :vouch
         batch.bindKotlin(fixture).add()
     }
     batch.execute()
+}
+
+fun Database.Transaction.insertAssistanceActionOptions() {
+    // language=sql
+    val sql = """
+INSERT INTO assistance_action_option (value, name_fi, is_other, priority) VALUES
+    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', FALSE, 10),
+    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', FALSE, 20),
+    ('SMALLER_GROUP', 'Pienennetty ryhmä', FALSE, 30),
+    ('SPECIAL_GROUP', 'Erityisryhmä', FALSE, 40),
+    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', FALSE, 50),
+    ('RESOURCE_PERSON', 'Resurssihenkilö', FALSE, 60),
+    ('RATIO_DECREASE', 'Suhdeluvun väljennys', FALSE, 70),
+    ('PERIODICAL_VEO_SUPPORT', 'Jaksottainen veon tuki (2–6 kk)', FALSE, 80),
+    ('OTHER', 'Muu tukitoimi', TRUE, 99);
+"""
+
+    createUpdate(sql).execute()
 }
 
 fun Database.Transaction.insertTestVardaOrganizer() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -621,7 +621,7 @@ VALUES (:id, :name, :validPlacementType, :defaultOption, :feeCoefficient, :vouch
 fun Database.Transaction.insertAssistanceActionOptions() {
     // language=sql
     val sql = """
-INSERT INTO assistance_action_option (value, name_fi, priority) VALUES
+INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
     ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10),
     ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20),
     ('SMALLER_GROUP', 'Pienennetty ryhmä', 30),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -621,16 +621,15 @@ VALUES (:id, :name, :validPlacementType, :defaultOption, :feeCoefficient, :vouch
 fun Database.Transaction.insertAssistanceActionOptions() {
     // language=sql
     val sql = """
-INSERT INTO assistance_action_option (value, name_fi, is_other, priority) VALUES
-    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', FALSE, 10),
-    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', FALSE, 20),
-    ('SMALLER_GROUP', 'Pienennetty ryhmä', FALSE, 30),
-    ('SPECIAL_GROUP', 'Erityisryhmä', FALSE, 40),
-    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', FALSE, 50),
-    ('RESOURCE_PERSON', 'Resurssihenkilö', FALSE, 60),
-    ('RATIO_DECREASE', 'Suhdeluvun väljennys', FALSE, 70),
-    ('PERIODICAL_VEO_SUPPORT', 'Jaksottainen veon tuki (2–6 kk)', FALSE, 80),
-    ('OTHER', 'Muu tukitoimi', TRUE, 99);
+INSERT INTO assistance_action_option (value, name_fi, priority) VALUES
+    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10),
+    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20),
+    ('SMALLER_GROUP', 'Pienennetty ryhmä', 30),
+    ('SPECIAL_GROUP', 'Erityisryhmä', 40),
+    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', 50),
+    ('RESOURCE_PERSON', 'Resurssihenkilö', 60),
+    ('RATIO_DECREASE', 'Suhdeluvun väljennys', 70),
+    ('PERIODICAL_VEO_SUPPORT', 'Jaksottainen veon tuki (2–6 kk)', 80);
 """
 
     createUpdate(sql).execute()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
@@ -60,17 +60,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `post first assistance action, with action types and measures`() {
-        val allActionTypes = setOf(
-            AssistanceActionType.ASSISTANCE_SERVICE_CHILD,
-            AssistanceActionType.ASSISTANCE_SERVICE_UNIT,
-            AssistanceActionType.SMALLER_GROUP,
-            AssistanceActionType.SPECIAL_GROUP,
-            AssistanceActionType.PERVASIVE_VEO_SUPPORT,
-            AssistanceActionType.RESOURCE_PERSON,
-            AssistanceActionType.RATIO_DECREASE,
-            AssistanceActionType.PERIODICAL_VEO_SUPPORT,
-            AssistanceActionType.OTHER
-        )
+        val allActionTypes = db.transaction { it.getAssistanceActionOptions() }.map { it.value }.toSet()
         val allMeasures = setOf(
             AssistanceMeasure.SPECIAL_ASSISTANCE_DECISION,
             AssistanceMeasure.INTENSIFIED_ASSISTANCE,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka.koski
 
 import fi.espoo.evaka.FullApplicationTest
-import fi.espoo.evaka.assistanceaction.AssistanceActionType
 import fi.espoo.evaka.assistanceaction.AssistanceMeasure
 import fi.espoo.evaka.assistanceneed.AssistanceBasis
 import fi.espoo.evaka.daycare.domain.ProviderType
@@ -369,7 +368,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         data class TestCase(
             val period: FiniteDateRange,
             val measure: AssistanceMeasure,
-            val action: AssistanceActionType? = null
+            val action: String? = null
         )
         insertPlacement(testChild_1)
         val testCases = listOf(
@@ -378,7 +377,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
             TestCase(
                 testPeriod(4L to 5L),
                 AssistanceMeasure.SPECIAL_ASSISTANCE_DECISION,
-                AssistanceActionType.SPECIAL_GROUP
+                "SPECIAL_GROUP"
             )
         )
         db.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceAction.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceAction.kt
@@ -12,7 +12,7 @@ data class AssistanceAction(
     val childId: UUID,
     val startDate: LocalDate,
     val endDate: LocalDate,
-    val actions: Set<AssistanceActionType>,
+    val actions: Set<String>,
     val otherAction: String,
     val measures: Set<AssistanceMeasure>
 )
@@ -20,22 +20,16 @@ data class AssistanceAction(
 data class AssistanceActionRequest(
     val startDate: LocalDate,
     val endDate: LocalDate,
-    val actions: Set<AssistanceActionType> = emptySet(),
+    val actions: Set<String> = emptySet(),
     val otherAction: String = "",
     val measures: Set<AssistanceMeasure> = emptySet()
 )
 
-enum class AssistanceActionType {
-    ASSISTANCE_SERVICE_CHILD,
-    ASSISTANCE_SERVICE_UNIT,
-    SMALLER_GROUP,
-    SPECIAL_GROUP,
-    PERVASIVE_VEO_SUPPORT,
-    RESOURCE_PERSON,
-    RATIO_DECREASE,
-    PERIODICAL_VEO_SUPPORT,
-    OTHER
-}
+data class AssistanceActionOption(
+    val value: String,
+    val nameFi: String,
+    val isOther: Boolean
+)
 
 enum class AssistanceMeasure {
     SPECIAL_ASSISTANCE_DECISION,

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceAction.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceAction.kt
@@ -27,8 +27,7 @@ data class AssistanceActionRequest(
 
 data class AssistanceActionOption(
     val value: String,
-    val nameFi: String,
-    val isOther: Boolean
+    val nameFi: String
 )
 
 enum class AssistanceMeasure {

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -84,4 +84,10 @@ class AssistanceActionController(
         assistanceActionService.deleteAssistanceAction(db, assistanceActionId)
         return noContent()
     }
+
+    @GetMapping("/assistance-action-options")
+    fun getAssistanceActionOptions(db: Database.Connection, user: AuthenticatedUser): List<AssistanceActionOption> {
+        user.requireAnyEmployee()
+        return assistanceActionService.getAssistanceActionOptions(db)
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionQueries.kt
@@ -164,6 +164,6 @@ fun Database.Transaction.deleteAssistanceActionOptionRefsByActionId(actionId: UU
 
 fun Database.Transaction.getAssistanceActionOptions(): List<AssistanceActionOption> {
     //language=sql
-    val sql = "SELECT value, name_fi, is_other FROM assistance_action_option ORDER BY priority"
+    val sql = "SELECT value, name_fi FROM assistance_action_option ORDER BY priority"
     return createQuery(sql).mapTo(AssistanceActionOption::class.java).list()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionQueries.kt
@@ -19,7 +19,6 @@ fun Database.Transaction.insertAssistanceAction(user: AuthenticatedUser, childId
             start_date, 
             end_date, 
             updated_by, 
-            actions,
             other_action,
             measures
         )
@@ -28,28 +27,66 @@ fun Database.Transaction.insertAssistanceAction(user: AuthenticatedUser, childId
             :startDate, 
             :endDate, 
             :updatedBy,
-            :actions::assistance_action_type[],
             :otherAction,
             :measures::assistance_measure[]
         )
-        RETURNING *
+        RETURNING id
         """.trimIndent()
 
-    return createQuery(sql)
+    val id = createQuery(sql)
         .bind("childId", childId)
         .bind("startDate", data.startDate)
         .bind("endDate", data.endDate)
         .bind("updatedBy", user.id)
-        .bind("actions", data.actions.map { it.toString() }.toTypedArray())
         .bind("otherAction", data.otherAction)
         .bind("measures", data.measures.map { it.toString() }.toTypedArray())
-        .mapTo(AssistanceAction::class.java)
+        .mapTo(UUID::class.java)
         .first()
+
+    insertAssistanceActionOptionRefs(id, data.actions)
+
+    return getAssistanceActionById(id)
+}
+
+fun Database.Transaction.insertAssistanceActionOptionRefs(actionId: UUID, options: Set<String>): IntArray {
+    //language=sql
+    val sql =
+        """
+        INSERT INTO assistance_action_option_ref (action_id, option_id)
+        VALUES (:action_id, (SELECT id FROM assistance_action_option WHERE value = :option))
+        ON CONFLICT DO NOTHING
+        """.trimIndent()
+    val batch = prepareBatch(sql)
+    options.forEach { option -> batch.bind("action_id", actionId).bind("option", option).add() }
+    return batch.execute()
+}
+
+fun Database.Read.getAssistanceActionById(id: UUID): AssistanceAction {
+    //language=sql
+    val sql =
+        """
+        SELECT aa.id, child_id, start_date, end_date, array_remove(array_agg(value), null) AS actions, other_action, measures
+        FROM assistance_action aa
+        LEFT JOIN assistance_action_option_ref aaor ON aaor.action_id = aa.id
+        LEFT JOIN assistance_action_option aao ON aao.id = aaor.option_id
+        WHERE aa.id = :id
+        GROUP BY aa.id, child_id, start_date, end_date, other_action, measures
+        """.trimIndent()
+    return createQuery(sql).bind("id", id).mapTo(AssistanceAction::class.java).first()
 }
 
 fun Database.Read.getAssistanceActionsByChild(childId: UUID): List<AssistanceAction> {
     //language=sql
-    val sql = "SELECT * FROM assistance_action WHERE child_id = :childId ORDER BY start_date DESC "
+    val sql =
+        """
+        SELECT aa.id, child_id, start_date, end_date, array_remove(array_agg(value), null) AS actions, other_action, measures
+        FROM assistance_action aa
+        LEFT JOIN assistance_action_option_ref aaor ON aaor.action_id = aa.id
+        LEFT JOIN assistance_action_option aao ON aao.id = aaor.option_id
+        WHERE child_id = :childId
+        GROUP BY aa.id, child_id, start_date, end_date, other_action, measures
+        ORDER BY start_date DESC
+        """.trimIndent()
     return createQuery(sql)
         .bind("childId", childId)
         .mapTo(AssistanceAction::class.java)
@@ -64,23 +101,26 @@ fun Database.Transaction.updateAssistanceAction(user: AuthenticatedUser, id: UUI
             start_date = :startDate,
             end_date = :endDate,
             updated_by = :updatedBy,
-            actions = :actions::assistance_action_type[],
             other_action = :otherAction,
             measures = :measures::assistance_measure[]
         WHERE id = :id
-        RETURNING *
+        RETURNING id
         """.trimIndent()
 
-    return createQuery(sql)
+    createQuery(sql)
         .bind("id", id)
         .bind("startDate", data.startDate)
         .bind("endDate", data.endDate)
         .bind("updatedBy", user.id)
-        .bind("actions", data.actions.map { it.toString() }.toTypedArray())
         .bind("otherAction", data.otherAction)
         .bind("measures", data.measures.map { it.toString() }.toTypedArray())
-        .mapTo(AssistanceAction::class.java)
+        .mapTo(UUID::class.java)
         .firstOrNull() ?: throw NotFound("Assistance action $id not found")
+
+    deleteAssistanceActionOptionRefsByActionId(id, data.actions)
+    insertAssistanceActionOptionRefs(id, data.actions)
+
+    return getAssistanceActionById(id)
 }
 
 fun Database.Transaction.shortenOverlappingAssistanceAction(user: AuthenticatedUser, childId: UUID, startDate: LocalDate, endDate: LocalDate) {
@@ -106,4 +146,24 @@ fun Database.Transaction.deleteAssistanceAction(id: UUID) {
     val sql = "DELETE FROM assistance_action WHERE id = :id"
     val deleted = createUpdate(sql).bind("id", id).execute()
     if (deleted == 0) throw NotFound("Assistance action $id not found")
+}
+
+fun Database.Transaction.deleteAssistanceActionOptionRefsByActionId(actionId: UUID, excluded: Set<String>): Int {
+    //language=sql
+    val sql =
+        """
+        DELETE FROM assistance_action_option_ref
+        WHERE action_id = :action_id
+        AND option_id NOT IN (SELECT id FROM assistance_action_option WHERE value = ANY(:excluded))
+        """.trimIndent()
+    return createUpdate(sql)
+        .bind("action_id", actionId)
+        .bind("excluded", excluded.toTypedArray())
+        .execute()
+}
+
+fun Database.Transaction.getAssistanceActionOptions(): List<AssistanceActionOption> {
+    //language=sql
+    val sql = "SELECT value, name_fi, is_other FROM assistance_action_option ORDER BY priority"
+    return createQuery(sql).mapTo(AssistanceActionOption::class.java).list()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionQueries.kt
@@ -164,6 +164,6 @@ fun Database.Transaction.deleteAssistanceActionOptionRefsByActionId(actionId: UU
 
 fun Database.Transaction.getAssistanceActionOptions(): List<AssistanceActionOption> {
     //language=sql
-    val sql = "SELECT value, name_fi FROM assistance_action_option ORDER BY priority"
+    val sql = "SELECT value, name_fi FROM assistance_action_option ORDER BY display_order"
     return createQuery(sql).mapTo(AssistanceActionOption::class.java).list()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.application.DaycarePlacementPlan
 import fi.espoo.evaka.application.fetchApplicationDetails
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.application.persistence.objectMapper
-import fi.espoo.evaka.assistanceaction.AssistanceActionType
 import fi.espoo.evaka.assistanceaction.AssistanceMeasure
 import fi.espoo.evaka.assistanceneed.AssistanceBasis
 import fi.espoo.evaka.daycare.CareType
@@ -1198,7 +1197,7 @@ data class DevAssistanceAction(
     val updatedBy: UUID,
     val startDate: LocalDate = LocalDate.of(2019, 1, 1),
     val endDate: LocalDate = LocalDate.of(2019, 12, 31),
-    val actions: Set<AssistanceActionType> = emptySet(),
+    val actions: Set<String> = emptySet(),
     val measures: Set<AssistanceMeasure> = emptySet(),
     val otherAction: String = ""
 )

--- a/service/src/main/resources/db/migration/R__koski_views.sql
+++ b/service/src/main/resources/db/migration/R__koski_views.sql
@@ -97,14 +97,18 @@ TABLE (
             ) AS special_assistance_decision_without_group
         FROM (
             SELECT
+                aa.id,
                 daterange(aa.start_date, aa.end_date, '[]') AS date_interval,
                 aa.start_date,
                 aa.end_date,
                 aa.measures,
-                aa.actions
+                array_remove(array_agg(aao.value), null) AS actions
             FROM assistance_action aa
+            LEFT JOIN assistance_action_option_ref aaor ON aaor.action_id = aa.id
+            LEFT JOIN assistance_action_option aao ON aao.id = aaor.option_id
             WHERE aa.child_id = p.child_id
             AND daterange(aa.start_date, aa.end_date, '[]') && full_range
+            GROUP BY aa.id, daterange(aa.start_date, aa.end_date, '[]'), aa.start_date, aa.end_date, aa.measures
             ORDER BY aa.id
         ) matching_assistance_action
     ) aa ON true

--- a/service/src/main/resources/db/migration/V97__assistance_action_option.sql
+++ b/service/src/main/resources/db/migration/V97__assistance_action_option.sql
@@ -1,0 +1,56 @@
+CREATE TABLE assistance_action_option (
+    id uuid PRIMARY KEY DEFAULT ext.uuid_generate_v1mc(),
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    updated timestamp with time zone DEFAULT now() NOT NULL,
+    value text NOT NULL,
+    name_fi text NOT NULL,
+    is_other boolean NOT NULL DEFAULT FALSE,
+    priority int
+);
+
+CREATE UNIQUE INDEX uniq$assistance_action_option_value ON assistance_action_option (value);
+CREATE UNIQUE INDEX uniq$assistance_action_option_is_other ON assistance_action_option (is_other) WHERE is_other;
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON assistance_action_option FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();
+
+INSERT INTO assistance_action_option (value, name_fi, is_other, priority)
+SELECT action, CASE action
+    WHEN 'ASSISTANCE_SERVICE_CHILD'::assistance_action_type THEN 'Avustamispalvelut yhdelle lapselle'
+    WHEN 'ASSISTANCE_SERVICE_UNIT'::assistance_action_type THEN 'Avustamispalvelut yksikköön'
+    WHEN 'SMALLER_GROUP'::assistance_action_type THEN 'Pienennetty ryhmä'
+    WHEN 'SPECIAL_GROUP'::assistance_action_type THEN 'Erityisryhmä'
+    WHEN 'PERVASIVE_VEO_SUPPORT'::assistance_action_type THEN 'Laaja-alaisen veon tuki'
+    WHEN 'RESOURCE_PERSON'::assistance_action_type THEN 'Resurssihenkilö'
+    WHEN 'RATIO_DECREASE'::assistance_action_type THEN 'Suhdeluvun väljennys'
+    WHEN 'PERIODICAL_VEO_SUPPORT'::assistance_action_type THEN 'Jaksottainen veon tuki (2–6 kk)'
+    WHEN 'OTHER'::assistance_action_type THEN 'Muu tukitoimi'
+END, CASE action
+    WHEN 'OTHER'::assistance_action_type THEN TRUE
+    ELSE FALSE
+END, CASE action
+    WHEN 'ASSISTANCE_SERVICE_CHILD'::assistance_action_type THEN 10
+    WHEN 'ASSISTANCE_SERVICE_UNIT'::assistance_action_type THEN 20
+    WHEN 'SMALLER_GROUP'::assistance_action_type THEN 30
+    WHEN 'SPECIAL_GROUP'::assistance_action_type THEN 40
+    WHEN 'PERVASIVE_VEO_SUPPORT'::assistance_action_type THEN 50
+    WHEN 'RESOURCE_PERSON'::assistance_action_type THEN 60
+    WHEN 'RATIO_DECREASE'::assistance_action_type THEN 70
+    WHEN 'PERIODICAL_VEO_SUPPORT'::assistance_action_type THEN 80
+    WHEN 'OTHER'::assistance_action_type THEN 99
+END
+FROM (SELECT DISTINCT unnest(actions) AS action FROM assistance_action) aa;
+
+CREATE TABLE assistance_action_option_ref (
+    action_id uuid NOT NULL REFERENCES assistance_action ON DELETE CASCADE,
+    option_id uuid NOT NULL REFERENCES assistance_action_option,
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY (action_id, option_id)
+);
+
+INSERT INTO assistance_action_option_ref (action_id, option_id, created)
+SELECT aa.id, aao.id, aa.updated
+FROM (SELECT id, updated, unnest(actions) AS action FROM assistance_action) aa
+LEFT JOIN assistance_action_option aao ON aao.value::assistance_action_type = aa.action
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE assistance_action DROP COLUMN actions;
+DROP TYPE assistance_action_type;

--- a/service/src/main/resources/db/migration/V97__assistance_action_option.sql
+++ b/service/src/main/resources/db/migration/V97__assistance_action_option.sql
@@ -4,13 +4,13 @@ CREATE TABLE assistance_action_option (
     updated timestamp with time zone DEFAULT now() NOT NULL,
     value text NOT NULL,
     name_fi text NOT NULL,
-    priority int
+    display_order int
 );
 
 CREATE UNIQUE INDEX uniq$assistance_action_option_value ON assistance_action_option (value);
 CREATE TRIGGER set_timestamp BEFORE UPDATE ON assistance_action_option FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();
 
-INSERT INTO assistance_action_option (value, name_fi, priority)
+INSERT INTO assistance_action_option (value, name_fi, display_order)
 SELECT action, CASE action
     WHEN 'ASSISTANCE_SERVICE_CHILD'::assistance_action_type THEN 'Avustamispalvelut yhdelle lapselle'
     WHEN 'ASSISTANCE_SERVICE_UNIT'::assistance_action_type THEN 'Avustamispalvelut yksikköön'

--- a/service/src/main/resources/dev-data/espoo-dev-data.sql
+++ b/service/src/main/resources/dev-data/espoo-dev-data.sql
@@ -1957,3 +1957,14 @@ INSERT INTO service_need_option (name, valid_placement_type, default_option, fee
     ('Osapäiväinen liittyvä, yhteensä enintään 40h', 'PREPARATORY_DAYCARE', FALSE, 0.35, 0.5, 1.0, 15, TRUE, FALSE, 'varhaiskasvatusta korkeintaan 15 h/vko', 'småbarnspedagogik högst 15 h/vecka', '', ''),
     ('Osapäiväinen ja osaviikkoinen liittyvä, yhteensä yli 40h alle 50h', 'PREPARATORY_DAYCARE', FALSE, 0.6, 0.5, 1.0, 20, TRUE, TRUE, 'varhaiskasvatusta 15-25 h/vko', 'småbarnspedagogik 15-25 h/vecka', '', ''),
     ('Osapäiväinen ja osaviikkoinen liittyvä, yhteensä enintään 40h', 'PREPARATORY_DAYCARE', FALSE, 0.35, 0.5, 1.0, 15, TRUE, TRUE, 'varhaiskasvatusta korkeintaan 15 h/vko', 'småbarnspedagogik högst 15 h/vecka', '', '');
+
+INSERT INTO assistance_action_option (value, name_fi, is_other, priority) VALUES
+    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', FALSE, 10),
+    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', FALSE, 20),
+    ('SMALLER_GROUP', 'Pienennetty ryhmä', FALSE, 30),
+    ('SPECIAL_GROUP', 'Erityisryhmä', FALSE, 40),
+    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', FALSE, 50),
+    ('RESOURCE_PERSON', 'Resurssihenkilö', FALSE, 60),
+    ('RATIO_DECREASE', 'Suhdeluvun väljennys', FALSE, 70),
+    ('PERIODICAL_VEO_SUPPORT', 'Jaksottainen veon tuki (2–6 kk)', FALSE, 80),
+    ('OTHER', 'Muu tukitoimi', TRUE, 99);

--- a/service/src/main/resources/dev-data/espoo-dev-data.sql
+++ b/service/src/main/resources/dev-data/espoo-dev-data.sql
@@ -1958,13 +1958,12 @@ INSERT INTO service_need_option (name, valid_placement_type, default_option, fee
     ('Osapäiväinen ja osaviikkoinen liittyvä, yhteensä yli 40h alle 50h', 'PREPARATORY_DAYCARE', FALSE, 0.6, 0.5, 1.0, 20, TRUE, TRUE, 'varhaiskasvatusta 15-25 h/vko', 'småbarnspedagogik 15-25 h/vecka', '', ''),
     ('Osapäiväinen ja osaviikkoinen liittyvä, yhteensä enintään 40h', 'PREPARATORY_DAYCARE', FALSE, 0.35, 0.5, 1.0, 15, TRUE, TRUE, 'varhaiskasvatusta korkeintaan 15 h/vko', 'småbarnspedagogik högst 15 h/vecka', '', '');
 
-INSERT INTO assistance_action_option (value, name_fi, is_other, priority) VALUES
-    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', FALSE, 10),
-    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', FALSE, 20),
-    ('SMALLER_GROUP', 'Pienennetty ryhmä', FALSE, 30),
-    ('SPECIAL_GROUP', 'Erityisryhmä', FALSE, 40),
-    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', FALSE, 50),
-    ('RESOURCE_PERSON', 'Resurssihenkilö', FALSE, 60),
-    ('RATIO_DECREASE', 'Suhdeluvun väljennys', FALSE, 70),
-    ('PERIODICAL_VEO_SUPPORT', 'Jaksottainen veon tuki (2–6 kk)', FALSE, 80),
-    ('OTHER', 'Muu tukitoimi', TRUE, 99);
+INSERT INTO assistance_action_option (value, name_fi, priority) VALUES
+    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10),
+    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20),
+    ('SMALLER_GROUP', 'Pienennetty ryhmä', 30),
+    ('SPECIAL_GROUP', 'Erityisryhmä', 40),
+    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', 50),
+    ('RESOURCE_PERSON', 'Resurssihenkilö', 60),
+    ('RATIO_DECREASE', 'Suhdeluvun väljennys', 70),
+    ('PERIODICAL_VEO_SUPPORT', 'Jaksottainen veon tuki (2–6 kk)', 80);

--- a/service/src/main/resources/dev-data/espoo-dev-data.sql
+++ b/service/src/main/resources/dev-data/espoo-dev-data.sql
@@ -1958,7 +1958,7 @@ INSERT INTO service_need_option (name, valid_placement_type, default_option, fee
     ('Osapäiväinen ja osaviikkoinen liittyvä, yhteensä yli 40h alle 50h', 'PREPARATORY_DAYCARE', FALSE, 0.6, 0.5, 1.0, 20, TRUE, TRUE, 'varhaiskasvatusta 15-25 h/vko', 'småbarnspedagogik 15-25 h/vecka', '', ''),
     ('Osapäiväinen ja osaviikkoinen liittyvä, yhteensä enintään 40h', 'PREPARATORY_DAYCARE', FALSE, 0.35, 0.5, 1.0, 15, TRUE, TRUE, 'varhaiskasvatusta korkeintaan 15 h/vko', 'småbarnspedagogik högst 15 h/vecka', '', '');
 
-INSERT INTO assistance_action_option (value, name_fi, priority) VALUES
+INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
     ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10),
     ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20),
     ('SMALLER_GROUP', 'Pienennetty ryhmä', 30),

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -94,3 +94,4 @@ V93__message_recipient_names.sql
 V94__create_fee_thresholds.sql
 V95__remove_absence_soft_delete.sql
 V96__message_account_foreign_keys.sql
+V97__assistance_action_option.sql


### PR DESCRIPTION
#### Summary

There are significant differences in assistance action options between installations. Also they are used for reports so simply creating union of all options (and hiding unnecessary options) is not smart here. So let's move options to database for full customization support. This is part 1 (i.e. edit works), ~~part 2 will add full support for the report (note: report will work correctly for previous hard-coded options)~~ it was agreed that you will add reports support.

Automatic database migration will only add options already in use, e.g. if some of the options are not currently used they will be missing. So after installing this change, you want to add all missing options with following SQL:

```
INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10),
    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20),
    ('SMALLER_GROUP', 'Pienennetty ryhmä', 30),
    ('SPECIAL_GROUP', 'Erityisryhmä', 40),
    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', 50),
    ('RESOURCE_PERSON', 'Resurssihenkilö', 60),
    ('RATIO_DECREASE', 'Suhdeluvun väljennys', 70),
    ('PERIODICAL_VEO_SUPPORT', 'Jaksottainen veon tuki (2–6 kk)', 80)
    ON CONFLICT (value) DO NOTHING;
```