### PR TITLE
EVAKA-4190 Refactor message account queries

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -5,11 +5,11 @@
 package fi.espoo.evaka.messaging
 
 import fi.espoo.evaka.PureJdbiTest
-import fi.espoo.evaka.messaging.message.MessageAccount
 import fi.espoo.evaka.messaging.message.MessageType
-import fi.espoo.evaka.messaging.message.createMessageAccountForPerson
-import fi.espoo.evaka.messaging.message.getMessageAccountForEndUser
-import fi.espoo.evaka.messaging.message.getMessageAccountsForEmployee
+import fi.espoo.evaka.messaging.message.createPersonMessageAccount
+import fi.espoo.evaka.messaging.message.getAccountNames
+import fi.espoo.evaka.messaging.message.getCitizenMessageAccount
+import fi.espoo.evaka.messaging.message.getEmployeeMessageAccounts
 import fi.espoo.evaka.messaging.message.getMessagesReceivedByAccount
 import fi.espoo.evaka.messaging.message.getMessagesSentByAccount
 import fi.espoo.evaka.messaging.message.getThreadByMessageId
@@ -19,9 +19,8 @@ import fi.espoo.evaka.messaging.message.insertMessageContent
 import fi.espoo.evaka.messaging.message.insertRecipients
 import fi.espoo.evaka.messaging.message.insertThread
 import fi.espoo.evaka.messaging.message.markThreadRead
-import fi.espoo.evaka.messaging.message.upsertMessageAccountForEmployee
+import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.resetDatabase
-import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestEmployee
@@ -45,11 +44,11 @@ class MessageQueriesTest : PureJdbiTest() {
         db.transaction { tx ->
             tx.insertTestPerson(DevPerson(id = person1Id, firstName = "Firstname", lastName = "Person"))
             tx.insertTestPerson(DevPerson(id = person2Id, firstName = "Firstname", lastName = "Person Two"))
-            listOf(person1Id, person2Id).forEach { tx.createMessageAccountForPerson(it) }
+            listOf(person1Id, person2Id).forEach { tx.createPersonMessageAccount(it) }
 
             tx.insertTestEmployee(DevEmployee(id = employee1Id, firstName = "Firstname", lastName = "Employee"))
             tx.insertTestEmployee(DevEmployee(id = employee2Id, firstName = "Firstname", lastName = "Employee Two"))
-            listOf(employee1Id, employee2Id).forEach { tx.upsertMessageAccountForEmployee(it) }
+            listOf(employee1Id, employee2Id).forEach { tx.upsertEmployeeMessageAccount(it) }
         }
     }
 
@@ -62,9 +61,9 @@ class MessageQueriesTest : PureJdbiTest() {
     fun `a thread can be created`() {
         val (employeeAccount, person1Account, person2Account) = db.read {
             listOf(
-                it.getMessageAccountsForEmployee(AuthenticatedUser.Employee(id = employee1Id, roles = setOf())).first(),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person1Id)),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person2Id))
+                it.getEmployeeMessageAccounts(employee1Id).first(),
+                it.getCitizenMessageAccount(person1Id),
+                it.getCitizenMessageAccount(person2Id)
             )
         }
 
@@ -73,7 +72,7 @@ class MessageQueriesTest : PureJdbiTest() {
         createThread(title, content, employeeAccount, listOf(person1Account, person2Account))
 
         assertEquals(
-            setOf(person1Account.id, person2Account.id),
+            setOf(person1Account, person2Account),
             db.read { it.createQuery("SELECT recipient_id FROM message_recipients").mapTo<UUID>().toSet() }
         )
         assertEquals(
@@ -89,8 +88,8 @@ class MessageQueriesTest : PureJdbiTest() {
             db.read { it.createQuery("SELECT sender_name FROM message").mapTo<String>().one() }
         )
         assertEquals(
-            "{\"Person Firstname\",\"Person Two Firstname\"}",
-            db.read { it.createQuery("SELECT recipient_names FROM message").mapTo<String>().one() }
+            setOf("Person Firstname", "Person Two Firstname"),
+            db.read { it.createQuery("SELECT recipient_names FROM message").mapTo<Array<String>>().one() }.toSet()
         )
     }
 
@@ -98,10 +97,10 @@ class MessageQueriesTest : PureJdbiTest() {
     fun `messages received by account are grouped properly`() {
         val (employee1Account, employee2Account, person1Account, person2Account) = db.read {
             listOf(
-                it.getMessageAccountsForEmployee(AuthenticatedUser.Employee(id = employee1Id, roles = setOf())).first(),
-                it.getMessageAccountsForEmployee(AuthenticatedUser.Employee(id = employee2Id, roles = setOf())).first(),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person1Id)),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person2Id))
+                it.getEmployeeMessageAccounts(employee1Id).first(),
+                it.getEmployeeMessageAccounts(employee2Id).first(),
+                it.getCitizenMessageAccount(person1Id),
+                it.getCitizenMessageAccount(person2Id)
             )
         }
 
@@ -110,8 +109,8 @@ class MessageQueriesTest : PureJdbiTest() {
         createThread("Lone Thread", "Alone", employee2Account, listOf(employee2Account))
 
         // employee is not a recipient in any threads
-        assertEquals(0, db.read { it.getMessagesReceivedByAccount(employee1Account.id, 10, 1) }.data.size)
-        val personResult = db.read { it.getMessagesReceivedByAccount(person1Account.id, 10, 1) }
+        assertEquals(0, db.read { it.getMessagesReceivedByAccount(employee1Account, 10, 1) }.data.size)
+        val personResult = db.read { it.getMessagesReceivedByAccount(person1Account, 10, 1) }
         assertEquals(2, personResult.data.size)
 
         val thread = personResult.data.first()
@@ -127,26 +126,26 @@ class MessageQueriesTest : PureJdbiTest() {
                 threadId = thread2Id,
                 sender = person1Account,
                 repliesToMessageId = thread.messages.last().id,
-                recipientNames = recipients.map { it.name }
+                recipientNames = listOf()
             )
-            it.insertRecipients(recipientAccountIds = recipients.map { it.id }.toSet(), messageId = messageId)
+            it.insertRecipients(recipientAccountIds = recipients.toSet(), messageId = messageId)
         }
 
         // then employee sees the thread
-        val employeeResult = db.read { it.getMessagesReceivedByAccount(employee1Account.id, 10, 1) }
+        val employeeResult = db.read { it.getMessagesReceivedByAccount(employee1Account, 10, 1) }
         assertEquals(1, employeeResult.data.size)
         assertEquals("Newest thread", employeeResult.data[0].title)
         assertEquals(2, employeeResult.data[0].messages.size)
 
         // person 1 is recipient in both threads
-        val person1Result = db.read { it.getMessagesReceivedByAccount(person1Account.id, 10, 1) }
+        val person1Result = db.read { it.getMessagesReceivedByAccount(person1Account, 10, 1) }
         assertEquals(2, person1Result.data.size)
 
         val newestThread = person1Result.data[0]
         assertEquals(thread2Id, newestThread.id)
         assertEquals("Newest thread", newestThread.title)
         assertEquals(
-            listOf(Pair(employee1Account.id, "Content 2"), Pair(person1Account.id, "Just replying here")),
+            listOf(Pair(employee1Account, "Content 2"), Pair(person1Account, "Just replying here")),
             newestThread.messages.map { Pair(it.senderId, it.content) }
         )
         assertEquals(employeeResult.data[0], newestThread)
@@ -155,15 +154,15 @@ class MessageQueriesTest : PureJdbiTest() {
         assertEquals(thread1Id, oldestThread.id)
 
         // person 2 is recipient in the oldest thread only
-        val person2Result = db.read { it.getMessagesReceivedByAccount(person2Account.id, 10, 1) }
+        val person2Result = db.read { it.getMessagesReceivedByAccount(person2Account, 10, 1) }
         assertEquals(1, person2Result.data.size)
         assertEquals(oldestThread, person2Result.data[0])
 
         // employee 2 is participating with himself
-        val employee2Result = db.read { it.getMessagesReceivedByAccount(employee2Account.id, 10, 1) }
+        val employee2Result = db.read { it.getMessagesReceivedByAccount(employee2Account, 10, 1) }
         assertEquals(1, employee2Result.data.size)
         assertEquals(1, employee2Result.data[0].messages.size)
-        assertEquals(employee2Account.id, employee2Result.data[0].messages[0].senderId)
+        assertEquals(employee2Account, employee2Result.data[0].messages[0].senderId)
         assertEquals("Alone", employee2Result.data[0].messages[0].content)
     }
 
@@ -171,15 +170,15 @@ class MessageQueriesTest : PureJdbiTest() {
     fun `received messages can be paged`() {
         val (employee1Account, person1Account) = db.read {
             listOf(
-                it.getMessageAccountsForEmployee(AuthenticatedUser.Employee(id = employee1Id, roles = setOf())).first(),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person1Id))
+                it.getEmployeeMessageAccounts(employee1Id).first(),
+                it.getCitizenMessageAccount(person1Id)
             )
         }
 
         createThread("t1", "c1", employee1Account, listOf(person1Account))
         createThread("t2", "c2", employee1Account, listOf(person1Account))
 
-        val messages = db.read { it.getMessagesReceivedByAccount(person1Account.id, 10, 1) }
+        val messages = db.read { it.getMessagesReceivedByAccount(person1Account, 10, 1) }
         assertEquals(2, messages.total)
         assertEquals(2, messages.data.size)
         assertEquals("t2", messages.data[0].title)
@@ -187,8 +186,8 @@ class MessageQueriesTest : PureJdbiTest() {
 
         val (page1, page2) = db.read {
             listOf(
-                it.getMessagesReceivedByAccount(person1Account.id, 1, 1),
-                it.getMessagesReceivedByAccount(person1Account.id, 1, 2)
+                it.getMessagesReceivedByAccount(person1Account, 1, 1),
+                it.getMessagesReceivedByAccount(person1Account, 1, 2)
             )
         }
         assertEquals(2, page1.total)
@@ -206,9 +205,9 @@ class MessageQueriesTest : PureJdbiTest() {
     fun `sent messages`() {
         val (employee1Account, person1Account, person2Account) = db.read {
             listOf(
-                it.getMessageAccountsForEmployee(AuthenticatedUser.Employee(id = employee1Id, roles = setOf())).first(),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person1Id)),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person2Id))
+                it.getEmployeeMessageAccounts(employee1Id).first(),
+                it.getCitizenMessageAccount(person1Id),
+                it.getCitizenMessageAccount(person2Id)
             )
         }
 
@@ -218,7 +217,7 @@ class MessageQueriesTest : PureJdbiTest() {
         val thread2Id = createThread("thread 2", "content 2", employee1Account, listOf(person1Account))
 
         // then sent messages are returned for sender id
-        val firstPage = db.read { it.getMessagesSentByAccount(employee1Account.id, 1, 1) }
+        val firstPage = db.read { it.getMessagesSentByAccount(employee1Account, 1, 1) }
         assertEquals(2, firstPage.total)
         assertEquals(2, firstPage.pages)
         assertEquals(1, firstPage.data.size)
@@ -227,9 +226,9 @@ class MessageQueriesTest : PureJdbiTest() {
         assertEquals("content 2", newestMessage.content)
         assertEquals("thread 2", newestMessage.threadTitle)
         assertEquals(thread2Id, newestMessage.threadId)
-        assertEquals(setOf(person1Account), newestMessage.recipients)
+        assertEquals(setOf(person1Account), newestMessage.recipients.map { it.id }.toSet())
 
-        val secondPage = db.read { it.getMessagesSentByAccount(employee1Account.id, 1, 2) }
+        val secondPage = db.read { it.getMessagesSentByAccount(employee1Account, 1, 2) }
         assertEquals(2, secondPage.total)
         assertEquals(2, secondPage.pages)
         assertEquals(1, secondPage.data.size)
@@ -238,19 +237,19 @@ class MessageQueriesTest : PureJdbiTest() {
         assertEquals("content 1", oldestMessage.content)
         assertEquals("thread 1", oldestMessage.threadTitle)
         assertEquals(threadId1, oldestMessage.threadId)
-        assertEquals(setOf(person1Account, person2Account), oldestMessage.recipients)
+        assertEquals(setOf(person1Account, person2Account), oldestMessage.recipients.map { it.id }.toSet())
 
         // then fetching sent messages by recipient ids does not return the messages
-        assertEquals(0, db.read { it.getMessagesSentByAccount(person1Account.id, 1, 1) }.total)
+        assertEquals(0, db.read { it.getMessagesSentByAccount(person1Account, 1, 1) }.total)
     }
 
     @Test
     fun `message participants by messageId`() {
         val (employee1Account, person1Account, person2Account) = db.read {
             listOf(
-                it.getMessageAccountsForEmployee(AuthenticatedUser.Employee(id = employee1Id, roles = setOf())).first(),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person1Id)),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person2Id))
+                it.getEmployeeMessageAccounts(employee1Id).first(),
+                it.getCitizenMessageAccount(person1Id),
+                it.getCitizenMessageAccount(person2Id)
             )
         }
 
@@ -264,8 +263,8 @@ class MessageQueriesTest : PureJdbiTest() {
         }
         assertEquals(threadId, participants?.threadId)
         assertEquals(MessageType.MESSAGE, participants?.type)
-        assertEquals(employee1Account.id, participants?.sender)
-        assertEquals(setOf(person1Account.id, person2Account.id), participants?.recipients)
+        assertEquals(employee1Account, participants?.sender)
+        assertEquals(setOf(person1Account, person2Account), participants?.recipients)
     }
 
     @Test
@@ -273,48 +272,48 @@ class MessageQueriesTest : PureJdbiTest() {
         // given
         val (employee1Account, person1Account, person2Account) = db.read {
             listOf(
-                it.getMessageAccountsForEmployee(AuthenticatedUser.Employee(id = employee1Id, roles = setOf())).first(),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person1Id)),
-                it.getMessageAccountForEndUser(AuthenticatedUser.Citizen(id = person2Id))
+                it.getEmployeeMessageAccounts(employee1Id).first(),
+                it.getCitizenMessageAccount(person1Id),
+                it.getCitizenMessageAccount(person2Id)
             )
         }
         val thread1 = createThread("Title", "Content", person1Account, listOf(employee1Account, person2Account))
 
         // then unread count is zero for sender and one for recipients
-        assertEquals(0, db.read { it.getUnreadMessagesCount(setOf(person1Account.id)) })
-        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(employee1Account.id)) })
-        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(person2Account.id)) })
+        assertEquals(0, db.read { it.getUnreadMessagesCount(setOf(person1Account)) })
+        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(employee1Account)) })
+        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(person2Account)) })
 
         // when employee reads the message
-        db.transaction { it.markThreadRead(employee1Account.id, thread1) }
+        db.transaction { it.markThreadRead(employee1Account, thread1) }
 
         // then the thread does not count towards unread messages
-        assertEquals(0, db.read { it.getUnreadMessagesCount(setOf(person1Account.id)) })
-        assertEquals(0, db.read { it.getUnreadMessagesCount(setOf(employee1Account.id)) })
-        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(person2Account.id)) })
+        assertEquals(0, db.read { it.getUnreadMessagesCount(setOf(person1Account)) })
+        assertEquals(0, db.read { it.getUnreadMessagesCount(setOf(employee1Account)) })
+        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(person2Account)) })
 
         // when a new thread is created
         val thread2 = createThread("Title", "Content", employee1Account, listOf(person1Account, person2Account))
 
         // then unread counts are bumped by one for recipients
-        assertEquals(0, db.read { it.getUnreadMessagesCount(setOf(employee1Account.id)) })
-        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(person1Account.id)) })
-        assertEquals(2, db.read { it.getUnreadMessagesCount(setOf(person2Account.id)) })
+        assertEquals(0, db.read { it.getUnreadMessagesCount(setOf(employee1Account)) })
+        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(person1Account)) })
+        assertEquals(2, db.read { it.getUnreadMessagesCount(setOf(person2Account)) })
 
         // when person two reads a thread
-        db.transaction { it.markThreadRead(person2Account.id, thread2) }
+        db.transaction { it.markThreadRead(person2Account, thread2) }
 
         // then unread count goes down by one
-        assertEquals(0, db.read { it.getUnreadMessagesCount(setOf(employee1Account.id)) })
-        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(person1Account.id)) })
-        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(person2Account.id)) })
+        assertEquals(0, db.read { it.getUnreadMessagesCount(setOf(employee1Account)) })
+        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(person1Account)) })
+        assertEquals(1, db.read { it.getUnreadMessagesCount(setOf(person2Account)) })
     }
 
     private fun createThread(
         title: String,
         content: String,
-        sender: MessageAccount,
-        recipientAccounts: List<MessageAccount>
+        sender: UUID,
+        recipientAccounts: List<UUID>
     ) =
         db.transaction { tx ->
             val contentId = tx.insertMessageContent(content, sender)
@@ -324,9 +323,9 @@ class MessageQueriesTest : PureJdbiTest() {
                     contentId = contentId,
                     threadId = threadId,
                     sender = sender,
-                    recipientNames = recipientAccounts.map { it.name }
+                    recipientNames = tx.getAccountNames(recipientAccounts.toSet())
                 )
-            tx.insertRecipients(recipientAccounts.map { it.id }.toSet(), messageId)
+            tx.insertRecipients(recipientAccounts.toSet(), messageId)
             threadId
         }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/UnitAcl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/UnitAcl.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.messaging.message.deactivateEmployeeMessageAccount
-import fi.espoo.evaka.messaging.message.upsertMessageAccountForEmployee
+import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.shared.auth.DaycareAclRow
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.clearDaycareGroupAcl
@@ -24,7 +24,7 @@ fun addUnitSupervisor(db: Database.Connection, daycareId: UUID, employeeId: UUID
     db.transaction {
         it.clearDaycareGroupAcl(daycareId, employeeId)
         it.insertDaycareAclRow(daycareId, employeeId, UserRole.UNIT_SUPERVISOR)
-        it.upsertMessageAccountForEmployee(employeeId)
+        it.upsertEmployeeMessageAccount(employeeId)
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -11,7 +11,7 @@ import fi.espoo.evaka.daycare.getGroupStats
 import fi.espoo.evaka.daycare.getUnitStats
 import fi.espoo.evaka.daycare.initCaretakers
 import fi.espoo.evaka.daycare.isValidDaycareId
-import fi.espoo.evaka.messaging.message.createMessageAccountForDaycareGroup
+import fi.espoo.evaka.messaging.message.createDaycareGroupMessageAccount
 import fi.espoo.evaka.messaging.message.deleteOrDeactivateDaycareGroupMessageAccount
 import fi.espoo.evaka.placement.getDaycareGroupPlacements
 import fi.espoo.evaka.shared.db.Database
@@ -47,7 +47,7 @@ class DaycareService {
         initialCaretakers: Double
     ): DaycareGroup = tx.createDaycareGroup(daycareId, name, startDate).also {
         tx.initCaretakers(it.id, it.startDate, initialCaretakers)
-        tx.createMessageAccountForDaycareGroup(it.id)
+        tx.createDaycareGroupMessageAccount(it.id)
     }
 
     fun deleteGroup(tx: Database.Transaction, daycareId: UUID, groupId: UUID) = try {

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
@@ -73,7 +73,7 @@ enum class AccountType {
     GROUP
 }
 
-data class AuthorizedMessageAccount(
+data class DetailedMessageAccount(
     val id: UUID,
     val name: String,
     @Nested("group_")

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccount.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccount.kt
@@ -4,8 +4,8 @@ import fi.espoo.evaka.shared.db.Database
 import java.util.UUID
 
 fun deleteOrDeactivateDaycareGroupMessageAccount(tx: Database.Transaction, daycareGroupId: UUID) {
-    val account = tx.getMessageAccountForDaycareGroup(daycareGroupId)
-    if (account != null && tx.accountHasMessages(account.id)) {
+    val accountId = tx.getDaycareGroupMessageAccount(daycareGroupId)
+    if (accountId != null && tx.accountHasMessages(accountId)) {
         tx.deactivateDaycareGroupMessageAccount(daycareGroupId)
     } else {
         tx.deleteDaycareGroupMessageAccount(daycareGroupId)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageService.kt
@@ -18,7 +18,7 @@ class MessageService(
         title: String,
         content: String,
         type: MessageType,
-        sender: MessageAccount,
+        sender: UUID,
         recipientGroups: Set<Set<UUID>>,
         recipientNames: List<String>,
     ): List<UUID> {
@@ -44,17 +44,17 @@ class MessageService(
     fun replyToThread(
         db: Database.Connection,
         replyToMessageId: UUID,
-        senderAccount: MessageAccount,
+        senderAccount: UUID,
         recipientAccountIds: Set<UUID>,
         content: String,
     ): UUID {
         val (threadId, type, sender, recipients) = db.read { it.getThreadByMessageId(replyToMessageId) }
             ?: throw NotFound("Message not found")
 
-        if (type == MessageType.BULLETIN && sender != senderAccount.id) throw Forbidden("Only the author can reply to bulletin")
+        if (type == MessageType.BULLETIN && sender != senderAccount) throw Forbidden("Only the author can reply to bulletin")
 
         val previousParticipants = recipients + sender
-        if (!previousParticipants.contains(senderAccount.id)) throw Forbidden("Not authorized to post to message")
+        if (!previousParticipants.contains(senderAccount)) throw Forbidden("Not authorized to post to message")
         if (!previousParticipants.containsAll(recipientAccountIds)) throw Forbidden("Not authorized to widen the audience")
 
         return db.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/Person.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/Person.kt
@@ -4,7 +4,7 @@
 
 package fi.espoo.evaka.pis
 
-import fi.espoo.evaka.messaging.message.createMessageAccountForPerson
+import fi.espoo.evaka.messaging.message.createPersonMessageAccount
 import fi.espoo.evaka.pis.controllers.CreatePersonBody
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
@@ -13,24 +13,24 @@ import java.util.UUID
 
 fun createPerson(tx: Database.Transaction, person: PersonIdentityRequest): PersonDTO {
     val result = tx.createPerson(person)
-    tx.createMessageAccountForPerson(result.id)
+    tx.createPersonMessageAccount(result.id)
     return result
 }
 
 fun createPerson(tx: Database.Transaction, person: CreatePersonBody): UUID {
     val personId = tx.createPerson(person)
-    tx.createMessageAccountForPerson(personId)
+    tx.createPersonMessageAccount(personId)
     return personId
 }
 
 fun createEmptyPerson(tx: Database.Transaction): PersonDTO {
     val result = tx.createEmptyPerson()
-    tx.createMessageAccountForPerson(result.id)
+    tx.createPersonMessageAccount(result.id)
     return result
 }
 
 fun createPersonFromVtj(tx: Database.Transaction, person: PersonDTO): PersonDTO {
     val result = tx.createPersonFromVtj(person)
-    tx.createMessageAccountForPerson(result.id)
+    tx.createPersonMessageAccount(result.id)
     return result
 }


### PR DESCRIPTION
#### Summary
- Use person/employee ids instead of `AuthenticatedUser` when querying message accounts, because only the `id` was used.
- Use account id to reference message accounts, instead of `MessageAccount` that also contains the rarely needed account name.
- Rename `getMessageAccountFor*()` to `get*MessageAccount()`
- Rename `getAuthorizedMessageAccountsForEmployee()` to `getEmployeeDetailedMessageAccount()`
