### PR TITLE
EVAKA-4190 Authorize daycare group message account access

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
+import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -44,7 +45,9 @@ import java.util.UUID
 class MessageAccountQueriesTest : PureJdbiTest() {
 
     private val personId: UUID = UUID.randomUUID()
-    private val employeeId: UUID = UUID.randomUUID()
+    private val supervisorId: UUID = UUID.randomUUID()
+    private val employee1Id: UUID = UUID.randomUUID()
+    private val employee2Id: UUID = UUID.randomUUID()
 
     @BeforeEach
     internal fun setUp() {
@@ -52,19 +55,36 @@ class MessageAccountQueriesTest : PureJdbiTest() {
             it.insertTestPerson(DevPerson(id = personId, firstName = "Firstname", lastName = "Person"))
             it.createPersonMessageAccount(personId)
 
-            it.insertTestEmployee(DevEmployee(id = employeeId, firstName = "Firstname", lastName = "Employee"))
-            it.upsertEmployeeMessageAccount(employeeId)
+            it.insertTestEmployee(DevEmployee(id = supervisorId, firstName = "Firstname", lastName = "Supervisor"))
+            it.upsertEmployeeMessageAccount(supervisorId)
+
+            it.insertTestEmployee(DevEmployee(id = employee1Id, firstName = "Firstname", lastName = "Employee 1"))
+            it.insertTestEmployee(DevEmployee(id = employee2Id, firstName = "Firstname", lastName = "Employee 2"))
 
             val randomUuid = it.insertTestEmployee(DevEmployee(firstName = "Random", lastName = "Employee"))
             it.upsertEmployeeMessageAccount(randomUuid)
 
-            it.insertTestEmployee(DevEmployee(firstName = "Random", lastName = "Employee without account"))
-
             val areaId = it.insertTestCareArea(DevCareArea())
             val daycareId = it.insertTestDaycare(DevDaycare(areaId = areaId))
-            val groupId = it.insertTestDaycareGroup(DevDaycareGroup(daycareId = daycareId))
+
+            val groupId = it.insertTestDaycareGroup(DevDaycareGroup(daycareId = daycareId, name = "Testiläiset"))
             it.createDaycareGroupMessageAccount(groupId)
-            it.insertDaycareAclRow(daycareId, employeeId, UserRole.UNIT_SUPERVISOR)
+
+            val group2Id = it.insertTestDaycareGroup(DevDaycareGroup(daycareId = daycareId, name = "Koekaniinit"))
+            it.createDaycareGroupMessageAccount(group2Id)
+
+            it.insertDaycareAclRow(daycareId, supervisorId, UserRole.UNIT_SUPERVISOR)
+
+            it.insertDaycareAclRow(daycareId, employee1Id, UserRole.STAFF)
+            it.insertDaycareGroupAcl(daycareId, employee1Id, listOf(groupId))
+
+            // employee2 has no groups
+            it.insertDaycareAclRow(daycareId, employee2Id, UserRole.STAFF)
+
+            // There should be no permissions to anything about this daycare
+            val daycare2Id = it.insertTestDaycare(DevDaycare(areaId = areaId, name = "Väärä päiväkoti"))
+            val group3Id = it.insertTestDaycareGroup(DevDaycareGroup(daycareId = daycare2Id, name = "Väärät"))
+            it.createDaycareGroupMessageAccount(group3Id)
         }
     }
 
@@ -79,20 +99,46 @@ class MessageAccountQueriesTest : PureJdbiTest() {
     }
 
     @Test
-    fun `employee gets access to personal and group accounts`() {
-        val personalAccountName = "Employee Firstname"
-        val groupAccountName = "Test Daycare - Testiläiset"
+    fun `supervisor get access to personal and all group accounts of his daycares`() {
+        val personalAccountName = "Supervisor Firstname"
+        val group1AccountName = "Test Daycare - Testiläiset"
+        val group2AccountName = "Test Daycare - Koekaniinit"
 
-        val accounts = db.transaction { it.getEmployeeMessageAccounts(employeeId) }
-        assertEquals(2, accounts.size)
+        val accounts = db.transaction { it.getEmployeeMessageAccounts(supervisorId) }
+        assertEquals(3, accounts.size)
 
-        val accounts2 = db.read { it.getEmployeeDetailedMessageAccounts(employeeId) }
-        assertEquals(2, accounts2.size)
+        val accounts2 = db.read { it.getEmployeeDetailedMessageAccounts(supervisorId) }
+        assertEquals(3, accounts2.size)
         val personalAccount =
             accounts2.find { it.type === AccountType.PERSONAL } ?: throw Error("Personal account not found")
         assertEquals(personalAccountName, personalAccount.name)
         assertEquals(AccountType.PERSONAL, personalAccount.type)
         assertNull(personalAccount.daycareGroup)
+
+        val groupAccount =
+            accounts2.find { it.name == group1AccountName } ?: throw Error("Group account $group1AccountName not found")
+        assertEquals(AccountType.GROUP, groupAccount.type)
+        assertEquals("Test Daycare", groupAccount.daycareGroup?.unitName)
+        assertEquals("Testiläiset", groupAccount.daycareGroup?.name)
+
+        val group2Account =
+            accounts2.find { it.name == group2AccountName } ?: throw Error("Group account $group2AccountName not found")
+        assertEquals(AccountType.GROUP, group2Account.type)
+        assertEquals("Test Daycare", group2Account.daycareGroup?.unitName)
+        assertEquals("Koekaniinit", group2Account.daycareGroup?.name)
+    }
+
+    @Test
+    fun `employee gets access to the accounts of his groups`() {
+        val groupAccountName = "Test Daycare - Testiläiset"
+
+        val accounts = db.transaction { it.getEmployeeMessageAccounts(employee1Id) }
+        assertEquals(1, accounts.size)
+
+        val accounts2 = db.read { it.getEmployeeDetailedMessageAccounts(employee1Id) }
+        assertEquals(1, accounts2.size)
+        assertNull(accounts2.find { it.type === fi.espoo.evaka.messaging.message.AccountType.PERSONAL })
+
         val groupAccount = accounts2.find { it.daycareGroup != null } ?: throw Error("Group account not found")
         assertEquals(groupAccountName, groupAccount.name)
         assertEquals(AccountType.GROUP, groupAccount.type)
@@ -101,17 +147,26 @@ class MessageAccountQueriesTest : PureJdbiTest() {
     }
 
     @Test
-    fun `employee has no access to inactive accounts`() {
-        assertEquals(2, db.read { it.getEmployeeMessageAccounts(employeeId) }.size)
-        db.transaction { it.deactivateEmployeeMessageAccount(employeeId) }
+    fun `employee not in any groups sees no accounts`() {
+        val accounts = db.transaction { it.getEmployeeMessageAccounts(employee2Id) }
+        assertEquals(0, accounts.size)
 
-        val accounts = db.transaction { it.getEmployeeMessageAccounts(employeeId) }
-        assertEquals(1, accounts.size)
+        val accounts2 = db.read { it.getEmployeeDetailedMessageAccounts(employee2Id) }
+        assertEquals(0, accounts2.size)
+    }
+
+    @Test
+    fun `employee has no access to inactive accounts`() {
+        assertEquals(3, db.read { it.getEmployeeMessageAccounts(supervisorId) }.size)
+        db.transaction { it.deactivateEmployeeMessageAccount(supervisorId) }
+
+        val accounts = db.transaction { it.getEmployeeMessageAccounts(supervisorId) }
+        assertEquals(2, accounts.size)
     }
 
     @Test
     fun `unread counts`() {
-        val accounts = db.read { it.getEmployeeDetailedMessageAccounts(employeeId) }
+        val accounts = db.read { it.getEmployeeDetailedMessageAccounts(supervisorId) }
         assertEquals(0, accounts.first().unreadCount)
 
         val employeeAccount = accounts.first().id
@@ -126,7 +181,7 @@ class MessageAccountQueriesTest : PureJdbiTest() {
             tx.insertRecipients(allAccounts.map { it.id }.toSet(), messageId)
         }
 
-        assertEquals(2, db.read { it.getUnreadMessagesCount(accounts.map { acc -> acc.id }.toSet()) })
-        assertEquals(1, db.read { it.getEmployeeDetailedMessageAccounts(employeeId) }.first().unreadCount)
+        assertEquals(3, db.read { it.getUnreadMessagesCount(accounts.map { acc -> acc.id }.toSet()) })
+        assertEquals(1, db.read { it.getEmployeeDetailedMessageAccounts(supervisorId) }.first().unreadCount)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
@@ -36,8 +36,9 @@ SELECT acc.id
 FROM message_account acc
 LEFT JOIN daycare_group dg ON acc.daycare_group_id = dg.id
     LEFT JOIN daycare dc ON dc.id = dg.daycare_id
-    LEFT JOIN daycare_acl acl ON acl.daycare_id = dg.daycare_id
-WHERE (acc.employee_id = :employeeId OR acl.employee_id = :employeeId)
+    LEFT JOIN daycare_acl acl ON acl.daycare_id = dg.daycare_id AND acl.role = 'UNIT_SUPERVISOR'
+    LEFT JOIN daycare_group_acl gacl on gacl.daycare_group_id = dg.id
+WHERE (acc.employee_id = :employeeId OR acl.employee_id = :employeeId OR gacl.employee_id = :employeeId)
     AND acc.active = true
 """
     return this.createQuery(sql)
@@ -66,7 +67,6 @@ FROM message_account acc
     LEFT JOIN message_recipients rec ON acc.id = rec.recipient_id AND rec.read_at IS NULL
     LEFT JOIN daycare_group dg ON acc.daycare_group_id = dg.id
     LEFT JOIN daycare dc ON dc.id = dg.daycare_id
-    LEFT JOIN daycare_acl acl ON acl.daycare_id = dg.daycare_id
 WHERE acc.id = ANY(:accountIds)
 GROUP BY acc.id, account_name, type, group_id, group_name, group_unitId, group_unitName
 """


### PR DESCRIPTION
#### Summary

- Supervisors see all group accounts in their daycares
- Staff members only see their own groups' accounts (based on `daycare_group_acl`)
- Admins do **not** see all message accounts. Not sure if this is desirable.