### PR TITLE
EVAKA-HOTFIX Move placement fixtures back to the future

### DIFF
--- a/frontend/src/e2e-test-common/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test-common/dev-api/fixtures.ts
@@ -735,8 +735,8 @@ export function createDaycarePlacementFixture(
   id: string,
   childId: string,
   unitId: string,
-  startDate = '2020-05-01',
-  endDate = '2021-08-31'
+  startDate = '2021-05-01',
+  endDate = '2022-08-31'
 ): DaycarePlacement {
   return {
     id,
@@ -752,8 +752,8 @@ export function createPreschoolDaycarePlacementFixture(
   id: string,
   childId: string,
   unitId: string,
-  startDate = '2020-05-01',
-  endDate = '2021-08-31'
+  startDate = '2021-05-01',
+  endDate = '2022-08-31'
 ): DaycarePlacement {
   return {
     id,
@@ -768,8 +768,8 @@ export function createPreschoolDaycarePlacementFixture(
 export function createDaycareGroupPlacementFixture(
   placementId: string,
   groupId: string,
-  startDate = '2020-05-01',
-  endDate = '2021-08-31'
+  startDate = '2021-05-01',
+  endDate = '2022-08-31'
 ): DaycareGroupPlacement {
   return {
     id: '2e19e400-ca0c-4059-b872-cce8b5282a72',

--- a/frontend/src/e2e-test/specs/5_employee/units.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/units.spec.ts
@@ -133,10 +133,10 @@ test('daycare has one child missing group', async (t) => {
     )
   await t
     .expect(row.placementDuration.textContent)
-    .eql('01.05.2020 - 31.08.2021')
+    .eql('01.05.2021 - 31.08.2022')
   await t
     .expect(row.groupMissingDuration.textContent)
-    .eql('01.05.2020 - 31.08.2021')
+    .eql('01.05.2021 - 31.08.2022')
   await t.expect(row.addToGroupBtn.visible).ok()
 })
 
@@ -169,7 +169,7 @@ test('child can be placed into a group and removed from it', async (t) => {
     )
   await t
     .expect(groupPlacement.placementDuration.textContent)
-    .eql('01.05.2020- 31.08.2021')
+    .eql('01.05.2021- 31.08.2022')
 
   // after removing the child is again visible at missing groups and no longer at the group
   await groupPlacement.remove()
@@ -184,10 +184,10 @@ test('child can be placed into a group and removed from it', async (t) => {
     )
   await t
     .expect(missingPlacement2.placementDuration.textContent)
-    .eql('01.05.2020 - 31.08.2021')
+    .eql('01.05.2021 - 31.08.2022')
   await t
     .expect(missingPlacement2.groupMissingDuration.textContent)
-    .eql('01.05.2020 - 31.08.2021')
+    .eql('01.05.2021 - 31.08.2022')
   await t.expect(group.groupPlacementRows.count).eql(0)
   await t.expect(group.noChildrenPlaceholder.visible).ok()
 })


### PR DESCRIPTION
#### Summary

The default end date for placement fixtures was 2021-08-31, which is 3 months minus one day from today. This caused an E2E test to fail.