### PR TITLE
EVAKA-4190: Prevent sender-receiver conflicts

### DIFF
--- a/frontend/src/employee-frontend/components/Header.tsx
+++ b/frontend/src/employee-frontend/components/Header.tsx
@@ -80,18 +80,18 @@ const UnreadCount = styled.span`
 const Header = React.memo(function Header({ location }: RouteComponentProps) {
   const { i18n } = useTranslation()
   const { user, loggedIn } = useContext(UserContext)
-  const { accountsRequest } = useContext(MessageContext)
+  const { accounts } = useContext(MessageContext)
   const [popupVisible, setPopupVisible] = useState(false)
 
   const unreadCount = useMemo<number>(
     () =>
-      accountsRequest.mapAll({
+      accounts.mapAll({
         failure: () => 0,
         loading: () => 0,
         success: (value) =>
           value.reduce((sum, { unreadCount }) => sum + unreadCount, 0)
       }),
-    [accountsRequest]
+    [accounts]
   )
 
   const path = location.pathname

--- a/frontend/src/employee-frontend/components/Header.tsx
+++ b/frontend/src/employee-frontend/components/Header.tsx
@@ -80,18 +80,18 @@ const UnreadCount = styled.span`
 const Header = React.memo(function Header({ location }: RouteComponentProps) {
   const { i18n } = useTranslation()
   const { user, loggedIn } = useContext(UserContext)
-  const { accounts } = useContext(MessageContext)
+  const { accountsRequest } = useContext(MessageContext)
   const [popupVisible, setPopupVisible] = useState(false)
 
   const unreadCount = useMemo<number>(
     () =>
-      accounts.mapAll({
+      accountsRequest.mapAll({
         failure: () => 0,
         loading: () => 0,
         success: (value) =>
           value.reduce((sum, { unreadCount }) => sum + unreadCount, 0)
       }),
-    [accounts]
+    [accountsRequest]
   )
 
   const path = location.pathname

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -36,7 +36,7 @@ const PAGE_SIZE = 20
 type RepliesByThread = Record<UUID, string>
 
 export interface MessagesState {
-  accountsRequest: Result<MessageAccount[]>
+  accounts: Result<MessageAccount[]>
   loadAccounts: () => void
   selectedDraft: DraftContent | undefined
   setSelectedDraft: (draft: DraftContent | undefined) => void
@@ -61,7 +61,7 @@ export interface MessagesState {
 }
 
 const defaultState: MessagesState = {
-  accountsRequest: Loading.of(),
+  accounts: Loading.of(),
   loadAccounts: () => undefined,
   selectedDraft: undefined,
   setSelectedDraft: () => undefined,
@@ -116,10 +116,10 @@ export const MessageContextProvider = React.memo(
       SelectOptionProps | undefined
     >()
 
-    const [accountsRequest, setAccountsRequest] = useState<
-      Result<MessageAccount[]>
-    >(Loading.of())
-    const getAccounts = useRestApi(getMessagingAccounts, setAccountsRequest)
+    const [accounts, setAccounts] = useState<Result<MessageAccount[]>>(
+      Loading.of()
+    )
+    const getAccounts = useRestApi(getMessagingAccounts, setAccounts)
     const loadAccounts = useDebouncedCallback(getAccounts, 100)
 
     useEffect(() => {
@@ -247,7 +247,7 @@ export const MessageContextProvider = React.memo(
           0
         )
         if (unreadCount > 0) {
-          setAccountsRequest((state) =>
+          setAccounts((state) =>
             state.map((accounts) =>
               accounts.map((acc) =>
                 acc.id === accountId
@@ -266,7 +266,7 @@ export const MessageContextProvider = React.memo(
 
     const value = useMemo(
       () => ({
-        accountsRequest,
+        accounts,
         loadAccounts,
         selectedDraft,
         setSelectedDraft,
@@ -290,7 +290,7 @@ export const MessageContextProvider = React.memo(
         refreshMessages
       }),
       [
-        accountsRequest,
+        accounts,
         loadAccounts,
         selectedDraft,
         selectedAccount,

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -1,3 +1,4 @@
+import { SelectOptionProps } from 'employee-frontend/components/common/Select'
 import React, {
   createContext,
   useCallback,
@@ -32,16 +33,17 @@ import {
 import { AccountView } from './types-view'
 
 const PAGE_SIZE = 20
-
 type RepliesByThread = Record<UUID, string>
 
 export interface MessagesState {
-  accounts: Result<MessageAccount[]>
+  accountsRequest: Result<MessageAccount[]>
   loadAccounts: () => void
   selectedDraft: DraftContent | undefined
   setSelectedDraft: (draft: DraftContent | undefined) => void
   selectedAccount: AccountView | undefined
   setSelectedAccount: (view: AccountView) => void
+  selectedUnit: SelectOptionProps | undefined
+  setSelectedUnit: (unit: SelectOptionProps) => void
   page: number
   setPage: (page: number) => void
   pages: number | undefined
@@ -59,12 +61,14 @@ export interface MessagesState {
 }
 
 const defaultState: MessagesState = {
-  accounts: Loading.of(),
+  accountsRequest: Loading.of(),
   loadAccounts: () => undefined,
   selectedDraft: undefined,
   setSelectedDraft: () => undefined,
   selectedAccount: undefined,
   setSelectedAccount: () => undefined,
+  selectedUnit: undefined,
+  setSelectedUnit: () => undefined,
   page: 1,
   setPage: () => undefined,
   pages: undefined,
@@ -108,10 +112,14 @@ export const MessageContextProvider = React.memo(
       [roles]
     )
 
-    const [accounts, setAccounts] = useState<Result<MessageAccount[]>>(
-      Loading.of()
-    )
-    const getAccounts = useRestApi(getMessagingAccounts, setAccounts)
+    const [selectedUnit, setSelectedUnit] = useState<
+      SelectOptionProps | undefined
+    >()
+
+    const [accountsRequest, setAccountsRequest] = useState<
+      Result<MessageAccount[]>
+    >(Loading.of())
+    const getAccounts = useRestApi(getMessagingAccounts, setAccountsRequest)
     const loadAccounts = useDebouncedCallback(getAccounts, 100)
 
     useEffect(() => {
@@ -239,7 +247,7 @@ export const MessageContextProvider = React.memo(
           0
         )
         if (unreadCount > 0) {
-          setAccounts((state) =>
+          setAccountsRequest((state) =>
             state.map((accounts) =>
               accounts.map((acc) =>
                 acc.id === accountId
@@ -258,12 +266,14 @@ export const MessageContextProvider = React.memo(
 
     const value = useMemo(
       () => ({
-        accounts,
+        accountsRequest,
         loadAccounts,
         selectedDraft,
         setSelectedDraft,
         selectedAccount,
         setSelectedAccount,
+        selectedUnit,
+        setSelectedUnit,
         page,
         setPage,
         pages,
@@ -280,10 +290,12 @@ export const MessageContextProvider = React.memo(
         refreshMessages
       }),
       [
-        accounts,
+        accountsRequest,
         loadAccounts,
         selectedDraft,
         selectedAccount,
+        selectedUnit,
+        setSelectedUnit,
         page,
         pages,
         receivedMessages,

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -34,7 +34,7 @@ const PanelContainer = styled.div`
 
 export default function MessagesPage() {
   const {
-    accountsRequest,
+    accounts,
     loadAccounts,
     selectedDraft,
     setSelectedDraft,
@@ -51,21 +51,21 @@ export default function MessagesPage() {
   useEffect(() => {
     const unitSelectionChange =
       selectedAccount &&
-      accountsRequest.isSuccess &&
-      !accountsRequest.value.find(
+      accounts.isSuccess &&
+      !accounts.value.find(
         (account) => account.id === selectedAccount.account.id
       )
     if (
       (!selectedAccount || unitSelectionChange) &&
-      accountsRequest.isSuccess &&
-      accountsRequest.value[0]
+      accounts.isSuccess &&
+      accounts.value[0]
     ) {
       setSelectedAccount({
         view: 'RECEIVED',
-        account: accountsRequest.value[0]
+        account: accounts.value[0]
       })
     }
-  }, [accountsRequest, setSelectedAccount, selectedAccount])
+  }, [accounts, setSelectedAccount, selectedAccount])
 
   const [showEditor, setShowEditor] = useState<boolean>(false)
 
@@ -137,7 +137,7 @@ export default function MessagesPage() {
           />
         )}
         {showEditor &&
-          accountsRequest.isSuccess &&
+          accounts.isSuccess &&
           selectedReceivers &&
           selectedAccount &&
           selectedUnit && (
@@ -146,7 +146,7 @@ export default function MessagesPage() {
                 value: selectedAccount.account.id,
                 label: selectedAccount.account.name
               }}
-              accounts={accountsRequest.value}
+              accounts={accounts.value}
               selectedUnit={selectedUnit}
               availableReceivers={selectedReceivers}
               onSend={onSend}

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -34,27 +34,38 @@ const PanelContainer = styled.div`
 
 export default function MessagesPage() {
   const {
-    accounts,
+    accountsRequest,
     loadAccounts,
     selectedDraft,
     setSelectedDraft,
     selectedAccount,
     setSelectedAccount,
+    selectedUnit,
     refreshMessages
   } = useContext(MessageContext)
 
   useEffect(() => loadAccounts(), [loadAccounts])
   useEffect(() => refreshMessages(), [refreshMessages])
 
-  // pre-select first account
+  // pre-select first account on page load and on unit change
   useEffect(() => {
-    if (!selectedAccount && accounts.isSuccess && accounts.value[0]) {
+    const unitSelectionChange =
+      selectedAccount &&
+      accountsRequest.isSuccess &&
+      !accountsRequest.value.find(
+        (account) => account.id === selectedAccount.account.id
+      )
+    if (
+      (!selectedAccount || unitSelectionChange) &&
+      accountsRequest.isSuccess &&
+      accountsRequest.value[0]
+    ) {
       setSelectedAccount({
         view: 'RECEIVED',
-        account: accounts.value[0]
+        account: accountsRequest.value[0]
       })
     }
-  }, [accounts, setSelectedAccount, selectedAccount])
+  }, [accountsRequest, setSelectedAccount, selectedAccount])
 
   const [showEditor, setShowEditor] = useState<boolean>(false)
 
@@ -126,18 +137,17 @@ export default function MessagesPage() {
           />
         )}
         {showEditor &&
-          accounts.isSuccess &&
+          accountsRequest.isSuccess &&
           selectedReceivers &&
-          selectedAccount && (
+          selectedAccount &&
+          selectedUnit && (
             <MessageEditor
               defaultSender={{
                 value: selectedAccount.account.id,
                 label: selectedAccount.account.name
               }}
-              senderOptions={accounts.value.map(({ name, id }) => ({
-                value: id,
-                label: name
-              }))}
+              accounts={accountsRequest.value}
+              selectedUnit={selectedUnit}
               availableReceivers={selectedReceivers}
               onSend={onSend}
               onDiscard={onDiscard}

--- a/frontend/src/employee-frontend/components/messages/SelectorNode.ts
+++ b/frontend/src/employee-frontend/components/messages/SelectorNode.ts
@@ -82,16 +82,13 @@ export const updateSelector = (
 export const getReceiverOptions = (
   selectorNode: SelectorNode
 ): ReactSelectOption[] => {
-  return (selectorNode.childNodes.length > 0
-    ? [{ label: selectorNode.name, value: selectorNode.selectorId }]
-    : []
-  ).concat(
-    !selectorNode.selected
-      ? selectorNode.childNodes.flatMap((childNode) =>
+  return !selectorNode.selected && selectorNode.childNodes.length > 0
+    ? [{ label: selectorNode.name, value: selectorNode.selectorId }].concat(
+        selectorNode.childNodes.flatMap((childNode: SelectorNode) =>
           getReceiverOptions(childNode)
         )
-      : []
-  )
+      )
+    : []
 }
 
 export const deselectAll = (selectorNode: SelectorNode): SelectorNode => {
@@ -161,4 +158,21 @@ export const getSelected = (selector: SelectorNode): ReactSelectOption[] => {
   } else {
     return [{ value: selector.selectorId, label: selector.name }]
   }
+}
+
+export const getSubTree = (
+  selector: SelectorNode,
+  selectorId: UUID
+): SelectorNode | undefined => {
+  if (selector.selectorId === selectorId) {
+    return selector
+  } else {
+    for (const child of selector.childNodes) {
+      const out = getSubTree(child, selectorId)
+      if (out) {
+        return out
+      }
+    }
+  }
+  return undefined
 }

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -13,7 +13,7 @@ import Loader from 'lib-components/atoms/Loader'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import { defaultMargins } from 'lib-components/white-space'
 import { sortBy, uniqBy } from 'lodash'
-import React, { useContext, useEffect } from 'react'
+import React, { useContext, useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 import colors from '../../../lib-customizations/common'
 import { useTranslation } from '../../state/i18n'
@@ -92,19 +92,22 @@ function Accounts({ accounts, setSelectedReceivers }: AccountsParams) {
     setSelectedUnit
   } = useContext(MessageContext)
 
-  const personalAccount = accounts.find(isPersonalMessageAccount)
-  const groupAccounts = accounts.filter(isGroupMessageAccount)
+  const [personalAccount, groupAccounts, unitOptions] = useMemo(() => {
+    const personalAccount = accounts.find(isPersonalMessageAccount)
+    const groupAccounts = accounts.filter(isGroupMessageAccount)
+    const unitOptions = sortBy(
+      uniqBy(
+        groupAccounts.map(({ daycareGroup }) => ({
+          value: daycareGroup.unitId,
+          label: daycareGroup.unitName
+        })),
+        (val) => val.value
+      ),
+      (u) => u.label
+    )
+    return [personalAccount, groupAccounts, unitOptions]
+  }, [accounts])
 
-  const unitOptions = sortBy(
-    uniqBy(
-      groupAccounts.map(({ daycareGroup }) => ({
-        value: daycareGroup.unitId,
-        label: daycareGroup.unitName
-      })),
-      (val) => val.value
-    ),
-    (u) => u.label
-  )
   const unitSelectionEnabled = unitOptions.length > 1
 
   useEffect(() => {

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -189,14 +189,14 @@ export default React.memo(function Sidebar({
   showEditor
 }: Props) {
   const { i18n } = useTranslation()
-  const { accountsRequest, selectedAccount, setSelectedAccount } = useContext(
+  const { accounts, selectedAccount, setSelectedAccount } = useContext(
     MessageContext
   )
 
   return (
     <Container>
       <AccountContainer>
-        {accountsRequest.mapAll({
+        {accounts.mapAll({
           loading() {
             return <Loader />
           },

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -109,7 +109,7 @@ function Accounts({ accounts, setSelectedReceivers }: AccountsParams) {
 
   useEffect(() => {
     !selectedUnit && setSelectedUnit(unitOptions[0])
-  })
+  }, [selectedUnit, setSelectedUnit, unitOptions])
 
   useEffect(() => {
     if (!selectedUnit) {

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -13,11 +13,11 @@ import Loader from 'lib-components/atoms/Loader'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import { defaultMargins } from 'lib-components/white-space'
 import { sortBy, uniqBy } from 'lodash'
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect } from 'react'
 import styled from 'styled-components'
 import colors from '../../../lib-customizations/common'
 import { useTranslation } from '../../state/i18n'
-import Select, { SelectOptionProps } from '../common/Select'
+import Select from '../common/Select'
 import GroupMessageAccountList from './GroupMessageAccountList'
 import MessageBox from './MessageBox'
 import { MessageContext } from './MessageContext'
@@ -85,9 +85,12 @@ interface AccountsParams {
 
 function Accounts({ accounts, setSelectedReceivers }: AccountsParams) {
   const { i18n } = useTranslation()
-  const { setSelectedAccount, selectedAccount: accountView } = useContext(
-    MessageContext
-  )
+  const {
+    setSelectedAccount,
+    selectedAccount,
+    selectedUnit,
+    setSelectedUnit
+  } = useContext(MessageContext)
 
   const personalAccount = accounts.find(isPersonalMessageAccount)
   const groupAccounts = accounts.filter(isGroupMessageAccount)
@@ -104,9 +107,9 @@ function Accounts({ accounts, setSelectedReceivers }: AccountsParams) {
   )
   const unitSelectionEnabled = unitOptions.length > 1
 
-  const [selectedUnit, setSelectedUnit] = useState<
-    SelectOptionProps | undefined
-  >(unitOptions[0])
+  useEffect(() => {
+    !selectedUnit && setSelectedUnit(unitOptions[0])
+  })
 
   useEffect(() => {
     if (!selectedUnit) {
@@ -140,7 +143,7 @@ function Accounts({ accounts, setSelectedReceivers }: AccountsParams) {
               key={view}
               view={view}
               account={personalAccount}
-              activeView={accountView}
+              activeView={selectedAccount}
               setView={setSelectedAccount}
             />
           ))}
@@ -165,7 +168,7 @@ function Accounts({ accounts, setSelectedReceivers }: AccountsParams) {
           )}
           <GroupMessageAccountList
             accounts={visibleGroupAccounts}
-            activeView={accountView}
+            activeView={selectedAccount}
             setView={setSelectedAccount}
           />
         </AccountSection>
@@ -186,14 +189,14 @@ export default React.memo(function Sidebar({
   showEditor
 }: Props) {
   const { i18n } = useTranslation()
-  const { accounts, selectedAccount, setSelectedAccount } = useContext(
+  const { accountsRequest, selectedAccount, setSelectedAccount } = useContext(
     MessageContext
   )
 
   return (
     <Container>
       <AccountContainer>
-        {accounts.mapAll({
+        {accountsRequest.mapAll({
           loading() {
             return <Loader />
           },
@@ -215,6 +218,7 @@ export default React.memo(function Sidebar({
             selectedAccount &&
             setSelectedAccount({ ...selectedAccount, view: 'RECEIVERS' })
           }
+          style={{ display: 'none' }}
         >
           {i18n.messages.receiverSelection.title}
         </Receivers>

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2393,7 +2393,7 @@ export const fi = {
       confirmText: 'Lähetä viesti valituille'
     },
     messageEditor: {
-      newMessage: 'Uusi viesti',
+      newMessage: (unitName: string) => `Uusi viesti (${unitName})`,
       to: {
         label: 'Vastaanottaja',
         placeholder: 'Valitse ryhmä',


### PR DESCRIPTION
#### Summary

* Prevent sender-receiver conflicts in frontend: If sending message as `daycare X group Y`, disable selecting receivers from daycares other than `X` and groups other than `Y`.
* Use sidebar unit selection to filter available accounts upon opening the editor (also specify which daycare is selected in the title).
* Misc improvements:
  * Minor refactoring
  * Prevent choosing empty groups as the selected sender account (this is to rule out some edge cases this update would introduce, but could make sense otherwise too).
  * Hide receiver selection from the sidebar.

Suggest doing everything in the frontend, as there doesn't seem to be a need to involve the backend in any of this.