### PR TITLE
EVAKA-4190 Load accounts on page load

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -1,13 +1,17 @@
 import React, {
   createContext,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useState
 } from 'react'
 import { Loading, Paged, Result } from '../../../lib-common/api'
+import { useDebouncedCallback } from '../../../lib-common/utils/useDebouncedCallback'
 import { useRestApi } from '../../../lib-common/utils/useRestApi'
+import { UserContext } from '../../state/user'
 import { UUID } from '../../types'
+import { requireRole } from '../../utils/roles'
 import {
   getMessageDrafts,
   getMessagingAccounts,
@@ -98,13 +102,23 @@ const appendMessageAndMoveThreadToTopOfList = (
 
 export const MessageContextProvider = React.memo(
   function MessageContextProvider({ children }: { children: JSX.Element }) {
-    const [selectedAccount, setSelectedAccount] = useState<AccountView>()
+    const { roles } = useContext(UserContext)
+    const messagingEnabled = useMemo(
+      () => requireRole(roles, 'UNIT_SUPERVISOR', 'STAFF'),
+      [roles]
+    )
 
     const [accounts, setAccounts] = useState<Result<MessageAccount[]>>(
       Loading.of()
     )
-    const loadAccounts = useRestApi(getMessagingAccounts, setAccounts)
+    const getAccounts = useRestApi(getMessagingAccounts, setAccounts)
+    const loadAccounts = useDebouncedCallback(getAccounts, 100)
 
+    useEffect(() => {
+      messagingEnabled && loadAccounts()
+    }, [messagingEnabled, loadAccounts])
+
+    const [selectedAccount, setSelectedAccount] = useState<AccountView>()
     const [selectedDraft, setSelectedDraft] = useState(
       defaultState.selectedDraft
     )

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -115,7 +115,7 @@ export const MessageContextProvider = React.memo(
     const loadAccounts = useDebouncedCallback(getAccounts, 100)
 
     useEffect(() => {
-      messagingEnabled && loadAccounts()
+      if (messagingEnabled) loadAccounts()
     }, [messagingEnabled, loadAccounts])
 
     const [selectedAccount, setSelectedAccount] = useState<AccountView>()

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -173,8 +173,6 @@ export const MessageContextProvider = React.memo(
       selectedAccount
     ])
 
-    useEffect(loadMessages, [loadMessages])
-
     const [replyState, setReplyState] = useState<Result<void>>()
     const setReplyResponse = useCallback((res: Result<ReplyResponse>) => {
       setReplyState(res.map(() => undefined))

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -44,6 +44,7 @@ export default function MessagesPage() {
   } = useContext(MessageContext)
 
   useEffect(() => loadAccounts(), [loadAccounts])
+  useEffect(() => refreshMessages(), [refreshMessages])
 
   // pre-select first account
   useEffect(() => {


### PR DESCRIPTION
#### Summary

Build on #950. 

Load accounts on context initialization too in order to always show unread messages count in header. This can later be replaced with a polling refresh

