### PR TITLE
EVAKA-4190 Enable messaging for UserRole.CITIZEN_WEAK

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageControllerCitizen.kt
@@ -104,7 +104,7 @@ class MessageControllerCitizen(
         db: Database.Connection,
         user: AuthenticatedUser
     ): UUID {
-        user.requireOneOfRoles(UserRole.END_USER)
+        user.requireOneOfRoles(UserRole.END_USER, UserRole.CITIZEN_WEAK)
         return db.read { it.getCitizenMessageAccount(user.id) }
     }
 }


### PR DESCRIPTION
#### Summary

Enable messaging endpoints for weakly authenticated citizens.
