### PR TITLE
Disable/enable preschool filter on employee applications view

### DIFF
--- a/frontend/src/employee-frontend/components/common/Filters.tsx
+++ b/frontend/src/employee-frontend/components/common/Filters.tsx
@@ -696,40 +696,42 @@ export function ApplicationTypeFilter({
               data-qa={`application-type-filter-${id}`}
               small
             />
-          ) : featureFlags.preschoolEnabled && (
-            <Fragment key={id}>
-              <Radio
-                key={id}
-                label={
-                  <>
-                    {i18n.applications.types[id]}
-                    <ApplicationOpenIcon
-                      icon={toggled === id ? faAngleUp : faAngleDown}
-                      size={'lg'}
-                      color={colors.greyscale.dark}
-                    />
-                  </>
-                }
-                ariaLabel={i18n.applications.types[id]}
-                checked={toggled === id}
-                onChange={toggle(id)}
-                data-qa={`application-type-filter-${id}`}
-                small
-              />
-              {toggled === id && (
-                <CustomDiv spacing={'xs'}>
-                  {preschoolTypes.map((type) => (
-                    <Checkbox
-                      key={type}
-                      label={i18n.applications.types[type]}
-                      checked={toggledPreschool.includes(type)}
-                      onChange={togglePreschool(type)}
-                      data-qa={`application-type-filter-preschool-${type}`}
-                    />
-                  ))}
-                </CustomDiv>
-              )}
-            </Fragment>
+          ) : (
+            featureFlags.preschoolEnabled && (
+              <Fragment key={id}>
+                <Radio
+                  key={id}
+                  label={
+                    <>
+                      {i18n.applications.types[id]}
+                      <ApplicationOpenIcon
+                        icon={toggled === id ? faAngleUp : faAngleDown}
+                        size={'lg'}
+                        color={colors.greyscale.dark}
+                      />
+                    </>
+                  }
+                  ariaLabel={i18n.applications.types[id]}
+                  checked={toggled === id}
+                  onChange={toggle(id)}
+                  data-qa={`application-type-filter-${id}`}
+                  small
+                />
+                {toggled === id && (
+                  <CustomDiv spacing={'xs'}>
+                    {preschoolTypes.map((type) => (
+                      <Checkbox
+                        key={type}
+                        label={i18n.applications.types[type]}
+                        checked={toggledPreschool.includes(type)}
+                        onChange={togglePreschool(type)}
+                        data-qa={`application-type-filter-preschool-${type}`}
+                      />
+                    ))}
+                  </CustomDiv>
+                )}
+              </Fragment>
+            )
           )
         })}
       </FixedSpaceColumn>

--- a/frontend/src/employee-frontend/components/common/Filters.tsx
+++ b/frontend/src/employee-frontend/components/common/Filters.tsx
@@ -43,6 +43,7 @@ import { CareArea } from '../../types/unit'
 import { Label, LabelText } from '../../components/common/styled/common'
 import { FinanceDecisionHandlerOption } from '../../state/invoicing-ui'
 import { ApplicationType } from 'lib-common/api-types/application/enums'
+import { featureFlags } from 'lib-customizations/employee'
 
 interface Props {
   freeText: string
@@ -695,7 +696,7 @@ export function ApplicationTypeFilter({
               data-qa={`application-type-filter-${id}`}
               small
             />
-          ) : (
+          ) : featureFlags.preschoolEnabled && (
             <Fragment key={id}>
               <Radio
                 key={id}


### PR DESCRIPTION
This was agreed with Espoo team to be done using the existing feature flag `preschoolEnabled`.