### PR TITLE
Update builder image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ aliases:
   - &nodejs_image cimg/node:14.15
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202010-01
-  - &builder_aws_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:18.04-d7214c52ce3670639a5b6868607198bde918cbcb
+  - &builder_aws_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:18.04-809ad64eaee48225fba439142026079a49d0f1d5
 
   - &default_contexts
     context:


### PR DESCRIPTION
#### Summary

The old image has old Terraform version and does not use tfenv.
