### PR TITLE
EVAKA-4184 sibling discounts in fee thresholds editor

### DIFF
--- a/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsItemEditor.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsItemEditor.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import DateRange from 'lib-common/date-range'
 import LocalDate from 'lib-common/local-date'
-import { H3LikeLabel, Label } from 'lib-components/typography'
+import { H3LikeLabel, H4, Label } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import {
   FixedSpaceColumn,
@@ -80,6 +80,7 @@ export default React.memo(function FeeThresholdsItemEditor({
           hideErrorsBeforeTouched
         />
       </RowWithMargin>
+      <H4>{i18n.financeBasics.fees.thresholds}</H4>
       <RowWithMargin spacing="XL">
         <FixedSpaceColumn spacing="xxs">
           <Label htmlFor="maxFee">{i18n.financeBasics.fees.maxFee}</Label>
@@ -246,6 +247,45 @@ export default React.memo(function FeeThresholdsItemEditor({
           hideErrorsBeforeTouched
         />
       </ColumnWithMargin>
+      <H4>{i18n.financeBasics.fees.siblingDiscounts}</H4>
+      <RowWithMargin spacing="XL">
+        <FixedSpaceColumn spacing="xxs">
+          <Label htmlFor="siblingDiscount2">
+            {i18n.financeBasics.fees.siblingDiscount2}
+          </Label>
+          <InputField
+            width="s"
+            value={editorState.siblingDiscount2}
+            onChange={(siblingDiscount2) =>
+              setEditorState((previousState) => ({
+                ...previousState,
+                siblingDiscount2
+              }))
+            }
+            symbol={'%'}
+            info={validationErrorInfo('siblingDiscount2')}
+            hideErrorsBeforeTouched
+          />
+        </FixedSpaceColumn>
+        <FixedSpaceColumn spacing="xxs">
+          <Label htmlFor="siblingDiscount2Plus">
+            {i18n.financeBasics.fees.siblingDiscount2Plus}
+          </Label>
+          <InputField
+            width="s"
+            value={editorState.siblingDiscount2Plus}
+            onChange={(siblingDiscount2Plus) =>
+              setEditorState((previousState) => ({
+                ...previousState,
+                siblingDiscount2Plus
+              }))
+            }
+            symbol={'%'}
+            info={validationErrorInfo('siblingDiscount2Plus')}
+            hideErrorsBeforeTouched
+          />
+        </FixedSpaceColumn>
+      </RowWithMargin>
       <ButtonRow>
         <Button text={i18n.common.cancel} onClick={close} />
         <AsyncButton
@@ -311,7 +351,9 @@ const centProps: readonly (keyof FormState)[] = [
   'incomeMultiplier4',
   'incomeMultiplier5',
   'incomeMultiplier6',
-  'incomeThresholdIncrease6Plus'
+  'incomeThresholdIncrease6Plus',
+  'siblingDiscount2',
+  'siblingDiscount2Plus'
 ]
 
 function validateForm(
@@ -394,8 +436,8 @@ function parseFormOrThrow(form: FormState): FeeThresholdsPayload {
     incomeThresholdIncrease6Plus: parseCentsOrThrow(
       form.incomeThresholdIncrease6Plus
     ),
-    siblingDiscount2: 0.5,
-    siblingDiscount2Plus: 0.8
+    siblingDiscount2: parseMultiplier(form.siblingDiscount2),
+    siblingDiscount2Plus: parseMultiplier(form.siblingDiscount2Plus)
   }
 }
 

--- a/frontend/src/employee-frontend/components/finance-basics/FeesSection.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeesSection.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { Loading, Result } from 'lib-common/api'
 import LocalDate from 'lib-common/local-date'
 import { useRestApi } from 'lib-common/utils/useRestApi'
-import { H2, H3 } from 'lib-components/typography'
+import { H2, H3, H4 } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import {
   FixedSpaceColumn,
@@ -100,10 +100,11 @@ const FeeThresholdsItem = React.memo(function FeeThresholdsItem({
   return (
     <>
       <div className="separator large" />
-      <H3 fitted>
+      <H3>
         {i18n.financeBasics.fees.validDuring}{' '}
         {feeThresholds.validDuring.format()}
       </H3>
+      <H4>{i18n.financeBasics.fees.thresholds}</H4>
       <RowWithMargin spacing="XL">
         <FixedSpaceColumn>
           <Label>{i18n.financeBasics.fees.maxFee}</Label>
@@ -166,6 +167,17 @@ const FeeThresholdsItem = React.memo(function FeeThresholdsItem({
           {formatCents(feeThresholds.incomeThresholdIncrease6Plus)} €
         </Indent>
       </ColumnWithMargin>
+      <H4>{i18n.financeBasics.fees.siblingDiscounts}</H4>
+      <RowWithMargin spacing="XL">
+        <FixedSpaceColumn>
+          <Label>{i18n.financeBasics.fees.siblingDiscount2}</Label>
+          <Indent>{feeThresholds.siblingDiscount2 * 100} %</Indent>
+        </FixedSpaceColumn>
+        <FixedSpaceColumn>
+          <Label>{i18n.financeBasics.fees.siblingDiscount2Plus}</Label>
+          <Indent>{feeThresholds.siblingDiscount2Plus * 100} %</Indent>
+        </FixedSpaceColumn>
+      </RowWithMargin>
     </>
   )
 })
@@ -198,10 +210,7 @@ type EditorState =
     }
 
 export type FormState = {
-  [k in keyof Omit<
-    FeeThresholds,
-    'id' | 'validDuring' | 'siblingDiscount2' | 'siblingDiscount2Plus'
-  >]: string
+  [k in keyof Omit<FeeThresholds, 'id' | 'validDuring'>]: string
 } & {
   validFrom: string
   validTo: string
@@ -227,5 +236,7 @@ const emptyForm = (latestEndDate?: LocalDate): FormState => ({
   incomeMultiplier4: '',
   incomeMultiplier5: '',
   incomeMultiplier6: '',
-  incomeThresholdIncrease6Plus: ''
+  incomeThresholdIncrease6Plus: '',
+  siblingDiscount2: '',
+  siblingDiscount2Plus: ''
 })

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2452,6 +2452,7 @@ export const fi = {
     fees: {
       title: 'Asiakasmaksut',
       add: 'Luo uudet asiakasmaksut',
+      thresholds: 'Tulorajat',
       validDuring: 'Asiakasmaksut ajalle',
       familySize: 'Perheen koko',
       minThreshold: 'Vähimmäisbruttotulo €/kk',
@@ -2462,7 +2463,10 @@ export const fi = {
         'Jos perheen koko on suurempi kuin 6, korotetaan maksun määräämisen perusteena olevaa tulorajaa korotussumman verran kustakin seuraavasta perheen alaikäisestä lapsesta.',
       multiplier: 'Maksu %',
       maxFee: 'Enimmäismaksu',
-      minFee: 'Pienin perittävä lapsikohtainen maksu'
+      minFee: 'Pienin perittävä lapsikohtainen maksu',
+      siblingDiscounts: 'Sisaralennukset',
+      siblingDiscount2: 'Alennus% 1. sisarus',
+      siblingDiscount2Plus: 'Alennus% muut sisarukset'
     }
   },
   roles: {

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -117,7 +117,7 @@ enum class Audit(
     FeeDecisionRead("evaka.fee-decision.read"),
     FeeDecisionSearch("evaka.fee-decision.search"),
     FeeDecisionSetType("evaka.fee-decision.set-type"),
-    FinanceBasicsPricingRead("evaka.finance-basics-pricing.read"),
+    FinanceBasicsFeeThresholdsRead("evaka.finance-basics-fee-thresholds.read"),
     FinanceBasicsFeeThresholdsCreate("evaka.finance-basics-fee-thresholds.create"),
     InvalidServiceNeedReportRead("evaka.invalid-service-need-report.read"),
     InvoicesCreate("evaka.invoices.create"),

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 class FinanceBasicsController {
     @GetMapping("/fee-thresholds")
     fun getFeeThresholds(db: Database.Connection, user: AuthenticatedUser): List<FeeThresholdsWithValidity> {
-        Audit.FinanceBasicsPricingRead.log()
+        Audit.FinanceBasicsFeeThresholdsRead.log()
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
 
         return db.read { it.getFeeThresholds().sortedByDescending { it.validDuring.start } }
@@ -35,7 +35,7 @@ class FinanceBasicsController {
         user: AuthenticatedUser,
         @RequestBody body: CreateFeeThresholdsBody
     ) {
-        Audit.FinanceBasicsPricingRead.log()
+        Audit.FinanceBasicsFeeThresholdsCreate.log()
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
 
         validateFeeThresholds(body)

--- a/service/src/main/resources/db/migration/V104__fee_thresholds_constraints.sql
+++ b/service/src/main/resources/db/migration/V104__fee_thresholds_constraints.sql
@@ -1,0 +1,7 @@
+ALTER TABLE fee_thresholds ADD CONSTRAINT fee_thresholds_no_overlap EXCLUDE USING GIST (valid_during WITH &&);
+
+ALTER TABLE fee_thresholds
+    ADD COLUMN created timestamp with time zone NOT NULL DEFAULT now(),
+    ADD COLUMN updated timestamp with time zone NOT NULL DEFAULT now();
+
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON fee_thresholds FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();

--- a/service/src/main/resources/dev-data/espoo-dev-data.sql
+++ b/service/src/main/resources/dev-data/espoo-dev-data.sql
@@ -844,9 +844,10 @@ INSERT INTO public.daycare (id, name, type, care_area_id, phone, url, created, u
     ('e48826f4-5c43-11ea-9908-276394407cbf', 'Hiirisuon kerho, 2-vuotiaiden kerho, ti ja to klo 9-11, 2020-2021', '{CLUB}', '10842fdc-5750-447d-9b6b-50a1ca66864c', 'UNIT_PHONE', 'https://www.espoo.fi/fi-FI/Kasvatus_ja_opetus/Varhaiskasvatus/Avoin_varhaiskasvatus_ja_kerhot/Kerhot/Espoon_keskus/Hiirisuon_kerho', '2020-03-02 05:08:45.385398', '2020-12-16 11:46:51.652556', null, null, '2020-08-13', '2021-06-04', 'UNIT_EMAIL@espoo.fi', null, '', 'd91b0b67-138d-4d93-a0f6-5824bca0510a', null, false, 0, '', '', '', '', 'Pohjoisentie 1', '02970', '', 'PL 97306, 02070 Espoon kaupunki', '(24.7378687,60.3028715)', null, null, null, false, 'MUNICIPAL', 'fi', false, null, null, null, '{1,2,3,4,5}', null, null, null, '[2020-03-01,)');
 
 
-INSERT INTO pricing (id, valid_from, valid_to, multiplier, max_threshold_difference, min_threshold_2, min_threshold_3, min_threshold_4, min_threshold_5, min_threshold_6, threshold_increase_6_plus) VALUES
-    ('51c2ec8a-bc76-40b3-9b5e-abba4042e361', '2000-01-01', '2020-07-31', 0.1070, 269700, 210200, 271300, 308000, 344700, 381300, 14200),
-    ('236e3ee8-a97f-11ea-889d-eb365ac53e7c', '2020-08-01', NULL, 0.1070, 268700, 213600, 275600, 312900, 350200, 387400, 14200);
+INSERT INTO fee_thresholds (id, valid_during, min_income_threshold_2, min_income_threshold_3, min_income_threshold_4, min_income_threshold_5, min_income_threshold_6, max_income_threshold_2, max_income_threshold_3, max_income_threshold_4, max_income_threshold_5, max_income_threshold_6, income_multiplier_2, income_multiplier_3, income_multiplier_4, income_multiplier_5, income_multiplier_6, income_threshold_increase_6_plus, sibling_discount_2, sibling_discount_2_plus, max_fee, min_fee)
+VALUES
+    ('51c2ec8a-bc76-40b3-9b5e-abba4042e361', daterange('2000-01-01', '2020-07-31', '[]'), 210200, 271300, 308000, 344700, 381300, 210200 + 269700, 271300 + 269700, 308000 + 269700, 344700 + 269700, 381300 + 269700, 0.1070, 0.1070, 0.1070, 0.1070, 0.1070, 14200, 0.5, 0.8, 28900, 2700),
+    ('236e3ee8-a97f-11ea-889d-eb365ac53e7c', daterange('2020-08-01', NULL), 213600, 275600, 312900, 350200, 387400, 213600 + 268700, 275600 + 268700, 312900 + 268700, 350200 + 268700, 387400 + 268700, 0.1070, 0.1070, 0.1070, 0.1070, 0.1070, 14200, 0.5, 0.8, 28800, 2700);
 
 INSERT INTO voucher_value (id, validity, voucher_value) VALUES ('084314dc-ed7f-4725-92f2-5c220bb4bb7e', daterange('2000-01-01', NULL, '[]'), 87000);
 

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -101,3 +101,4 @@ V100__child_images.sql
 V101__update_fee_decision_pricing.sql
 V102__service_need_option_display_order.sql
 V103__add_variable_time_to_daily_service_time_type.sql
+V104__fee_thresholds_constraints.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
* Add sibling discounts to fee thresholds editor.
* Insert dev data into `fee_thresholds` table instead of `pricing`.
* Add overlap constraint and `created` & `updated` columns to `fee_thresholds`

