### PR TITLE
EVAKA-HOTFIX Fix failing tests that create preschool applications

### DIFF
--- a/frontend/src/e2e-test-common/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test-common/dev-api/fixtures.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { format } from 'date-fns'
+import { format, getMonth, setMonth } from 'date-fns'
 import config from '../config'
 import {
   Application,
@@ -473,76 +473,88 @@ const applicationForm = (
   otherGuardianAgreementStatus: OtherGuardianAgreementStatus = null,
   preferredUnits: string[] = [daycareFixture.id],
   connectedDaycare = false
-): ApplicationForm => ({
-  type,
-  additionalDetails: {
-    allergyType: '',
-    dietType: '',
-    otherInfo: ''
-  },
-  apply: {
-    preferredUnits: preferredUnits,
-    siblingBasis: false
-  },
-  careDetails: {
-    assistanceNeeded: false
-  },
-  child: {
-    firstName: child.firstName,
-    lastName: child.lastName,
-    socialSecurityNumber: child.ssn,
-    address: {
-      street: child.streetAddress,
-      postalCode: child.postalCode,
-      city: child.postOffice,
-      editable: false
+): ApplicationForm => {
+  // Try to make sure there's an active preschool term for the preferred start date
+  let startDate = new Date()
+  if (
+    type === 'PRESCHOOL' &&
+    // May-Aug
+    [4, 5, 6, 7].includes(getMonth(startDate))
+  ) {
+    // => Sep
+    startDate = setMonth(startDate, 8)
+  }
+  return {
+    type,
+    additionalDetails: {
+      allergyType: '',
+      dietType: '',
+      otherInfo: ''
     },
-    nationality: 'FI',
-    language: 'fi',
-    restricted: false
-  },
-  connectedDaycare: type === 'PRESCHOOL' && connectedDaycare,
-  docVersion: 0,
-  extendedCare: false,
-  guardian: {
-    firstName: guardian.firstName,
-    lastName: guardian.lastName,
-    socialSecurityNumber: guardian.ssn,
-    address: {
-      street: guardian.streetAddress,
-      postalCode: guardian.postalCode,
-      city: guardian.postOffice,
-      editable: false
+    apply: {
+      preferredUnits: preferredUnits,
+      siblingBasis: false
     },
-    phoneNumber: guardian.phone,
-    email: guardian.email,
-    restricted: false
-  },
-  guardian2: {
-    firstName: '',
-    lastName: '',
-    socialSecurityNumber: '',
-    address: {
-      street: '',
-      postalCode: '',
-      city: '',
-      editable: false
+    careDetails: {
+      assistanceNeeded: false
     },
-    phoneNumber: guardian2Phone,
-    email: guardian2Email,
-    restricted: false
-  },
-  hasOtherAdult: false,
-  hasOtherChildren: false,
-  otherAdults: [],
-  otherChildren: [],
-  partTime: false,
-  preferredStartDate: new Date().toISOString(),
-  serviceEnd: '08:00',
-  serviceStart: '16:00',
-  urgent: false,
-  otherGuardianAgreementStatus
-})
+    child: {
+      firstName: child.firstName,
+      lastName: child.lastName,
+      socialSecurityNumber: child.ssn,
+      address: {
+        street: child.streetAddress,
+        postalCode: child.postalCode,
+        city: child.postOffice,
+        editable: false
+      },
+      nationality: 'FI',
+      language: 'fi',
+      restricted: false
+    },
+    connectedDaycare: type === 'PRESCHOOL' && connectedDaycare,
+    docVersion: 0,
+    extendedCare: false,
+    guardian: {
+      firstName: guardian.firstName,
+      lastName: guardian.lastName,
+      socialSecurityNumber: guardian.ssn,
+      address: {
+        street: guardian.streetAddress,
+        postalCode: guardian.postalCode,
+        city: guardian.postOffice,
+        editable: false
+      },
+      phoneNumber: guardian.phone,
+      email: guardian.email,
+      restricted: false
+    },
+    guardian2: {
+      firstName: '',
+      lastName: '',
+      socialSecurityNumber: '',
+      address: {
+        street: '',
+        postalCode: '',
+        city: '',
+        editable: false
+      },
+      phoneNumber: guardian2Phone,
+      email: guardian2Email,
+      restricted: false
+    },
+    hasOtherAdult: false,
+    hasOtherChildren: false,
+    otherAdults: [],
+    otherChildren: [],
+    partTime: false,
+    preferredStartDate: startDate.toISOString(),
+    serviceEnd: '08:00',
+    serviceStart: '16:00',
+    urgent: false,
+    otherGuardianAgreementStatus
+  }
+}
 
 export const applicationFixtureId = '9dd0e1ba-9b3b-11ea-bb37-0242ac130002'
 export const applicationFixture = (

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
@@ -87,7 +87,7 @@ test('Citizen sees her decisions, accepts preschool and rejects preschool daycar
     preschoolDecisionId,
     `${enduserChildFixtureJari.firstName} ${enduserChildFixtureJari.lastName}`,
     'Päätös esiopetuksesta',
-    format(new Date(application.form.preferredStartDate), 'dd.MM.yyyy'),
+    format(new Date(), 'dd.MM.yyyy'),
     'Vahvistettavana huoltajalla'
   )
 
@@ -96,7 +96,7 @@ test('Citizen sees her decisions, accepts preschool and rejects preschool daycar
     preschoolDaycareDecisionId,
     `${enduserChildFixtureJari.firstName} ${enduserChildFixtureJari.lastName}`,
     'Päätös liittyvästä varhaiskasvatuksesta',
-    format(new Date(application.form.preferredStartDate), 'dd.MM.yyyy'),
+    format(new Date(), 'dd.MM.yyyy'),
     'Vahvistettavana huoltajalla'
   )
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
@@ -233,7 +233,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
                 guardian = guardian,
                 appliedType = PlacementType.PRESCHOOL,
                 applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 13)
+                preferredStartDate = LocalDate.of(2021, 8, 11)
             )
         }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.application
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
+import fi.espoo.evaka.application.utils.currentDateInFinland
 import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
@@ -306,7 +307,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
         uploadAttachment(applicationId, endUser, AttachmentType.URGENCY)
         uploadAttachment(applicationId, endUser, AttachmentType.EXTENDED_CARE)
         db.transaction { tx ->
-            stateService.sendApplication(tx, serviceWorker, applicationId)
+            stateService.sendApplication(tx, serviceWorker, applicationId, currentDateInFinland())
             stateService.moveToWaitingPlacement(tx, serviceWorker, applicationId)
             stateService.createPlacementPlan(
                 tx,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.application
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.application.utils.currentDateInFinland
 import fi.espoo.evaka.daycare.getNextPreschoolTerm
 import fi.espoo.evaka.decision.Decision
 import fi.espoo.evaka.decision.DecisionService
@@ -200,7 +201,15 @@ class ApplicationControllerCitizen(
         Audit.ApplicationUpdate.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.END_USER)
 
-        db.transaction { applicationStateService.updateOwnApplicationContentsCitizen(it, user, applicationId, applicationForm) }
+        db.transaction {
+            applicationStateService.updateOwnApplicationContentsCitizen(
+                it,
+                user,
+                applicationId,
+                applicationForm,
+                currentDateInFinland()
+            )
+        }
         return ResponseEntity.noContent().build()
     }
 
@@ -214,7 +223,16 @@ class ApplicationControllerCitizen(
         Audit.ApplicationUpdate.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.END_USER)
 
-        db.transaction { applicationStateService.updateOwnApplicationContentsCitizen(it, user, applicationId, applicationForm, asDraft = true) }
+        db.transaction {
+            applicationStateService.updateOwnApplicationContentsCitizen(
+                it,
+                user,
+                applicationId,
+                applicationForm,
+                currentDateInFinland(),
+                asDraft = true
+            )
+        }
         return ResponseEntity.noContent().build()
     }
 
@@ -246,7 +264,7 @@ class ApplicationControllerCitizen(
         user: AuthenticatedUser,
         @PathVariable applicationId: UUID
     ): ResponseEntity<Unit> {
-        db.transaction { applicationStateService.sendApplication(it, user, applicationId, isEnduser = true) }
+        db.transaction { applicationStateService.sendApplication(it, user, applicationId, currentDateInFinland(), isEnduser = true) }
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.application
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.application.utils.currentDateInFinland
 import fi.espoo.evaka.application.utils.ok
 import fi.espoo.evaka.decision.Decision
 import fi.espoo.evaka.decision.DecisionDraft
@@ -293,7 +294,16 @@ class ApplicationControllerV2(
         Audit.ApplicationUpdate.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
-        db.transaction { applicationStateService.updateApplicationContentsServiceWorker(it, user, applicationId, application, user.id) }
+        db.transaction {
+            applicationStateService.updateApplicationContentsServiceWorker(
+                it,
+                user,
+                applicationId,
+                application,
+                user.id,
+                currentDateInFinland()
+            )
+        }
         return ResponseEntity.noContent().build()
     }
 
@@ -303,7 +313,7 @@ class ApplicationControllerV2(
         user: AuthenticatedUser,
         @PathVariable applicationId: UUID
     ): ResponseEntity<Unit> {
-        db.transaction { applicationStateService.sendApplication(it, user, applicationId) }
+        db.transaction { applicationStateService.sendApplication(it, user, applicationId, currentDateInFinland()) }
         return ResponseEntity.noContent().build()
     }
 


### PR DESCRIPTION
#### Summary

E2E: Try to make sure that an active preschool term exists by moving the preferred start date to September if it's summer currently.

Integration: Change application validation to be parametrized with the current date.