### PR TITLE
Update proxy OS packages on build

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -9,7 +9,10 @@ LABEL maintainer="https://github.com/espoon-voltti/evaka"
 ENV NGINX_ENV=local \
     TZ=UTC
 
+ARG CACHE_BUST=2021-06-07
+
 RUN apk add --no-cache 'ruby=~2.7' \
+ && apk --no-cache upgrade \
  && curl -sSfL https://github.com/espoon-voltti/s3-downloader/releases/download/v1.3.0/s3downloader-linux-amd64 \
        -o /bin/s3download \
  && chmod +x /bin/s3download \


### PR DESCRIPTION
#### Summary

We want to upgrade operating system packages on build so we will fix possible issues before upstream container.

Includes the fixed versions of packages with the following vulnerabilities:

- CVE-2021-3517: HIGH
- CVE-2021-3518: MEDIUM
- CVE-2021-3537: MEDIUM
- CVE-2021-22901: UNDEFINED
- CVE-2021-22898: UNDEFINED