### PR TITLE
Add template provider for customization

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.decision.createDecisionPdf
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.shared.config.PDFConfig
+import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.template.EvakaTemplateProvider
 import fi.espoo.evaka.shared.template.ITemplateProvider
 import fi.espoo.evaka.test.validPreschoolApplication
@@ -148,6 +149,7 @@ class PDFServiceTest {
     private fun createPDF(decision: Decision, isTransferApplication: Boolean, lang: String) {
         val decisionPdfByteArray =
             createDecisionPdf(
+                EvakaMessageProvider(),
                 EvakaTemplateProvider(),
                 pdfService,
                 decision,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
@@ -14,6 +14,8 @@ import fi.espoo.evaka.decision.createDecisionPdf
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.shared.config.PDFConfig
+import fi.espoo.evaka.shared.template.EvakaTemplateProvider
+import fi.espoo.evaka.shared.template.ITemplateProvider
 import fi.espoo.evaka.test.validPreschoolApplication
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1
@@ -23,6 +25,8 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
 import java.io.File
 import java.io.FileOutputStream
 import java.time.LocalDate
@@ -100,9 +104,15 @@ private val guardian = PersonDTO(
 )
 private val manager = DaycareManager("Pirkko Päiväkodinjohtaja", "pirkko.paivakodinjohtaja@example.com", "0401231234")
 
+@TestConfiguration
+class PDFServiceTestConfiguration {
+    @Bean
+    fun templateProvider(): ITemplateProvider = EvakaTemplateProvider()
+}
+
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.NONE,
-    classes = [PDFConfig::class, PDFService::class]
+    classes = [PDFServiceTestConfiguration::class, PDFConfig::class, PDFService::class]
 )
 class PDFServiceTest {
 
@@ -138,6 +148,7 @@ class PDFServiceTest {
     private fun createPDF(decision: Decision, isTransferApplication: Boolean, lang: String) {
         val decisionPdfByteArray =
             createDecisionPdf(
+                EvakaTemplateProvider(),
                 pdfService,
                 decision,
                 guardian,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -23,6 +23,8 @@ import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.dev.runDevScript
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
+import fi.espoo.evaka.shared.template.EvakaTemplateProvider
+import fi.espoo.evaka.shared.template.ITemplateProvider
 import fi.espoo.voltti.auth.JwtKeys
 import fi.espoo.voltti.auth.loadPublicKeys
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig
@@ -159,4 +161,7 @@ class SharedIntegrationTestConfig {
 
     @Bean
     fun messageProvider(): IMessageProvider = EvakaMessageProvider()
+
+    @Bean
+    fun templateProvider(): ITemplateProvider = EvakaTemplateProvider()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
+import fi.espoo.evaka.shared.template.EvakaTemplateProvider
+import fi.espoo.evaka.shared.template.ITemplateProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -25,4 +27,7 @@ class EspooConfig {
 
     @Bean
     fun messageProvider(): IMessageProvider = EvakaMessageProvider()
+
+    @Bean
+    fun templateProvider(): ITemplateProvider = EvakaTemplateProvider()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionAddress.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionAddress.kt
@@ -5,25 +5,27 @@
 package fi.espoo.evaka.decision
 
 import fi.espoo.evaka.pis.service.PersonDTO
+import fi.espoo.evaka.shared.message.IMessageProvider
+import fi.espoo.evaka.shared.message.MessageLanguage
 
 private fun addressIsUnusable(streetAddress: String?, postalCode: String?, postOffice: String?): Boolean {
     return streetAddress.isNullOrBlank() || postalCode.isNullOrBlank() || postOffice.isNullOrBlank()
 }
 
-fun getSendAddress(guardian: PersonDTO, lang: String): DecisionSendAddress {
+fun getSendAddress(messageProvider: IMessageProvider, guardian: PersonDTO, lang: String): DecisionSendAddress {
     val logMissingAddress = {
         logger.warn("Cannot deliver daycare decision to guardian ${guardian.id} with incomplete address. Using default decision address.")
     }
     return when {
         guardian.restrictedDetailsEnabled -> when (lang) {
-            "sv" -> defaultAddressSv
-            else -> defaultAddressFi
+            "sv" -> messageProvider.getDefaultDecisionAddress(MessageLanguage.SV)
+            else -> messageProvider.getDefaultDecisionAddress(MessageLanguage.FI)
         }
         addressIsUnusable(guardian.streetAddress, guardian.postalCode, guardian.postOffice) -> {
             logMissingAddress()
             when (lang) {
-                "sv" -> defaultAddressSv
-                else -> defaultAddressFi
+                "sv" -> messageProvider.getDefaultDecisionAddress(MessageLanguage.SV)
+                else -> messageProvider.getDefaultDecisionAddress(MessageLanguage.FI)
             }
         }
         else -> DecisionSendAddress(
@@ -44,22 +46,4 @@ data class DecisionSendAddress(
     val row1: String,
     val row2: String,
     val row3: String
-)
-
-val defaultAddressFi = DecisionSendAddress(
-    street = "PL 3125",
-    postalCode = "02070",
-    postOffice = "Espoon kaupunki",
-    row1 = "Varhaiskasvatuksen palveluohjaus",
-    row2 = "PL 3125",
-    row3 = "02070 Espoon kaupunki"
-)
-
-val defaultAddressSv = DecisionSendAddress(
-    street = "PB 32",
-    postalCode = "02070",
-    postOffice = "ESBO STAD",
-    row1 = "Svenska bildningstjänster",
-    row2 = "Småbarnspedagogik",
-    row3 = "PB 32, 02070 ESBO STAD"
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -109,6 +109,7 @@ class DecisionService(
         unitManager: DaycareManager
     ): URI {
         val decisionBytes = createDecisionPdf(
+            messageProvider,
             templateProvider,
             pdfService,
             decision,
@@ -219,7 +220,7 @@ class DecisionService(
         }
 
         val lang = tx.getDecisionLanguage(decision.id)
-        val sendAddress = getSendAddress(guardian, lang)
+        val sendAddress = getSendAddress(messageProvider, guardian, lang)
         // SFI expects unique string for each message so document.id is not suitable as it is NOT string and NOT unique
         val uniqueId = "${decision.id}|${guardian.id}"
         val message = SuomiFiMessage(
@@ -284,6 +285,7 @@ class DecisionService(
 }
 
 fun createDecisionPdf(
+    messageProvider: IMessageProvider,
     templateProvider: ITemplateProvider,
     pdfService: PDFService,
     decision: Decision,
@@ -293,7 +295,7 @@ fun createDecisionPdf(
     lang: String,
     unitManager: DaycareManager
 ): ByteArray {
-    val sendAddress = getSendAddress(guardian, lang)
+    val sendAddress = getSendAddress(messageProvider, guardian, lang)
     val template = createTemplate(templateProvider, decision, isTransferApplication)
     val isPartTimeDecision: Boolean = decision.type === DecisionType.DAYCARE_PART_TIME
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/PdfService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/PdfService.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.invoicing.domain.MailAddress
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionDetailed
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.template.ITemplateProvider
 import org.springframework.stereotype.Component
 import org.thymeleaf.ITemplateEngine
 import org.thymeleaf.context.Context
@@ -61,6 +62,7 @@ fun instantFmt(instant: Instant?): String =
 
 @Component
 class PDFService(
+    private val templateProvider: ITemplateProvider,
     private val templateEngine: ITemplateEngine
 ) {
     fun processPage(page: Page): String = templateEngine.process(page.template.value, page.context)
@@ -101,15 +103,15 @@ class PDFService(
     }
 
     fun generateFeeDecisionPdf(data: FeeDecisionPdfData): ByteArray {
-
-        val page = Page(Template("fee-decision/decision"), createFeeDecisionPdfContext(data))
+        val template = Template(templateProvider.getFeeDecisionPath())
+        val page = Page(template, createFeeDecisionPdfContext(data))
 
         return render(page)
     }
 
     fun generateVoucherValueDecisionPdf(data: VoucherValueDecisionPdfData): ByteArray {
-
-        val page = Page(Template("fee-decision/voucher-value-decision"), createVoucherValueDecisionPdfContext(data))
+        val template = Template(templateProvider.getVoucherValueDecisionPath())
+        val page = Page(template, createVoucherValueDecisionPdfContext(data))
 
         return render(page)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageProvider.kt
@@ -4,6 +4,8 @@
 
 package fi.espoo.evaka.shared.message
 
+import fi.espoo.evaka.decision.DecisionSendAddress
+
 class EvakaMessageProvider() : IMessageProvider {
 
     override fun getDecisionHeader(lang: MessageLanguage): String = when (lang) {
@@ -70,5 +72,24 @@ Klientavgifterna för kommunal småbarnspedagogik varierar enligt familjens stor
 
 Klientavgiften för småbarnspedagogik gäller tills vidare och familjen är skyldig att meddela om familjens inkomster väsentligt förändras (+/- 10 %). Eftersom du har tagit Suomi.fi-tjänsten i bruk, kan du läsa beslutet i bilagorna nedan.
 """
+    }
+
+    override fun getDefaultDecisionAddress(lang: MessageLanguage): DecisionSendAddress = when (lang) {
+        MessageLanguage.FI -> DecisionSendAddress(
+            street = "PL 3125",
+            postalCode = "02070",
+            postOffice = "Espoon kaupunki",
+            row1 = "Varhaiskasvatuksen palveluohjaus",
+            row2 = "PL 3125",
+            row3 = "02070 Espoon kaupunki"
+        )
+        MessageLanguage.SV -> DecisionSendAddress(
+            street = "PB 32",
+            postalCode = "02070",
+            postOffice = "ESBO STAD",
+            row1 = "Svenska bildningstjänster",
+            row2 = "Småbarnspedagogik",
+            row3 = "PB 32, 02070 ESBO STAD"
+        )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/message/MessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/message/MessageProvider.kt
@@ -4,6 +4,8 @@
 
 package fi.espoo.evaka.shared.message
 
+import fi.espoo.evaka.decision.DecisionSendAddress
+
 interface IMessageProvider {
     fun getDecisionHeader(lang: MessageLanguage): String
     fun getDecisionContent(lang: MessageLanguage): String
@@ -11,6 +13,11 @@ interface IMessageProvider {
     fun getFeeDecisionContent(lang: MessageLanguage): String
     fun getVoucherValueDecisionHeader(lang: MessageLanguage): String
     fun getVoucherValueDecisionContent(lang: MessageLanguage): String
+
+    /**
+     * Returns address used for decisions when person has restricted details enabled or missing address.
+     */
+    fun getDefaultDecisionAddress(lang: MessageLanguage): DecisionSendAddress
 }
 
 enum class MessageLanguage {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/template/EvakaTemplateProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/template/EvakaTemplateProvider.kt
@@ -1,0 +1,12 @@
+package fi.espoo.evaka.shared.template
+
+class EvakaTemplateProvider : ITemplateProvider {
+    override fun getFeeDecisionPath(): String = "fee-decision/decision"
+    override fun getVoucherValueDecisionPath(): String = "fee-decision/voucher-value-decision"
+    override fun getClubDecisionPath(): String = "club/decision"
+    override fun getDaycareVoucherDecisionPath(): String = "daycare/voucher/decision"
+    override fun getDaycareTransferDecisionPath(): String = "daycare/transfer/decision"
+    override fun getDaycareDecisionPath(): String = "daycare/decision"
+    override fun getPreschoolDecisionPath(): String = "preschool/decision"
+    override fun getPreparatoryDecisionPath(): String = "preparatory/decision"
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/template/ITemplateProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/template/ITemplateProvider.kt
@@ -1,0 +1,12 @@
+package fi.espoo.evaka.shared.template
+
+interface ITemplateProvider {
+    fun getFeeDecisionPath(): String
+    fun getVoucherValueDecisionPath(): String
+    fun getClubDecisionPath(): String
+    fun getDaycareVoucherDecisionPath(): String
+    fun getDaycareTransferDecisionPath(): String
+    fun getDaycareDecisionPath(): String
+    fun getPreschoolDecisionPath(): String
+    fun getPreparatoryDecisionPath(): String
+}

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/service/PdfServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/service/PdfServiceTest.kt
@@ -21,6 +21,7 @@ import fi.espoo.evaka.invoicing.testDecision1
 import fi.espoo.evaka.invoicing.testDecisionIncome
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.config.PDFConfig
+import fi.espoo.evaka.shared.template.EvakaTemplateProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
@@ -30,7 +31,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class PdfServiceTest {
-    private val service: PDFService = PDFService(PDFConfig.templateEngine())
+    private val service: PDFService = PDFService(EvakaTemplateProvider(), PDFConfig.templateEngine())
 
     val testPricing: FeeThresholds = fi.espoo.evaka.invoicing.testPricing.withoutDates()
 


### PR DESCRIPTION
#### Summary

Refactor PDF templates to support customization.

Also moves hard-coded default address used for decisions into message provider.
