### PR TITLE
Add daily job scheduler

### DIFF
--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -20,6 +20,7 @@ javaPlatform {
 dependencies {
     constraints {
         api("com.auth0:java-jwt:3.16.0")
+        api("com.github.kagkarlsson:db-scheduler:10.3")
         api("com.github.kittinunf.fuel:fuel:${Version.fuel}")
         api("com.github.kittinunf.fuel:fuel-jackson:${Version.fuel}")
         api("com.google.guava:guava:30.1.1-jre")

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -119,6 +119,7 @@ dependencies {
     implementation("org.xhtmlrenderer:flying-saucer-pdf-openpdf")
 
     // Miscellaneous
+    implementation("com.github.kagkarlsson:db-scheduler")
     implementation("com.auth0:java-jwt")
     implementation("javax.annotation:javax.annotation-api")
     implementation("org.apache.commons:commons-pool2")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
@@ -8,9 +8,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
-import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.RunDailyJob
-import fi.espoo.evaka.shared.daily.DailyJob
+import fi.espoo.evaka.shared.daily.DailyJobs
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
@@ -31,7 +29,7 @@ import java.util.UUID
 
 class AttendanceUpkeepIntegrationTest : FullApplicationTest() {
     @Autowired
-    private lateinit var asyncJobRunner: AsyncJobRunner
+    private lateinit var dailyJobs: DailyJobs
 
     private val groupId = UUID.randomUUID()
     private val daycarePlacementId = UUID.randomUUID()
@@ -78,10 +76,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest() {
             )
         }
 
-        db.transaction { tx ->
-            asyncJobRunner.plan(tx, listOf(RunDailyJob(DailyJob.EndOfDayAttendanceUpkeep)))
-        }
-        asyncJobRunner.runPendingJobsSync()
+        dailyJobs.endOfDayAttendanceUpkeep(db)
 
         val attendances = db.read {
             it.createQuery(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/daily/DailyJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/daily/DailyJobRunnerTest.kt
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.daily
+
+import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.application.utils.helsinkiZone
+import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.config.getTestDataSource
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalTime
+import java.util.concurrent.atomic.AtomicReference
+
+class DailyJobRunnerTest : PureJdbiTest() {
+    private lateinit var asyncJobRunner: AsyncJobRunner
+    private val testTime = LocalTime.of(1, 0)
+    private val testSchedule = object : DailySchedule {
+        override fun getTimeForJob(job: DailyJob): LocalTime? = if (job == DailyJob.EndOfDayAttendanceUpkeep) {
+            testTime
+        } else null
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        db.transaction { it.resetDatabase() }
+        asyncJobRunner = AsyncJobRunner(jdbi, syncMode = true)
+    }
+
+    @Test
+    fun `a job specified by DailySchedule is scheduled and executed correctly`() {
+        DailyJobRunner(jdbi, asyncJobRunner, getTestDataSource(), testSchedule).use { runner ->
+            runner.scheduler.start()
+            val exec = runner.getScheduledExecutionsForTask(DailyJob.EndOfDayAttendanceUpkeep).singleOrNull()!!
+            assertEquals(exec.executionTime.atZone(helsinkiZone).toLocalTime(), testTime)
+
+            runner.scheduler.reschedule(exec.taskInstance, Instant.EPOCH)
+            runner.scheduler.triggerCheckForDueExecutions()
+
+            val start = Instant.now()
+            while (asyncJobRunner.getPendingJobCount() == 0) {
+                Thread.sleep(100)
+
+                assert(Duration.between(start, Instant.now()) < Duration.ofSeconds(10))
+            }
+        }
+
+        val executedJob = AtomicReference<DailyJob?>(null)
+        asyncJobRunner.runDailyJob = { _, msg ->
+            val previous = executedJob.getAndSet(msg.dailyJob)
+            assertNull(previous)
+        }
+        asyncJobRunner.runPendingJobsSync()
+        assertEquals(executedJob.get(), DailyJob.EndOfDayAttendanceUpkeep)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -6,6 +6,8 @@ package fi.espoo.evaka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
+import fi.espoo.evaka.shared.daily.DailySchedule
+import fi.espoo.evaka.shared.daily.DefaultDailySchedule
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
 import fi.espoo.evaka.shared.template.EvakaTemplateProvider
@@ -30,4 +32,7 @@ class EspooConfig {
 
     @Bean
     fun templateProvider(): ITemplateProvider = EvakaTemplateProvider()
+
+    @Bean
+    fun dailySchedule(): DailySchedule = DefaultDailySchedule()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.koski.KoskiSearchParams
 import fi.espoo.evaka.koski.KoskiStudyRightKey
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.daily.DailyJob
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.time.Duration
 import java.time.LocalDate
@@ -35,7 +36,8 @@ enum class AsyncJobType {
     GARBAGE_COLLECT_PAIRING,
     VARDA_UPDATE,
     SEND_PENDING_DECISION_EMAIL,
-    SEND_UNREAD_MESSAGE_NOTIFICATION
+    SEND_UNREAD_MESSAGE_NOTIFICATION,
+    RUN_DAILY_JOB
 }
 
 interface AsyncJobPayload {
@@ -156,6 +158,11 @@ data class VTJRefresh(val personId: UUID, val requestingUserId: UUID) : AsyncJob
 
 class VardaUpdate : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.VARDA_UPDATE
+    override val user: AuthenticatedUser? = null
+}
+
+data class RunDailyJob(val dailyJob: DailyJob) : AsyncJobPayload {
+    override val asyncJobType = AsyncJobType.RUN_DAILY_JOB
     override val user: AuthenticatedUser? = null
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -101,6 +101,9 @@ class AsyncJobRunner(
     @Volatile
     var sendMessageNotificationEmail: (db: Database, msg: SendMessageNotificationEmail) -> Unit = noHandler
 
+    @Volatile
+    var runDailyJob: (db: Database, msg: RunDailyJob) -> Unit = noHandler
+
     fun plan(
         tx: Database.Transaction,
         payloads: Iterable<AsyncJobPayload>,
@@ -217,6 +220,7 @@ class AsyncJobRunner(
                     AsyncJobType.SCHEDULE_KOSKI_UPLOADS -> it.runJob(job, this.scheduleKoskiUploads)
                     AsyncJobType.SEND_PENDING_DECISION_EMAIL -> it.runJob(job, this.sendPendingDecisionEmail)
                     AsyncJobType.SEND_UNREAD_MESSAGE_NOTIFICATION -> it.runJob(job, this.sendMessageNotificationEmail)
+                    AsyncJobType.RUN_DAILY_JOB -> it.runJob(job, this.runDailyJob)
                 }.exhaust()
             }
             if (completed) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/DailyJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/DailyJobConfig.kt
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.config
+
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.daily.DailyJobRunner
+import fi.espoo.evaka.shared.daily.DailySchedule
+import org.jdbi.v3.core.Jdbi
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.context.event.EventListener
+import javax.sql.DataSource
+
+@Configuration
+@Profile("production")
+class DailyJobConfig {
+    @Bean
+    fun dailyJobRunner(
+        jdbi: Jdbi,
+        asyncJobRunner: AsyncJobRunner,
+        dataSource: DataSource,
+        schedule: DailySchedule
+    ) = DailyJobRunner(jdbi, asyncJobRunner, dataSource, schedule)
+
+    @Bean
+    fun dailyJobRunnerStart(runner: DailyJobRunner) = object {
+        @EventListener
+        fun onApplicationReady(@Suppress("UNUSED_PARAMETER") event: ApplicationReadyEvent) {
+            runner.scheduler.start()
+        }
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledOperationController.kt
@@ -97,16 +97,7 @@ class ScheduledOperationController(
 
     @PostMapping("/attendance-upkeep")
     fun endOfDayAttendanceUpkeep(db: Database.Connection): ResponseEntity<Unit> {
-        db.transaction {
-            it.createUpdate(
-                // language=SQL
-                """
-                    UPDATE child_attendance ca
-                    SET departed = ((arrived AT TIME ZONE 'Europe/Helsinki')::date + time '23:59') AT TIME ZONE 'Europe/Helsinki'
-                    WHERE departed IS NULL
-                """.trimIndent()
-            ).execute()
-        }
+        // executed by DailyJobRunner instead
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/daily/DailyJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/daily/DailyJobRunner.kt
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.daily
+
+import com.github.kagkarlsson.scheduler.ScheduledExecution
+import com.github.kagkarlsson.scheduler.Scheduler
+import com.github.kagkarlsson.scheduler.task.helper.Tasks
+import com.github.kagkarlsson.scheduler.task.schedule.Daily
+import fi.espoo.evaka.application.utils.helsinkiZone
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.async.RunDailyJob
+import fi.espoo.evaka.shared.db.Database
+import org.jdbi.v3.core.Jdbi
+import java.time.Duration
+import javax.sql.DataSource
+
+private const val SCHEDULER_THREADS = 1
+private const val ASYNC_JOB_RETRY_COUNT = 12
+private val POLLING_INTERVAL = Duration.ofMinutes(1)
+
+class DailyJobRunner(
+    private val jdbi: Jdbi,
+    private val asyncJobRunner: AsyncJobRunner,
+    dataSource: DataSource,
+    schedule: DailySchedule
+) : AutoCloseable {
+    val scheduler = Scheduler.create(dataSource)
+        .startTasks(
+            DailyJob.values()
+                .mapNotNull { job -> schedule.getTimeForJob(job)?.let { Pair(job, it) } }
+                .map { (job, time) ->
+                    Tasks.recurring(job.name, Daily(helsinkiZone, time)).execute { _, _ ->
+                        Database(jdbi).connect { this.planAsyncJob(it, job) }
+                    }
+                }
+        )
+        .threads(SCHEDULER_THREADS)
+        .pollingInterval(POLLING_INTERVAL)
+        .build()
+
+    private fun planAsyncJob(db: Database.Connection, job: DailyJob) {
+        db.transaction { tx ->
+            asyncJobRunner.plan(tx, listOf(RunDailyJob(job)), retryCount = ASYNC_JOB_RETRY_COUNT)
+        }
+        asyncJobRunner.scheduleImmediateRun()
+    }
+
+    fun getScheduledExecutionsForTask(job: DailyJob): List<ScheduledExecution<Unit>> =
+        scheduler.getScheduledExecutionsForTask(job.name, Unit::class.java)
+
+    override fun close() = scheduler.stop()
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/daily/DailyJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/daily/DailyJobs.kt
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.daily
+
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.db.Database
+import org.springframework.stereotype.Component
+
+enum class DailyJob(val fn: (DailyJobs, Database.Connection) -> Unit) {
+    EndOfDayAttendanceUpkeep(DailyJobs::endOfDayAttendanceUpkeep),
+}
+
+@Component
+class DailyJobs(asyncJobRunner: AsyncJobRunner) {
+    init {
+        asyncJobRunner.runDailyJob = { db, msg ->
+            db.connect { msg.dailyJob.fn(this, it) }
+        }
+    }
+
+    fun endOfDayAttendanceUpkeep(db: Database.Connection) {
+        db.transaction {
+            it.createUpdate(
+                // language=SQL
+                """
+                    UPDATE child_attendance ca
+                    SET departed = ((arrived AT TIME ZONE 'Europe/Helsinki')::date + time '23:59') AT TIME ZONE 'Europe/Helsinki'
+                    WHERE departed IS NULL
+                """.trimIndent()
+            ).execute()
+        }
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/daily/DailySchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/daily/DailySchedule.kt
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.daily
+
+import java.time.LocalTime
+
+interface DailySchedule {
+    fun getTimeForJob(job: DailyJob): LocalTime?
+}
+
+class DefaultDailySchedule : DailySchedule {
+    override fun getTimeForJob(job: DailyJob): LocalTime? = when (job) {
+        DailyJob.EndOfDayAttendanceUpkeep -> LocalTime.of(0, 0)
+    }
+}

--- a/service/src/main/resources/db/migration/V107__scheduled_tasks.sql
+++ b/service/src/main/resources/db/migration/V107__scheduled_tasks.sql
@@ -1,0 +1,14 @@
+CREATE TABLE scheduled_tasks (
+  task_name text NOT NULL,
+  task_instance text NOT NULL,
+  task_data bytea,
+  execution_time timestamp with time zone NOT NULL,
+  picked boolean NOT NULL,
+  picked_by text,
+  last_success timestamp with time zone,
+  last_failure timestamp with time zone,
+  consecutive_failures int,
+  last_heartbeat timestamp with time zone,
+  version bigint NOT NULL,
+  PRIMARY KEY (task_name, task_instance)
+);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -104,3 +104,4 @@ V103__add_variable_time_to_daily_service_time_type.sql
 V104__fee_thresholds_constraints.sql
 V105__new_fee_decision_fixes.sql
 V106__create_varda_organizer_child.sql
+V107__scheduled_tasks.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- add daily job scheduler based on the `db-scheduler` library
- tasks executed by the daily job scheduler only plan a corresponding async job. All actual work happens in the async job executed by AsyncJobRunner
- switch endOfDayAttendanceUpkeep to use the new daily job scheduler