### PR TITLE
Speed up freetext searches

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PersonQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PersonQueriesIntegrationTest.kt
@@ -199,6 +199,14 @@ class PersonQueriesIntegrationTest : PureJdbiTest() {
     }
 
     @Test
+    fun `person can be found by first name when it contains umlauts`() {
+        val created = db.transaction { createVtjPerson(it) }
+        val persons = db.read { it.searchPeople(adminUser, "Yrjö", "last_name", "ASC") }
+
+        Assertions.assertEquals(persons[0].firstName, created.firstName)
+    }
+
+    @Test
     fun `unit supervisor cannot find a child without acl access`() {
         db.transaction { createVtjPerson(it) }
         val persons = db.read { it.searchPeople(AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.UNIT_SUPERVISOR)), "Matti", "last_name", "ASC") }
@@ -317,7 +325,7 @@ class PersonQueriesIntegrationTest : PureJdbiTest() {
             customerId = 0L,
             identity = ExternalIdentifier.SSN.getInstance(validSSN),
             dateOfBirth = getDobFromSsn(validSSN),
-            firstName = "Matti Pekka Jari-Ville",
+            firstName = "Matti Yrjö Jari-Ville",
             lastName = "O'Brien",
             email = null,
             phone = null,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
@@ -209,7 +209,7 @@ fun Database.Read.searchValueDecisions(
         "financeDecisionHandlerId" to financeDecisionHandlerId
     )
 
-    val (freeTextQuery, freeTextParams) = freeTextSearchQuery(listOf("head", "partner", "child"), searchTerms)
+    val (freeTextQuery, freeTextParams) = freeTextSearchQuery(listOf("head", "child"), searchTerms)
 
     val conditions = listOfNotNull(
         if (areas.isNotEmpty()) "area.short_name = ANY(:areas)" else null,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
@@ -209,7 +209,7 @@ fun Database.Read.searchValueDecisions(
         "financeDecisionHandlerId" to financeDecisionHandlerId
     )
 
-    val (freeTextQuery, freeTextParams) = freeTextSearchQuery(listOf("head", "child"), searchTerms)
+    val (freeTextQuery, freeTextParams) = freeTextSearchQuery(listOf("head", "partner", "child"), searchTerms)
 
     val conditions = listOfNotNull(
         if (areas.isNotEmpty()) "area.short_name = ANY(:areas)" else null,
@@ -247,6 +247,7 @@ SELECT
 FROM voucher_value_decision AS decision
 LEFT JOIN person AS head ON decision.head_of_family_id = head.id
 LEFT JOIN person AS child ON decision.child_id = child.id
+LEFT JOIN person AS partner ON decision.partner_id = partner.id
 LEFT JOIN daycare AS placement_unit ON placement_unit.id = decision.placement_unit_id
 LEFT JOIN care_area AS area ON placement_unit.care_area_id = area.id
 WHERE

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonQueries.kt
@@ -69,7 +69,31 @@ fun Database.Read.searchPeople(user: AuthenticatedUser, searchTerms: String, sor
 
     // language=SQL
     val sql = """
-        SELECT DISTINCT person.*
+        SELECT DISTINCT
+            id,
+            customer_id,
+            social_security_number,
+            first_name,
+            last_name,
+            email,
+            phone,
+            backup_phone,
+            language,
+            date_of_birth,
+            date_of_death,
+            nationalities,
+            restricted_details_enabled,
+            restricted_details_end_date,
+            street_address,
+            postal_code,
+            post_office,
+            residence_code,
+            updated_from_vtj,
+            invoice_recipient_name,
+            invoicing_street_address,
+            invoicing_postal_code,
+            invoicing_post_office,
+            force_manual_fee_decisions
         FROM person
         ${if (scopedRole) "JOIN child_acl_view acl ON acl.child_id = person.id AND acl.employee_id = :userId" else ""}
         WHERE $freeTextQuery

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Search.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Search.kt
@@ -21,7 +21,7 @@ fun freeTextSearchQuery(tables: List<String>, searchText: String): DBQuery {
     val freeTextString = searchText.let(removeSsnParams).let(removeDateParams)
 
     val freeTextQuery =
-        if (freeTextString.isNotBlank()) freeTextQuery(tables, freeTextParamName)
+        if (freeTextString.isNotBlank()) freeTextComputedColumnQuery(tables, freeTextParamName)
         else null
 
     val ssnQuery =
@@ -77,6 +77,10 @@ private fun freeTextQuery(tables: List<String>, param: String, columns: List<Str
     val tsQuery = "to_tsquery('simple', :$param)"
 
     return "($tsVector @@ $tsQuery)"
+}
+
+private fun freeTextComputedColumnQuery(tables: List<String>, param: String): String {
+    return "(" + tables.joinToString(" OR ") { table -> "$table.freetext_vec @@ to_tsquery('simple', :$param)" } + ")"
 }
 
 private fun findSsnParams(str: String) = splitSearchText(str).filter(SSN_PATTERN.toRegex()::matches)

--- a/service/src/main/resources/db/migration/V108__person_freetext_search.sql
+++ b/service/src/main/resources/db/migration/V108__person_freetext_search.sql
@@ -1,0 +1,14 @@
+create text search configuration unaccent (copy = pg_catalog.simple);
+
+-- Remove accents from words
+alter text search configuration unaccent
+    alter mapping for hword, hword_part, word with unaccent, simple;
+
+alter table person add column freetext_vec tsvector generated always as (
+    to_tsvector('unaccent', coalesce(first_name, '')) ||
+    to_tsvector('unaccent', coalesce(last_name, '')) ||
+    to_tsvector('unaccent', street_address) ||
+    to_tsvector('unaccent', postal_code)
+) stored;
+
+create index person_freetext on person using gin(freetext_vec);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -105,3 +105,4 @@ V104__fee_thresholds_constraints.sql
 V105__new_fee_decision_fixes.sql
 V106__create_varda_organizer_child.sql
 V107__scheduled_tasks.sql
+V108__person_freetext_search.sql


### PR DESCRIPTION
#### Summary

Precompute the tsvector used for person free text search search using a generated column `freetext_vec`, and index that column. Use the new column for person, application, invoice, fee decision and voucher value decision searches.

With a set of 100,000 generated persons, this change speeds up the person search request from 300-400 ms to about 50-80 ms on my machine (~75-85 % faster). I didn't test the the performance effect for other search endpoints, because they would have needed much more complicated test data.

This also fixes the value decision free text search that was broken. Add some simple regression tests for it, too.

