### PR TITLE
EVAKA-FIX: add missing varda unit type

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUnits.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUnits.kt
@@ -119,7 +119,8 @@ enum class VardaUnitType(val vardaCode: String) {
     PRESCHOOL("tm01"),
     PREPARATORY_EDUCATION(""),
     FAMILY("tm02"),
-    GROUP_FAMILY("tm03")
+    GROUP_FAMILY("tm03"),
+    CLUB("")
 }
 
 //  https://virkailija.opintopolku.fi/koodisto-service/rest/json/kieli/koodi


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Add CLUB to Varda unit types to avoid `UnableToProduceResultException: no VardaUnitType value could be matched to the name CLUB`