### PR TITLE
CI: Add shell script linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ aliases:
   # Version of remote Docker engine used with setup_remote_docker (not including machine executors)
   - &remote_docker_version "19.03.13"
   - &yarn_version '1.22.\*'
+  - &shellcheck_image_version v0.7.2
   - &nodejs_image cimg/node:14.15
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202010-01
@@ -159,6 +160,17 @@ executors:
     machine:
       image: *ubuntu_machine_image
       resource_class: large
+  shellcheck:
+    parameters:
+      shellcheck_image_version:
+        type: string
+        default: *shellcheck_image_version
+    docker:
+      - image: koalaman/shellcheck-alpine:<< parameters.shellcheck_image_version >>
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    working_directory: *workspace_root
 
 commands:
   attach_root_workspace:
@@ -570,6 +582,19 @@ jobs:
             - evaka-infra
       - notify_slack
 
+  lint_scripts:
+    executor: shellcheck
+    steps:
+      - *restore_repo
+      - run:
+          name: Install dependencies
+          command: apk add curl jq git
+      - run:
+          name: Lint shell scripts
+          command: |
+            ./bin/run-shellcheck.sh
+      - notify_slack
+
   # BUILD JOBS
 
   build_base_image:
@@ -975,6 +1000,10 @@ workflows:
           <<: *aws_contexts
           requires:
             - checkout_repo
+      - lint_scripts:
+          <<: *default_contexts
+          requires:
+            - checkout_repo
       - build_base_image:
           <<: *default_contexts
           requires:
@@ -1088,6 +1117,7 @@ workflows:
       - clone_infra_repo:
           <<: *aws_contexts
           requires:
+            - lint_scripts
             - e2e-test-citizen
             - e2e-test-invoicing
             - e2e-test-employee

--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ usage: reuse addheader [-h] [--copyright COPYRIGHT] [--license LICENSE]
 reuse addheader: error: 'frontend/packages/employee-frontend/src/components/voucher-value-decision/VoucherValueDecisionActionBar.tsx' does not have a recognised file extension, please use --style, --explicit-license or --skip-unrecognised
 ```
 
+### Linting shell scripts
+
+CI does this automatically but you can manually lint all the shell scripts in
+this repo with: `./bin/run-shellcheck.sh`. See [shellcheck](https://github.com/koalaman/shellcheck)
+for more details on the linter.
+
 ## Contact information
 
 eVaka is developed in the [City of Espoo](https://www.espoo.fi), Finland.

--- a/apigw/entrypoint.sh
+++ b/apigw/entrypoint.sh
@@ -6,9 +6,9 @@
 
 set -euo pipefail
 
-# For log tagging (allow for local fallback)
-HOST_IP=$(curl --fail -s http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
-export HOST_IP
+# For log tagging (with a default value and error logging without crashing)
+# shellcheck disable=SC2155
+export HOST_IP=$(curl --silent --fail --show-error http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
 
 # Download deployment specific files from S3 if in a non-local environment
 if [ "${VOLTTI_ENV:-X}" != "local" ]; then

--- a/apigw/entrypoint.sh
+++ b/apigw/entrypoint.sh
@@ -7,7 +7,8 @@
 set -euo pipefail
 
 # For log tagging (allow for local fallback)
-export HOST_IP=$(curl --fail -s http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
+HOST_IP=$(curl --fail -s http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
+export HOST_IP
 
 # Download deployment specific files from S3 if in a non-local environment
 if [ "${VOLTTI_ENV:-X}" != "local" ]; then

--- a/bin/run-shellcheck.sh
+++ b/bin/run-shellcheck.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Run shellcheck for scripts
+#
+# Usage: ./run-shellcheck.sh [path_to_shellcheck_binary]
+
+set -eu
+
+DEBUG=${DEBUG:-false}
+if [ "$DEBUG" = "true" ]; then
+  set -x
+fi
+
+# In CI, the bin can be in a different location
+SHELLCHECK_BIN="${1:-shellcheck}"
+
+git ls-files "*.sh" "*.bash" | xargs "$SHELLCHECK_BIN" --external-sources

--- a/compose/run-after-db.sh
+++ b/compose/run-after-db.sh
@@ -11,4 +11,4 @@ until nc -z "localhost" "5432"; do
   sleep 1
 done
 
-exec $*
+exec "$@"

--- a/frontend/init-pro-icons.sh
+++ b/frontend/init-pro-icons.sh
@@ -4,6 +4,4 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-VERSION=5.14.0
-
 aws --profile voltti-local s3 sync s3://evaka-deployment-local/frontend/vendor/fortawesome/ ./vendor/fortawesome/

--- a/message-service/entrypoint.sh
+++ b/message-service/entrypoint.sh
@@ -6,9 +6,9 @@
 
 set -euo pipefail
 
-# For logback tagging (allow for local fallback)
-HOST_IP=$(curl --fail -s http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
-export HOST_IP
+# For log tagging (with a default value and error logging without crashing)
+# shellcheck disable=SC2155
+export HOST_IP=$(curl --silent --fail --show-error http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
 
 # Download deployment specific files from S3 if in a non-local environment
 if [ "${VOLTTI_ENV:-X}" != "local" ]; then

--- a/message-service/entrypoint.sh
+++ b/message-service/entrypoint.sh
@@ -7,7 +7,8 @@
 set -euo pipefail
 
 # For logback tagging (allow for local fallback)
-export HOST_IP=$(wget -qO- http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
+HOST_IP=$(curl --fail -s http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
+export HOST_IP
 
 # Download deployment specific files from S3 if in a non-local environment
 if [ "${VOLTTI_ENV:-X}" != "local" ]; then

--- a/message-service/entrypoint.sh
+++ b/message-service/entrypoint.sh
@@ -17,4 +17,5 @@ fi
 
 # Run as exec so the application can receive any Unix signals sent to the container, e.g.,
 # Ctrl + C.
+# shellcheck disable=SC2086
 exec java -cp . -server $JAVA_OPTS org.springframework.boot.loader.JarLauncher "$@"

--- a/proxy/files/bin/proxy-start.sh
+++ b/proxy/files/bin/proxy-start.sh
@@ -4,10 +4,9 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-# For log tagging (allow for local fallback)
-
-HOST_IP=$(wget -qO- http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
-export HOST_IP
+# For log tagging (with a default value and error logging without crashing)
+# shellcheck disable=SC2155
+export HOST_IP=$(curl --silent --fail --show-error http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
 
 if [ "${STATIC_FILES_ENDPOINT_URL:-X}" = 'X' ]; then
   echo 'ERROR: STATIC_FILES_ENDPOINT_URL must be a non-empty string!'

--- a/service/entrypoint.sh
+++ b/service/entrypoint.sh
@@ -6,9 +6,9 @@
 
 set -euo pipefail
 
-# For logback tagging (allow for local fallback)
-HOST_IP=$(curl --fail -s http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
-export HOST_IP
+# For log tagging (with a default value and error logging without crashing)
+# shellcheck disable=SC2155
+export HOST_IP=$(curl --silent --fail --show-error http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
 
 # Download deployment specific files from S3 if in a non-local environment
 if [ "${VOLTTI_ENV:-X}" != "local" ]; then

--- a/service/entrypoint.sh
+++ b/service/entrypoint.sh
@@ -7,7 +7,8 @@
 set -euo pipefail
 
 # For logback tagging (allow for local fallback)
-export HOST_IP=$(wget -qO- http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
+HOST_IP=$(curl --fail -s http://169.254.169.254/latest/meta-data/local-ipv4 || printf 'UNAVAILABLE')
+export HOST_IP
 
 # Download deployment specific files from S3 if in a non-local environment
 if [ "${VOLTTI_ENV:-X}" != "local" ]; then

--- a/service/entrypoint.sh
+++ b/service/entrypoint.sh
@@ -17,4 +17,5 @@ fi
 
 # Run as exec so the application can receive any Unix signals sent to the container, e.g.,
 # Ctrl + C.
+# shellcheck disable=SC2086
 exec java -cp . -server $JAVA_OPTS org.springframework.boot.loader.JarLauncher "$@"


### PR DESCRIPTION
#### Summary
- CI: add shell script linting with shellcheck
   - Lint all shell scripts with the excellent shellcheck tool to avoid the most common mistakes (variable expansion, incorrect whitespace, unused variables etc)
   - Fix minor issues in existing scripts found by the new script
   - Ran in parallel to multiple slower jobs -> no increase in total workflow time
- Improve AWS metadata error logging in all image entrypoints
   - Don't suppress error messages from `curl` when fetching host IP from AWS metadata during image startups, while still falling back to a default value
   - Also ignore SC2155: we already handle the error case with the fallback value "UNAVAILABLE" and output error messages from `curl` to stderr (without crashing as that's not desirable here)
- Fix minor existing issues with all the shell scripts