### PR TITLE
Indicate no message account access

### DIFF
--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -64,6 +64,10 @@ const AccountHeader = styled.div`
   font-weight: 600;
 `
 
+const NoAccounts = styled.div`
+  padding: ${defaultMargins.s};
+`
+
 const UnitSelection = styled.div`
   padding: 0 ${defaultMargins.s};
 `
@@ -138,6 +142,10 @@ function Accounts({ accounts, setSelectedReceivers }: AccountsParams) {
 
   return (
     <>
+      {accounts.length === 0 && (
+        <NoAccounts>{i18n.messages.sidePanel.noAccountAccess}</NoAccounts>
+      )}
+
       {personalAccount && (
         <AccountSection>
           <AccountHeader>{i18n.messages.sidePanel.ownMessages}</AccountHeader>
@@ -196,6 +204,7 @@ export default React.memo(function Sidebar({
     MessageContext
   )
 
+  const newMessageEnabled = accounts.isSuccess && accounts.value.length > 0
   return (
     <Container>
       <AccountContainer>
@@ -229,6 +238,7 @@ export default React.memo(function Sidebar({
       <ButtonContainer>
         <Button
           primary
+          disabled={!newMessageEnabled}
           text={i18n.messages.messageBoxes.newMessage}
           onClick={showEditor}
           data-qa="new-message-btn"

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2392,7 +2392,8 @@ export const fi = {
     },
     sidePanel: {
       ownMessages: 'Omat viestit',
-      groupsMessages: 'Ryhmien viestit'
+      groupsMessages: 'Ryhmien viestit',
+      noAccountAccess: 'Sinulla ei ole käyttöoikeutta yhteenkään ryhmään.'
     },
     messageBoxes: {
       names: {


### PR DESCRIPTION
#### Summary

Show "no access" text instead of an empty panel when the user does not have access to any message accounts.

<img width="340" alt="image" src="https://user-images.githubusercontent.com/1176169/121997793-99511500-cdb3-11eb-8018-af0f808982a3.png">
