### PR TITLE
EVAKA-4203 Glue current WIP vasu implementations together

### DIFF
--- a/frontend/src/employee-frontend/components/vasu/api.ts
+++ b/frontend/src/employee-frontend/components/vasu/api.ts
@@ -32,13 +32,10 @@ export interface VasuDocumentResponse {
 export async function createVasuDocument(
   childId: UUID,
   templateId: UUID
-): Promise<Result<null>> {
+): Promise<Result<UUID>> {
   return client
-    .post(`/vasu`, { childId, templateId })
-    .then((res) => {
-      console.log('createRes: ', res)
-      return Success.of(null)
-    })
+    .post<VasuDocumentResponse>(`/vasu`, { childId, templateId })
+    .then((res) => Success.of(res.data.id))
     .catch((e) => Failure.fromError(e))
 }
 

--- a/frontend/src/lib-components/molecules/modals/FormModal.tsx
+++ b/frontend/src/lib-components/molecules/modals/FormModal.tsx
@@ -66,7 +66,7 @@ export const ModalContainer = styled.div<ModalContainerProps>`
   padding-right: ${defaultMargins.XXL};
   margin-left: ${defaultMargins.xxs};
   margin-right: ${defaultMargins.xxs};
-  overflow-y: scroll;
+  overflow-y: auto;
 
   @media (max-width: ${tabletMin}) {
     padding-left: ${defaultMargins.XL};

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -837,7 +837,7 @@ export const fi = {
         REVIEWED: 'Arvioitu',
         CLOSED: 'Päättynyt'
       },
-      errorInitializing: 'Varhaiskasvatussuunitelman luonti ei onnistunut'
+      errorInitializing: 'Vasun luonti epäonnistui'
     }
   },
   personSearch: {

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -836,7 +836,8 @@ export const fi = {
         CREATED: 'Laadittu',
         REVIEWED: 'Arvioitu',
         CLOSED: 'Päättynyt'
-      }
+      },
+      errorInitializing: 'Varhaiskasvatussuunitelman luonti ei onnistunut'
     }
   },
   personSearch: {

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
@@ -4,7 +4,6 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
-import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -13,7 +12,6 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.UUID
 
 @RestController
@@ -79,35 +77,6 @@ class VasuController {
     ): List<VasuDocumentSummary> {
         user.requireOneOfRoles(UserRole.ADMIN)
 
-        return listOf(
-            VasuDocumentSummary(
-                id = UUID.randomUUID(),
-                name = "Varhaiskasvatussuunnitelma 2021-2022",
-                state = VasuDocumentState.DRAFT,
-                modifiedAt = HelsinkiDateTime.now(),
-            ),
-            VasuDocumentSummary(
-                id = UUID.randomUUID(),
-                name = "Varhaiskasvatussuunnitelma 2020-2021",
-                state = VasuDocumentState.CREATED,
-                modifiedAt = HelsinkiDateTime.of(
-                    LocalDateTime.of(2020, 10, 5, 7, 13)
-                ),
-                publishedAt = HelsinkiDateTime.of(
-                    LocalDateTime.of(2020, 9, 1, 12, 0)
-                ),
-            ),
-            VasuDocumentSummary(
-                id = UUID.randomUUID(),
-                name = "Varhaiskasvatussuunnitelma 2019-2020",
-                state = VasuDocumentState.CLOSED,
-                modifiedAt = HelsinkiDateTime.of(
-                    LocalDateTime.of(2019, 9, 24, 12, 45)
-                ),
-                publishedAt = HelsinkiDateTime.of(
-                    LocalDateTime.of(2020, 8, 7, 15, 0)
-                ),
-            )
-        )
+        return db.read { tx -> tx.getVasuDocumentSummaries(childId) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuQueries.kt
@@ -61,3 +61,25 @@ fun Database.Transaction.updateVasuDocument(id: UUID, content: VasuContent) {
         .bind("content", content)
         .updateExactlyOne()
 }
+
+fun Database.Read.getVasuDocumentSummaries(childId: UUID): List<VasuDocumentSummary> {
+    // language=sql
+    val sql = """
+        SELECT 
+            vd.id,
+            vt.name AS name,
+            vc.updated AS modified_at,
+            -- TODO published at logic
+            'DRAFT' as state           -- TODO implement document state
+        FROM vasu_document vd
+        JOIN vasu_content vc on vd.content_id = vc.id
+        JOIN vasu_template vt on vd.template_id = vt.id
+        JOIN child c on c.id = vd.child_id
+        WHERE c.id = :childId
+    """.trimIndent()
+
+    return createQuery(sql)
+        .bind("childId", childId)
+        .mapTo<VasuDocumentSummary>()
+        .list()
+}


### PR DESCRIPTION
#### Summary

- Return child's actual vasu documents instead of mock data
- Navigate to vasu edit view from vasu list
- Initialize new vasu document and navigate to edit view if successful

Initialization has to be reworked to select the currently valid template and restrict to only one document per template.