### PR TITLE
EVAKA-HOTFIX: Fix services failing to get HOST_IP

### DIFF
--- a/message-service/Dockerfile
+++ b/message-service/Dockerfile
@@ -7,7 +7,7 @@ FROM evaka-base:latest
 USER root
 RUN set -eux \
     && apt-get update && apt-get -y --no-install-recommends install \
-       wget \
+       curl \
        openjdk-11-jre-headless \
     && rm -rf /var/lib/apt/lists/*
 

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -7,7 +7,7 @@ FROM evaka-base:latest
 USER root
 RUN set -eux \
     && apt-get update && apt-get -y --no-install-recommends install \
-       wget \
+       curl \
        openjdk-11-jre-headless \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
#### Summary
- Fixes missing `hostIp` field in service and message-service logs due to `curl` not being available in the images
- Install `curl` instead of `wget` which was replaced in the entrypoints in 31c52d6c47417e2ee6721395ac5a918e552b4337
    - I was so sure I checked that `curl` was installed but apparently not...