### PR TITLE
Improve async job contention handling

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueries.kt
@@ -83,7 +83,7 @@ WITH started_job AS (
   FROM async_job
   WHERE id = :jobId
   AND claimed_by = :txId
-  FOR UPDATE SKIP LOCKED
+  FOR UPDATE
 )
 UPDATE async_job
 SET started_at = clock_timestamp()


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- SKIP LOCKED can skip jobs too eagerly. With normal jobs this is not a huge problem, since they are retried. For nightly one-shot jobs this is not a good thing
- instead of skipping, require a successful lock
- use a transaction-local lock timeout to avoid long waits
- `define` is used instead of `bind`, because SET LOCAL is not a normal query and can't use normal bind parameters