### PR TITLE
EVAKA-4184 fee decision clean up

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -600,21 +599,6 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
             decision.let(::toDetailed),
             deserializeResult(result.get()).data
         )
-    }
-
-    @Test
-    fun `fee percent and minimum threshold works when getting one decision`() {
-        db.transaction { tx -> tx.upsertFeeDecisions(testDecisions) }
-        val decision = testDecisions[0]
-
-        val (_, _, result) = http.get("/decisions/${decision.id}")
-            .asUser(user)
-            .responseString()
-
-        val resultObject = deserializeResult(result.get()).data
-
-        assertEquals(BigDecimal.valueOf(10.7), resultObject.feePercent())
-        assertEquals(271300, resultObject.minThreshold())
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
@@ -182,14 +182,6 @@ data class FeeDecisionDetailed(
         val sentAtLocalDate = sentAt?.atZone(ZoneId.of("UTC"))
         return isRetroactive(this.validDuring.start, LocalDate.from(sentAtLocalDate ?: LocalDate.now()))
     }
-
-    // TODO: remove
-    @JsonProperty("minThreshold")
-    fun minThreshold(): Int = feeThresholds.minIncomeThreshold
-
-    // TODO: remove
-    @JsonProperty("feePercent")
-    fun feePercent(): BigDecimal = feeThresholds.incomeMultiplier.multiply(BigDecimal(100)).setScale(1, RoundingMode.HALF_UP)
 }
 
 fun isRetroactive(decisionValidFrom: LocalDate, sentAt: LocalDate): Boolean {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/PdfService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/PdfService.kt
@@ -228,8 +228,10 @@ class PDFService(
             "showTotalIncome" to !hideTotalIncome,
             "validFor" to with(decision) { "${dateFmt(validDuring.start)} - ${dateFmt(validDuring.end)}" },
             "validFrom" to dateFmt(decision.validDuring.start),
-            "feePercent" to decision.feePercent().toDecimalString(),
-            "incomeMinThreshold" to formatCents(-1 * decision.minThreshold()),
+            "feePercent" to (decision.feeThresholds.incomeMultiplier * BigDecimal(100))
+                .setScale(1, RoundingMode.HALF_UP)
+                .toDecimalString(),
+            "incomeMinThreshold" to formatCents(-1 * decision.feeThresholds.minIncomeThreshold),
             "familySize" to decision.familySize,
             "showValidTo" to (decision.validDuring.end?.isBefore(LocalDate.now()) ?: false),
             "approverFirstName" to (


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Remove fields in `FeeDecisionDetailed` that aren't in use since https://github.com/espoon-voltti/evaka/pull/1021.

