### PR TITLE
EVAKA-HOTFIX axios connection error handling

### DIFF
--- a/frontend/src/lib-common/api.ts
+++ b/frontend/src/lib-common/api.ts
@@ -84,8 +84,9 @@ export class Failure<T> {
 
   static fromError<T>(e: Error): Failure<T> {
     if (axios.isAxiosError(e)) {
-      const response = e.response as AxiosResponse<{ errorCode?: string }>
-      return new Failure(e.message, response.status, response?.data.errorCode)
+      const response: AxiosResponse<{ errorCode?: string }> | undefined =
+        e.response
+      return new Failure(e.message, response?.status, response?.data.errorCode)
     }
     return new Failure(e.message)
   }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The axios error's `response` property was incorrectly cast into a type that is never undefined although the property might sometimes be missing, like when there was a connection error, so remove the cast.

