### PR TITLE
Dump local database using docker

### DIFF
--- a/compose/.gitignore
+++ b/compose/.gitignore
@@ -27,3 +27,4 @@ fabric.properties
 .DS_Store
 # binaries
 *.jar
+backup

--- a/compose/README.md
+++ b/compose/README.md
@@ -143,7 +143,7 @@ Access the frontends at
 ## Database dump
 
 To dump local database run `./db.sh dump` and restore it with `./db.sh restore`.
-Optional dump path can be given to script, example `./db.sh dump /tmp/my.dump`.
+Optional dump name can be given to script, example `./db.sh dump my.dump`.
 
 ## Troubleshooting
 

--- a/compose/docker-compose.dbdump.yml
+++ b/compose/docker-compose.dbdump.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2017-2020 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# This file is ment to be used with db.sh
+
+version: '3.5'
+
+services:
+  dbdump:
+    build: ./db
+    ports:
+    - "5432:5432"
+    environment:
+      PGPASSWORD: "postgres"
+    volumes:
+    - ./backup:/backup
+    command: /bin/false


### PR DESCRIPTION
#### Summary

Developers have Postgres locally with different verisions and locals than we have in development environment (docker-compose) so to combat the issue here we dump the local development database with docker(-compose) instead of local tools.
