### PR TITLE
EVAKA-FIX: remove income application id reference on update

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -89,7 +89,7 @@ class IncomeController(
 
         db.transaction { tx ->
             val existing = tx.getIncome(mapper, parseUUID(incomeId))
-            val validIncome = income.copy(id = parseUUID(incomeId)).let(::validateIncome)
+            val validIncome = income.copy(id = parseUUID(incomeId), applicationId = null).let(::validateIncome)
             tx.upsertIncome(mapper, validIncome, user.id)
 
             val expandedPeriod = existing?.let {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
@@ -55,7 +55,8 @@ fun Database.Transaction.upsertIncome(mapper: ObjectMapper, income: Income, upda
             valid_to = :valid_to,
             notes = :notes,
             updated_at = now(),
-            updated_by = :updated_by
+            updated_by = :updated_by,
+            application_id = :application_id
     """
 
     val update = createUpdate(sql)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Set applicationId to null on upsert
