### PR TITLE
EVAKA-FIX: case-insensitive ssn when searching people

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PersonQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PersonQueriesIntegrationTest.kt
@@ -176,6 +176,14 @@ class PersonQueriesIntegrationTest : PureJdbiTest() {
     }
 
     @Test
+    fun `person can be found by case-insensitive ssn`() {
+        val created = db.transaction { createVtjPerson(it, "230601A329J") }
+        val persons = db.read { it.searchPeople(adminUser, "230601a329J", "last_name", "ASC") }
+        Assertions.assertEquals(1, persons.size)
+        Assertions.assertEquals(persons[0].identity, created.identity)
+    }
+
+    @Test
     fun `person can be found by first part of address`() {
         val created = db.transaction { createVtjPerson(it) }
         val persons = db.read { it.searchPeople(adminUser, "Jokutie", "last_name", "ASC") }
@@ -313,8 +321,7 @@ class PersonQueriesIntegrationTest : PureJdbiTest() {
         Assertions.assertEquals(persons[0].identity, created.identity)
     }
 
-    private fun createVtjPerson(tx: Database.Transaction): PersonDTO {
-        val validSSN = "010199-8137"
+    private fun createVtjPerson(tx: Database.Transaction, validSSN: String = "010199-8137"): PersonDTO {
         val inputPerson = testPerson(validSSN)
         return tx.createPersonFromVtj(inputPerson)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/identity/SSNUtils.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/identity/SSNUtils.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.identity
 
 import java.time.LocalDate
 
-const val SSN_PATTERN = "^(\\d{2})(\\d{2})(\\d{2})[A+-](\\d{3})[\\dA-Z]$"
+const val SSN_PATTERN = "^(\\d{2})(\\d{2})(\\d{2})[Aa+-](\\d{3})[\\dA-Z]$"
 private val CHECK_DIGITS = arrayOf(
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'H',
     'J', 'K', 'L', 'M', 'N', 'P', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y'

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Search.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Search.kt
@@ -90,7 +90,7 @@ private fun ssnQuery(tablePrefixes: List<String>, params: Collection<String>): S
     return params
         .mapIndexed { index, _ ->
             tablePrefixes
-                .map { table -> "$table.social_security_number = :${ssnParamName(index)}" }
+                .map { table -> "lower($table.social_security_number) = lower(:${ssnParamName(index)})" }
                 .joinToString(" OR ", "(", ")")
         }
         .joinToString(" AND ", "(", ")")


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Use lower when matching ssn's.