### PR TITLE
EVAKA FIX update architecture diagrams

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,8 @@ You can generate PNG, SVG or even AsciiArt files from [PlantUML](https://plantum
 ### Using the command line tool
 
 1. Install Java (e.g. [OpenJDK](https://openjdk.java.net/install/))
-1. Download [PlantUML jar](https://search.maven.org/remotecontent?filepath=net/sourceforge/plantuml/plantuml/1.2020.11/plantuml-1.2020.11.jar) (version `1.2020.11`) from e.g. central Maven repository
+1. Install [Graphviz](https://graphviz.org/)
+1. Download [PlantUML jar](https://search.maven.org/remotecontent?filepath=net/sourceforge/plantuml/plantuml/1.2021.8/plantuml-1.2021.8.jar) (version `1.2021.8`) from e.g. central Maven repository
 1. Generate SVG image from e.g. `source.puml` file by executing following command: `$ java -jar plantuml.jar -tsvg source.puml -o diagrams/svg/`
 1. Check out the generated image from `diagrams/svg/` directory
 

--- a/docs/convert.sh
+++ b/docs/convert.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 BASEDIR=$(dirname "$0")
-PLANTUML_VERSION=1.2020.11
+PLANTUML_VERSION=1.2021.8
 
 mkdir -p "$BASEDIR"/diagrams/svg
 rm -rf "$BASEDIR"/svg/*
@@ -15,5 +15,5 @@ rm -rf "$BASEDIR"/svg/*
 for FILE in "$BASEDIR"/diagrams/src/*.puml; do
   FILE_SVG="$BASEDIR"/diagrams/svg/"$(basename "$FILE" | sed 's/puml/svg/')"
   echo Converting "${FILE} -> ${FILE_SVG}"
-  docker run --rm -i think/plantuml:"$PLANTUML_VERSION" > "$FILE_SVG" < "$FILE"
+  docker run --rm -i dstockhammer/plantuml:"$PLANTUML_VERSION" -pipe -tsvg > "$FILE_SVG" < "$FILE"
 done

--- a/docs/diagrams/src/evaka-container.puml
+++ b/docs/diagrams/src/evaka-container.puml
@@ -11,8 +11,8 @@ Person(huoltaja, "Huoltaja", "Varhaiskasvatuksen, kerhotoiminnan tai esiopetukse
 Person(virkailija, "Virkailija", "Kaupungin työntekijä, jolla on Azure AD -tunnukset")
 
 System_Boundary(evaka, "eVaka – Espoon varhaiskasvatuksen toiminnanohjausjärjestelmä") {
-  Container(evaka_front, "evaka-frontend\n(huoltaja)", "Vue, TypeScript", "SPA-sovellus, joka ajetaan käyttäjän selaimessa ja tarjotaan AWS:n S3:sta. Sovelluksen avulla haetaan paikkaa kerhoon tai varhaiskasvatukseen, sekä ilmoitetaan lapsi esiopetukseen .")
-  Container(evaka_admin_front, "evaka-frontend\n(virkailja)", "React, Vue, TypeScript", "SPA-sovellus, joka ajetaan käyttäjän selaimessa ja tarjotaan AWS:n S3:sta. Toteuttaa virkailijan käyttöliittymän kaikki toiminnot.")
+  Container(evaka_front, "evaka-frontend\n(huoltaja)", "TypeScript", "SPA-sovellus, joka ajetaan käyttäjän selaimessa ja tarjotaan AWS:n S3:sta. Sovelluksen avulla haetaan paikkaa kerhoon tai varhaiskasvatukseen, sekä ilmoitetaan lapsi esiopetukseen .")
+  Container(evaka_admin_front, "evaka-frontend\n(virkailja)", "React, TypeScript", "SPA-sovellus, joka ajetaan käyttäjän selaimessa ja tarjotaan AWS:n S3:sta. Toteuttaa virkailijan käyttöliittymän kaikki toiminnot.")
 
   Container(evaka_proxy, "evaka-proxy", "nginx", "Palvelun edustaproxy")
   Container(evaka_apigw, "evaka-api-gateway", "node.js, TypeScript", "Välittää edustan kutsut oikeille mikropalveluille ja hoitaa SAML2-autentikoinnin.")

--- a/docs/diagrams/src/evaka-context.puml
+++ b/docs/diagrams/src/evaka-context.puml
@@ -34,15 +34,16 @@ Boundary(kunnan_tyontekija, "Kunnan työntekijä") {
   Person(palveluohjaaja, "Palveluohjaaja", "Vastaa oman palvelualueensa varhaiskasvatuksen sijoituksista ja päätöksistä")
   Person(yksikon_esimies, "Yksikön esimies", "Vastaa yhdestä tai useammasta toimipisteestä, sekä yksikön henkilökunnasta")
   Person(talouden_henkilo, "Talouden henkilö", "Huolehtii maksupäätöksistä, arvopäätöksistä ja laskuista")
-  Person(henkilokunta, "Henkilökunta", "Vastaa yksikköön sijoitettujen lasten poissaolomerkinnöistä")
+  Person(henkilokunta, "Henkilökunta", "Vastaa yksikköön sijoitettujen lasten merkinnöistä")
   Person(veo, "Varhaiskasvatuksen erityisopettaja", "Arvioi tuen tarpeellisten lasten sijoitukset")
 }
 
 
-Rel_R(hakija, evaka, "Hakee varhaiskasvatuspaikkaa huollettavalleen")
-Rel_L(partner, evaka, "Tunnistautuu")
+Rel_R(hakija, evaka, "Hakee varhaiskasvatuspaikkaa huollettavalleen ja viestii tähän liittyen")
+Rel_R(partner, evaka, "Hyväksyy palvelusetelinyksikköön tehdyt sijoitukset")
+Rel_L(partner, suomifi, "Tunnistautuu")
 Rel_U(hakija, suomifi, "Tunnistautuu")
-Rel_U(evaka, suomifi, "Ohjaa hakijan tunnistautumaan")
+Rel_U(evaka, suomifi, "Ohjaa hakijan ja yksityisen palvelutuottajan tunnistautumaan")
 Rel_R(evaka, ad, "Ohjaa kunnan työntekijän tunnistautumaan")
 Rel_U(evaka, vtj, "Hakee kuntalaisen tiedot ja huollettavat")
 Rel_U(evaka, varda, "Varhaiskasvatuksen tilastointi")
@@ -53,7 +54,7 @@ Rel_L(evaka, suomifiviestit, "Lähettää varhaiskasvatuksen päätökset kuntal
 
 Rel_U(palveluohjaaja, evaka, "Käsittelee hakemuksen, sijoittaa lapsen varhaiskasvatukseen ja tekee päätöksen")
 Rel_U(yksikon_esimies, evaka, "Ryhmittelee, merkitsee palvelutarpeet")
-Rel_U(henkilokunta, evaka, "Merkitsee poissaolot")
+Rel_U(henkilokunta, evaka, "Merkitsee poissaolot ja muistiinpanot")
 Rel_U(talouden_henkilo, evaka, "Luo maksupäätökset ja laskut")
 Rel_U(veo, evaka, "Arvioi tuen tarpeen hakemuksella")
 


### PR DESCRIPTION
- Upgrade to latest PlantUML on up-to-date docker image
- Sync diagrams better with current implementation
  - suomi.fi for private service providers 
  - messaging and memos added
- Drop Vue from diagrams

To test, run convert.sh and compare generated images with ones on https://github.com/espoon-voltti/evaka/wiki/Yleinen-arkkitehtuuridokumentaatio