### PR TITLE
[EVAKA] CI: refactor workflow for speed and parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,6 +829,11 @@ jobs:
       - run:
           working_directory: *workspace_service
           command: ./gradlew assemble compileIntegrationTestKotlin
+      - run:
+          working_directory: *workspace_service
+          command: |
+            cd custom-ktlint-rules
+            ./gradlew assemble
       - *store_service_gradle
       - persist_to_workspace:
           root: *workspace_root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ commands:
   store_service_gradle:
     steps:
       - save_cache:
-          key: gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
+          key: gradle-home-service-v5-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
           paths:
             - service/buildSrc/.gradle
             - service/.gradle
@@ -245,12 +245,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
-            - gradle-home-service-v4-
+            - gradle-home-service-v5-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
+            - gradle-home-service-v5-
   store_message_service_gradle:
     steps:
       - save_cache:
-          key: gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
+          key: gradle-home-message-service-v5-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
           paths:
             - message-service/buildSrc/.gradle
             - message-service/.gradle
@@ -261,13 +261,13 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
-            - gradle-home-message-service-v4-
+            - gradle-home-message-service-v5-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
+            - gradle-home-message-service-v5-
 
   store_service_build_cache:
     steps:
       - save_cache:
-          key: gradle-service-build-cache-v1-{{ .Environment.CIRCLE_SHA1 }}
+          key: gradle-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - service/build
             - service/buildSrc/build
@@ -278,12 +278,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gradle-service-build-cache-v1-{{ .Environment.CIRCLE_SHA1 }}
-            - gradle-service-build-cache-v1-
+            - gradle-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}
+            - gradle-service-build-cache-v2-
   store_message_service_build_cache:
     steps:
       - save_cache:
-          key: gradle-message-service-build-cache-v1-{{ .Environment.CIRCLE_SHA1 }}
+          key: gradle-message-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - message-service/build
             - message-service/buildSrc/build
@@ -292,8 +292,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gradle-message-service-build-cache-v1-{{ .Environment.CIRCLE_SHA1 }}
-            - gradle-message-service-build-cache-v1-
+            - gradle-message-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}
+            - gradle-message-service-build-cache-v2-
 
   # Misc commands
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,13 @@ aliases:
     save_cache:
       key: gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
       paths:
+        - service/buildSrc/.gradle
         - service/.gradle
-        - .gradle-user-home
+        - service/custom-ktlint-rules/.gradle
+        - service-lib/.gradle
+        - evaka-bom/.gradle
+        - .gradle-user-home/wrapper
+        - .gradle-user-home/caches
 
   - &restore_message_service_gradle
     restore_cache:
@@ -119,8 +124,12 @@ aliases:
     save_cache:
       key: gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
       paths:
+        - message-service/buildSrc/.gradle
         - message-service/.gradle
-        - .gradle-user-home
+        - service-lib/.gradle
+        - evaka-bom/.gradle
+        - .gradle-user-home/wrapper
+        - .gradle-user-home/caches
 
 executors:
   aws_executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@4.1.3
+  slack: circleci/slack@4.4.2
   owasp: entur/owasp@0.0.15
 
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,10 @@ aliases:
 
   - &jvm_config
     <<: *default_config
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2048m"'
+    environment: &jvm_env
+      GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:MaxRAMPercentage=80"'
       GRADLE_USER_HOME: << pipeline.parameters.workspace_root >>/.gradle-user-home
-      JAVA_TOOL_OPTIONS: "-Xmx2048m"
+      JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=80"
 
 executors:
   aws_core_executor:
@@ -108,6 +108,13 @@ executors:
     machine:
       image: *ubuntu_machine_image
       resource_class: large
+    environment:
+      # YAML anchors don't merge nested keys, so re-referencing is required
+      <<: *jvm_env
+      # Leave more memory for testcontainers than the default 20%.
+      # With large instances, this will still be 7.5GB for Gradle/services.
+      GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:MaxRAMPercentage=50"'
+      JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=50"
   shellcheck:
     parameters:
       shellcheck_image_version:
@@ -278,7 +285,7 @@ commands:
     steps:
       - save_cache:
           name: Store build cache
-          key: gradle-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}-{{ checksum ".circleci/config.yml" }}
+          key: gradle-service-build-cache-v2-{{ .Branch }}-{{ .Revision }}-{{ checksum ".circleci/config.yml" }}
           paths:
             - service/build
             - service/buildSrc/build
@@ -290,13 +297,13 @@ commands:
       - restore_cache:
           name: Restore build cache
           keys:
-            - gradle-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}-{{ checksum ".circleci/config.yml" }}
+            - gradle-service-build-cache-v2-{{ .Branch }}-{{ .Revision }}-{{ checksum ".circleci/config.yml" }}
             - gradle-service-build-cache-v2-
   store_message_service_build_cache:
     steps:
       - save_cache:
           name: Store build cache
-          key: gradle-message-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}-{{ checksum ".circleci/config.yml" }}
+          key: gradle-message-service-build-cache-v2-{{ .Branch }}-{{ .Revision }}-{{ checksum ".circleci/config.yml" }}
           paths:
             - message-service/build
             - message-service/buildSrc/build
@@ -306,7 +313,7 @@ commands:
       - restore_cache:
           name: Restore build cache
           keys:
-            - gradle-message-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}-{{ checksum ".circleci/config.yml" }}
+            - gradle-message-service-build-cache-v2-{{ .Branch }}-{{ .Revision }}-{{ checksum ".circleci/config.yml" }}
             - gradle-message-service-build-cache-v2-
 
   # Misc commands

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.1.3
-  owasp: entur/owasp@0.0.14
+  owasp: entur/owasp@0.0.15
 
 parameters:
   workspace_root:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -987,7 +987,7 @@ jobs:
       - *restore_message_service_gradle
       - run:
           working_directory: *workspace_message_service
-          command: ./gradlew assemble
+          command: ./gradlew assemble compileIntegrationTestKotlin
       - *store_message_service_gradle
       - *store_message_service_build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -731,7 +731,7 @@ jobs:
 
   e2e-test-testcafe:
     executor: e2e_executor
-    parallelism: 16
+    parallelism: 8
     steps:
       - e2e_test
       - notify_slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,12 +345,23 @@ commands:
             if [ "<< parameters.suite >>" != "" ]; then
               yarn "<< parameters.suite >>"
             else
-              # Get list of test files that should run on this node
-              TESTFILES=$(circleci tests glob "src/e2e-test/**/*.spec.ts" \
-                  | circleci tests split --split-by=timings --timings-type=filename)
-              echo "Prepared arguments for yarn: $TESTFILES"
+              # Get list of test files that should run on this node.
+              # NOTE: Currently testcafe-reporter-junit doesn't provide
+              # filenames in its output so they can't be used for splitting
+              # -> use fixture names instead.
+              FIXTURE_NAMES=$(git grep '^\w*fixture(' -- src/e2e-test/specs/ \
+                | awk -F "'" '{print $2}' \
+                | sort -h | uniq \
+                | circleci tests split --split-by=timings --timings-type classname)
+              # NOTE: This is extremely brittle but necessary as Testcafe
+              # doesn't support multiple --fixture arguments (+ the above
+              # report issue) -> everything must be a single regex.
+              TESTCAFE_FIXTURE_REGEX=$(echo "$FIXTURE_NAMES" | sed 's/[^-A-Za-z0-9_]/\\&/g' | awk '{print "^"$0"$"}' | tr '\n' '|')
+              # Strip the last "|"
+              TESTCAFE_FIXTURE_REGEX=${TESTCAFE_FIXTURE_REGEX%?}
+              echo "Prepared arguments for yarn: ${TESTCAFE_FIXTURE_REGEX}"
 
-              yarn e2e-ci-base $TESTFILES
+              yarn e2e-ci-base --fixture-grep "${TESTCAFE_FIXTURE_REGEX}" -- src/e2e-test/specs/
             fi
       - run:
           name: Collect docker-compose logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,10 +109,23 @@ aliases:
         - service/buildSrc/.gradle
         - service/.gradle
         - service/custom-ktlint-rules/.gradle
-        - service-lib/.gradle
-        - evaka-bom/.gradle
         - .gradle-user-home/wrapper
         - .gradle-user-home/caches
+
+  - &restore_service_build
+    restore_cache:
+      keys:
+        - gradle-build-service-v4-{{ .Revision }}
+
+  - &store_service_build
+    save_cache:
+      key: gradle-build-service-v4-{{ .Revision }}
+      paths:
+        - service/build
+        - service/buildSrc/build
+        - service/custom-ktlint-rules/build
+        - service/vtjclient/build
+        - service-lib/build
 
   - &restore_message_service_gradle
     restore_cache:
@@ -126,10 +139,21 @@ aliases:
       paths:
         - message-service/buildSrc/.gradle
         - message-service/.gradle
-        - service-lib/.gradle
-        - evaka-bom/.gradle
         - .gradle-user-home/wrapper
         - .gradle-user-home/caches
+
+  - &restore_message_service_build
+    restore_cache:
+      keys:
+        - gradle-build-message-service-v4-{{ .Revision }}
+
+  - &store_message_service_build
+    save_cache:
+      key: gradle-build-message-service-v4-{{ .Revision }}
+      paths:
+        - message-service/build
+        - message-service/buildSrc/build
+        - message-service-lib/build
 
 executors:
   aws_executor:
@@ -835,10 +859,7 @@ jobs:
             cd custom-ktlint-rules
             ./gradlew assemble
       - *store_service_gradle
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - service/build
+      - *store_service_build
       - run:
           working_directory: *workspace_service
           command: ./gradlew lintKotlin
@@ -869,6 +890,7 @@ jobs:
     steps:
       - *restore_repo
       - attach_root_workspace
+      - *restore_service_build
       - setup_remote_docker:
           version: *remote_docker_version
           docker_layer_caching: true
@@ -890,7 +912,7 @@ jobs:
     executor: service_test_executor
     steps:
       - *restore_repo
-      - attach_root_workspace
+      - *restore_service_build
       - *restore_service_gradle
       - run:
           name: gradle test
@@ -919,7 +941,7 @@ jobs:
     parallelism: 4
     steps:
       - *restore_repo
-      - attach_root_workspace
+      - *restore_service_build
       - *restore_service_gradle
       - login_docker_hub
       - run:
@@ -967,10 +989,7 @@ jobs:
           working_directory: *workspace_message_service
           command: ./gradlew assemble
       - *store_message_service_gradle
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - message-service/build
+      - *store_message_service_build
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew lintKotlin
@@ -997,7 +1016,7 @@ jobs:
     executor: service_test_executor
     steps:
       - *restore_repo
-      - attach_root_workspace
+      - *restore_message_service_build
       - *restore_message_service_gradle
       - run:
           working_directory: *workspace_message_service
@@ -1023,6 +1042,7 @@ jobs:
     steps:
       - *restore_repo
       - attach_root_workspace
+      - *restore_message_service_build
       - setup_remote_docker:
           version: *remote_docker_version
           docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,9 @@ aliases:
   - &nodejs_image cimg/node:14.15
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202104-01
-  - &builder_aws_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:18.04-853d39120a28cf475e0c8aa5b25a5973e198b27a
+  - &builder_aws_core_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:core-bullseye-slim-e2518f5ece6862d780ff4224aad606e13cfe8293
+  - &builder_aws_docker_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:docker-bullseye-slim-e2518f5ece6862d780ff4224aad606e13cfe8293
+  - &builder_aws_terraform_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:terraform-bullseye-slim-e2518f5ece6862d780ff4224aad606e13cfe8293
 
   - &default_contexts
     context:
@@ -159,10 +161,18 @@ aliases:
         - message-service-lib/build
 
 executors:
-  aws_executor:
+  aws_core_executor:
     <<: *default_config
     docker:
-      - image: *builder_aws_image
+      - image: *builder_aws_core_image
+  aws_docker_executor:
+    <<: *default_config
+    docker:
+      - image: *builder_aws_docker_image
+  aws_terraform_executor:
+    <<: *default_config
+    docker:
+      - image: *builder_aws_terraform_image
   apigw_executor:
     <<: *node_config
     docker:
@@ -575,7 +585,7 @@ jobs:
       - notify_slack
 
   fetch_private_dependencies:
-    executor: aws_executor
+    executor: aws_core_executor
     steps:
       - *restore_repo
       - *restore_frontend_comm_deps
@@ -589,7 +599,7 @@ jobs:
       - notify_slack
 
   clone_infra_repo:
-    executor: aws_executor
+    executor: aws_terraform_executor
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -663,7 +673,7 @@ jobs:
       - notify_slack
 
   apigw_build_image:
-    executor: aws_executor
+    executor: aws_docker_executor
     steps:
       - *restore_repo
       - attach_root_workspace
@@ -681,7 +691,7 @@ jobs:
       - notify_slack
 
   apigw_push_image:
-    executor: aws_executor
+    executor: aws_docker_executor
     steps:
       - attach_root_workspace
       - setup_remote_docker:
@@ -748,7 +758,7 @@ jobs:
   # DEPLOY JOBS
 
   services_deploy:
-    executor: aws_executor
+    executor: aws_terraform_executor
     parameters:
       target_env:
         type: string
@@ -758,7 +768,7 @@ jobs:
       - notify_slack
 
   frontend_deploy:
-    executor: aws_executor
+    executor: aws_core_executor
     parameters:
       target_env:
         type: string
@@ -768,7 +778,7 @@ jobs:
       - notify_slack
 
   proxy_build_and_push_image:
-    executor: aws_executor
+    executor: aws_docker_executor
     steps:
       - *restore_repo
       - setup_authenticated_remote_docker
@@ -832,7 +842,7 @@ jobs:
       - notify_slack
 
   service_build_image:
-    executor: aws_executor
+    executor: aws_docker_executor
     steps:
       - *restore_repo
       - attach_root_workspace
@@ -912,7 +922,7 @@ jobs:
       - notify_slack
 
   service_push_image:
-    executor: aws_executor
+    executor: aws_docker_executor
     steps:
       - *restore_repo
       - attach_root_workspace
@@ -991,7 +1001,7 @@ jobs:
       - notify_slack
 
   message_service_build_and_push_image:
-    executor: aws_executor
+    executor: aws_docker_executor
     steps:
       - *restore_repo
       - attach_root_workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,27 +158,41 @@ commands:
           key: << parameters.dir >>-image-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - run: docker load -i << parameters.dir >>/image.tar
 
-  store_service_build:
+  # Artifacts or sub-workspaces would be ideal here but instead we need to
+  # abuse CircleCI's caching to store build artifacts and only restore them
+  # in specific jobs within a single workflow execution. This avoid wasting time
+  # in downstream jobs that don't need the files.
+  store_service_artifacts:
     steps:
       - save_cache:
+          name: Store build artifacts
           key: service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
           paths:
             - << pipeline.parameters.workspace_root >>/service/build/libs/
-  restore_service_build:
+  restore_service_artifacts:
     steps:
       - restore_cache:
+          name: Restore build artifacts
           key: service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
-  store_message_service_build:
+  store_message_service_artifacts:
     steps:
       - save_cache:
+          name: Store build artifacts
           key: message-service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
           paths:
             - << pipeline.parameters.workspace_root >>/message-service/build/libs/
-  restore_message_service_build:
+  restore_message_service_artifacts:
     steps:
       - restore_cache:
+          name: Restore build artifacts
           key: message-service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
 
+  store_apigw_deps:
+    steps:
+      - save_cache:
+          key: yarn-cache-apigw-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "apigw/yarn.lock" }}
+          paths:
+            - apigw/.yarn/cache
   restore_apigw_deps:
     steps:
       - restore_cache:
@@ -186,20 +200,7 @@ commands:
             - yarn-cache-apigw-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "apigw/yarn.lock" }}
             - yarn-cache-apigw-v1-
             - yarn-cache-apigw-
-  store_apigw_deps:
-    steps:
-      - save_cache:
-          key: yarn-cache-apigw-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "apigw/yarn.lock" }}
-          paths:
-            - apigw/.yarn/cache
 
-  restore_frontend_deps:
-    steps:
-      - restore_cache:
-          keys:
-            - yarn-cache-frontend-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
-            - yarn-cache-frontend-v1-
-            - yarn-cache-frontend-
   store_frontend_deps:
     steps:
       - save_cache:
@@ -207,7 +208,20 @@ commands:
           paths:
             - frontend/.yarn/cache
             - frontend/node_modules
+  restore_frontend_deps:
+    steps:
+      - restore_cache:
+          keys:
+            - yarn-cache-frontend-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
+            - yarn-cache-frontend-v1-
+            - yarn-cache-frontend-
 
+  store_frontend_comm_deps:
+    steps:
+      - save_cache:
+          key: frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
+          paths:
+            - frontend/vendor/fortawesome
   restore_frontend_comm_deps:
     steps:
       - restore_cache:
@@ -215,59 +229,71 @@ commands:
             - frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
             - frontend-comm-deps-v1-
             - frontend-comm-deps-
-  store_frontend_comm_deps:
-    steps:
-      - save_cache:
-          key: frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
-          paths:
-            - frontend/vendor/fortawesome
 
-  restore_service_gradle:
-    steps:
-      - restore_cache:
-          keys:
-            - gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
-            - gradle-home-service-v4-
   store_service_gradle:
     steps:
       - save_cache:
           key: gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
           paths:
-            # Actual Gradle files
             - service/buildSrc/.gradle
             - service/.gradle
             - service/custom-ktlint-rules/.gradle
             - .gradle-user-home/wrapper
             - .gradle-user-home/caches
             - .gradle-user-home/notifications
-            # Build files
-            - service/build
-            - service/buildSrc/build
-            - service/custom-ktlint-rules/build
-            - service/vtjclient/build
-            - service-lib/build
-
+  restore_service_gradle:
+    steps:
+      - restore_cache:
+          keys:
+            - gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
+            - gradle-home-service-v4-
+  store_message_service_gradle:
+    steps:
+      - save_cache:
+          key: gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
+          paths:
+            - message-service/buildSrc/.gradle
+            - message-service/.gradle
+            - .gradle-user-home/wrapper
+            - .gradle-user-home/caches
+            - .gradle-user-home/notifications
   restore_message_service_gradle:
     steps:
       - restore_cache:
           keys:
             - gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
             - gradle-home-message-service-v4-
-  store_message_service_gradle:
+
+  store_service_build_cache:
     steps:
       - save_cache:
-          key: gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
+          key: gradle-service-build-cache-v1-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            # Actual Gradle files
-            - message-service/buildSrc/.gradle
-            - message-service/.gradle
-            - .gradle-user-home/wrapper
-            - .gradle-user-home/caches
-            - .gradle-user-home/notifications
-            # Build files
+            - service/build
+            - service/buildSrc/build
+            - service/custom-ktlint-rules/build
+            - service/vtjclient/build
+            - service-lib/build
+  restore_service_build_cache:
+    steps:
+      - restore_cache:
+          keys:
+            - gradle-service-build-cache-v1-{{ .Environment.CIRCLE_SHA1 }}
+            - gradle-service-build-cache-v1-
+  store_message_service_build_cache:
+    steps:
+      - save_cache:
+          key: gradle-message-service-build-cache-v1-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
             - message-service/build
             - message-service/buildSrc/build
             - message-service-lib/build
+  restore_message_service_build_cache:
+    steps:
+      - restore_cache:
+          keys:
+            - gradle-message-service-build-cache-v1-{{ .Environment.CIRCLE_SHA1 }}
+            - gradle-message-service-build-cache-v1-
 
   # Misc commands
 
@@ -835,13 +861,14 @@ jobs:
       - run:
           working_directory: *workspace_service
           command: ./gradlew assemble compileIntegrationTestKotlin
-      - store_service_build
+      - store_service_artifacts
       - run:
           working_directory: *workspace_service
           command: |
             cd custom-ktlint-rules
             ./gradlew assemble
       - store_service_gradle
+      - store_service_build_cache
       - run:
           working_directory: *workspace_service
           command: ./gradlew lintKotlin
@@ -872,7 +899,7 @@ jobs:
     steps:
       - restore_repo
       - attach_root_workspace
-      - restore_service_build
+      - restore_service_artifacts
       - setup_remote_docker:
           version: *remote_docker_version
           docker_layer_caching: true
@@ -894,6 +921,7 @@ jobs:
     steps:
       - restore_repo
       - restore_service_gradle
+      - restore_service_build_cache
       - run:
           name: gradle test
           working_directory: *workspace_service
@@ -922,6 +950,7 @@ jobs:
     steps:
       - restore_repo
       - restore_service_gradle
+      - restore_service_build_cache
       - login_docker_hub
       - run:
           name: gradle integrationTest
@@ -955,8 +984,9 @@ jobs:
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew assemble compileIntegrationTestKotlin
-      - store_message_service_build
+      - store_message_service_artifacts
       - store_message_service_gradle
+      - store_message_service_build_cache
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew lintKotlin
@@ -984,6 +1014,7 @@ jobs:
     steps:
       - restore_repo
       - restore_message_service_gradle
+      - restore_message_service_build_cache
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew test
@@ -998,6 +1029,7 @@ jobs:
     steps:
       - restore_repo
       - restore_message_service_gradle
+      - restore_message_service_build_cache
       - login_docker_hub
       - run:
           name: gradle integrationTest
@@ -1016,7 +1048,7 @@ jobs:
     steps:
       - restore_repo
       - attach_root_workspace
-      - restore_message_service_build
+      - restore_message_service_artifacts
       - setup_remote_docker:
           version: *remote_docker_version
           docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,17 +64,6 @@ aliases:
       GRADLE_USER_HOME: << pipeline.parameters.workspace_root >>/.gradle-user-home
       JAVA_TOOL_OPTIONS: "-Xmx2048m"
 
-  - &restore_repo
-    restore_cache:
-      keys:
-        - repo-v1-{{ .Branch }}-{{ .Revision }}
-
-  - &store_repo
-    save_cache:
-      key: repo-v1-{{ .Branch }}-{{ .Revision }}
-      paths:
-        - .
-
   - &restore_apigw_deps
     restore_cache:
       keys:
@@ -222,6 +211,59 @@ commands:
       - attach_workspace:
           at: << pipeline.parameters.workspace_root >>
 
+  # Caching commands
+
+  store_repo:
+    steps:
+      - save_cache:
+          key: repo-v1-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .
+  restore_repo:
+    steps:
+      - restore_cache:
+          keys:
+            - repo-v1-{{ .Branch }}-{{ .Revision }}
+  store_docker_image:
+    parameters:
+      dir:
+        type: string
+    steps:
+      - save_cache:
+          key: << parameters.dir >>-image-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          paths:
+            - << pipeline.parameters.workspace_root >>/<< parameters.dir >>/image.tar
+  restore_docker_image:
+    parameters:
+      dir:
+        type: string
+    steps:
+      - restore_cache:
+          key: << parameters.dir >>-image-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+      - run: docker load -i << parameters.dir >>/image.tar
+  store_service_build:
+    steps:
+      - save_cache:
+          key: service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          paths:
+            - << pipeline.parameters.workspace_root >>/service/build/libs/
+  restore_service_build:
+    steps:
+      - restore_cache:
+          key: service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+  store_message_service_build:
+    steps:
+      - save_cache:
+          key: message-service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          paths:
+            - << pipeline.parameters.workspace_root >>/message-service/build/libs/
+  restore_message_service_build:
+    steps:
+      - restore_cache:
+          key: message-service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+
+  # Misc commands
+
   login_docker_hub:
     description: Log in to Docker Hub for authenticated pulls
     steps:
@@ -280,13 +322,12 @@ commands:
         type: boolean
         default: true
     steps:
-      - *restore_repo
+      - restore_repo
       - attach_root_workspace
-      - run:
-          name: Load docker images
-          command: |
-            docker load -i apigw/image.tar
-            docker load -i service/image.tar
+      - restore_docker_image:
+          dir: apigw
+      - restore_docker_image:
+          dir: service
       - login_docker_hub
       - run:
           name: Start up compose stack
@@ -456,7 +497,7 @@ commands:
     steps:
       - run:
           name: Deploy Storybook
-          working_directory: << pipeline.parameters.workspace_root >>/frontend
+          working_directory: *workspace_frontend
           command: |
             if [ "<< parameters.target_env >>" = "dev" ]; then
               aws --profile voltti-dev s3 cp storybook-build/ s3://evaka-static-dev/master/storybook/ --recursive --acl public-read
@@ -475,7 +516,7 @@ commands:
         type: string
       dir:
         type: string
-      push_after:
+      save_image:
         type: boolean
         default: false
     steps:
@@ -488,21 +529,15 @@ commands:
               --build-arg "build=${CIRCLE_BUILD_NUM}" \
               --build-arg "commit=${CIRCLE_SHA1}" \
               .
-      - when:
-          condition: << parameters.push_after >>
-          steps:
-            - run:
-                name: Push docker image
-                command: |
-                  ecr-login
-                  ecr-push << parameters.image >>
-      - unless:
-          condition: << parameters.push_after >>
-          steps:
-            - run:
-                name: Save docker image
-                working_directory: << parameters.dir >>
-                command: docker save << parameters.image >> > image.tar
+      - run:
+          name: Push docker image
+          command: |
+            ecr-login
+            ecr-push << parameters.image >>
+      - run:
+          name: Save docker image
+          working_directory: << parameters.dir >>
+          command: docker save << parameters.image >> > image.tar
 
   push_docker_image:
     parameters:
@@ -581,13 +616,13 @@ jobs:
     executor: apigw_executor
     steps:
       - checkout
-      - *store_repo
+      - store_repo
       - notify_slack
 
   fetch_private_dependencies:
     executor: aws_core_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - *restore_frontend_comm_deps
       - run: replace-credentials
       - run:
@@ -615,7 +650,7 @@ jobs:
   lint_scripts:
     executor: shellcheck
     steps:
-      - *restore_repo
+      - restore_repo
       - run:
           name: Install dependencies
           command: apk add curl jq git
@@ -630,7 +665,7 @@ jobs:
   build_base_image:
     executor: apigw_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - setup_authenticated_remote_docker
       - run:
           name: Build base image
@@ -649,7 +684,7 @@ jobs:
   apigw_build_and_test:
     executor: apigw_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - *restore_apigw_deps
       - run:
           working_directory: *workspace_apigw
@@ -672,10 +707,10 @@ jobs:
           path: << pipeline.parameters.workspace_root >>/apigw/build/test-reports
       - notify_slack
 
-  apigw_build_image:
+  apigw_build_and_push_image:
     executor: aws_docker_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - attach_root_workspace
       - setup_remote_docker:
           version: *remote_docker_version
@@ -684,27 +719,15 @@ jobs:
       - build_docker_image:
           image: evaka/api-gateway
           dir: *workspace_apigw
-      - persist_to_workspace:
-          root: << pipeline.parameters.workspace_root >>
-          paths:
-            - apigw/image.tar
-      - notify_slack
-
-  apigw_push_image:
-    executor: aws_docker_executor
-    steps:
-      - attach_root_workspace
-      - setup_remote_docker:
-          version: *remote_docker_version
-      - push_docker_image:
-          image: evaka/api-gateway
-          dir: *workspace_apigw
+          save_image: true
+      - store_docker_image:
+          dir: apigw
       - notify_slack
 
   frontend_build_and_test:
     executor: frontend_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - *restore_frontend_deps
       - *restore_frontend_comm_deps
       - run:
@@ -780,7 +803,7 @@ jobs:
   proxy_build_and_push_image:
     executor: aws_docker_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - setup_authenticated_remote_docker
       - run:
           name: Test proxy image configuration
@@ -795,21 +818,17 @@ jobs:
       - build_docker_image:
           image: evaka/proxy
           dir: *workspace_proxy
-          push_after: true
       - notify_slack
 
   service_build:
     executor: service_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - *restore_service_gradle
       - run:
           working_directory: *workspace_service
           command: ./gradlew assemble compileIntegrationTestKotlin
-      - persist_to_workspace:
-          root: << pipeline.parameters.workspace_root >>
-          paths:
-            - service/build/libs/
+      - store_service_build
       - run:
           working_directory: *workspace_service
           command: |
@@ -841,11 +860,12 @@ jobs:
           path: << pipeline.parameters.workspace_root >>/service/build/reports/
       - notify_slack
 
-  service_build_image:
+  service_build_and_push_image:
     executor: aws_docker_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - attach_root_workspace
+      - restore_service_build
       - setup_remote_docker:
           version: *remote_docker_version
           docker_layer_caching: true
@@ -856,17 +876,16 @@ jobs:
       - load_base_image
       - build_docker_image:
           image: evaka/service
-          dir: *workspace_service
-      - persist_to_workspace:
-          root: << pipeline.parameters.workspace_root >>
-          paths:
-            - service/image.tar
+          dir: << pipeline.parameters.workspace_root >>/service
+          save_image: true
+      - store_docker_image:
+          dir: service
       - notify_slack
 
   service_test:
     executor: service_test_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - *restore_service_gradle
       - run:
           name: gradle test
@@ -894,7 +913,7 @@ jobs:
     executor: service_test_executor
     parallelism: 4
     steps:
-      - *restore_repo
+      - restore_repo
       - *restore_service_gradle
       - login_docker_hub
       - run:
@@ -921,30 +940,15 @@ jobs:
           path: << pipeline.parameters.workspace_root >>/service-lib/build/reports/
       - notify_slack
 
-  service_push_image:
-    executor: aws_docker_executor
-    steps:
-      - *restore_repo
-      - attach_root_workspace
-      - setup_remote_docker:
-          version: *remote_docker_version
-      - push_docker_image:
-          image: evaka/service
-          dir: *workspace_service
-      - notify_slack
-
   message_service_build:
     executor: service_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - *restore_message_service_gradle
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew assemble compileIntegrationTestKotlin
-      - persist_to_workspace:
-          root: << pipeline.parameters.workspace_root >>
-          paths:
-            - message-service/build/libs/
+      - store_message_service_build
       - *store_message_service_gradle
       - run:
           working_directory: *workspace_message_service
@@ -971,7 +975,7 @@ jobs:
   message_service_test:
     executor: service_test_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - *restore_message_service_gradle
       - run:
           working_directory: *workspace_message_service
@@ -985,7 +989,7 @@ jobs:
   message_service_integration_test:
     executor: service_test_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - *restore_message_service_gradle
       - login_docker_hub
       - run:
@@ -1003,8 +1007,9 @@ jobs:
   message_service_build_and_push_image:
     executor: aws_docker_executor
     steps:
-      - *restore_repo
+      - restore_repo
       - attach_root_workspace
+      - restore_message_service_build
       - setup_remote_docker:
           version: *remote_docker_version
           docker_layer_caching: true
@@ -1016,7 +1021,6 @@ jobs:
       - build_docker_image:
           image: evaka/message-service
           dir: *workspace_message_service
-          push_after: true
       - notify_slack
 
 workflows:
@@ -1047,15 +1051,11 @@ workflows:
           <<: *default_contexts
           requires:
             - checkout_repo
-      - apigw_build_image:
+      - apigw_build_and_push_image:
           <<: *aws_contexts
           requires:
             - build_base_image
             - apigw_build_and_test
-      - apigw_push_image:
-          <<: *aws_contexts
-          requires:
-            - apigw_build_image
 
       - frontend_build_and_test:
           context:
@@ -1069,14 +1069,14 @@ workflows:
           <<: *default_contexts
           requires:
             - frontend_build_and_test
-            - apigw_build_image
-            - service_build_image
+            - apigw_build_and_push_image
+            - service_build_and_push_image
       - e2e-test-playwright:
           <<: *default_contexts
           requires:
             - frontend_build_and_test
-            - apigw_build_image
-            - service_build_image
+            - apigw_build_and_push_image
+            - service_build_and_push_image
 
       - proxy_build_and_push_image:
           context:
@@ -1090,7 +1090,7 @@ workflows:
           <<: *default_contexts
           requires:
             - checkout_repo
-      - service_build_image:
+      - service_build_and_push_image:
           <<: *aws_contexts
           requires:
             - build_base_image
@@ -1103,12 +1103,6 @@ workflows:
           <<: *default_contexts
           requires:
             - service_build
-      - service_push_image:
-          <<: *aws_contexts
-          requires:
-            - service_build_image
-            - service_test
-            - service_integration_test
 
       - message_service_build:
           <<: *default_contexts
@@ -1135,9 +1129,9 @@ workflows:
             - lint_scripts
             - e2e-test-testcafe
             - e2e-test-playwright
-            - apigw_push_image
+            - apigw_build_and_push_image
             - proxy_build_and_push_image
-            - service_push_image
+            - service_build_and_push_image
             - message_service_build_and_push_image
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,12 +131,14 @@ commands:
   store_repo:
     steps:
       - save_cache:
+          name: Store repo
           key: repo-v1-{{ .Branch }}-{{ .Revision }}
           paths:
             - .
   restore_repo:
     steps:
       - restore_cache:
+          name: Restore repo
           keys:
             - repo-v1-{{ .Branch }}-{{ .Revision }}
 
@@ -146,6 +148,7 @@ commands:
         type: string
     steps:
       - save_cache:
+          name: Store Docker image in cache
           key: << parameters.dir >>-image-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
           paths:
             - << pipeline.parameters.workspace_root >>/<< parameters.dir >>/image.tar
@@ -155,6 +158,7 @@ commands:
         type: string
     steps:
       - restore_cache:
+          name: Restore Docker image from cache
           key: << parameters.dir >>-image-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - run: docker load -i << parameters.dir >>/image.tar
 
@@ -219,12 +223,14 @@ commands:
   store_frontend_comm_deps:
     steps:
       - save_cache:
+          name: Store commercial dependencies
           key: frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
           paths:
             - frontend/vendor/fortawesome
   restore_frontend_comm_deps:
     steps:
       - restore_cache:
+          name: Restore commercial dependencies
           keys:
             - frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
             - frontend-comm-deps-v1-
@@ -233,6 +239,7 @@ commands:
   store_service_gradle:
     steps:
       - save_cache:
+          name: Store Gradle cache
           key: gradle-home-service-v5-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
           paths:
             - service/buildSrc/.gradle
@@ -244,12 +251,14 @@ commands:
   restore_service_gradle:
     steps:
       - restore_cache:
+          name: Restore Gradle cache
           keys:
             - gradle-home-service-v5-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
             - gradle-home-service-v5-
   store_message_service_gradle:
     steps:
       - save_cache:
+          name: Store Gradle cache
           key: gradle-home-message-service-v5-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
           paths:
             - message-service/buildSrc/.gradle
@@ -260,6 +269,7 @@ commands:
   restore_message_service_gradle:
     steps:
       - restore_cache:
+          name: Restore Gradle cache
           keys:
             - gradle-home-message-service-v5-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
             - gradle-home-message-service-v5-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ aliases:
       key: yarn-cache-frontend-v1-{{ checksum "frontend/yarn.lock" }}
       paths:
         - frontend/.yarn/cache
+        - frontend/node_modules
 
   - &restore_service_gradle
     restore_cache:
@@ -276,6 +277,10 @@ commands:
               && chromedriver --version
       - *restore_frontend_deps
       - run:
+          name: Install frontend dependencies from Yarn cache
+          working_directory: *workspace_frontend
+          command: yarn install --immutable --immutable-cache
+      - run:
           name: Run e2e tests against compose
           working_directory: *workspace_frontend
           command: |
@@ -334,6 +339,10 @@ commands:
             sudo apt-get update && sudo apt-get --yes install --no-install-recommends yarn=<< parameters.yarn_version >>
             yarn --version
       - *restore_frontend_deps
+      - run:
+          name: Install frontend dependencies from Yarn cache
+          working_directory: *workspace_frontend
+          command: yarn install --immutable --immutable-cache
       - run:
           name: Install Playwright dependencies
           command: |
@@ -696,7 +705,6 @@ jobs:
           paths:
             - frontend/dist
             - frontend/storybook-build
-            - frontend/node_modules
       - run:
           working_directory: *workspace_frontend
           command: yarn lint-strict

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,91 +64,6 @@ aliases:
       GRADLE_USER_HOME: << pipeline.parameters.workspace_root >>/.gradle-user-home
       JAVA_TOOL_OPTIONS: "-Xmx2048m"
 
-  - &restore_apigw_deps
-    restore_cache:
-      keys:
-        - yarn-cache-apigw-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "apigw/yarn.lock" }}
-        - yarn-cache-apigw-v1-
-        - yarn-cache-apigw-
-
-  - &store_apigw_deps
-    save_cache:
-      key: yarn-cache-apigw-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "apigw/yarn.lock" }}
-      paths:
-        - apigw/.yarn/cache
-
-  - &restore_frontend_deps
-    restore_cache:
-      keys:
-        - yarn-cache-frontend-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
-        - yarn-cache-frontend-v1-
-        - yarn-cache-frontend-
-
-  - &store_frontend_deps
-    save_cache:
-      key: yarn-cache-frontend-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
-      paths:
-        - frontend/.yarn/cache
-        - frontend/node_modules
-
-  - &restore_frontend_comm_deps
-    restore_cache:
-      keys:
-        - frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
-        - frontend-comm-deps-v1-
-        - frontend-comm-deps-
-
-  - &store_frontend_comm_deps
-    save_cache:
-      key: frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
-      paths:
-        - frontend/vendor/fortawesome
-
-  - &restore_service_gradle
-    restore_cache:
-      keys:
-        - gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
-        - gradle-home-service-v4-
-
-  - &store_service_gradle
-    save_cache:
-      key: gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
-      paths:
-        # Actual Gradle files
-        - service/buildSrc/.gradle
-        - service/.gradle
-        - service/custom-ktlint-rules/.gradle
-        - .gradle-user-home/wrapper
-        - .gradle-user-home/caches
-        - .gradle-user-home/notifications
-        # Build files
-        - service/build
-        - service/buildSrc/build
-        - service/custom-ktlint-rules/build
-        - service/vtjclient/build
-        - service-lib/build
-
-  - &restore_message_service_gradle
-    restore_cache:
-      keys:
-        - gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
-        - gradle-home-message-service-v4-
-
-  - &store_message_service_gradle
-    save_cache:
-      key: gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
-      paths:
-        # Actual Gradle files
-        - message-service/buildSrc/.gradle
-        - message-service/.gradle
-        - .gradle-user-home/wrapper
-        - .gradle-user-home/caches
-        - .gradle-user-home/notifications
-        # Build files
-        - message-service/build
-        - message-service/buildSrc/build
-        - message-service-lib/build
-
 executors:
   aws_core_executor:
     <<: *default_config
@@ -224,6 +139,7 @@ commands:
       - restore_cache:
           keys:
             - repo-v1-{{ .Branch }}-{{ .Revision }}
+
   store_docker_image:
     parameters:
       dir:
@@ -241,6 +157,7 @@ commands:
       - restore_cache:
           key: << parameters.dir >>-image-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - run: docker load -i << parameters.dir >>/image.tar
+
   store_service_build:
     steps:
       - save_cache:
@@ -261,6 +178,96 @@ commands:
     steps:
       - restore_cache:
           key: message-service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+
+  restore_apigw_deps:
+    steps:
+      - restore_cache:
+          keys:
+            - yarn-cache-apigw-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "apigw/yarn.lock" }}
+            - yarn-cache-apigw-v1-
+            - yarn-cache-apigw-
+  store_apigw_deps:
+    steps:
+      - save_cache:
+          key: yarn-cache-apigw-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "apigw/yarn.lock" }}
+          paths:
+            - apigw/.yarn/cache
+
+  restore_frontend_deps:
+    steps:
+      - restore_cache:
+          keys:
+            - yarn-cache-frontend-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
+            - yarn-cache-frontend-v1-
+            - yarn-cache-frontend-
+  store_frontend_deps:
+    steps:
+      - save_cache:
+          key: yarn-cache-frontend-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
+          paths:
+            - frontend/.yarn/cache
+            - frontend/node_modules
+
+  restore_frontend_comm_deps:
+    steps:
+      - restore_cache:
+          keys:
+            - frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
+            - frontend-comm-deps-v1-
+            - frontend-comm-deps-
+  store_frontend_comm_deps:
+    steps:
+      - save_cache:
+          key: frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
+          paths:
+            - frontend/vendor/fortawesome
+
+  restore_service_gradle:
+    steps:
+      - restore_cache:
+          keys:
+            - gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
+            - gradle-home-service-v4-
+  store_service_gradle:
+    steps:
+      - save_cache:
+          key: gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
+          paths:
+            # Actual Gradle files
+            - service/buildSrc/.gradle
+            - service/.gradle
+            - service/custom-ktlint-rules/.gradle
+            - .gradle-user-home/wrapper
+            - .gradle-user-home/caches
+            - .gradle-user-home/notifications
+            # Build files
+            - service/build
+            - service/buildSrc/build
+            - service/custom-ktlint-rules/build
+            - service/vtjclient/build
+            - service-lib/build
+
+  restore_message_service_gradle:
+    steps:
+      - restore_cache:
+          keys:
+            - gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
+            - gradle-home-message-service-v4-
+  store_message_service_gradle:
+    steps:
+      - save_cache:
+          key: gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
+          paths:
+            # Actual Gradle files
+            - message-service/buildSrc/.gradle
+            - message-service/.gradle
+            - .gradle-user-home/wrapper
+            - .gradle-user-home/caches
+            - .gradle-user-home/notifications
+            # Build files
+            - message-service/build
+            - message-service/buildSrc/build
+            - message-service-lib/build
 
   # Misc commands
 
@@ -376,8 +383,8 @@ commands:
                 name: Install Playwright dependencies
                 command: |
                   sudo apt-get update && sudo apt-get --yes install --no-install-recommends libgbm1
-      - *restore_frontend_deps
-      - *restore_frontend_comm_deps
+      - restore_frontend_deps
+      - restore_frontend_comm_deps
       - run:
           name: Install frontend dependencies from Yarn cache
           working_directory: *workspace_frontend
@@ -623,14 +630,14 @@ jobs:
     executor: aws_core_executor
     steps:
       - restore_repo
-      - *restore_frontend_comm_deps
+      - restore_frontend_comm_deps
       - run: replace-credentials
       - run:
           name: Fetch commercial frontend dependencies
           working_directory: *workspace_frontend
           command: |
             ./init-pro-icons.sh
-      - *store_frontend_comm_deps
+      - store_frontend_comm_deps
       - notify_slack
 
   clone_infra_repo:
@@ -685,11 +692,11 @@ jobs:
     executor: apigw_executor
     steps:
       - restore_repo
-      - *restore_apigw_deps
+      - restore_apigw_deps
       - run:
           working_directory: *workspace_apigw
           command: yarn install --immutable
-      - *store_apigw_deps
+      - store_apigw_deps
       - run:
           working_directory: *workspace_apigw
           command: yarn build
@@ -728,8 +735,8 @@ jobs:
     executor: frontend_executor
     steps:
       - restore_repo
-      - *restore_frontend_deps
-      - *restore_frontend_comm_deps
+      - restore_frontend_deps
+      - restore_frontend_comm_deps
       - run:
           working_directory: *workspace_frontend
           command: yarn install --immutable
@@ -738,7 +745,7 @@ jobs:
           working_directory: *workspace_frontend
           command: |
             ./unpack-pro-icons.sh
-      - *store_frontend_deps
+      - store_frontend_deps
       - build_frontend
       - build_maintenance_page
       - build_storybook
@@ -824,7 +831,7 @@ jobs:
     executor: service_executor
     steps:
       - restore_repo
-      - *restore_service_gradle
+      - restore_service_gradle
       - run:
           working_directory: *workspace_service
           command: ./gradlew assemble compileIntegrationTestKotlin
@@ -834,7 +841,7 @@ jobs:
           command: |
             cd custom-ktlint-rules
             ./gradlew assemble
-      - *store_service_gradle
+      - store_service_gradle
       - run:
           working_directory: *workspace_service
           command: ./gradlew lintKotlin
@@ -886,7 +893,7 @@ jobs:
     executor: service_test_executor
     steps:
       - restore_repo
-      - *restore_service_gradle
+      - restore_service_gradle
       - run:
           name: gradle test
           working_directory: *workspace_service
@@ -914,7 +921,7 @@ jobs:
     parallelism: 4
     steps:
       - restore_repo
-      - *restore_service_gradle
+      - restore_service_gradle
       - login_docker_hub
       - run:
           name: gradle integrationTest
@@ -944,12 +951,12 @@ jobs:
     executor: service_executor
     steps:
       - restore_repo
-      - *restore_message_service_gradle
+      - restore_message_service_gradle
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew assemble compileIntegrationTestKotlin
       - store_message_service_build
-      - *store_message_service_gradle
+      - store_message_service_gradle
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew lintKotlin
@@ -976,7 +983,7 @@ jobs:
     executor: service_test_executor
     steps:
       - restore_repo
-      - *restore_message_service_gradle
+      - restore_message_service_gradle
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew test
@@ -990,7 +997,7 @@ jobs:
     executor: service_test_executor
     steps:
       - restore_repo
-      - *restore_message_service_gradle
+      - restore_message_service_gradle
       - login_docker_hub
       - run:
           name: gradle integrationTest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ commands:
     steps:
       - save_cache:
           name: Store Docker image in cache
-          key: << parameters.dir >>-image-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          key: << parameters.dir >>-image-v1-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           paths:
             - << pipeline.parameters.workspace_root >>/<< parameters.dir >>/image.tar
   restore_docker_image:
@@ -169,7 +169,7 @@ commands:
     steps:
       - restore_cache:
           name: Restore Docker image from cache
-          key: << parameters.dir >>-image-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          key: << parameters.dir >>-image-v1-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run: docker load -i << parameters.dir >>/image.tar
 
   # Artifacts or sub-workspaces would be ideal here but instead we need to
@@ -180,26 +180,26 @@ commands:
     steps:
       - save_cache:
           name: Store build artifacts
-          key: service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          key: service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           paths:
             - << pipeline.parameters.workspace_root >>/service/build/libs/
   restore_service_artifacts:
     steps:
       - restore_cache:
           name: Restore build artifacts
-          key: service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          key: service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
   store_message_service_artifacts:
     steps:
       - save_cache:
           name: Store build artifacts
-          key: message-service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          key: message-service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           paths:
             - << pipeline.parameters.workspace_root >>/message-service/build/libs/
   restore_message_service_artifacts:
     steps:
       - restore_cache:
           name: Restore build artifacts
-          key: message-service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          key: message-service-build-v1-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
 
   store_apigw_deps:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,6 +458,7 @@ commands:
                 | awk -F "'" '{print $2}' \
                 | sort -h | uniq \
                 | circleci tests split --split-by=timings --timings-type classname)
+              echo "Fixtures selected for node: ${FIXTURE_NAMES}"
               # NOTE: This is extremely brittle but necessary as Testcafe
               # doesn't support multiple --fixture arguments (+ the above
               # report issue) -> everything must be a single regex.
@@ -984,10 +985,11 @@ jobs:
                 | sed 's/.*src\/integrationTest\/kotlin\///' \
                 | sed 's@/@.@g' \
                 | sed 's/.kt//' \
+                | sort -h \
                 | circleci tests split --split-by=timings --timings-type=classname)
             # Format the arguments for Gradle
             GRADLE_ARGS=$(echo "$CLASSNAMES" | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
-            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            echo "Prepared arguments for Gradle:\n$GRADLE_ARGS"
             ./gradlew integrationTest $GRADLE_ARGS
       - store_test_results:
           path: << pipeline.parameters.workspace_root >>/service/build/test-results/integrationTest/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,7 @@ commands:
     parameters:
       suite:
         type: string
+        default: ""
       yarn_version:
         type: string
         default: *yarn_version
@@ -318,12 +319,26 @@ commands:
           working_directory: *workspace_frontend
           command: yarn install --immutable --immutable-cache
       - run:
+          name: Wait for compose stack to be up
+          working_directory: *workspace_frontend
+          command: |
+            ./wait-for-dev-api.sh 'http://localhost:9999' || (cd << pipeline.parameters.workspace_root >>/compose && ./compose-e2e logs && false)
+      - run:
           name: Run e2e tests against compose
           working_directory: *workspace_frontend
           command: |
             nvm use
-            ./wait-for-dev-api.sh 'http://localhost:9999' || (cd << pipeline.parameters.workspace_root >>/compose && ./compose-e2e logs && false)
-            yarn << parameters.suite >>
+
+            if [ "<< parameters.suite >>" != "" ]; then
+              yarn "<< parameters.suite >>"
+            else
+              # Get list of test files that should run on this node
+              TESTFILES=$(circleci tests glob "src/e2e-test/**/*.spec.ts" \
+                  | circleci tests split --split-by=timings --timings-type=filename)
+              echo "Prepared arguments for yarn: $TESTFILES"
+
+              yarn e2e-ci-base $TESTFILES
+            fi
       - run:
           name: Collect docker-compose logs
           command: |
@@ -694,13 +709,10 @@ jobs:
   # E2E JOBS
 
   e2e-test-testcafe:
-    parameters:
-      suite:
-        type: string
     executor: e2e_executor
+    parallelism: 8
     steps:
-      - e2e_test:
-          suite: e2e-ci-<< parameters.suite >>
+      - e2e_test
       - notify_slack
 
   e2e-test-playwright:
@@ -1024,20 +1036,10 @@ workflows:
 
       - e2e-test-testcafe:
           <<: *default_contexts
-          name: e2e-test-<< matrix.suite >>
           requires:
             - frontend_build_and_test
             - apigw_build_image
             - service_build_image
-          matrix:
-            parameters:
-              suite:
-                - citizen
-                - invoicing
-                - employee
-                - employee-2
-                - mobile
-                - messaging
       - e2e-test-playwright:
           <<: *default_contexts
           requires:
@@ -1100,12 +1102,7 @@ workflows:
           <<: *aws_contexts
           requires:
             - lint_scripts
-            - e2e-test-citizen
-            - e2e-test-invoicing
-            - e2e-test-employee
-            - e2e-test-employee-2
-            - e2e-test-mobile
-            - e2e-test-messaging
+            - e2e-test-testcafe
             - e2e-test-playwright
             - apigw_push_image
             - proxy_build_and_push_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,12 +99,12 @@ aliases:
   - &restore_service_gradle
     restore_cache:
       keys:
-        - gradle-home-service-v4-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
+        - gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
         - gradle-home-service-v4-
 
   - &store_service_gradle
     save_cache:
-      key: gradle-home-service-v4-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
+      key: gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
       paths:
         - service/.gradle
         - .gradle-user-home
@@ -819,7 +819,7 @@ jobs:
       - *restore_service_gradle
       - run:
           working_directory: *workspace_service
-          command: ./gradlew assemble
+          command: ./gradlew assemble compileIntegrationTestKotlin
       - *store_service_gradle
       - persist_to_workspace:
           root: *workspace_root
@@ -927,18 +927,7 @@ jobs:
           name: gradle custom-ktlint-rules test
           command: |
             cd custom-ktlint-rules
-            # Get list of classnames of tests that should run on this node
-            CLASSNAMES=$(circleci tests glob \
-                "src/test/kotlin/**/*{Test,Tests}.kt" \
-                "../service-lib/src/test/kotlin/**/*{Test,Tests}.kt" \
-                | sed 's/.*src\/test\/kotlin\///' \
-                | sed 's@/@.@g' \
-                | sed 's/.kt//' \
-                | circleci tests split --split-by=timings --timings-type=classname)
-            # Format the arguments for Gradle
-            GRADLE_ARGS=$(echo "$CLASSNAMES" | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
-            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
-            ./gradlew test $GRADLE_ARGS
+            ./gradlew test
       - store_test_results:
           path: /home/circleci/repo/service/custom-ktlint-rules/build/test-results/test/
       - notify_slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,19 @@ orbs:
   slack: circleci/slack@4.1.3
   owasp: entur/owasp@0.0.14
 
+parameters:
+  workspace_root:
+    type: string
+    default: /home/circleci/repo
+
 aliases:
-  - &workspace_root /home/circleci/repo
-  - &workspace_evaka_base /home/circleci/repo/evaka-base
-  - &workspace_apigw /home/circleci/repo/apigw
-  - &workspace_frontend /home/circleci/repo/frontend
-  - &workspace_proxy /home/circleci/repo/proxy
-  - &workspace_service /home/circleci/repo/service
-  - &workspace_message_service /home/circleci/repo/message-service
-  - &workspace_compose /home/circleci/repo/compose
+  - &workspace_evaka_base << pipeline.parameters.workspace_root >>/evaka-base
+  - &workspace_apigw << pipeline.parameters.workspace_root >>/apigw
+  - &workspace_frontend << pipeline.parameters.workspace_root >>/frontend
+  - &workspace_proxy << pipeline.parameters.workspace_root >>/proxy
+  - &workspace_service << pipeline.parameters.workspace_root >>/service
+  - &workspace_message_service << pipeline.parameters.workspace_root >>/message-service
+  - &workspace_compose << pipeline.parameters.workspace_root >>/compose
 
   # SSH key fingerprint for checking out other eVaka repositories
   - &ci_evaka_fingerprint 86:d0:b3:3d:aa:fc:d5:b9:6b:69:1e:c7:f5:56:66:aa
@@ -43,7 +47,7 @@ aliases:
       - org-global
 
   - &default_config
-    working_directory: *workspace_root
+    working_directory: << pipeline.parameters.workspace_root >>
 
   - &node_config
     <<: *default_config
@@ -55,7 +59,7 @@ aliases:
     <<: *default_config
     environment:
       GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2048m"'
-      GRADLE_USER_HOME: /home/circleci/repo/.gradle-user-home
+      GRADLE_USER_HOME: << pipeline.parameters.workspace_root >>/.gradle-user-home
       JAVA_TOOL_OPTIONS: "-Xmx2048m"
 
   - &restore_repo
@@ -188,13 +192,13 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-    working_directory: *workspace_root
+    working_directory: << pipeline.parameters.workspace_root >>
 
 commands:
   attach_root_workspace:
     steps:
       - attach_workspace:
-          at: *workspace_root
+          at: << pipeline.parameters.workspace_root >>
 
   login_docker_hub:
     description: Log in to Docker Hub for authenticated pulls
@@ -304,12 +308,12 @@ commands:
           working_directory: *workspace_frontend
           command: |
             nvm use
-            ./wait-for-dev-api.sh 'http://localhost:9999' || (cd /home/circleci/repo/compose && ./compose-e2e logs && false)
+            ./wait-for-dev-api.sh 'http://localhost:9999' || (cd << pipeline.parameters.workspace_root >>/compose && ./compose-e2e logs && false)
             yarn << parameters.suite >>
       - run:
           name: Collect docker-compose logs
           command: |
-            cd /home/circleci/repo/compose
+            cd << pipeline.parameters.workspace_root >>/compose
             ./compose-e2e logs --tail=all > /tmp/docker-compose-logs.txt
           when: always
       - store_artifacts:
@@ -371,12 +375,12 @@ commands:
           working_directory: *workspace_frontend
           command: |
             nvm use
-            ./wait-for-dev-api.sh 'http://localhost:9999' || (cd /home/circleci/repo/compose && ./compose-e2e logs && false)
+            ./wait-for-dev-api.sh 'http://localhost:9999' || (cd << pipeline.parameters.workspace_root >>/compose && ./compose-e2e logs && false)
             yarn << parameters.suite >>
       - run:
           name: Collect docker-compose logs
           command: |
-            cd /home/circleci/repo/compose
+            cd << pipeline.parameters.workspace_root >>/compose
             ./compose-e2e logs --tail=all > /tmp/docker-compose-logs.txt
           when: always
       - store_artifacts:
@@ -427,7 +431,7 @@ commands:
     steps:
       - run:
           name: Deploy (<< parameters.from >>)
-          working_directory: /home/circleci/repo/<< parameters.from >>
+          working_directory: << pipeline.parameters.workspace_root >>/<< parameters.from >>
           command: |
             aws s3 cp ./index.html s3://evaka-static-<< parameters.target_env >>/<< parameters.to >>/index.html \
               --acl public-read \
@@ -454,7 +458,7 @@ commands:
     steps:
       - run:
           name: Deploy Storybook
-          working_directory: /home/circleci/repo/frontend
+          working_directory: << pipeline.parameters.workspace_root >>/frontend
           command: |
             if [ "<< parameters.target_env >>" = "dev" ]; then
               aws --profile voltti-dev s3 cp storybook-build/ s3://evaka-static-dev/master/storybook/ --recursive --acl public-read
@@ -464,7 +468,7 @@ commands:
     steps:
       - run:
           name: Load base image
-          working_directory: *workspace_root
+          working_directory: << pipeline.parameters.workspace_root >>
           command: docker load -i evaka-base.tar
 
   build_docker_image:
@@ -593,7 +597,7 @@ jobs:
           command: |
             ./init-pro-icons.sh
       - persist_to_workspace:
-          root: *workspace_root
+          root: << pipeline.parameters.workspace_root >>
           paths:
             - frontend/vendor/fortawesome/*
       - notify_slack
@@ -607,7 +611,7 @@ jobs:
       - attach_root_workspace
       - run: git clone git@github.com:espoon-voltti/evaka-infra.git
       - persist_to_workspace:
-          root: *workspace_root
+          root: << pipeline.parameters.workspace_root >>
           paths:
             - evaka-infra
       - notify_slack
@@ -634,14 +638,14 @@ jobs:
       - setup_authenticated_remote_docker
       - run:
           name: Build base image
-          working_directory: *workspace_evaka_base
+          working_directory: << pipeline.parameters.workspace_root >>/evaka-base
           command: ./build.sh
       - run:
           name: Save base image
-          working_directory: *workspace_root
+          working_directory: << pipeline.parameters.workspace_root >>
           command: docker save evaka-base > evaka-base.tar
       - persist_to_workspace:
-          root: *workspace_root
+          root: << pipeline.parameters.workspace_root >>
           paths:
             - evaka-base.tar
       - notify_slack
@@ -659,7 +663,7 @@ jobs:
           working_directory: *workspace_apigw
           command: yarn build
       - persist_to_workspace:
-          root: *workspace_root
+          root: << pipeline.parameters.workspace_root >>
           paths:
             - apigw/dist
       - run:
@@ -669,7 +673,7 @@ jobs:
           working_directory: *workspace_apigw
           command: yarn test-ci
       - store_test_results:
-          path: /home/circleci/repo/apigw/build/test-reports
+          path: << pipeline.parameters.workspace_root >>/apigw/build/test-reports
       - notify_slack
 
   apigw_build_image:
@@ -685,7 +689,7 @@ jobs:
           image: evaka/api-gateway
           dir: *workspace_apigw
       - persist_to_workspace:
-          root: *workspace_root
+          root: << pipeline.parameters.workspace_root >>
           paths:
             - apigw/image.tar
       - notify_slack
@@ -720,7 +724,7 @@ jobs:
       - build_maintenance_page
       - build_storybook
       - persist_to_workspace:
-          root: *workspace_root
+          root: << pipeline.parameters.workspace_root >>
           paths:
             - frontend/dist
             - frontend/storybook-build
@@ -734,7 +738,7 @@ jobs:
           working_directory: *workspace_frontend
           command: yarn test --maxWorkers=2
       - store_test_results:
-          path: /home/circleci/repo/frontend/test-results
+          path: << pipeline.parameters.workspace_root >>/frontend/test-results
       - notify_slack
 
   # E2E JOBS
@@ -840,7 +844,7 @@ jobs:
           working_directory: *workspace_service
           command: ./gradlew assemble compileIntegrationTestKotlin
       - persist_to_workspace:
-          root: *workspace_root
+          root: << pipeline.parameters.workspace_root >>
           paths:
             - service/build/libs/
       - run:
@@ -864,14 +868,14 @@ jobs:
           working_directory: *workspace_service
           command: ./gradlew dependencyCheckUpdate
       - owasp/store_owasp_cache:
-          cve_data_directory: /home/circleci/repo/.gradle-user-home/dependency-check-data
+          cve_data_directory: << pipeline.parameters.workspace_root >>/.gradle-user-home/dependency-check-data
           cache_key: gradle-v1-cache-key
       - run:
           name: Run OWASP Dependency-Check Analyzer
           working_directory: *workspace_service
           command: ./gradlew dependencyCheckAnalyze
       - store_artifacts:
-          path: /home/circleci/repo/service/build/reports/
+          path: << pipeline.parameters.workspace_root >>/service/build/reports/
       - notify_slack
 
   service_build_image:
@@ -891,7 +895,7 @@ jobs:
           image: evaka/service
           dir: *workspace_service
       - persist_to_workspace:
-          root: *workspace_root
+          root: << pipeline.parameters.workspace_root >>
           paths:
             - service/image.tar
       - notify_slack
@@ -906,13 +910,13 @@ jobs:
           working_directory: *workspace_service
           command: ./gradlew test
       - store_test_results:
-          path: /home/circleci/repo/service/build/test-results/test/
+          path: << pipeline.parameters.workspace_root >>/service/build/test-results/test/
       - store_test_results:
-          path: /home/circleci/repo/service-lib/build/test-results/test/
+          path: << pipeline.parameters.workspace_root >>/service-lib/build/test-results/test/
       - store_artifacts:
-          path: /home/circleci/repo/service/build/reports/
+          path: << pipeline.parameters.workspace_root >>/service/build/reports/
       - store_artifacts:
-          path: /home/circleci/repo/service-lib/build/reports/
+          path: << pipeline.parameters.workspace_root >>/service-lib/build/reports/
       - run:
           working_directory: *workspace_service
           name: gradle custom-ktlint-rules test
@@ -920,7 +924,7 @@ jobs:
             cd custom-ktlint-rules
             ./gradlew test
       - store_test_results:
-          path: /home/circleci/repo/service/custom-ktlint-rules/build/test-results/test/
+          path: << pipeline.parameters.workspace_root >>/service/custom-ktlint-rules/build/test-results/test/
       - notify_slack
 
   service_integration_test:
@@ -947,11 +951,11 @@ jobs:
             echo "Prepared arguments for Gradle: $GRADLE_ARGS"
             ./gradlew integrationTest $GRADLE_ARGS
       - store_test_results:
-          path: /home/circleci/repo/service/build/test-results/integrationTest/
+          path: << pipeline.parameters.workspace_root >>/service/build/test-results/integrationTest/
       - store_artifacts:
-          path: /home/circleci/repo/service/build/reports/
+          path: << pipeline.parameters.workspace_root >>/service/build/reports/
       - store_artifacts:
-          path: /home/circleci/repo/service-lib/build/reports/
+          path: << pipeline.parameters.workspace_root >>/service-lib/build/reports/
       - notify_slack
 
   service_push_image:
@@ -975,7 +979,7 @@ jobs:
           working_directory: *workspace_message_service
           command: ./gradlew assemble compileIntegrationTestKotlin
       - persist_to_workspace:
-          root: *workspace_root
+          root: << pipeline.parameters.workspace_root >>
           paths:
             - message-service/build/libs/
       - *store_message_service_gradle
@@ -991,14 +995,14 @@ jobs:
           working_directory: *workspace_message_service
           command: ./gradlew dependencyCheckUpdate
       - owasp/store_owasp_cache:
-          cve_data_directory: /home/circleci/repo/.gradle-user-home/dependency-check-data
+          cve_data_directory: << pipeline.parameters.workspace_root >>/.gradle-user-home/dependency-check-data
           cache_key: gradle-v1-cache-key
       - run:
           name: Run OWASP Dependency-Check Analyzer
           working_directory: *workspace_message_service
           command: ./gradlew dependencyCheckAnalyze
       - store_artifacts:
-          path: /home/circleci/repo/message-service/build/reports/
+          path: << pipeline.parameters.workspace_root >>/message-service/build/reports/
       - notify_slack
 
   message_service_test:
@@ -1010,9 +1014,9 @@ jobs:
           working_directory: *workspace_message_service
           command: ./gradlew test
       - store_test_results:
-          path: /home/circleci/repo/message-service/build/test-results/test/
+          path: << pipeline.parameters.workspace_root >>/message-service/build/test-results/test/
       - store_test_results:
-          path: /home/circleci/repo/service-lib/build/test-results/test/
+          path: << pipeline.parameters.workspace_root >>/service-lib/build/test-results/test/
       - notify_slack
 
   message_service_integration_test:
@@ -1026,11 +1030,11 @@ jobs:
           working_directory: *workspace_message_service
           command: ./gradlew integrationTest
       - store_test_results:
-          path: /home/circleci/repo/message-service/build/test-results/integrationTest/
+          path: << pipeline.parameters.workspace_root >>/message-service/build/test-results/integrationTest/
       - store_artifacts:
-          path: /home/circleci/repo/message-service/build/reports/
+          path: << pipeline.parameters.workspace_root >>/message-service/build/reports/
       - store_artifacts:
-          path: /home/circleci/repo/service-lib/build/reports/
+          path: << pipeline.parameters.workspace_root >>/service-lib/build/reports/
       - notify_slack
 
   message_service_build_and_push_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1025,10 +1025,32 @@ jobs:
           path: /home/circleci/repo/message-service/build/test-results/test/
       - store_test_results:
           path: /home/circleci/repo/service-lib/build/test-results/test/
+      - notify_slack
+
+  message_service_integration_test:
+    executor: service_test_executor
+    parallelism: 4
+    steps:
+      - *restore_repo
+      - *restore_message_service_build
+      - *restore_message_service_gradle
       - login_docker_hub
       - run:
+          name: gradle integrationTest
           working_directory: *workspace_message_service
-          command: ./gradlew integrationTest
+          command: |
+            # Get list of classnames of tests that should run on this node
+            CLASSNAMES=$(circleci tests glob \
+                "src/integrationTest/kotlin/**/*{Test,Tests}.kt" \
+                "../service-lib/src/integrationTest/kotlin/**/*{Test,Tests}.kt" \
+                | sed 's/.*src\/integrationTest\/kotlin\///' \
+                | sed 's@/@.@g' \
+                | sed 's/.kt//' \
+                | circleci tests split --split-by=timings --timings-type=classname)
+            # Format the arguments for Gradle
+            GRADLE_ARGS=$(echo "$CLASSNAMES" | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
+            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            ./gradlew integrationTest $GRADLE_ARGS
       - store_test_results:
           path: /home/circleci/repo/message-service/build/test-results/integrationTest/
       - store_artifacts:
@@ -1185,11 +1207,16 @@ workflows:
           <<: *default_contexts
           requires:
             - message_service_build
+      - message_service_integration_test:
+          <<: *default_contexts
+          requires:
+            - message_service_build
       - message_service_build_and_push_image:
           <<: *aws_contexts
           requires:
             - build_base_image
             - message_service_test
+            - message_service_integration_test
 
       - clone_infra_repo:
           <<: *aws_contexts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ aliases:
   - &ci_evaka_fingerprint 86:d0:b3:3d:aa:fc:d5:b9:6b:69:1e:c7:f5:56:66:aa
 
   # Version of remote Docker engine used with setup_remote_docker (not including machine executors)
-  - &remote_docker_version "19.03.13"
+  - &remote_docker_version "20.10.6"
   - &yarn_version '1.22.\*'
   - &shellcheck_image_version v0.7.2
   - &nodejs_image cimg/node:14.15

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,26 +72,26 @@ aliases:
   - &restore_apigw_deps
     restore_cache:
       keys:
-        - yarn-cache-apigw-v1-{{ checksum "apigw/yarn.lock" }}
+        - yarn-cache-apigw-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "apigw/yarn.lock" }}
         - yarn-cache-apigw-v1-
         - yarn-cache-apigw-
 
   - &store_apigw_deps
     save_cache:
-      key: yarn-cache-apigw-v1-{{ checksum "apigw/yarn.lock" }}
+      key: yarn-cache-apigw-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "apigw/yarn.lock" }}
       paths:
         - apigw/.yarn/cache
 
   - &restore_frontend_deps
     restore_cache:
       keys:
-        - yarn-cache-frontend-v1-{{ checksum "frontend/yarn.lock" }}
+        - yarn-cache-frontend-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
         - yarn-cache-frontend-v1-
         - yarn-cache-frontend-
 
   - &store_frontend_deps
     save_cache:
-      key: yarn-cache-frontend-v1-{{ checksum "frontend/yarn.lock" }}
+      key: yarn-cache-frontend-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
       paths:
         - frontend/.yarn/cache
         - frontend/node_modules
@@ -112,12 +112,12 @@ aliases:
   - &restore_message_service_gradle
     restore_cache:
       keys:
-        - gradle-home-message-service-v4-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
+        - gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
         - gradle-home-message-service-v4-
 
   - &store_message_service_gradle
     save_cache:
-      key: gradle-home-message-service-v4-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
+      key: gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
       paths:
         - message-service/.gradle
         - .gradle-user-home

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -917,7 +917,7 @@ jobs:
       - notify_slack
 
   service_test:
-    executor: service_test_executor
+    executor: service_executor
     steps:
       - restore_repo
       - restore_service_gradle
@@ -1010,7 +1010,7 @@ jobs:
       - notify_slack
 
   message_service_test:
-    executor: service_test_executor
+    executor: service_executor
     steps:
       - restore_repo
       - restore_message_service_gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,46 +693,14 @@ jobs:
 
   # E2E JOBS
 
-  e2e-test-citizen:
+  e2e-test-testcafe:
+    parameters:
+      suite:
+        type: string
     executor: e2e_executor
     steps:
       - e2e_test:
-          suite: e2e-ci-citizen
-      - notify_slack
-
-  e2e-test-invoicing:
-    executor: e2e_executor
-    steps:
-      - e2e_test:
-          suite: e2e-ci-invoicing
-      - notify_slack
-
-  e2e-test-employee:
-    executor: e2e_executor
-    steps:
-      - e2e_test:
-          suite: e2e-ci-employee
-      - notify_slack
-
-  e2e-test-employee-2:
-    executor: e2e_executor
-    steps:
-      - e2e_test:
-          suite: e2e-ci-employee-2
-      - notify_slack
-
-  e2e-test-mobile:
-    executor: e2e_executor
-    steps:
-      - e2e_test:
-          suite: e2e-ci-mobile
-      - notify_slack
-
-  e2e-test-messaging:
-    executor: e2e_executor
-    steps:
-      - e2e_test:
-          suite: e2e-ci-messaging
+          suite: e2e-ci-<< parameters.suite >>
       - notify_slack
 
   e2e-test-playwright:
@@ -1053,42 +1021,23 @@ workflows:
             - sentry-release
           requires:
             - fetch_private_dependencies
-      - e2e-test-citizen:
+
+      - e2e-test-testcafe:
           <<: *default_contexts
+          name: e2e-test-<< matrix.suite >>
           requires:
             - frontend_build_and_test
             - apigw_build_image
             - service_build_image
-      - e2e-test-invoicing:
-          <<: *default_contexts
-          requires:
-            - frontend_build_and_test
-            - apigw_build_image
-            - service_build_image
-      - e2e-test-employee:
-          <<: *default_contexts
-          requires:
-            - frontend_build_and_test
-            - apigw_build_image
-            - service_build_image
-      - e2e-test-employee-2:
-          <<: *default_contexts
-          requires:
-            - frontend_build_and_test
-            - apigw_build_image
-            - service_build_image
-      - e2e-test-mobile:
-          <<: *default_contexts
-          requires:
-            - frontend_build_and_test
-            - apigw_build_image
-            - service_build_image
-      - e2e-test-messaging:
-          <<: *default_contexts
-          requires:
-            - frontend_build_and_test
-            - apigw_build_image
-            - service_build_image
+          matrix:
+            parameters:
+              suite:
+                - citizen
+                - invoicing
+                - employee
+                - employee-2
+                - mobile
+                - messaging
       - e2e-test-playwright:
           <<: *default_contexts
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ aliases:
         - service/custom-ktlint-rules/.gradle
         - .gradle-user-home/wrapper
         - .gradle-user-home/caches
+        - .gradle-user-home/notifications
         # Build files
         - service/build
         - service/buildSrc/build
@@ -134,6 +135,7 @@ aliases:
         - message-service/.gradle
         - .gradle-user-home/wrapper
         - .gradle-user-home/caches
+        - .gradle-user-home/notifications
         # Build files
         - message-service/build
         - message-service/buildSrc/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,6 @@ executors:
     <<: *node_config
     machine:
       image: *ubuntu_machine_image
-      docker_layer_caching: true
       resource_class: large
   service_executor:
     <<: *jvm_config
@@ -709,7 +708,7 @@ jobs:
 
   e2e-test-testcafe:
     executor: e2e_executor
-    parallelism: 8
+    parallelism: 16
     steps:
       - e2e_test
       - notify_slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ parameters:
   workspace_root:
     type: string
     default: /home/circleci/repo
+  builder_aws_version:
+    type: string
+    default: bullseye-slim-e2518f5ece6862d780ff4224aad606e13cfe8293
 
 aliases:
   - &workspace_evaka_base << pipeline.parameters.workspace_root >>/evaka-base
@@ -35,9 +38,9 @@ aliases:
   - &nodejs_image cimg/node:14.15
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202104-01
-  - &builder_aws_core_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:core-bullseye-slim-e2518f5ece6862d780ff4224aad606e13cfe8293
-  - &builder_aws_docker_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:docker-bullseye-slim-e2518f5ece6862d780ff4224aad606e13cfe8293
-  - &builder_aws_terraform_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:terraform-bullseye-slim-e2518f5ece6862d780ff4224aad606e13cfe8293
+  - &builder_aws_core_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:core-<< pipeline.parameters.builder_aws_version >>
+  - &builder_aws_docker_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:docker-<< pipeline.parameters.builder_aws_version >>
+  - &builder_aws_terraform_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:terraform-<< pipeline.parameters.builder_aws_version >>
 
   - &default_contexts
     context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,19 @@ aliases:
         - frontend/.yarn/cache
         - frontend/node_modules
 
+  - &restore_frontend_comm_deps
+    restore_cache:
+      keys:
+        - frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
+        - frontend-comm-deps-v1-
+        - frontend-comm-deps-
+
+  - &store_frontend_comm_deps
+    save_cache:
+      key: frontend-comm-deps-v1-{{ checksum ".circleci/config.yml" }}-{{ checksum "frontend/yarn.lock" }}
+      paths:
+        - frontend/vendor/fortawesome
+
   - &restore_service_gradle
     restore_cache:
       keys:
@@ -313,6 +326,7 @@ commands:
                 command: |
                   sudo apt-get update && sudo apt-get --yes install --no-install-recommends libgbm1
       - *restore_frontend_deps
+      - *restore_frontend_comm_deps
       - run:
           name: Install frontend dependencies from Yarn cache
           working_directory: *workspace_frontend
@@ -553,16 +567,14 @@ jobs:
     executor: aws_executor
     steps:
       - *restore_repo
+      - *restore_frontend_comm_deps
       - run: replace-credentials
       - run:
           name: Fetch commercial frontend dependencies
           working_directory: *workspace_frontend
           command: |
             ./init-pro-icons.sh
-      - persist_to_workspace:
-          root: << pipeline.parameters.workspace_root >>
-          paths:
-            - frontend/vendor/fortawesome/*
+      - *store_frontend_comm_deps
       - notify_slack
 
   clone_infra_repo:
@@ -672,8 +684,8 @@ jobs:
     executor: frontend_executor
     steps:
       - *restore_repo
-      - attach_root_workspace
       - *restore_frontend_deps
+      - *restore_frontend_comm_deps
       - run:
           working_directory: *workspace_frontend
           command: yarn install --immutable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,21 +106,13 @@ aliases:
     save_cache:
       key: gradle-home-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
       paths:
+        # Actual Gradle files
         - service/buildSrc/.gradle
         - service/.gradle
         - service/custom-ktlint-rules/.gradle
         - .gradle-user-home/wrapper
         - .gradle-user-home/caches
-
-  - &restore_service_build
-    restore_cache:
-      keys:
-        - gradle-build-service-v4-{{ .Revision }}
-
-  - &store_service_build
-    save_cache:
-      key: gradle-build-service-v4-{{ .Revision }}
-      paths:
+        # Build files
         - service/build
         - service/buildSrc/build
         - service/custom-ktlint-rules/build
@@ -137,20 +129,12 @@ aliases:
     save_cache:
       key: gradle-home-message-service-v4-{{ checksum ".circleci/config.yml" }}-{{ checksum "message-service/build.gradle.kts" }}-{{ checksum "message-service/gradle.properties" }}-{{ checksum "message-service/settings.gradle.kts" }}
       paths:
+        # Actual Gradle files
         - message-service/buildSrc/.gradle
         - message-service/.gradle
         - .gradle-user-home/wrapper
         - .gradle-user-home/caches
-
-  - &restore_message_service_build
-    restore_cache:
-      keys:
-        - gradle-build-message-service-v4-{{ .Revision }}
-
-  - &store_message_service_build
-    save_cache:
-      key: gradle-build-message-service-v4-{{ .Revision }}
-      paths:
+        # Build files
         - message-service/build
         - message-service/buildSrc/build
         - message-service-lib/build
@@ -853,13 +837,16 @@ jobs:
       - run:
           working_directory: *workspace_service
           command: ./gradlew assemble compileIntegrationTestKotlin
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - service/build/libs/
       - run:
           working_directory: *workspace_service
           command: |
             cd custom-ktlint-rules
             ./gradlew assemble
       - *store_service_gradle
-      - *store_service_build
       - run:
           working_directory: *workspace_service
           command: ./gradlew lintKotlin
@@ -890,7 +877,6 @@ jobs:
     steps:
       - *restore_repo
       - attach_root_workspace
-      - *restore_service_build
       - setup_remote_docker:
           version: *remote_docker_version
           docker_layer_caching: true
@@ -912,7 +898,6 @@ jobs:
     executor: service_test_executor
     steps:
       - *restore_repo
-      - *restore_service_build
       - *restore_service_gradle
       - run:
           name: gradle test
@@ -941,7 +926,6 @@ jobs:
     parallelism: 4
     steps:
       - *restore_repo
-      - *restore_service_build
       - *restore_service_gradle
       - login_docker_hub
       - run:
@@ -988,8 +972,11 @@ jobs:
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew assemble compileIntegrationTestKotlin
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - message-service/build/libs/
       - *store_message_service_gradle
-      - *store_message_service_build
       - run:
           working_directory: *workspace_message_service
           command: ./gradlew lintKotlin
@@ -1016,7 +1003,6 @@ jobs:
     executor: service_test_executor
     steps:
       - *restore_repo
-      - *restore_message_service_build
       - *restore_message_service_gradle
       - run:
           working_directory: *workspace_message_service
@@ -1032,7 +1018,6 @@ jobs:
     parallelism: 4
     steps:
       - *restore_repo
-      - *restore_message_service_build
       - *restore_message_service_gradle
       - login_docker_hub
       - run:
@@ -1064,7 +1049,6 @@ jobs:
     steps:
       - *restore_repo
       - attach_root_workspace
-      - *restore_message_service_build
       - setup_remote_docker:
           version: *remote_docker_version
           docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -874,21 +874,48 @@ jobs:
 
   service_test:
     executor: service_test_executor
+    parallelism: 4
     steps:
       - *restore_repo
       - attach_root_workspace
       - *restore_service_gradle
       - run:
+          name: gradle test
           working_directory: *workspace_service
-          command: ./gradlew test
+          command: |
+            # Get list of classnames of tests that should run on this node
+            CLASSNAMES=$(circleci tests glob \
+                "src/test/kotlin/**/*{Test,Tests}.kt" \
+                "../service-lib/src/test/kotlin/**/*{Test,Tests}.kt" \
+                | sed 's/.*src\/test\/kotlin\///' \
+                | sed 's@/@.@g' \
+                | sed 's/.kt//' \
+                | circleci tests split --split-by=timings --timings-type=classname)
+            # Format the arguments for Gradle
+            GRADLE_ARGS=$(echo "$CLASSNAMES" | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
+            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            ./gradlew test $GRADLE_ARGS
       - store_test_results:
           path: /home/circleci/repo/service/build/test-results/test/
       - store_test_results:
           path: /home/circleci/repo/service-lib/build/test-results/test/
       - login_docker_hub
       - run:
+          name: gradle integrationTest
           working_directory: *workspace_service
-          command: ./gradlew integrationTest
+          command: |
+            # Get list of classnames of tests that should run on this node
+            CLASSNAMES=$(circleci tests glob \
+                "src/integrationTest/kotlin/**/*{Test,Tests}.kt" \
+                "../service-lib/src/integrationTest/kotlin/**/*{Test,Tests}.kt" \
+                | sed 's/.*src\/integrationTest\/kotlin\///' \
+                | sed 's@/@.@g' \
+                | sed 's/.kt//' \
+                | circleci tests split --split-by=timings --timings-type=classname)
+            # Format the arguments for Gradle
+            GRADLE_ARGS=$(echo "$CLASSNAMES" | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
+            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            ./gradlew integrationTest $GRADLE_ARGS
       - store_test_results:
           path: /home/circleci/repo/service/build/test-results/integrationTest/
       - store_artifacts:
@@ -897,9 +924,21 @@ jobs:
           path: /home/circleci/repo/service-lib/build/reports/
       - run:
           working_directory: *workspace_service
+          name: gradle custom-ktlint-rules test
           command: |
             cd custom-ktlint-rules
-            ./gradlew test
+            # Get list of classnames of tests that should run on this node
+            CLASSNAMES=$(circleci tests glob \
+                "src/test/kotlin/**/*{Test,Tests}.kt" \
+                "../service-lib/src/test/kotlin/**/*{Test,Tests}.kt" \
+                | sed 's/.*src\/test\/kotlin\///' \
+                | sed 's@/@.@g' \
+                | sed 's/.kt//' \
+                | circleci tests split --split-by=timings --timings-type=classname)
+            # Format the arguments for Gradle
+            GRADLE_ARGS=$(echo "$CLASSNAMES" | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
+            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            ./gradlew test $GRADLE_ARGS
       - store_test_results:
           path: /home/circleci/repo/service/custom-ktlint-rules/build/test-results/test/
       - notify_slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ aliases:
   - &nodejs_image cimg/node:14.15
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202104-01
-  - &builder_aws_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:18.04-809ad64eaee48225fba439142026079a49d0f1d5
+  - &builder_aws_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:18.04-853d39120a28cf475e0c8aa5b25a5973e198b27a
 
   - &default_contexts
     context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -967,7 +967,7 @@ jobs:
 
   service_integration_test:
     executor: service_test_executor
-    parallelism: 4
+    parallelism: 8
     steps:
       - restore_repo
       - restore_service_gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,8 @@ commands:
   store_service_build_cache:
     steps:
       - save_cache:
-          key: gradle-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}
+          name: Store build cache
+          key: gradle-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}-{{ checksum ".circleci/config.yml" }}
           paths:
             - service/build
             - service/buildSrc/build
@@ -277,13 +278,15 @@ commands:
   restore_service_build_cache:
     steps:
       - restore_cache:
+          name: Restore build cache
           keys:
-            - gradle-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}
+            - gradle-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}-{{ checksum ".circleci/config.yml" }}
             - gradle-service-build-cache-v2-
   store_message_service_build_cache:
     steps:
       - save_cache:
-          key: gradle-message-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}
+          name: Store build cache
+          key: gradle-message-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}-{{ checksum ".circleci/config.yml" }}
           paths:
             - message-service/build
             - message-service/buildSrc/build
@@ -291,8 +294,9 @@ commands:
   restore_message_service_build_cache:
     steps:
       - restore_cache:
+          name: Restore build cache
           keys:
-            - gradle-message-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}
+            - gradle-message-service-build-cache-v2-{{ .Environment.CIRCLE_SHA1 }}-{{ checksum ".circleci/config.yml" }}
             - gradle-message-service-build-cache-v2-
 
   # Misc commands

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -883,7 +883,7 @@ jobs:
 
   service_test:
     executor: service_test_executor
-    parallelism: 4
+    parallelism: 8
     steps:
       - *restore_repo
       - attach_root_workspace
@@ -908,6 +908,27 @@ jobs:
           path: /home/circleci/repo/service/build/test-results/test/
       - store_test_results:
           path: /home/circleci/repo/service-lib/build/test-results/test/
+      - store_artifacts:
+          path: /home/circleci/repo/service/build/reports/
+      - store_artifacts:
+          path: /home/circleci/repo/service-lib/build/reports/
+      - run:
+          working_directory: *workspace_service
+          name: gradle custom-ktlint-rules test
+          command: |
+            cd custom-ktlint-rules
+            ./gradlew test
+      - store_test_results:
+          path: /home/circleci/repo/service/custom-ktlint-rules/build/test-results/test/
+      - notify_slack
+
+  service_integration_test:
+    executor: service_test_executor
+    parallelism: 8
+    steps:
+      - *restore_repo
+      - attach_root_workspace
+      - *restore_service_gradle
       - login_docker_hub
       - run:
           name: gradle integrationTest
@@ -931,14 +952,6 @@ jobs:
           path: /home/circleci/repo/service/build/reports/
       - store_artifacts:
           path: /home/circleci/repo/service-lib/build/reports/
-      - run:
-          working_directory: *workspace_service
-          name: gradle custom-ktlint-rules test
-          command: |
-            cd custom-ktlint-rules
-            ./gradlew test
-      - store_test_results:
-          path: /home/circleci/repo/service/custom-ktlint-rules/build/test-results/test/
       - notify_slack
 
   service_push_image:
@@ -1141,11 +1154,16 @@ workflows:
           <<: *default_contexts
           requires:
             - service_build
+      - service_integration_test:
+          <<: *default_contexts
+          requires:
+            - service_build
       - service_push_image:
           <<: *aws_contexts
           requires:
             - service_build_image
             - service_test
+            - service_integration_test
 
       - message_service_build:
           <<: *default_contexts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,7 +888,6 @@ jobs:
 
   service_test:
     executor: service_test_executor
-    parallelism: 2
     steps:
       - *restore_repo
       - attach_root_workspace
@@ -896,19 +895,7 @@ jobs:
       - run:
           name: gradle test
           working_directory: *workspace_service
-          command: |
-            # Get list of classnames of tests that should run on this node
-            CLASSNAMES=$(circleci tests glob \
-                "src/test/kotlin/**/*{Test,Tests}.kt" \
-                "../service-lib/src/test/kotlin/**/*{Test,Tests}.kt" \
-                | sed 's/.*src\/test\/kotlin\///' \
-                | sed 's@/@.@g' \
-                | sed 's/.kt//' \
-                | circleci tests split --split-by=timings --timings-type=classname)
-            # Format the arguments for Gradle
-            GRADLE_ARGS=$(echo "$CLASSNAMES" | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
-            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
-            ./gradlew test $GRADLE_ARGS
+          command: ./gradlew test
       - store_test_results:
           path: /home/circleci/repo/service/build/test-results/test/
       - store_test_results:
@@ -929,7 +916,7 @@ jobs:
 
   service_integration_test:
     executor: service_test_executor
-    parallelism: 8
+    parallelism: 4
     steps:
       - *restore_repo
       - attach_root_workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,9 +341,8 @@ commands:
             fi
       - run:
           name: Collect docker-compose logs
-          command: |
-            cd << pipeline.parameters.workspace_root >>/compose
-            ./compose-e2e logs --tail=all > /tmp/docker-compose-logs.txt
+          working_directory: *workspace_compose
+          command: ./compose-e2e logs --tail=all > /tmp/docker-compose-logs.txt
           when: always
       - store_artifacts:
           path: /tmp/docker-compose-logs.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,7 +888,7 @@ jobs:
 
   service_test:
     executor: service_test_executor
-    parallelism: 8
+    parallelism: 2
     steps:
       - *restore_repo
       - attach_root_workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1015,7 +1015,6 @@ jobs:
 
   message_service_integration_test:
     executor: service_test_executor
-    parallelism: 4
     steps:
       - *restore_repo
       - *restore_message_service_gradle
@@ -1023,19 +1022,7 @@ jobs:
       - run:
           name: gradle integrationTest
           working_directory: *workspace_message_service
-          command: |
-            # Get list of classnames of tests that should run on this node
-            CLASSNAMES=$(circleci tests glob \
-                "src/integrationTest/kotlin/**/*{Test,Tests}.kt" \
-                "../service-lib/src/integrationTest/kotlin/**/*{Test,Tests}.kt" \
-                | sed 's/.*src\/integrationTest\/kotlin\///' \
-                | sed 's@/@.@g' \
-                | sed 's/.kt//' \
-                | circleci tests split --split-by=timings --timings-type=classname)
-            # Format the arguments for Gradle
-            GRADLE_ARGS=$(echo "$CLASSNAMES" | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
-            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
-            ./gradlew integrationTest $GRADLE_ARGS
+          command: ./gradlew integrationTest
       - store_test_results:
           path: /home/circleci/repo/message-service/build/test-results/integrationTest/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,15 +369,14 @@ commands:
 
   e2e_test:
     parameters:
-      suite:
-        type: string
-        default: ""
       yarn_version:
         type: string
         default: *yarn_version
-      install_browsers:
-        type: boolean
-        default: true
+      test_runner:
+        type: enum
+        enum:
+          - testcafe
+          - playwright
     steps:
       - restore_repo
       - attach_root_workspace
@@ -404,7 +403,8 @@ commands:
             sudo apt-get update && sudo apt-get --yes install --no-install-recommends yarn=<< parameters.yarn_version >>
             yarn --version
       - when:
-          condition: << parameters.install_browsers >>
+          condition:
+            equal: ["testcafe", "<< parameters.test_runner >>"]
           steps:
             - run:
                 name: Install browsers
@@ -427,7 +427,7 @@ commands:
                     && chromedriver --version
       - when:
           condition:
-            not: << parameters.install_browsers >>
+            equal: ["playwright", "<< parameters.test_runner >>"]
           steps:
             - run:
                 name: Install Playwright dependencies
@@ -450,9 +450,15 @@ commands:
           command: |
             nvm use
 
-            if [ "<< parameters.suite >>" != "" ]; then
-              yarn "<< parameters.suite >>"
-            else
+            if [ "<< parameters.test_runner >>" = "playwright" ]; then
+              # Get list of test files that should run on this node.
+              FILENAMES=($(circleci tests glob \
+                  'src/e2e-playwright/specs/**/*.spec.ts' \
+                  | sort -h \
+                  | circleci tests split --split-by=timings --timings-type=filename))
+              echo -e "Spec files selected for node:\n$(echo "${FILENAMES[@]}" | tr ' ' '\n')"
+              yarn e2e-ci-playwright "${FILENAMES[@]}"
+            elif [ "<< parameters.test_runner >>" = "testcafe" ]; then
               # Get list of test files that should run on this node.
               # NOTE: Currently testcafe-reporter-junit doesn't provide
               # filenames in its output so they can't be used for splitting
@@ -461,7 +467,7 @@ commands:
                 | awk -F "'" '{print $2}' \
                 | sort -h | uniq \
                 | circleci tests split --split-by=timings --timings-type classname)
-              echo "Fixtures selected for node: ${FIXTURE_NAMES}"
+              echo -e "Fixtures selected for node:\n${FIXTURE_NAMES[@]}"
               # NOTE: This is extremely brittle but necessary as Testcafe
               # doesn't support multiple --fixture arguments (+ the above
               # report issue) -> everything must be a single regex.
@@ -470,7 +476,11 @@ commands:
               TESTCAFE_FIXTURE_REGEX=${TESTCAFE_FIXTURE_REGEX%?}
               echo "Prepared arguments for yarn: ${TESTCAFE_FIXTURE_REGEX}"
 
-              yarn e2e-ci-base --fixture-grep "${TESTCAFE_FIXTURE_REGEX}" -- src/e2e-test/specs/
+              yarn e2e-ci-testcafe --fixture-grep "${TESTCAFE_FIXTURE_REGEX}" -- src/e2e-test/specs/
+
+            else
+              echo 'ERROR: Invalid test_runner: "<< parameters.test_runner >>"'
+              exit 1
             fi
       - run:
           name: Collect docker-compose logs
@@ -824,16 +834,16 @@ jobs:
     executor: e2e_executor
     parallelism: 8
     steps:
-      - e2e_test
+      - e2e_test:
+          test_runner: testcafe
       - notify_slack
 
   e2e-test-playwright:
     executor: e2e_executor
+    parallelism: 4
     steps:
       - e2e_test:
-          suite: e2e-ci-playwright
-          # Playwright doesn't need Chrome externally installed
-          install_browsers: false
+          test_runner: playwright
       - notify_slack
 
   # DEPLOY JOBS
@@ -992,7 +1002,7 @@ jobs:
                 | circleci tests split --split-by=timings --timings-type=classname)
             # Format the arguments for Gradle
             GRADLE_ARGS=$(echo "$CLASSNAMES" | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
-            echo "Prepared arguments for Gradle:\n$GRADLE_ARGS"
+            echo -e "Prepared arguments for Gradle:\n$GRADLE_ARGS"
             ./gradlew integrationTest $GRADLE_ARGS
       - store_test_results:
           path: << pipeline.parameters.workspace_root >>/service/build/test-results/integrationTest/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ aliases:
     environment:
       GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2048m"'
       GRADLE_USER_HOME: /home/circleci/repo/.gradle-user-home
-      _JAVA_OPTIONS: "-Xmx2048m"
+      JAVA_TOOL_OPTIONS: "-Xmx2048m"
 
   - &restore_repo
     restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,9 @@ commands:
       yarn_version:
         type: string
         default: *yarn_version
+      install_browsers:
+        type: boolean
+        default: true
     steps:
       - *restore_repo
       - attach_root_workspace
@@ -279,25 +282,36 @@ commands:
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
             sudo apt-get update && sudo apt-get --yes install --no-install-recommends yarn=<< parameters.yarn_version >>
             yarn --version
-      - run:
-          name: Install chrome
-          command: |
-            curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-              && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
-              && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
-              && sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
-                  "/opt/google/chrome/google-chrome" \
-              && google-chrome --version
-            CHROME_VERSION="$(google-chrome --version)" \
-              && export CHROMEDRIVER_RELEASE="$(echo $CHROME_VERSION | sed 's/^Google Chrome //')" && export CHROMEDRIVER_RELEASE=${CHROMEDRIVER_RELEASE%%.*} \
-              && CHROMEDRIVER_VERSION=$(curl --silent --show-error --location --fail --retry 4 --retry-delay 5 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_RELEASE}) \
-              && curl --silent --show-error --location --fail --retry 4 --retry-delay 5 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
-              && cd /tmp \
-              && unzip chromedriver_linux64.zip \
-              && rm -rf chromedriver_linux64.zip \
-              && sudo mv chromedriver /usr/local/bin/chromedriver \
-              && sudo chmod +x /usr/local/bin/chromedriver \
-              && chromedriver --version
+      - when:
+          condition: << parameters.install_browsers >>
+          steps:
+            - run:
+                name: Install browsers
+                command: |
+                  curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+                    && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
+                    && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
+                    && sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
+                        "/opt/google/chrome/google-chrome" \
+                    && google-chrome --version
+                  CHROME_VERSION="$(google-chrome --version)" \
+                    && export CHROMEDRIVER_RELEASE="$(echo $CHROME_VERSION | sed 's/^Google Chrome //')" && export CHROMEDRIVER_RELEASE=${CHROMEDRIVER_RELEASE%%.*} \
+                    && CHROMEDRIVER_VERSION=$(curl --silent --show-error --location --fail --retry 4 --retry-delay 5 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_RELEASE}) \
+                    && curl --silent --show-error --location --fail --retry 4 --retry-delay 5 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
+                    && cd /tmp \
+                    && unzip chromedriver_linux64.zip \
+                    && rm -rf chromedriver_linux64.zip \
+                    && sudo mv chromedriver /usr/local/bin/chromedriver \
+                    && sudo chmod +x /usr/local/bin/chromedriver \
+                    && chromedriver --version
+      - when:
+          condition:
+            not: << parameters.install_browsers >>
+          steps:
+            - run:
+                name: Install Playwright dependencies
+                command: |
+                  sudo apt-get update && sudo apt-get --yes install --no-install-recommends libgbm1
       - *restore_frontend_deps
       - run:
           name: Install frontend dependencies from Yarn cache
@@ -325,70 +339,6 @@ commands:
       - store_artifacts:
           path: frontend/videos
           destination: videos
-      - store_test_results:
-          path: frontend/test-results
-
-  e2e_test_playwright:
-    parameters:
-      suite:
-        type: string
-      yarn_version:
-        type: string
-        default: *yarn_version
-    steps:
-      - *restore_repo
-      - attach_root_workspace
-      - run:
-          name: Load docker images
-          command: |
-            docker load -i apigw/image.tar
-            docker load -i service/image.tar
-      - login_docker_hub
-      - run:
-          name: Start up compose stack
-          working_directory: *workspace_compose
-          command: |
-            docker-compose build
-            CI=true LOCAL_DIR='../frontend' ./compose-e2e up -d
-      - run:
-          name: Install Node.js and yarn
-          command: |
-            export DEBIAN_FRONTEND=noninteractive
-            nvm install
-            node --version
-
-            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-            sudo apt-get update && sudo apt-get --yes install --no-install-recommends yarn=<< parameters.yarn_version >>
-            yarn --version
-      - *restore_frontend_deps
-      - run:
-          name: Install frontend dependencies from Yarn cache
-          working_directory: *workspace_frontend
-          command: yarn install --immutable --immutable-cache
-      - run:
-          name: Install Playwright dependencies
-          command: |
-            sudo apt-get update && sudo apt-get --yes install --no-install-recommends libgbm1
-      - run:
-          name: Run e2e tests against compose
-          working_directory: *workspace_frontend
-          command: |
-            nvm use
-            ./wait-for-dev-api.sh 'http://localhost:9999' || (cd << pipeline.parameters.workspace_root >>/compose && ./compose-e2e logs && false)
-            yarn << parameters.suite >>
-      - run:
-          name: Collect docker-compose logs
-          command: |
-            cd << pipeline.parameters.workspace_root >>/compose
-            ./compose-e2e logs --tail=all > /tmp/docker-compose-logs.txt
-          when: always
-      - store_artifacts:
-          path: /tmp/docker-compose-logs.txt
-          destination: docker-compose-logs.txt
-      - store_artifacts:
-          path: frontend/screenshots
-          destination: screenshots
       - store_test_results:
           path: frontend/test-results
 
@@ -788,8 +738,10 @@ jobs:
   e2e-test-playwright:
     executor: e2e_executor
     steps:
-      - e2e_test_playwright:
+      - e2e_test:
           suite: e2e-ci-playwright
+          # Playwright doesn't need Chrome externally installed
+          install_browsers: false
       - notify_slack
 
   # DEPLOY JOBS

--- a/frontend/.testcaferc.json
+++ b/frontend/.testcaferc.json
@@ -6,6 +6,10 @@
       "output": "test-results/junit.xml"
     }
   ],
-  "tsConfigPath": "./src/e2e-test/tsconfig.json",
+  "compilerOptions": {
+    "typescript": {
+      "configPath": "./src/e2e-test/tsconfig.json"
+    }
+  },
   "clientScripts": "./src/e2e-test-common/injected.js"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "e2e-mobile": "testcafe 'chrome --start-fullscreen' src/e2e-test/specs/6_mobile/*.spec.ts",
     "e2e-messaging": "testcafe 'chrome --start-fullscreen' src/e2e-test/specs/7_messaging/*.spec.ts",
     "e2e-playwright": "jest --testTimeout 60000 --runInBand src/e2e-playwright/specs",
+    "e2e-ci-base": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
     "e2e-ci": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/**/*.spec.ts -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
     "e2e-ci-accessibility": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/**/*.spec.ts --fixture-meta subType=accessibility -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
     "e2e-ci-citizen": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/specs/0_citizen/*.spec.ts -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,16 +30,8 @@
     "e2e-mobile": "testcafe 'chrome --start-fullscreen' src/e2e-test/specs/6_mobile/*.spec.ts",
     "e2e-messaging": "testcafe 'chrome --start-fullscreen' src/e2e-test/specs/7_messaging/*.spec.ts",
     "e2e-playwright": "jest --testTimeout 60000 --runInBand src/e2e-playwright/specs",
-    "e2e-ci-base": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
-    "e2e-ci": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/**/*.spec.ts -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
-    "e2e-ci-accessibility": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/**/*.spec.ts --fixture-meta subType=accessibility -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
-    "e2e-ci-citizen": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/specs/0_citizen/*.spec.ts -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
-    "e2e-ci-invoicing": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/specs/4_invoicing/*.spec.ts -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
-    "e2e-ci-employee": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/specs/5_employee/*.spec.ts -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
-    "e2e-ci-employee-2": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/specs/2_employee-2/*.spec.ts -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
-    "e2e-ci-mobile": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=375;height=667' src/e2e-test/specs/6_mobile/*.spec.ts -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
-    "e2e-ci-messaging": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' src/e2e-test/specs/7_messaging/*.spec.ts -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
-    "e2e-ci-playwright": "BASE_URL=http://localhost:9999 jest src/e2e-playwright/specs --testTimeout 60000 --runInBand --bail 1"
+    "e2e-ci-testcafe": "BASE_URL=http://localhost:9999 testcafe 'chrome:headless:emulation:width=1920;height=1080' -s takeOnFails=true --video videos --video-options failedOnly=true --stop-on-first-fail",
+    "e2e-ci-playwright": "BASE_URL=http://localhost:9999 jest --testTimeout 60000 --runInBand --bail 1"
   },
   "dependencies": {
     "@evaka/eslint-plugin": "link:eslint-plugin",
@@ -206,7 +198,8 @@
     }
   },
   "jest-junit": {
-    "outputDirectory": "test-results/"
+    "outputDirectory": "test-results/",
+    "addFileAttribute": "true"
   },
   "postcss": {
     "plugins": {

--- a/frontend/src/e2e-test/specs/2_employee-2/employee-dailynote.spec.ts
+++ b/frontend/src/e2e-test/specs/2_employee-2/employee-dailynote.spec.ts
@@ -44,7 +44,7 @@ let careArea: CareAreaBuilder
 
 const employeeHome = new EmployeeHome()
 
-fixture('Mobile daily notes')
+fixture('Mobile employee daily notes')
   .meta({ type: 'regression', subType: 'mobile' })
   .beforeEach(async () => {
     await resetDatabase()

--- a/frontend/src/e2e-test/specs/5_employee/income.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/income.spec.ts
@@ -15,7 +15,7 @@ const fridgeHeadInformation = new FridgeHeadInformationPage()
 
 let personId: string
 
-fixture('Invoicing - invoices')
+fixture('Invoicing - income')
   .meta({ type: 'regression', subType: 'invoices' })
   .beforeEach(async (t) => {
     await resetDatabase()

--- a/message-service/build.gradle.kts
+++ b/message-service/build.gradle.kts
@@ -193,7 +193,7 @@ tasks {
         useJUnitPlatform()
         systemProperty("spring.profiles.active", "test")
         filter {
-            setFailOnNoMatchingTests(false)
+            isFailOnNoMatchingTests = false
         }
     }
 

--- a/message-service/build.gradle.kts
+++ b/message-service/build.gradle.kts
@@ -192,6 +192,9 @@ tasks {
     test {
         useJUnitPlatform()
         systemProperty("spring.profiles.active", "test")
+        filter {
+            setFailOnNoMatchingTests(false)
+        }
     }
 
     create("integrationTest", Test::class) {

--- a/service-lib/build.gradle.kts
+++ b/service-lib/build.gradle.kts
@@ -52,5 +52,8 @@ tasks.withType<KotlinCompile> {
 tasks {
     test {
         useJUnitPlatform()
+        filter {
+            setFailOnNoMatchingTests(false)
+        }
     }
 }

--- a/service-lib/build.gradle.kts
+++ b/service-lib/build.gradle.kts
@@ -53,7 +53,7 @@ tasks {
     test {
         useJUnitPlatform()
         filter {
-            setFailOnNoMatchingTests(false)
+            isFailOnNoMatchingTests = false
         }
     }
 }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -180,7 +180,7 @@ tasks {
         useJUnitPlatform()
         systemProperty("spring.profiles.active", "test")
         filter {
-            setFailOnNoMatchingTests(false)
+            isFailOnNoMatchingTests = false
         }
     }
 
@@ -192,6 +192,9 @@ tasks {
         classpath = sourceSets["integrationTest"].runtimeClasspath
         shouldRunAfter("test")
         outputs.upToDateWhen { false }
+        filter {
+            isFailOnNoMatchingTests = false
+        }
     }
 
     bootRun {

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -179,6 +179,9 @@ tasks {
     test {
         useJUnitPlatform()
         systemProperty("spring.profiles.active", "test")
+        filter {
+            setFailOnNoMatchingTests(false)
+        }
     }
 
     create("integrationTest", Test::class) {

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -200,7 +200,7 @@ tasks {
     }
 
     create("bootRunTest", org.springframework.boot.gradle.tasks.run.BootRun::class) {
-        main = "fi.espoo.evaka.MainKt"
+        mainClass.set("fi.espoo.evaka.MainKt")
         classpath = sourceSets["main"].runtimeClasspath
         systemProperty("spring.profiles.active", "local")
         systemProperty("spring.datasource.url", "jdbc:postgresql://localhost:15432/evaka_it")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
@@ -151,7 +151,7 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
 
         val beforeClearingUrgency = db.transaction { it.fetchApplicationDetails(application.id) }
         assertEquals(true, beforeClearingUrgency!!.form.preferences.urgent)
-        assertEquals(2, beforeClearingUrgency!!.attachments.size)
+        assertEquals(2, beforeClearingUrgency.attachments.size)
 
         // when
         val updatedApplication =
@@ -166,8 +166,8 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
         // then
         val afterClearingUrgency = db.transaction { it.fetchApplicationDetails(application.id) }
         assertEquals(false, afterClearingUrgency!!.form.preferences.urgent)
-        assertEquals(0, afterClearingUrgency!!.attachments.filter { it.type === AttachmentType.URGENCY }.size)
-        assertEquals(1, afterClearingUrgency!!.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
+        assertEquals(0, afterClearingUrgency.attachments.filter { it.type === AttachmentType.URGENCY }.size)
+        assertEquals(1, afterClearingUrgency.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
     }
 
     @Test
@@ -181,7 +181,7 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
 
         val beforeClearingUrgency = db.transaction { it.fetchApplicationDetails(application.id) }
         assertEquals(true, beforeClearingUrgency!!.form.preferences.urgent)
-        assertEquals(2, beforeClearingUrgency!!.attachments.size)
+        assertEquals(2, beforeClearingUrgency.attachments.size)
 
         // when
         val updatedApplication =
@@ -196,8 +196,8 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
         // then
         val afterClearingUrgency = db.transaction { it.fetchApplicationDetails(application.id) }
         assertEquals(false, afterClearingUrgency!!.form.preferences.urgent)
-        assertEquals(0, afterClearingUrgency!!.attachments.filter { it.type === AttachmentType.URGENCY }.size)
-        assertEquals(1, afterClearingUrgency!!.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
+        assertEquals(0, afterClearingUrgency.attachments.filter { it.type === AttachmentType.URGENCY }.size)
+        assertEquals(1, afterClearingUrgency.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
     }
 
     @Test
@@ -211,7 +211,7 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
 
         val beforeClearingShiftCare = db.transaction { it.fetchApplicationDetails(application.id) }
         assertEquals(true, beforeClearingShiftCare!!.form.preferences.urgent)
-        assertEquals(2, beforeClearingShiftCare!!.attachments.size)
+        assertEquals(2, beforeClearingShiftCare.attachments.size)
 
         // when
         val updatedApplication =
@@ -230,8 +230,8 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
         // then
         val afterClearingShiftCare = db.transaction { it.fetchApplicationDetails(application.id) }
         assertEquals(false, afterClearingShiftCare!!.form.preferences.serviceNeed!!.shiftCare)
-        assertEquals(1, afterClearingShiftCare!!.attachments.filter { it.type === AttachmentType.URGENCY }.size)
-        assertEquals(0, afterClearingShiftCare!!.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
+        assertEquals(1, afterClearingShiftCare.attachments.filter { it.type === AttachmentType.URGENCY }.size)
+        assertEquals(0, afterClearingShiftCare.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
     }
 
     @Test
@@ -245,7 +245,7 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
 
         val beforeClearingShiftCare = db.transaction { it.fetchApplicationDetails(application.id) }
         assertEquals(true, beforeClearingShiftCare!!.form.preferences.serviceNeed!!.shiftCare)
-        assertEquals(2, beforeClearingShiftCare!!.attachments.size)
+        assertEquals(2, beforeClearingShiftCare.attachments.size)
 
         // when
         val updatedApplication =
@@ -264,8 +264,8 @@ class ApplicationUpdateIntegrationTest : FullApplicationTest() {
         // then
         val afterClearingShiftCare = db.transaction { it.fetchApplicationDetails(application.id) }
         assertEquals(false, afterClearingShiftCare!!.form.preferences.serviceNeed!!.shiftCare)
-        assertEquals(1, afterClearingShiftCare!!.attachments.filter { it.type === AttachmentType.URGENCY }.size)
-        assertEquals(0, afterClearingShiftCare!!.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
+        assertEquals(1, afterClearingShiftCare.attachments.filter { it.type === AttachmentType.URGENCY }.size)
+        assertEquals(0, afterClearingShiftCare.attachments.filter { it.type === AttachmentType.EXTENDED_CARE }.size)
     }
 
     private fun insertSentApplication(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2IntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2IntegrationTest.kt
@@ -370,7 +370,7 @@ class VardaUpdateServiceV2IntegrationTest : FullApplicationTest() {
         insertVardaChild(db, testChild_1.id)
         val since = HelsinkiDateTime.now()
         val serviceNeedPeriod = DateRange(since.minusDays(100).toLocalDate(), since.toLocalDate())
-        val id = createServiceNeed(db, since, snDefaultDaycare, testChild_1, serviceNeedPeriod.start, serviceNeedPeriod.end!!)
+        createServiceNeed(db, since, snDefaultDaycare, testChild_1, serviceNeedPeriod.start, serviceNeedPeriod.end!!)
 
         updateChildData(db, vardaClient, since)
         assertVardaElementCounts(0, 0, 0)
@@ -424,7 +424,7 @@ class VardaUpdateServiceV2IntegrationTest : FullApplicationTest() {
         createServiceNeed(db, since, snDefaultDaycare, testChild_1, serviceNeedPeriod.start, serviceNeedPeriod.end!!)
 
         val feeDecisionPeriod = DateRange(serviceNeedPeriod.start, serviceNeedPeriod.start.plusDays(10))
-        val voucherDecisionPeriod = DateRange(feeDecisionPeriod.end!!.plusDays(1), null)
+        DateRange(feeDecisionPeriod.end!!.plusDays(1), null)
         createFeeDecision(db, testChild_1, testAdult_2.id, DateRange(feeDecisionPeriod.start, feeDecisionPeriod.end), since.toInstant())
 
         updateChildData(db, vardaClient, since)
@@ -444,7 +444,7 @@ class VardaUpdateServiceV2IntegrationTest : FullApplicationTest() {
         val voucherDecisionPeriod = DateRange(feeDecisionPeriod.end!!.plusDays(1), null)
         val child = testChild_1
         val adult = testAdult_1
-        val id = createServiceNeed(db, since, snDefaultDaycare, child, serviceNeedPeriod.start, serviceNeedPeriod.end!!)
+        createServiceNeed(db, since, snDefaultDaycare, child, serviceNeedPeriod.start, serviceNeedPeriod.end!!)
         createFeeDecision(db, child, adult.id, DateRange(feeDecisionPeriod.start, feeDecisionPeriod.end), since.toInstant())
         updateChildData(db, vardaClient, since)
         assertVardaElementCounts(1, 1, 1)
@@ -462,7 +462,7 @@ class VardaUpdateServiceV2IntegrationTest : FullApplicationTest() {
         val voucherDecisionPeriod = DateRange(feeDecisionPeriod.end!!.plusDays(1), null)
         val child = testChild_1
         val adult = testAdult_1
-        val id = createServiceNeed(db, since, snDefaultDaycare, child, serviceNeedPeriod.start, serviceNeedPeriod.end!!)
+        createServiceNeed(db, since, snDefaultDaycare, child, serviceNeedPeriod.start, serviceNeedPeriod.end!!)
         createVoucherDecision(db, voucherDecisionPeriod.start, voucherDecisionPeriod.end, testDaycare.id, VOUCHER_VALUE, VOUCHER_CO_PAYMENT, adult.id, child, since.toInstant())
         updateChildData(db, vardaClient, since)
         assertVardaElementCounts(1, 1, 1)


### PR DESCRIPTION
#### Summary

| Thing | Current | New |
|-|-|-|
| Branch workflow | ~23 min | **~17 min** :tada: |
| Service tests | ~13 min | **~3 min** :tada: |
| Frontend deploys | ~3 min | **~30 s** :rocket: |
| E2E tests | ~12 min (slowest) | ~9 min :+1: |
| Workspace attaching | 30 s - 2.5 min | **~2 s** :muscle: |
| Developers | :cry: | :smiley: |

- Parallelize E2E tests and service integration tests based on historical test timing data
    - Total actual time (when all parallel tests are finished) is minimized
    - Automatic test splitting means that we don't need to manually select which tests are run together for an optimal set (timings wise)
    - New tests are randomly split until timings for them exist
    - For E2E tests this has the additional benefit of somewhat ensuring that fixtures are independent as any two fixtures aren't guaranteed to be ran on the same node every time or in a specific order
- Move most files out of the CircleCI workspace into workflow-run-specific caches to avoid downloading unnecessary files in all downstream jobs
    - **Major** speed up for frontend deploys: ~2.5 min is immediately shaved, bringing total down to ~15 s
    - This is totally abusing CircleCI's caches but currently there isn't any sort of "sub-workspace" solution (that I know of) that could do partial downloads
- Cache Gradle builds within a single workflow execution and pre-compile [integration] test classes for test parallelization
    - Also avoid caching unnecessary Gradle files
- Split service & message-service test and integration test runs into parallel jobs
- Drop layer caching for E2E jobs
    - This feature is really costly (:dollar:) without _that_ big of a benefit, especially with parallelization (200 credits * 8 parallel jobs for every single workflow execution adds up quickly)
    - Lost performance is gained back with the other optimizations in this PR
- Merge build and push image jobs
    - Pushing doesn't take _that_ long in the context of the whole workflow and just complicates the config (and workflow visualization)
    - Starting another executor just for pushing takes ~20s, meaning the time to push an image roughly doubles (depending on image size etc. of course)
- Update Docker to 20.10.6
- Update `voltti/builder-aws` to the latest version & use a more optimized (read: smaller) variant where some tools aren't needed
    - Image sizes drop down from ~1.13GB -> ~300MB in the best case and even in the worst case (Terraform deploys) roughly 200MB can be saved, leading to a small improvement over time
- Use Yarn cache for `node_modules` persistence
    - Instead of "caching" the `frontend/node_modules` directory in the workspace, use a real cache
    - This should speed up all jobs attaching workspaces (pretty much all jobs) as they don't need to fetch the ~500MB of `node_modules` contents just to start
- Use the official `JAVA_TOOL_OPTIONS` instead of the unofficial (but pretty widely supported) `_JAVA_OPTIONS` for setting JVM configs
- General refactoring: aliases to commands & parameters, dedupe jobs, clearer names for steps
- Adjust JVM memory configs to better utilize resources
    - E.g. prefer the modern `MaxRAMPercentage` over `Xmx`
    - No real performance benefit right now, just not leaving resources explicitly unused (2 GB out of 4 GB vs. 80 % of 4 GB)
- Fix Kotlin linter warnings and deprecated Gradle features
    - Couldn't yet figure out some warnings related to Gradle 8.x deprecations
- Ensure unique E2E fixture names
    - As `testcafe-reporter-junit` doesn't output the `filename` attribute in its reports, we have to use fixture names -> they need to be unique to ensure correct test splitting
- Cache commercial dependencies (minor optimization, couple of seconds)
- Use new TS config config for Testcafe (`tsConfigPath is deprecated)
- Update CircleCI orbs (nothing worth noting, just keeping up-to-date)

#### Comparisons

##### Current branch

Total branch workflow execution (~23 min):

![image](https://user-images.githubusercontent.com/5830147/123813327-79663900-d8fd-11eb-8cd9-e65f53ac3236.png)

##### New workflow

Total branch workflow execution (~16 min):

![image](https://user-images.githubusercontent.com/5830147/123813409-8c790900-d8fd-11eb-9041-c98d2f1d61d9.png)

Parallel executions in UI:

![image](https://user-images.githubusercontent.com/5830147/123813540-ac103180-d8fd-11eb-8426-abdcb7326aba.png)

#### Notes

- For the cache abuse trick, there's the danger of the cache getting randomly cleared _just_ when its needed but IME CircleCI pretty consistenly keeps the caches available for the documented 14 days and so far I haven't faced this issue in a few days of testing
- Frontend (TypeScript mainly) builds are still slow and slow down the entire workflow as they block E2E test jobs from starting (they need the built frontends)
- Decided to _not_ cache Gradle _builds_ between workflow executions to avoid poisoning other builds, especially with Spring included
    - This slows down the build by ~1.5 min but IMO clean builds are worth it
- Service unit tests and message service unit & integration tests are fast enough to not benefit from parallelization (executor start and Gradle boot take enough time to take away any benefits gained from parallel test execution)