### PR TITLE
EVAKA FIX architecture diagrams update take 2

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,1 @@
-diagrams/svg/
+diagrams/png/

--- a/docs/convert.sh
+++ b/docs/convert.sh
@@ -7,13 +7,14 @@
 set -euo pipefail
 
 BASEDIR=$(dirname "$0")
+TARGETDIR="${BASEDIR}/diagrams/png"
 PLANTUML_VERSION=1.2021.8
 
-mkdir -p "$BASEDIR"/diagrams/svg
-rm -rf "$BASEDIR"/svg/*
+rm -rf "${TARGETDIR}"
+mkdir -p "${TARGETDIR}"
 
-for FILE in "$BASEDIR"/diagrams/src/*.puml; do
-  FILE_SVG="$BASEDIR"/diagrams/svg/"$(basename "$FILE" | sed 's/puml/svg/')"
-  echo Converting "${FILE} -> ${FILE_SVG}"
-  docker run --rm -i dstockhammer/plantuml:"$PLANTUML_VERSION" -pipe -tsvg > "$FILE_SVG" < "$FILE"
+for SRCFILE in "${BASEDIR}"/diagrams/src/*.puml; do
+  TARGETFILE="${TARGETDIR}"/$(basename "${SRCFILE}" | sed 's/puml/png/')
+  echo Converting "${SRCFILE} -> ${TARGETFILE}"
+  docker run --rm -i dstockhammer/plantuml:"${PLANTUML_VERSION}" -pipe > "${TARGETFILE}" < "${SRCFILE}"
 done

--- a/docs/diagrams/src/evaka-container.puml
+++ b/docs/diagrams/src/evaka-container.puml
@@ -9,6 +9,7 @@ title eVakan container-kaavio
 
 Person(huoltaja, "Huoltaja", "Varhaiskasvatuksen, kerhotoiminnan tai esiopetuksen piirissä olevan lapsen huoltaja")
 Person(virkailija, "Virkailija", "Kaupungin työntekijä, jolla on Azure AD -tunnukset")
+Person(psvirkailija, "Palveluntuottaja", "Yksityisen varhaiskasvatuksen palveluseteliyksikön johtaja")
 
 System_Boundary(evaka, "eVaka – Espoon varhaiskasvatuksen toiminnanohjausjärjestelmä") {
   Container(evaka_front, "evaka-frontend\n(huoltaja)", "TypeScript", "SPA-sovellus, joka ajetaan käyttäjän selaimessa ja tarjotaan AWS:n S3:sta. Sovelluksen avulla haetaan paikkaa kerhoon tai varhaiskasvatukseen, sekä ilmoitetaan lapsi esiopetukseen .")
@@ -41,10 +42,14 @@ Rel(huoltaja, evaka_front, "käyttää", "HTTPS")
 Rel(virkailija, espooad, "tunnistautuu", "SAML/HTTPS")
 Rel(virkailija, evaka_admin_front, "käyttää","HTTPS")
 
+Rel_L(psvirkailija, suomifi, "tunnistautuu", "SAML/HTTPS")
+Rel(psvirkailija, evaka_admin_front, "käyttää", "HTTPS")
+
 Rel_U(evaka_front, suomifi, "ohjaa huoltajan tunnistautumaan", "SAML/HTTPS")
 Rel(evaka_front, evaka_proxy, "käyttää", "JSON/HTTPS")
 
 Rel_R(evaka_admin_front, espooad, "ohjaa virkailijan tunnistautumaan", "SAML/HTTPS")
+Rel_R(evaka_admin_front, suomifi, "ohjaa palvelutuottajan tunnistautumaan", "SAML/HTTPS")
 Rel(evaka_admin_front, evaka_proxy, "käyttää", "JSON/HTTPS")
 Rel_D(evaka_service, evaka_s3_bucket, "hakee tiedoston", "HTTPS")
 

--- a/docs/diagrams/src/evaka-container.puml
+++ b/docs/diagrams/src/evaka-container.puml
@@ -32,8 +32,10 @@ System_Boundary(evaka, "eVaka – Espoon varhaiskasvatuksen toiminnanohjausjärj
 
 System_Ext(suomifi, "Suomi.fi -tunnistus")
 System_Ext(espooad, "Espoo AD -tunnistus")
+System_Ext(laskutus, "Kaupungin taloushallinto")
 System_Ext(suomifiviestit, "Suomi.fi-viestit")
 System_Ext(varda, "Varda Varhaiskasvatuksen tietovaranto")
+System_Ext(koski, "Koski tietovaranto")
 System_Ext(vtj, "VTJ Väestötietojärjestelmä")
 
 Rel_L(huoltaja, suomifi, "tunnistautuu", "SAML/HTTPS")
@@ -69,5 +71,9 @@ Rel(evaka_proxy, evaka_static_s3_bucket, "lukee", "HTTPS")
 
 Rel_D(evaka_service, vtj, "lukee", "SOAP/HTTPS")
 Rel_D(evaka_service, varda, "lukee ja kirjoittaa", "REST/HTTPS")
+
+Rel_D(evaka_service, koski, "kirjoittaa", "JSON/HTTPS")
+
+Rel_D(evaka_service, laskutus, "kirjoittaa", "JSON/HTTPS")
 
 @enduml

--- a/docs/diagrams/src/evaka-container.puml
+++ b/docs/diagrams/src/evaka-container.puml
@@ -8,10 +8,10 @@
 title eVakan container-kaavio
 
 Person(huoltaja, "Huoltaja", "Varhaiskasvatuksen, kerhotoiminnan tai esiopetuksen piirissä olevan lapsen huoltaja")
-Person(virkailija, "Virkailija", "Kaupungin työntekijä, jolla on Azure AD -tunnukset")
+Person(virkailija, "Virkailija", "Kaupungin työntekijä, jolla on kaupungin AD -tunnukset")
 Person(psvirkailija, "Palveluntuottaja", "Yksityisen varhaiskasvatuksen palveluseteliyksikön johtaja")
 
-System_Boundary(evaka, "eVaka – Espoon varhaiskasvatuksen toiminnanohjausjärjestelmä") {
+System_Boundary(evaka, "eVaka – varhaiskasvatuksen toiminnanohjausjärjestelmä") {
   Container(evaka_front, "evaka-frontend\n(huoltaja)", "TypeScript", "SPA-sovellus, joka ajetaan käyttäjän selaimessa ja tarjotaan AWS:n S3:sta. Sovelluksen avulla haetaan paikkaa kerhoon tai varhaiskasvatukseen, sekä ilmoitetaan lapsi esiopetukseen .")
   Container(evaka_admin_front, "evaka-frontend\n(virkailja)", "React, TypeScript", "SPA-sovellus, joka ajetaan käyttäjän selaimessa ja tarjotaan AWS:n S3:sta. Toteuttaa virkailijan käyttöliittymän kaikki toiminnot.")
 
@@ -31,7 +31,7 @@ System_Boundary(evaka, "eVaka – Espoon varhaiskasvatuksen toiminnanohjausjärj
 
 
 System_Ext(suomifi, "Suomi.fi -tunnistus")
-System_Ext(espooad, "Espoo AD -tunnistus")
+System_Ext(ad, "Kaupungin AD -tunnistus")
 System_Ext(laskutus, "Kaupungin taloushallinto")
 System_Ext(suomifiviestit, "Suomi.fi-viestit")
 System_Ext(varda, "Varda Varhaiskasvatuksen tietovaranto")
@@ -41,7 +41,7 @@ System_Ext(vtj, "VTJ Väestötietojärjestelmä")
 Rel_L(huoltaja, suomifi, "tunnistautuu", "SAML/HTTPS")
 Rel(huoltaja, evaka_front, "käyttää", "HTTPS")
 
-Rel(virkailija, espooad, "tunnistautuu", "SAML/HTTPS")
+Rel(virkailija, ad, "tunnistautuu", "SAML/HTTPS")
 Rel(virkailija, evaka_admin_front, "käyttää","HTTPS")
 
 Rel_L(psvirkailija, suomifi, "tunnistautuu", "SAML/HTTPS")
@@ -50,7 +50,7 @@ Rel(psvirkailija, evaka_admin_front, "käyttää", "HTTPS")
 Rel_U(evaka_front, suomifi, "ohjaa huoltajan tunnistautumaan", "SAML/HTTPS")
 Rel(evaka_front, evaka_proxy, "käyttää", "JSON/HTTPS")
 
-Rel_R(evaka_admin_front, espooad, "ohjaa virkailijan tunnistautumaan", "SAML/HTTPS")
+Rel_R(evaka_admin_front, ad, "ohjaa virkailijan tunnistautumaan", "SAML/HTTPS")
 Rel_R(evaka_admin_front, suomifi, "ohjaa palvelutuottajan tunnistautumaan", "SAML/HTTPS")
 Rel(evaka_admin_front, evaka_proxy, "käyttää", "JSON/HTTPS")
 Rel_D(evaka_service, evaka_s3_bucket, "hakee tiedoston", "HTTPS")

--- a/docs/diagrams/src/evaka-container.puml
+++ b/docs/diagrams/src/evaka-container.puml
@@ -35,34 +35,34 @@ System_Ext(suomifiviestit, "Suomi.fi-viestit")
 System_Ext(varda, "Varda Varhaiskasvatuksen tietovaranto")
 System_Ext(vtj, "VTJ Väestötietojärjestelmä")
 
-Rel_L(huoltaja, suomifi, "tunnistautuu\n[SAML/HTTPS]")
-Rel(huoltaja, evaka_front, "käyttää\n[HTTPS]")
+Rel_L(huoltaja, suomifi, "tunnistautuu", "SAML/HTTPS")
+Rel(huoltaja, evaka_front, "käyttää", "HTTPS")
 
-Rel(virkailija, espooad, "tunnistautuu\n[SAML/HTTPS]")
-Rel(virkailija, evaka_admin_front, "käyttää\n[HTTPS]")
+Rel(virkailija, espooad, "tunnistautuu", "SAML/HTTPS")
+Rel(virkailija, evaka_admin_front, "käyttää","HTTPS")
 
-Rel_U(evaka_front, suomifi, "ohjaa huoltajan tunnistautumaan\n[SAML/HTTPS]")
-Rel(evaka_front, evaka_proxy, "käyttää\n[JSON/HTTPS]")
+Rel_U(evaka_front, suomifi, "ohjaa huoltajan tunnistautumaan", "SAML/HTTPS")
+Rel(evaka_front, evaka_proxy, "käyttää", "JSON/HTTPS")
 
-Rel_R(evaka_admin_front, espooad, "ohjaa virkailijan tunnistautumaan\n[SAML/HTTPS]")
-Rel(evaka_admin_front, evaka_proxy, "käyttää\n[JSON/HTTPS]")
-Rel_D(evaka_service, evaka_s3_bucket, "hakee tiedoston\n[HTTPS]")
+Rel_R(evaka_admin_front, espooad, "ohjaa virkailijan tunnistautumaan", "SAML/HTTPS")
+Rel(evaka_admin_front, evaka_proxy, "käyttää", "JSON/HTTPS")
+Rel_D(evaka_service, evaka_s3_bucket, "hakee tiedoston", "HTTPS")
 
-Rel_R(evaka_proxy, evaka_apigw, "käyttää\n[JSON/HTTP]")
+Rel_R(evaka_proxy, evaka_apigw, "käyttää", "JSON/HTTP")
 
-Rel_R(evaka_apigw, evaka_session_store, "käyttää\n[RESP/TCP]")
-Rel(evaka_apigw, evaka_service, "käyttää\n[JSON/HTTP]")
+Rel_R(evaka_apigw, evaka_session_store, "käyttää", "RESP/TCP")
+Rel(evaka_apigw, evaka_service, "käyttää", "JSON/HTTP")
 
-Rel(evaka_service, evaka_message_service, "käyttää\n[JSON/HTTP]")
-Rel(evaka_message_service, evaka_s3_bucket, "hakee tiedoston\n[HTTPS]")
+Rel(evaka_service, evaka_message_service, "käyttää", "JSON/HTTP")
+Rel(evaka_message_service, evaka_s3_bucket, "hakee tiedoston", "HTTPS")
 
-Rel(evaka_message_service, suomifiviestit, "Lähettää\n[SOAP/HTTPS]")
+Rel(evaka_message_service, suomifiviestit, "Lähettää", "SOAP/HTTPS")
 
-Rel_D(evaka_service, evaka_service_db, "lukee ja kirjoittaa\n[JDBC]")
+Rel_D(evaka_service, evaka_service_db, "lukee ja kirjoittaa", "JDBC")
 
-Rel(evaka_proxy, evaka_static_s3_bucket, "lukee\n[HTTPS]")
+Rel(evaka_proxy, evaka_static_s3_bucket, "lukee", "HTTPS")
 
-Rel_D(evaka_service, vtj, "lukee\n[SOAP/HTTPS]")
-Rel_D(evaka_service, varda, "lukee ja kirjoittaa\n[REST/HTTPS]")
+Rel_D(evaka_service, vtj, "lukee", "SOAP/HTTPS")
+Rel_D(evaka_service, varda, "lukee ja kirjoittaa", "REST/HTTPS")
 
 @enduml


### PR DESCRIPTION
- Switch to produce png for main wiki need directly
- Fix puml source format to match latest generator
- Add private service provider role
- Add Koski and finance integrations
- Use generic terms instead of Espoo specific ones

