### PR TITLE
[EVAKA] CI: split frontend job to start E2E test faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ commands:
           paths:
             - frontend/.yarn/cache
             - frontend/node_modules
+            - /home/circleci/.npm/sentry-cli
   restore_frontend_deps:
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -823,13 +823,6 @@ jobs:
     executor: frontend_executor
     steps:
       - prepare_frontend_build
-      - build_maintenance_page
-      - build_storybook
-      - persist_to_workspace:
-          root: << pipeline.parameters.workspace_root >>
-          paths:
-            - frontend/dist/maintenance-page
-            - frontend/storybook-build
       - run:
           working_directory: *workspace_frontend
           command: yarn lint-strict
@@ -839,6 +832,13 @@ jobs:
       - run:
           working_directory: *workspace_frontend
           command: yarn test --maxWorkers=2
+      - build_maintenance_page
+      - build_storybook
+      - persist_to_workspace:
+          root: << pipeline.parameters.workspace_root >>
+          paths:
+            - frontend/dist/maintenance-page
+            - frontend/storybook-build
       - store_test_results:
           path: << pipeline.parameters.workspace_root >>/frontend/test-results
       - notify_slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,21 @@ commands:
           docker_layer_caching: true
       - login_docker_hub
 
+  prepare_frontend_build:
+    steps:
+      - restore_repo
+      - restore_frontend_deps
+      - restore_frontend_comm_deps
+      - run:
+          working_directory: *workspace_frontend
+          command: yarn install --immutable
+      - run:
+          name: Unpack commercial frontend dependencies
+          working_directory: *workspace_frontend
+          command: |
+            ./unpack-pro-icons.sh
+      - store_frontend_deps
+
   build_frontend:
     steps:
       - run:
@@ -792,28 +807,27 @@ jobs:
           dir: apigw
       - notify_slack
 
-  frontend_build_and_test:
+  frontend_build_core:
     executor: frontend_executor
     steps:
-      - restore_repo
-      - restore_frontend_deps
-      - restore_frontend_comm_deps
-      - run:
-          working_directory: *workspace_frontend
-          command: yarn install --immutable
-      - run:
-          name: Unpack commercial frontend dependencies
-          working_directory: *workspace_frontend
-          command: |
-            ./unpack-pro-icons.sh
-      - store_frontend_deps
+      - prepare_frontend_build
       - build_frontend
+      - persist_to_workspace:
+          root: << pipeline.parameters.workspace_root >>
+          paths:
+            - frontend/dist
+      - notify_slack
+
+  frontend_build_misc_and_test:
+    executor: frontend_executor
+    steps:
+      - prepare_frontend_build
       - build_maintenance_page
       - build_storybook
       - persist_to_workspace:
           root: << pipeline.parameters.workspace_root >>
           paths:
-            - frontend/dist
+            - frontend/dist/maintenance-page
             - frontend/storybook-build
       - run:
           working_directory: *workspace_frontend
@@ -1132,24 +1146,28 @@ workflows:
             - build_base_image
             - apigw_build_and_test
 
-      - frontend_build_and_test:
+      - frontend_build_core:
           context:
             - voltti-slack
             - voltti-dockerhub
             - sentry-release
           requires:
             - fetch_private_dependencies
+      - frontend_build_misc_and_test:
+          <<: *default_contexts
+          requires:
+            - fetch_private_dependencies
 
       - e2e-test-testcafe:
           <<: *default_contexts
           requires:
-            - frontend_build_and_test
+            - frontend_build_core
             - apigw_build_and_push_image
             - service_build_and_push_image
       - e2e-test-playwright:
           <<: *default_contexts
           requires:
-            - frontend_build_and_test
+            - frontend_build_core
             - apigw_build_and_push_image
             - service_build_and_push_image
 
@@ -1202,6 +1220,7 @@ workflows:
           <<: *aws_contexts
           requires:
             - lint_scripts
+            - frontend_build_misc_and_test
             - e2e-test-testcafe
             - e2e-test-playwright
             - apigw_build_and_push_image


### PR DESCRIPTION
#### Summary

- CI: split frontend job for 1.5 - 2 min faster total time as E2E tests can be started earlier
    - Everything not directly upstream of the E2E tests will always finish before them
    - Maintenance-page, storybook, linting and type-checking aren't necessary to start E2E testing
    - Wastes an extra ~20s of CircleCI credit time as Yarn cache restoration + install from that cache needs to be run on both jobs but saves 1.5 - 2 minutes of real time (i.e. much more expensive developer time)
    - In a void, parallelization would save 3 minutes but now service build + service image build become the next bottlenecks blocking full benefits of this
- CI: cache sentry-cli binaries
    - No reason not to as these always take a few unnecessary seconds to re-download and more importantly cause a lot of noise in the step output
- CI: reorder frontend steps for likely faster feedback loop
    - It's way more likely that there are errors from linting, type checking or tests than from the builds of the maintenance-page or storybook -> re-ordering the steps will cause the job to fail earlier and give faster feedback to the developer
    - Would save ~40s per fail

