### PR TITLE
Add phantom type -based data class for identifiers

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.github.kittinunf.fuel.core.isSuccessful
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.DaycareAclRow
 import fi.espoo.evaka.shared.auth.DaycareAclRowEmployee
@@ -32,7 +33,7 @@ import java.util.UUID
 
 class UnitAclControllerIntegrationTest : FullApplicationTest() {
     private val employee = DaycareAclRowEmployee(
-        id = UUID.randomUUID(),
+        id = EmployeeId(UUID.randomUUID()),
         firstName = "First",
         lastName = "Last",
         email = "test@example.com"
@@ -53,7 +54,7 @@ class UnitAclControllerIntegrationTest : FullApplicationTest() {
             employee.also {
                 tx.insertTestEmployee(
                     DevEmployee(
-                        id = it.id,
+                        id = it.id.raw,
                         firstName = it.firstName,
                         lastName = it.lastName,
                         email = it.email

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -21,6 +21,9 @@ import fi.espoo.evaka.messaging.message.insertRecipients
 import fi.espoo.evaka.messaging.message.insertThread
 import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
 import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
@@ -76,7 +79,7 @@ class MessageAccountQueriesTest : PureJdbiTest() {
             it.insertDaycareAclRow(daycareId, supervisorId, UserRole.UNIT_SUPERVISOR)
 
             it.insertDaycareAclRow(daycareId, employee1Id, UserRole.STAFF)
-            it.insertDaycareGroupAcl(daycareId, employee1Id, listOf(groupId))
+            it.insertDaycareGroupAcl(DaycareId(daycareId), EmployeeId(employee1Id), listOf(GroupId(groupId)))
 
             // employee2 has no groups
             it.insertDaycareAclRow(daycareId, employee2Id, UserRole.STAFF)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
@@ -61,6 +61,16 @@ class JdbiExtensionsTest : PureJdbiTest() {
     }
 
     @Test
+    fun testCoordinateListResult() {
+        data class QueryResult(val values: List<Coordinate>)
+
+        val result = db.read {
+            it.createQuery("SELECT array[point(22.0, 11.0), point(44.0, 33.0)]::point[] AS values").mapTo<QueryResult>().single()
+        }
+        assertEquals(listOf(Coordinate(lat = 11.0, lon = 22.0), Coordinate(lat = 33.0, lon = 44.0)), result.values)
+    }
+
+    @Test
     fun testDateRange() {
         val input = DateRange(LocalDate.of(2020, 1, 2), LocalDate.of(2020, 3, 4))
 
@@ -93,6 +103,16 @@ class JdbiExtensionsTest : PureJdbiTest() {
     }
 
     @Test
+    fun testDateRangeListResult() {
+        data class QueryResult(val values: List<DateRange>)
+
+        val result = db.read {
+            it.createQuery("SELECT array[daterange('2020-06-07', NULL, '[]'), daterange('2021-01-01', '2021-01-02', '[]')]::daterange[] AS values").mapTo<QueryResult>().single()
+        }
+        assertEquals(listOf(DateRange(LocalDate.of(2020, 6, 7), null), DateRange(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 2))), result.values)
+    }
+
+    @Test
     fun testFiniteDateRange() {
         val input = FiniteDateRange(LocalDate.of(2020, 9, 10), LocalDate.of(2020, 11, 12))
 
@@ -111,6 +131,16 @@ class JdbiExtensionsTest : PureJdbiTest() {
             it.createQuery("SELECT NULL::daterange AS value").mapTo<QueryResult>().single()
         }
         assertNull(result.value)
+    }
+
+    @Test
+    fun testFiniteDateRangeListResult() {
+        data class QueryResult(val values: List<FiniteDateRange>)
+
+        val result = db.read {
+            it.createQuery("SELECT array[daterange('2020-06-07', '2021-01-01', '[]'), daterange('2021-01-01', '2021-01-02', '[]')]::daterange[] AS values").mapTo<QueryResult>().single()
+        }
+        assertEquals(listOf(FiniteDateRange(LocalDate.of(2020, 6, 7), LocalDate.of(2021, 1, 1)), FiniteDateRange(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 2))), result.values)
     }
 
     @Test
@@ -135,6 +165,16 @@ class JdbiExtensionsTest : PureJdbiTest() {
     }
 
     @Test
+    fun testExternalIdListResult() {
+        data class QueryResult(val values: List<ExternalId>)
+
+        val result = db.read {
+            it.createQuery("SELECT array['test:123456', 'more:42']::text[] AS values").mapTo<QueryResult>().single()
+        }
+        assertEquals(listOf(ExternalId.of(namespace = "test", value = "123456"), ExternalId.of(namespace = "more", value = "42")), result.values)
+    }
+
+    @Test
     fun testHelsinkiDateTime() {
         val input = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(13, 59), europeHelsinki))
 
@@ -153,6 +193,23 @@ class JdbiExtensionsTest : PureJdbiTest() {
             it.createQuery("SELECT NULL::timestamptz AS value").mapTo<QueryResult>().single()
         }
         assertNull(result.value)
+    }
+
+    @Test
+    fun testHelsinkiDateTimeListResult() {
+        data class QueryResult(val values: List<HelsinkiDateTime>)
+
+        val result = db.read {
+            it.createQuery("SELECT array['2020-05-07T10:59Z', '2021-01-10T06:42Z']::timestamptz[] AS values").mapTo<QueryResult>().single()
+        }
+        val values = result.values.map { it.toZonedDateTime().withZoneSameInstant(utc) }
+        assertEquals(
+            listOf(
+                ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(10, 59), utc),
+                ZonedDateTime.of(LocalDate.of(2021, 1, 10), LocalTime.of(6, 42), utc)
+            ),
+            values
+        )
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
 
 private inline fun <reified T : Any> Database.Read.passThrough(input: T) = createQuery(
@@ -36,6 +37,8 @@ private inline fun <reified T : Any> Database.Read.checkMatch(@Language("sql") s
     .single()
 
 class JdbiExtensionsTest : PureJdbiTest() {
+    private val utc: ZoneId = ZoneId.of("UTC")
+
     @Test
     fun testCoordinate() {
         val input = Coordinate(lat = 11.0, lon = 22.0)
@@ -160,7 +163,7 @@ class JdbiExtensionsTest : PureJdbiTest() {
         val result = db.read {
             it.createQuery("SELECT jsonb_build_object('value', '2020-05-07T10:59Z'::timestamptz) AS jsonb").mapTo<QueryResult>().single()
         }
-        val expected = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(13, 59), europeHelsinki))
-        assertEquals(expected, result.jsonb.value)
+        val expected = ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(10, 59), utc)
+        assertEquals(expected, result.jsonb.value.toZonedDateTime().withZoneSameInstant(utc))
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
@@ -12,6 +12,9 @@ import fi.espoo.evaka.daycare.getDaycareAclRows
 import fi.espoo.evaka.daycare.removeSpecialEducationTeacher
 import fi.espoo.evaka.daycare.removeStaffMember
 import fi.espoo.evaka.daycare.removeUnitSupervisor
+import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.DaycareAclRow
@@ -26,7 +29,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 class UnitAclController(private val acl: AccessControlList) {
@@ -34,7 +36,7 @@ class UnitAclController(private val acl: AccessControlList) {
     fun getAcl(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID
+        @PathVariable daycareId: DaycareId
     ): ResponseEntity<DaycareAclResponse> {
         Audit.UnitAclRead.log()
         acl.getRolesForUnit(user, daycareId)
@@ -47,8 +49,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun insertUnitSupervisor(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -61,8 +63,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun deleteUnitSupervisor(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -75,8 +77,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun insertSpecialEducationTeacher(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -89,8 +91,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun deleteSpecialEducationTeacher(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -103,8 +105,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun insertStaff(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -117,8 +119,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun deleteStaff(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -131,8 +133,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun updateStaffGroupAcl(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID,
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId,
         @RequestBody update: GroupAclUpdate
     ) {
         Audit.UnitGroupAclUpdate.log(targetId = daycareId, objectId = employeeId)
@@ -145,7 +147,7 @@ class UnitAclController(private val acl: AccessControlList) {
         }
     }
 
-    data class GroupAclUpdate(val groupIds: List<UUID>)
+    data class GroupAclUpdate(val groupIds: List<GroupId>)
 }
 
 data class DaycareAclResponse(val rows: List<DaycareAclRow>)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -4,6 +4,8 @@
 
 package fi.espoo.evaka.shared
 
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.KeyDeserializer
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.util.StdConverter
@@ -23,7 +25,7 @@ typealias GroupId = Id<DatabaseTable.Group>
 typealias PersonId = Id<DatabaseTable.Person>
 
 @JsonSerialize(converter = Id.ToJson::class)
-@JsonDeserialize(converter = Id.FromJson::class)
+@JsonDeserialize(converter = Id.FromJson::class, keyUsing = Id.KeyFromJson::class)
 data class Id<T : DatabaseTable>(val raw: UUID) {
     override fun toString(): String = raw.toString()
 
@@ -33,5 +35,10 @@ data class Id<T : DatabaseTable>(val raw: UUID) {
 
     class ToJson : StdConverter<Id<*>, UUID>() {
         override fun convert(value: Id<*>): UUID = value.raw
+    }
+
+    class KeyFromJson : KeyDeserializer() {
+        override fun deserializeKey(key: String, ctxt: DeserializationContext): Any =
+            Id<DatabaseTable>(UUID.fromString(key))
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.util.StdConverter
+import java.util.UUID
+
+sealed interface DatabaseTable {
+    sealed class Daycare : DatabaseTable
+    sealed class Employee : DatabaseTable
+    sealed class Group : DatabaseTable
+    sealed class Person : DatabaseTable
+}
+
+typealias ChildId = Id<DatabaseTable.Person>
+typealias DaycareId = Id<DatabaseTable.Daycare>
+typealias EmployeeId = Id<DatabaseTable.Employee>
+typealias GroupId = Id<DatabaseTable.Group>
+typealias PersonId = Id<DatabaseTable.Person>
+
+@JsonSerialize(converter = Id.ToJson::class)
+@JsonDeserialize(converter = Id.FromJson::class)
+data class Id<T : DatabaseTable>(val raw: UUID) {
+    override fun toString(): String = raw.toString()
+
+    class FromJson : StdConverter<UUID, Id<*>>() {
+        override fun convert(value: UUID): Id<DatabaseTable> = Id(value)
+    }
+
+    class ToJson : StdConverter<Id<*>, UUID>() {
+        override fun convert(value: Id<*>): UUID = value.raw
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.auth
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import org.jdbi.v3.core.Jdbi
@@ -38,7 +39,8 @@ class AccessControlList(private val jdbi: Jdbi) {
             AclAuthorization.Subset(Database(jdbi).read { it.selectAuthorizedDaycares(user, roles) })
         }
 
-    fun getRolesForUnit(user: AuthenticatedUser, daycareId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForUnit(user: AuthenticatedUser, daycareId: UUID): AclAppliedRoles = getRolesForUnit(user, DaycareId(daycareId))
+    fun getRolesForUnit(user: AuthenticatedUser, daycareId: DaycareId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/SpringMvcConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/SpringMvcConfig.kt
@@ -5,12 +5,14 @@
 package fi.espoo.evaka.shared.config
 
 import fi.espoo.evaka.identity.ExternalId
+import fi.espoo.evaka.shared.DatabaseTable
+import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.getAuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Unauthorized
 import fi.espoo.evaka.shared.utils.asArgumentResolver
-import fi.espoo.evaka.shared.utils.convertFromString
+import fi.espoo.evaka.shared.utils.convertFrom
 import fi.espoo.evaka.shared.utils.runAfterCompletion
 import org.jdbi.v3.core.Jdbi
 import org.springframework.context.annotation.Configuration
@@ -22,6 +24,7 @@ import org.springframework.web.context.request.WebRequest.SCOPE_REQUEST
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import java.util.UUID
 import javax.servlet.http.HttpServletRequest
 
 /**
@@ -31,6 +34,7 @@ import javax.servlet.http.HttpServletRequest
  * - `Database.Connection`: a request-scoped database connection, closed automatically at request completion (regardless of success or failure)
  * - `AuthenticatedUser`: user performing the request
  * - `ExternalId`: an external id, is automatically parsed from a string value (e.g. path variable / query parameter, depending on annotations)
+ * - `Id<*>`: a type-safe identifier, which is serialized/deserialized as UUID (= string)
  */
 @Configuration
 class SpringMvcConfig(private val jdbi: Jdbi) : WebMvcConfigurer {
@@ -45,7 +49,8 @@ class SpringMvcConfig(private val jdbi: Jdbi) : WebMvcConfigurer {
     }
 
     override fun addFormatters(registry: FormatterRegistry) {
-        registry.addConverter(convertFromString { ExternalId.parse(it) })
+        registry.addConverter(convertFrom<String, ExternalId> { ExternalId.parse(it) })
+        registry.addConverter(convertFrom<String, Id<*>> { Id<DatabaseTable>(UUID.fromString(it)) })
     }
 
     private fun WebRequest.getOrOpenConnection(): Database.Connection = getConnection()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionDetailed
 import fi.espoo.evaka.invoicing.domain.FeeDecisionSummary
 import fi.espoo.evaka.shared.Id
 import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.array.SqlArrayType
 import org.jdbi.v3.core.generic.GenericType
 import org.jdbi.v3.core.generic.GenericTypes
 import org.jdbi.v3.core.kotlin.KotlinPlugin
@@ -97,6 +98,12 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
     }
     jdbi.register(helsinkiDateTimeColumnMapper)
     jdbi.registerArrayType(UUID::class.java, "uuid")
+    jdbi.registerArrayType { elementType, _ ->
+        Optional.ofNullable(
+            SqlArrayType.of<Id<*>>("uuid") { it.raw }
+                .takeIf { Id::class.java.isAssignableFrom(GenericTypes.getErasedType(elementType)) }
+        )
+    }
     jdbi.registerRowMapper(FeeDecision::class.java, feeDecisionRowMapper(objectMapper))
     jdbi.registerRowMapper(FeeDecisionDetailed::class.java, feeDecisionDetailedRowMapper(objectMapper))
     jdbi.registerRowMapper(FeeDecisionSummary::class.java, feeDecisionSummaryRowMapper)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
@@ -20,6 +20,8 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionSummary
 import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
+import fi.espoo.evaka.shared.DatabaseTable
+import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -72,6 +74,8 @@ val identityArgumentFactory = customArgumentFactory<ExternalIdentifier>(Types.VA
 
 val externalIdArgumentFactory = toStringArgumentFactory<ExternalId>()
 
+val idArgumentFactory = customArgumentFactory<Id<DatabaseTable>>(Types.OTHER) { CustomObjectArgument(it.raw) }
+
 val helsinkiDateTimeArgumentFactory = customArgumentFactory<HelsinkiDateTime>(Types.TIMESTAMP_WITH_TIMEZONE) {
     CustomObjectArgument(it.toZonedDateTime().toOffsetDateTime())
 }
@@ -107,6 +111,8 @@ val coordinateColumnMapper = PgObjectColumnMapper {
 
 val externalIdColumnMapper =
     ColumnMapper { r, columnNumber, _ -> r.getString(columnNumber)?.let { ExternalId.parse(it) } }
+
+val idColumnMapper = ColumnMapper<Id<*>> { r, columnNumber, _ -> r.getObject(columnNumber, UUID::class.java)?.let { Id<DatabaseTable>(it) } }
 
 val helsinkiDateTimeColumnMapper =
     ColumnMapper { r, columnNumber, _ -> r.getObject(columnNumber, OffsetDateTime::class.java)?.let { HelsinkiDateTime.from(it.toInstant()) } }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/utils/SpringMvc.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/utils/SpringMvc.kt
@@ -35,11 +35,11 @@ fun runAfterCompletion(f: (request: WebRequest, ex: Exception?) -> Unit): WebReq
         override fun afterCompletion(request: WebRequest, ex: Exception?) = f(request, ex)
     }
 
-inline fun <reified T> convertFromString(crossinline f: (source: String) -> T): GenericConverter =
+inline fun <reified I, reified O> convertFrom(crossinline f: (source: I) -> O): GenericConverter =
     object : GenericConverter {
         override fun getConvertibleTypes(): Set<GenericConverter.ConvertiblePair> =
-            setOf(GenericConverter.ConvertiblePair(String::class.java, T::class.java))
+            setOf(GenericConverter.ConvertiblePair(I::class.java, O::class.java))
 
         override fun convert(source: Any?, sourceType: TypeDescriptor, targetType: TypeDescriptor): Any? =
-            source?.let { f(source as String) }
+            (source as? I)?.let(f)
     }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- a minimal wrapper for UUIDs with more type-safety
- `@JvmInline` + `value class` would be optimal, but Java libraries that use reflection have some problems with it -> use normal `data class` instead
- handle `Id<*>` transparently in REST endpoint parameters (Spring MVC / Jackson), JSON serialization (Jackson), and database parameters / return values (JDBI)
- this pull request switches only a small part of the codebase to use the wrappers