### PR TITLE
Fix static chip color and add story

### DIFF
--- a/frontend/src/employee-frontend/components/common/VasuStateChip.tsx
+++ b/frontend/src/employee-frontend/components/common/VasuStateChip.tsx
@@ -22,9 +22,5 @@ interface StateChipProps {
 }
 
 export function VasuStateChip({ labels, state }: StateChipProps) {
-  return (
-    <StaticChip color={vasuStateChip[state]} textColor={colors.greyscale.white}>
-      {labels[state]}
-    </StaticChip>
-  )
+  return <StaticChip color={vasuStateChip[state]}>{labels[state]}</StaticChip>
 }

--- a/frontend/src/lib-components/atoms/Chip.stories.tsx
+++ b/frontend/src/lib-components/atoms/Chip.stories.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { useTheme } from 'styled-components'
+import { FixedSpaceRow } from '../layout/flex-helpers'
+import { H2, H3 } from '../typography'
+import { Gap } from '../white-space'
+import { StaticChip } from './Chip'
+
+storiesOf('evaka/atoms/Chip', module).add('StaticChip', () =>
+  React.createElement(() => {
+    const theme = useTheme()
+
+    const renderChips = (colors: Record<string, string>) =>
+      Object.entries(colors).map(([key, value]) => (
+        <StaticChip key={key} color={value}>
+          {key}
+        </StaticChip>
+      ))
+
+    return (
+      <div>
+        <H2>Brand Colors</H2>
+        <H3>Espoo</H3>
+        <FixedSpaceRow>{renderChips(theme.colors.brand)}</FixedSpaceRow>
+
+        <Gap />
+
+        <H2>Evaka Colors</H2>
+
+        <H3>Main</H3>
+        <FixedSpaceRow>{renderChips(theme.colors.main)}</FixedSpaceRow>
+
+        <Gap />
+
+        <H3>Greyscale</H3>
+        <FixedSpaceRow>{renderChips(theme.colors.greyscale)}</FixedSpaceRow>
+
+        <Gap />
+
+        <H3>Accents</H3>
+        <FixedSpaceRow>{renderChips(theme.colors.accents)}</FixedSpaceRow>
+      </div>
+    )
+  })
+)

--- a/frontend/src/lib-components/atoms/Chip.tsx
+++ b/frontend/src/lib-components/atoms/Chip.tsx
@@ -24,7 +24,7 @@ export const StaticChip = styled.div<{ color: string; textColor?: string }>`
   background-color: ${(p) => p.color};
   color: ${({ theme: { colors }, ...p }) =>
     p.textColor ??
-    readableColor(p.color, colors.greyscale.darkest, colors.greyscale.white)};
+    readableColor(p.color, colors.greyscale.white, colors.greyscale.darkest)};
   padding: ${defaultMargins.xxs}
     calc(${defaultMargins.xs} + ${defaultMargins.xxs});
 


### PR DESCRIPTION
#### Summary

- Add storybook story for `StaticChip`
- Fix `readableColor` parameter order in `StaticChip`
- Remove color override from `VasuStateChip`

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/1176169/124270723-3f877380-db45-11eb-921d-92e276230af5.png">

