### PR TITLE
Remove old Terraform variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -664,7 +664,6 @@ commands:
               -var evaka-srv_version="${CIRCLE_SHA1}" \
               -var message-srv_version="${CIRCLE_SHA1}" \
               -var proxy_version="${CIRCLE_SHA1}" \
-              -var scheduled-api-calls_version="${CIRCLE_SHA1}" \
               -var ses-notification-processor_version="${CIRCLE_SHA1}"
 
   # Must be the last step in a job


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->


```
Error: Value for undeclared variable

A variable named "scheduled-api-calls_version" was assigned on the command
line, but the root module does not declare a variable of that name. To use
this value, add a "variable" block to the configuration.
```
