### PR TITLE
Clarify and refactor group placement query

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -144,7 +144,7 @@ class DaycareController(
         acl.getRolesForUnitGroup(user, groupId)
             .requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
 
-        db.transaction { daycareService.deleteGroup(it, daycareId, groupId) }
+        db.transaction { daycareService.deleteGroup(it, groupId) }
         return noContent()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.daycare.initCaretakers
 import fi.espoo.evaka.daycare.isValidDaycareId
 import fi.espoo.evaka.messaging.message.createDaycareGroupMessageAccount
 import fi.espoo.evaka.messaging.message.deleteDaycareGroupMessageAccount
-import fi.espoo.evaka.placement.getDaycareGroupPlacements
+import fi.espoo.evaka.placement.hasGroupPlacements
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.psqlCause
 import fi.espoo.evaka.shared.domain.Conflict
@@ -50,15 +50,8 @@ class DaycareService {
         tx.createDaycareGroupMessageAccount(it.id)
     }
 
-    fun deleteGroup(tx: Database.Transaction, daycareId: UUID, groupId: UUID) = try {
-        val isEmpty = tx.getDaycareGroupPlacements(
-            daycareId = daycareId,
-            groupId = groupId,
-            startDate = null,
-            endDate = null
-        ).isEmpty()
-
-        if (!isEmpty) throw Conflict("Cannot delete group which has children placed in it")
+    fun deleteGroup(tx: Database.Transaction, groupId: UUID) = try {
+        if (tx.hasGroupPlacements(groupId)) throw Conflict("Cannot delete group which has children placed in it")
 
         tx.deleteDaycareGroupMessageAccount(groupId)
         tx.deleteDaycareGroup(groupId)

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -376,6 +376,13 @@ fun Database.Read.getIdenticalPostcedingGroupPlacement(
         .firstOrNull()
 }
 
+fun Database.Read.hasGroupPlacements(groupId: UUID): Boolean = createQuery(
+    "SELECT EXISTS (SELECT 1 FROM daycare_group_placement WHERE daycare_group_id = :groupId)"
+)
+    .bind("groupId", groupId)
+    .mapTo<Boolean>()
+    .one()
+
 fun Database.Read.getDaycareGroupPlacements(
     daycareId: UUID,
     startDate: LocalDate?,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -101,9 +101,6 @@ fun Database.Transaction.checkAndCreateGroupPlacement(
     if (endDate.isBefore(startDate))
         throw BadRequest("Must not end before even starting")
 
-    if (getDaycareGroupPlacements(daycarePlacementId, startDate, endDate, groupId).isNotEmpty())
-        throw BadRequest("Group placement must not overlap with existing group placement")
-
     val daycarePlacement = getDaycarePlacement(daycarePlacementId)
         ?: throw NotFound("Placement $daycarePlacementId does not exist")
 

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
+import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.NotFound
 import org.jdbi.v3.core.kotlin.mapTo
@@ -256,7 +257,7 @@ fun Database.Read.getDetailedDaycarePlacements(
 
     val groupPlacements =
         when {
-            daycareId != null -> getDaycareGroupPlacements(daycareId, minDate, maxDate, null)
+            daycareId != null -> getGroupPlacementsAtDaycare(daycareId, DateRange(minDate, maxDate))
             childId != null -> getChildGroupPlacements(childId)
             else -> listOf()
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Time.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Time.kt
@@ -123,6 +123,7 @@ data class DateRange(val start: LocalDate, val end: LocalDate?) {
     }
 
     fun asFiniteDateRange(): FiniteDateRange? = end?.let { FiniteDateRange(start, it) }
+    fun asFiniteDateRange(defaultEnd: LocalDate): FiniteDateRange = FiniteDateRange(start, end ?: defaultEnd)
 
     fun contains(other: DateRange) = this.start <= other.start && orMax(other.end) <= orMax(this.end)
     fun contains(other: FiniteDateRange) = contains(other.asDateRange())


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- remove broken check. It never worked, because a daycare placement ID was passed where a daycare ID was expected
- query used in two places with different requirements -> refactor to two simple queries instead