### PR TITLE
Typesafe IDs in backend

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevAssistanceNeed
 import fi.espoo.evaka.shared.dev.DevChild
@@ -317,7 +318,7 @@ class FixtureBuilder(
     ) {
         private var from: LocalDate? = null
         private var to: LocalDate? = null
-        private var optionId: UUID? = null
+        private var optionId: ServiceNeedOptionId? = null
         private var serviceNeedOption: ServiceNeedOption? = null
         private var employeeId: UUID? = null
         private var updated: HelsinkiDateTime = HelsinkiDateTime.now()
@@ -327,7 +328,7 @@ class FixtureBuilder(
         fun fromDay(relativeDays: Int) = this.apply { this.from = today.plusDays(relativeDays.toLong()) }
         fun toDay(date: LocalDate) = this.apply { this.to = date }
         fun toDay(relativeDays: Int) = this.apply { this.to = today.plusDays(relativeDays.toLong()) }
-        fun withOption(id: UUID) = this.apply { this.optionId = id }
+        fun withOption(id: ServiceNeedOptionId) = this.apply { this.optionId = id }
         fun withOption(serviceNeedOption: ServiceNeedOption) = this.apply { this.serviceNeedOption = serviceNeedOption }
         fun createdBy(employeeId: UUID) = this.apply { this.employeeId = employeeId }
         fun withUpdated(updated: HelsinkiDateTime) = this.apply { this.updated = updated }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
@@ -160,7 +161,7 @@ class FixtureBuilder(
     ) {
         private var from: LocalDate = today
         private var to: LocalDate = today
-        private var unitId: UUID? = null
+        private var unitId: DaycareId? = null
         private var type: PlacementType? = null
         private var deleted = false
         private var preschoolDaycareDates: FiniteDateRange? = null
@@ -169,7 +170,7 @@ class FixtureBuilder(
         fun fromDay(relativeDays: Int) = this.apply { this.from = today.plusDays(relativeDays.toLong()) }
         fun toDay(relativeDays: Int) = this.apply { this.to = today.plusDays(relativeDays.toLong()) }
         fun toDay(date: LocalDate) = this.apply { this.to = date }
-        fun toUnit(id: UUID) = this.apply { this.unitId = id }
+        fun toUnit(id: DaycareId) = this.apply { this.unitId = id }
         fun ofType(type: PlacementType) = this.apply { this.type = type }
         fun asDeleted() = this.apply { this.deleted = true }
         fun withPreschoolDaycareDates(range: FiniteDateRange) = this.apply { this.preschoolDaycareDates = range }
@@ -202,14 +203,14 @@ class FixtureBuilder(
     ) {
         private var from: LocalDate = today
         private var to: LocalDate = today
-        private var unitId: UUID? = null
+        private var unitId: DaycareId? = null
         private var groupId: GroupId? = null
 
         fun fromDay(date: LocalDate) = this.apply { this.from = date }
         fun fromDay(relativeDays: Int) = this.apply { this.from = today.plusDays(relativeDays.toLong()) }
         fun toDay(relativeDays: Int) = this.apply { this.to = today.plusDays(relativeDays.toLong()) }
         fun toDay(date: LocalDate) = this.apply { this.to = date }
-        fun toUnit(id: UUID) = this.apply { this.unitId = id }
+        fun toUnit(id: DaycareId) = this.apply { this.unitId = id }
         fun toGroup(id: GroupId) = this.apply { this.groupId = id }
 
         fun save(): ChildFixture {
@@ -231,14 +232,14 @@ class FixtureBuilder(
     ) {
         private var from: LocalDate = today
         private var to: LocalDate = today
-        private var unitId: UUID? = null
+        private var unitId: DaycareId? = null
         private var type: PlacementType? = null
 
         fun fromDay(date: LocalDate) = this.apply { this.from = date }
         fun fromDay(relativeDays: Int) = this.apply { this.from = today.plusDays(relativeDays.toLong()) }
         fun toDay(relativeDays: Int) = this.apply { this.to = today.plusDays(relativeDays.toLong()) }
         fun toDay(date: LocalDate) = this.apply { this.to = date }
-        fun toUnit(id: UUID) = this.apply { this.unitId = id }
+        fun toUnit(id: DaycareId) = this.apply { this.unitId = id }
         fun ofType(type: PlacementType) = this.apply { this.type = type }
 
         fun save(): ChildFixture {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevAssistanceNeed
 import fi.espoo.evaka.shared.dev.DevChild
@@ -273,7 +274,7 @@ class FixtureBuilder(
     class PlacementFixture(
         private val tx: Database.Transaction,
         private val today: LocalDate,
-        val placementId: UUID,
+        val placementId: PlacementId,
         val placementPeriod: FiniteDateRange
     ) {
         fun addGroupPlacement() = GroupPlacementBuilder(tx, today, this)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevAssistanceNeed
 import fi.espoo.evaka.shared.dev.DevChild
@@ -201,14 +202,14 @@ class FixtureBuilder(
         private var from: LocalDate = today
         private var to: LocalDate = today
         private var unitId: UUID? = null
-        private var groupId: UUID? = null
+        private var groupId: GroupId? = null
 
         fun fromDay(date: LocalDate) = this.apply { this.from = date }
         fun fromDay(relativeDays: Int) = this.apply { this.from = today.plusDays(relativeDays.toLong()) }
         fun toDay(relativeDays: Int) = this.apply { this.to = today.plusDays(relativeDays.toLong()) }
         fun toDay(date: LocalDate) = this.apply { this.to = date }
         fun toUnit(id: UUID) = this.apply { this.unitId = id }
-        fun toGroup(id: UUID) = this.apply { this.groupId = id }
+        fun toGroup(id: GroupId) = this.apply { this.groupId = id }
 
         fun save(): ChildFixture {
             tx.insertTestBackUpCare(
@@ -287,13 +288,13 @@ class FixtureBuilder(
     ) {
         private var from: LocalDate? = null
         private var to: LocalDate? = null
-        private var groupId: UUID? = null
+        private var groupId: GroupId? = null
 
         fun fromDay(date: LocalDate) = this.apply { this.from = date }
         fun fromDay(relativeDays: Int) = this.apply { this.from = today.plusDays(relativeDays.toLong()) }
         fun toDay(date: LocalDate) = this.apply { this.to = date }
         fun toDay(relativeDays: Int) = this.apply { this.to = today.plusDays(relativeDays.toLong()) }
-        fun toGroup(id: UUID) = this.apply { this.groupId = id }
+        fun toGroup(id: GroupId) = this.apply { this.groupId = id }
 
         fun save(): PlacementFixture {
             tx.insertTestDaycareGroupPlacement(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.serviceneed.ServiceNeedOption
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevAssistanceNeed
 import fi.espoo.evaka.shared.dev.DevChild
@@ -320,7 +321,7 @@ class FixtureBuilder(
         private var serviceNeedOption: ServiceNeedOption? = null
         private var employeeId: UUID? = null
         private var updated: HelsinkiDateTime = HelsinkiDateTime.now()
-        private var id: UUID? = null
+        private var id: ServiceNeedId? = null
 
         fun fromDay(date: LocalDate) = this.apply { this.from = date }
         fun fromDay(relativeDays: Int) = this.apply { this.from = today.plusDays(relativeDays.toLong()) }
@@ -330,7 +331,7 @@ class FixtureBuilder(
         fun withOption(serviceNeedOption: ServiceNeedOption) = this.apply { this.serviceNeedOption = serviceNeedOption }
         fun createdBy(employeeId: UUID) = this.apply { this.employeeId = employeeId }
         fun withUpdated(updated: HelsinkiDateTime) = this.apply { this.updated = updated }
-        fun withId(id: UUID) = this.apply { this.id = id }
+        fun withId(id: ServiceNeedId) = this.apply { this.id = id }
 
         fun save(): PlacementFixture {
             if (serviceNeedOption != null) tx.insertServiceNeedOption(serviceNeedOption!!)
@@ -344,7 +345,7 @@ class FixtureBuilder(
                     to ?: placementFixture.placementPeriod.end
                 ),
                 updated = updated,
-                id = id ?: UUID.randomUUID()
+                id = id ?: ServiceNeedId(UUID.randomUUID())
             )
 
             return placementFixture

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.core.FileDataPart
 import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.isSuccessful
 import fi.espoo.evaka.application.AttachmentType
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.config.SharedIntegrationTestConfig
@@ -30,7 +31,6 @@ import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.core.env.Environment
 import java.io.File
 import java.time.LocalDate
-import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(
@@ -84,7 +84,7 @@ abstract class FullApplicationTest {
         db.close()
     }
 
-    fun uploadAttachment(applicationId: UUID, user: AuthenticatedUser, type: AttachmentType = AttachmentType.URGENCY): Boolean {
+    fun uploadAttachment(applicationId: ApplicationId, user: AuthenticatedUser, type: AttachmentType = AttachmentType.URGENCY): Boolean {
         val path = if (user.isEndUser) "/attachments/citizen/applications/$applicationId" else "/attachments/applications/$applicationId"
         val (_, res, _) = http.upload(path, parameters = listOf("type" to type))
             .add(FileDataPart(File(pngFile.toURI()), name = "file"))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/ServiceNeedTestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/ServiceNeedTestFixtures.kt
@@ -8,11 +8,12 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionServiceNeed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionServiceNeed
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import java.math.BigDecimal
 import java.util.UUID
 
 val snDefaultDaycare = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Kokopäiväinen",
     validPlacementType = PlacementType.DAYCARE,
     defaultOption = true,
@@ -29,7 +30,7 @@ val snDefaultDaycare = ServiceNeedOption(
 )
 
 val snDefaultPartDayDaycare = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Osapäiväinen",
     validPlacementType = PlacementType.DAYCARE_PART_TIME,
     defaultOption = true,
@@ -46,7 +47,7 @@ val snDefaultPartDayDaycare = ServiceNeedOption(
 )
 
 val snDefaultFiveYearOldsDaycare = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Viisivuotiaiden kokopäiväinen",
     validPlacementType = PlacementType.DAYCARE_FIVE_YEAR_OLDS,
     defaultOption = true,
@@ -63,7 +64,7 @@ val snDefaultFiveYearOldsDaycare = ServiceNeedOption(
 )
 
 val snDefaultFiveYearOldsPartDayDaycare = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Viisivuotiaiden osapäiväinen",
     validPlacementType = PlacementType.DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
     defaultOption = true,
@@ -80,7 +81,7 @@ val snDefaultFiveYearOldsPartDayDaycare = ServiceNeedOption(
 )
 
 val snDefaultPreschool = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Esiopetus",
     validPlacementType = PlacementType.PRESCHOOL,
     defaultOption = true,
@@ -97,7 +98,7 @@ val snDefaultPreschool = ServiceNeedOption(
 )
 
 val snDefaultPreschoolDaycare = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Esiopetus ja liittyvä varhaiskasvatus",
     validPlacementType = PlacementType.PRESCHOOL_DAYCARE,
     defaultOption = true,
@@ -114,7 +115,7 @@ val snDefaultPreschoolDaycare = ServiceNeedOption(
 )
 
 val snDefaultPreparatory = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Valmistava opetus",
     validPlacementType = PlacementType.PREPARATORY,
     defaultOption = true,
@@ -131,7 +132,7 @@ val snDefaultPreparatory = ServiceNeedOption(
 )
 
 val snDefaultPreparatoryDaycare = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Valmistava opetus ja liittyvä varhaiskasvatus",
     validPlacementType = PlacementType.PREPARATORY_DAYCARE,
     defaultOption = true,
@@ -148,7 +149,7 @@ val snDefaultPreparatoryDaycare = ServiceNeedOption(
 )
 
 val snDefaultClub = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Kerho",
     validPlacementType = PlacementType.CLUB,
     defaultOption = true,
@@ -165,7 +166,7 @@ val snDefaultClub = ServiceNeedOption(
 )
 
 val snDefaultTemporaryDaycare = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Kokopäiväinen tilapäinen",
     validPlacementType = PlacementType.TEMPORARY_DAYCARE,
     defaultOption = true,
@@ -182,7 +183,7 @@ val snDefaultTemporaryDaycare = ServiceNeedOption(
 )
 
 val snDefaultTemporaryPartDayDaycare = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Osapäiväinen tilapäinen",
     validPlacementType = PlacementType.TEMPORARY_DAYCARE_PART_DAY,
     defaultOption = true,
@@ -199,7 +200,7 @@ val snDefaultTemporaryPartDayDaycare = ServiceNeedOption(
 )
 
 val snDaycareFullDay35 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Kokopäiväinen, vähintään 35h",
     validPlacementType = PlacementType.DAYCARE,
     defaultOption = false,
@@ -216,7 +217,7 @@ val snDaycareFullDay35 = ServiceNeedOption(
 )
 
 val snDaycareFullDay25to35 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Kokopäiväinen, 25-35h",
     validPlacementType = PlacementType.DAYCARE,
     defaultOption = false,
@@ -233,7 +234,7 @@ val snDaycareFullDay25to35 = ServiceNeedOption(
 )
 
 val snDaycareFullDayPartWeek25 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Osaviikkoinen, enintään 25h",
     validPlacementType = PlacementType.DAYCARE,
     defaultOption = false,
@@ -250,7 +251,7 @@ val snDaycareFullDayPartWeek25 = ServiceNeedOption(
 )
 
 val snDaycarePartDay25 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Osapäiväinen",
     validPlacementType = PlacementType.DAYCARE_PART_TIME,
     defaultOption = false,
@@ -267,7 +268,7 @@ val snDaycarePartDay25 = ServiceNeedOption(
 )
 
 val snPreschoolDaycare45 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Kokopäiväinen liittyvä, yhteensä vähintään 45h",
     validPlacementType = PlacementType.PRESCHOOL_DAYCARE,
     defaultOption = false,
@@ -284,7 +285,7 @@ val snPreschoolDaycare45 = ServiceNeedOption(
 )
 
 val snPreschoolDaycarePartDay35to45 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Osapäiväinen liittyvä, yhteensä 35-45h",
     validPlacementType = PlacementType.PRESCHOOL_DAYCARE,
     defaultOption = false,
@@ -301,7 +302,7 @@ val snPreschoolDaycarePartDay35to45 = ServiceNeedOption(
 )
 
 val snPreschoolDaycarePartDay35 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Osapäiväinen liittyvä, yhteensä enintään 35h",
     validPlacementType = PlacementType.PRESCHOOL_DAYCARE,
     defaultOption = false,
@@ -318,7 +319,7 @@ val snPreschoolDaycarePartDay35 = ServiceNeedOption(
 )
 
 val snPreparatoryDaycare50 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Kokopäiväinen liittyvä, yhteensä vähintään 50h",
     validPlacementType = PlacementType.PREPARATORY_DAYCARE,
     defaultOption = false,
@@ -335,7 +336,7 @@ val snPreparatoryDaycare50 = ServiceNeedOption(
 )
 
 val snPreparatoryDaycarePartDay40to50 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Osapäiväinen liittyvä, yhteensä 40-50h",
     validPlacementType = PlacementType.PREPARATORY_DAYCARE,
     defaultOption = false,
@@ -352,7 +353,7 @@ val snPreparatoryDaycarePartDay40to50 = ServiceNeedOption(
 )
 
 val snPreparatoryDaycarePartDay40 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "Osapäiväinen liittyvä, yhteensä enintään 40h",
     validPlacementType = PlacementType.PREPARATORY_DAYCARE,
     defaultOption = false,
@@ -369,7 +370,7 @@ val snPreparatoryDaycarePartDay40 = ServiceNeedOption(
 )
 
 val snDaycareFiveYearOldsFullDayPartWeek25 = ServiceNeedOption(
-    id = UUID.randomUUID(),
+    id = ServiceNeedOptionId(UUID.randomUUID()),
     name = "5-vuotiaiden osaviikkoinen, yli 20h enintään 25h",
     validPlacementType = PlacementType.DAYCARE_FIVE_YEAR_OLDS,
     defaultOption = false,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -26,6 +26,7 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.invoicing.domain.VoucherValue
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.UserRole
@@ -678,7 +679,7 @@ fun Database.Transaction.insertApplication(
     hasAdditionalInfo: Boolean = false,
     maxFeeAccepted: Boolean = false,
     preferredStartDate: LocalDate? = LocalDate.now().plusMonths(4),
-    applicationId: UUID = UUID.randomUUID(),
+    applicationId: ApplicationId = ApplicationId(UUID.randomUUID()),
     status: ApplicationStatus = ApplicationStatus.CREATED,
     guardianEmail: String = "abc@espoo.fi"
 ): ApplicationDetails {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -26,6 +26,7 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.invoicing.domain.VoucherValue
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -55,11 +56,11 @@ import java.util.UUID
  Queries and data classes for initializing integration tests with person and unit data
  */
 
-val testAreaId = UUID.randomUUID()
+val testAreaId = AreaId(UUID.randomUUID())
 val testAreaCode = 200
-val testArea2Id = UUID.randomUUID()
+val testArea2Id = AreaId(UUID.randomUUID())
 val testArea2Code = 300
-val svebiTestId = UUID.randomUUID()
+val svebiTestId = AreaId(UUID.randomUUID())
 val svebiTestCode = 400
 
 val defaultMunicipalOrganizerOid = "1.2.246.562.10.888888888888"

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -26,6 +26,7 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.invoicing.domain.VoucherValue
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevCareArea
@@ -68,7 +69,7 @@ val unitSupervisorExternalId = ExternalId.of("test", UUID.randomUUID().toString(
 
 val testDaycare =
     UnitData.Detailed(
-        id = UUID.randomUUID(),
+        id = DaycareId(UUID.randomUUID()),
         name = "Test Daycare",
         areaId = testAreaId,
         areaName = "Test Area",
@@ -76,16 +77,16 @@ val testDaycare =
     )
 val testDaycare2 =
     UnitData.Detailed(
-        id = UUID.randomUUID(),
+        id = DaycareId(UUID.randomUUID()),
         name = "Test Daycare 2",
         areaId = testArea2Id,
         areaName = "Lwiz Foo",
         language = "fi"
     )
-val testDaycareNotInvoiced = UnitData.InvoicedByMunicipality(id = UUID.randomUUID(), invoicedByMunicipality = false)
+val testDaycareNotInvoiced = UnitData.InvoicedByMunicipality(id = DaycareId(UUID.randomUUID()), invoicedByMunicipality = false)
 val testSvebiDaycare =
     UnitData.Detailed(
-        id = UUID.randomUUID(),
+        id = DaycareId(UUID.randomUUID()),
         name = "Test Svebi Daycare",
         areaId = svebiTestId,
         areaName = "Svenska Bildningstjanster",
@@ -94,7 +95,7 @@ val testSvebiDaycare =
 
 val testPurchasedDaycare =
     UnitData.Detailed(
-        id = UUID.randomUUID(),
+        id = DaycareId(UUID.randomUUID()),
         name = "Test Purchased Daycare",
         areaId = testAreaId,
         areaName = "Lwiz Foo",
@@ -103,7 +104,7 @@ val testPurchasedDaycare =
 
 val testVoucherDaycare =
     UnitData.Detailed(
-        id = UUID.randomUUID(),
+        id = DaycareId(UUID.randomUUID()),
         name = "Test Voucher Daycare",
         areaId = testAreaId,
         areaName = "Lwiz Foo",
@@ -112,7 +113,7 @@ val testVoucherDaycare =
 
 val testVoucherDaycare2 =
     UnitData.Detailed(
-        id = UUID.randomUUID(),
+        id = DaycareId(UUID.randomUUID()),
         name = "Test Voucher Daycare 2",
         areaId = testAreaId,
         areaName = "Lwiz Foo",
@@ -120,7 +121,7 @@ val testVoucherDaycare2 =
     )
 
 val testClub = DevDaycare(
-    id = UUID.randomUUID(),
+    id = DaycareId(UUID.randomUUID()),
     name = "Test Club",
     areaId = testAreaId,
     type = setOf(CareType.CLUB),
@@ -132,7 +133,7 @@ val testClub = DevDaycare(
 )
 
 val testGhostUnitDaycare = DevDaycare(
-    id = UUID.randomUUID(),
+    id = DaycareId(UUID.randomUUID()),
     name = "Test Ghost Unit Daycare",
     areaId = testAreaId,
     type = setOf(CareType.CENTRE),
@@ -142,7 +143,7 @@ val testGhostUnitDaycare = DevDaycare(
 )
 
 val testRoundTheClockDaycare = DevDaycare(
-    id = UUID.randomUUID(),
+    id = DaycareId(UUID.randomUUID()),
     name = "Test Ghost Unit Daycare",
     areaId = testAreaId,
     type = setOf(CareType.CENTRE),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.insertApplication
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -227,7 +228,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `email is sent after sending preschool application`() {
-        val applicationId = UUID.randomUUID()
+        val applicationId = ApplicationId(UUID.randomUUID())
         db.transaction { tx ->
             tx.insertApplication(
                 guardian = guardian,
@@ -423,7 +424,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
         assert(email.textBody.contains(expectedTextPart, true))
     }
 
-    private fun assertApplicationIsSent(applicationId: UUID) {
+    private fun assertApplicationIsSent(applicationId: ApplicationId) {
         db.read {
             assertEquals(ApplicationStatus.SENT, it.fetchApplicationDetails(applicationId)!!.status)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -30,6 +30,7 @@ import fi.espoo.evaka.placement.getPlacementPlan
 import fi.espoo.evaka.placement.getPlacementsForChild
 import fi.espoo.evaka.preschoolTerm2020
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -82,7 +83,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
-    private val applicationId = UUID.randomUUID()
+    private val applicationId = ApplicationId(UUID.randomUUID())
     private val mainPeriod = preschoolTerm2020
     private val connectedPeriod = FiniteDateRange(preschoolTerm2020.start.minusDays(12), preschoolTerm2020.end.plusDays(15))
 
@@ -145,7 +146,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         }
     }
 
-    private fun assertDueDate(applicationId: UUID, expected: Instant?) {
+    private fun assertDueDate(applicationId: ApplicationId, expected: Instant?) {
         db.read {
             val application = it.fetchApplicationDetails(applicationId)!!
             if (expected != null) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -31,6 +31,7 @@ import fi.espoo.evaka.placement.getPlacementsForChild
 import fi.espoo.evaka.preschoolTerm2020
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -1290,7 +1291,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIndefinite = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1330,7 +1331,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncome = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1370,7 +1371,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val laterIndefiniteIncome = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1410,7 +1411,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncome = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1452,7 +1453,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val laterIncome = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1492,7 +1493,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIndefinite = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1530,7 +1531,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val sameDayIncomeIndefinite = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1569,7 +1570,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val sameDayIncome = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1609,7 +1610,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val dayBeforeIncomeIndefinite = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1650,7 +1651,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val nextDayIncomeIndefinite = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1690,7 +1691,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val incomeDayBefore = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1730,7 +1731,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncomeEndingOnSameDay = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1770,7 +1771,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncomeEndingOnNextDay = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",
@@ -1810,7 +1811,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             // given
             val financeUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.FINANCE_ADMIN))
             val earlierIncomeEndingOnDayBefore = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.NOT_AVAILABLE,
                 notes = "Income not available",

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.application.utils.currentDateInFinland
 import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -220,7 +221,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             val data =
                 tx.createQuery("""select id from application""")
-                    .mapTo<UUID>()
+                    .mapTo<ApplicationId>()
                     .toList()
 
             assertEquals(3, data.size)
@@ -231,7 +232,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             val data =
                 tx.createQuery("""select id from application""")
-                    .mapTo<UUID>()
+                    .mapTo<ApplicationId>()
                     .toSet()
 
             assertEquals(setOf(id1, id2), data)
@@ -292,7 +293,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
         assertEquals(2, endUserResult.get().attachments.size)
     }
 
-    private fun createPlacementProposalWithAttachments(unitId: DaycareId): UUID {
+    private fun createPlacementProposalWithAttachments(unitId: DaycareId): ApplicationId {
         val applicationId = db.transaction { tx ->
             val applicationId = tx.insertTestApplication(
                 childId = testChild_1.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.application.utils.currentDateInFinland
 import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -291,7 +292,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
         assertEquals(2, endUserResult.get().attachments.size)
     }
 
-    private fun createPlacementProposalWithAttachments(unitId: UUID): UUID {
+    private fun createPlacementProposalWithAttachments(unitId: DaycareId): UUID {
         val applicationId = db.transaction { tx ->
             val applicationId = tx.insertTestApplication(
                 childId = testChild_1.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.emailclient.MockEmail
 import fi.espoo.evaka.emailclient.MockEmailClient
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -40,7 +41,7 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
     @Autowired
     lateinit var scheduledJobs: ScheduledJobs
 
-    private val applicationId = UUID.randomUUID()
+    private val applicationId = ApplicationId(UUID.randomUUID())
     private val childId = testChild_1.id
     private val guardianId = testAdult_6.id
     private val unitId = testDaycare.id

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.AssistanceActionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -223,7 +224,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
     @Test
     fun `update assistance action, not found responds 404`() {
         whenPutAssistanceActionThenExpectError(
-            UUID.randomUUID(),
+            AssistanceActionId(UUID.randomUUID()),
             AssistanceActionRequest(
                 startDate = testDate(9),
                 endDate = testDate(22)
@@ -261,12 +262,12 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `delete assistance action, not found responds 404`() {
-        whenDeleteAssistanceActionThenExpectError(UUID.randomUUID(), 404)
+        whenDeleteAssistanceActionThenExpectError(AssistanceActionId(UUID.randomUUID()), 404)
     }
 
     private fun testDate(day: Int) = LocalDate.of(2000, 1, day)
 
-    private fun givenAssistanceAction(start: Int, end: Int, childId: UUID = testChild_1.id): UUID {
+    private fun givenAssistanceAction(start: Int, end: Int, childId: UUID = testChild_1.id): AssistanceActionId {
         return db.transaction {
             it.insertTestAssistanceAction(
                 DevAssistanceAction(
@@ -307,7 +308,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
         return result.get()
     }
 
-    private fun whenPutAssistanceActionThenExpectSuccess(id: UUID, request: AssistanceActionRequest): AssistanceAction {
+    private fun whenPutAssistanceActionThenExpectSuccess(id: AssistanceActionId, request: AssistanceActionRequest): AssistanceAction {
         val (_, res, result) = http.put("/assistance-actions/$id")
             .jsonBody(objectMapper.writeValueAsString(request))
             .asUser(assistanceWorker)
@@ -317,7 +318,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
         return result.get()
     }
 
-    private fun whenPutAssistanceActionThenExpectError(id: UUID, request: AssistanceActionRequest, status: Int) {
+    private fun whenPutAssistanceActionThenExpectError(id: AssistanceActionId, request: AssistanceActionRequest, status: Int) {
         val (_, res, _) = http.put("/assistance-actions/$id")
             .jsonBody(objectMapper.writeValueAsString(request))
             .asUser(assistanceWorker)
@@ -326,7 +327,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
         assertEquals(status, res.statusCode)
     }
 
-    private fun whenDeleteAssistanceActionThenExpectSuccess(id: UUID) {
+    private fun whenDeleteAssistanceActionThenExpectSuccess(id: AssistanceActionId) {
         val (_, res, _) = http.delete("/assistance-actions/$id")
             .asUser(assistanceWorker)
             .response()
@@ -334,7 +335,7 @@ class AssistanceActionIntegrationTest : FullApplicationTest() {
         assertEquals(204, res.statusCode)
     }
 
-    private fun whenDeleteAssistanceActionThenExpectError(id: UUID, status: Int) {
+    private fun whenDeleteAssistanceActionThenExpectError(id: AssistanceActionId, status: Int) {
         val (_, res, _) = http.delete("/assistance-actions/$id")
             .asUser(assistanceWorker)
             .response()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -239,7 +240,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
     @Test
     fun `update assistance need, not found responds 404`() {
         whenPutAssistanceNeedThenExpectError(
-            UUID.randomUUID(),
+            AssistanceNeedId(UUID.randomUUID()),
             AssistanceNeedRequest(
                 startDate = testDate(9),
                 endDate = testDate(22),
@@ -279,12 +280,12 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `delete assistance need, not found responds 404`() {
-        whenDeleteAssistanceNeedThenExpectError(UUID.randomUUID(), 404)
+        whenDeleteAssistanceNeedThenExpectError(AssistanceNeedId(UUID.randomUUID()), 404)
     }
 
     private fun testDate(day: Int) = LocalDate.of(2000, 1, day)
 
-    private fun givenAssistanceNeed(start: Int, end: Int, childId: UUID = testChild_1.id): UUID {
+    private fun givenAssistanceNeed(start: Int, end: Int, childId: UUID = testChild_1.id): AssistanceNeedId {
         return db.transaction {
             it.insertTestAssistanceNeed(
                 DevAssistanceNeed(
@@ -325,7 +326,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
         return result.get()
     }
 
-    private fun whenPutAssistanceNeedThenExpectSuccess(id: UUID, request: AssistanceNeedRequest): AssistanceNeed {
+    private fun whenPutAssistanceNeedThenExpectSuccess(id: AssistanceNeedId, request: AssistanceNeedRequest): AssistanceNeed {
         val (_, res, result) = http.put("/assistance-needs/$id")
             .jsonBody(objectMapper.writeValueAsString(request))
             .asUser(assistanceWorker)
@@ -335,7 +336,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
         return result.get()
     }
 
-    private fun whenPutAssistanceNeedThenExpectError(id: UUID, request: AssistanceNeedRequest, status: Int) {
+    private fun whenPutAssistanceNeedThenExpectError(id: AssistanceNeedId, request: AssistanceNeedRequest, status: Int) {
         val (_, res, _) = http.put("/assistance-needs/$id")
             .jsonBody(objectMapper.writeValueAsString(request))
             .asUser(assistanceWorker)
@@ -344,7 +345,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
         assertEquals(status, res.statusCode)
     }
 
-    private fun whenDeleteAssistanceNeedThenExpectSuccess(id: UUID) {
+    private fun whenDeleteAssistanceNeedThenExpectSuccess(id: AssistanceNeedId) {
         val (_, res, _) = http.delete("/assistance-needs/$id")
             .asUser(assistanceWorker)
             .response()
@@ -352,7 +353,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
         assertEquals(204, res.statusCode)
     }
 
-    private fun whenDeleteAssistanceNeedThenExpectError(id: UUID, status: Int) {
+    private fun whenDeleteAssistanceNeedThenExpectError(id: AssistanceNeedId, status: Int) {
         val (_, res, _) = http.delete("/assistance-needs/$id")
             .asUser(assistanceWorker)
             .response()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsControllerIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.application.deleteApplication
 import fi.espoo.evaka.insertApplication
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.testAdult_5
 import org.junit.jupiter.api.AfterEach
@@ -22,7 +23,7 @@ import kotlin.test.assertTrue
 class AttachmentsControllerIntegrationTest : FullApplicationTest() {
 
     private lateinit var user: AuthenticatedUser
-    private val applicationId = UUID.randomUUID()
+    private val applicationId = ApplicationId(UUID.randomUUID())
 
     @BeforeEach
     protected fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -42,7 +43,7 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
     private val mobileUser = AuthenticatedUser.MobileDevice(userId)
     private val groupId = GroupId(UUID.randomUUID())
     private val groupName = "Testaajat"
-    private val daycarePlacementId = UUID.randomUUID()
+    private val daycarePlacementId = PlacementId(UUID.randomUUID())
     private val placementStart = LocalDate.now().minusDays(30)
     private val placementEnd = LocalDate.now().plusDays(30)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -39,7 +40,7 @@ import kotlin.test.assertTrue
 class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
     private val userId = UUID.randomUUID()
     private val mobileUser = AuthenticatedUser.MobileDevice(userId)
-    private val groupId = UUID.randomUUID()
+    private val groupId = GroupId(UUID.randomUUID())
     private val groupName = "Testaajat"
     private val daycarePlacementId = UUID.randomUUID()
     private val placementStart = LocalDate.now().minusDays(30)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
@@ -31,7 +32,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest() {
     @Autowired
     private lateinit var scheduledJobs: ScheduledJobs
 
-    private val groupId = UUID.randomUUID()
+    private val groupId = GroupId(UUID.randomUUID())
     private val daycarePlacementId = UUID.randomUUID()
     private val placementStart = LocalDate.now().minusDays(30)
     private val placementEnd = LocalDate.now().plusDays(30)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
@@ -33,7 +34,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest() {
     private lateinit var scheduledJobs: ScheduledJobs
 
     private val groupId = GroupId(UUID.randomUUID())
-    private val daycarePlacementId = UUID.randomUUID()
+    private val daycarePlacementId = PlacementId(UUID.randomUUID())
     private val placementStart = LocalDate.now().minusDays(30)
     private val placementEnd = LocalDate.now().plusDays(30)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -42,8 +43,8 @@ import kotlin.test.assertTrue
 class GetAttendancesIntegrationTest : FullApplicationTest() {
     private val userId = UUID.randomUUID()
     private val mobileUser = AuthenticatedUser.MobileDevice(userId)
-    private val groupId = UUID.randomUUID()
-    private val groupId2 = UUID.randomUUID()
+    private val groupId = GroupId(UUID.randomUUID())
+    private val groupId2 = GroupId(UUID.randomUUID())
     private val groupName = "Testaajat"
     private val daycarePlacementId = UUID.randomUUID()
     private val placementStart = LocalDate.now().minusDays(30)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -46,7 +47,7 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
     private val groupId = GroupId(UUID.randomUUID())
     private val groupId2 = GroupId(UUID.randomUUID())
     private val groupName = "Testaajat"
-    private val daycarePlacementId = UUID.randomUUID()
+    private val daycarePlacementId = PlacementId(UUID.randomUUID())
     private val placementStart = LocalDate.now().minusDays(30)
     private val placementEnd = LocalDate.now().plusDays(30)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -186,7 +187,7 @@ class BackupCareIntegrationTest : FullApplicationTest() {
     private fun createBackupCareAndAssert(
         childId: UUID = testChild_1.id,
         unitId: UUID = testDaycare.id,
-        groupId: UUID? = null,
+        groupId: GroupId? = null,
         period: FiniteDateRange = FiniteDateRange(LocalDate.of(2020, 7, 1), LocalDate.of(2020, 7, 31))
     ): UUID {
         val (_, res, result) = http.post("/children/$childId/backup-cares")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.BackupCareId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -190,7 +191,7 @@ class BackupCareIntegrationTest : FullApplicationTest() {
         unitId: DaycareId = testDaycare.id,
         groupId: GroupId? = null,
         period: FiniteDateRange = FiniteDateRange(LocalDate.of(2020, 7, 1), LocalDate.of(2020, 7, 31))
-    ): UUID {
+    ): BackupCareId {
         val (_, res, result) = http.post("/children/$childId/backup-cares")
             .jsonBody(
                 objectMapper.writeValueAsString(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -186,7 +187,7 @@ class BackupCareIntegrationTest : FullApplicationTest() {
 
     private fun createBackupCareAndAssert(
         childId: UUID = testChild_1.id,
-        unitId: UUID = testDaycare.id,
+        unitId: DaycareId = testDaycare.id,
         groupId: GroupId? = null,
         period: FiniteDateRange = FiniteDateRange(LocalDate.of(2020, 7, 1), LocalDate.of(2020, 7, 31))
     ): UUID {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.daycare.controllers.DaycareResponse
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -29,7 +30,6 @@ import fi.espoo.evaka.testDecisionMaker_1
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -117,7 +117,7 @@ class DaycareEditIntegrationTest : FullApplicationTest() {
         getAndAssertDaycareFields(testDaycare.id, fields)
     }
 
-    private fun getAndAssertDaycareFields(daycareId: UUID, fields: DaycareFields) {
+    private fun getAndAssertDaycareFields(daycareId: DaycareId, fields: DaycareFields) {
         val (_, _, body) = http.get("/daycares/$daycareId")
             .asUser(admin)
             .responseObject<DaycareResponse>(objectMapper)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.daycare.service.Stats
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.messaging.message.createDaycareGroupMessageAccount
 import fi.espoo.evaka.messaging.message.insertMessageContent
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -229,7 +230,7 @@ class DaycareControllerIntegrationTest : FullApplicationTest() {
         return body.get()
     }
 
-    private fun deleteDaycareGroup(daycareId: UUID, groupId: UUID, expectedStatus: Int = 204) {
+    private fun deleteDaycareGroup(daycareId: UUID, groupId: GroupId, expectedStatus: Int = 204) {
         val (_, res) = http.delete("/daycares/$daycareId/groups/$groupId")
             .asUser(supervisor)
             .response()
@@ -237,7 +238,7 @@ class DaycareControllerIntegrationTest : FullApplicationTest() {
         assertEquals(expectedStatus, res.statusCode)
     }
 
-    private fun groupHasMessageAccount(groupId: UUID): Boolean {
+    private fun groupHasMessageAccount(groupId: GroupId): Boolean {
         // language=SQL
         val sql = """
             SELECT EXISTS(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.daycare.service.Stats
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.messaging.message.createDaycareGroupMessageAccount
 import fi.espoo.evaka.messaging.message.insertMessageContent
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -189,7 +190,7 @@ class DaycareControllerIntegrationTest : FullApplicationTest() {
         assertEquals(Stats(minimum = 8.5, maximum = 8.5), stats.unitTotalCaretakers)
     }
 
-    private fun getDaycare(daycareId: UUID): DaycareResponse {
+    private fun getDaycare(daycareId: DaycareId): DaycareResponse {
         val (_, res, body) = http.get("/daycares/$daycareId")
             .asUser(staffMember)
             .responseObject<DaycareResponse>(objectMapper)
@@ -198,7 +199,7 @@ class DaycareControllerIntegrationTest : FullApplicationTest() {
         return body.get()
     }
 
-    private fun getDaycareStats(daycareId: UUID, from: LocalDate, to: LocalDate): DaycareCapacityStats {
+    private fun getDaycareStats(daycareId: DaycareId, from: LocalDate, to: LocalDate): DaycareCapacityStats {
         val (_, res, body) = http.get("/daycares/$daycareId/stats?from=$from&to=$to")
             .asUser(staffMember)
             .responseObject<DaycareCapacityStats>(objectMapper)
@@ -208,7 +209,7 @@ class DaycareControllerIntegrationTest : FullApplicationTest() {
     }
 
     private fun createDaycareGroup(
-        daycareId: UUID,
+        daycareId: DaycareId,
         name: String,
         startDate: LocalDate,
         initialCaretakers: Double
@@ -230,7 +231,7 @@ class DaycareControllerIntegrationTest : FullApplicationTest() {
         return body.get()
     }
 
-    private fun deleteDaycareGroup(daycareId: UUID, groupId: GroupId, expectedStatus: Int = 204) {
+    private fun deleteDaycareGroup(daycareId: DaycareId, groupId: GroupId, expectedStatus: Int = 204) {
         val (_, res) = http.delete("/daycares/$daycareId/groups/$groupId")
             .asUser(supervisor)
             .response()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.github.kittinunf.fuel.core.isSuccessful
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.DaycareAclRow
 import fi.espoo.evaka.shared.auth.DaycareAclRowEmployee
@@ -32,7 +33,7 @@ import kotlin.test.assertTrue
 
 class UnitAclControllerIntegrationTest : FullApplicationTest() {
     private val employee = DaycareAclRowEmployee(
-        id = UUID.randomUUID(),
+        id = EmployeeId(UUID.randomUUID()),
         firstName = "First",
         lastName = "Last",
         email = "test@example.com"
@@ -53,7 +54,7 @@ class UnitAclControllerIntegrationTest : FullApplicationTest() {
             employee.also {
                 tx.insertTestEmployee(
                     DevEmployee(
-                        id = it.id,
+                        id = it.id.raw,
                         firstName = it.firstName,
                         lastName = it.lastName,
                         email = it.email

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.github.kittinunf.fuel.core.isSuccessful
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.DaycareAclRow
@@ -112,14 +113,14 @@ class UnitAclControllerIntegrationTest : FullApplicationTest() {
         return body.get().rows
     }
 
-    private fun insertSupervisor(daycareId: UUID) {
+    private fun insertSupervisor(daycareId: DaycareId) {
         val (_, res, _) = http.put("/daycares/$daycareId/supervisors/${employee.id}")
             .asUser(admin)
             .response()
         assertTrue(res.isSuccessful)
     }
 
-    private fun deleteSupervisor(daycareId: UUID) {
+    private fun deleteSupervisor(daycareId: DaycareId) {
         val (_, res, _) = http.delete("/daycares/$daycareId/supervisors/${employee.id}")
             .asUser(admin)
             .response()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/CaretakerQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/CaretakerQueriesIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.daycare.getGroupStats
 import fi.espoo.evaka.daycare.getUnitStats
 import fi.espoo.evaka.daycare.service.Stats
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.junit.jupiter.api.AfterEach
@@ -20,8 +21,8 @@ import kotlin.test.assertEquals
 
 class CaretakerQueriesIntegrationTest : PureJdbiTest() {
     val careAreaId = UUID.randomUUID()
-    val daycareId = UUID.randomUUID()
-    val daycareId2 = UUID.randomUUID()
+    val daycareId = DaycareId(UUID.randomUUID())
+    val daycareId2 = DaycareId(UUID.randomUUID())
     val groupId1 = GroupId(UUID.randomUUID())
     val groupId2 = GroupId(UUID.randomUUID())
     val groupId3 = GroupId(UUID.randomUUID())

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/CaretakerQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/CaretakerQueriesIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.daycare.getGroupStats
 import fi.espoo.evaka.daycare.getUnitStats
 import fi.espoo.evaka.daycare.service.Stats
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -21,10 +22,10 @@ class CaretakerQueriesIntegrationTest : PureJdbiTest() {
     val careAreaId = UUID.randomUUID()
     val daycareId = UUID.randomUUID()
     val daycareId2 = UUID.randomUUID()
-    val groupId1 = UUID.randomUUID()
-    val groupId2 = UUID.randomUUID()
-    val groupId3 = UUID.randomUUID()
-    val groupId4 = UUID.randomUUID()
+    val groupId1 = GroupId(UUID.randomUUID())
+    val groupId2 = GroupId(UUID.randomUUID())
+    val groupId3 = GroupId(UUID.randomUUID())
+    val groupId4 = GroupId(UUID.randomUUID())
 
     @BeforeEach
     fun setup() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/PlacementQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/PlacementQueriesIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getDaycarePlacements
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -17,7 +18,7 @@ import java.util.UUID
 class PlacementQueriesIntegrationTest : PureJdbiTest() {
     // data from migration scripts
     val childId = UUID.fromString("2b929594-13ab-4042-9b13-74e84921e6f0")
-    val daycareId = UUID.fromString("68851e10-eb86-443e-b28d-0f6ee9642a3c")
+    val daycareId = DaycareId(UUID.fromString("68851e10-eb86-443e-b28d-0f6ee9642a3c"))
 
     val placementId = UUID.randomUUID()
     val placementStart = LocalDate.now().plusDays(300)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.dev.DevBackupCare
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -41,7 +42,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest() {
     val testUserId = UUID.randomUUID()
     val daycareId = testDaycare.id
     val daycareName = testDaycare.name
-    val groupId = UUID.randomUUID()
+    val groupId = GroupId(UUID.randomUUID())
     val groupName = "Testiryhmä"
     val placementStart = LocalDate.of(2019, 8, 1)
     val placementEnd = LocalDate.of(2019, 12, 31)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.daycare.service
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.testDaycare
@@ -20,7 +21,7 @@ class CaretakerServiceIntegrationTest : PureJdbiTest() {
     val service = CaretakerService()
 
     private val daycareId = testDaycare.id
-    private val groupId = UUID.randomUUID()
+    private val groupId = GroupId(UUID.randomUUID())
     private val groupStart = LocalDate.of(2000, 1, 1)
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/LocationServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/LocationServiceIntegrationTest.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.daycare.domain.ProviderType.MUNICIPAL
 import fi.espoo.evaka.daycare.domain.ProviderType.MUNICIPAL_SCHOOL
 import fi.espoo.evaka.daycare.domain.ProviderType.PRIVATE
 import fi.espoo.evaka.daycare.updateDaycare
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import org.assertj.core.api.Assertions.assertThat
@@ -97,7 +98,7 @@ class LocationServiceIntegrationTest : PureJdbiTest() {
         }
     }
 
-    private fun createDaycare(location: Location, openingDate: LocalDate? = null, closingDate: LocalDate? = null): UUID = db.transaction { tx ->
+    private fun createDaycare(location: Location, openingDate: LocalDate? = null, closingDate: LocalDate? = null): DaycareId = db.transaction { tx ->
         val id = tx.createDaycare(location.care_area_id, location.name)
         tx.updateDaycare(
             id,
@@ -148,7 +149,7 @@ class LocationServiceIntegrationTest : PureJdbiTest() {
         type: Set<fi.espoo.evaka.daycare.CareType> = setOf(CENTRE),
         providerType: ProviderType = MUNICIPAL
     ) = Location(
-        id = UUID.randomUUID(),
+        id = DaycareId(UUID.randomUUID()),
         name = "Test ${UUID.randomUUID()}",
         care_area_id = areaId,
         type = type,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/LocationServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/LocationServiceIntegrationTest.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.daycare.domain.ProviderType.MUNICIPAL
 import fi.espoo.evaka.daycare.domain.ProviderType.MUNICIPAL_SCHOOL
 import fi.espoo.evaka.daycare.domain.ProviderType.PRIVATE
 import fi.espoo.evaka.daycare.updateDaycare
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
@@ -34,7 +35,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class LocationServiceIntegrationTest : PureJdbiTest() {
-    private val areaId = UUID.randomUUID()
+    private val areaId = AreaId(UUID.randomUUID())
 
     @BeforeEach
     internal fun setUp() {
@@ -145,7 +146,7 @@ class LocationServiceIntegrationTest : PureJdbiTest() {
     }
 
     private fun createGenericUnit(
-        areaId: UUID,
+        areaId: AreaId,
         type: Set<fi.espoo.evaka.daycare.CareType> = setOf(CENTRE),
         providerType: ProviderType = MUNICIPAL
     ) = Location(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.daycare.service
 
 import fi.espoo.evaka.daycare.AbstractIntegrationTest
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -29,7 +30,7 @@ class StaffAttendanceServiceIntegrationTest : AbstractIntegrationTest() {
     lateinit var staffAttendanceService: StaffAttendanceService
 
     val areaId: UUID = UUID.randomUUID()
-    val daycareId: UUID = UUID.randomUUID()
+    val daycareId: DaycareId = DaycareId(UUID.randomUUID())
     val groupId: GroupId = GroupId(UUID.randomUUID())
     val groupName = "Testiryhmä"
     val groupStartDate: LocalDate = LocalDate.of(2019, 1, 1)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.daycare.service
 
 import fi.espoo.evaka.daycare.AbstractIntegrationTest
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.dev.DevCareArea
@@ -29,7 +30,7 @@ class StaffAttendanceServiceIntegrationTest : AbstractIntegrationTest() {
     @Autowired
     lateinit var staffAttendanceService: StaffAttendanceService
 
-    val areaId: UUID = UUID.randomUUID()
+    val areaId: AreaId = AreaId(UUID.randomUUID())
     val daycareId: DaycareId = DaycareId(UUID.randomUUID())
     val groupId: GroupId = GroupId(UUID.randomUUID())
     val groupName = "Testiryhmä"

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.daycare.service
 
 import fi.espoo.evaka.daycare.AbstractIntegrationTest
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -29,11 +30,11 @@ class StaffAttendanceServiceIntegrationTest : AbstractIntegrationTest() {
 
     val areaId: UUID = UUID.randomUUID()
     val daycareId: UUID = UUID.randomUUID()
-    val groupId: UUID = UUID.randomUUID()
+    val groupId: GroupId = GroupId(UUID.randomUUID())
     val groupName = "Testiryhmä"
     val groupStartDate: LocalDate = LocalDate.of(2019, 1, 1)
 
-    val groupId2: UUID = UUID.randomUUID()
+    val groupId2: GroupId = GroupId(UUID.randomUUID())
     val groupName2 = "Koekaniinit"
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -22,6 +22,7 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -305,7 +306,7 @@ WHERE id = :unitId
     }
 
     private fun checkDecisionDrafts(
-        applicationId: UUID,
+        applicationId: ApplicationId,
         unit: UnitData.Detailed = testDaycare,
         adult: PersonData.Detailed = testAdult_5,
         child: PersonData.Detailed = testChild_6,
@@ -352,7 +353,7 @@ WHERE id = :unitId
     }
 
     private fun createDecisions(
-        applicationId: UUID
+        applicationId: ApplicationId
     ): List<DecisionTableRow> {
         val (_, res, _) = http.post("/v2/applications/$applicationId/actions/send-decisions-without-proposal")
             .asUser(serviceWorker)
@@ -409,7 +410,7 @@ WHERE id = :unitId
         period: FiniteDateRange,
         preschoolDaycarePeriod: FiniteDateRange? = null,
         preparatoryEducation: Boolean = false
-    ): UUID = db.transaction { tx ->
+    ): ApplicationId = db.transaction { tx ->
         val applicationId = tx.insertTestApplication(
             status = ApplicationStatus.WAITING_PLACEMENT,
             guardianId = adult.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -321,7 +322,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun acceptDecisionAndAssert(user: AuthenticatedUser, applicationId: ApplicationId, decisionId: UUID, requestedStartDate: LocalDate) {
+    private fun acceptDecisionAndAssert(user: AuthenticatedUser, applicationId: ApplicationId, decisionId: DecisionId, requestedStartDate: LocalDate) {
         val path = "${if (user.roles.contains(UserRole.END_USER)) "/citizen" else "/v2"}/applications/$applicationId/actions/accept-decision"
 
         val (_, res, _) = http.post(path)
@@ -340,7 +341,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun rejectDecisionAndAssert(user: AuthenticatedUser, applicationId: ApplicationId, decisionId: UUID) {
+    private fun rejectDecisionAndAssert(user: AuthenticatedUser, applicationId: ApplicationId, decisionId: DecisionId) {
         val path = "${if (user.roles.contains(UserRole.END_USER)) "/citizen" else "/v2"}/applications/$applicationId/actions/reject-decision"
 
         val (_, res, _) = http.post(path)
@@ -438,6 +439,6 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
 
 private data class DataIdentifiers(
     val applicationId: ApplicationId,
-    val primaryId: UUID?,
-    val preschoolDaycareId: UUID?
+    val primaryId: DecisionId?,
+    val preschoolDaycareId: DecisionId?
 )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -56,7 +57,7 @@ data class DecisionResolutionTestCase(val isServiceWorker: Boolean, val isAccept
 class DecisionResolutionIntegrationTest : FullApplicationTest() {
     private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
     private val endUser = AuthenticatedUser.Citizen(testAdult_1.id)
-    private val applicationId = UUID.randomUUID()
+    private val applicationId = ApplicationId(UUID.randomUUID())
 
     @BeforeEach
     private fun beforeEach() {
@@ -320,7 +321,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun acceptDecisionAndAssert(user: AuthenticatedUser, applicationId: UUID, decisionId: UUID, requestedStartDate: LocalDate) {
+    private fun acceptDecisionAndAssert(user: AuthenticatedUser, applicationId: ApplicationId, decisionId: UUID, requestedStartDate: LocalDate) {
         val path = "${if (user.roles.contains(UserRole.END_USER)) "/citizen" else "/v2"}/applications/$applicationId/actions/accept-decision"
 
         val (_, res, _) = http.post(path)
@@ -339,7 +340,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun rejectDecisionAndAssert(user: AuthenticatedUser, applicationId: UUID, decisionId: UUID) {
+    private fun rejectDecisionAndAssert(user: AuthenticatedUser, applicationId: ApplicationId, decisionId: UUID) {
         val path = "${if (user.roles.contains(UserRole.END_USER)) "/citizen" else "/v2"}/applications/$applicationId/actions/reject-decision"
 
         val (_, res, _) = http.post(path)
@@ -436,7 +437,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest() {
 }
 
 private data class DataIdentifiers(
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val primaryId: UUID?,
     val preschoolDaycareId: UUID?
 )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -301,7 +302,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
     fun `search works with distinctions param UNCONFIRMED_HOURS`() {
         val testDecision = testDecisions[0]
         val testDecisionMissingServiceNeed = testDecisions[1].copy(
-            id = UUID.randomUUID(),
+            id = FeeDecisionId(UUID.randomUUID()),
             children = testDecisions[1].children[0].let { part ->
                 listOf(part.copy(serviceNeed = part.serviceNeed.copy(missing = true)))
             }
@@ -938,7 +939,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
     fun `confirmDrafts updates conflicting sent decision end date on confirm`() {
         val draft = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
         val conflict = draft.copy(
-            id = UUID.randomUUID(),
+            id = FeeDecisionId(UUID.randomUUID()),
             status = FeeDecisionStatus.SENT,
             validDuring = draft.validDuring.copy(start = draft.validFrom.minusDays(30))
         )
@@ -964,7 +965,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
     fun `confirmDrafts updates conflicting decisions with exactly same validity dates to annulled state`() {
         val draft = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
         val conflict = draft.copy(
-            id = UUID.randomUUID(),
+            id = FeeDecisionId(UUID.randomUUID()),
             status = FeeDecisionStatus.SENT
         )
         db.transaction { tx -> tx.upsertFeeDecisions(listOf(draft, conflict)) }
@@ -989,12 +990,12 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
     fun `confirmDrafts updates completely overlapped conflicting decisions to annulled state`() {
         val draft = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
         val conflict1 = draft.copy(
-            id = UUID.randomUUID(),
+            id = FeeDecisionId(UUID.randomUUID()),
             status = FeeDecisionStatus.SENT,
             validDuring = DateRange(draft.validFrom.plusDays(5), draft.validFrom.plusDays(10))
         )
         val conflict2 = draft.copy(
-            id = UUID.randomUUID(),
+            id = FeeDecisionId(UUID.randomUUID()),
             status = FeeDecisionStatus.SENT,
             validDuring = DateRange(draft.validFrom.plusDays(11), draft.validFrom.plusDays(20))
         )
@@ -1030,7 +1031,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
     fun `confirmDrafts updates conflicting sent decision to annulled even when the sent decision would end later`() {
         val draft = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
         val conflict = draft.copy(
-            id = UUID.randomUUID(),
+            id = FeeDecisionId(UUID.randomUUID()),
             status = FeeDecisionStatus.SENT,
             validDuring = draft.validDuring.copy(end = draft.validTo!!.plusDays(10))
         )
@@ -1057,16 +1058,16 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
         val originalDraft = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
         val splitDrafts = listOf(
             originalDraft.copy(
-                id = UUID.randomUUID(),
+                id = FeeDecisionId(UUID.randomUUID()),
                 validDuring = originalDraft.validDuring.copy(end = originalDraft.validFrom.plusDays(7))
             ),
             originalDraft.copy(
-                id = UUID.randomUUID(),
+                id = FeeDecisionId(UUID.randomUUID()),
                 validDuring = originalDraft.validDuring.copy(start = originalDraft.validFrom.plusDays(8))
             )
         )
         val conflict = originalDraft.copy(
-            id = UUID.randomUUID(),
+            id = FeeDecisionId(UUID.randomUUID()),
             status = FeeDecisionStatus.SENT
         )
         db.transaction { tx -> tx.upsertFeeDecisions(splitDrafts + conflict) }
@@ -1092,16 +1093,16 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
         val originalDraft = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
         val splitDrafts = listOf(
             originalDraft.copy(
-                id = UUID.randomUUID(),
+                id = FeeDecisionId(UUID.randomUUID()),
                 validDuring = DateRange(originalDraft.validFrom.minusDays(1), originalDraft.validFrom.plusDays(7))
             ),
             originalDraft.copy(
-                id = UUID.randomUUID(),
+                id = FeeDecisionId(UUID.randomUUID()),
                 validDuring = DateRange(originalDraft.validFrom.plusDays(8), originalDraft.validTo!!.plusDays(1))
             )
         )
         val conflict = originalDraft.copy(
-            id = UUID.randomUUID(),
+            id = FeeDecisionId(UUID.randomUUID()),
             status = FeeDecisionStatus.SENT
         )
         db.transaction { tx -> tx.upsertFeeDecisions(splitDrafts + conflict) }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/IncomeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/IncomeIntegrationTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.invoicing.domain.IncomeType
 import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -39,7 +40,7 @@ class IncomeIntegrationTest : FullApplicationTest() {
     lateinit var mapper: ObjectMapper
 
     private fun assertEqualEnough(expected: List<Income>, actual: List<Income>) {
-        val nullId = UUID.fromString("00000000-0000-0000-0000-000000000000")
+        val nullId = IncomeId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
         assertEquals(
             expected.map { it.copy(id = nullId, updatedAt = null) }.toSet(),
             actual.map { it.copy(id = nullId, updatedAt = null) }.toSet()
@@ -63,7 +64,7 @@ class IncomeIntegrationTest : FullApplicationTest() {
     }
 
     private fun testIncome() = Income(
-        id = UUID.randomUUID(),
+        id = IncomeId(UUID.randomUUID()),
         personId = testAdult_1.id,
         effect = IncomeEffect.INCOME,
         data = mapOf(IncomeType.MAIN_INCOME to IncomeValue(500000, IncomeCoefficient.MONTHLY_NO_HOLIDAY_BONUS)),
@@ -105,7 +106,7 @@ class IncomeIntegrationTest : FullApplicationTest() {
         val testIncome = testIncome()
         val incomes = listOf(
             testIncome.copy(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 validFrom = testIncome.validFrom.plusYears(1),
                 validTo = testIncome.validTo!!.plusYears(1)
             ),
@@ -291,7 +292,7 @@ class IncomeIntegrationTest : FullApplicationTest() {
 
         val anotherIncome = with(testIncome) {
             this.copy(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 validFrom = validFrom.plusYears(1),
                 validTo = validTo!!.plusYears(1)
             )
@@ -366,7 +367,7 @@ class IncomeIntegrationTest : FullApplicationTest() {
         val testIncome = testIncome()
         val anotherIncome = with(testIncome) {
             this.copy(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 validFrom = validFrom.plusYears(1),
                 validTo = validTo!!.plusYears(1)
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.placement.PlacementCreateRequestBody
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.PlacementUpdateRequestBody
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -38,7 +39,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
-import java.util.UUID
 import kotlin.test.assertEquals
 
 class VoucherValueDecisionIntegrationTest : FullApplicationTest() {
@@ -246,7 +246,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest() {
     private fun createPlacement(
         startDate: LocalDate,
         endDate: LocalDate,
-        unitId: UUID = testVoucherDaycare.id
+        unitId: DaycareId = testVoucherDaycare.id
     ): PlacementId {
         val body = PlacementCreateRequestBody(
             type = PlacementType.DAYCARE,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.PlacementUpdateRequestBody
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.Paged
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -246,7 +247,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest() {
         startDate: LocalDate,
         endDate: LocalDate,
         unitId: UUID = testVoucherDaycare.id
-    ): UUID {
+    ): PlacementId {
         val body = PlacementCreateRequestBody(
             type = PlacementType.DAYCARE,
             childId = testChild_1.id,
@@ -272,7 +273,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest() {
         return data.get().first().id
     }
 
-    private fun updatePlacement(id: UUID, startDate: LocalDate, endDate: LocalDate) {
+    private fun updatePlacement(id: PlacementId, startDate: LocalDate, endDate: LocalDate) {
         val body = PlacementUpdateRequestBody(
             startDate = startDate,
             endDate = endDate

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionStatus
 import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.config.defaultObjectMapper
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.snDaycareFullDay35
@@ -131,7 +132,7 @@ class FeeDecisionQueriesTest : PureJdbiTest() {
             val decisions = listOf(
                 testDecisions[0],
                 testDecisions[0].copy(
-                    id = UUID.randomUUID(),
+                    id = FeeDecisionId(UUID.randomUUID()),
                     validDuring = DateRange(testPeriod.start.minusYears(1), testPeriod.end!!.minusYears(1))
                 )
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueriesTest.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.invoicing.domain.IncomeType
 import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.config.defaultObjectMapper
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
@@ -48,7 +49,7 @@ class IncomeQueriesTest : PureJdbiTest() {
     private val personId = testAdult_1.id
     private val userId = UUID.randomUUID()
     private val testIncome = Income(
-        id = UUID.randomUUID(),
+        id = IncomeId(UUID.randomUUID()),
         personId = personId,
         effect = IncomeEffect.INCOME,
         data = mapOf(IncomeType.MAIN_INCOME to IncomeValue(500000, IncomeCoefficient.MONTHLY_NO_HOLIDAY_BONUS)),
@@ -102,7 +103,7 @@ class IncomeQueriesTest : PureJdbiTest() {
         db.transaction { tx ->
             tx.upsertIncome(mapper, testIncome, userId)
 
-            val overlappingIncome = testIncome.copy(id = UUID.randomUUID())
+            val overlappingIncome = testIncome.copy(id = IncomeId(UUID.randomUUID()))
 
             assertThrows<Conflict> { tx.upsertIncome(mapper, overlappingIncome, userId) }
         }
@@ -114,7 +115,7 @@ class IncomeQueriesTest : PureJdbiTest() {
             tx.upsertIncome(mapper, testIncome, userId)
 
             val overlappingIncome = with(testIncome) {
-                this.copy(id = UUID.randomUUID(), validFrom = validTo!!, validTo = validTo!!.plusYears(1))
+                this.copy(id = IncomeId(UUID.randomUUID()), validFrom = validTo!!, validTo = validTo!!.plusYears(1))
             }
 
             assertThrows<Conflict> { tx.upsertIncome(mapper, overlappingIncome, userId) }
@@ -124,7 +125,7 @@ class IncomeQueriesTest : PureJdbiTest() {
     @Test
     fun `getIncome with no income`() {
         db.transaction { tx ->
-            val result = tx.getIncome(mapper, UUID.randomUUID())
+            val result = tx.getIncome(mapper, IncomeId(UUID.randomUUID()))
 
             assertNull(result)
         }
@@ -160,7 +161,7 @@ class IncomeQueriesTest : PureJdbiTest() {
                 tx.upsertIncome(
                     mapper,
                     this.copy(
-                        id = UUID.randomUUID(),
+                        id = IncomeId(UUID.randomUUID()),
                         validFrom = validFrom.plusYears(1),
                         validTo = validTo!!.plusYears(1)
                     ),
@@ -171,7 +172,7 @@ class IncomeQueriesTest : PureJdbiTest() {
                 tx.upsertIncome(
                     mapper,
                     this.copy(
-                        id = UUID.randomUUID(),
+                        id = IncomeId(UUID.randomUUID()),
                         validFrom = validFrom.plusYears(2),
                         validTo = validTo!!.plusYears(2)
                     ),
@@ -225,7 +226,7 @@ class IncomeQueriesTest : PureJdbiTest() {
 
             val anotherIncome = with(testIncome) {
                 this.copy(
-                    id = UUID.randomUUID(),
+                    id = IncomeId(UUID.randomUUID()),
                     validFrom = validTo!!.plusDays(1),
                     validTo = validTo!!.plusDays(1).plusMonths(1)
                 )
@@ -242,10 +243,10 @@ class IncomeQueriesTest : PureJdbiTest() {
     fun `update with multiple incomes only updates one of them`() {
         db.transaction { tx ->
             val secondIncome = with(testIncome) {
-                this.copy(id = UUID.randomUUID(), validFrom = validFrom.plusYears(1), validTo = validTo!!.plusYears(1))
+                this.copy(id = IncomeId(UUID.randomUUID()), validFrom = validFrom.plusYears(1), validTo = validTo!!.plusYears(1))
             }
             val thirdIncome = with(testIncome) {
-                this.copy(id = UUID.randomUUID(), validFrom = validFrom.plusYears(2), validTo = validTo!!.plusYears(2))
+                this.copy(id = IncomeId(UUID.randomUUID()), validFrom = validFrom.plusYears(2), validTo = validTo!!.plusYears(2))
             }
 
             tx.upsertIncome(mapper, testIncome, userId)
@@ -277,7 +278,7 @@ class IncomeQueriesTest : PureJdbiTest() {
             tx.upsertIncome(
                 mapper,
                 testIncome.copy(
-                    id = UUID.randomUUID(),
+                    id = IncomeId(UUID.randomUUID()),
                     validFrom = testIncome.validTo!!.plusDays(1),
                     validTo = testIncome.validTo!!.plusYears(1)
                 ),
@@ -301,7 +302,7 @@ class IncomeQueriesTest : PureJdbiTest() {
             tx.upsertIncome(
                 mapper,
                 testIncome.copy(
-                    id = UUID.randomUUID(),
+                    id = IncomeId(UUID.randomUUID()),
                     validFrom = testIncome.validTo!!.plusDays(1),
                     validTo = testIncome.validTo!!.plusYears(1)
                 ),
@@ -325,7 +326,7 @@ class IncomeQueriesTest : PureJdbiTest() {
             tx.upsertIncome(
                 mapper,
                 testIncome.copy(
-                    id = UUID.randomUUID(),
+                    id = IncomeId(UUID.randomUUID()),
                     validFrom = testIncome.validTo!!.plusDays(1),
                     validTo = testIncome.validTo!!.plusYears(1)
                 ),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -33,6 +33,7 @@ import fi.espoo.evaka.placement.PlacementType.PRESCHOOL_DAYCARE
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestFeeAlteration
 import fi.espoo.evaka.shared.dev.insertTestIncome
@@ -1772,7 +1773,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     private fun insertServiceNeed(
         placementId: PlacementId,
         period: FiniteDateRange,
-        optionId: UUID
+        optionId: ServiceNeedOptionId
     ) {
         db.transaction { tx ->
             tx.insertTestServiceNeed(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -32,6 +32,7 @@ import fi.espoo.evaka.placement.PlacementType.PRESCHOOL
 import fi.espoo.evaka.placement.PlacementType.PRESCHOOL_DAYCARE
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.dev.DevPerson
@@ -1729,14 +1730,14 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
 
     private fun assertEqualEnoughDecisions(expected: FeeDecision, actual: FeeDecision) {
         val createdAt = Instant.now()
-        UUID.randomUUID().let { uuid ->
+        FeeDecisionId(UUID.randomUUID()).let { uuid ->
             assertEquals(expected.copy(id = uuid, created = createdAt), actual.copy(id = uuid, created = createdAt))
         }
     }
 
     private fun assertEqualEnoughDecisions(expected: List<FeeDecision>, actual: List<FeeDecision>) {
         val createdAt = Instant.now()
-        UUID.randomUUID().let { uuid ->
+        FeeDecisionId(UUID.randomUUID()).let { uuid ->
             assertEquals(
                 expected.map { it.copy(id = uuid, created = createdAt) },
                 actual.map { it.copy(id = uuid, created = createdAt) }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -31,6 +31,7 @@ import fi.espoo.evaka.placement.PlacementType.PREPARATORY_DAYCARE
 import fi.espoo.evaka.placement.PlacementType.PRESCHOOL
 import fi.espoo.evaka.placement.PlacementType.PRESCHOOL_DAYCARE
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestFeeAlteration
 import fi.espoo.evaka.shared.dev.insertTestIncome
@@ -1741,7 +1742,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: UUID): UUID {
+    private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: UUID): PlacementId {
         return db.transaction { tx ->
             tx.insertTestPlacement(
                 childId = childId,
@@ -1768,7 +1769,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertServiceNeed(
-        placementId: UUID,
+        placementId: PlacementId,
         period: FiniteDateRange,
         optionId: UUID
     ) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -31,6 +31,7 @@ import fi.espoo.evaka.placement.PlacementType.PREPARATORY_DAYCARE
 import fi.espoo.evaka.placement.PlacementType.PRESCHOOL
 import fi.espoo.evaka.placement.PlacementType.PRESCHOOL_DAYCARE
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestFeeAlteration
@@ -1742,7 +1743,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: UUID): PlacementId {
+    private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: DaycareId): PlacementId {
         return db.transaction { tx ->
             tx.insertTestPlacement(
                 childId = childId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.invoicing.domain.merge
 import fi.espoo.evaka.placement.PlacementType.DAYCARE
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.DateRange
@@ -125,7 +126,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: UUID): UUID {
+    private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: UUID): PlacementId {
         return db.transaction { tx ->
             tx.insertTestPlacement(
                 childId = childId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.invoicing.domain.merge
 import fi.espoo.evaka.placement.PlacementType.DAYCARE
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
@@ -126,7 +127,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: UUID): PlacementId {
+    private fun insertPlacement(childId: UUID, period: DateRange, type: fi.espoo.evaka.placement.PlacementType, daycareId: DaycareId): PlacementId {
         return db.transaction { tx ->
             tx.insertTestPlacement(
                 childId = childId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -26,6 +26,7 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.Product
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
@@ -402,7 +403,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
         insertDecisionsAndPlacements(
             listOf(
                 decision.copy(validDuring = decision.validDuring.copy(end = period.start.plusDays(7))),
-                decision.copy(id = UUID.randomUUID(), validDuring = decision.validDuring.copy(start = period.start.plusDays(8)))
+                decision.copy(id = FeeDecisionId(UUID.randomUUID()), validDuring = decision.validDuring.copy(start = period.start.plusDays(8)))
             )
         )
 
@@ -457,7 +458,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
         insertDecisionsAndPlacements(
             listOf(
                 decision.copy(validDuring = decision.validDuring.copy(end = period.start.plusDays(7))),
-                decision.copy(id = UUID.randomUUID(), validDuring = decision.validDuring.copy(start = period.start.plusDays(8)))
+                decision.copy(id = FeeDecisionId(UUID.randomUUID()), validDuring = decision.validDuring.copy(start = period.start.plusDays(8)))
             )
         )
 
@@ -513,7 +514,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
             listOf(
                 decision.copy(validDuring = decision.validDuring.copy(end = period.start.plusDays(7))),
                 decision.copy(
-                    id = UUID.randomUUID(),
+                    id = FeeDecisionId(UUID.randomUUID()),
                     validDuring = decision.validDuring.copy(start = period.start.plusDays(8)),
                     familySize = decision.familySize + 1,
                     children = decision.children + createFeeDecisionChildFixture(
@@ -813,7 +814,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
             listOf(
                 decision.copy(validDuring = decision.validDuring.copy(end = period.start.plusDays(7))),
                 decision.copy(
-                    id = UUID.randomUUID(),
+                    id = FeeDecisionId(UUID.randomUUID()),
                     validDuring = decision.validDuring.copy(start = period.start.plusDays(8)),
                     children = listOf(decision.children[0], decision.children[1].copy(fee = 10000, finalFee = 10000))
                 )
@@ -1068,7 +1069,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 endDate = period.end!!
             )
             tx.upsertFeeDecisions(
-                listOf(decision, decision.copy(id = UUID.randomUUID(), headOfFamily = PersonData.JustId(testAdult_2.id)))
+                listOf(decision, decision.copy(id = FeeDecisionId(UUID.randomUUID()), headOfFamily = PersonData.JustId(testAdult_2.id)))
             )
         }
 
@@ -1122,7 +1123,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
                 endDate = placementPeriod.end!!
             )
             tx.upsertFeeDecisions(
-                listOf(decision, decision.copy(id = UUID.randomUUID(), headOfFamily = PersonData.JustId(testAdult_2.id)))
+                listOf(decision, decision.copy(id = FeeDecisionId(UUID.randomUUID()), headOfFamily = PersonData.JustId(testAdult_2.id)))
             )
         }
 
@@ -2266,7 +2267,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
         insertDecisionsAndPlacements(
             listOf(
                 decision.copy(validDuring = decision.validDuring.copy(end = period.start.plusDays(7))),
-                decision.copy(id = UUID.randomUUID(), validDuring = decision.validDuring.copy(start = period.start.plusDays(8)))
+                decision.copy(id = FeeDecisionId(UUID.randomUUID()), validDuring = decision.validDuring.copy(start = period.start.plusDays(8)))
             )
         )
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
@@ -269,7 +270,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun insertPlacement(childId: UUID, period: DateRange, type: PlacementType, daycareId: UUID): UUID {
+    private fun insertPlacement(childId: UUID, period: DateRange, type: PlacementType, daycareId: UUID): PlacementId {
         return db.transaction { tx ->
             tx.insertTestPlacement(
                 childId = childId,
@@ -290,7 +291,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest() {
     }
 
     private fun insertServiceNeed(
-        placementId: UUID,
+        placementId: PlacementId,
         period: FiniteDateRange,
         optionId: UUID
     ) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
@@ -294,7 +295,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest() {
     private fun insertServiceNeed(
         placementId: PlacementId,
         period: FiniteDateRange,
-        optionId: UUID
+        optionId: ServiceNeedOptionId
     ) {
         db.transaction { tx ->
             tx.insertTestServiceNeed(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
@@ -270,7 +271,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun insertPlacement(childId: UUID, period: DateRange, type: PlacementType, daycareId: UUID): PlacementId {
+    private fun insertPlacement(childId: UUID, period: DateRange, type: PlacementType, daycareId: DaycareId): PlacementId {
         return db.transaction { tx ->
             tx.insertTestPlacement(
                 childId = childId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.preschoolTerm2019
 import fi.espoo.evaka.preschoolTerm2020
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevAssistanceAction
 import fi.espoo.evaka.shared.dev.DevAssistanceNeed
@@ -752,7 +753,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         daycareId: UUID = testDaycare.id,
         period: FiniteDateRange = preschoolTerm2019,
         type: PlacementType = PlacementType.PRESCHOOL
-    ): UUID = db.transaction {
+    ): PlacementId = db.transaction {
         it.insertTestPlacement(
             DevPlacement(
                 childId = child.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.preschoolTerm2019
 import fi.espoo.evaka.preschoolTerm2020
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevAssistanceAction
@@ -319,7 +320,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         assertEquals(1, searchByExistingDaycare.size)
 
         val searchByRandomDaycare = db.read {
-            it.getPendingStudyRights(today, KoskiSearchParams(daycareIds = listOf(UUID.randomUUID())))
+            it.getPendingStudyRights(today, KoskiSearchParams(daycareIds = listOf(DaycareId(UUID.randomUUID()))))
         }
         assertEquals(0, searchByRandomDaycare.size)
     }
@@ -750,7 +751,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
 
     private fun insertPlacement(
         child: PersonData.Detailed = testChild_1,
-        daycareId: UUID = testDaycare.id,
+        daycareId: DaycareId = testDaycare.id,
         period: FiniteDateRange = preschoolTerm2019,
         type: PlacementType = PlacementType.PRESCHOOL
     ): PlacementId = db.transaction {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTestHelpers.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTestHelpers.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.koski
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.UploadToKoski
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.testDaycare
@@ -16,7 +17,7 @@ import java.util.UUID
 internal data class KoskiStudyRightRaw(
     val id: UUID,
     val childId: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val type: OpiskeluoikeudenTyyppiKoodi,
     val version: Int,
     val studyRightOid: String?,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -21,6 +21,9 @@ import fi.espoo.evaka.messaging.message.insertRecipients
 import fi.espoo.evaka.messaging.message.insertThread
 import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
 import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
@@ -76,7 +79,7 @@ class MessageAccountQueriesTest : PureJdbiTest() {
             it.insertDaycareAclRow(daycareId, supervisorId, UserRole.UNIT_SUPERVISOR)
 
             it.insertDaycareAclRow(daycareId, employee1Id, UserRole.STAFF)
-            it.insertDaycareGroupAcl(daycareId, employee1Id, listOf(groupId))
+            it.insertDaycareGroupAcl(DaycareId(daycareId), EmployeeId(employee1Id), listOf(GroupId(groupId)))
 
             // employee2 has no groups
             it.insertDaycareAclRow(daycareId, employee2Id, UserRole.STAFF)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -21,7 +21,6 @@ import fi.espoo.evaka.messaging.message.insertRecipients
 import fi.espoo.evaka.messaging.message.insertThread
 import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.resetDatabase
-import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
@@ -78,7 +77,7 @@ class MessageAccountQueriesTest : PureJdbiTest() {
             it.insertDaycareAclRow(daycareId, supervisorId, UserRole.UNIT_SUPERVISOR)
 
             it.insertDaycareAclRow(daycareId, employee1Id, UserRole.STAFF)
-            it.insertDaycareGroupAcl(DaycareId(daycareId), EmployeeId(employee1Id), listOf(groupId))
+            it.insertDaycareGroupAcl(daycareId, EmployeeId(employee1Id), listOf(groupId))
 
             // employee2 has no groups
             it.insertDaycareAclRow(daycareId, employee2Id, UserRole.STAFF)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -23,7 +23,6 @@ import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
-import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
 import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
@@ -79,7 +78,7 @@ class MessageAccountQueriesTest : PureJdbiTest() {
             it.insertDaycareAclRow(daycareId, supervisorId, UserRole.UNIT_SUPERVISOR)
 
             it.insertDaycareAclRow(daycareId, employee1Id, UserRole.STAFF)
-            it.insertDaycareGroupAcl(DaycareId(daycareId), EmployeeId(employee1Id), listOf(GroupId(groupId)))
+            it.insertDaycareGroupAcl(DaycareId(daycareId), EmployeeId(employee1Id), listOf(groupId))
 
             // employee2 has no groups
             it.insertDaycareAclRow(daycareId, employee2Id, UserRole.STAFF)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.messaging.message.getMessagesSentByAccount
 import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -71,7 +72,7 @@ class MessageIntegrationTest : FullApplicationTest() {
     private val person2 = AuthenticatedUser.Citizen(id = person2Id)
     private val person3 = AuthenticatedUser.Citizen(id = person3Id)
     private val person4 = AuthenticatedUser.Citizen(id = person4Id)
-    private val groupId = UUID.randomUUID()
+    private val groupId = GroupId(UUID.randomUUID())
     private val placementStart = LocalDate.now().minusDays(30)
     private val placementEnd = LocalDate.now().plusDays(30)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -80,10 +80,8 @@ class MessageIntegrationTest : FullApplicationTest() {
         tx.insertTestPerson(DevPerson(id = child.id, firstName = child.firstName, lastName = child.lastName))
         tx.insertTestChild(DevChild(id = child.id))
 
-        val placementId = UUID.randomUUID()
-        tx.insertTestPlacement(
+        val placementId = tx.insertTestPlacement(
             DevPlacement(
-                id = placementId,
                 childId = child.id,
                 unitId = testDaycare.id,
                 startDate = placementStart,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -76,10 +76,8 @@ class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest() {
                 )
             )
 
-            val placementId = UUID.randomUUID()
-            tx.insertTestPlacement(
+            val placementId = tx.insertTestPlacement(
                 DevPlacement(
-                    id = placementId,
                     childId = testChild_1.id,
                     unitId = testDaycare.id,
                     startDate = placementStart,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.messaging.message.getEmployeeMessageAccounts
 import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -66,7 +67,7 @@ class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest() {
             tx.resetDatabase()
             tx.insertGeneralTestFixtures()
 
-            val groupId = UUID.randomUUID()
+            val groupId = GroupId(UUID.randomUUID())
             tx.insertTestDaycareGroup(
                 DevDaycareGroup(
                     id = groupId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageReceiversIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageReceiversIntegrationTest.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.pis.createParentship
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -73,7 +74,7 @@ class MessageReceiversIntegrationTest : FullApplicationTest() {
         tx: Database.Transaction,
         childId: UUID,
         guardianId: UUID,
-        unitId: UUID
+        unitId: DaycareId
     ): PlacementId {
         tx.insertGuardian(guardianId, childId)
         return tx.insertTestPlacement(
@@ -91,7 +92,7 @@ class MessageReceiversIntegrationTest : FullApplicationTest() {
         childId: UUID,
         guardianId: UUID,
         groupId: GroupId,
-        unitId: UUID
+        unitId: DaycareId
     ) {
         val daycarePlacementId = insertChildToUnit(tx, childId, guardianId, unitId)
         tx.insertTestDaycareGroupPlacement(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageReceiversIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageReceiversIntegrationTest.kt
@@ -21,6 +21,7 @@ import fi.espoo.evaka.pis.createParentship
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -73,7 +74,7 @@ class MessageReceiversIntegrationTest : FullApplicationTest() {
         childId: UUID,
         guardianId: UUID,
         unitId: UUID
-    ): UUID {
+    ): PlacementId {
         tx.insertGuardian(guardianId, childId)
         return tx.insertTestPlacement(
             DevPlacement(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageReceiversIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageReceiversIntegrationTest.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.pis.createParentship
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -60,9 +61,9 @@ class MessageReceiversIntegrationTest : FullApplicationTest() {
     private val supervisor2Id = UUID.randomUUID()
     private val supervisor2 = AuthenticatedUser.Employee(supervisor2Id, setOf(UserRole.UNIT_SUPERVISOR))
     private val guardianPerson = testAdult_6
-    private val groupId = UUID.randomUUID()
+    private val groupId = GroupId(UUID.randomUUID())
     private val groupName = "Testaajat"
-    private val secondGroupId = UUID.randomUUID()
+    private val secondGroupId = GroupId(UUID.randomUUID())
     private val secondGroupName = "Koekaniinit"
     private val placementStart = LocalDate.now().minusDays(30)
     private val placementEnd = LocalDate.now().plusDays(30)
@@ -88,7 +89,7 @@ class MessageReceiversIntegrationTest : FullApplicationTest() {
         tx: Database.Transaction,
         childId: UUID,
         guardianId: UUID,
-        groupId: UUID,
+        groupId: GroupId,
         unitId: UUID
     ) {
         val daycarePlacementId = insertChildToUnit(tx, childId, guardianId, unitId)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.insertServiceNeedOptions
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.Id
@@ -40,8 +41,8 @@ import fi.espoo.evaka.daycare.service.CareType as AbsenceCareType
 class OccupancyTest : PureJdbiTest() {
     val today = LocalDate.of(2020, 1, 16) // Thursday
 
-    val careArea1: UUID = UUID.randomUUID()
-    val careArea2: UUID = UUID.randomUUID()
+    val careArea1: AreaId = AreaId(UUID.randomUUID())
+    val careArea2: AreaId = AreaId(UUID.randomUUID())
 
     val daycareInArea1: DaycareId = DaycareId(UUID.randomUUID())
     val daycareGroup1: GroupId = GroupId(UUID.randomUUID())

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.insertServiceNeedOptions
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -41,12 +42,12 @@ class OccupancyTest : PureJdbiTest() {
     val careArea2: UUID = UUID.randomUUID()
 
     val daycareInArea1: UUID = UUID.randomUUID()
-    val daycareGroup1: UUID = UUID.randomUUID()
-    val daycareGroup2: UUID = UUID.randomUUID()
+    val daycareGroup1: GroupId = GroupId(UUID.randomUUID())
+    val daycareGroup2: GroupId = GroupId(UUID.randomUUID())
 
     val familyUnitInArea2: UUID = UUID.randomUUID()
-    val familyGroup1: UUID = UUID.randomUUID()
-    val familyGroup2: UUID = UUID.randomUUID()
+    val familyGroup1: GroupId = GroupId(UUID.randomUUID())
+    val familyGroup2: GroupId = GroupId(UUID.randomUUID())
 
     val employeeId: UUID = UUID.randomUUID()
 
@@ -583,7 +584,7 @@ class OccupancyTest : PureJdbiTest() {
     private fun getAndAssertOccupancyInGroup(
         tx: Database.Read,
         unitId: UUID,
-        groupId: UUID,
+        groupId: GroupId,
         type: OccupancyType,
         date: LocalDate,
         expectedSum: Double
@@ -591,7 +592,7 @@ class OccupancyTest : PureJdbiTest() {
         assertOccupancySum(
             expectedSum = expectedSum,
             date = date,
-            groupingId = groupId,
+            groupingId = groupId.raw,
             occupancyValues = tx.calculateDailyGroupOccupancyValues(
                 today = today,
                 queryPeriod = FiniteDateRange(date, date),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTest.kt
@@ -11,7 +11,9 @@ import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.insertServiceNeedOptions
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -41,11 +43,11 @@ class OccupancyTest : PureJdbiTest() {
     val careArea1: UUID = UUID.randomUUID()
     val careArea2: UUID = UUID.randomUUID()
 
-    val daycareInArea1: UUID = UUID.randomUUID()
+    val daycareInArea1: DaycareId = DaycareId(UUID.randomUUID())
     val daycareGroup1: GroupId = GroupId(UUID.randomUUID())
     val daycareGroup2: GroupId = GroupId(UUID.randomUUID())
 
-    val familyUnitInArea2: UUID = UUID.randomUUID()
+    val familyUnitInArea2: DaycareId = DaycareId(UUID.randomUUID())
     val familyGroup1: GroupId = GroupId(UUID.randomUUID())
     val familyGroup2: GroupId = GroupId(UUID.randomUUID())
 
@@ -563,7 +565,7 @@ class OccupancyTest : PureJdbiTest() {
 
     private fun getAndAssertOccupancyInUnit(
         tx: Database.Read,
-        unitId: UUID,
+        unitId: DaycareId,
         type: OccupancyType,
         date: LocalDate,
         expectedSum: Double
@@ -583,7 +585,7 @@ class OccupancyTest : PureJdbiTest() {
 
     private fun getAndAssertOccupancyInGroup(
         tx: Database.Read,
-        unitId: UUID,
+        unitId: DaycareId,
         groupId: GroupId,
         type: OccupancyType,
         date: LocalDate,
@@ -592,7 +594,7 @@ class OccupancyTest : PureJdbiTest() {
         assertOccupancySum(
             expectedSum = expectedSum,
             date = date,
-            groupingId = groupId.raw,
+            groupingId = groupId,
             occupancyValues = tx.calculateDailyGroupOccupancyValues(
                 today = today,
                 queryPeriod = FiniteDateRange(date, date),
@@ -605,7 +607,7 @@ class OccupancyTest : PureJdbiTest() {
     private fun <K : OccupancyGroupingKey> assertOccupancySum(
         expectedSum: Double,
         date: LocalDate,
-        groupingId: UUID,
+        groupingId: Id<*>,
         occupancyValues: List<DailyOccupancyValues<K>>
     ) {
         assertEquals(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -271,7 +272,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             challengeKey = "foo",
             responseKey = "bar",
             expires = HelsinkiDateTime.now().plusMinutes(1),
-            mobileDeviceId = UUID.randomUUID()
+            mobileDeviceId = MobileDeviceId(UUID.randomUUID())
         )
         givenPairing(pairing)
         postPairingValidationAssertOk(pairing.id, pairing.challengeKey, pairing.responseKey!!)
@@ -286,7 +287,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             challengeKey = "foo",
             responseKey = "bar",
             expires = HelsinkiDateTime.now().plusMinutes(1),
-            mobileDeviceId = UUID.randomUUID()
+            mobileDeviceId = MobileDeviceId(UUID.randomUUID())
         )
         givenPairing(pairing)
         postPairingValidationAssertFail(UUID.randomUUID(), pairing.challengeKey, pairing.responseKey!!, 404)
@@ -301,7 +302,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             challengeKey = "foo",
             responseKey = "bar",
             expires = HelsinkiDateTime.now().plusMinutes(1),
-            mobileDeviceId = UUID.randomUUID()
+            mobileDeviceId = MobileDeviceId(UUID.randomUUID())
         )
         givenPairing(pairing)
         postPairingValidationAssertFail(pairing.id, "wrong", pairing.responseKey!!, 404)
@@ -316,7 +317,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             challengeKey = "foo",
             responseKey = "bar",
             expires = HelsinkiDateTime.now().plusMinutes(1),
-            mobileDeviceId = UUID.randomUUID()
+            mobileDeviceId = MobileDeviceId(UUID.randomUUID())
         )
         givenPairing(pairing)
         postPairingValidationAssertFail(pairing.id, pairing.challengeKey, "wrong", 404)
@@ -331,7 +332,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             challengeKey = "foo",
             responseKey = "bar",
             expires = HelsinkiDateTime.now().plusMinutes(1),
-            mobileDeviceId = UUID.randomUUID()
+            mobileDeviceId = MobileDeviceId(UUID.randomUUID())
         )
         givenPairing(pairing)
         postPairingValidationAssertFail(pairing.id, pairing.challengeKey, pairing.responseKey!!, 404)
@@ -346,7 +347,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             challengeKey = "foo",
             responseKey = "bar",
             expires = HelsinkiDateTime.now().plusMinutes(1),
-            mobileDeviceId = UUID.randomUUID()
+            mobileDeviceId = MobileDeviceId(UUID.randomUUID())
         )
         givenPairing(pairing, attempts = 101)
         postPairingValidationAssertFail(pairing.id, pairing.challengeKey, pairing.responseKey!!, 404)
@@ -361,7 +362,7 @@ class PairingIntegrationTest : FullApplicationTest() {
             challengeKey = "foo",
             responseKey = "bar",
             expires = HelsinkiDateTime.now().minusMinutes(1),
-            mobileDeviceId = UUID.randomUUID()
+            mobileDeviceId = MobileDeviceId(UUID.randomUUID())
         )
         givenPairing(pairing)
         postPairingValidationAssertFail(pairing.id, pairing.challengeKey, pairing.responseKey!!, 404)
@@ -538,7 +539,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         return result.get()
     }
 
-    private fun getMobileDeviceAssertOk(id: UUID): MobileDevice {
+    private fun getMobileDeviceAssertOk(id: MobileDeviceId): MobileDevice {
         val (_, res, result) = http.get("/system/mobile-devices/$id")
             .asUser(AuthenticatedUser.SystemInternalUser)
             .responseObject<MobileDevice>(objectMapper)
@@ -547,7 +548,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         return result.get()
     }
 
-    private fun getMobileDeviceAssertFail(id: UUID, status: Int) {
+    private fun getMobileDeviceAssertFail(id: MobileDeviceId, status: Int) {
         val (_, res, _) = http.get("/system/mobile-devices/$id")
             .asUser(AuthenticatedUser.SystemInternalUser)
             .response()
@@ -555,7 +556,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         assertEquals(status, res.statusCode)
     }
 
-    private fun putMobileDeviceNameAssertOk(id: UUID, name: String) {
+    private fun putMobileDeviceNameAssertOk(id: MobileDeviceId, name: String) {
         val (_, res, _) = http.put("/mobile-devices/$id/name")
             .jsonBody(
                 objectMapper.writeValueAsString(
@@ -570,7 +571,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         assertEquals(204, res.statusCode)
     }
 
-    private fun deleteMobileDeviceAssertOk(id: UUID) {
+    private fun deleteMobileDeviceAssertOk(id: MobileDeviceId) {
         val (_, res, _) = http.delete("/mobile-devices/$id")
             .asUser(user)
             .response()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -408,7 +409,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         }
     }
 
-    private fun postPairingAssertOk(unitId: UUID): Pairing {
+    private fun postPairingAssertOk(unitId: DaycareId): Pairing {
         val (_, res, result) = http.post("/pairings")
             .jsonBody(
                 objectMapper.writeValueAsString(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.MobileDeviceId
+import fi.espoo.evaka.shared.PairingId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -121,7 +122,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingChallenge - happy case`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.WAITING_CHALLENGE,
             challengeKey = "foo",
@@ -140,7 +141,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingChallenge - pairing expired returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.WAITING_CHALLENGE,
             challengeKey = "foo",
@@ -154,7 +155,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingChallenge - pairing in wrong status returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
@@ -168,7 +169,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingResponse - happy case`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
@@ -182,7 +183,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingResponse - wrong id returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
@@ -190,13 +191,13 @@ class PairingIntegrationTest : FullApplicationTest() {
             expires = HelsinkiDateTime.now().plusMinutes(1)
         )
         givenPairing(pairing)
-        postPairingResponseAssertFail(UUID.randomUUID(), pairing.challengeKey, pairing.responseKey!!, 404)
+        postPairingResponseAssertFail(PairingId(UUID.randomUUID()), pairing.challengeKey, pairing.responseKey!!, 404)
     }
 
     @Test
     fun `postPairingResponse - wrong challengeKey returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
@@ -210,7 +211,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingResponse - wrong responseKey returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
@@ -224,7 +225,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingResponse - wrong status returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.READY,
             challengeKey = "foo",
@@ -238,7 +239,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingResponse - attempts exceeded returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
@@ -252,7 +253,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingResponse - pairing expired returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.WAITING_RESPONSE,
             challengeKey = "foo",
@@ -266,7 +267,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingValidation - happy case`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.READY,
             challengeKey = "foo",
@@ -281,7 +282,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingValidation - wrong id returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.READY,
             challengeKey = "foo",
@@ -290,13 +291,13 @@ class PairingIntegrationTest : FullApplicationTest() {
             mobileDeviceId = MobileDeviceId(UUID.randomUUID())
         )
         givenPairing(pairing)
-        postPairingValidationAssertFail(UUID.randomUUID(), pairing.challengeKey, pairing.responseKey!!, 404)
+        postPairingValidationAssertFail(PairingId(UUID.randomUUID()), pairing.challengeKey, pairing.responseKey!!, 404)
     }
 
     @Test
     fun `postPairingValidation - wrong challengeKey returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.READY,
             challengeKey = "foo",
@@ -311,7 +312,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingValidation - wrong responseKey returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.READY,
             challengeKey = "foo",
@@ -326,7 +327,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingValidation - wrong status returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.PAIRED,
             challengeKey = "foo",
@@ -341,7 +342,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingValidation - attempts exceeded returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.READY,
             challengeKey = "foo",
@@ -356,7 +357,7 @@ class PairingIntegrationTest : FullApplicationTest() {
     @Test
     fun `postPairingValidation - pairing expired returns 404`() {
         val pairing = Pairing(
-            id = UUID.randomUUID(),
+            id = PairingId(UUID.randomUUID()),
             unitId = testUnitId,
             status = PairingStatus.READY,
             challengeKey = "foo",
@@ -455,7 +456,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         assertEquals(status, res.statusCode)
     }
 
-    private fun postPairingResponseAssertOk(id: UUID, challengeKey: String, responseKey: String): Pairing {
+    private fun postPairingResponseAssertOk(id: PairingId, challengeKey: String, responseKey: String): Pairing {
         val (_, res, result) = http.post("/pairings/$id/response")
             .jsonBody(
                 objectMapper.writeValueAsString(
@@ -472,7 +473,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         return result.get()
     }
 
-    private fun postPairingResponseAssertFail(id: UUID, challengeKey: String, responseKey: String, status: Int) {
+    private fun postPairingResponseAssertFail(id: PairingId, challengeKey: String, responseKey: String, status: Int) {
         val (_, res, _) = http.post("/pairings/$id/response")
             .jsonBody(
                 objectMapper.writeValueAsString(
@@ -488,7 +489,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         assertEquals(status, res.statusCode)
     }
 
-    private fun postPairingValidationAssertOk(id: UUID, challengeKey: String, responseKey: String): MobileDeviceIdentity {
+    private fun postPairingValidationAssertOk(id: PairingId, challengeKey: String, responseKey: String): MobileDeviceIdentity {
         val (_, res, result) = http.post("/system/pairings/$id/validation")
             .jsonBody(
                 objectMapper.writeValueAsString(
@@ -505,7 +506,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         return result.get()
     }
 
-    private fun postPairingValidationAssertFail(id: UUID, challengeKey: String, responseKey: String, status: Int) {
+    private fun postPairingValidationAssertFail(id: PairingId, challengeKey: String, responseKey: String, status: Int) {
         val (_, res, _) = http.post("/system/pairings/$id/validation")
             .jsonBody(
                 objectMapper.writeValueAsString(
@@ -521,7 +522,7 @@ class PairingIntegrationTest : FullApplicationTest() {
         assertEquals(status, res.statusCode)
     }
 
-    private fun getPairingStatusAssertOk(id: UUID, authenticated: Boolean): PairingStatus {
+    private fun getPairingStatusAssertOk(id: PairingId, authenticated: Boolean): PairingStatus {
         val (_, res, result) = http.get("/public/pairings/$id/status")
             .let { if (authenticated) it.asUser(user) else it }
             .responseObject<PairingsController.PairingStatusRes>(objectMapper)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.pairing.MobileDeviceIdentity
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
@@ -28,7 +29,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SystemIdentityControllerTest : FullApplicationTest() {
-    private lateinit var areaId: UUID
+    private lateinit var areaId: AreaId
     private lateinit var unitId: DaycareId
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.pairing.MobileDeviceIdentity
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.db.Database
@@ -28,7 +29,7 @@ import kotlin.test.assertTrue
 
 class SystemIdentityControllerTest : FullApplicationTest() {
     private lateinit var areaId: UUID
-    private lateinit var unitId: UUID
+    private lateinit var unitId: DaycareId
 
     @BeforeEach
     protected fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemIdentityControllerTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.pairing.MobileDeviceIdentity
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.db.Database
@@ -60,8 +61,8 @@ class SystemIdentityControllerTest : FullApplicationTest() {
         assertEquals(404, res.statusCode)
     }
 
-    private fun Database.Transaction.insertTestDevice(longTermToken: UUID? = null, deleted: Boolean = false): UUID {
-        val id = insertTestEmployee(DevEmployee())
+    private fun Database.Transaction.insertTestDevice(longTermToken: UUID? = null, deleted: Boolean = false): MobileDeviceId {
+        val id = MobileDeviceId(insertTestEmployee(DevEmployee()))
         insertTestMobileDevice(
             DevMobileDevice(
                 id = id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/FamilySchemaConstraintsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/FamilySchemaConstraintsIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.pis.createParentship
 import fi.espoo.evaka.pis.createPerson
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonIdentityRequest
+import fi.espoo.evaka.shared.PartnershipId
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -22,7 +23,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val person2 = testPerson2()
         val startDate = LocalDate.now()
         val endDate = startDate.plusDays(200)
-        val partnershipId = UUID.randomUUID()
+        val partnershipId = PartnershipId(UUID.randomUUID())
         createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate)
         createPartnerRecord(partnershipId, 2, person2.id, startDate, endDate)
     }
@@ -33,14 +34,14 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val person2 = testPerson2()
         val startDate1 = LocalDate.now()
         val endDate1 = startDate1.plusDays(200)
-        UUID.randomUUID().let { partnershipId ->
+        PartnershipId(UUID.randomUUID()).let { partnershipId ->
             createPartnerRecord(partnershipId, 1, person1.id, startDate1, endDate1)
             createPartnerRecord(partnershipId, 2, person2.id, startDate1, endDate1)
         }
 
         val startDate2 = endDate1.plusDays(1)
         val endDate2 = startDate2.plusDays(200)
-        UUID.randomUUID().let { partnershipId ->
+        PartnershipId(UUID.randomUUID()).let { partnershipId ->
             createPartnerRecord(partnershipId, 1, person1.id, startDate2, endDate2)
             createPartnerRecord(partnershipId, 2, person2.id, startDate2, endDate2)
         }
@@ -52,7 +53,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val person2 = testPerson2()
         val startDate1 = LocalDate.now()
         val endDate1 = startDate1.plusDays(200)
-        UUID.randomUUID().let { partnershipId ->
+        PartnershipId(UUID.randomUUID()).let { partnershipId ->
             createPartnerRecord(partnershipId, 1, person1.id, startDate1, endDate1)
             createPartnerRecord(partnershipId, 2, person2.id, startDate1, endDate1)
         }
@@ -61,7 +62,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate2 = startDate2.plusDays(200)
 
         assertThatThrownBy {
-            val partnershipId = UUID.randomUUID()
+            val partnershipId = PartnershipId(UUID.randomUUID())
             createPartnerRecord(partnershipId, 1, person1.id, startDate2, endDate2)
             createPartnerRecord(partnershipId, 2, person2.id, startDate2, endDate2)
         }
@@ -76,7 +77,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
 
         assertThatThrownBy {
-            val partnershipId = UUID.randomUUID()
+            val partnershipId = PartnershipId(UUID.randomUUID())
             createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate)
             createPartnerRecord(partnershipId, 2, person2.id, startDate, endDate)
             createPartnerRecord(partnershipId, 3, person3.id, startDate, endDate)
@@ -92,7 +93,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
 
         assertThatThrownBy {
-            val partnershipId = UUID.randomUUID()
+            val partnershipId = PartnershipId(UUID.randomUUID())
             createPartnerRecord(partnershipId, 0, person1.id, startDate, endDate)
             createPartnerRecord(partnershipId, 1, person2.id, startDate, endDate)
             createPartnerRecord(partnershipId, 2, person3.id, startDate, endDate)
@@ -108,7 +109,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
 
         assertThatThrownBy {
-            val partnershipId = UUID.randomUUID()
+            val partnershipId = PartnershipId(UUID.randomUUID())
             createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate)
             createPartnerRecord(partnershipId, 2, person2.id, startDate, endDate)
             createPartnerRecord(partnershipId, 2, person3.id, startDate, endDate)
@@ -122,7 +123,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
 
         assertThatThrownBy {
-            val partnershipId = UUID.randomUUID()
+            val partnershipId = PartnershipId(UUID.randomUUID())
             createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate)
             createPartnerRecord(partnershipId, 2, person1.id, startDate, endDate)
         }
@@ -137,7 +138,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate1.plusDays(200)
 
         assertThatThrownBy {
-            val partnershipId = UUID.randomUUID()
+            val partnershipId = PartnershipId(UUID.randomUUID())
             createPartnerRecord(partnershipId, 1, person1.id, startDate1, endDate)
             createPartnerRecord(partnershipId, 2, person2.id, startDate2, endDate)
         }
@@ -152,7 +153,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate2 = endDate1.plusDays(1)
 
         assertThatThrownBy {
-            val partnershipId = UUID.randomUUID()
+            val partnershipId = PartnershipId(UUID.randomUUID())
             createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate1)
             createPartnerRecord(partnershipId, 2, person2.id, startDate, endDate2)
         }
@@ -166,7 +167,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.minusDays(200)
 
         assertThatThrownBy {
-            val partnershipId = UUID.randomUUID()
+            val partnershipId = PartnershipId(UUID.randomUUID())
             createPartnerRecord(partnershipId, 1, person1.id, startDate, endDate)
             createPartnerRecord(partnershipId, 2, person2.id, startDate, endDate)
         }
@@ -226,7 +227,7 @@ class FamilySchemaConstraintsIntegrationTest : AbstractIntegrationTest() {
     }
 
     private fun createPartnerRecord(
-        partnershipId: UUID,
+        partnershipId: PartnershipId,
         indx: Int,
         personId: UUID,
         startDate: LocalDate,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PartnershipDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PartnershipDAOIntegrationTest.kt
@@ -45,7 +45,7 @@ class PartnershipDAOIntegrationTest : AbstractIntegrationTest() {
         assertEquals(listOf(partnership1), person1Partnerships)
 
         val person2Partnerships = db.read { it.getPartnershipsForPerson(person2.id) }
-        assertEquals(listOf(partnership1, partnership2), person2Partnerships)
+        assertEquals(listOf(partnership1, partnership2).sortedBy { it.id }, person2Partnerships.sortedBy { it.id })
 
         val person3Partnerships = db.read { it.getPartnershipsForPerson(person3.id) }
         assertEquals(listOf(partnership2), person3Partnerships)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
@@ -10,6 +10,7 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -313,7 +314,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
         val (_, res, _) = createGroupPlacement(
             testPlacement.id,
             GroupPlacementRequestBody(
-                UUID.randomUUID(),
+                GroupId(UUID.randomUUID()),
                 placementStart,
                 placementEnd
             )
@@ -341,7 +342,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
         val (_, res, _) = createGroupPlacement(
             testPlacement.id,
             GroupPlacementRequestBody(
-                UUID.randomUUID(),
+                GroupId(UUID.randomUUID()),
                 placementStart.minusDays(1),
                 placementEnd
             )
@@ -355,7 +356,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
         val (_, res, _) = createGroupPlacement(
             testPlacement.id,
             GroupPlacementRequestBody(
-                UUID.randomUUID(),
+                GroupId(UUID.randomUUID()),
                 placementStart,
                 placementEnd.plusDays(1)
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -547,7 +548,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
     }
 
     private fun createGroupPlacement(
-        placementId: UUID,
+        placementId: PlacementId,
         groupPlacement: GroupPlacementRequestBody
     ): ResponseResultOf<ByteArray> {
         return http.post("/placements/$placementId/group-placements")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
@@ -10,6 +10,7 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -557,7 +558,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest() {
             .response()
     }
 
-    private fun getGroupPlacements(childId: UUID, daycareId: UUID): List<DaycareGroupPlacement> {
+    private fun getGroupPlacements(childId: UUID, daycareId: DaycareId): List<DaycareGroupPlacement> {
         return http.get("/placements?childId=$childId&daycareId=$daycareId")
             .asUser(serviceWorker)
             .responseObject<Set<DaycarePlacementWithDetails>>(objectMapper)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -38,7 +39,6 @@ import fi.espoo.evaka.toDaycareFormChild
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -274,7 +274,7 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
     }
 
     private fun checkPlacementPlanDraft(
-        applicationId: UUID,
+        applicationId: ApplicationId,
         type: PlacementType,
         child: PersonData.Detailed = testChild_1,
         preferredUnits: List<UnitData.Detailed> = listOf(testDaycare, testDaycare2),
@@ -311,7 +311,7 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
     }
 
     private fun createPlacementPlanAndAssert(
-        applicationId: UUID,
+        applicationId: ApplicationId,
         type: PlacementType,
         proposal: DaycarePlacementPlan
     ) {
@@ -342,7 +342,7 @@ class PlacementPlanIntegrationTest : FullApplicationTest() {
         preschoolDaycare: Boolean = false,
         preferredUnits: List<UnitData.Detailed> = listOf(testDaycare, testDaycare2),
         preparatory: Boolean = false
-    ): UUID = db.transaction { tx ->
+    ): ApplicationId = db.transaction { tx ->
         val applicationId = tx.insertTestApplication(
             status = status,
             guardianId = adult.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
@@ -40,8 +41,8 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
     val placementEnd = LocalDate.of(year, month, 20)
 
     lateinit var oldPlacement: Placement
-    lateinit var groupId1: UUID
-    lateinit var groupId2: UUID
+    lateinit var groupId1: GroupId
+    lateinit var groupId2: GroupId
     lateinit var daycarePlacementId: UUID
     lateinit var groupPlacementId: UUID
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
@@ -45,7 +46,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
     lateinit var groupId1: GroupId
     lateinit var groupId2: GroupId
     lateinit var daycarePlacementId: PlacementId
-    lateinit var groupPlacementId: UUID
+    lateinit var groupPlacementId: GroupPlacementId
 
     @BeforeEach
     internal fun setUp() {
@@ -799,11 +800,11 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
             )
         }
 
-        val groupPlacementId1 = UUID.randomUUID()
-        val groupPlacementId2 = UUID.randomUUID()
-        val groupPlacementId3 = UUID.randomUUID()
-        val groupPlacementId4 = UUID.randomUUID()
-        val groupPlacementId5 = UUID.randomUUID()
+        val groupPlacementId1 = GroupPlacementId(UUID.randomUUID())
+        val groupPlacementId2 = GroupPlacementId(UUID.randomUUID())
+        val groupPlacementId3 = GroupPlacementId(UUID.randomUUID())
+        val groupPlacementId4 = GroupPlacementId(UUID.randomUUID())
+        val groupPlacementId5 = GroupPlacementId(UUID.randomUUID())
         val groupPlacementIds =
             listOf(groupPlacementId1, groupPlacementId2, groupPlacementId3, groupPlacementId4, groupPlacementId5)
         val groupPlacementDays = listOf(3 to 5, 6 to 9, 12 to 12, 16 to 17, 19 to 20)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
@@ -43,7 +44,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
     lateinit var oldPlacement: Placement
     lateinit var groupId1: GroupId
     lateinit var groupId2: GroupId
-    lateinit var daycarePlacementId: UUID
+    lateinit var daycarePlacementId: PlacementId
     lateinit var groupPlacementId: UUID
 
     @BeforeEach
@@ -727,7 +728,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `if no group placements then getDaycarePlacements shows full range without groupId`() {
-        val daycarePlacementId = UUID.randomUUID()
+        val daycarePlacementId = PlacementId(UUID.randomUUID())
         val daycarePlacementStartDate = placementStart
         val daycarePlacementEndDate = placementStart.plusDays(5)
         val daycarePlacementType = PlacementType.DAYCARE
@@ -782,7 +783,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest() {
     fun `if there are group placements then getDaycarePlacements also shows gaps without groupId`() {
         val date = { day: Int -> LocalDate.of(year, month, day) }
 
-        val daycarePlacementId = UUID.randomUUID()
+        val daycarePlacementId = PlacementId(UUID.randomUUID())
         val daycarePlacementStartDate = date(1)
         val daycarePlacementEndDate = date(20)
         val daycarePlacementType = PlacementType.DAYCARE

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionServiceNeed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -121,7 +122,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
 
     private val adminUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.ADMIN))
 
-    private fun getAreaReport(areaId: UUID, year: Int, month: Int): List<ServiceVoucherValueUnitAggregate> {
+    private fun getAreaReport(areaId: AreaId, year: Int, month: Int): List<ServiceVoucherValueUnitAggregate> {
         val (_, response, data) = http.get(
             "/reports/service-voucher-value/units",
             listOf("areaId" to areaId, "year" to year, "month" to month)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionServiceNeed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -112,7 +113,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
         febReportNewArea.assertContainsSum(testDaycare2.id, 2 * 58200)
     }
 
-    private fun List<ServiceVoucherValueUnitAggregate>.assertContainsSum(unitId: UUID, sum: Int) {
+    private fun List<ServiceVoucherValueUnitAggregate>.assertContainsSum(unitId: DaycareId, sum: Int) {
         val row = this.find { it.unit.id == unitId }
         assertNotNull(row)
         assertEquals(sum, row!!.monthlyPaymentSum)
@@ -146,7 +147,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
 
     private fun createVoucherDecision(
         validFrom: LocalDate,
-        unitId: UUID,
+        unitId: DaycareId,
         value: Int,
         coPayment: Int,
         adultId: UUID,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.reports.VoucherReportRowType.CORRECTION
 import fi.espoo.evaka.reports.VoucherReportRowType.ORIGINAL
 import fi.espoo.evaka.reports.VoucherReportRowType.REFUND
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -38,7 +39,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZonedDateTime
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -279,7 +279,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
 
     private val adminUser = AuthenticatedUser.Employee(id = testDecisionMaker_1.id, roles = setOf(UserRole.ADMIN))
 
-    private fun getUnitReport(unitId: UUID, year: Int, month: Int): List<ServiceVoucherValueRow> {
+    private fun getUnitReport(unitId: DaycareId, year: Int, month: Int): List<ServiceVoucherValueRow> {
         val (_, response, data) = http.get(
             "/reports/service-voucher-value/units/$unitId",
             listOf("year" to year, "month" to month)
@@ -295,7 +295,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
 
     private fun createVoucherDecision(
         validFrom: LocalDate,
-        unitId: UUID,
+        unitId: DaycareId,
         value: Int,
         coPayment: Int,
         approvedAt: Instant = ZonedDateTime.of(validFrom, LocalTime.of(15, 0), europeHelsinki).toInstant()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.DaycarePlacementWithDetails
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -33,7 +34,7 @@ import kotlin.test.assertTrue
 class ServiceNeedIntegrationTest : FullApplicationTest() {
     private val unitSupervisor = AuthenticatedUser.Employee(unitSupervisorOfTestDaycare.id, setOf(UserRole.UNIT_SUPERVISOR))
 
-    lateinit var placementId: UUID
+    lateinit var placementId: PlacementId
 
     @BeforeEach
     private fun beforeEach() {
@@ -291,7 +292,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
 
     private fun testDate(day: Int) = LocalDate.now().plusDays(day.toLong())
 
-    private fun givenServiceNeed(start: Int, end: Int, placementId: UUID, optionId: UUID = snDefaultDaycare.id): UUID {
+    private fun givenServiceNeed(start: Int, end: Int, placementId: PlacementId, optionId: UUID = snDefaultDaycare.id): UUID {
         return db.transaction { tx ->
             tx.insertTestServiceNeed(
                 confirmedBy = unitSupervisor.id,
@@ -311,7 +312,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
         assertEquals(expectedStatus, res.statusCode)
     }
 
-    private fun getServiceNeeds(childId: UUID, placementId: UUID): List<ServiceNeed> {
+    private fun getServiceNeeds(childId: UUID, placementId: PlacementId): List<ServiceNeed> {
         val (_, res, result) = http.get("/placements?childId=$childId")
             .asUser(unitSupervisor)
             .responseObject<List<DaycarePlacementWithDetails>>(objectMapper)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.DaycarePlacementWithDetails
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -292,7 +293,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
 
     private fun testDate(day: Int) = LocalDate.now().plusDays(day.toLong())
 
-    private fun givenServiceNeed(start: Int, end: Int, placementId: PlacementId, optionId: UUID = snDefaultDaycare.id): UUID {
+    private fun givenServiceNeed(start: Int, end: Int, placementId: PlacementId, optionId: UUID = snDefaultDaycare.id): ServiceNeedId {
         return db.transaction { tx ->
             tx.insertTestServiceNeed(
                 confirmedBy = unitSupervisor.id,
@@ -321,7 +322,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
         return result.get().first { it.id == placementId }.serviceNeeds
     }
 
-    private fun putServiceNeed(id: UUID, request: ServiceNeedController.ServiceNeedUpdateRequest, expectedStatus: Int = 204) {
+    private fun putServiceNeed(id: ServiceNeedId, request: ServiceNeedController.ServiceNeedUpdateRequest, expectedStatus: Int = 204) {
         val (_, res, _) = http.put("/service-needs/$id")
             .jsonBody(objectMapper.writeValueAsString(request))
             .asUser(unitSupervisor)
@@ -330,7 +331,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
         assertEquals(expectedStatus, res.statusCode)
     }
 
-    private fun deleteServiceNeed(id: UUID) {
+    private fun deleteServiceNeed(id: ServiceNeedId) {
         val (_, res, _) = http.delete("/service-needs/$id")
             .asUser(unitSupervisor)
             .response()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.placement.DaycarePlacementWithDetails
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -293,7 +294,7 @@ class ServiceNeedIntegrationTest : FullApplicationTest() {
 
     private fun testDate(day: Int) = LocalDate.now().plusDays(day.toLong())
 
-    private fun givenServiceNeed(start: Int, end: Int, placementId: PlacementId, optionId: UUID = snDefaultDaycare.id): ServiceNeedId {
+    private fun givenServiceNeed(start: Int, end: Int, placementId: PlacementId, optionId: ServiceNeedOptionId = snDefaultDaycare.id): ServiceNeedId {
         return db.transaction { tx ->
             tx.insertTestServiceNeed(
                 confirmedBy = unitSupervisor.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
@@ -176,7 +176,7 @@ class PDFServiceTest {
 }
 
 fun createValidDecision(
-    id: UUID = UUID.randomUUID(),
+    id: DecisionId = DecisionId(UUID.randomUUID()),
     createdBy: String = "John Doe",
     type: DecisionType = DecisionType.DAYCARE,
     startDate: LocalDate = LocalDate.of(2019, 1, 1),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
@@ -195,7 +195,7 @@ fun createValidDecision(
         "Kamreerintie 2, 02200 Espoo",
         providerType = ProviderType.MUNICIPAL
     ),
-    applicationId: UUID = UUID.randomUUID(),
+    applicationId: ApplicationId = ApplicationId(UUID.randomUUID()),
     childId: UUID = UUID.randomUUID(),
     documentKey: String? = null,
     otherGuardianDocumentKey: String? = null,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/PDFServiceTest.kt
@@ -56,7 +56,7 @@ private val clubDecision = createValidDecision(applicationId = application.id, t
 private val voucherDecision = daycareDecision.copy(
     endDate = LocalDate.of(2019, 7, 31),
     unit = DecisionUnit(
-        UUID.randomUUID(),
+        DaycareId(UUID.randomUUID()),
         "Suomenniemen palvelusetelipäiväkoti",
         "Suomenniemen palvelusetelipäiväkoti",
         "Suomenniemen palvelusetelipäiväkodin esiopetus",
@@ -182,7 +182,7 @@ fun createValidDecision(
     startDate: LocalDate = LocalDate.of(2019, 1, 1),
     endDate: LocalDate = LocalDate.of(2019, 12, 31),
     unit: DecisionUnit = DecisionUnit(
-        UUID.randomUUID(),
+        DaycareId(UUID.randomUUID()),
         "Kuusenkerkän päiväkoti",
         "Kuusenkerkän päiväkoti",
         "Kuusenkerkän päiväkodin esiopetus",

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.shared.async
 
 import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
@@ -31,7 +32,7 @@ class AsyncJobQueriesTest : PureJdbiTest() {
 
     @Test
     fun testCompleteHappyCase() {
-        val id = UUID.randomUUID()
+        val id = DecisionId(UUID.randomUUID())
         db.transaction {
             it.insertJob(
                 JobParams(
@@ -66,7 +67,7 @@ class AsyncJobQueriesTest : PureJdbiTest() {
 
     @Test
     fun testParallelClaimContention() {
-        val payloads = (0..1).map { NotifyDecisionCreated(UUID.randomUUID(), user, sendAsMessage = false) }
+        val payloads = (0..1).map { NotifyDecisionCreated(DecisionId(UUID.randomUUID()), user, sendAsMessage = false) }
         db.transaction { tx ->
             payloads.map { tx.insertJob(JobParams(it, 999, Duration.ZERO, HelsinkiDateTime.now())) }
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.async
 
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.getTestDataSource
 import fi.espoo.evaka.shared.db.Database
@@ -50,7 +51,7 @@ class AsyncJobRunnerTest {
     fun testPlanRollback() {
         assertThrows<LetsRollbackException> {
             db.transaction { tx ->
-                asyncJobRunner.plan(tx, listOf(NotifyDecisionCreated(UUID.randomUUID(), user, false)))
+                asyncJobRunner.plan(tx, listOf(NotifyDecisionCreated(DecisionId(UUID.randomUUID()), user, false)))
                 throw LetsRollbackException()
             }
         }
@@ -59,7 +60,7 @@ class AsyncJobRunnerTest {
 
     @Test
     fun testCompleteHappyCase() {
-        val decisionId = UUID.randomUUID()
+        val decisionId = DecisionId(UUID.randomUUID())
         val future = this.setAsyncJobCallback { msg -> msg }
         db.transaction { asyncJobRunner.plan(it, listOf(NotifyDecisionCreated(decisionId, user, false))) }
         asyncJobRunner.scheduleImmediateRun(maxCount = 1)
@@ -70,7 +71,7 @@ class AsyncJobRunnerTest {
 
     @Test
     fun testCompleteRetry() {
-        val decisionId = UUID.randomUUID()
+        val decisionId = DecisionId(UUID.randomUUID())
         val failingFuture = this.setAsyncJobCallback { throw LetsRollbackException() }
         db.transaction { asyncJobRunner.plan(it, listOf(NotifyDecisionCreated(decisionId, user, false)), 20, Duration.ZERO) }
         asyncJobRunner.scheduleImmediateRun(maxCount = 1)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
 import fi.espoo.evaka.messaging.daycarydailynote.createDaycareDailyNote
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -43,7 +44,7 @@ class AclIntegrationTest : PureJdbiTest() {
     private lateinit var childId: UUID
     private lateinit var applicationId: UUID
     private lateinit var decisionId: UUID
-    private lateinit var placementId: UUID
+    private lateinit var placementId: PlacementId
     private lateinit var mobileId: UUID
     private lateinit var noteId: UUID
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
 import fi.espoo.evaka.messaging.daycarydailynote.createDaycareDailyNote
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.DevCareArea
@@ -45,7 +46,7 @@ class AclIntegrationTest : PureJdbiTest() {
     private lateinit var groupId: GroupId
     private lateinit var childId: UUID
     private lateinit var applicationId: ApplicationId
-    private lateinit var decisionId: UUID
+    private lateinit var decisionId: DecisionId
     private lateinit var placementId: PlacementId
     private lateinit var mobileId: UUID
     private lateinit var noteId: UUID

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
 import fi.espoo.evaka.messaging.daycarydailynote.createDaycareDailyNote
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
@@ -43,7 +44,7 @@ class AclIntegrationTest : PureJdbiTest() {
     private lateinit var daycareId: DaycareId
     private lateinit var groupId: GroupId
     private lateinit var childId: UUID
-    private lateinit var applicationId: UUID
+    private lateinit var applicationId: ApplicationId
     private lateinit var decisionId: UUID
     private lateinit var placementId: PlacementId
     private lateinit var mobileId: UUID

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
 import fi.espoo.evaka.messaging.daycarydailynote.createDaycareDailyNote
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -38,7 +39,7 @@ import kotlin.test.assertEquals
 class AclIntegrationTest : PureJdbiTest() {
     private lateinit var employeeId: UUID
     private lateinit var daycareId: UUID
-    private lateinit var groupId: UUID
+    private lateinit var groupId: GroupId
     private lateinit var childId: UUID
     private lateinit var applicationId: UUID
     private lateinit var decisionId: UUID

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
 import fi.espoo.evaka.messaging.daycarydailynote.createDaycareDailyNote
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.DaycareDailyNoteId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
@@ -50,7 +51,7 @@ class AclIntegrationTest : PureJdbiTest() {
     private lateinit var decisionId: DecisionId
     private lateinit var placementId: PlacementId
     private lateinit var mobileId: MobileDeviceId
-    private lateinit var noteId: UUID
+    private lateinit var noteId: DaycareDailyNoteId
 
     private lateinit var acl: AccessControlList
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevChild
@@ -48,7 +49,7 @@ class AclIntegrationTest : PureJdbiTest() {
     private lateinit var applicationId: ApplicationId
     private lateinit var decisionId: DecisionId
     private lateinit var placementId: PlacementId
-    private lateinit var mobileId: UUID
+    private lateinit var mobileId: MobileDeviceId
     private lateinit var noteId: UUID
 
     private lateinit var acl: AccessControlList
@@ -75,7 +76,7 @@ class AclIntegrationTest : PureJdbiTest() {
                 )
             )
             placementId = it.insertTestPlacement(childId = childId, unitId = daycareId)
-            mobileId = it.insertTestEmployee(DevEmployee())
+            mobileId = MobileDeviceId(it.insertTestEmployee(DevEmployee()))
             noteId = it.createDaycareDailyNote(
                 DaycareDailyNote(
                     id = null,
@@ -148,7 +149,7 @@ class AclIntegrationTest : PureJdbiTest() {
 
     @Test
     fun testMobileAclRoleAuthorization() {
-        val user = AuthenticatedUser.MobileDevice(mobileId)
+        val user = AuthenticatedUser.MobileDevice(mobileId.raw)
 
         val expectedAclAuth = AclAuthorization.Subset(setOf(daycareId))
         val expectedAclRoles = AclAppliedRoles(setOf(UserRole.MOBILE))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
 import fi.espoo.evaka.messaging.daycarydailynote.createDaycareDailyNote
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.DevCareArea
@@ -39,7 +40,7 @@ import kotlin.test.assertEquals
 
 class AclIntegrationTest : PureJdbiTest() {
     private lateinit var employeeId: UUID
-    private lateinit var daycareId: UUID
+    private lateinit var daycareId: DaycareId
     private lateinit var groupId: GroupId
     private lateinit var childId: UUID
     private lateinit var applicationId: UUID

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
@@ -61,6 +61,16 @@ class JdbiExtensionsTest : PureJdbiTest() {
     }
 
     @Test
+    fun testCoordinateListResult() {
+        data class QueryResult(val values: List<Coordinate>)
+
+        val result = db.read {
+            it.createQuery("SELECT array[point(22.0, 11.0), point(44.0, 33.0)]::point[] AS values").mapTo<QueryResult>().single()
+        }
+        assertEquals(listOf(Coordinate(lat = 11.0, lon = 22.0), Coordinate(lat = 33.0, lon = 44.0)), result.values)
+    }
+
+    @Test
     fun testDateRange() {
         val input = DateRange(LocalDate.of(2020, 1, 2), LocalDate.of(2020, 3, 4))
 
@@ -93,6 +103,16 @@ class JdbiExtensionsTest : PureJdbiTest() {
     }
 
     @Test
+    fun testDateRangeListResult() {
+        data class QueryResult(val values: List<DateRange>)
+
+        val result = db.read {
+            it.createQuery("SELECT array[daterange('2020-06-07', NULL, '[]'), daterange('2021-01-01', '2021-01-02', '[]')]::daterange[] AS values").mapTo<QueryResult>().single()
+        }
+        assertEquals(listOf(DateRange(LocalDate.of(2020, 6, 7), null), DateRange(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 2))), result.values)
+    }
+
+    @Test
     fun testFiniteDateRange() {
         val input = FiniteDateRange(LocalDate.of(2020, 9, 10), LocalDate.of(2020, 11, 12))
 
@@ -111,6 +131,16 @@ class JdbiExtensionsTest : PureJdbiTest() {
             it.createQuery("SELECT NULL::daterange AS value").mapTo<QueryResult>().single()
         }
         assertNull(result.value)
+    }
+
+    @Test
+    fun testFiniteDateRangeListResult() {
+        data class QueryResult(val values: List<FiniteDateRange>)
+
+        val result = db.read {
+            it.createQuery("SELECT array[daterange('2020-06-07', '2021-01-01', '[]'), daterange('2021-01-01', '2021-01-02', '[]')]::daterange[] AS values").mapTo<QueryResult>().single()
+        }
+        assertEquals(listOf(FiniteDateRange(LocalDate.of(2020, 6, 7), LocalDate.of(2021, 1, 1)), FiniteDateRange(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 2))), result.values)
     }
 
     @Test
@@ -135,6 +165,16 @@ class JdbiExtensionsTest : PureJdbiTest() {
     }
 
     @Test
+    fun testExternalIdListResult() {
+        data class QueryResult(val values: List<ExternalId>)
+
+        val result = db.read {
+            it.createQuery("SELECT array['test:123456', 'more:42']::text[] AS values").mapTo<QueryResult>().single()
+        }
+        assertEquals(listOf(ExternalId.of(namespace = "test", value = "123456"), ExternalId.of(namespace = "more", value = "42")), result.values)
+    }
+
+    @Test
     fun testHelsinkiDateTime() {
         val input = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(13, 59), europeHelsinki))
 
@@ -153,6 +193,23 @@ class JdbiExtensionsTest : PureJdbiTest() {
             it.createQuery("SELECT NULL::timestamptz AS value").mapTo<QueryResult>().single()
         }
         assertNull(result.value)
+    }
+
+    @Test
+    fun testHelsinkiDateTimeListResult() {
+        data class QueryResult(val values: List<HelsinkiDateTime>)
+
+        val result = db.read {
+            it.createQuery("SELECT array['2020-05-07T10:59Z', '2021-01-10T06:42Z']::timestamptz[] AS values").mapTo<QueryResult>().single()
+        }
+        val values = result.values.map { it.toZonedDateTime().withZoneSameInstant(utc) }
+        assertEquals(
+            listOf(
+                ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(10, 59), utc),
+                ZonedDateTime.of(LocalDate.of(2021, 1, 10), LocalTime.of(6, 42), utc)
+            ),
+            values
+        )
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.shared.db
 
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.identity.ExternalId
+import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -19,6 +20,7 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -172,6 +174,49 @@ class JdbiExtensionsTest : PureJdbiTest() {
             it.createQuery("SELECT array['test:123456', 'more:42']::text[] AS values").mapTo<QueryResult>().single()
         }
         assertEquals(listOf(ExternalId.of(namespace = "test", value = "123456"), ExternalId.of(namespace = "more", value = "42")), result.values)
+    }
+
+    @Test
+    fun testId() {
+        val input = PersonId(UUID.fromString("5ea2618c-3e9d-4fd3-8094-8d2f35311962"))
+
+        val match = db.read { it.checkMatch("SELECT :input = '5ea2618c-3e9d-4fd3-8094-8d2f35311962'", input) }
+        assertTrue(match)
+
+        val output = db.read { it.passThrough(input) }
+        assertEquals(input, output)
+    }
+
+    @Test
+    fun testNullId() {
+        data class QueryResult(val value: PersonId?)
+
+        val result = db.read {
+            it.createQuery("SELECT NULL::uuid AS value").mapTo<QueryResult>().single()
+        }
+        assertNull(result.value)
+    }
+
+    @Test
+    fun testIdListResult() {
+        data class QueryResult(val values: List<PersonId>)
+
+        val result = db.read {
+            it.createQuery("SELECT array['5ea2618c-3e9d-4fd3-8094-8d2f35311962', '2db6c1c7-402f-4d86-a308-a7f1b19bb313']::uuid[] AS values").mapTo<QueryResult>().single()
+        }
+        assertEquals(listOf(PersonId(UUID.fromString("5ea2618c-3e9d-4fd3-8094-8d2f35311962")), PersonId(UUID.fromString("2db6c1c7-402f-4d86-a308-a7f1b19bb313"))), result.values)
+    }
+
+    @Test
+    fun testIdInJsonb() {
+        data class JsonbObject(val value: PersonId)
+        data class QueryResult(@Json val jsonb: JsonbObject)
+
+        val result = db.read {
+            it.createQuery("SELECT jsonb_build_object('value', '5ea2618c-3e9d-4fd3-8094-8d2f35311962'::uuid) AS jsonb").mapTo<QueryResult>().single()
+        }
+        val expected = PersonId(UUID.fromString("5ea2618c-3e9d-4fd3-8094-8d2f35311962"))
+        assertEquals(expected, result.jsonb.value)
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
@@ -17,6 +17,7 @@ import org.jdbi.v3.json.Json
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -36,6 +37,8 @@ private inline fun <reified T : Any> Database.Read.checkMatch(@Language("sql") s
     .single()
 
 class JdbiExtensionsTest : PureJdbiTest() {
+    private val utc: ZoneId = ZoneId.of("UTC")
+
     @Test
     fun testCoordinate() {
         val input = Coordinate(lat = 11.0, lon = 22.0)
@@ -160,7 +163,7 @@ class JdbiExtensionsTest : PureJdbiTest() {
         val result = db.read {
             it.createQuery("SELECT jsonb_build_object('value', '2020-05-07T10:59Z'::timestamptz) AS jsonb").mapTo<QueryResult>().single()
         }
-        val expected = HelsinkiDateTime.from(ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(13, 59), europeHelsinki))
-        assertEquals(expected, result.jsonb.value)
+        val expected = ZonedDateTime.of(LocalDate.of(2020, 5, 7), LocalTime.of(10, 59), utc)
+        assertEquals(expected, result.jsonb.value.toZonedDateTime().withZoneSameInstant(utc))
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.shared.domain
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.testAreaId
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.Month
-import java.util.UUID
 import kotlin.test.assertEquals
 
 class TimeIntegrationTest : PureJdbiTest() {
@@ -60,8 +60,8 @@ class TimeIntegrationTest : PureJdbiTest() {
 
     @Test
     fun `operational days with no holidays and multiple round the clock units in database`() {
-        var secondUnitId: UUID? = null
-        var thirdUnitId: UUID? = null
+        var secondUnitId: DaycareId? = null
+        var thirdUnitId: DaycareId? = null
         db.transaction { tx ->
             secondUnitId = tx.insertTestDaycare(DevDaycare(areaId = testAreaId, name = "second round the clock unit"))
             thirdUnitId = tx.insertTestDaycare(DevDaycare(areaId = testAreaId, name = "third round the clock unit"))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.messaging.daycarydailynote.getChildDaycareDailyNotes
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.insertPlacement
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -66,8 +67,8 @@ class ScheduledJobsTest : FullApplicationTest() {
 
     @Test
     fun `Draft application and attachments older than 30 days is cleaned up`() {
-        val id_to_be_deleted = UUID.randomUUID()
-        val id_not_to_be_deleted = UUID.randomUUID()
+        val id_to_be_deleted = ApplicationId(UUID.randomUUID())
+        val id_not_to_be_deleted = ApplicationId(UUID.randomUUID())
         val user = AuthenticatedUser.Citizen(testAdult_5.id)
 
         db.transaction { tx ->
@@ -99,7 +100,7 @@ class ScheduledJobsTest : FullApplicationTest() {
         }
     }
 
-    private fun setApplicationCreatedDate(db: Database.Transaction, applicationId: UUID, created: LocalDate) {
+    private fun setApplicationCreatedDate(db: Database.Transaction, applicationId: ApplicationId, created: LocalDate) {
         db.handle.createUpdate("""UPDATE application SET created = :created WHERE id = :id""")
             .bind("created", created)
             .bind("id", applicationId)
@@ -442,7 +443,7 @@ class ScheduledJobsTest : FullApplicationTest() {
         preschoolDaycare: Boolean = false,
         childId: UUID = testChild_1.id,
         status: ApplicationStatus = ApplicationStatus.SENT
-    ): UUID {
+    ): ApplicationId {
         return db.transaction { tx ->
             val applicationId = tx.insertTestApplication(
                 status = status,
@@ -467,7 +468,7 @@ class ScheduledJobsTest : FullApplicationTest() {
         preferredStartDate: LocalDate,
         preparatory: Boolean = false,
         childId: UUID = testChild_1.id
-    ): UUID {
+    ): ApplicationId {
         return db.transaction { tx ->
             val applicationId = tx.insertTestApplication(
                 status = ApplicationStatus.SENT,
@@ -500,7 +501,7 @@ class ScheduledJobsTest : FullApplicationTest() {
         }
     }
 
-    private fun getApplicationStatus(applicationId: UUID): ApplicationStatus {
+    private fun getApplicationStatus(applicationId: ApplicationId): ApplicationStatus {
         return db.read {
             it.createQuery("SELECT status FROM application WHERE id = :id")
                 .bind("id", applicationId)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -21,6 +21,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.insertPlacement
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.DaycareDailyNoteId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -321,8 +322,8 @@ class ScheduledJobsTest : FullApplicationTest() {
     fun removeDaycareDailyNotes() {
         val now = Instant.now()
         val twelveHoursAgo = now.minusSeconds(60 * 60 * 12)
-        val expiredNoteId = UUID.randomUUID()
-        val validNoteId = UUID.randomUUID()
+        val expiredNoteId = DaycareDailyNoteId(UUID.randomUUID())
+        val validNoteId = DaycareDailyNoteId(UUID.randomUUID())
         db.transaction {
             it.createDaycareDailyNote(
                 DaycareDailyNote(
@@ -379,8 +380,8 @@ class ScheduledJobsTest : FullApplicationTest() {
     fun removeOldBackupCareDaycareDailyNotes() {
         val now = Instant.now()
         val twelveHoursAgo = now.minusSeconds(60 * 60 * 12)
-        val expiredNoteId = UUID.randomUUID()
-        val validNoteId = UUID.randomUUID()
+        val expiredNoteId = DaycareDailyNoteId(UUID.randomUUID())
+        val validNoteId = DaycareDailyNoteId(UUID.randomUUID())
         db.transaction {
             it.createDaycareDailyNote(
                 DaycareDailyNote(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/utils/SpringMvcTestController.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/utils/SpringMvcTestController.kt
@@ -4,8 +4,8 @@
 
 package fi.espoo.evaka.shared.utils
 
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -17,14 +17,21 @@ class SpringMvcTestController {
     val lastDbConnection = AtomicReference<Database.Connection?>()
 
     @GetMapping("/db-connection-pass")
-    fun dbConnectionPass(db: Database.Connection): ResponseEntity<Unit> {
+    fun dbConnectionPass(db: Database.Connection) {
         lastDbConnection.set(db)
-        return ResponseEntity.noContent().build()
     }
 
     @GetMapping("/db-connection-fail")
-    fun dbConnectionFail(db: Database.Connection): ResponseEntity<Unit> {
+    fun dbConnectionFail(db: Database.Connection) {
         lastDbConnection.set(db)
         throw RuntimeException("Failed")
+    }
+
+    @GetMapping("/require-auth")
+    fun requireAuth(user: AuthenticatedUser) {
+    }
+
+    @GetMapping("/require-auth-employee")
+    fun requireAuth(user: AuthenticatedUser.Employee) {
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestData.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestData.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.application.PersonBasics
 import fi.espoo.evaka.application.Preferences
 import fi.espoo.evaka.application.PreferredUnit
 import fi.espoo.evaka.application.ServiceNeed
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testClub
@@ -44,7 +45,7 @@ val validVoucherApplication =
     )
 
 private fun applicationDetails(vararg preferredUnits: PreferredUnit, shiftCare: Boolean = false) = ApplicationDetails(
-    id = UUID.randomUUID(),
+    id = ApplicationId(UUID.randomUUID()),
     type = ApplicationType.DAYCARE,
     status = ApplicationStatus.WAITING_DECISION,
     origin = ApplicationOrigin.ELECTRONIC,
@@ -127,7 +128,7 @@ private fun applicationDetails(vararg preferredUnits: PreferredUnit, shiftCare: 
 )
 
 val validPreschoolApplication = ApplicationDetails(
-    id = UUID.randomUUID(),
+    id = ApplicationId(UUID.randomUUID()),
     type = ApplicationType.PRESCHOOL,
     status = ApplicationStatus.WAITING_DECISION,
     origin = ApplicationOrigin.ELECTRONIC,
@@ -215,7 +216,7 @@ val validPreschoolApplication = ApplicationDetails(
 )
 
 val validClubApplication = ApplicationDetails(
-    id = UUID.randomUUID(),
+    id = ApplicationId(UUID.randomUUID()),
     type = ApplicationType.CLUB,
     status = ApplicationStatus.WAITING_DECISION,
     origin = ApplicationOrigin.ELECTRONIC,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.application.ApplicationStatus
 import fi.espoo.evaka.decision.DecisionStatus
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
@@ -33,7 +34,7 @@ data class DecisionTableRow(
     val number: Int,
     val createdBy: UUID,
     val sentDate: LocalDate,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val applicationId: UUID,
     val type: DecisionType,
     val startDate: LocalDate,
@@ -61,7 +62,7 @@ data class PlacementTableRow(
     val id: PlacementId,
     val type: PlacementType,
     val childId: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val startDate: LocalDate,
     val endDate: LocalDate
 ) {
@@ -76,7 +77,7 @@ fun Database.Read.getPlacementRowsByChild(childId: UUID) = createQuery(
 data class PlacementPlanTableRow(
     val id: UUID,
     val type: PlacementType,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val applicationId: UUID,
     val startDate: LocalDate,
     val endDate: LocalDate,
@@ -102,7 +103,7 @@ fun Database.Read.getPlacementPlanRowByApplication(applicationId: UUID) = create
 data class BackupCareTableRow(
     val id: UUID,
     val childId: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val groupId: GroupId?,
     val startDate: LocalDate,
     val endDate: LocalDate

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.application.ApplicationStatus
 import fi.espoo.evaka.decision.DecisionStatus
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
@@ -18,7 +19,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-fun Database.Read.getApplicationStatus(applicationId: UUID): ApplicationStatus = createQuery(
+fun Database.Read.getApplicationStatus(applicationId: ApplicationId): ApplicationStatus = createQuery(
     // language=SQL
     """
 SELECT status
@@ -35,7 +36,7 @@ data class DecisionTableRow(
     val createdBy: UUID,
     val sentDate: LocalDate,
     val unitId: DaycareId,
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val type: DecisionType,
     val startDate: LocalDate,
     val endDate: LocalDate,
@@ -48,7 +49,7 @@ data class DecisionTableRow(
     fun period() = FiniteDateRange(startDate, endDate)
 }
 
-fun Database.Read.getDecisionRowsByApplication(applicationId: UUID) = createQuery(
+fun Database.Read.getDecisionRowsByApplication(applicationId: ApplicationId) = createQuery(
     // language=SQL
     "SELECT * FROM decision WHERE application_id = :applicationId ORDER BY type"
 ).bind("applicationId", applicationId).mapTo<DecisionTableRow>()
@@ -78,7 +79,7 @@ data class PlacementPlanTableRow(
     val id: UUID,
     val type: PlacementType,
     val unitId: DaycareId,
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val startDate: LocalDate,
     val endDate: LocalDate,
     val preschoolDaycareStartDate: LocalDate?,
@@ -95,7 +96,7 @@ data class PlacementPlanTableRow(
         ) else null
 }
 
-fun Database.Read.getPlacementPlanRowByApplication(applicationId: UUID) = createQuery(
+fun Database.Read.getPlacementPlanRowByApplication(applicationId: ApplicationId) = createQuery(
     // language=SQL
     "SELECT * FROM placement_plan WHERE application_id = :applicationId"
 ).bind("applicationId", applicationId).mapTo<PlacementPlanTableRow>()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
@@ -31,7 +32,7 @@ WHERE id = :applicationId
     .one()
 
 data class DecisionTableRow(
-    val id: UUID,
+    val id: DecisionId,
     val number: Int,
     val createdBy: UUID,
     val sentDate: LocalDate,
@@ -54,7 +55,7 @@ fun Database.Read.getDecisionRowsByApplication(applicationId: ApplicationId) = c
     "SELECT * FROM decision WHERE application_id = :applicationId ORDER BY type"
 ).bind("applicationId", applicationId).mapTo<DecisionTableRow>()
 
-fun Database.Read.getDecisionRowById(id: UUID) = createQuery(
+fun Database.Read.getDecisionRowById(id: DecisionId) = createQuery(
     // language=SQL
     "SELECT * FROM decision WHERE id = :id"
 ).bind("id", id).mapTo<DecisionTableRow>()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.decision.DecisionStatus
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import org.jdbi.v3.core.kotlin.mapTo
@@ -57,7 +58,7 @@ fun Database.Read.getDecisionRowById(id: UUID) = createQuery(
 ).bind("id", id).mapTo<DecisionTableRow>()
 
 data class PlacementTableRow(
-    val id: UUID,
+    val id: PlacementId,
     val type: PlacementType,
     val childId: UUID,
     val unitId: UUID,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.decision.DecisionStatus
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.BackupCareId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
@@ -104,7 +105,7 @@ fun Database.Read.getPlacementPlanRowByApplication(applicationId: ApplicationId)
 ).bind("applicationId", applicationId).mapTo<PlacementPlanTableRow>()
 
 data class BackupCareTableRow(
-    val id: UUID,
+    val id: BackupCareId,
     val childId: UUID,
     val unitId: DaycareId,
     val groupId: GroupId?,
@@ -114,7 +115,7 @@ data class BackupCareTableRow(
     fun period() = FiniteDateRange(startDate, endDate)
 }
 
-fun Database.Read.getBackupCareRowById(id: UUID) = createQuery(
+fun Database.Read.getBackupCareRowById(id: BackupCareId) = createQuery(
     // language=SQL
     "SELECT * FROM backup_care WHERE id = :id"
 ).bind("id", id).mapTo<BackupCareTableRow>()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.application.ApplicationStatus
 import fi.espoo.evaka.decision.DecisionStatus
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import org.jdbi.v3.core.kotlin.mapTo
@@ -101,7 +102,7 @@ data class BackupCareTableRow(
     val id: UUID,
     val childId: UUID,
     val unitId: UUID,
-    val groupId: UUID?,
+    val groupId: GroupId?,
     val startDate: LocalDate,
     val endDate: LocalDate
 ) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/test/TestQueries.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.PlacementPlanId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import org.jdbi.v3.core.kotlin.mapTo
@@ -77,7 +78,7 @@ fun Database.Read.getPlacementRowsByChild(childId: UUID) = createQuery(
 ).bind("childId", childId).mapTo<PlacementTableRow>()
 
 data class PlacementPlanTableRow(
-    val id: UUID,
+    val id: PlacementPlanId,
     val type: PlacementType,
     val unitId: DaycareId,
     val applicationId: ApplicationId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaChildrenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaChildrenIntegrationTest.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.defaultMunicipalOrganizerOid
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevPerson
@@ -281,7 +282,7 @@ class VardaChildrenIntegrationTest : FullApplicationTest() {
     }
 }
 
-private fun insertTestVardaUnit(db: Database.Connection, id: UUID) = db.transaction {
+private fun insertTestVardaUnit(db: Database.Connection, id: DaycareId) = db.transaction {
     // language=sql
     val sql =
         """

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.updatePlacementStartAndEndDate
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.serviceneed.deleteServiceNeed
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -900,7 +901,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
 
 internal fun insertServiceNeed(
     db: Database.Connection,
-    placementId: UUID,
+    placementId: PlacementId,
     period: FiniteDateRange,
     optionId: UUID
 ): UUID {
@@ -975,7 +976,7 @@ fun insertDecisionWithApplication(
     it.insertTestDecision(acceptedDecision)
 }
 
-fun insertPlacementWithDecision(db: Database.Connection, child: PersonData.Detailed, unitId: UUID, period: FiniteDateRange): Pair<UUID, UUID> {
+fun insertPlacementWithDecision(db: Database.Connection, child: PersonData.Detailed, unitId: UUID, period: FiniteDateRange): Pair<UUID, PlacementId> {
     val decisionId = insertDecisionWithApplication(db, child = child, period = period, unitId = unitId)
     return db.transaction {
         val placementId = it.insertTestPlacement(
@@ -994,7 +995,7 @@ fun insertPlacementWithDecision(db: Database.Connection, child: PersonData.Detai
     }
 }
 
-private fun deletePlacement(db: Database.Connection, id: UUID) = db.transaction {
+private fun deletePlacement(db: Database.Connection, id: PlacementId) = db.transaction {
     it.createUpdate("DELETE FROM placement WHERE id = :id")
         .bind("id", id)
         .execute()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.updatePlacementStartAndEndDate
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.serviceneed.deleteServiceNeed
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.TestDecision
@@ -940,7 +941,7 @@ fun insertDecisionWithApplication(
     db: Database.Connection,
     child: PersonData.Detailed,
     period: FiniteDateRange,
-    unitId: UUID = testDaycare.id,
+    unitId: DaycareId = testDaycare.id,
     decisionType: DecisionType = DecisionType.DAYCARE,
     sentDate: LocalDate = LocalDate.of(2019, 1, 1),
     decisionStatus: DecisionStatus = DecisionStatus.ACCEPTED
@@ -976,7 +977,7 @@ fun insertDecisionWithApplication(
     it.insertTestDecision(acceptedDecision)
 }
 
-fun insertPlacementWithDecision(db: Database.Connection, child: PersonData.Detailed, unitId: UUID, period: FiniteDateRange): Pair<UUID, PlacementId> {
+fun insertPlacementWithDecision(db: Database.Connection, child: PersonData.Detailed, unitId: DaycareId, period: FiniteDateRange): Pair<UUID, PlacementId> {
     val decisionId = insertDecisionWithApplication(db, child = child, period = period, unitId = unitId)
     return db.transaction {
         val placementId = it.insertTestPlacement(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -22,6 +22,7 @@ import fi.espoo.evaka.serviceneed.deleteServiceNeed
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -905,7 +906,7 @@ internal fun insertServiceNeed(
     db: Database.Connection,
     placementId: PlacementId,
     period: FiniteDateRange,
-    optionId: UUID
+    optionId: ServiceNeedOptionId
 ): ServiceNeedId {
     return db.transaction {
         it.insertTestServiceNeed(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.placement.updatePlacementStartAndEndDate
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.serviceneed.deleteServiceNeed
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
@@ -947,7 +948,7 @@ fun insertDecisionWithApplication(
     decisionType: DecisionType = DecisionType.DAYCARE,
     sentDate: LocalDate = LocalDate.of(2019, 1, 1),
     decisionStatus: DecisionStatus = DecisionStatus.ACCEPTED
-): UUID = db.transaction {
+): DecisionId = db.transaction {
     val applicationId = it.insertTestApplication(childId = child.id, guardianId = testAdult_1.id, sentDate = sentDate)
     it.insertTestApplicationForm(
         applicationId,
@@ -979,7 +980,7 @@ fun insertDecisionWithApplication(
     it.insertTestDecision(acceptedDecision)
 }
 
-fun insertPlacementWithDecision(db: Database.Connection, child: PersonData.Detailed, unitId: DaycareId, period: FiniteDateRange): Pair<UUID, PlacementId> {
+fun insertPlacementWithDecision(db: Database.Connection, child: PersonData.Detailed, unitId: DaycareId, period: FiniteDateRange): Pair<DecisionId, PlacementId> {
     val decisionId = insertDecisionWithApplication(db, child = child, period = period, unitId = unitId)
     return db.transaction {
         val placementId = it.insertTestPlacement(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaDecisionsIntegrationTest.kt
@@ -21,6 +21,7 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.serviceneed.deleteServiceNeed
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -888,7 +889,7 @@ class VardaDecisionsIntegrationTest : FullApplicationTest() {
             .toList()
     }
 
-    private fun updateServiceNeed(id: UUID, updatedAt: Instant) = db.transaction {
+    private fun updateServiceNeed(id: ServiceNeedId, updatedAt: Instant) = db.transaction {
         it.createUpdate("UPDATE service_need SET updated = :updatedAt WHERE id = :id")
             .bind("id", id)
             .bind("updatedAt", updatedAt)
@@ -905,7 +906,7 @@ internal fun insertServiceNeed(
     placementId: PlacementId,
     period: FiniteDateRange,
     optionId: UUID
-): UUID {
+): ServiceNeedId {
     return db.transaction {
         it.insertTestServiceNeed(
             confirmedBy = testDecisionMaker_1.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -25,6 +25,9 @@ import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.FeeDecisionId
+import fi.espoo.evaka.shared.VardaDecisionId
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -121,7 +124,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             assertEquals(feeDecision.id, row.evakaFeeDecisionId)
             assertEquals(mockEndpoint.feeData.keys.first(), row.vardaId)
             db.read {
-                val decisionId = it.createQuery("SELECT id FROM varda_decision LIMIT 1").mapTo<UUID>().first()
+                val decisionId = it.createQuery("SELECT id FROM varda_decision LIMIT 1").mapTo<VardaDecisionId>().first()
                 assertEquals(decisionId, row.vardaDecisionId)
                 val childId = it.createQuery("SELECT id FROM varda_child LIMIT 1").mapTo<UUID>().first()
                 assertEquals(childId, row.vardaChildId)
@@ -574,7 +577,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
             assertEquals(voucherValueDecisions.first().id, row.evakaVoucherValueDecisionId)
             assertEquals(mockEndpoint.feeData.keys.first(), row.vardaId)
             db.read {
-                val decisionId = it.createQuery("SELECT id FROM varda_decision LIMIT 1").mapTo<UUID>().first()
+                val decisionId = it.createQuery("SELECT id FROM varda_decision LIMIT 1").mapTo<VardaDecisionId>().first()
                 assertEquals(decisionId, row.vardaDecisionId)
                 val childId = it.createQuery("SELECT id FROM varda_child LIMIT 1").mapTo<UUID>().first()
                 assertEquals(childId, row.vardaChildId)
@@ -693,10 +696,10 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
 
     data class VardaFeeDataRow(
         val id: UUID,
-        val evakaFeeDecisionId: UUID?,
-        val evakaVoucherValueDecisionId: UUID?,
+        val evakaFeeDecisionId: FeeDecisionId?,
+        val evakaVoucherValueDecisionId: VoucherValueDecisionId?,
         val vardaId: Long?,
-        val vardaDecisionId: UUID?,
+        val vardaDecisionId: VardaDecisionId?,
         val vardaChildId: UUID?,
         val createdAt: Instant,
         val uploadedAt: Instant

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -24,6 +24,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -671,7 +672,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
     private fun createDecisionsAndPlacements(
         period: FiniteDateRange,
         child: PersonData.Detailed = testChild_1,
-        daycareId: UUID = testDaycare.id
+        daycareId: DaycareId = testDaycare.id
     ) {
         insertDecisionWithApplication(db, child, period, unitId = daycareId)
         db.transaction {
@@ -712,7 +713,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
         children: List<PersonData.Detailed>,
         period: FiniteDateRange,
         placementType: PlacementType = PlacementType.DAYCARE,
-        daycareId: UUID = testVoucherDaycare.id,
+        daycareId: DaycareId = testVoucherDaycare.id,
         guardian: UUID = testAdult_1.id
     ): FeeDecision = db.transaction {
         val feeDecision = createFeeDecisionFixture(
@@ -739,7 +740,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
         children: List<PersonData.Detailed>,
         period: FiniteDateRange,
         placementType: PlacementType = PlacementType.DAYCARE,
-        unitId: UUID = testDaycare.id,
+        unitId: DaycareId = testDaycare.id,
         guardian: UUID = testAdult_1.id
     ): List<VoucherValueDecision> = db.transaction {
         val voucherValueDecisions = children.map { child ->

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.PlacementType.DAYCARE
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.insertTestPlacement
@@ -414,7 +415,7 @@ internal fun getVardaPlacements(db: Database.Connection) = db.read {
         .toList()
 }
 
-internal fun insertVardaUnit(db: Database.Connection, unitId: UUID = testDaycare.id, unitOid: String? = "1.2.3") {
+internal fun insertVardaUnit(db: Database.Connection, unitId: DaycareId = testDaycare.id, unitOid: String? = "1.2.3") {
     db.transaction {
         it
             .createUpdate(
@@ -460,7 +461,7 @@ internal fun insertPlacement(
     childId: UUID,
     period: FiniteDateRange,
     type: PlacementType = DAYCARE,
-    unitId: UUID = testDaycare.id
+    unitId: DaycareId = testDaycare.id
 ): PlacementId {
     return db.transaction {
         it.insertTestPlacement(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.PlacementType.DAYCARE
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -436,7 +437,7 @@ VALUES (:evakaDaycareId, :vardaUnitId,  :createdAt, :uploadedAt)
     }
 }
 
-internal fun insertTestVardaDecision(db: Database.Connection, decisionId: UUID? = null, placementId: UUID? = null): UUID {
+internal fun insertTestVardaDecision(db: Database.Connection, decisionId: UUID? = null, placementId: PlacementId? = null): UUID {
     val id = UUID.randomUUID()
     db.transaction {
         insertVardaDecision(
@@ -460,7 +461,7 @@ internal fun insertPlacement(
     period: FiniteDateRange,
     type: PlacementType = DAYCARE,
     unitId: UUID = testDaycare.id
-): UUID {
+): PlacementId {
     return db.transaction {
         it.insertTestPlacement(
             childId = childId,
@@ -472,7 +473,7 @@ internal fun insertPlacement(
     }
 }
 
-internal fun updatePlacement(db: Database.Connection, id: UUID, updatedAt: Instant) {
+internal fun updatePlacement(db: Database.Connection, id: PlacementId, updatedAt: Instant) {
     db.transaction {
         it.createUpdate("UPDATE placement SET updated = :updatedAt WHERE id = :id")
             .bind("id", id)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -11,7 +11,9 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.PlacementType.DAYCARE
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.VardaDecisionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -438,8 +440,8 @@ VALUES (:evakaDaycareId, :vardaUnitId,  :createdAt, :uploadedAt)
     }
 }
 
-internal fun insertTestVardaDecision(db: Database.Connection, decisionId: UUID? = null, placementId: PlacementId? = null): UUID {
-    val id = UUID.randomUUID()
+internal fun insertTestVardaDecision(db: Database.Connection, decisionId: DecisionId? = null, placementId: PlacementId? = null): VardaDecisionId {
+    val id = VardaDecisionId(UUID.randomUUID())
     db.transaction {
         insertVardaDecision(
             it,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.insertTestVardaOrganizer
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -24,7 +25,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.Instant
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
@@ -109,7 +109,7 @@ fun getVardaUnits(db: Database.Connection): List<VardaUnitRow> = db.read {
 }
 
 data class VardaUnitRow(
-    val evakaDaycareId: UUID,
+    val evakaDaycareId: DaycareId,
     val vardaUnitId: Long,
     val uploadedAt: Instant,
     val createdAt: Instant

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2IntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2IntegrationTest.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
 import fi.espoo.evaka.serviceneed.deleteServiceNeed
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestPerson
@@ -656,7 +657,7 @@ class VardaUpdateServiceV2IntegrationTest : FullApplicationTest() {
         db: Database.Connection,
         validFrom: LocalDate,
         validTo: LocalDate?,
-        unitId: UUID,
+        unitId: DaycareId,
         value: Int,
         coPayment: Int,
         adultId: UUID,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2IntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2IntegrationTest.kt
@@ -24,7 +24,9 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
 import fi.espoo.evaka.serviceneed.deleteServiceNeed
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestPerson
@@ -630,7 +632,7 @@ class VardaUpdateServiceV2IntegrationTest : FullApplicationTest() {
         return serviceNeedId
     }
 
-    private fun createFeeDecision(db: Database.Connection, child: PersonData.Detailed, headOfFamilyId: UUID, period: DateRange, sentAt: Instant, status: FeeDecisionStatus = FeeDecisionStatus.SENT): UUID {
+    private fun createFeeDecision(db: Database.Connection, child: PersonData.Detailed, headOfFamilyId: UUID, period: DateRange, sentAt: Instant, status: FeeDecisionStatus = FeeDecisionStatus.SENT): FeeDecisionId {
         val fd = createFeeDecisionFixture(
             status,
             FeeDecisionType.NORMAL,
@@ -710,7 +712,7 @@ private fun ServiceNeedOption.toFeeDecisionServiceNeed() = FeeDecisionServiceNee
     missing = false
 )
 
-private fun Database.Transaction.setFeeDecisionSentAt(id: UUID, sentAt: Instant) = createUpdate(
+private fun Database.Transaction.setFeeDecisionSentAt(id: FeeDecisionId, sentAt: Instant) = createUpdate(
     """
 UPDATE fee_decision SET sent_at = :sentAt
 WHERE id = :id 
@@ -719,7 +721,7 @@ WHERE id = :id
     .bind("sentAt", sentAt)
     .execute()
 
-private fun Database.Transaction.setVoucherValueDecisionSentAt(id: UUID, sentAt: Instant) = createUpdate(
+private fun Database.Transaction.setVoucherValueDecisionSentAt(id: VoucherValueDecisionId, sentAt: Instant) = createUpdate(
     """
 UPDATE voucher_value_decision SET sent_at = :sentAt
 WHERE id = :id 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.placement.PlacementPlanConfirmationStatus
 import fi.espoo.evaka.placement.PlacementPlanRejectReason
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -62,7 +63,7 @@ data class PersonApplicationSummary(
     val applicationId: UUID,
     val childId: UUID,
     val guardianId: UUID,
-    val preferredUnitId: UUID?,
+    val preferredUnitId: DaycareId?,
     val preferredUnitName: String?,
     val childName: String?,
     val childSsn: String?,
@@ -142,7 +143,7 @@ enum class ApplicationOrigin {
 }
 
 data class PreferredUnit(
-    val id: UUID,
+    val id: DaycareId,
     val name: String
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.placement.PlacementPlanConfirmationStatus
 import fi.espoo.evaka.placement.PlacementPlanRejectReason
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
@@ -60,7 +61,7 @@ data class PlacementProposalStatus(
 )
 
 data class PersonApplicationSummary(
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val childId: UUID,
     val guardianId: UUID,
     val preferredUnitId: DaycareId?,
@@ -77,7 +78,7 @@ data class PersonApplicationSummary(
 )
 
 data class ApplicationDetails(
-    val id: UUID,
+    val id: ApplicationId,
     val type: ApplicationType,
     val form: ApplicationForm,
     val status: ApplicationStatus,
@@ -149,7 +150,7 @@ data class PreferredUnit(
 
 data class ApplicationNote(
     val id: UUID,
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val content: String,
     val createdBy: UUID,
     val createdByName: String,
@@ -160,7 +161,7 @@ data class ApplicationNote(
 )
 
 data class ApplicationUnitSummary(
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val firstName: String,
     val lastName: String,
     val dateOfBirth: LocalDate,
@@ -176,7 +177,7 @@ data class ApplicationUnitSummary(
 )
 
 data class CitizenApplicationSummary(
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val type: String,
     val childId: UUID,
     val childName: String?,
@@ -194,7 +195,7 @@ fun fetchApplicationDetailsWithCurrentOtherGuardianInfoAndFilteredAttachments(
     user: AuthenticatedUser,
     tx: Database.Transaction,
     personService: PersonService,
-    applicationId: UUID
+    applicationId: ApplicationId
 ): ApplicationDetails? = tx.fetchApplicationDetails(applicationId, includeCitizenAttachmentsOnly = true)
     ?.let { application ->
         application.copy(

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.placement.PlacementPlanConfirmationStatus
 import fi.espoo.evaka.placement.PlacementPlanRejectReason
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.ApplicationNoteId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
@@ -149,7 +150,7 @@ data class PreferredUnit(
 )
 
 data class ApplicationNote(
-    val id: UUID,
+    val id: ApplicationNoteId,
     val applicationId: ApplicationId,
     val content: String,
     val createdBy: UUID,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.decision.getOwnDecisions
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.pis.service.getGuardianChildIds
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -333,7 +334,7 @@ class ApplicationControllerCitizen(
     fun downloadDecisionPdf(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable id: UUID
+        @PathVariable id: DecisionId
     ): ResponseEntity<ByteArray> {
         Audit.DecisionDownloadPdf.log(targetId = id)
         user.requireOneOfRoles(UserRole.END_USER)
@@ -372,7 +373,7 @@ data class ApplicationDecisions(
 )
 
 data class DecisionSummary(
-    val decisionId: UUID,
+    val decisionId: DecisionId,
     val type: DecisionType,
     val status: DecisionStatus,
     val sentDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.decision.getDecisionsByGuardian
 import fi.espoo.evaka.decision.getOwnDecisions
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.pis.service.getGuardianChildIds
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -78,7 +79,7 @@ class ApplicationControllerCitizen(
     fun getApplication(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID
+        @PathVariable applicationId: ApplicationId
     ): ResponseEntity<ApplicationDetails> {
         Audit.ApplicationRead.log(targetId = user.id, objectId = applicationId)
         user.requireOneOfRoles(UserRole.END_USER)
@@ -98,7 +99,7 @@ class ApplicationControllerCitizen(
         db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody body: CreateApplicationBody
-    ): ResponseEntity<UUID> {
+    ): ResponseEntity<ApplicationId> {
         Audit.ApplicationCreate.log(targetId = user.id, objectId = body)
         user.requireOneOfRoles(UserRole.END_USER)
 
@@ -195,7 +196,7 @@ class ApplicationControllerCitizen(
     fun updateApplication(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestBody applicationForm: ApplicationFormUpdate
     ): ResponseEntity<Unit> {
         Audit.ApplicationUpdate.log(targetId = applicationId)
@@ -217,7 +218,7 @@ class ApplicationControllerCitizen(
     fun saveApplicationAsDraft(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestBody applicationForm: ApplicationFormUpdate
     ): ResponseEntity<Unit> {
         Audit.ApplicationUpdate.log(targetId = applicationId)
@@ -240,7 +241,7 @@ class ApplicationControllerCitizen(
     fun deleteUnprocessedApplication(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID
+        @PathVariable applicationId: ApplicationId
     ): ResponseEntity<Unit> {
         Audit.ApplicationDelete.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.END_USER)
@@ -262,7 +263,7 @@ class ApplicationControllerCitizen(
     fun sendApplication(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID
+        @PathVariable applicationId: ApplicationId
     ): ResponseEntity<Unit> {
         db.transaction { applicationStateService.sendApplication(it, user, applicationId, currentDateInFinland(), isEnduser = true) }
         return ResponseEntity.noContent().build()
@@ -279,7 +280,7 @@ class ApplicationControllerCitizen(
     fun getApplicationDecisions(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID
+        @PathVariable applicationId: ApplicationId
     ): ResponseEntity<List<Decision>> {
         Audit.DecisionReadByApplication.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.END_USER)
@@ -297,7 +298,7 @@ class ApplicationControllerCitizen(
     fun acceptDecision(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestBody body: AcceptDecisionRequest
     ): ResponseEntity<Unit> {
         // note: applicationStateService handles logging and authorization
@@ -318,7 +319,7 @@ class ApplicationControllerCitizen(
     fun rejectDecision(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestBody body: RejectDecisionRequest
     ): ResponseEntity<Unit> {
         // note: applicationStateService handles logging and authorization
@@ -365,7 +366,7 @@ data class CreateApplicationBody(
 )
 
 data class ApplicationDecisions(
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val childName: String,
     val decisions: List<DecisionSummary>
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -24,6 +24,7 @@ import fi.espoo.evaka.placement.PlacementPlanDraft
 import fi.espoo.evaka.placement.PlacementPlanRejectReason
 import fi.espoo.evaka.placement.PlacementPlanService
 import fi.espoo.evaka.placement.getPlacementPlanUnitName
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AccessControlList
@@ -118,7 +119,7 @@ class ApplicationControllerV2(
         db: Database,
         user: AuthenticatedUser,
         @RequestBody body: PaperApplicationCreateRequest
-    ): ResponseEntity<UUID> {
+    ): ResponseEntity<ApplicationId> {
         Audit.ApplicationCreate.log(targetId = body.guardianId, objectId = body.childId)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN)
 
@@ -252,7 +253,7 @@ class ApplicationControllerV2(
     fun getApplicationDetails(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable(value = "applicationId") applicationId: UUID
+        @PathVariable(value = "applicationId") applicationId: ApplicationId
     ): ResponseEntity<ApplicationResponse> {
         Audit.ApplicationRead.log(targetId = applicationId)
         Audit.DecisionRead.log(targetId = applicationId)
@@ -289,7 +290,7 @@ class ApplicationControllerV2(
     fun updateApplication(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestBody application: ApplicationUpdate
     ): ResponseEntity<Unit> {
         Audit.ApplicationUpdate.log(targetId = applicationId)
@@ -312,7 +313,7 @@ class ApplicationControllerV2(
     fun sendApplication(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID
+        @PathVariable applicationId: ApplicationId
     ): ResponseEntity<Unit> {
         db.transaction { applicationStateService.sendApplication(it, user, applicationId, currentDateInFinland()) }
         return ResponseEntity.noContent().build()
@@ -322,7 +323,7 @@ class ApplicationControllerV2(
     fun getPlacementPlanDraft(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable(value = "applicationId") applicationId: UUID
+        @PathVariable(value = "applicationId") applicationId: ApplicationId
     ): ResponseEntity<PlacementPlanDraft> {
         Audit.PlacementPlanDraftRead.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN)
@@ -334,7 +335,7 @@ class ApplicationControllerV2(
     fun getDecisionDrafts(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable(value = "applicationId") applicationId: UUID
+        @PathVariable(value = "applicationId") applicationId: ApplicationId
     ): ResponseEntity<DecisionDraftJSON> {
         Audit.DecisionDraftRead.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN)
@@ -391,7 +392,7 @@ class ApplicationControllerV2(
     fun updateDecisionDrafts(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable(value = "applicationId") applicationId: UUID,
+        @PathVariable(value = "applicationId") applicationId: ApplicationId,
         @RequestBody body: List<DecisionDraftService.DecisionDraftUpdate>
     ): ResponseEntity<Unit> {
         Audit.DecisionDraftUpdate.log(targetId = applicationId)
@@ -440,7 +441,7 @@ class ApplicationControllerV2(
     fun createPlacementPlan(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestBody body: DaycarePlacementPlan
     ): ResponseEntity<Unit> {
         Audit.PlacementPlanCreate.log(targetId = applicationId, objectId = body.unitId)
@@ -454,7 +455,7 @@ class ApplicationControllerV2(
     fun respondToPlacementProposal(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestBody body: PlacementProposalConfirmationUpdate
     ): ResponseEntity<Unit> {
         db.transaction {
@@ -474,7 +475,7 @@ class ApplicationControllerV2(
     fun acceptDecision(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestBody body: AcceptDecisionRequest
     ): ResponseEntity<Unit> {
         db.transaction {
@@ -487,7 +488,7 @@ class ApplicationControllerV2(
     fun rejectDecision(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestBody body: RejectDecisionRequest
     ): ResponseEntity<Unit> {
         db.transaction { applicationStateService.rejectDecision(it, user, applicationId, body.decisionId) }
@@ -498,7 +499,7 @@ class ApplicationControllerV2(
     fun simpleAction(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @PathVariable action: String
     ): ResponseEntity<Unit> {
         val simpleActions = mapOf(
@@ -539,7 +540,7 @@ data class ApplicationResponse(
 )
 
 data class SimpleBatchRequest(
-    val applicationIds: Set<UUID>
+    val applicationIds: Set<ApplicationId>
 )
 
 data class PlacementProposalConfirmationUpdate(

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -26,6 +26,7 @@ import fi.espoo.evaka.placement.PlacementPlanService
 import fi.espoo.evaka.placement.getPlacementPlanUnitName
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -556,12 +557,12 @@ data class DaycarePlacementPlan(
 )
 
 data class AcceptDecisionRequest(
-    val decisionId: UUID,
+    val decisionId: DecisionId,
     val requestedStartDate: LocalDate
 )
 
 data class RejectDecisionRequest(
-    val decisionId: UUID
+    val decisionId: DecisionId
 )
 
 data class DecisionDraftJSON(

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -24,6 +24,7 @@ import fi.espoo.evaka.placement.PlacementPlanDraft
 import fi.espoo.evaka.placement.PlacementPlanRejectReason
 import fi.espoo.evaka.placement.PlacementPlanService
 import fi.espoo.evaka.placement.getPlacementPlanUnitName
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -404,7 +405,7 @@ class ApplicationControllerV2(
     fun acceptPlacementProposal(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable(value = "unitId") unitId: UUID
+        @PathVariable(value = "unitId") unitId: DaycareId
     ): ResponseEntity<Unit> {
         db.transaction { applicationStateService.acceptPlacementProposal(it, user, unitId) }
         return ResponseEntity.noContent().build()
@@ -548,7 +549,7 @@ data class PlacementProposalConfirmationUpdate(
 )
 
 data class DaycarePlacementPlan(
-    val unitId: UUID,
+    val unitId: DaycareId,
     val period: FiniteDateRange,
     val preschoolDaycarePeriod: FiniteDateRange? = null
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationDetailsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationDetailsService.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.application
 import fi.espoo.evaka.placement.Placement
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getPlacementsForChildDuring
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import java.time.LocalDate
 import java.util.UUID
@@ -25,7 +26,7 @@ fun Database.Read.applicationFlags(
     childId: UUID,
     formType: ApplicationType,
     startDate: LocalDate,
-    preferredUnits: List<UUID>,
+    preferredUnits: List<DaycareId>,
     connectedDaycare: Boolean
 ): ApplicationFlags {
     return when (formType) {
@@ -70,7 +71,7 @@ fun Database.Read.applicationFlags(
 
 fun isAdditionalDaycareApplication(
     connectedDaycare: Boolean,
-    preferredUnits: List<UUID>,
+    preferredUnits: List<DaycareId>,
     existingPreschoolPlacements: List<Placement>
 ): Boolean {
     if (!connectedDaycare) {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.application.utils.exhaust
 import fi.espoo.evaka.placement.PlacementPlanConfirmationStatus
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.AttachmentId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.WithCount
@@ -850,7 +851,7 @@ fun Database.Transaction.deleteApplication(id: ApplicationId) {
     createUpdate(sql).bind("id", id).execute()
 }
 
-fun Database.Transaction.removeOldDrafts(deleteAttachment: (db: Database.Transaction, id: UUID) -> Unit) {
+fun Database.Transaction.removeOldDrafts(deleteAttachment: (db: Database.Transaction, id: AttachmentId) -> Unit) {
     val thresholdDays = 31
 
     // language=SQL
@@ -878,7 +879,7 @@ fun Database.Transaction.removeOldDrafts(deleteAttachment: (db: Database.Transac
                 createUpdate("""DELETE FROM attachment WHERE application_id = :id RETURNING id""")
                     .bind("id", applicationId)
                     .executeAndReturnGeneratedKeys()
-                    .mapTo<UUID>()
+                    .mapTo<AttachmentId>()
                     .toList()
 
             attachmentIds.forEach { attachmentId ->

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -52,6 +52,7 @@ import fi.espoo.evaka.placement.deletePlacementPlans
 import fi.espoo.evaka.placement.getPlacementPlan
 import fi.espoo.evaka.placement.updatePlacementPlanUnitConfirmation
 import fi.espoo.evaka.s3.DocumentService
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.async.InitializeFamilyFromApplication
@@ -311,7 +312,7 @@ class ApplicationStateService(
         }
     }
 
-    fun acceptPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, unitId: UUID) {
+    fun acceptPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, unitId: DaycareId) {
         Audit.PlacementProposalAccept.log(targetId = unitId)
         if (!acl.getAuthorizedUnits(user).isAuthorized(unitId))
             throw Forbidden("Not authorized to accept placement proposal for unit $unitId")

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -52,6 +52,7 @@ import fi.espoo.evaka.placement.deletePlacementPlans
 import fi.espoo.evaka.placement.getPlacementPlan
 import fi.espoo.evaka.placement.updatePlacementPlanUnitConfirmation
 import fi.espoo.evaka.s3.DocumentService
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
@@ -94,7 +95,7 @@ class ApplicationStateService(
     fun sendApplication(
         tx: Database.Transaction,
         user: AuthenticatedUser,
-        applicationId: UUID,
+        applicationId: ApplicationId,
         currentDate: LocalDate,
         isEnduser: Boolean = false,
     ) {
@@ -158,7 +159,7 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, SENT)
     }
 
-    fun moveToWaitingPlacement(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
+    fun moveToWaitingPlacement(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
         Audit.ApplicationVerify.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
@@ -193,7 +194,7 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, WAITING_PLACEMENT)
     }
 
-    fun returnToSent(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
+    fun returnToSent(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
         Audit.ApplicationReturnToSent.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
@@ -202,7 +203,7 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, SENT)
     }
 
-    fun cancelApplication(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
+    fun cancelApplication(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
         Audit.ApplicationCancel.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
@@ -211,7 +212,7 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, CANCELLED)
     }
 
-    fun setVerified(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
+    fun setVerified(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
         Audit.ApplicationAdminDetailsUpdate.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
@@ -220,7 +221,7 @@ class ApplicationStateService(
         tx.setApplicationVerified(applicationId, true)
     }
 
-    fun setUnverified(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
+    fun setUnverified(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
         Audit.ApplicationAdminDetailsUpdate.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
@@ -229,7 +230,7 @@ class ApplicationStateService(
         tx.setApplicationVerified(applicationId, false)
     }
 
-    fun createPlacementPlan(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID, placementPlan: DaycarePlacementPlan) {
+    fun createPlacementPlan(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId, placementPlan: DaycarePlacementPlan) {
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_PLACEMENT)
 
@@ -248,7 +249,7 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, WAITING_DECISION)
     }
 
-    fun cancelPlacementPlan(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
+    fun cancelPlacementPlan(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
         Audit.ApplicationReturnToWaitingPlacement.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
@@ -259,7 +260,7 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, WAITING_PLACEMENT)
     }
 
-    fun sendDecisionsWithoutProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
+    fun sendDecisionsWithoutProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
         Audit.DecisionCreate.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
@@ -268,7 +269,7 @@ class ApplicationStateService(
         finalizeDecisions(tx, user, application)
     }
 
-    fun sendPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
+    fun sendPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
         Audit.PlacementProposalCreate.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
@@ -277,7 +278,7 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, WAITING_UNIT_CONFIRMATION)
     }
 
-    fun withdrawPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
+    fun withdrawPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
         Audit.ApplicationReturnToWaitingDecision.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
@@ -289,7 +290,7 @@ class ApplicationStateService(
     fun respondToPlacementProposal(
         tx: Database.Transaction,
         user: AuthenticatedUser,
-        applicationId: UUID,
+        applicationId: ApplicationId,
         status: PlacementPlanConfirmationStatus,
         rejectReason: PlacementPlanRejectReason? = null,
         rejectOtherReason: String? = null
@@ -328,7 +329,7 @@ class ApplicationStateService(
         val applicationStates = tx.createQuery(sql)
             .bind("unitId", unitId)
             .map { row ->
-                Pair<UUID, PlacementPlanConfirmationStatus>(
+                Pair<ApplicationId, PlacementPlanConfirmationStatus>(
                     row.mapColumn("application_id"),
                     row.mapColumn("unit_confirmation_status")
                 )
@@ -343,7 +344,7 @@ class ApplicationStateService(
             .forEach { finalizeDecisions(tx, user, it) }
     }
 
-    fun confirmDecisionMailed(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID) {
+    fun confirmDecisionMailed(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
         Audit.DecisionConfirmMailed.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)
 
@@ -352,7 +353,7 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, WAITING_CONFIRMATION)
     }
 
-    fun acceptDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID, decisionId: UUID, requestedStartDate: LocalDate, isEnduser: Boolean = false) {
+    fun acceptDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId, decisionId: UUID, requestedStartDate: LocalDate, isEnduser: Boolean = false) {
         Audit.DecisionAccept.log(targetId = decisionId)
         val application = getApplication(tx, applicationId)
         if (isEnduser) {
@@ -409,7 +410,7 @@ class ApplicationStateService(
         }
     }
 
-    fun rejectDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: UUID, decisionId: UUID, isEnduser: Boolean = false) {
+    fun rejectDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId, decisionId: UUID, isEnduser: Boolean = false) {
         Audit.DecisionReject.log(targetId = decisionId)
         val application = getApplication(tx, applicationId)
         if (isEnduser) {
@@ -449,7 +450,7 @@ class ApplicationStateService(
     fun updateOwnApplicationContentsCitizen(
         tx: Database.Transaction,
         user: AuthenticatedUser,
-        applicationId: UUID,
+        applicationId: ApplicationId,
         update: ApplicationFormUpdate,
         currentDate: LocalDate,
         asDraft: Boolean = false
@@ -493,7 +494,7 @@ class ApplicationStateService(
     fun updateApplicationContentsServiceWorker(
         tx: Database.Transaction,
         user: AuthenticatedUser,
-        applicationId: UUID,
+        applicationId: ApplicationId,
         update: ApplicationUpdate,
         userId: UUID,
         currentDate: LocalDate
@@ -538,7 +539,7 @@ class ApplicationStateService(
         }
     }
 
-    private fun Database.Transaction.updateManuallySetDueDate(applicationId: UUID, manuallySetDueDate: LocalDate) {
+    private fun Database.Transaction.updateManuallySetDueDate(applicationId: ApplicationId, manuallySetDueDate: LocalDate) {
         createUpdate("UPDATE application SET duedate = :dueDate, duedate_set_manually_at = :dueDateSetManuallyAt WHERE id = :id")
             .bind("id", applicationId)
             .bind("dueDate", manuallySetDueDate)
@@ -562,7 +563,7 @@ class ApplicationStateService(
             .execute()
     }
 
-    fun reCalculateDueDate(tx: Database.Transaction, applicationId: UUID) {
+    fun reCalculateDueDate(tx: Database.Transaction, applicationId: ApplicationId) {
         val application = tx.fetchApplicationDetails(applicationId)
             ?: throw NotFound("Application $applicationId was not found")
         tx.calculateAndUpdateDueDate(application, application.form.preferences.urgent)
@@ -570,7 +571,7 @@ class ApplicationStateService(
 
     // HELPERS
 
-    private fun getApplication(tx: Database.Read, applicationId: UUID): ApplicationDetails {
+    private fun getApplication(tx: Database.Read, applicationId: ApplicationId): ApplicationDetails {
         return tx.fetchApplicationDetails(applicationId)
             ?: throw NotFound("Application $applicationId not found")
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -54,6 +54,7 @@ import fi.espoo.evaka.placement.updatePlacementPlanUnitConfirmation
 import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.async.InitializeFamilyFromApplication
@@ -353,7 +354,7 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, WAITING_CONFIRMATION)
     }
 
-    fun acceptDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId, decisionId: UUID, requestedStartDate: LocalDate, isEnduser: Boolean = false) {
+    fun acceptDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId, decisionId: DecisionId, requestedStartDate: LocalDate, isEnduser: Boolean = false) {
         Audit.DecisionAccept.log(targetId = decisionId)
         val application = getApplication(tx, applicationId)
         if (isEnduser) {
@@ -410,7 +411,7 @@ class ApplicationStateService(
         }
     }
 
-    fun rejectDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId, decisionId: UUID, isEnduser: Boolean = false) {
+    fun rejectDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId, decisionId: DecisionId, isEnduser: Boolean = false) {
         Audit.DecisionReject.log(targetId = decisionId)
         val application = getApplication(tx, applicationId)
         if (isEnduser) {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -55,6 +55,7 @@ import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
+import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.async.InitializeFamilyFromApplication
@@ -701,7 +702,7 @@ class ApplicationStateService(
         } else {
             val period = DateRange(start = validFrom, end = null)
             val validIncome = Income(
-                id = UUID.randomUUID(),
+                id = IncomeId(UUID.randomUUID()),
                 data = mapOf(),
                 effect = IncomeEffect.MAX_FEE_ACCEPTED,
                 notes = "created automatically from application",

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/ApplicationNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/ApplicationNoteQueries.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.application.notes
 
 import fi.espoo.evaka.application.ApplicationNote
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.kotlin.mapTo
 import java.util.UUID
@@ -19,7 +20,7 @@ fun Database.Read.getApplicationNoteCreatedBy(id: UUID): UUID {
         .first()
 }
 
-fun Database.Read.getApplicationNotes(applicationId: UUID): List<ApplicationNote> {
+fun Database.Read.getApplicationNotes(applicationId: ApplicationId): List<ApplicationNote> {
     // language=SQL
     val sql =
         """
@@ -40,7 +41,7 @@ ORDER BY n.created
         .toList()
 }
 
-fun Database.Transaction.createApplicationNote(applicationId: UUID, content: String, createdBy: UUID): ApplicationNote {
+fun Database.Transaction.createApplicationNote(applicationId: ApplicationId, content: String, createdBy: UUID): ApplicationNote {
     // language=SQL
     val sql =
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/ApplicationNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/ApplicationNoteQueries.kt
@@ -6,11 +6,12 @@ package fi.espoo.evaka.application.notes
 
 import fi.espoo.evaka.application.ApplicationNote
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.ApplicationNoteId
 import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.kotlin.mapTo
 import java.util.UUID
 
-fun Database.Read.getApplicationNoteCreatedBy(id: UUID): UUID {
+fun Database.Read.getApplicationNoteCreatedBy(id: ApplicationNoteId): UUID {
     // language=SQL
     val sql = "SELECT created_by FROM application_note WHERE id = :id"
 
@@ -62,7 +63,7 @@ LEFT JOIN employee e ON n.created_by = e.id
         .first()
 }
 
-fun Database.Transaction.updateApplicationNote(id: UUID, content: String, updatedBy: UUID): ApplicationNote {
+fun Database.Transaction.updateApplicationNote(id: ApplicationNoteId, content: String, updatedBy: UUID): ApplicationNote {
     // language=SQL
     val sql =
         """
@@ -87,7 +88,7 @@ LEFT JOIN employee e2 ON n.updated_by = e2.id
         .first()
 }
 
-fun Database.Transaction.deleteApplicationNote(id: UUID) {
+fun Database.Transaction.deleteApplicationNote(id: ApplicationNoteId) {
     // language=SQL
     val sql = "DELETE FROM application_note WHERE id = :id"
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.application.notes
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.application.ApplicationNote
 import fi.espoo.evaka.application.utils.toHelsinkiLocalDateTime
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -49,7 +50,7 @@ class NoteController(private val acl: AccessControlList) {
     fun createNote(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("id") applicationId: UUID,
+        @PathVariable("id") applicationId: ApplicationId,
         @RequestBody note: NoteRequest
     ): ResponseEntity<NoteJSON> {
         Audit.NoteCreate.log(targetId = applicationId)
@@ -132,7 +133,7 @@ private fun userIsAllowedToEditNote(tx: Database.Read, user: AuthenticatedUser, 
 }
 
 data class NoteSearchDTO(
-    val applicationIds: Set<UUID> = emptySet()
+    val applicationIds: Set<ApplicationId> = emptySet()
 ) {
     companion object {
         val All = NoteSearchDTO()
@@ -148,7 +149,7 @@ data class NotesWrapperJSON(
 )
 
 data class NoteJSON(
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val id: UUID,
     val text: String,
     val created: LocalDateTime,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.application.ApplicationNote
 import fi.espoo.evaka.application.utils.toHelsinkiLocalDateTime
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.ApplicationNoteId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -87,7 +88,7 @@ class NoteController(private val acl: AccessControlList) {
     fun updateNote(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("noteId") noteId: UUID,
+        @PathVariable("noteId") noteId: ApplicationNoteId,
         @RequestBody note: NoteRequest
     ): ResponseEntity<Unit> {
         Audit.NoteUpdate.log(targetId = noteId)
@@ -107,7 +108,7 @@ class NoteController(private val acl: AccessControlList) {
     fun deleteNote(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("noteId") noteId: UUID
+        @PathVariable("noteId") noteId: ApplicationNoteId
     ): ResponseEntity<Unit> {
         Audit.NoteDelete.log(targetId = noteId)
         db.transaction { tx ->
@@ -119,7 +120,7 @@ class NoteController(private val acl: AccessControlList) {
     }
 }
 
-private fun userIsAllowedToEditNote(tx: Database.Read, user: AuthenticatedUser, noteId: UUID): Boolean {
+private fun userIsAllowedToEditNote(tx: Database.Read, user: AuthenticatedUser, noteId: ApplicationNoteId): Boolean {
     return if (user.hasOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER)) {
         true
     } else {
@@ -150,7 +151,7 @@ data class NotesWrapperJSON(
 
 data class NoteJSON(
     val applicationId: ApplicationId,
-    val id: UUID,
+    val id: ApplicationNoteId,
     val text: String,
     val created: LocalDateTime,
     val createdBy: UUID,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/persistence/club/ClubFormV0.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/persistence/club/ClubFormV0.kt
@@ -6,8 +6,8 @@ package fi.espoo.evaka.application.persistence.club
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import fi.espoo.evaka.application.persistence.DatabaseForm
+import fi.espoo.evaka.shared.DaycareId
 import java.time.LocalDate
-import java.util.UUID
 
 const val DEFAULT_CHILD_NATIONALITY = "FI"
 const val DEFAULT_CHILD_LANGUAGE = "fi"
@@ -167,7 +167,7 @@ data class ClubAdditionalDetails(
 )
 
 data class Apply(
-    val preferredUnits: List<UUID> = emptyList(),
+    val preferredUnits: List<DaycareId> = emptyList(),
     val siblingBasis: Boolean = false,
     val siblingName: String = "",
     val siblingSsn: String = ""

--- a/service/src/main/kotlin/fi/espoo/evaka/application/persistence/daycare/DaycareFormV0.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/persistence/daycare/DaycareFormV0.kt
@@ -11,8 +11,8 @@ import fi.espoo.evaka.application.ApplicationType
 import fi.espoo.evaka.application.OtherGuardianAgreementStatus
 import fi.espoo.evaka.application.ServiceNeedOption
 import fi.espoo.evaka.application.persistence.DatabaseForm
+import fi.espoo.evaka.shared.DaycareId
 import java.time.LocalDate
-import java.util.UUID
 
 const val DEFAULT_CHILD_NATIONALITY = "FI"
 const val DEFAULT_CHILD_LANGUAGE = "fi"
@@ -227,7 +227,7 @@ data class DaycareAdditionalDetails(
 )
 
 data class Apply(
-    val preferredUnits: List<UUID> = emptyList(),
+    val preferredUnits: List<DaycareId> = emptyList(),
     val siblingBasis: Boolean = false,
     val siblingName: String = "",
     val siblingSsn: String = ""

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceAction.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceAction.kt
@@ -4,11 +4,12 @@
 
 package fi.espoo.evaka.assistanceaction
 
+import fi.espoo.evaka.shared.AssistanceActionId
 import java.time.LocalDate
 import java.util.UUID
 
 data class AssistanceAction(
-    val id: UUID,
+    val id: AssistanceActionId,
     val childId: UUID,
     val startDate: LocalDate,
     val endDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.created
 import fi.espoo.evaka.daycare.controllers.utils.noContent
 import fi.espoo.evaka.daycare.controllers.utils.ok
+import fi.espoo.evaka.shared.AssistanceActionId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -60,7 +61,7 @@ class AssistanceActionController(
     fun updateAssistanceAction(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("id") assistanceActionId: UUID,
+        @PathVariable("id") assistanceActionId: AssistanceActionId,
         @RequestBody body: AssistanceActionRequest
     ): ResponseEntity<AssistanceAction> {
         Audit.ChildAssistanceActionUpdate.log(targetId = assistanceActionId)
@@ -77,7 +78,7 @@ class AssistanceActionController(
     fun deleteAssistanceAction(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("id") assistanceActionId: UUID
+        @PathVariable("id") assistanceActionId: AssistanceActionId
     ): ResponseEntity<Unit> {
         Audit.ChildAssistanceActionDelete.log(targetId = assistanceActionId)
         acl.getRolesForAssistanceAction(user, assistanceActionId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionService.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.assistanceaction
 
+import fi.espoo.evaka.shared.AssistanceActionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
@@ -30,7 +31,7 @@ class AssistanceActionService {
         return db.read { it.getAssistanceActionsByChild(childId) }
     }
 
-    fun updateAssistanceAction(db: Database.Connection, user: AuthenticatedUser, id: UUID, data: AssistanceActionRequest): AssistanceAction {
+    fun updateAssistanceAction(db: Database.Connection, user: AuthenticatedUser, id: AssistanceActionId, data: AssistanceActionRequest): AssistanceAction {
         try {
             return db.transaction { tx ->
                 validateActions(data, tx.getAssistanceActionOptions().map { it.value })
@@ -41,7 +42,7 @@ class AssistanceActionService {
         }
     }
 
-    fun deleteAssistanceAction(db: Database.Connection, id: UUID) {
+    fun deleteAssistanceAction(db: Database.Connection, id: AssistanceActionId) {
         db.transaction { it.deleteAssistanceAction(id) }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeed.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeed.kt
@@ -4,11 +4,12 @@
 
 package fi.espoo.evaka.assistanceneed
 
+import fi.espoo.evaka.shared.AssistanceNeedId
 import java.time.LocalDate
 import java.util.UUID
 
 data class AssistanceNeed(
-    val id: UUID,
+    val id: AssistanceNeedId,
     val childId: UUID,
     val startDate: LocalDate,
     val endDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.created
 import fi.espoo.evaka.daycare.controllers.utils.noContent
 import fi.espoo.evaka.daycare.controllers.utils.ok
+import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -60,7 +61,7 @@ class AssistanceNeedController(
     fun updateAssistanceNeed(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("id") assistanceNeedId: UUID,
+        @PathVariable("id") assistanceNeedId: AssistanceNeedId,
         @RequestBody body: AssistanceNeedRequest
     ): ResponseEntity<AssistanceNeed> {
         Audit.ChildAssistanceNeedUpdate.log(targetId = assistanceNeedId)
@@ -77,7 +78,7 @@ class AssistanceNeedController(
     fun deleteAssistanceNeed(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("id") assistanceNeedId: UUID
+        @PathVariable("id") assistanceNeedId: AssistanceNeedId
     ): ResponseEntity<Unit> {
         Audit.ChildAssistanceNeedDelete.log(targetId = assistanceNeedId)
         acl.getRolesForAssistanceNeed(user, assistanceNeedId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.assistanceneed
 
+import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.NotFound
@@ -59,7 +60,7 @@ fun Database.Read.getAssistanceNeedsByChild(childId: UUID): List<AssistanceNeed>
         .list()
 }
 
-fun Database.Transaction.updateAssistanceNeed(user: AuthenticatedUser, id: UUID, data: AssistanceNeedRequest): AssistanceNeed {
+fun Database.Transaction.updateAssistanceNeed(user: AuthenticatedUser, id: AssistanceNeedId, data: AssistanceNeedRequest): AssistanceNeed {
     //language=sql
     val sql =
         """
@@ -106,7 +107,7 @@ fun Database.Transaction.shortenOverlappingAssistanceNeed(user: AuthenticatedUse
         .execute()
 }
 
-fun Database.Transaction.deleteAssistanceNeed(id: UUID) {
+fun Database.Transaction.deleteAssistanceNeed(id: AssistanceNeedId) {
     //language=sql
     val sql = "DELETE FROM assistance_need WHERE id = :id"
     val deleted = createUpdate(sql).bind("id", id).execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.assistanceneed
 
+import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
@@ -28,7 +29,7 @@ class AssistanceNeedService {
         return db.transaction { it.getAssistanceNeedsByChild(childId) }
     }
 
-    fun updateAssistanceNeed(db: Database.Connection, user: AuthenticatedUser, id: UUID, data: AssistanceNeedRequest): AssistanceNeed {
+    fun updateAssistanceNeed(db: Database.Connection, user: AuthenticatedUser, id: AssistanceNeedId, data: AssistanceNeedRequest): AssistanceNeed {
         try {
             return db.transaction { it.updateAssistanceNeed(user, id, data) }
         } catch (e: JdbiException) {
@@ -36,7 +37,7 @@ class AssistanceNeedService {
         }
     }
 
-    fun deleteAssistanceNeed(db: Database.Connection, id: UUID) {
+    fun deleteAssistanceNeed(db: Database.Connection, id: AssistanceNeedId) {
         db.transaction { it.deleteAssistanceNeed(id) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.attachment
 
 import fi.espoo.evaka.application.Attachment
 import fi.espoo.evaka.application.AttachmentType
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.kotlin.mapTo
@@ -15,7 +16,7 @@ fun Database.Transaction.insertAttachment(
     id: UUID,
     name: String,
     contentType: String,
-    applicationId: UUID,
+    applicationId: ApplicationId,
     uploadedByEnduser: UUID?,
     uploadedByEmployee: UUID?,
     type: AttachmentType
@@ -81,7 +82,7 @@ fun Database.Transaction.deleteAttachment(id: UUID) {
         .execute()
 }
 
-fun Database.Transaction.deleteAttachmentsByApplicationAndType(applicationId: UUID, type: AttachmentType, userId: UUID): List<UUID> {
+fun Database.Transaction.deleteAttachmentsByApplicationAndType(applicationId: ApplicationId, type: AttachmentType, userId: UUID): List<UUID> {
     return this.createQuery(
         """
             DELETE FROM attachment 

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
@@ -7,13 +7,14 @@ package fi.espoo.evaka.attachment
 import fi.espoo.evaka.application.Attachment
 import fi.espoo.evaka.application.AttachmentType
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.AttachmentId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.kotlin.mapTo
 import java.util.UUID
 
 fun Database.Transaction.insertAttachment(
-    id: UUID,
+    id: AttachmentId,
     name: String,
     contentType: String,
     applicationId: ApplicationId,
@@ -39,12 +40,12 @@ fun Database.Transaction.insertAttachment(
         .execute()
 }
 
-fun Database.Read.getAttachment(id: UUID): Attachment? = this
+fun Database.Read.getAttachment(id: AttachmentId): Attachment? = this
     .createQuery("SELECT * FROM attachment WHERE id = :id")
     .bind("id", id).mapTo<Attachment>()
     .first()
 
-fun Database.Read.isOwnAttachment(attachmentId: UUID, user: AuthenticatedUser): Boolean {
+fun Database.Read.isOwnAttachment(attachmentId: AttachmentId, user: AuthenticatedUser): Boolean {
     val sql =
         """
         SELECT EXISTS 
@@ -60,7 +61,7 @@ fun Database.Read.isOwnAttachment(attachmentId: UUID, user: AuthenticatedUser): 
         .first()
 }
 
-fun Database.Read.isSelfUploadedAttachment(attachmentId: UUID, user: AuthenticatedUser): Boolean {
+fun Database.Read.isSelfUploadedAttachment(attachmentId: AttachmentId, user: AuthenticatedUser): Boolean {
     val sql =
         """
         SELECT EXISTS
@@ -76,13 +77,13 @@ fun Database.Read.isSelfUploadedAttachment(attachmentId: UUID, user: Authenticat
         .first()
 }
 
-fun Database.Transaction.deleteAttachment(id: UUID) {
+fun Database.Transaction.deleteAttachment(id: AttachmentId) {
     this.createUpdate("DELETE FROM attachment WHERE id = :id")
         .bind("id", id)
         .execute()
 }
 
-fun Database.Transaction.deleteAttachmentsByApplicationAndType(applicationId: ApplicationId, type: AttachmentType, userId: UUID): List<UUID> {
+fun Database.Transaction.deleteAttachmentsByApplicationAndType(applicationId: ApplicationId, type: AttachmentType, userId: UUID): List<AttachmentId> {
     return this.createQuery(
         """
             DELETE FROM attachment 
@@ -95,6 +96,6 @@ fun Database.Transaction.deleteAttachmentsByApplicationAndType(applicationId: Ap
         .bind("applicationId", applicationId)
         .bind("type", type)
         .bind("userId", userId)
-        .mapTo<UUID>()
+        .mapTo<AttachmentId>()
         .toList()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.application.AttachmentType
 import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.s3.DocumentWrapper
 import fi.espoo.evaka.s3.checkFileContentType
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -46,7 +47,7 @@ class AttachmentsController(
     fun uploadApplicationAttachmentEmployee(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestParam type: AttachmentType,
         @RequestPart("file") file: MultipartFile
     ): ResponseEntity<UUID> {
@@ -61,7 +62,7 @@ class AttachmentsController(
     fun uploadApplicationAttachmentCitizen(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestParam type: AttachmentType,
         @RequestPart("file") file: MultipartFile
     ): ResponseEntity<UUID> {
@@ -78,7 +79,7 @@ class AttachmentsController(
     private fun handleFileUpload(
         db: Database,
         user: AuthenticatedUser,
-        applicationId: UUID,
+        applicationId: ApplicationId,
         file: MultipartFile,
         type: AttachmentType
     ): UUID {
@@ -175,7 +176,7 @@ private fun Database.authorizeAttachmentDownload(user: AuthenticatedUser, attach
     throw NotFound("Attachment $attachmentId not found")
 }
 
-fun Database.Read.isOwnApplication(applicationId: UUID, user: AuthenticatedUser): Boolean {
+fun Database.Read.isOwnApplication(applicationId: ApplicationId, user: AuthenticatedUser): Boolean {
     return this.createQuery("SELECT 1 FROM application WHERE id = :id AND guardian_id = :userId")
         .bind("id", applicationId)
         .bind("userId", user.id)

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
@@ -8,6 +8,8 @@ import fi.espoo.evaka.dailyservicetimes.DailyServiceTimes
 import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.AbsenceId
+import fi.espoo.evaka.shared.AttendanceId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import java.time.Instant
@@ -100,7 +102,7 @@ enum class AttendanceStatus {
 }
 
 data class ChildAttendance(
-    val id: UUID,
+    val id: AttendanceId,
     val childId: UUID,
     val unitId: DaycareId,
     val arrived: Instant,
@@ -108,7 +110,7 @@ data class ChildAttendance(
 )
 
 data class ChildAbsence(
-    val id: UUID,
+    val id: AbsenceId,
     val childId: UUID,
     val careType: CareType
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.dailyservicetimes.DailyServiceTimes
 import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.GroupId
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -59,7 +60,7 @@ data class UnitInfo(
 )
 
 data class GroupInfo(
-    val id: UUID,
+    val id: GroupId,
     val name: String,
     val dailyNote: DaycareDailyNote?
 )
@@ -72,7 +73,7 @@ data class ChildBasics(
     val dateOfBirth: LocalDate,
     val dailyServiceTimes: DailyServiceTimes?,
     val placementType: PlacementType,
-    val groupId: UUID,
+    val groupId: GroupId,
     val backup: Boolean,
     val imageUrl: String?
 )
@@ -83,7 +84,7 @@ data class Child(
     val lastName: String,
     val preferredName: String?,
     val placementType: PlacementType,
-    val groupId: UUID,
+    val groupId: GroupId,
     val backup: Boolean,
     val status: AttendanceStatus,
     val attendance: ChildAttendance?,

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.dailyservicetimes.DailyServiceTimes
 import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.messaging.daycarydailynote.DaycareDailyNote
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import java.time.Instant
 import java.time.LocalDate
@@ -53,7 +54,7 @@ data class AttendanceResponse(
 )
 
 data class UnitInfo(
-    val id: UUID,
+    val id: DaycareId,
     val name: String,
     val groups: List<GroupInfo>,
     val staff: List<Staff>
@@ -101,7 +102,7 @@ enum class AttendanceStatus {
 data class ChildAttendance(
     val id: UUID,
     val childId: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val arrived: Instant,
     val departed: Instant?
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.pis.getEmployeeUser
 import fi.espoo.evaka.pis.resetEmployeePinFailureCount
 import fi.espoo.evaka.pis.updateEmployeePinFailureCountAndCheckIfLocked
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -122,7 +123,7 @@ class ChildAttendanceController(
     fun getAttendances(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID
+        @PathVariable unitId: DaycareId
     ): ResponseEntity<AttendanceResponse> {
         Audit.ChildAttendancesRead.log(targetId = unitId)
         acl.getRolesForUnit(user, unitId).requireOneOfRoles(*authorizedRoles)
@@ -139,7 +140,7 @@ class ChildAttendanceController(
     fun postArrival(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID,
+        @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID,
         @RequestBody body: ArrivalRequest
     ): ResponseEntity<AttendanceResponse> {
@@ -172,7 +173,7 @@ class ChildAttendanceController(
     fun returnToComing(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID,
+        @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID
     ): ResponseEntity<AttendanceResponse> {
         Audit.ChildAttendancesReturnToComing.log(targetId = childId)
@@ -206,7 +207,7 @@ class ChildAttendanceController(
     fun getChildDeparture(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID,
+        @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID,
         @RequestParam @DateTimeFormat(pattern = "HH:mm") time: LocalTime
     ): ResponseEntity<DepartureInfoResponse> {
@@ -241,7 +242,7 @@ class ChildAttendanceController(
     fun postDeparture(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID,
+        @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID,
         @RequestBody body: DepartureRequest
     ): ResponseEntity<AttendanceResponse> {
@@ -296,7 +297,7 @@ class ChildAttendanceController(
     fun returnToPresent(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID,
+        @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID
     ): ResponseEntity<AttendanceResponse> {
         Audit.ChildAttendancesReturnToPresent.log(targetId = childId)
@@ -329,7 +330,7 @@ class ChildAttendanceController(
     fun postFullDayAbsence(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID,
+        @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID,
         @RequestBody body: FullDayAbsenceRequest
     ): ResponseEntity<AttendanceResponse> {
@@ -365,7 +366,7 @@ class ChildAttendanceController(
     fun postAbsenceRange(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID,
+        @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID,
         @RequestBody body: AbsenceRangeRequest
     ): ResponseEntity<AttendanceResponse> {
@@ -410,7 +411,7 @@ data class ChildPlacementBasics(
     val placementType: PlacementType,
     val dateOfBirth: LocalDate
 )
-private fun Database.Read.fetchChildPlacementBasics(childId: UUID, unitId: UUID): ChildPlacementBasics {
+private fun Database.Read.fetchChildPlacementBasics(childId: UUID, unitId: DaycareId): ChildPlacementBasics {
     // language=sql
     val sql =
         """
@@ -435,7 +436,7 @@ data class PlacementTypeDate(
     val date: LocalDate,
     val placementType: PlacementType
 )
-private fun Database.Read.fetchChildPlacementTypeDates(childId: UUID, unitId: UUID, startDate: LocalDate, endDate: LocalDate): List<PlacementTypeDate> {
+private fun Database.Read.fetchChildPlacementTypeDates(childId: UUID, unitId: DaycareId, startDate: LocalDate, endDate: LocalDate): List<PlacementTypeDate> {
 
     // language=sql
     val sql = """
@@ -456,7 +457,7 @@ private fun Database.Read.fetchChildPlacementTypeDates(childId: UUID, unitId: UU
         .list()
 }
 
-private fun Database.Read.getAttendancesResponse(unitId: UUID): AttendanceResponse {
+private fun Database.Read.getAttendancesResponse(unitId: DaycareId): AttendanceResponse {
     val unitInfo = fetchUnitInfo(unitId)
     val childrenBasics = fetchChildrenBasics(unitId)
     val childrenAttendances = fetchChildrenAttendances(unitId)

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.messaging.daycarydailynote.getDaycareDailyNotesForDaycareG
 import fi.espoo.evaka.pis.controllers.fetchFamilyContacts
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.placement.getPlacementsForChild
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
@@ -25,7 +26,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-fun Database.Transaction.insertAttendance(childId: UUID, unitId: UUID, arrived: Instant, departed: Instant? = null): ChildAttendance {
+fun Database.Transaction.insertAttendance(childId: UUID, unitId: DaycareId, arrived: Instant, departed: Instant? = null): ChildAttendance {
     // language=sql
     val sql =
         """
@@ -62,7 +63,7 @@ fun Database.Transaction.insertAbsence(user: AuthenticatedUser, childId: UUID, d
         .first()
 }
 
-fun Database.Read.getChildCurrentDayAttendance(childId: UUID, unitId: UUID): ChildAttendance? {
+fun Database.Read.getChildCurrentDayAttendance(childId: UUID, unitId: DaycareId): ChildAttendance? {
     // language=sql
     val sql =
         """
@@ -82,7 +83,7 @@ fun Database.Read.getChildCurrentDayAttendance(childId: UUID, unitId: UUID): Chi
         .firstOrNull()
 }
 
-fun Database.Read.getChildOngoingAttendance(childId: UUID, unitId: UUID): ChildAttendance? {
+fun Database.Read.getChildOngoingAttendance(childId: UUID, unitId: DaycareId): ChildAttendance? {
     // language=sql
     val sql =
         """
@@ -98,9 +99,9 @@ fun Database.Read.getChildOngoingAttendance(childId: UUID, unitId: UUID): ChildA
         .firstOrNull()
 }
 
-fun Database.Read.fetchUnitInfo(unitId: UUID): UnitInfo {
+fun Database.Read.fetchUnitInfo(unitId: DaycareId): UnitInfo {
     data class UnitBasics(
-        val id: UUID,
+        val id: DaycareId,
         val name: String
     )
     // language=sql
@@ -165,7 +166,7 @@ fun Database.Read.fetchUnitInfo(unitId: UUID): UnitInfo {
         }
 }
 
-fun Database.Read.fetchChildrenBasics(unitId: UUID): List<ChildBasics> {
+fun Database.Read.fetchChildrenBasics(unitId: DaycareId): List<ChildBasics> {
     // language=sql
     val sql =
         """
@@ -271,7 +272,7 @@ private val placedChildrenSql =
     WHERE bc.unit_id = :unitId AND daterange(bc.start_date, bc.end_date, '[]') @> :today    
     """.trimIndent()
 
-fun Database.Read.fetchChildrenAttendances(unitId: UUID): List<ChildAttendance> {
+fun Database.Read.fetchChildrenAttendances(unitId: DaycareId): List<ChildAttendance> {
     // language=sql
     val sql =
         """
@@ -292,7 +293,7 @@ fun Database.Read.fetchChildrenAttendances(unitId: UUID): List<ChildAttendance> 
         .list()
 }
 
-fun Database.Read.fetchChildrenAbsences(unitId: UUID): List<ChildAbsence> {
+fun Database.Read.fetchChildrenAbsences(unitId: DaycareId): List<ChildAbsence> {
     // language=sql
     val sql =
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.messaging.daycarydailynote.getDaycareDailyNotesForDaycareG
 import fi.espoo.evaka.pis.controllers.fetchFamilyContacts
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.placement.getPlacementsForChild
+import fi.espoo.evaka.shared.AttendanceId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
@@ -312,7 +313,7 @@ fun Database.Read.fetchChildrenAbsences(unitId: DaycareId): List<ChildAbsence> {
         .list()
 }
 
-fun Database.Transaction.updateAttendance(attendanceId: UUID, arrived: Instant, departed: Instant?) {
+fun Database.Transaction.updateAttendance(attendanceId: AttendanceId, arrived: Instant, departed: Instant?) {
     // language=sql
     val sql =
         """
@@ -328,7 +329,7 @@ fun Database.Transaction.updateAttendance(attendanceId: UUID, arrived: Instant, 
         .execute()
 }
 
-fun Database.Transaction.updateAttendanceEnd(attendanceId: UUID, departed: Instant?) {
+fun Database.Transaction.updateAttendanceEnd(attendanceId: AttendanceId, departed: Instant?) {
     // language=sql
     val sql =
         """
@@ -343,7 +344,7 @@ fun Database.Transaction.updateAttendanceEnd(attendanceId: UUID, departed: Insta
         .execute()
 }
 
-fun Database.Transaction.deleteAttendance(id: UUID) {
+fun Database.Transaction.deleteAttendance(id: AttendanceId) {
     // language=sql
     val sql =
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCare.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCare.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.backupcare
 
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import org.jdbi.v3.core.mapper.Nested
 import org.jdbi.v3.core.mapper.PropagateNull
@@ -36,5 +37,5 @@ data class GroupBackupCare(
 data class BackupCareChild(val id: UUID, val firstName: String, val lastName: String, val birthDate: LocalDate)
 data class BackupCareUnit(val id: UUID, val name: String)
 @PropagateNull("group_id")
-data class BackupCareGroup(val id: UUID, val name: String)
-data class NewBackupCare(val unitId: UUID, val groupId: UUID?, val period: FiniteDateRange)
+data class BackupCareGroup(val id: GroupId, val name: String)
+data class NewBackupCare(val unitId: UUID, val groupId: GroupId?, val period: FiniteDateRange)

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCare.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCare.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.backupcare
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import org.jdbi.v3.core.mapper.Nested
@@ -35,7 +36,7 @@ data class GroupBackupCare(
 )
 
 data class BackupCareChild(val id: UUID, val firstName: String, val lastName: String, val birthDate: LocalDate)
-data class BackupCareUnit(val id: UUID, val name: String)
+data class BackupCareUnit(val id: DaycareId, val name: String)
 @PropagateNull("group_id")
 data class BackupCareGroup(val id: GroupId, val name: String)
-data class NewBackupCare(val unitId: UUID, val groupId: GroupId?, val period: FiniteDateRange)
+data class NewBackupCare(val unitId: DaycareId, val groupId: GroupId?, val period: FiniteDateRange)

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCare.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCare.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.backupcare
 
+import fi.espoo.evaka.shared.BackupCareId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -13,7 +14,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class ChildBackupCare(
-    val id: UUID,
+    val id: BackupCareId,
     @Nested("unit_") val unit: BackupCareUnit,
     @Nested("group_")
     val group: BackupCareGroup?,
@@ -21,7 +22,7 @@ data class ChildBackupCare(
 )
 
 data class UnitBackupCare(
-    val id: UUID,
+    val id: BackupCareId,
     @Nested("child_") val child: BackupCareChild,
     @Nested("group_")
     val group: BackupCareGroup?,
@@ -30,7 +31,7 @@ data class UnitBackupCare(
 )
 
 data class GroupBackupCare(
-    val id: UUID,
+    val id: BackupCareId,
     val childId: UUID,
     val period: FiniteDateRange
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.backupcare
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -102,5 +103,5 @@ class BackupCareController(private val acl: AccessControlList) {
 
 data class ChildBackupCaresResponse(val backupCares: List<ChildBackupCare>)
 data class UnitBackupCaresResponse(val backupCares: List<UnitBackupCare>)
-data class BackupCareUpdateRequest(val period: FiniteDateRange, val groupId: UUID?)
+data class BackupCareUpdateRequest(val period: FiniteDateRange, val groupId: GroupId?)
 data class BackupCareCreateResponse(val id: UUID)

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.backupcare
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -89,7 +90,7 @@ class BackupCareController(private val acl: AccessControlList) {
     fun getForDaycare(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
         @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
     ): ResponseEntity<UnitBackupCaresResponse> {

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.backupcare
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.BackupCareId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
@@ -61,7 +62,7 @@ class BackupCareController(private val acl: AccessControlList) {
     fun update(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("id") backupCareId: UUID,
+        @PathVariable("id") backupCareId: BackupCareId,
         @RequestBody body: BackupCareUpdateRequest
     ): ResponseEntity<Unit> {
         Audit.BackupCareUpdate.log(targetId = backupCareId, objectId = body.groupId)
@@ -78,7 +79,7 @@ class BackupCareController(private val acl: AccessControlList) {
     fun delete(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("id") backupCareId: UUID
+        @PathVariable("id") backupCareId: BackupCareId
     ): ResponseEntity<Unit> {
         Audit.BackupCareDelete.log(targetId = backupCareId)
         acl.getRolesForBackupCare(user, backupCareId).requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
@@ -105,4 +106,4 @@ class BackupCareController(private val acl: AccessControlList) {
 data class ChildBackupCaresResponse(val backupCares: List<ChildBackupCare>)
 data class UnitBackupCaresResponse(val backupCares: List<UnitBackupCare>)
 data class BackupCareUpdateRequest(val period: FiniteDateRange, val groupId: GroupId?)
-data class BackupCareCreateResponse(val id: UUID)
+data class BackupCareCreateResponse(val id: BackupCareId)

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.backupcare
 
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -86,7 +87,7 @@ RETURNING id
     .mapTo<UUID>()
     .one()
 
-fun Database.Transaction.updateBackupCare(id: UUID, period: FiniteDateRange, groupId: UUID?) = createUpdate(
+fun Database.Transaction.updateBackupCare(id: UUID, period: FiniteDateRange, groupId: GroupId?) = createUpdate(
     // language=SQL
     """
 UPDATE backup_care

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.backupcare
 
+import fi.espoo.evaka.shared.BackupCareId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
@@ -71,7 +72,7 @@ AND daterange(backup_care.start_date, backup_care.end_date, '[]') && :period
     .mapTo<UnitBackupCare>()
     .list()
 
-fun Database.Transaction.createBackupCare(childId: UUID, backupCare: NewBackupCare): UUID = createUpdate(
+fun Database.Transaction.createBackupCare(childId: UUID, backupCare: NewBackupCare): BackupCareId = createUpdate(
     // language=SQL
     """
 INSERT INTO backup_care (child_id, unit_id, group_id, start_date, end_date)
@@ -85,10 +86,10 @@ RETURNING id
     .bind("start", backupCare.period.start)
     .bind("end", backupCare.period.end)
     .executeAndReturnGeneratedKeys()
-    .mapTo<UUID>()
+    .mapTo<BackupCareId>()
     .one()
 
-fun Database.Transaction.updateBackupCare(id: UUID, period: FiniteDateRange, groupId: GroupId?) = createUpdate(
+fun Database.Transaction.updateBackupCare(id: BackupCareId, period: FiniteDateRange, groupId: GroupId?) = createUpdate(
     // language=SQL
     """
 UPDATE backup_care
@@ -105,7 +106,7 @@ WHERE id = :id
     .bindNullable("groupId", groupId)
     .execute()
 
-fun Database.Transaction.deleteBackupCare(id: UUID) = createUpdate(
+fun Database.Transaction.deleteBackupCare(id: BackupCareId) = createUpdate(
     // language=SQL
     """
 DELETE FROM backup_care

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.backupcare
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
@@ -33,7 +34,7 @@ WHERE child_id = :childId
     .mapTo<ChildBackupCare>()
     .list()
 
-fun Database.Read.getBackupCaresForDaycare(daycareId: UUID, period: FiniteDateRange): List<UnitBackupCare> = createQuery(
+fun Database.Read.getBackupCaresForDaycare(daycareId: DaycareId, period: FiniteDateRange): List<UnitBackupCare> = createQuery(
     // language=SQL
     """
 SELECT

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/CareArea.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/CareArea.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
@@ -89,7 +90,7 @@ data class DaycareDecisionCustomization(
     val handlerAddress: String
 )
 
-data class DaycareCareArea(val id: UUID, val name: String, val shortName: String)
+data class DaycareCareArea(val id: AreaId, val name: String, val shortName: String)
 
 enum class CareType {
     CLUB, FAMILY, CENTRE, GROUP_FAMILY, PRESCHOOL, PREPARATORY_EDUCATION
@@ -99,7 +100,7 @@ data class Location(
     val id: DaycareId,
     val name: String,
     val type: Set<CareType>,
-    val care_area_id: UUID,
+    val care_area_id: AreaId,
     @Nested("")
     val visitingAddress: VisitingAddress,
     @Nested("mailing")
@@ -115,7 +116,7 @@ data class Location(
 )
 
 data class CareArea(
-    val id: UUID,
+    val id: AreaId,
     val name: String,
     val shortName: String,
     val locations: List<Location>

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/CareArea.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/CareArea.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import org.jdbi.v3.core.mapper.Nested
@@ -28,7 +29,7 @@ data class MailingAddress(
 )
 
 data class Daycare(
-    val id: UUID,
+    val id: DaycareId,
     val name: String,
     val openingDate: LocalDate?,
     val closingDate: LocalDate?,
@@ -95,7 +96,7 @@ enum class CareType {
 }
 
 data class Location(
-    val id: UUID,
+    val id: DaycareId,
     val name: String,
     val type: Set<CareType>,
     val care_area_id: UUID,
@@ -121,6 +122,6 @@ data class CareArea(
 )
 
 data class UnitStub(
-    val id: UUID,
+    val id: DaycareId,
     val name: String
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/CaretakerQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/CaretakerQueries.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.daycare.service.Stats
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.jdbi.v3.core.kotlin.mapTo
@@ -12,7 +13,7 @@ import org.jdbi.v3.core.mapper.Nested
 import java.time.LocalDate
 import java.util.UUID
 
-fun Database.Transaction.initCaretakers(groupId: UUID, startDate: LocalDate, amount: Double) {
+fun Database.Transaction.initCaretakers(groupId: GroupId, startDate: LocalDate, amount: Double) {
     // language=SQL
     val sql = "INSERT INTO daycare_caretaker (group_id, start_date, amount) VALUES (:groupId, :startDate, :amount)"
 
@@ -53,7 +54,7 @@ fun Database.Read.getUnitStats(unitId: UUID, startDate: LocalDate, endDate: Loca
         .first()
 }
 
-fun Database.Read.getGroupStats(unitId: UUID, startDate: LocalDate, endDate: LocalDate): Map<UUID, Stats> {
+fun Database.Read.getGroupStats(unitId: UUID, startDate: LocalDate, endDate: LocalDate): Map<GroupId, Stats> {
     // language=SQL
     val sql =
         """
@@ -79,6 +80,6 @@ fun Database.Read.getGroupStats(unitId: UUID, startDate: LocalDate, endDate: Loc
 }
 
 private data class GroupStats(
-    val groupId: UUID,
+    val groupId: GroupId,
     @Nested val stats: Stats
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/CaretakerQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/CaretakerQueries.kt
@@ -5,13 +5,13 @@
 package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.daycare.service.Stats
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.mapper.Nested
 import java.time.LocalDate
-import java.util.UUID
 
 fun Database.Transaction.initCaretakers(groupId: GroupId, startDate: LocalDate, amount: Double) {
     // language=SQL
@@ -24,7 +24,7 @@ fun Database.Transaction.initCaretakers(groupId: GroupId, startDate: LocalDate, 
         .execute()
 }
 
-fun Database.Read.getUnitStats(unitId: UUID, startDate: LocalDate, endDate: LocalDate): Stats {
+fun Database.Read.getUnitStats(unitId: DaycareId, startDate: LocalDate, endDate: LocalDate): Stats {
     if (startDate.isBefore(endDate.minusYears(5))) {
         throw BadRequest("Too long time range")
     }
@@ -54,7 +54,7 @@ fun Database.Read.getUnitStats(unitId: UUID, startDate: LocalDate, endDate: Loca
         .first()
 }
 
-fun Database.Read.getGroupStats(unitId: UUID, startDate: LocalDate, endDate: LocalDate): Map<GroupId, Stats> {
+fun Database.Read.getGroupStats(unitId: DaycareId, startDate: LocalDate, endDate: LocalDate): Map<GroupId, Stats> {
     // language=SQL
     val sql =
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareGroupQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareGroupQueries.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.daycare.service.DaycareGroup
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.PGConstants
@@ -14,9 +15,8 @@ import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.NotFound
 import org.jdbi.v3.core.kotlin.mapTo
 import java.time.LocalDate
-import java.util.UUID
 
-private fun Database.Read.createDaycareGroupQuery(groupId: GroupId?, daycareId: UUID?, period: FiniteDateRange?) = createQuery(
+private fun Database.Read.createDaycareGroupQuery(groupId: GroupId?, daycareId: DaycareId?, period: FiniteDateRange?) = createQuery(
     // language=SQL
     """
 SELECT
@@ -33,7 +33,7 @@ AND (:period::daterange IS NULL OR daterange(start_date, end_date, '[]') && :per
     .bindNullable("daycareId", daycareId)
     .bindNullable("period", period)
 
-fun Database.Transaction.createDaycareGroup(daycareId: UUID, name: String, startDate: LocalDate): DaycareGroup = createUpdate(
+fun Database.Transaction.createDaycareGroup(daycareId: DaycareId, name: String, startDate: LocalDate): DaycareGroup = createUpdate(
     // language=SQL
     """
 INSERT INTO daycare_group (daycare_id, name, start_date)
@@ -66,7 +66,7 @@ fun Database.Read.getDaycareGroup(groupId: GroupId): DaycareGroup? =
         .asSequence()
         .firstOrNull()
 
-fun Database.Read.getDaycareGroups(daycareId: UUID, startDate: LocalDate?, endDate: LocalDate?): List<DaycareGroup> =
+fun Database.Read.getDaycareGroups(daycareId: DaycareId, startDate: LocalDate?, endDate: LocalDate?): List<DaycareGroup> =
     createDaycareGroupQuery(
         groupId = null,
         daycareId = daycareId,

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.daycare.controllers.PublicUnit
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.service.DaycareManager
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.db.Database
@@ -90,13 +91,13 @@ fun Database.Read.getDaycares(authorizedUnits: AclAuthorization): List<Daycare> 
     .toList()
 
 data class UnitApplyPeriods(
-    val id: UUID,
+    val id: DaycareId,
     val daycareApplyPeriod: DateRange?,
     val preschoolApplyPeriod: DateRange?,
     val clubApplyPeriod: DateRange?
 )
 
-fun Database.Read.getUnitApplyPeriods(ids: Collection<UUID>): List<UnitApplyPeriods> = createQuery(
+fun Database.Read.getUnitApplyPeriods(ids: Collection<DaycareId>): List<UnitApplyPeriods> = createQuery(
     // language=SQL
     """
 SELECT id, daycare_apply_period, preschool_apply_period, club_apply_period
@@ -107,20 +108,20 @@ WHERE id = ANY(:ids)
     .mapTo<UnitApplyPeriods>()
     .toList()
 
-fun Database.Read.getDaycare(id: UUID): Daycare? = getDaycaresQuery()
+fun Database.Read.getDaycare(id: DaycareId): Daycare? = getDaycaresQuery()
     .bindNullable("idFilter", listOf(id))
     .mapTo<Daycare>()
     .asSequence()
     .firstOrNull()
 
-fun Database.Read.isValidDaycareId(id: UUID): Boolean = createQuery(
+fun Database.Read.isValidDaycareId(id: DaycareId): Boolean = createQuery(
     // language=SQL
     """
 SELECT EXISTS (SELECT 1 FROM daycare WHERE id = :id) AS valid
     """.trimIndent()
 ).bind("id", id).mapTo<Boolean>().asSequence().single()
 
-fun Database.Read.getDaycareStub(daycareId: UUID): UnitStub? = createQuery(
+fun Database.Read.getDaycareStub(daycareId: DaycareId): UnitStub? = createQuery(
     // language=SQL
     """
 SELECT id, name
@@ -133,7 +134,7 @@ WHERE id = :daycareId
     .asSequence()
     .firstOrNull()
 
-fun Database.Transaction.createDaycare(areaId: UUID, name: String): UUID = createUpdate(
+fun Database.Transaction.createDaycare(areaId: UUID, name: String): DaycareId = createUpdate(
     // language=SQL
     """
 WITH insert_manager AS (
@@ -148,10 +149,10 @@ FROM insert_manager
     .bind("name", name)
     .bind("areaId", areaId)
     .executeAndReturnGeneratedKeys()
-    .mapTo<UUID>()
+    .mapTo<DaycareId>()
     .one()
 
-fun Database.Transaction.updateDaycareManager(daycareId: UUID, manager: UnitManager) = createUpdate(
+fun Database.Transaction.updateDaycareManager(daycareId: DaycareId, manager: UnitManager) = createUpdate(
     // language=SQL
     """
 UPDATE unit_manager
@@ -166,7 +167,7 @@ WHERE id = (SELECT unit_manager_id FROM daycare WHERE id = :daycareId)
     .bindKotlin(manager)
     .execute()
 
-fun Database.Transaction.updateDaycare(id: UUID, fields: DaycareFields) = createUpdate(
+fun Database.Transaction.updateDaycare(id: DaycareId, fields: DaycareFields) = createUpdate(
     // language=SQL
     """
 UPDATE daycare
@@ -298,7 +299,7 @@ ORDER BY name ASC
         .toList()
 }
 
-fun Database.Read.getUnitManager(unitId: UUID): DaycareManager? = createQuery(
+fun Database.Read.getUnitManager(unitId: DaycareId): DaycareManager? = createQuery(
     // language=SQL
     """
     SELECT coalesce(m.name, '') AS name, coalesce(m.email, '') AS email, coalesce(m.phone, '') AS phone
@@ -311,7 +312,7 @@ fun Database.Read.getUnitManager(unitId: UUID): DaycareManager? = createQuery(
     .mapTo<DaycareManager>()
     .firstOrNull()
 
-fun Database.Read.getDaycareGroupSummaries(daycareId: UUID): List<DaycareGroupSummary> = createQuery(
+fun Database.Read.getDaycareGroupSummaries(daycareId: DaycareId): List<DaycareGroupSummary> = createQuery(
     """
 SELECT id, name
 FROM daycare_group

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.daycare.controllers.PublicUnit
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.service.DaycareManager
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
@@ -62,7 +63,7 @@ data class DaycareFields(
     }
 }
 
-data class DaycareGroupSummary(val id: UUID, val name: String)
+data class DaycareGroupSummary(val id: GroupId, val name: String)
 
 private fun Database.Read.getDaycaresQuery() = createQuery(
     // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.daycare.controllers.PublicUnit
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.service.DaycareManager
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AclAuthorization
@@ -28,7 +29,7 @@ data class DaycareFields(
     val name: String,
     val openingDate: LocalDate?,
     val closingDate: LocalDate?,
-    val areaId: UUID,
+    val areaId: AreaId,
     val type: Set<CareType>,
     val daycareApplyPeriod: DateRange?,
     val preschoolApplyPeriod: DateRange?,
@@ -134,7 +135,7 @@ WHERE id = :daycareId
     .asSequence()
     .firstOrNull()
 
-fun Database.Transaction.createDaycare(areaId: UUID, name: String): DaycareId = createUpdate(
+fun Database.Transaction.createDaycare(areaId: AreaId, name: String): DaycareId = createUpdate(
     // language=SQL
     """
 WITH insert_manager AS (

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/UnitAcl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/UnitAcl.kt
@@ -24,7 +24,7 @@ fun getDaycareAclRows(db: Database.Connection, daycareId: DaycareId): List<Dayca
 fun addUnitSupervisor(db: Database.Connection, daycareId: DaycareId, employeeId: EmployeeId) {
     db.transaction {
         it.clearDaycareGroupAcl(daycareId, employeeId)
-        it.insertDaycareAclRow(daycareId.raw, employeeId.raw, UserRole.UNIT_SUPERVISOR)
+        it.insertDaycareAclRow(daycareId, employeeId.raw, UserRole.UNIT_SUPERVISOR)
         it.upsertEmployeeMessageAccount(employeeId.raw)
     }
 }
@@ -42,7 +42,7 @@ fun removeUnitSupervisor(db: Database.Connection, daycareId: DaycareId, employee
 fun addSpecialEducationTeacher(db: Database.Connection, daycareId: DaycareId, employeeId: EmployeeId) {
     db.transaction {
         it.clearDaycareGroupAcl(daycareId, employeeId)
-        it.insertDaycareAclRow(daycareId.raw, employeeId.raw, UserRole.SPECIAL_EDUCATION_TEACHER)
+        it.insertDaycareAclRow(daycareId, employeeId.raw, UserRole.SPECIAL_EDUCATION_TEACHER)
     }
 }
 
@@ -51,7 +51,7 @@ fun removeSpecialEducationTeacher(db: Database.Connection, daycareId: DaycareId,
 }
 
 fun addStaffMember(db: Database.Connection, daycareId: DaycareId, employeeId: EmployeeId) {
-    db.transaction { it.insertDaycareAclRow(daycareId.raw, employeeId.raw, UserRole.STAFF) }
+    db.transaction { it.insertDaycareAclRow(daycareId, employeeId.raw, UserRole.STAFF) }
 }
 
 fun removeStaffMember(db: Database.Connection, daycareId: DaycareId, employeeId: EmployeeId) {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.daycare.service.AbsenceDelete
 import fi.espoo.evaka.daycare.service.AbsenceGroup
 import fi.espoo.evaka.daycare.service.AbsenceService
 import fi.espoo.evaka.daycare.service.batchDeleteAbsences
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -35,7 +36,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
         user: AuthenticatedUser,
         @RequestParam year: Int,
         @RequestParam month: Int,
-        @PathVariable groupId: UUID
+        @PathVariable groupId: GroupId
     ): ResponseEntity<Wrapper<AbsenceGroup>> {
         Audit.AbsenceRead.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
@@ -49,7 +50,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
         db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody absences: Wrapper<List<Absence>>,
-        @PathVariable groupId: UUID
+        @PathVariable groupId: GroupId
     ): ResponseEntity<Unit> {
         Audit.AbsenceUpdate.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
@@ -67,7 +68,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
         db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody deletions: List<AbsenceDelete>,
-        @PathVariable groupId: UUID
+        @PathVariable groupId: GroupId
     ): ResponseEntity<Unit> {
         Audit.AbsenceUpdate.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -25,6 +25,7 @@ import fi.espoo.evaka.daycare.service.DaycareService
 import fi.espoo.evaka.daycare.updateDaycare
 import fi.espoo.evaka.daycare.updateDaycareManager
 import fi.espoo.evaka.daycare.updateGroup
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -63,7 +64,7 @@ class DaycareController(
     fun getDaycare(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID
+        @PathVariable("daycareId") daycareId: DaycareId
     ): ResponseEntity<DaycareResponse> {
         Audit.UnitRead.log(targetId = daycareId)
         val currentUserRoles = acl.getRolesForUnit(user, daycareId)
@@ -80,7 +81,7 @@ class DaycareController(
     fun getGroups(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @RequestParam(
             value = "from",
             required = false
@@ -101,7 +102,7 @@ class DaycareController(
     fun createGroup(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @RequestBody body: CreateGroupRequest
     ): ResponseEntity<DaycareGroup> {
         Audit.UnitGroupsCreate.log(targetId = daycareId)
@@ -121,7 +122,7 @@ class DaycareController(
     fun updateGroup(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @PathVariable("groupId") groupId: GroupId,
         @RequestBody body: GroupUpdateRequest
     ): ResponseEntity<Unit> {
@@ -138,7 +139,7 @@ class DaycareController(
     fun deleteGroup(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @PathVariable("groupId") groupId: GroupId
     ): ResponseEntity<Unit> {
         Audit.UnitGroupsDelete.log(targetId = groupId)
@@ -153,7 +154,7 @@ class DaycareController(
     fun getCaretakers(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @PathVariable("groupId") groupId: GroupId
     ): ResponseEntity<CaretakersResponse> {
         Audit.UnitGroupsCaretakersRead.log(targetId = groupId)
@@ -176,7 +177,7 @@ class DaycareController(
     fun createCaretakers(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @PathVariable("groupId") groupId: GroupId,
         @RequestBody body: CaretakerRequest
     ): ResponseEntity<Unit> {
@@ -200,7 +201,7 @@ class DaycareController(
     fun updateCaretakers(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @PathVariable("groupId") groupId: GroupId,
         @PathVariable("id") id: UUID,
         @RequestBody body: CaretakerRequest
@@ -226,7 +227,7 @@ class DaycareController(
     fun removeCaretakers(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @PathVariable("groupId") groupId: GroupId,
         @PathVariable("id") id: UUID
     ): ResponseEntity<Unit> {
@@ -248,7 +249,7 @@ class DaycareController(
     fun getStats(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @RequestParam(
             value = "from",
             required = true
@@ -266,7 +267,7 @@ class DaycareController(
     fun updateDaycare(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycareId") daycareId: UUID,
+        @PathVariable("daycareId") daycareId: DaycareId,
         @RequestBody fields: DaycareFields
     ): ResponseEntity<Daycare> {
         Audit.UnitUpdate.log(targetId = daycareId)
@@ -302,7 +303,7 @@ class DaycareController(
         )
     }
 
-    data class CreateDaycareResponse(val id: UUID)
+    data class CreateDaycareResponse(val id: DaycareId)
 
     data class CreateGroupRequest(
         val name: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -25,6 +25,7 @@ import fi.espoo.evaka.daycare.service.DaycareService
 import fi.espoo.evaka.daycare.updateDaycare
 import fi.espoo.evaka.daycare.updateDaycareManager
 import fi.espoo.evaka.daycare.updateGroup
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -121,7 +122,7 @@ class DaycareController(
         db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
-        @PathVariable("groupId") groupId: UUID,
+        @PathVariable("groupId") groupId: GroupId,
         @RequestBody body: GroupUpdateRequest
     ): ResponseEntity<Unit> {
         Audit.UnitGroupsUpdate.log(targetId = groupId)
@@ -138,7 +139,7 @@ class DaycareController(
         db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
-        @PathVariable("groupId") groupId: UUID
+        @PathVariable("groupId") groupId: GroupId
     ): ResponseEntity<Unit> {
         Audit.UnitGroupsDelete.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
@@ -153,7 +154,7 @@ class DaycareController(
         db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
-        @PathVariable("groupId") groupId: UUID
+        @PathVariable("groupId") groupId: GroupId
     ): ResponseEntity<CaretakersResponse> {
         Audit.UnitGroupsCaretakersRead.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
@@ -176,7 +177,7 @@ class DaycareController(
         db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
-        @PathVariable("groupId") groupId: UUID,
+        @PathVariable("groupId") groupId: GroupId,
         @RequestBody body: CaretakerRequest
     ): ResponseEntity<Unit> {
         Audit.UnitGroupsCaretakersCreate.log(targetId = groupId)
@@ -200,7 +201,7 @@ class DaycareController(
         db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
-        @PathVariable("groupId") groupId: UUID,
+        @PathVariable("groupId") groupId: GroupId,
         @PathVariable("id") id: UUID,
         @RequestBody body: CaretakerRequest
     ): ResponseEntity<Unit> {
@@ -226,7 +227,7 @@ class DaycareController(
         db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: UUID,
-        @PathVariable("groupId") groupId: UUID,
+        @PathVariable("groupId") groupId: GroupId,
         @PathVariable("id") id: UUID
     ): ResponseEntity<Unit> {
         Audit.UnitGroupsCaretakersDelete.log(targetId = id)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.getAllApplicableUnits
 import fi.espoo.evaka.daycare.getApplicationUnits
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
@@ -120,7 +121,7 @@ WHERE (
     """.trimIndent()
 )
     .bind("now", LocalDate.now())
-    .reduceRows(mutableMapOf<UUID, Pair<CareArea, MutableList<Location>>>()) { map, row ->
+    .reduceRows(mutableMapOf<AreaId, Pair<CareArea, MutableList<Location>>>()) { map, row ->
         val (_, locations) = map.computeIfAbsent(row.mapColumn("care_area_id")) { id ->
             Pair(
                 CareArea(

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.daycare.service.StaffAttendanceForDates
 import fi.espoo.evaka.daycare.service.StaffAttendanceService
 import fi.espoo.evaka.daycare.service.StaffAttendanceUpdate
 import fi.espoo.evaka.daycare.service.UnitStaffAttendance
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -50,7 +51,7 @@ class StaffAttendanceController(
         user: AuthenticatedUser,
         @RequestParam year: Int,
         @RequestParam month: Int,
-        @PathVariable groupId: UUID
+        @PathVariable groupId: GroupId
     ): ResponseEntity<Wrapper<StaffAttendanceForDates>> {
         Audit.StaffAttendanceRead.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)
@@ -64,7 +65,7 @@ class StaffAttendanceController(
         db: Database.Connection,
         user: AuthenticatedUser,
         @RequestBody staffAttendance: StaffAttendanceUpdate,
-        @PathVariable groupId: UUID
+        @PathVariable groupId: GroupId
     ): ResponseEntity<Unit> {
         Audit.StaffAttendanceUpdate.log(targetId = groupId)
         acl.getRolesForUnitGroup(user, groupId)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.daycare.service.StaffAttendanceForDates
 import fi.espoo.evaka.daycare.service.StaffAttendanceService
 import fi.espoo.evaka.daycare.service.StaffAttendanceUpdate
 import fi.espoo.evaka.daycare.service.UnitStaffAttendance
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -25,7 +26,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.util.UUID
 
 @RestController
 @RequestMapping("/staff-attendances")
@@ -37,7 +37,7 @@ class StaffAttendanceController(
     fun getAttendancesByUnit(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID
+        @PathVariable unitId: DaycareId
     ): ResponseEntity<UnitStaffAttendance> {
         Audit.UnitStaffAttendanceRead.log(targetId = unitId)
         acl.getRolesForUnit(user, unitId).requireOneOfRoles(UserRole.MOBILE)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
@@ -12,6 +12,9 @@ import fi.espoo.evaka.daycare.getDaycareAclRows
 import fi.espoo.evaka.daycare.removeSpecialEducationTeacher
 import fi.espoo.evaka.daycare.removeStaffMember
 import fi.espoo.evaka.daycare.removeUnitSupervisor
+import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.DaycareAclRow
@@ -26,7 +29,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 class UnitAclController(private val acl: AccessControlList) {
@@ -34,7 +36,7 @@ class UnitAclController(private val acl: AccessControlList) {
     fun getAcl(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID
+        @PathVariable daycareId: DaycareId
     ): ResponseEntity<DaycareAclResponse> {
         Audit.UnitAclRead.log()
         acl.getRolesForUnit(user, daycareId)
@@ -47,8 +49,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun insertUnitSupervisor(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -61,8 +63,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun deleteUnitSupervisor(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -75,8 +77,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun insertSpecialEducationTeacher(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -89,8 +91,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun deleteSpecialEducationTeacher(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -103,8 +105,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun insertStaff(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -117,8 +119,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun deleteStaff(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId
     ): ResponseEntity<Unit> {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
         acl.getRolesForUnit(user, daycareId)
@@ -131,8 +133,8 @@ class UnitAclController(private val acl: AccessControlList) {
     fun updateStaffGroupAcl(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable daycareId: UUID,
-        @PathVariable employeeId: UUID,
+        @PathVariable daycareId: DaycareId,
+        @PathVariable employeeId: EmployeeId,
         @RequestBody update: GroupAclUpdate
     ) {
         Audit.UnitGroupAclUpdate.log(targetId = daycareId, objectId = employeeId)
@@ -145,7 +147,7 @@ class UnitAclController(private val acl: AccessControlList) {
         }
     }
 
-    data class GroupAclUpdate(val groupIds: List<UUID>)
+    data class GroupAclUpdate(val groupIds: List<GroupId>)
 }
 
 data class DaycareAclResponse(val rows: List<DaycareAclRow>)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.backupcare.GroupBackupCare
 import fi.espoo.evaka.daycare.getDaycare
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -329,7 +330,7 @@ fun Database.Read.getGroupName(groupId: GroupId): String? {
         .firstOrNull()
 }
 
-fun Database.Read.getDaycareIdByGroup(groupId: GroupId): UUID {
+fun Database.Read.getDaycareIdByGroup(groupId: GroupId): DaycareId {
     //language=SQL
     val sql =
         """
@@ -341,7 +342,7 @@ fun Database.Read.getDaycareIdByGroup(groupId: GroupId): UUID {
 
     return createQuery(sql)
         .bind("groupId", groupId)
-        .mapTo<UUID>()
+        .mapTo<DaycareId>()
         .first()
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.backupcare.GroupBackupCare
 import fi.espoo.evaka.daycare.getDaycare
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
@@ -23,7 +24,7 @@ private val logger = KotlinLogging.logger { }
 
 @Service
 class AbsenceService {
-    fun getAbsencesByMonth(tx: Database.Read, groupId: UUID, year: Int, month: Int): AbsenceGroup {
+    fun getAbsencesByMonth(tx: Database.Read, groupId: GroupId, year: Int, month: Int): AbsenceGroup {
         val startDate = LocalDate.of(year, month, 1)
         val endDate = startDate.with(lastDayOfMonth())
         val period = FiniteDateRange(startDate, endDate)
@@ -169,7 +170,7 @@ enum class CareType {
 }
 
 data class AbsenceGroup(
-    val groupId: UUID,
+    val groupId: GroupId,
     val daycareName: String,
     var groupName: String,
     var children: List<AbsenceChild>,
@@ -313,7 +314,7 @@ fun Database.Read.getUserNameById(userId: UUID): String {
         .first()
 }
 
-fun Database.Read.getGroupName(groupId: UUID): String? {
+fun Database.Read.getGroupName(groupId: GroupId): String? {
     //language=SQL
     val sql =
         """
@@ -328,7 +329,7 @@ fun Database.Read.getGroupName(groupId: UUID): String? {
         .firstOrNull()
 }
 
-fun Database.Read.getDaycareIdByGroup(groupId: UUID): UUID {
+fun Database.Read.getDaycareIdByGroup(groupId: GroupId): UUID {
     //language=SQL
     val sql =
         """
@@ -344,7 +345,7 @@ fun Database.Read.getDaycareIdByGroup(groupId: UUID): UUID {
         .first()
 }
 
-fun Database.Read.getPlacementsByRange(groupId: UUID, period: FiniteDateRange): List<AbsencePlacement> {
+fun Database.Read.getPlacementsByRange(groupId: GroupId, period: FiniteDateRange): List<AbsencePlacement> {
     //language=SQL
     val sql =
         """
@@ -381,7 +382,7 @@ fun Database.Read.getPlacementsByRange(groupId: UUID, period: FiniteDateRange): 
         .list()
 }
 
-fun Database.Read.getAbsencesByRange(groupId: UUID, period: FiniteDateRange): List<Absence> {
+fun Database.Read.getAbsencesByRange(groupId: GroupId, period: FiniteDateRange): List<Absence> {
     //language=SQL
     val sql =
         """
@@ -445,7 +446,7 @@ fun Database.Read.getAbsencesByChildByPeriod(childId: UUID, period: DateRange): 
         .list()
 }
 
-private fun Database.Read.getBackupCaresAffectingGroup(groupId: UUID, period: FiniteDateRange): List<GroupBackupCare> =
+private fun Database.Read.getBackupCaresAffectingGroup(groupId: GroupId, period: FiniteDateRange): List<GroupBackupCare> =
     createQuery(
         // language=SQL
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.daycare.isValidDaycareId
 import fi.espoo.evaka.messaging.message.createDaycareGroupMessageAccount
 import fi.espoo.evaka.messaging.message.deleteDaycareGroupMessageAccount
 import fi.espoo.evaka.placement.hasGroupPlacements
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.psqlCause
 import fi.espoo.evaka.shared.domain.Conflict
@@ -50,7 +51,7 @@ class DaycareService {
         tx.createDaycareGroupMessageAccount(it.id)
     }
 
-    fun deleteGroup(tx: Database.Transaction, groupId: UUID) = try {
+    fun deleteGroup(tx: Database.Transaction, groupId: GroupId) = try {
         if (tx.hasGroupPlacements(groupId)) throw Conflict("Cannot delete group which has children placed in it")
 
         tx.deleteDaycareGroupMessageAccount(groupId)
@@ -75,7 +76,7 @@ data class DaycareManager(
 )
 
 data class DaycareGroup(
-    val id: UUID,
+    val id: GroupId,
     val daycareId: UUID,
     val name: String,
     val startDate: LocalDate,
@@ -85,7 +86,7 @@ data class DaycareGroup(
 
 data class DaycareCapacityStats(
     val unitTotalCaretakers: Stats,
-    val groupCaretakers: Map<UUID, Stats>
+    val groupCaretakers: Map<GroupId, Stats>
 )
 
 data class Stats(

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.daycare.isValidDaycareId
 import fi.espoo.evaka.messaging.message.createDaycareGroupMessageAccount
 import fi.espoo.evaka.messaging.message.deleteDaycareGroupMessageAccount
 import fi.espoo.evaka.placement.hasGroupPlacements
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.psqlCause
@@ -23,13 +24,12 @@ import org.jdbi.v3.core.statement.UnableToExecuteStatementException
 import org.postgresql.util.PSQLState
 import org.springframework.stereotype.Service
 import java.time.LocalDate
-import java.util.UUID
 
 @Service
 class DaycareService {
     fun getDaycareCapacityStats(
         tx: Database.Read,
-        daycareId: UUID,
+        daycareId: DaycareId,
         startDate: LocalDate,
         endDate: LocalDate
     ): DaycareCapacityStats {
@@ -42,7 +42,7 @@ class DaycareService {
 
     fun createGroup(
         tx: Database.Transaction,
-        daycareId: UUID,
+        daycareId: DaycareId,
         name: String,
         startDate: LocalDate,
         initialCaretakers: Double
@@ -62,7 +62,7 @@ class DaycareService {
             ?: e
     }
 
-    fun getDaycareGroups(tx: Database.Read, daycareId: UUID, startDate: LocalDate?, endDate: LocalDate?): List<DaycareGroup> {
+    fun getDaycareGroups(tx: Database.Read, daycareId: DaycareId, startDate: LocalDate?, endDate: LocalDate?): List<DaycareGroup> {
         if (!tx.isValidDaycareId(daycareId)) throw NotFound("No daycare found with id $daycareId")
 
         return tx.getDaycareGroups(daycareId, startDate, endDate)
@@ -77,7 +77,7 @@ data class DaycareManager(
 
 data class DaycareGroup(
     val id: GroupId,
-    val daycareId: UUID,
+    val daycareId: DaycareId,
     val name: String,
     val startDate: LocalDate,
     val endDate: LocalDate?,

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceService.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.daycare.service
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.PGConstants.maxDate
@@ -13,11 +14,10 @@ import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters.lastDayOfMonth
-import java.util.UUID
 
 @Service
 class StaffAttendanceService {
-    fun getUnitAttendancesForDate(db: Database.Connection, unitId: UUID, date: LocalDate): UnitStaffAttendance {
+    fun getUnitAttendancesForDate(db: Database.Connection, unitId: DaycareId, date: LocalDate): UnitStaffAttendance {
         return db.read { tx ->
             tx.getUnitStaffAttendanceForDate(unitId, date)
         }
@@ -166,7 +166,7 @@ fun Database.Read.getStaffAttendanceByRange(
         .list()
 }
 
-fun Database.Read.getUnitStaffAttendanceForDate(unitId: UUID, date: LocalDate): UnitStaffAttendance {
+fun Database.Read.getUnitStaffAttendanceForDate(unitId: DaycareId, date: LocalDate): UnitStaffAttendance {
     //language=SQL
     val sql =
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceService.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.daycare.service
 
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.PGConstants.maxDate
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -22,7 +23,7 @@ class StaffAttendanceService {
         }
     }
 
-    fun getGroupAttendancesByMonth(db: Database.Connection, year: Int, month: Int, groupId: UUID): StaffAttendanceForDates {
+    fun getGroupAttendancesByMonth(db: Database.Connection, year: Int, month: Int, groupId: GroupId): StaffAttendanceForDates {
         val rangeStart = LocalDate.of(year, month, 1)
         val rangeEnd = rangeStart.with(lastDayOfMonth())
 
@@ -48,7 +49,7 @@ class StaffAttendanceService {
 }
 
 data class GroupStaffAttendance(
-    val groupId: UUID,
+    val groupId: GroupId,
     val date: LocalDate,
     val count: Double,
     val countOther: Double,
@@ -64,7 +65,7 @@ data class UnitStaffAttendance(
 )
 
 data class StaffAttendanceForDates(
-    val groupId: UUID,
+    val groupId: GroupId,
     val groupName: String,
     val startDate: LocalDate,
     val endDate: LocalDate?,
@@ -72,20 +73,20 @@ data class StaffAttendanceForDates(
 )
 
 data class GroupInfo(
-    val groupId: UUID,
+    val groupId: GroupId,
     val groupName: String,
     val startDate: LocalDate,
     val endDate: LocalDate
 )
 
 data class StaffAttendanceUpdate(
-    val groupId: UUID,
+    val groupId: GroupId,
     val date: LocalDate,
     val count: Double?,
     val countOther: Double?
 )
 
-fun Database.Read.getGroupInfo(groupId: UUID): GroupInfo? {
+fun Database.Read.getGroupInfo(groupId: GroupId): GroupInfo? {
     //language=SQL
     val sql =
         """
@@ -146,7 +147,7 @@ fun Database.Transaction.upsertStaffAttendance(staffAttendance: StaffAttendanceU
 fun Database.Read.getStaffAttendanceByRange(
     rangeStart: LocalDate,
     rangeEnd: LocalDate,
-    groupId: UUID
+    groupId: GroupId
 ): List<GroupStaffAttendance> {
     //language=SQL
     val sql =

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/Decision.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/Decision.kt
@@ -7,12 +7,13 @@ package fi.espoo.evaka.decision
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
 import java.util.UUID
 
 data class Decision(
-    val id: UUID,
+    val id: DecisionId,
     val createdBy: String,
     val type: DecisionType,
     val startDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/Decision.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/Decision.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.decision
 
 import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
@@ -17,7 +18,7 @@ data class Decision(
     val startDate: LocalDate,
     val endDate: LocalDate,
     val unit: DecisionUnit,
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val childId: UUID,
     val childName: String,
     val documentKey: String?,

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/Decision.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/Decision.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.decision
 
 import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
 import java.util.UUID
@@ -45,7 +46,7 @@ data class Decision(
 }
 
 data class DecisionUnit(
-    val id: UUID,
+    val id: DaycareId,
     val name: String,
     val daycareDecisionName: String,
     val preschoolDecisionName: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.application.fetchApplicationDetails
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -81,7 +82,7 @@ class DecisionController(
     fun downloadDecisionPdf(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("id") decisionId: UUID
+        @PathVariable("id") decisionId: DecisionId
     ): ResponseEntity<ByteArray> {
         Audit.DecisionDownloadPdf.log(targetId = decisionId)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.decision
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.application.fetchApplicationDetails
 import fi.espoo.evaka.pis.service.PersonService
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -59,7 +60,7 @@ class DecisionController(
     fun getDecisionsByApplication(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @RequestParam("id") applicationId: UUID
+        @RequestParam("id") applicationId: ApplicationId
     ): ResponseEntity<DecisionListResponse> {
         Audit.DecisionRead.log(targetId = applicationId)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionDraft.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionDraft.kt
@@ -4,12 +4,13 @@
 
 package fi.espoo.evaka.decision
 
+import fi.espoo.evaka.shared.DaycareId
 import java.time.LocalDate
 import java.util.UUID
 
 data class DecisionDraft(
     val id: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val type: DecisionType,
     val startDate: LocalDate,
     val endDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionDraftService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionDraftService.kt
@@ -8,9 +8,11 @@ import fi.espoo.evaka.application.ApplicationDetails
 import fi.espoo.evaka.placement.PlacementPlan
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getPlacementPlan
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getEnum
+import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.NotFound
 import org.springframework.stereotype.Service
 import java.sql.ResultSet
@@ -83,7 +85,7 @@ class DecisionDraftService {
 
     data class DecisionDraftUpdate(
         val id: UUID,
-        val unitId: UUID,
+        val unitId: DaycareId,
         val startDate: LocalDate,
         val endDate: LocalDate,
         val planned: Boolean
@@ -100,7 +102,7 @@ class DecisionDraftService {
             .toList()
     }
 
-    fun getDecisionUnit(tx: Database.Read, unitId: UUID): DecisionUnit {
+    fun getDecisionUnit(tx: Database.Read, unitId: DaycareId): DecisionUnit {
         // language=SQL
         val sql =
             """
@@ -198,7 +200,7 @@ LEFT JOIN unit_manager m ON u.unit_manager_id = m.id
 
 private val toDecisionUnit = { rs: ResultSet ->
     DecisionUnit(
-        id = UUID.fromString(rs.getString("id")),
+        id = DaycareId(rs.getUUID("id")),
         name = rs.getString("name"),
         manager = rs.getString("manager"),
         streetAddress = rs.getString("street_address"),

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionDraftService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionDraftService.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.application.ApplicationDetails
 import fi.espoo.evaka.placement.PlacementPlan
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getPlacementPlan
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
@@ -56,7 +57,7 @@ class DecisionDraftService {
         batch.execute()
     }
 
-    fun updateDecisionDrafts(tx: Database.Transaction, applicationId: UUID, updates: List<DecisionDraftUpdate>) {
+    fun updateDecisionDrafts(tx: Database.Transaction, applicationId: ApplicationId, updates: List<DecisionDraftUpdate>) {
         // language=sql
         val sql =
             """
@@ -171,7 +172,7 @@ class DecisionDraftService {
     }
 }
 
-fun Database.Transaction.clearDecisionDrafts(applicationIds: List<UUID>) {
+fun Database.Transaction.clearDecisionDrafts(applicationIds: List<ApplicationId>) {
     // language=sql
     val sql =
         """DELETE FROM decision WHERE application_id = ANY(:applicationIds) AND sent_date IS NULL""".trimIndent()

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionQueries.kt
@@ -6,10 +6,12 @@ package fi.espoo.evaka.decision
 
 import fi.espoo.evaka.application.ApplicationDecisions
 import fi.espoo.evaka.application.DecisionSummary
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getEnum
+import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.statement.StatementContext
@@ -52,7 +54,7 @@ private fun decisionFromResultSet(rs: ResultSet): Decision = Decision(
     requestedStartDate = rs.getDate("requested_start_date")?.toLocalDate(),
     resolved = rs.getDate("resolved")?.toLocalDate(),
     unit = DecisionUnit(
-        id = UUID.fromString(rs.getString("unit_id")),
+        id = DaycareId(rs.getUUID("unit_id")),
         name = rs.getString("name"),
         daycareDecisionName = rs.getString("decision_daycare_name"),
         preschoolDecisionName = rs.getString("decision_preschool_name"),
@@ -186,7 +188,7 @@ fun Database.Transaction.insertDecision(
     userId: UUID,
     sentDate: LocalDate,
     applicationId: UUID,
-    unitId: UUID,
+    unitId: DaycareId,
     decisionType: String,
     startDate: LocalDate,
     endDate: LocalDate

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.s3.Document
 import fi.espoo.evaka.s3.DocumentLocation
 import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.s3.DocumentWrapper
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyDecisionCreated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -54,7 +55,7 @@ class DecisionService(
     fun finalizeDecisions(
         tx: Database.Transaction,
         user: AuthenticatedUser,
-        applicationId: UUID,
+        applicationId: ApplicationId,
         sendAsMessage: Boolean
     ): List<UUID> {
         val decisionIds = tx.finalizeDecisions(applicationId)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/client/S3DocumentClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/client/S3DocumentClient.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.invoicing.client
 
+import fi.espoo.evaka.shared.FeeDecisionId
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -11,7 +12,6 @@ import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
-import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
 
@@ -43,9 +43,9 @@ class S3DocumentClient(
         logger.debug { "PDF (object name: $key) uploaded to S3 bucket $bucket." }
     }
 
-    private fun getFeeDecisionDocumentKey(decisionId: UUID, lang: String) = "feedecision_${decisionId}_$lang.pdf"
+    private fun getFeeDecisionDocumentKey(decisionId: FeeDecisionId, lang: String) = "feedecision_${decisionId}_$lang.pdf"
 
-    fun uploadFeeDecisionPdf(decisionId: UUID, documentBytes: ByteArray, lang: String): String {
+    fun uploadFeeDecisionPdf(decisionId: FeeDecisionId, documentBytes: ByteArray, lang: String): String {
         val documentKey = getFeeDecisionDocumentKey(decisionId, lang)
 
         logger.debug { "Uploading fee decision PDF for $decisionId to S3." }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionSummary
 import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.invoicing.service.FeeDecisionService
 import fi.espoo.evaka.invoicing.service.FinanceDecisionGenerator
+import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyFeeDecisionApproved
@@ -113,7 +114,7 @@ class FeeDecisionController(
     }
 
     @PostMapping("/confirm")
-    fun confirmDrafts(db: Database.Connection, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
+    fun confirmDrafts(db: Database.Connection, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<FeeDecisionId>): ResponseEntity<Unit> {
         Audit.FeeDecisionConfirm.log(targetId = feeDecisionIds)
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         db.transaction { tx ->
@@ -125,7 +126,7 @@ class FeeDecisionController(
     }
 
     @PostMapping("/mark-sent")
-    fun setSent(db: Database.Connection, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<UUID>): ResponseEntity<Unit> {
+    fun setSent(db: Database.Connection, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<FeeDecisionId>): ResponseEntity<Unit> {
         Audit.FeeDecisionMarkSent.log(targetId = feeDecisionIds)
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         db.transaction { service.setSent(it, feeDecisionIds) }
@@ -133,7 +134,7 @@ class FeeDecisionController(
     }
 
     @GetMapping("/pdf/{uuid}")
-    fun getDecisionPdf(db: Database.Connection, user: AuthenticatedUser, @PathVariable uuid: UUID): ResponseEntity<ByteArray> {
+    fun getDecisionPdf(db: Database.Connection, user: AuthenticatedUser, @PathVariable uuid: FeeDecisionId): ResponseEntity<ByteArray> {
         Audit.FeeDecisionPdfRead.log(targetId = uuid)
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         val headers = HttpHeaders()
@@ -144,7 +145,7 @@ class FeeDecisionController(
     }
 
     @GetMapping("/{uuid}")
-    fun getDecision(db: Database.Connection, user: AuthenticatedUser, @PathVariable uuid: UUID): ResponseEntity<Wrapper<FeeDecisionDetailed>> {
+    fun getDecision(db: Database.Connection, user: AuthenticatedUser, @PathVariable uuid: FeeDecisionId): ResponseEntity<Wrapper<FeeDecisionDetailed>> {
         Audit.FeeDecisionRead.log(targetId = uuid)
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         val res = db.read { it.getFeeDecision(uuid) }
@@ -187,7 +188,7 @@ class FeeDecisionController(
     fun setType(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable uuid: UUID,
+        @PathVariable uuid: FeeDecisionId,
         @RequestBody request: FeeDecisionTypeRequest
     ): ResponseEntity<Unit> {
         Audit.FeeDecisionSetType.log(targetId = uuid)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionSummary
 import fi.espoo.evaka.invoicing.domain.updateEndDatesOrAnnulConflictingDecisions
 import fi.espoo.evaka.invoicing.service.VoucherValueDecisionService
 import fi.espoo.evaka.shared.Paged
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.NotifyVoucherValueDecisionApproved
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -98,7 +99,7 @@ class VoucherValueDecisionController(
     fun getDecision(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable id: UUID
+        @PathVariable id: VoucherValueDecisionId
     ): ResponseEntity<Wrapper<VoucherValueDecisionDetailed>> {
         Audit.VoucherValueDecisionRead.log(targetId = id)
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -108,7 +109,7 @@ class VoucherValueDecisionController(
     }
 
     @PostMapping("/send")
-    fun sendDrafts(db: Database.Connection, user: AuthenticatedUser, @RequestBody decisionIds: List<UUID>): ResponseEntity<Unit> {
+    fun sendDrafts(db: Database.Connection, user: AuthenticatedUser, @RequestBody decisionIds: List<VoucherValueDecisionId>): ResponseEntity<Unit> {
         Audit.VoucherValueDecisionSend.log(targetId = decisionIds)
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         db.transaction {
@@ -125,7 +126,7 @@ class VoucherValueDecisionController(
     }
 
     @PostMapping("/mark-sent")
-    fun markSent(db: Database.Connection, user: AuthenticatedUser, @RequestBody ids: List<UUID>): ResponseEntity<Unit> {
+    fun markSent(db: Database.Connection, user: AuthenticatedUser, @RequestBody ids: List<VoucherValueDecisionId>): ResponseEntity<Unit> {
         Audit.VoucherValueDecisionMarkSent.log(targetId = ids)
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         db.transaction { tx ->
@@ -138,7 +139,7 @@ class VoucherValueDecisionController(
     }
 
     @GetMapping("/pdf/{id}")
-    fun getDecisionPdf(db: Database.Connection, user: AuthenticatedUser, @PathVariable id: UUID): ResponseEntity<ByteArray> {
+    fun getDecisionPdf(db: Database.Connection, user: AuthenticatedUser, @PathVariable id: VoucherValueDecisionId): ResponseEntity<ByteArray> {
         Audit.FeeDecisionPdfRead.log(targetId = id)
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         val (filename, pdf) = db.read { valueDecisionService.getDecisionPdf(it, id) }
@@ -155,7 +156,7 @@ fun sendVoucherValueDecisions(
     asyncJobRunner: AsyncJobRunner,
     user: AuthenticatedUser,
     now: Instant,
-    ids: List<UUID>
+    ids: List<VoucherValueDecisionId>
 ) {
     tx.lockValueDecisions(ids)
     val decisions = tx.getValueDecisionsByIds(ids)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
@@ -8,8 +8,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import fi.espoo.evaka.invoicing.domain.Income
 import fi.espoo.evaka.invoicing.domain.IncomeEffect
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
+import fi.espoo.evaka.shared.db.getNullableUUID
 import fi.espoo.evaka.shared.domain.DateRange
 import org.jdbi.v3.core.statement.StatementContext
 import org.postgresql.util.PGobject
@@ -171,6 +173,6 @@ fun toIncome(objectMapper: ObjectMapper) = { rs: ResultSet, _: StatementContext 
         notes = rs.getString("notes"),
         updatedAt = rs.getTimestamp("updated_at").toInstant(),
         updatedBy = (rs.getString("updated_by_employee")),
-        applicationId = rs.getString("application_id")?.let { UUID.fromString(it) },
+        applicationId = rs.getNullableUUID("application_id")?.let(::ApplicationId),
     )
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FinanceDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FinanceDecisions.kt
@@ -4,12 +4,12 @@
 
 package fi.espoo.evaka.invoicing.domain
 
+import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.domain.DateRange
 import java.time.LocalDate
-import java.util.UUID
 
 interface FinanceDecision<Decision : FinanceDecision<Decision>> {
-    val id: UUID
+    val id: Id<*>
     val validFrom: LocalDate
     val validTo: LocalDate?
     val headOfFamily: PersonData.JustId

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.invoicing.domain
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import fi.espoo.evaka.shared.ApplicationId
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Instant
@@ -25,7 +26,7 @@ data class Income(
     val notes: String,
     val updatedAt: Instant? = null,
     val updatedBy: String? = null,
-    val applicationId: UUID? = null
+    val applicationId: ApplicationId? = null
 ) {
     @JsonProperty("totalIncome")
     fun totalIncome(): Int =

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.invoicing.domain
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.IncomeId
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Instant
@@ -15,7 +16,7 @@ import java.util.UUID
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Income(
-    val id: UUID? = null,
+    val id: IncomeId? = null,
     val personId: UUID,
     val effect: IncomeEffect,
     val data: Map<IncomeType, IncomeValue>,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Placements.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Placements.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.invoicing.domain
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import java.math.BigDecimal
 import java.util.UUID
@@ -27,7 +28,7 @@ sealed class UnitData {
     data class InvoicedByMunicipality(val id: DaycareId, val invoicedByMunicipality: Boolean) : UnitData()
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    data class Detailed(val id: DaycareId, val name: String, val areaId: UUID, val areaName: String, val language: String) : UnitData()
+    data class Detailed(val id: DaycareId, val name: String, val areaId: AreaId, val areaName: String, val language: String) : UnitData()
 }
 
 data class PlacementWithServiceNeed(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Placements.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Placements.kt
@@ -6,31 +6,32 @@ package fi.espoo.evaka.invoicing.domain
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import java.math.BigDecimal
 import java.util.UUID
 
-sealed class Placement(open val unit: UUID)
+sealed class Placement(open val unit: DaycareId)
 
 data class PermanentPlacement(
-    override val unit: UUID,
+    override val unit: DaycareId,
     val type: PlacementType
 ) : Placement(unit)
 
-data class TemporaryPlacement(override val unit: UUID, val partDay: Boolean) : Placement(unit)
+data class TemporaryPlacement(override val unit: DaycareId, val partDay: Boolean) : Placement(unit)
 
 sealed class UnitData {
     @JsonIgnoreProperties(ignoreUnknown = true)
-    data class JustId(val id: UUID) : UnitData()
+    data class JustId(val id: DaycareId) : UnitData()
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    data class InvoicedByMunicipality(val id: UUID, val invoicedByMunicipality: Boolean) : UnitData()
+    data class InvoicedByMunicipality(val id: DaycareId, val invoicedByMunicipality: Boolean) : UnitData()
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    data class Detailed(val id: UUID, val name: String, val areaId: UUID, val areaName: String, val language: String) : UnitData()
+    data class Detailed(val id: DaycareId, val name: String, val areaId: UUID, val areaName: String, val language: String) : UnitData()
 }
 
 data class PlacementWithServiceNeed(
-    val unitId: UUID,
+    val unitId: DaycareId,
     val type: PlacementType,
     val serviceNeed: ServiceNeedValue,
     val missingServiceNeed: Boolean

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Placements.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Placements.kt
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.ServiceNeedId
 import java.math.BigDecimal
-import java.util.UUID
 
 sealed class Placement(open val unit: DaycareId)
 
@@ -39,7 +39,7 @@ data class PlacementWithServiceNeed(
 )
 
 data class ServiceNeedValue(
-    val id: UUID,
+    val id: ServiceNeedId,
     val feeCoefficient: BigDecimal,
     val voucherValueCoefficient: BigDecimal,
     val feeDescriptionFi: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/VoucherValueDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/VoucherValueDecisions.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.invoicing.domain
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.domain.DateRange
 import org.jdbi.v3.core.mapper.Nested
 import org.jdbi.v3.json.Json
@@ -16,7 +17,7 @@ import java.time.ZoneId
 import java.util.UUID
 
 data class VoucherValueDecision(
-    override val id: UUID,
+    override val id: VoucherValueDecisionId,
     override val validFrom: LocalDate,
     override val validTo: LocalDate?,
     @Nested("head_of_family")
@@ -54,7 +55,7 @@ data class VoucherValueDecision(
     val sentAt: Instant? = null,
     val created: Instant = Instant.now()
 ) : FinanceDecision<VoucherValueDecision> {
-    override fun withRandomId() = this.copy(id = UUID.randomUUID())
+    override fun withRandomId() = this.copy(id = VoucherValueDecisionId(UUID.randomUUID()))
     override fun withValidity(period: DateRange) = this.copy(validFrom = period.start, validTo = period.end)
     override fun contentEquals(decision: VoucherValueDecision): Boolean {
         return this.headOfFamily == decision.headOfFamily &&
@@ -97,7 +98,7 @@ enum class VoucherValueDecisionStatus {
 }
 
 data class VoucherValueDecisionDetailed(
-    val id: UUID,
+    val id: VoucherValueDecisionId,
     val validFrom: LocalDate,
     val validTo: LocalDate?,
     val status: VoucherValueDecisionStatus,
@@ -167,7 +168,7 @@ data class VoucherValueDecisionDetailed(
 }
 
 data class VoucherValueDecisionSummary(
-    val id: UUID,
+    val id: VoucherValueDecisionId,
     val validFrom: LocalDate,
     val validTo: LocalDate?,
     val status: VoucherValueDecisionStatus,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGenerator.kt
@@ -31,6 +31,7 @@ import fi.espoo.evaka.invoicing.domain.decisionContentsAreEqual
 import fi.espoo.evaka.invoicing.domain.toFeeAlterationsWithEffects
 import fi.espoo.evaka.placement.Placement
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.DateRange
@@ -180,7 +181,7 @@ private fun generateFeeDecisions2(
             }
 
             period to FeeDecision(
-                id = UUID.randomUUID(),
+                id = FeeDecisionId(UUID.randomUUID()),
                 validDuring = period,
                 status = FeeDecisionStatus.DRAFT,
                 decisionType = FeeDecisionType.NORMAL,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGenerator.kt
@@ -30,6 +30,7 @@ import fi.espoo.evaka.invoicing.domain.calculateFeeBeforeFeeAlterations
 import fi.espoo.evaka.invoicing.domain.decisionContentsAreEqual
 import fi.espoo.evaka.invoicing.domain.toFeeAlterationsWithEffects
 import fi.espoo.evaka.placement.Placement
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.DateRange
@@ -97,7 +98,7 @@ private fun generateFeeDecisions2(
     prices: List<FeeThresholds>,
     incomes: List<Income>,
     feeAlterations: List<FeeAlteration>,
-    invoicedUnits: List<UUID>
+    invoicedUnits: List<DaycareId>
 ): List<FeeDecision> {
     val periods = incomes.map { DateRange(it.validFrom, it.validTo) } +
         prices.map { it.validDuring } +
@@ -196,9 +197,9 @@ private fun generateFeeDecisions2(
         .map { (period, decision) -> decision.withValidity(period) }
 }
 
-private fun Database.Read.getUnitsThatAreInvoiced(): List<UUID> {
+private fun Database.Read.getUnitsThatAreInvoiced(): List<DaycareId> {
     return createQuery("SELECT id FROM daycare WHERE invoiced_by_municipality")
-        .mapTo<UUID>()
+        .mapTo<DaycareId>()
         .toList()
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -26,6 +26,7 @@ import fi.espoo.evaka.invoicing.domain.getProductFromActivity
 import fi.espoo.evaka.invoicing.domain.invoiceRowTotal
 import fi.espoo.evaka.invoicing.domain.merge
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.PGConstants
 import fi.espoo.evaka.shared.db.getEnum
@@ -82,7 +83,7 @@ internal fun generateDraftInvoices(
     decisions: Map<UUID, List<FeeDecision>>,
     placements: Map<UUID, List<Placements>>,
     period: DateRange,
-    daycareCodes: Map<UUID, DaycareCodes>,
+    daycareCodes: Map<DaycareId, DaycareCodes>,
     operationalDays: OperationalDays,
     absences: List<AbsenceStub> = listOf(),
     freeChildren: List<UUID> = listOf()
@@ -115,7 +116,7 @@ internal fun generateDraftInvoice(
     decisions: List<FeeDecision>,
     placements: List<Placements>,
     invoicePeriod: DateRange,
-    daycareCodes: Map<UUID, DaycareCodes>,
+    daycareCodes: Map<DaycareId, DaycareCodes>,
     operationalDays: OperationalDays,
     absences: List<AbsenceStub>,
     freeChildren: List<UUID>
@@ -552,9 +553,9 @@ fun Database.Read.getAbsenceStubs(spanningPeriod: DateRange, careTypes: List<Car
         .toList()
 }
 
-sealed class PlacementStub(open val unit: UUID) {
-    data class Temporary(override val unit: UUID, val partDay: Boolean) : PlacementStub(unit)
-    data class Permanent(override val unit: UUID) : PlacementStub(unit)
+sealed class PlacementStub(open val unit: DaycareId) {
+    data class Temporary(override val unit: DaycareId, val partDay: Boolean) : PlacementStub(unit)
+    data class Permanent(override val unit: DaycareId) : PlacementStub(unit)
 }
 
 data class Placements(
@@ -586,7 +587,7 @@ internal fun Database.Read.getInvoiceablePlacements(
                         rs.getObject("start_date", LocalDate::class.java),
                         rs.getObject("end_date", LocalDate::class.java)
                     ),
-                    rs.getUUID("unit_id"),
+                    DaycareId(rs.getUUID("unit_id")),
                     rs.getEnum<PlacementType>("type")
                 )
             )
@@ -705,7 +706,7 @@ fun Database.Read.getChildrenWithHeadOfFamilies(
         .list()
 }
 
-fun Database.Read.getDaycareCodes(): Map<UUID, DaycareCodes> {
+fun Database.Read.getDaycareCodes(): Map<DaycareId, DaycareCodes> {
     val sql =
         """
         SELECT daycare.id, daycare.cost_center, area.area_code, area.sub_cost_center
@@ -713,7 +714,7 @@ fun Database.Read.getDaycareCodes(): Map<UUID, DaycareCodes> {
     """
     return createQuery(sql)
         .map { rs, _ ->
-            UUID.fromString(rs.getString("id")) to DaycareCodes(
+            DaycareId(rs.getUUID("id")) to DaycareCodes(
                 areaCode = rs.getObject("area_code") as Int?,
                 costCenter = rs.getString("cost_center"),
                 subCostCenter = rs.getString("sub_cost_center")

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
@@ -30,6 +30,7 @@ import fi.espoo.evaka.invoicing.domain.decisionContentsAreEqual
 import fi.espoo.evaka.invoicing.domain.getAgeCoefficient
 import fi.espoo.evaka.invoicing.domain.toFeeAlterationsWithEffects
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.asDistinctPeriods
@@ -169,7 +170,7 @@ private fun generateNewValueDecisions(
                     val value = calculateVoucherValue(baseValue, ageCoefficient, placement.serviceNeed.voucherValueCoefficient)
 
                     period to VoucherValueDecision(
-                        id = UUID.randomUUID(),
+                        id = VoucherValueDecisionId(UUID.randomUUID()),
                         status = VoucherValueDecisionStatus.DRAFT,
                         headOfFamily = headOfFamily,
                         partner = partner,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
@@ -29,8 +29,8 @@ import fi.espoo.evaka.invoicing.domain.calculateVoucherValue
 import fi.espoo.evaka.invoicing.domain.decisionContentsAreEqual
 import fi.espoo.evaka.invoicing.domain.getAgeCoefficient
 import fi.espoo.evaka.invoicing.domain.toFeeAlterationsWithEffects
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.asDistinctPeriods
 import fi.espoo.evaka.shared.domain.mergePeriods
@@ -101,7 +101,7 @@ private fun generateNewValueDecisions(
     voucherValues: List<Pair<DateRange, Int>>,
     incomes: List<Income>,
     feeAlterations: List<FeeAlteration>,
-    serviceVoucherUnits: List<UUID>
+    serviceVoucherUnits: List<DaycareId>
 ): List<VoucherValueDecision> {
     val periods = incomes.map { DateRange(it.validFrom, it.validTo) } +
         prices.map { it.validDuring } +
@@ -204,10 +204,10 @@ private fun generateNewValueDecisions(
         .map { (period, decision) -> decision.withValidity(period) }
 }
 
-private fun Database.Read.getServiceVoucherUnits(): List<UUID> {
+private fun Database.Read.getServiceVoucherUnits(): List<DaycareId> {
     // language=sql
     return createQuery("SELECT id FROM daycare WHERE provider_type = 'PRIVATE_SERVICE_VOUCHER' AND NOT invoiced_by_municipality")
-        .map { rs, _ -> rs.getUUID("id") }
+        .mapTo<DaycareId>()
         .toList()
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.koski
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import org.jdbi.v3.core.kotlin.bindKotlin
@@ -11,7 +12,7 @@ import org.jdbi.v3.core.kotlin.mapTo
 import java.time.LocalDate
 import java.util.UUID
 
-data class KoskiStudyRightKey(val childId: UUID, val unitId: UUID, val type: OpiskeluoikeudenTyyppiKoodi)
+data class KoskiStudyRightKey(val childId: UUID, val unitId: DaycareId, val type: OpiskeluoikeudenTyyppiKoodi)
 
 fun Database.Read.getPendingStudyRights(
     today: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.koski
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.UploadToKoski
 import fi.espoo.evaka.shared.db.Database
@@ -17,7 +18,7 @@ private val logger = KotlinLogging.logger { }
 
 data class KoskiSearchParams(
     val personIds: List<UUID> = listOf(),
-    val daycareIds: List<UUID> = listOf()
+    val daycareIds: List<DaycareId> = listOf()
 )
 
 @Service

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNote.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNote.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.messaging.daycarydailynote
 
+import fi.espoo.evaka.shared.GroupId
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -11,7 +12,7 @@ import java.util.UUID
 data class DaycareDailyNote(
     val id: UUID?,
     val childId: UUID?,
-    val groupId: UUID?,
+    val groupId: GroupId?,
     val date: LocalDate,
     val note: String?,
     val feedingNote: DaycareDailyNoteLevelInfo?,

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNote.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNote.kt
@@ -4,13 +4,14 @@
 
 package fi.espoo.evaka.messaging.daycarydailynote
 
+import fi.espoo.evaka.shared.DaycareDailyNoteId
 import fi.espoo.evaka.shared.GroupId
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
 data class DaycareDailyNote(
-    val id: UUID?,
+    val id: DaycareDailyNoteId?,
     val childId: UUID?,
     val groupId: GroupId?,
     val date: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.messaging.daycarydailynote
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareDailyNoteId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -61,7 +62,7 @@ class DaycareDailyNoteController(
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: DaycareDailyNote
-    ): ResponseEntity<UUID> {
+    ): ResponseEntity<DaycareDailyNoteId> {
         Audit.DaycareDailyNoteCreate.log(user.id)
 
         acl.getRolesForChild(user, childId)
@@ -91,7 +92,7 @@ class DaycareDailyNoteController(
         user: AuthenticatedUser,
         @PathVariable groupId: GroupId,
         @RequestBody body: DaycareDailyNote
-    ): ResponseEntity<UUID> {
+    ): ResponseEntity<DaycareDailyNoteId> {
         Audit.DaycareDailyNoteCreate.log(user.id)
 
         acl.getRolesForUnitGroup(user, groupId)
@@ -119,7 +120,7 @@ class DaycareDailyNoteController(
     fun deleteDailyNote(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable noteId: UUID
+        @PathVariable noteId: DaycareDailyNoteId
     ) {
         Audit.DaycareDailyNoteDelete.log(user.id)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.messaging.daycarydailynote
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -30,7 +31,7 @@ class DaycareDailyNoteController(
     fun getDaycareDailyNotesForGroup(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable groupId: UUID
+        @PathVariable groupId: GroupId
     ): ResponseEntity<List<DaycareDailyNote>> {
         Audit.DaycareDailyNoteRead.log(user.id)
 
@@ -88,7 +89,7 @@ class DaycareDailyNoteController(
     fun createDailyNoteForGroup(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable groupId: UUID,
+        @PathVariable groupId: GroupId,
         @RequestBody body: DaycareDailyNote
     ): ResponseEntity<UUID> {
         Audit.DaycareDailyNoteCreate.log(user.id)
@@ -103,7 +104,7 @@ class DaycareDailyNoteController(
     fun updateDailyNoteForGroup(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable groupId: UUID,
+        @PathVariable groupId: GroupId,
         @RequestBody body: DaycareDailyNote
     ): ResponseEntity<DaycareDailyNote> {
         Audit.DaycareDailyNoteUpdate.log(user.id)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.messaging.daycarydailynote
 
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.kotlin.mapTo
 import java.time.Instant
@@ -59,14 +60,14 @@ WHERE
         .list()
 }
 
-fun Database.Read.getGroupDaycareDailyNotes(groupId: UUID): List<DaycareDailyNote> {
+fun Database.Read.getGroupDaycareDailyNotes(groupId: GroupId): List<DaycareDailyNote> {
     return createQuery("SELECT * FROM daycare_daily_note WHERE group_id = :id")
         .bind("id", groupId)
         .mapTo<DaycareDailyNote>()
         .list()
 }
 
-fun Database.Read.getDaycareDailyNotesForChildrenInGroup(groupId: UUID): List<DaycareDailyNote> {
+fun Database.Read.getDaycareDailyNotesForChildrenInGroup(groupId: GroupId): List<DaycareDailyNote> {
     return createQuery(
         """
 SELECT * FROM daycare_daily_note 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.messaging.daycarydailynote
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.kotlin.mapTo
@@ -17,7 +18,7 @@ fun Database.Read.getChildDaycareDailyNotes(childId: UUID): List<DaycareDailyNot
         .list()
 }
 
-fun Database.Read.getDaycareDailyNotesForChildrenPlacedInUnit(unitId: UUID): List<DaycareDailyNote> {
+fun Database.Read.getDaycareDailyNotesForChildrenPlacedInUnit(unitId: DaycareId): List<DaycareDailyNote> {
     return createQuery(
         """
 SELECT note.* 
@@ -44,7 +45,7 @@ WHERE
         .list()
 }
 
-fun Database.Read.getDaycareDailyNotesForDaycareGroups(unitId: UUID): List<DaycareDailyNote> {
+fun Database.Read.getDaycareDailyNotesForDaycareGroups(unitId: DaycareId): List<DaycareDailyNote> {
     return createQuery(
         """
 SELECT note.* 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/daycarydailynote/DaycareDailyNoteQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.messaging.daycarydailynote
 
+import fi.espoo.evaka.shared.DaycareDailyNoteId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
@@ -90,7 +91,7 @@ WHERE child_id IN (
         .list()
 }
 
-fun Database.Transaction.createDaycareDailyNote(note: DaycareDailyNote): UUID {
+fun Database.Transaction.createDaycareDailyNote(note: DaycareDailyNote): DaycareDailyNoteId {
     return createUpdate(
         """
 INSERT INTO daycare_daily_note (id, child_id, group_id, date, note, feeding_note, sleeping_note, sleeping_minutes, reminders, reminder_note, modified_by, modified_at)
@@ -98,7 +99,7 @@ VALUES(:id, :childId, :groupId, :date, :note, :feedingNote, :sleepingNote, :slee
 RETURNING id
         """.trimIndent()
     )
-        .bind("id", note.id ?: UUID.randomUUID())
+        .bind("id", note.id ?: DaycareDailyNoteId(UUID.randomUUID()))
         .bind("childId", note.childId)
         .bind("groupId", note.groupId)
         .bind("date", note.date)
@@ -111,7 +112,7 @@ RETURNING id
         .bind("modifiedBy", note.modifiedBy)
         .bind("modifiedAt", note.modifiedAt)
         .executeAndReturnGeneratedKeys()
-        .mapTo<UUID>()
+        .mapTo<DaycareDailyNoteId>()
         .first()
 }
 
@@ -150,7 +151,7 @@ RETURNING *
         .first()
 }
 
-fun Database.Transaction.deleteDaycareDailyNote(noteId: UUID) {
+fun Database.Transaction.deleteDaycareDailyNote(noteId: DaycareDailyNoteId) {
     createUpdate("DELETE from daycare_daily_note WHERE id = :noteId")
         .bind("noteId", noteId)
         .execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.messaging.message
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.jdbi.v3.core.mapper.Nested
@@ -69,7 +70,7 @@ data class Group(
     @PropagateNull
     val id: UUID,
     val name: String,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.messaging.message
 
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.jdbi.v3.core.mapper.Nested
 import org.jdbi.v3.core.mapper.PropagateNull
@@ -46,7 +47,7 @@ enum class MessageType {
 }
 
 data class MessageReceiversResponse(
-    val groupId: UUID,
+    val groupId: GroupId,
     val groupName: String,
     val receivers: List<MessageReceiver>
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
@@ -4,11 +4,12 @@
 
 package fi.espoo.evaka.messaging.message
 
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.kotlin.mapTo
 import java.util.UUID
 
-fun Database.Read.getDaycareGroupMessageAccount(daycareGroupId: UUID): UUID {
+fun Database.Read.getDaycareGroupMessageAccount(daycareGroupId: GroupId): UUID {
     val sql = """
 SELECT acc.id FROM message_account acc
 WHERE acc.daycare_group_id = :daycareGroupId AND acc.active = true
@@ -89,7 +90,7 @@ fun Database.Read.getAccountNames(accountIds: Set<UUID>): List<String> {
         .list()
 }
 
-fun Database.Transaction.createDaycareGroupMessageAccount(daycareGroupId: UUID): UUID {
+fun Database.Transaction.createDaycareGroupMessageAccount(daycareGroupId: GroupId): UUID {
     // language=SQL
     val sql = """
         INSERT INTO message_account (daycare_group_id) VALUES (:daycareGroupId)
@@ -101,7 +102,7 @@ fun Database.Transaction.createDaycareGroupMessageAccount(daycareGroupId: UUID):
         .one()
 }
 
-fun Database.Transaction.deleteDaycareGroupMessageAccount(daycareGroupId: UUID) {
+fun Database.Transaction.deleteDaycareGroupMessageAccount(daycareGroupId: GroupId) {
     // language=SQL
     val sql = """
         DELETE FROM message_account WHERE daycare_group_id = :daycareGroupId

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.messaging.message
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -199,7 +200,7 @@ class MessageController(
     fun getReceiversForNewMessage(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @RequestParam unitId: UUID
+        @RequestParam unitId: DaycareId
     ): List<MessageReceiversResponse> {
         Audit.MessagingMessageReceiversRead.log(unitId)
         acl.getRolesForUnit(user, unitId).requireOneOfRoles(

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.messaging.message
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.WithCount
@@ -368,7 +369,7 @@ data class MessageReceiversResult(
 
 fun Database.Read.getReceiversForNewMessage(
     employeeId: UUID,
-    unitId: UUID
+    unitId: DaycareId
 ): List<MessageReceiversResponse> {
     // language=sql
     val sql = """

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.messaging.message
 
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.WithCount
 import fi.espoo.evaka.shared.db.Database
@@ -355,7 +356,7 @@ fun Database.Read.getThreadByMessageId(messageId: UUID): ThreadWithParticipants?
 
 data class MessageReceiversResult(
     val childId: UUID,
-    val groupId: UUID,
+    val groupId: GroupId,
     val groupName: String,
     val childFirstName: String,
     val childLastName: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.occupancy
 import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.daycare.service.getAbsenceCareTypes
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.mapColumn
@@ -43,10 +44,10 @@ data class UnitKey(
 data class UnitGroupKey(
     override val unitId: UUID,
     val unitName: String,
-    val groupId: UUID,
+    val groupId: GroupId,
     val groupName: String
 ) : OccupancyGroupingKey {
-    override val groupingId = groupId
+    override val groupingId = groupId.raw
 }
 
 data class DailyOccupancyValues<K : OccupancyGroupingKey>(
@@ -74,7 +75,7 @@ data class OccupancyPeriod(
 )
 
 data class OccupancyPeriodGroupLevel(
-    val groupId: UUID,
+    val groupId: GroupId,
     val period: FiniteDateRange,
     val sum: Double,
     val headcount: Int,

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.daycare.service.getAbsenceCareTypes
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.mapColumn
@@ -541,7 +542,7 @@ private data class Caretakers<K : OccupancyGroupingKey>(
 
 private data class Placement(
     val groupingId: UUID,
-    val placementId: UUID,
+    val placementId: PlacementId,
     val childId: UUID,
     val unitId: UUID,
     val type: PlacementType,
@@ -562,7 +563,7 @@ private data class Child(
 )
 
 private data class ServiceNeed(
-    val placementId: UUID,
+    val placementId: PlacementId,
     val occupancyCoefficient: BigDecimal,
     val period: FiniteDateRange
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.occupancy
 import fi.espoo.evaka.daycare.service.CareType
 import fi.espoo.evaka.daycare.service.getAbsenceCareTypes
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.Id
@@ -90,7 +91,7 @@ fun Database.Read.calculateDailyUnitOccupancyValues(
     today: LocalDate,
     queryPeriod: FiniteDateRange,
     type: OccupancyType,
-    areaId: UUID? = null,
+    areaId: AreaId? = null,
     unitId: DaycareId? = null
 ): List<DailyOccupancyValues<UnitKey>> {
     if (areaId == null && unitId == null) error("Must provide areaId or unitId")
@@ -120,7 +121,7 @@ fun Database.Read.calculateDailyGroupOccupancyValues(
     today: LocalDate,
     queryPeriod: FiniteDateRange,
     type: OccupancyType,
-    areaId: UUID? = null,
+    areaId: AreaId? = null,
     unitId: DaycareId? = null
 ): List<DailyOccupancyValues<UnitGroupKey>> {
     if (areaId == null && unitId == null) error("Must provide areaId or unitId")
@@ -195,7 +196,7 @@ private fun getAndValidatePeriod(
 private inline fun <reified K : OccupancyGroupingKey> Database.Read.getCaretakers(
     type: OccupancyType,
     period: FiniteDateRange,
-    areaId: UUID?,
+    areaId: AreaId?,
     unitId: DaycareId?,
     noinline mapper: (RowView) -> Caretakers<K>
 ): Map<K, List<Caretakers<K>>> {

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.occupancy
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -20,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.util.UUID
 
 @RestController
 @RequestMapping("/occupancy")
@@ -29,7 +29,7 @@ class OccupancyController(private val acl: AccessControlList) {
     fun getOccupancyPeriods(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID,
+        @PathVariable unitId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
         @RequestParam type: OccupancyType
@@ -54,7 +54,7 @@ class OccupancyController(private val acl: AccessControlList) {
     fun getOccupancyPeriodsOnGroups(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID,
+        @PathVariable unitId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
         @RequestParam type: OccupancyType
@@ -104,7 +104,7 @@ data class OccupancyResponse(
  * - assistance need coefficient = X, or default = 1.0
  */
 fun Database.Read.calculateOccupancyPeriods(
-    unitId: UUID,
+    unitId: DaycareId,
     period: FiniteDateRange,
     type: OccupancyType
 ): List<OccupancyPeriod> {
@@ -118,7 +118,7 @@ fun Database.Read.calculateOccupancyPeriods(
 }
 
 fun Database.Read.calculateOccupancyPeriodsGroupLevel(
-    unitId: UUID,
+    unitId: DaycareId,
     period: FiniteDateRange,
     type: OccupancyType
 ): List<OccupancyPeriodGroupLevel> {

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.occupancy
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -84,7 +85,7 @@ class OccupancyController(private val acl: AccessControlList) {
 }
 
 data class OccupancyResponseGroupLevel(
-    val groupId: UUID,
+    val groupId: GroupId,
     val occupancies: OccupancyResponse
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDeviceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDeviceQueries.kt
@@ -5,13 +5,14 @@
 package fi.espoo.evaka.pairing
 
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.updateExactlyOne
 import fi.espoo.evaka.shared.domain.NotFound
 import org.jdbi.v3.core.kotlin.mapTo
 import java.util.UUID
 
-fun Database.Read.getDevice(id: UUID): MobileDevice {
+fun Database.Read.getDevice(id: MobileDeviceId): MobileDevice {
     // language=sql
     val sql = "SELECT * FROM mobile_device WHERE id = :id AND deleted = false"
     return createQuery(sql)
@@ -34,7 +35,7 @@ fun Database.Read.listDevices(unitId: DaycareId): List<MobileDevice> {
         .list()
 }
 
-fun Database.Transaction.renameDevice(id: UUID, name: String) {
+fun Database.Transaction.renameDevice(id: MobileDeviceId, name: String) {
     // language=sql
     val deviceUpdate = "UPDATE mobile_device SET name = :name WHERE id = :id"
     createUpdate(deviceUpdate)
@@ -50,7 +51,7 @@ fun Database.Transaction.renameDevice(id: UUID, name: String) {
         .execute()
 }
 
-fun Database.Transaction.softDeleteDevice(id: UUID) {
+fun Database.Transaction.softDeleteDevice(id: MobileDeviceId) {
     // language=sql
     val sql = "UPDATE mobile_device SET deleted = true WHERE id = :id"
     createUpdate(sql).bind("id", id).execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDeviceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDeviceQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.pairing
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.updateExactlyOne
 import fi.espoo.evaka.shared.domain.NotFound
@@ -24,7 +25,7 @@ fun Database.Read.getDeviceByToken(token: UUID): MobileDeviceIdentity = createQu
 ).bind("token", token).mapTo<MobileDeviceIdentity>().singleOrNull()
     ?: throw NotFound("Device not found with token $token")
 
-fun Database.Read.listDevices(unitId: UUID): List<MobileDevice> {
+fun Database.Read.listDevices(unitId: DaycareId): List<MobileDevice> {
     // language=sql
     val sql = "SELECT * FROM mobile_device WHERE unit_id = :unitId AND deleted = false"
     return createQuery(sql)

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.pairing
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -27,7 +28,7 @@ class MobileDevicesController(
     fun getMobileDevices(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @RequestParam unitId: UUID
+        @RequestParam unitId: DaycareId
     ): ResponseEntity<List<MobileDevice>> {
         Audit.MobileDevicesList.log(targetId = unitId)
         acl.getRolesForUnit(user, unitId).requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.pairing
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -18,7 +19,6 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 class MobileDevicesController(
@@ -41,7 +41,7 @@ class MobileDevicesController(
     fun getMobileDevice(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable id: UUID
+        @PathVariable id: MobileDeviceId
     ): ResponseEntity<MobileDevice> {
         Audit.MobileDevicesRead.log(targetId = id)
         user.assertSystemInternalUser()
@@ -58,7 +58,7 @@ class MobileDevicesController(
     fun putMobileDeviceName(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable id: UUID,
+        @PathVariable id: MobileDeviceId,
         @RequestBody body: RenameRequest
     ): ResponseEntity<Unit> {
         Audit.MobileDevicesRename.log(targetId = id)
@@ -72,7 +72,7 @@ class MobileDevicesController(
     fun deleteMobileDevice(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable id: UUID
+        @PathVariable id: MobileDeviceId
     ): ResponseEntity<Unit> {
         Audit.MobileDevicesDelete.log(targetId = id)
         acl.getRolesForMobileDevice(user, id).requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/Pairing.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/Pairing.kt
@@ -4,12 +4,13 @@
 
 package fi.espoo.evaka.pairing
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.util.UUID
 
 data class Pairing(
     val id: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val challengeKey: String,
     val responseKey: String?,
     val expires: HelsinkiDateTime,
@@ -24,7 +25,7 @@ enum class PairingStatus {
 data class MobileDevice(
     val id: UUID,
     val name: String,
-    val unitId: UUID
+    val unitId: DaycareId
 )
 
 data class MobileDeviceIdentity(val id: UUID, val longTermToken: UUID)

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/Pairing.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/Pairing.kt
@@ -6,11 +6,12 @@ package fi.espoo.evaka.pairing
 
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.MobileDeviceId
+import fi.espoo.evaka.shared.PairingId
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.util.UUID
 
 data class Pairing(
-    val id: UUID,
+    val id: PairingId,
     val unitId: DaycareId,
     val challengeKey: String,
     val responseKey: String?,

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/Pairing.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/Pairing.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.pairing
 
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.util.UUID
 
@@ -15,7 +16,7 @@ data class Pairing(
     val responseKey: String?,
     val expires: HelsinkiDateTime,
     val status: PairingStatus,
-    val mobileDeviceId: UUID? = null
+    val mobileDeviceId: MobileDeviceId? = null
 )
 
 enum class PairingStatus {
@@ -23,9 +24,9 @@ enum class PairingStatus {
 }
 
 data class MobileDevice(
-    val id: UUID,
+    val id: MobileDeviceId,
     val name: String,
     val unitId: DaycareId
 )
 
-data class MobileDeviceIdentity(val id: UUID, val longTermToken: UUID)
+data class MobileDeviceIdentity(val id: MobileDeviceId, val longTermToken: UUID)

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.pairing
 
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.PairingId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
@@ -50,7 +51,7 @@ fun Database.Transaction.challengePairing(challengeKey: String): Pairing {
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
 }
 
-fun Database.Transaction.respondPairingChallengeCreateDevice(id: UUID, challengeKey: String, responseKey: String): Pairing {
+fun Database.Transaction.respondPairingChallengeCreateDevice(id: PairingId, challengeKey: String, responseKey: String): Pairing {
     val defaultDeviceName = "Nimeämätön laite"
 
     // language=sql
@@ -90,7 +91,7 @@ fun Database.Transaction.respondPairingChallengeCreateDevice(id: UUID, challenge
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
 }
 
-fun Database.Transaction.validatePairing(id: UUID, challengeKey: String, responseKey: String): MobileDeviceIdentity {
+fun Database.Transaction.validatePairing(id: PairingId, challengeKey: String, responseKey: String): MobileDeviceIdentity {
     // language=sql
     val sql =
         """
@@ -115,7 +116,7 @@ RETURNING id, long_term_token
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
 }
 
-fun Database.Read.fetchPairingStatus(id: UUID): PairingStatus {
+fun Database.Read.fetchPairingStatus(id: PairingId): PairingStatus {
     // language=sql
     val sql =
         """
@@ -132,7 +133,7 @@ fun Database.Read.fetchPairingStatus(id: UUID): PairingStatus {
         .firstOrNull() ?: throw NotFound("Valid pairing not found")
 }
 
-fun Database.Transaction.incrementAttempts(id: UUID, challengeKey: String) {
+fun Database.Transaction.incrementAttempts(id: PairingId, challengeKey: String) {
     // language=sql
     val sql =
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.pairing
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
@@ -14,7 +15,7 @@ import java.util.UUID
 const val maxAttempts = 100 // additional brute-force protection
 const val expiresInMinutes = 60L
 
-fun Database.Transaction.initPairing(unitId: UUID): Pairing {
+fun Database.Transaction.initPairing(unitId: DaycareId): Pairing {
     // language=sql
     val sql =
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.pairing
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GarbageCollectPairing
 import fi.espoo.evaka.shared.auth.AccessControlList
@@ -34,7 +35,7 @@ class PairingsController(
      * Pairing status is WAITING_CHALLENGE.
      */
     data class PostPairingReq(
-        val unitId: UUID
+        val unitId: DaycareId
     )
     @PostMapping("/pairings")
     fun postPairing(

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.pairing
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.PairingId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GarbageCollectPairing
 import fi.espoo.evaka.shared.auth.AccessControlList
@@ -20,7 +21,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 class PairingsController(
@@ -96,7 +96,7 @@ class PairingsController(
     fun postPairingResponse(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable id: UUID,
+        @PathVariable id: PairingId,
         @RequestBody body: PostPairingResponseReq
     ): ResponseEntity<Pairing> {
         Audit.PairingResponse.log(targetId = id)
@@ -128,7 +128,7 @@ class PairingsController(
     @PostMapping("/system/pairings/{id}/validation")
     fun postPairingValidation(
         db: Database.Connection,
-        @PathVariable id: UUID,
+        @PathVariable id: PairingId,
         @RequestBody body: PostPairingValidationReq
     ): ResponseEntity<MobileDeviceIdentity> {
         Audit.PairingValidation.log(targetId = id)
@@ -151,7 +151,7 @@ class PairingsController(
     @GetMapping("/public/pairings/{id}/status")
     fun getPairingStatus(
         db: Database.Connection,
-        @PathVariable id: UUID
+        @PathVariable id: PairingId
     ): ResponseEntity<PairingStatusRes> {
         Audit.PairingStatusRead.log(targetId = id)
         return db

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.pis
 
 import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.pis.controllers.PinCode
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -36,7 +37,7 @@ data class EmployeeUser(
 )
 
 data class DaycareRole(
-    val daycareId: UUID,
+    val daycareId: DaycareId,
     val daycareName: String,
     val role: UserRole
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/ParentshipQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/ParentshipQueries.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.pis
 
 import fi.espoo.evaka.pis.service.Parentship
 import fi.espoo.evaka.pis.service.PersonJSON
+import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.getUUID
@@ -17,7 +18,7 @@ import java.sql.ResultSet
 import java.time.LocalDate
 import java.util.UUID
 
-fun Database.Read.getParentship(id: UUID): Parentship? {
+fun Database.Read.getParentship(id: ParentshipId): Parentship? {
     // language=SQL
     val sql =
         """
@@ -105,7 +106,7 @@ fun Database.Transaction.createParentship(
         .first()
 }
 
-fun Database.Transaction.updateParentshipDuration(id: UUID, startDate: LocalDate, endDate: LocalDate): Boolean {
+fun Database.Transaction.updateParentshipDuration(id: ParentshipId, startDate: LocalDate, endDate: LocalDate): Boolean {
     // language=sql
     val sql = "UPDATE fridge_child SET start_date = :startDate, end_date = :endDate WHERE id = :id"
 
@@ -116,7 +117,7 @@ fun Database.Transaction.updateParentshipDuration(id: UUID, startDate: LocalDate
         .execute() > 0
 }
 
-fun Database.Transaction.retryParentship(id: UUID) {
+fun Database.Transaction.retryParentship(id: ParentshipId) {
     // language=SQL
     val sql = "UPDATE fridge_child SET conflict = false WHERE id = :id"
     createUpdate(sql)
@@ -124,7 +125,7 @@ fun Database.Transaction.retryParentship(id: UUID) {
         .execute()
 }
 
-fun Database.Transaction.deleteParentship(id: UUID): Boolean {
+fun Database.Transaction.deleteParentship(id: ParentshipId): Boolean {
     // language=SQL
     val sql = "DELETE FROM fridge_child WHERE id = :id RETURNING id"
 
@@ -164,7 +165,7 @@ private val personColumns = listOf(
 private val toParentship: (String, String) -> (ResultSet, StatementContext) -> Parentship = { childAlias, headAlias ->
     { rs, _ ->
         Parentship(
-            id = rs.getUUID("id"),
+            id = ParentshipId(rs.getUUID("id")),
             childId = rs.getUUID("child_id"),
             child = toPersonJSON(childAlias, rs),
             headOfChildId = rs.getUUID("head_of_child"),

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.pis.getParentship
 import fi.espoo.evaka.pis.getParentships
 import fi.espoo.evaka.pis.service.Parentship
 import fi.espoo.evaka.pis.service.ParentshipService
+import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -86,7 +87,7 @@ class ParentshipController(
     fun getParentship(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable(value = "id") id: UUID
+        @PathVariable(value = "id") id: ParentshipId
     ): ResponseEntity<Parentship> {
         Audit.ParentShipsRead.log(targetId = id)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
@@ -102,7 +103,7 @@ class ParentshipController(
     fun updateParentship(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable(value = "id") id: UUID,
+        @PathVariable(value = "id") id: ParentshipId,
         @RequestBody body: ParentshipUpdateRequest
     ): ResponseEntity<Parentship> {
         Audit.ParentShipsUpdate.log(targetId = id)
@@ -124,7 +125,7 @@ class ParentshipController(
     fun retryPartnership(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable(value = "id") parentshipId: UUID
+        @PathVariable(value = "id") parentshipId: ParentshipId
     ): ResponseEntity<Unit> {
         Audit.ParentShipsRetry.log(targetId = parentshipId)
         user.requireOneOfRoles(
@@ -143,7 +144,7 @@ class ParentshipController(
     fun deleteParentship(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable(value = "id") id: UUID
+        @PathVariable(value = "id") id: ParentshipId
     ): ResponseEntity<Unit> {
         Audit.ParentShipsDelete.log(targetId = id)
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.pis.getPartnership
 import fi.espoo.evaka.pis.getPartnershipsForPerson
 import fi.espoo.evaka.pis.service.Partnership
 import fi.espoo.evaka.pis.service.PartnershipService
+import fi.espoo.evaka.shared.PartnershipId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -77,7 +78,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
     fun getPartnership(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable(value = "id") partnershipId: UUID
+        @PathVariable(value = "id") partnershipId: PartnershipId
     ): ResponseEntity<Partnership> {
         Audit.PartnerShipsRead.log(targetId = partnershipId)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
@@ -91,7 +92,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
     fun updatePartnership(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable(value = "id") partnershipId: UUID,
+        @PathVariable(value = "id") partnershipId: PartnershipId,
         @RequestBody body: PartnershipUpdateRequest
     ): ResponseEntity<Partnership> {
         Audit.PartnerShipsUpdate.log(targetId = partnershipId)
@@ -119,7 +120,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
     fun retryPartnership(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable(value = "id") partnershipId: UUID
+        @PathVariable(value = "id") partnershipId: PartnershipId
     ): ResponseEntity<Unit> {
         Audit.PartnerShipsRetry.log(targetId = partnershipId)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
@@ -142,7 +143,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
     fun deletePartnership(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable(value = "id") partnershipId: UUID
+        @PathVariable(value = "id") partnershipId: PartnershipId
     ): ResponseEntity<Unit> {
         Audit.PartnerShipsDelete.log(targetId = partnershipId)
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyOverviewService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyOverviewService.kt
@@ -11,7 +11,9 @@ import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.invoicing.domain.getTotalIncome
 import fi.espoo.evaka.invoicing.domain.getTotalIncomeEffect
 import fi.espoo.evaka.invoicing.domain.incomeTotal
+import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.db.getNullableUUID
 import fi.espoo.evaka.shared.domain.NotFound
 import org.springframework.stereotype.Service
 import java.sql.ResultSet
@@ -129,7 +131,7 @@ data class FamilyOverviewPerson(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val incomeTotal: Int? = null,
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val incomeId: UUID? = null,
+    val incomeId: IncomeId? = null,
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val incomeEffect: IncomeEffect? = null
 )
@@ -145,7 +147,7 @@ fun toFamilyOverviewPerson(rs: ResultSet, objectMapper: ObjectMapper): FamilyOve
         postalCode = rs.getString("postal_code"),
         postOffice = rs.getString("post_office"),
         headOfChild = rs.getString("head_of_child")?.let { UUID.fromString(it) },
-        incomeId = rs.getString("income_id")?.let { UUID.fromString(it) },
+        incomeId = rs.getNullableUUID("income_id")?.let(::IncomeId),
         incomeEffect = rs.getString("income_effect")?.let { IncomeEffect.valueOf(it) },
         incomeTotal = rs.getString("income_data")?.let { incomeTotal(objectMapper.readValue(it)) }
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/ParentshipService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/ParentshipService.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.pis.getParentship
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.pis.retryParentship
 import fi.espoo.evaka.pis.updateParentshipDuration
+import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.db.Database
@@ -42,7 +43,7 @@ class ParentshipService(private val asyncJobRunner: AsyncJobRunner) {
         }
     }
 
-    fun updateParentshipDuration(tx: Database.Transaction, id: UUID, startDate: LocalDate, endDate: LocalDate): Parentship {
+    fun updateParentshipDuration(tx: Database.Transaction, id: ParentshipId, startDate: LocalDate, endDate: LocalDate): Parentship {
         val oldParentship = tx.getParentship(id) ?: throw NotFound("No parentship found with id $id")
         validateDates(oldParentship.child.dateOfBirth, startDate, endDate)
         try {
@@ -61,7 +62,7 @@ class ParentshipService(private val asyncJobRunner: AsyncJobRunner) {
         return oldParentship.copy(startDate = startDate, endDate = endDate)
     }
 
-    fun retryParentship(tx: Database.Transaction, id: UUID) {
+    fun retryParentship(tx: Database.Transaction, id: ParentshipId) {
         try {
             tx.getParentship(id)
                 ?.takeIf { it.conflict }
@@ -78,7 +79,7 @@ class ParentshipService(private val asyncJobRunner: AsyncJobRunner) {
         }
     }
 
-    fun deleteParentship(tx: Database.Transaction, id: UUID) {
+    fun deleteParentship(tx: Database.Transaction, id: ParentshipId) {
         val parentship = tx.getParentship(id)
         val success = tx.deleteParentship(id)
         if (parentship == null || !success) throw NotFound("No parentship found with id $id")
@@ -105,7 +106,7 @@ private fun validateDates(childDateOfBirth: LocalDate, startDate: LocalDate, end
 }
 
 data class Parentship(
-    val id: UUID,
+    val id: ParentshipId,
     val childId: UUID,
     val child: PersonJSON,
     val headOfChildId: UUID,

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PartnershipService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PartnershipService.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.pis.deletePartnership
 import fi.espoo.evaka.pis.getPartnership
 import fi.espoo.evaka.pis.retryPartnership
 import fi.espoo.evaka.pis.updatePartnershipDuration
+import fi.espoo.evaka.shared.PartnershipId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
 import fi.espoo.evaka.shared.domain.NotFound
@@ -35,7 +36,7 @@ class PartnershipService {
 
     fun updatePartnershipDuration(
         tx: Database.Transaction,
-        partnershipId: UUID,
+        partnershipId: PartnershipId,
         startDate: LocalDate,
         endDate: LocalDate?
     ): Partnership {
@@ -51,7 +52,7 @@ class PartnershipService {
         return partnership.copy(startDate = startDate, endDate = endDate)
     }
 
-    fun retryPartnership(tx: Database.Transaction, partnershipId: UUID): Partnership? {
+    fun retryPartnership(tx: Database.Transaction, partnershipId: PartnershipId): Partnership? {
         return try {
             tx.getPartnership(partnershipId)
                 ?.takeIf { it.conflict }
@@ -61,7 +62,7 @@ class PartnershipService {
         }
     }
 
-    fun deletePartnership(tx: Database.Transaction, partnershipId: UUID): Partnership? {
+    fun deletePartnership(tx: Database.Transaction, partnershipId: PartnershipId): Partnership? {
         return tx.getPartnership(partnershipId)?.also {
             tx.deletePartnership(partnershipId)
         }
@@ -69,7 +70,7 @@ class PartnershipService {
 }
 
 data class Partnership(
-    val id: UUID,
+    val id: PartnershipId,
     val partners: Set<PersonJSON>,
     val startDate: LocalDate,
     val endDate: LocalDate?,
@@ -77,7 +78,7 @@ data class Partnership(
 )
 
 data class Partner(
-    val partnershipId: UUID,
+    val partnershipId: PartnershipId,
     val person: PersonJSON,
     val startDate: LocalDate,
     val endDate: LocalDate?,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/Placement.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/Placement.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.placement
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import java.time.LocalDate
 import java.util.UUID
@@ -12,7 +13,7 @@ data class Placement(
     val id: PlacementId,
     val type: PlacementType,
     val childId: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val startDate: LocalDate,
     val endDate: LocalDate
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/Placement.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/Placement.kt
@@ -4,11 +4,12 @@
 
 package fi.espoo.evaka.placement
 
+import fi.espoo.evaka.shared.PlacementId
 import java.time.LocalDate
 import java.util.UUID
 
 data class Placement(
-    val id: UUID,
+    val id: PlacementId,
     val type: PlacementType,
     val childId: UUID,
     val unitId: UUID,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.daycare.controllers.utils.noContent
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.daycare.createChild
 import fi.espoo.evaka.daycare.getChild
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -52,7 +53,7 @@ class PlacementController(
     fun getPlacements(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @RequestParam(value = "daycareId", required = false) daycareId: UUID? = null,
+        @RequestParam(value = "daycareId", required = false) daycareId: DaycareId? = null,
         @RequestParam(value = "childId", required = false) childId: UUID? = null,
         @RequestParam(
             value = "from",
@@ -87,7 +88,7 @@ class PlacementController(
     fun getPlacementPlans(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @RequestParam(value = "daycareId", required = true) daycareId: UUID,
+        @RequestParam(value = "daycareId", required = true) daycareId: DaycareId,
         @RequestParam(
             value = "from",
             required = false
@@ -256,7 +257,7 @@ class PlacementController(
 data class PlacementCreateRequestBody(
     val type: PlacementType,
     val childId: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val startDate: LocalDate,
     val endDate: LocalDate
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.daycare.controllers.utils.noContent
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.daycare.createChild
 import fi.espoo.evaka.daycare.getChild
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.auth.AccessControlList
@@ -265,12 +266,12 @@ data class PlacementUpdateRequestBody(
 )
 
 data class GroupPlacementRequestBody(
-    val groupId: UUID,
+    val groupId: GroupId,
     val startDate: LocalDate,
     val endDate: LocalDate
 )
 
 data class GroupTransferRequestBody(
-    val groupId: UUID,
+    val groupId: GroupId,
     val startDate: LocalDate
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.daycare.createChild
 import fi.espoo.evaka.daycare.getChild
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.auth.AccessControlList
@@ -145,7 +146,7 @@ class PlacementController(
     fun updatePlacementById(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("placementId") placementId: UUID,
+        @PathVariable("placementId") placementId: PlacementId,
         @RequestBody body: PlacementUpdateRequestBody
     ): ResponseEntity<Unit> {
         Audit.PlacementUpdate.log(targetId = placementId)
@@ -177,7 +178,7 @@ class PlacementController(
     fun deletePlacement(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("placementId") placementId: UUID
+        @PathVariable("placementId") placementId: PlacementId
     ): ResponseEntity<Unit> {
         Audit.PlacementCancel.log(targetId = placementId)
         acl.getRolesForPlacement(user, placementId)
@@ -199,7 +200,7 @@ class PlacementController(
     fun createGroupPlacement(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("placementId") placementId: UUID,
+        @PathVariable("placementId") placementId: PlacementId,
         @RequestBody body: GroupPlacementRequestBody
     ): ResponseEntity<UUID> {
         Audit.DaycareGroupPlacementCreate.log(targetId = placementId, objectId = body.groupId)
@@ -222,7 +223,7 @@ class PlacementController(
     fun deleteGroupPlacement(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycarePlacementId") daycarePlacementId: UUID,
+        @PathVariable("daycarePlacementId") daycarePlacementId: PlacementId,
         @PathVariable("groupPlacementId") groupPlacementId: UUID
     ): ResponseEntity<Unit> {
         Audit.DaycareGroupPlacementDelete.log(targetId = groupPlacementId)
@@ -238,7 +239,7 @@ class PlacementController(
     fun transferGroupPlacement(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable("daycarePlacementId") daycarePlacementId: UUID,
+        @PathVariable("daycarePlacementId") daycarePlacementId: PlacementId,
         @PathVariable("groupPlacementId") groupPlacementId: UUID,
         @RequestBody body: GroupTransferRequestBody
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.daycare.createChild
 import fi.espoo.evaka.daycare.getChild
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
@@ -203,7 +204,7 @@ class PlacementController(
         user: AuthenticatedUser,
         @PathVariable("placementId") placementId: PlacementId,
         @RequestBody body: GroupPlacementRequestBody
-    ): ResponseEntity<UUID> {
+    ): ResponseEntity<GroupPlacementId> {
         Audit.DaycareGroupPlacementCreate.log(targetId = placementId, objectId = body.groupId)
         acl.getRolesForPlacement(user, placementId)
             .requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
@@ -225,7 +226,7 @@ class PlacementController(
         db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycarePlacementId") daycarePlacementId: PlacementId,
-        @PathVariable("groupPlacementId") groupPlacementId: UUID
+        @PathVariable("groupPlacementId") groupPlacementId: GroupPlacementId
     ): ResponseEntity<Unit> {
         Audit.DaycareGroupPlacementDelete.log(targetId = groupPlacementId)
         acl.getRolesForPlacement(user, daycarePlacementId)
@@ -241,7 +242,7 @@ class PlacementController(
         db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable("daycarePlacementId") daycarePlacementId: PlacementId,
-        @PathVariable("groupPlacementId") groupPlacementId: UUID,
+        @PathVariable("groupPlacementId") groupPlacementId: GroupPlacementId,
         @RequestBody body: GroupTransferRequestBody
     ): ResponseEntity<Unit> {
         Audit.DaycareGroupPlacementTransfer.log(targetId = groupPlacementId)

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlan.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlan.kt
@@ -4,13 +4,14 @@
 
 package fi.espoo.evaka.placement
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
 import java.util.UUID
 
 data class PlacementPlan(
     val id: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val applicationId: UUID,
     val type: PlacementType,
     val period: FiniteDateRange,
@@ -19,7 +20,7 @@ data class PlacementPlan(
 
 data class PlacementPlanDetails(
     val id: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val applicationId: UUID,
     val type: PlacementType,
     val period: FiniteDateRange,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlan.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlan.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.placement
 
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
@@ -12,7 +13,7 @@ import java.util.UUID
 data class PlacementPlan(
     val id: UUID,
     val unitId: DaycareId,
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val type: PlacementType,
     val period: FiniteDateRange,
     val preschoolDaycarePeriod: FiniteDateRange?
@@ -21,7 +22,7 @@ data class PlacementPlan(
 data class PlacementPlanDetails(
     val id: UUID,
     val unitId: DaycareId,
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val type: PlacementType,
     val period: FiniteDateRange,
     val preschoolDaycarePeriod: FiniteDateRange?,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlan.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlan.kt
@@ -6,12 +6,13 @@ package fi.espoo.evaka.placement
 
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.PlacementPlanId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
 import java.util.UUID
 
 data class PlacementPlan(
-    val id: UUID,
+    val id: PlacementPlanId,
     val unitId: DaycareId,
     val applicationId: ApplicationId,
     val type: PlacementType,
@@ -20,7 +21,7 @@ data class PlacementPlan(
 )
 
 data class PlacementPlanDetails(
-    val id: UUID,
+    val id: PlacementPlanId,
     val unitId: DaycareId,
     val applicationId: ApplicationId,
     val type: PlacementType,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanDraft.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanDraft.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.placement
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
@@ -20,7 +21,7 @@ data class PlacementPlanDraft(
 )
 
 data class PlacementDraftChild(val id: UUID, val firstName: String, val lastName: String, val dob: LocalDate)
-data class PlacementDraftUnit(val id: UUID, val name: String)
+data class PlacementDraftUnit(val id: DaycareId, val name: String)
 
 data class PlacementDraftPlacement(
     val id: PlacementId,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanDraft.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanDraft.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.placement
 
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
 import java.util.UUID
@@ -22,7 +23,7 @@ data class PlacementDraftChild(val id: UUID, val firstName: String, val lastName
 data class PlacementDraftUnit(val id: UUID, val name: String)
 
 data class PlacementDraftPlacement(
-    val id: UUID,
+    val id: PlacementId,
     val type: PlacementType,
     val childId: UUID,
     val unit: PlacementDraftUnit,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanQueries.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.placement
 
 import fi.espoo.evaka.application.ApplicationStatus
 import fi.espoo.evaka.application.DaycarePlacementPlan
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -14,14 +15,14 @@ import org.jdbi.v3.core.kotlin.mapTo
 import java.time.LocalDate
 import java.util.UUID
 
-fun Database.Transaction.deletePlacementPlans(applicationIds: List<UUID>) {
+fun Database.Transaction.deletePlacementPlans(applicationIds: List<ApplicationId>) {
     execute(
         "DELETE FROM placement_plan WHERE application_id = ANY(?)",
         applicationIds.toTypedArray()
     )
 }
 
-fun Database.Transaction.softDeletePlacementPlanIfUnused(applicationId: UUID) {
+fun Database.Transaction.softDeletePlacementPlanIfUnused(applicationId: ApplicationId) {
     createUpdate(
         // language=SQL
         """
@@ -38,7 +39,7 @@ AND NOT EXISTS (
 }
 
 fun Database.Transaction.createPlacementPlan(
-    applicationId: UUID,
+    applicationId: ApplicationId,
     type: PlacementType,
     plan: DaycarePlacementPlan
 ) {
@@ -66,11 +67,11 @@ VALUES (
         .execute()
 }
 
-fun Database.Read.getPlacementPlan(applicationId: UUID): PlacementPlan? {
+fun Database.Read.getPlacementPlan(applicationId: ApplicationId): PlacementPlan? {
     data class QueryResult(
         val id: UUID,
         val unitId: DaycareId,
-        val applicationId: UUID,
+        val applicationId: ApplicationId,
         val type: PlacementType,
         val startDate: LocalDate,
         val endDate: LocalDate,
@@ -102,7 +103,7 @@ WHERE application_id = :applicationId AND deleted = false
         }
 }
 
-fun Database.Read.getPlacementPlanUnitName(applicationId: UUID): String {
+fun Database.Read.getPlacementPlanUnitName(applicationId: ApplicationId): String {
     return createQuery(
         // language=SQL
         """
@@ -121,7 +122,7 @@ fun Database.Read.getPlacementPlans(unitId: DaycareId, from: LocalDate?, to: Loc
     data class QueryResult(
         val id: UUID,
         val unitId: DaycareId,
-        val applicationId: UUID,
+        val applicationId: ApplicationId,
         val type: PlacementType,
         val startDate: LocalDate,
         val endDate: LocalDate,
@@ -180,7 +181,7 @@ WHERE unit_id = :unitId AND a.status = ANY(:statuses::application_status_type[])
 }
 
 fun Database.Transaction.updatePlacementPlanUnitConfirmation(
-    applicationId: UUID,
+    applicationId: ApplicationId,
     status: PlacementPlanConfirmationStatus,
     rejectReason: PlacementPlanRejectReason?,
     rejectOtherReason: String?

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanQueries.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.application.ApplicationStatus
 import fi.espoo.evaka.application.DaycarePlacementPlan
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.PlacementPlanId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.NotFound
@@ -69,7 +70,7 @@ VALUES (
 
 fun Database.Read.getPlacementPlan(applicationId: ApplicationId): PlacementPlan? {
     data class QueryResult(
-        val id: UUID,
+        val id: PlacementPlanId,
         val unitId: DaycareId,
         val applicationId: ApplicationId,
         val type: PlacementType,
@@ -120,7 +121,7 @@ WHERE application_id = :applicationId AND deleted = false
 
 fun Database.Read.getPlacementPlans(unitId: DaycareId, from: LocalDate?, to: LocalDate?, statuses: List<ApplicationStatus> = ApplicationStatus.values().asList()): List<PlacementPlanDetails> {
     data class QueryResult(
-        val id: UUID,
+        val id: PlacementPlanId,
         val unitId: DaycareId,
         val applicationId: ApplicationId,
         val type: PlacementType,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanQueries.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.placement
 
 import fi.espoo.evaka.application.ApplicationStatus
 import fi.espoo.evaka.application.DaycarePlacementPlan
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.NotFound
@@ -68,7 +69,7 @@ VALUES (
 fun Database.Read.getPlacementPlan(applicationId: UUID): PlacementPlan? {
     data class QueryResult(
         val id: UUID,
-        val unitId: UUID,
+        val unitId: DaycareId,
         val applicationId: UUID,
         val type: PlacementType,
         val startDate: LocalDate,
@@ -116,10 +117,10 @@ WHERE application_id = :applicationId AND deleted = false
         .orElseThrow { NotFound("Placement plan for application $applicationId not found") }
 }
 
-fun Database.Read.getPlacementPlans(unitId: UUID, from: LocalDate?, to: LocalDate?, statuses: List<ApplicationStatus> = ApplicationStatus.values().asList()): List<PlacementPlanDetails> {
+fun Database.Read.getPlacementPlans(unitId: DaycareId, from: LocalDate?, to: LocalDate?, statuses: List<ApplicationStatus> = ApplicationStatus.values().asList()): List<PlacementPlanDetails> {
     data class QueryResult(
         val id: UUID,
-        val unitId: UUID,
+        val unitId: DaycareId,
         val applicationId: UUID,
         val type: PlacementType,
         val startDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.application.DaycarePlacementPlan
 import fi.espoo.evaka.application.fetchApplicationDetails
 import fi.espoo.evaka.daycare.getActiveClubTermAt
 import fi.espoo.evaka.daycare.getActivePreschoolTermAt
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
@@ -29,7 +30,7 @@ class PlacementPlanService(
 ) {
     private val useFiveYearsOldDaycare = env.getProperty("fi.espoo.evaka.five_years_old_daycare.enabled", Boolean::class.java, true)
 
-    fun getPlacementPlanDraft(tx: Database.Read, applicationId: UUID): PlacementPlanDraft {
+    fun getPlacementPlanDraft(tx: Database.Read, applicationId: ApplicationId): PlacementPlanDraft {
         val application = tx.fetchApplicationDetails(applicationId)
             ?: throw NotFound("Application $applicationId not found")
 
@@ -105,7 +106,7 @@ class PlacementPlanService(
         }
     }
 
-    fun softDeleteUnusedPlacementPlanByApplication(tx: Database.Transaction, applicationId: UUID) =
+    fun softDeleteUnusedPlacementPlanByApplication(tx: Database.Transaction, applicationId: ApplicationId) =
         tx.softDeletePlacementPlanIfUnused(applicationId)
 
     fun createPlacementPlan(tx: Database.Transaction, application: ApplicationDetails, placementPlan: DaycarePlacementPlan) =

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.application.DaycarePlacementPlan
 import fi.espoo.evaka.application.fetchApplicationDetails
 import fi.espoo.evaka.daycare.getActiveClubTermAt
 import fi.espoo.evaka.daycare.getActivePreschoolTermAt
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.db.Database
@@ -201,7 +202,7 @@ class PlacementPlanService(
         }
     }
 
-    fun isSvebiUnit(tx: Database.Read, unitId: UUID): Boolean {
+    fun isSvebiUnit(tx: Database.Read, unitId: DaycareId): Boolean {
         return tx.createQuery(
             """
             SELECT ca.short_name = 'svenska-bildningstjanster' AS is_svebi

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.placement
 
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.PGConstants
@@ -302,7 +303,7 @@ fun Database.Read.getDaycarePlacement(id: PlacementId): DaycarePlacement? {
         .firstOrNull()
 }
 
-fun Database.Read.getDaycareGroupPlacement(id: UUID): DaycareGroupPlacement? {
+fun Database.Read.getDaycareGroupPlacement(id: GroupPlacementId): DaycareGroupPlacement? {
     // language=SQL
     val sql =
         """
@@ -445,7 +446,7 @@ fun Database.Transaction.createGroupPlacement(
     groupId: GroupId,
     startDate: LocalDate,
     endDate: LocalDate
-): UUID {
+): GroupPlacementId {
     // language=SQL
     val sql =
         """
@@ -459,11 +460,11 @@ fun Database.Transaction.createGroupPlacement(
         .bind("groupId", groupId)
         .bind("startDate", startDate)
         .bind("endDate", endDate)
-        .mapTo<UUID>()
+        .mapTo<GroupPlacementId>()
         .one()
 }
 
-fun Database.Transaction.updateGroupPlacementStartDate(id: UUID, startDate: LocalDate): Boolean {
+fun Database.Transaction.updateGroupPlacementStartDate(id: GroupPlacementId, startDate: LocalDate): Boolean {
     // language=SQL
     val sql = "UPDATE daycare_group_placement SET start_date = :startDate WHERE id = :id RETURNING id"
 
@@ -474,24 +475,24 @@ fun Database.Transaction.updateGroupPlacementStartDate(id: UUID, startDate: Loca
         .firstOrNull() != null
 }
 
-fun Database.Transaction.updateGroupPlacementEndDate(id: UUID, endDate: LocalDate): Boolean {
+fun Database.Transaction.updateGroupPlacementEndDate(id: GroupPlacementId, endDate: LocalDate): Boolean {
     // language=SQL
     val sql = "UPDATE daycare_group_placement SET end_date = :endDate WHERE id = :id RETURNING id"
 
     return createQuery(sql)
         .bind("id", id)
         .bind("endDate", endDate)
-        .mapTo<UUID>()
+        .mapTo<GroupPlacementId>()
         .firstOrNull() != null
 }
 
-fun Database.Transaction.deleteGroupPlacement(id: UUID): Boolean {
+fun Database.Transaction.deleteGroupPlacement(id: GroupPlacementId): Boolean {
     // language=SQL
     val sql = "DELETE FROM daycare_group_placement WHERE id = :id RETURNING id"
 
     return createQuery(sql)
         .bind("id", id)
-        .mapTo<UUID>()
+        .mapTo<GroupPlacementId>()
         .firstOrNull() != null
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.placement
 
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.PGConstants
 import fi.espoo.evaka.shared.db.bindNullable
@@ -323,7 +324,7 @@ fun Database.Read.getDaycareGroupPlacement(id: UUID): DaycareGroupPlacement? {
 
 fun Database.Read.getIdenticalPrecedingGroupPlacement(
     daycarePlacementId: UUID,
-    groupId: UUID,
+    groupId: GroupId,
     startDate: LocalDate
 ): DaycareGroupPlacement? {
     // language=SQL
@@ -351,7 +352,7 @@ fun Database.Read.getIdenticalPrecedingGroupPlacement(
 
 fun Database.Read.getIdenticalPostcedingGroupPlacement(
     daycarePlacementId: UUID,
-    groupId: UUID,
+    groupId: GroupId,
     endDate: LocalDate
 ): DaycareGroupPlacement? {
     // language=SQL
@@ -377,7 +378,7 @@ fun Database.Read.getIdenticalPostcedingGroupPlacement(
         .firstOrNull()
 }
 
-fun Database.Read.hasGroupPlacements(groupId: UUID): Boolean = createQuery(
+fun Database.Read.hasGroupPlacements(groupId: GroupId): Boolean = createQuery(
     "SELECT EXISTS (SELECT 1 FROM daycare_group_placement WHERE daycare_group_id = :groupId)"
 )
     .bind("groupId", groupId)
@@ -439,7 +440,7 @@ fun Database.Read.getChildGroupPlacements(
 
 fun Database.Transaction.createGroupPlacement(
     placementId: UUID,
-    groupId: UUID,
+    groupId: GroupId,
     startDate: LocalDate,
     endDate: LocalDate
 ): UUID {

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.placement
 
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.PGConstants
 import fi.espoo.evaka.shared.db.bindNullable
@@ -25,7 +26,7 @@ private val placementSelector =
         FROM placement p
     """.trimIndent()
 
-fun Database.Read.getPlacement(id: UUID): Placement? {
+fun Database.Read.getPlacement(id: PlacementId): Placement? {
     return createQuery("$placementSelector WHERE p.id = :id")
         .bind("id", id)
         .mapTo<Placement>()
@@ -34,7 +35,7 @@ fun Database.Read.getPlacement(id: UUID): Placement? {
 
 fun Database.Read.getPlacementDraftPlacements(childId: UUID): List<PlacementDraftPlacement> {
     data class QueryResult(
-        val id: UUID,
+        val id: PlacementId,
         val type: PlacementType,
         val childId: UUID,
         val unitId: UUID,
@@ -108,7 +109,7 @@ fun Database.Transaction.insertPlacement(
         .first()
 }
 
-fun Database.Transaction.updatePlacementStartDate(placementId: UUID, date: LocalDate) {
+fun Database.Transaction.updatePlacementStartDate(placementId: PlacementId, date: LocalDate) {
     createUpdate(
         //language=SQL
         """
@@ -120,7 +121,7 @@ fun Database.Transaction.updatePlacementStartDate(placementId: UUID, date: Local
         .execute()
 }
 
-fun Database.Transaction.updatePlacementEndDate(placementId: UUID, date: LocalDate) {
+fun Database.Transaction.updatePlacementEndDate(placementId: PlacementId, date: LocalDate) {
     createUpdate(
         //language=SQL
         """
@@ -132,7 +133,7 @@ fun Database.Transaction.updatePlacementEndDate(placementId: UUID, date: LocalDa
         .execute()
 }
 
-fun Database.Transaction.updatePlacementStartAndEndDate(placementId: UUID, startDate: LocalDate, endDate: LocalDate) {
+fun Database.Transaction.updatePlacementStartAndEndDate(placementId: PlacementId, startDate: LocalDate, endDate: LocalDate) {
     createUpdate("UPDATE placement SET start_date = :start, end_date = :end WHERE id = :id")
         .bind("id", placementId)
         .bind("start", startDate)
@@ -140,7 +141,7 @@ fun Database.Transaction.updatePlacementStartAndEndDate(placementId: UUID, start
         .execute()
 }
 
-fun Database.Transaction.cancelPlacement(id: UUID): Triple<UUID, LocalDate, LocalDate> {
+fun Database.Transaction.cancelPlacement(id: PlacementId): Triple<UUID, LocalDate, LocalDate> {
     data class QueryResult(
         val childId: UUID,
         val startDate: LocalDate,
@@ -181,7 +182,7 @@ fun Database.Transaction.cancelPlacement(id: UUID): Triple<UUID, LocalDate, Loca
         }
 }
 
-fun Database.Transaction.clearGroupPlacementsAfter(placementId: UUID, date: LocalDate) {
+fun Database.Transaction.clearGroupPlacementsAfter(placementId: PlacementId, date: LocalDate) {
     createUpdate(
         //language=SQL
         """
@@ -205,7 +206,7 @@ fun Database.Transaction.clearGroupPlacementsAfter(placementId: UUID, date: Loca
         .execute()
 }
 
-fun Database.Transaction.clearGroupPlacementsBefore(placementId: UUID, date: LocalDate) {
+fun Database.Transaction.clearGroupPlacementsBefore(placementId: PlacementId, date: LocalDate) {
     createUpdate(
         //language=SQL
         """
@@ -269,7 +270,7 @@ fun Database.Read.getDaycarePlacements(
         .toList()
 }
 
-fun Database.Read.getDaycarePlacement(id: UUID): DaycarePlacement? {
+fun Database.Read.getDaycarePlacement(id: PlacementId): DaycarePlacement? {
     // language=SQL
     val sql =
         """
@@ -323,7 +324,7 @@ fun Database.Read.getDaycareGroupPlacement(id: UUID): DaycareGroupPlacement? {
 }
 
 fun Database.Read.getIdenticalPrecedingGroupPlacement(
-    daycarePlacementId: UUID,
+    daycarePlacementId: PlacementId,
     groupId: GroupId,
     startDate: LocalDate
 ): DaycareGroupPlacement? {
@@ -351,7 +352,7 @@ fun Database.Read.getIdenticalPrecedingGroupPlacement(
 }
 
 fun Database.Read.getIdenticalPostcedingGroupPlacement(
-    daycarePlacementId: UUID,
+    daycarePlacementId: PlacementId,
     groupId: GroupId,
     endDate: LocalDate
 ): DaycareGroupPlacement? {
@@ -439,7 +440,7 @@ fun Database.Read.getChildGroupPlacements(
 }
 
 fun Database.Transaction.createGroupPlacement(
-    placementId: UUID,
+    placementId: PlacementId,
     groupId: GroupId,
     startDate: LocalDate,
     endDate: LocalDate
@@ -495,7 +496,7 @@ fun Database.Transaction.deleteGroupPlacement(id: UUID): Boolean {
 
 private val toDaycarePlacement: (ResultSet, StatementContext) -> DaycarePlacement = { rs, _ ->
     DaycarePlacement(
-        id = rs.getUUID("placement_id"),
+        id = PlacementId(rs.getUUID("placement_id")),
         child = ChildBasics(
             id = rs.getUUID("child_id"),
             socialSecurityNumber = rs.getString("child_ssn"),
@@ -517,7 +518,7 @@ private val toDaycarePlacement: (ResultSet, StatementContext) -> DaycarePlacemen
 
 private val toDaycarePlacementDetails: (ResultSet, StatementContext) -> DaycarePlacementDetails = { rs, _ ->
     DaycarePlacementDetails(
-        id = rs.getUUID("id"),
+        id = PlacementId(rs.getUUID("id")),
         child = ChildBasics(
             id = rs.getUUID("child_id"),
             socialSecurityNumber = rs.getString("social_security_number"),

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.placement
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
@@ -38,7 +39,7 @@ fun Database.Read.getPlacementDraftPlacements(childId: UUID): List<PlacementDraf
         val id: PlacementId,
         val type: PlacementType,
         val childId: UUID,
-        val unitId: UUID,
+        val unitId: DaycareId,
         val unitName: String,
         val startDate: LocalDate,
         val endDate: LocalDate
@@ -88,7 +89,7 @@ fun Database.Read.getPlacementsForChildDuring(childId: UUID, start: LocalDate, e
 fun Database.Transaction.insertPlacement(
     type: PlacementType,
     childId: UUID,
-    unitId: UUID,
+    unitId: DaycareId,
     startDate: LocalDate,
     endDate: LocalDate
 ): Placement {
@@ -231,7 +232,7 @@ fun Database.Transaction.clearGroupPlacementsBefore(placementId: PlacementId, da
 }
 
 fun Database.Read.getDaycarePlacements(
-    daycareId: UUID?,
+    daycareId: DaycareId?,
     childId: UUID?,
     startDate: LocalDate?,
     endDate: LocalDate?
@@ -386,7 +387,7 @@ fun Database.Read.hasGroupPlacements(groupId: GroupId): Boolean = createQuery(
     .mapTo<Boolean>()
     .one()
 
-fun Database.Read.getGroupPlacementsAtDaycare(daycareId: UUID, placementRange: DateRange): List<DaycareGroupPlacement> {
+fun Database.Read.getGroupPlacementsAtDaycare(daycareId: DaycareId, placementRange: DateRange): List<DaycareGroupPlacement> {
     // language=SQL
     val sql =
         """
@@ -505,7 +506,7 @@ private val toDaycarePlacement: (ResultSet, StatementContext) -> DaycarePlacemen
             dateOfBirth = rs.getDate("child_date_of_birth").toLocalDate()
         ),
         daycare = DaycareBasics(
-            id = rs.getUUID("unit_id"),
+            id = DaycareId(rs.getUUID("unit_id")),
             name = rs.getString("unit_name"),
             area = rs.getString("area_name"),
             providerType = rs.getEnum("provider_type")
@@ -527,7 +528,7 @@ private val toDaycarePlacementDetails: (ResultSet, StatementContext) -> DaycareP
             dateOfBirth = rs.getDate("date_of_birth").toLocalDate()
         ),
         daycare = DaycareBasics(
-            id = rs.getUUID("unit_id"),
+            id = DaycareId(rs.getUUID("unit_id")),
             name = rs.getString("daycare_name"),
             area = rs.getString("area_name"),
             providerType = rs.getEnum("provider_type")

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.serviceneed.ServiceNeed
 import fi.espoo.evaka.serviceneed.clearServiceNeedsFromPeriod
 import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
 import fi.espoo.evaka.serviceneed.getServiceNeedsByUnit
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
@@ -95,7 +96,7 @@ fun Database.Transaction.updatePlacement(
 
 fun Database.Transaction.checkAndCreateGroupPlacement(
     daycarePlacementId: UUID,
-    groupId: UUID,
+    groupId: GroupId,
     startDate: LocalDate,
     endDate: LocalDate
 ): UUID {
@@ -139,7 +140,7 @@ fun Database.Transaction.checkAndCreateGroupPlacement(
     }
 }
 
-fun Database.Transaction.transferGroup(daycarePlacementId: UUID, groupPlacementId: UUID, groupId: UUID, startDate: LocalDate) {
+fun Database.Transaction.transferGroup(daycarePlacementId: UUID, groupPlacementId: UUID, groupId: GroupId, startDate: LocalDate) {
     val groupPlacement = getDaycareGroupPlacement(groupPlacementId)
         ?: throw NotFound("Group placement not found")
 
@@ -484,7 +485,7 @@ data class DaycarePlacementWithDetails(
 
 data class DaycareGroupPlacement(
     val id: UUID?,
-    val groupId: UUID?,
+    val groupId: GroupId?,
     val groupName: String?,
     val daycarePlacementId: UUID,
     val startDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
 import fi.espoo.evaka.serviceneed.getServiceNeedsByUnit
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.db.Database
@@ -101,7 +102,7 @@ fun Database.Transaction.checkAndCreateGroupPlacement(
     groupId: GroupId,
     startDate: LocalDate,
     endDate: LocalDate
-): UUID {
+): GroupPlacementId {
     if (endDate.isBefore(startDate))
         throw BadRequest("Must not end before even starting")
 
@@ -142,7 +143,7 @@ fun Database.Transaction.checkAndCreateGroupPlacement(
     }
 }
 
-fun Database.Transaction.transferGroup(daycarePlacementId: PlacementId, groupPlacementId: UUID, groupId: GroupId, startDate: LocalDate) {
+fun Database.Transaction.transferGroup(daycarePlacementId: PlacementId, groupPlacementId: GroupPlacementId, groupId: GroupId, startDate: LocalDate) {
     val groupPlacement = getDaycareGroupPlacement(groupPlacementId)
         ?: throw NotFound("Group placement not found")
 
@@ -486,7 +487,7 @@ data class DaycarePlacementWithDetails(
 )
 
 data class DaycareGroupPlacement(
-    val id: UUID?,
+    val id: GroupPlacementId?,
     val groupId: GroupId?,
     val groupName: String?,
     val daycarePlacementId: PlacementId,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.serviceneed.clearServiceNeedsFromPeriod
 import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
 import fi.espoo.evaka.serviceneed.getServiceNeedsByUnit
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
@@ -48,7 +49,7 @@ fun createPlacement(
 }
 
 fun Database.Transaction.updatePlacement(
-    id: UUID,
+    id: PlacementId,
     startDate: LocalDate,
     endDate: LocalDate,
     aclAuth: AclAuthorization = AclAuthorization.All,
@@ -95,7 +96,7 @@ fun Database.Transaction.updatePlacement(
 }
 
 fun Database.Transaction.checkAndCreateGroupPlacement(
-    daycarePlacementId: UUID,
+    daycarePlacementId: PlacementId,
     groupId: GroupId,
     startDate: LocalDate,
     endDate: LocalDate
@@ -140,7 +141,7 @@ fun Database.Transaction.checkAndCreateGroupPlacement(
     }
 }
 
-fun Database.Transaction.transferGroup(daycarePlacementId: UUID, groupPlacementId: UUID, groupId: GroupId, startDate: LocalDate) {
+fun Database.Transaction.transferGroup(daycarePlacementId: PlacementId, groupPlacementId: UUID, groupId: GroupId, startDate: LocalDate) {
     val groupPlacement = getDaycareGroupPlacement(groupPlacementId)
         ?: throw NotFound("Group placement not found")
 
@@ -169,7 +170,7 @@ fun Database.Transaction.transferGroup(daycarePlacementId: UUID, groupPlacementI
     createGroupPlacement(daycarePlacementId, groupId, startDate, groupPlacement.endDate)
 }
 
-private fun Database.Transaction.clearOldPlacements(childId: UUID, from: LocalDate, to: LocalDate, excludePlacement: UUID? = null, aclAuth: AclAuthorization = AclAuthorization.All) {
+private fun Database.Transaction.clearOldPlacements(childId: UUID, from: LocalDate, to: LocalDate, excludePlacement: PlacementId? = null, aclAuth: AclAuthorization = AclAuthorization.All) {
     if (from.isAfter(to)) throw IllegalArgumentException("inverted range")
 
     getPlacementsForChildDuring(childId, from, to)
@@ -358,7 +359,7 @@ fun getMissingGroupPlacements(
 ): List<MissingGroupPlacement> {
     data class GroupPlacementGap(
         val backup: Boolean,
-        val placementId: UUID,
+        val placementId: PlacementId,
         val placementType: PlacementType?,
         val placementRange: FiniteDateRange,
         val childId: UUID,
@@ -368,7 +369,7 @@ fun getMissingGroupPlacements(
     val evakaLaunch = LocalDate.of(2020, 3, 1)
 
     data class PlacementResult(
-        val id: UUID,
+        val id: PlacementId,
         val type: PlacementType,
         val range: FiniteDateRange,
         val childId: UUID,
@@ -452,7 +453,7 @@ fun getMissingGroupPlacements(
 }
 
 data class DaycarePlacement(
-    val id: UUID,
+    val id: PlacementId,
     val child: ChildBasics,
     val daycare: DaycareBasics,
     val startDate: LocalDate,
@@ -461,7 +462,7 @@ data class DaycarePlacement(
 )
 
 data class DaycarePlacementDetails(
-    val id: UUID,
+    val id: PlacementId,
     val child: ChildBasics,
     val daycare: DaycareBasics,
     val startDate: LocalDate,
@@ -471,7 +472,7 @@ data class DaycarePlacementDetails(
 )
 
 data class DaycarePlacementWithDetails(
-    val id: UUID,
+    val id: PlacementId,
     val child: ChildBasics,
     val daycare: DaycareBasics,
     val startDate: LocalDate,
@@ -487,13 +488,13 @@ data class DaycareGroupPlacement(
     val id: UUID?,
     val groupId: GroupId?,
     val groupName: String?,
-    val daycarePlacementId: UUID,
+    val daycarePlacementId: PlacementId,
     val startDate: LocalDate,
     val endDate: LocalDate
 )
 
 data class MissingGroupPlacement(
-    val placementId: UUID,
+    val placementId: PlacementId,
     val placementType: PlacementType?, // null for backup care
     val backup: Boolean,
     val placementPeriod: FiniteDateRange,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.serviceneed.ServiceNeed
 import fi.espoo.evaka.serviceneed.clearServiceNeedsFromPeriod
 import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
 import fi.espoo.evaka.serviceneed.getServiceNeedsByUnit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AclAuthorization
@@ -30,7 +31,7 @@ fun createPlacement(
     tx: Database.Transaction,
     type: PlacementType,
     childId: UUID,
-    unitId: UUID,
+    unitId: DaycareId,
     startDate: LocalDate,
     endDate: LocalDate,
     useFiveYearsOldDaycare: Boolean
@@ -248,7 +249,7 @@ private fun checkAclAuth(aclAuth: AclAuthorization, placement: Placement) {
 }
 
 fun Database.Read.getDetailedDaycarePlacements(
-    daycareId: UUID?,
+    daycareId: DaycareId?,
     childId: UUID?,
     startDate: LocalDate?,
     endDate: LocalDate?
@@ -355,7 +356,7 @@ private fun handleFiveYearOldDaycare(tx: Database.Transaction, childId: UUID, ty
 
 fun getMissingGroupPlacements(
     tx: Database.Read,
-    unitId: UUID
+    unitId: DaycareId
 ): List<MissingGroupPlacement> {
     data class GroupPlacementGap(
         val backup: Boolean,
@@ -514,7 +515,7 @@ data class ChildBasics(
 )
 
 data class DaycareBasics(
-    val id: UUID,
+    val id: DaycareId,
     val name: String,
     val area: String,
     val providerType: ProviderType

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.util.UUID
 
 @RestController
 class ApplicationsReportController {
@@ -78,7 +78,7 @@ private fun Database.Read.getApplicationsRows(from: LocalDate, to: LocalDate): L
         .map { rs, _ ->
             ApplicationsReportRow(
                 careAreaName = rs.getString("care_area_name"),
-                unitId = rs.getUUID("unit_id"),
+                unitId = DaycareId(rs.getUUID("unit_id")),
                 unitName = rs.getString("unit_name"),
                 unitProviderType = rs.getString("provider_type"),
                 under3Years = rs.getInt("under_3_years_count"),
@@ -93,7 +93,7 @@ private fun Database.Read.getApplicationsRows(from: LocalDate, to: LocalDate): L
 
 data class ApplicationsReportRow(
     val careAreaName: String,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val unitProviderType: String,
     val under3Years: Int,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
@@ -19,7 +20,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.util.UUID
 
 @RestController
 class AssistanceNeedsAndActionsReportController(private val acl: AccessControlList) {
@@ -97,7 +97,7 @@ fun Database.Read.getAssistanceNeedsAndActionsReportRows(date: LocalDate, author
         .map { rs, _ ->
             AssistanceNeedsAndActionsReportRow(
                 careAreaName = rs.getString("care_area_name"),
-                unitId = rs.getUUID("unit_id"),
+                unitId = DaycareId(rs.getUUID("unit_id")),
                 unitName = rs.getString("unit_name"),
                 groupId = GroupId(rs.getUUID("group_id")),
                 groupName = rs.getString("group_name"),
@@ -134,7 +134,7 @@ fun Database.Read.getAssistanceNeedsAndActionsReportRows(date: LocalDate, author
 
 data class AssistanceNeedsAndActionsReportRow(
     val careAreaName: String,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val groupId: GroupId,
     val groupName: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -98,7 +99,7 @@ fun Database.Read.getAssistanceNeedsAndActionsReportRows(date: LocalDate, author
                 careAreaName = rs.getString("care_area_name"),
                 unitId = rs.getUUID("unit_id"),
                 unitName = rs.getString("unit_name"),
-                groupId = rs.getUUID("group_id"),
+                groupId = GroupId(rs.getUUID("group_id")),
                 groupName = rs.getString("group_name"),
                 unitType = (rs.getArray("unit_type").array as Array<out Any>).map { it.toString() }.toSet().let(::getPrimaryUnitType),
                 unitProviderType = rs.getString("unit_provider_type"),
@@ -135,7 +136,7 @@ data class AssistanceNeedsAndActionsReportRow(
     val careAreaName: String,
     val unitId: UUID,
     val unitName: String,
-    val groupId: UUID,
+    val groupId: GroupId,
     val groupName: String,
     val unitType: UnitType?,
     val unitProviderType: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -18,7 +19,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.util.UUID
 
 @RestController
 class ChildAgeLanguageReportController(private val acl: AccessControlList) {
@@ -95,7 +95,7 @@ private fun Database.Read.getChildAgeLanguageRows(date: LocalDate, authorizedUni
         .map { rs, _ ->
             ChildAgeLanguageReportRow(
                 careAreaName = rs.getString("care_area_name"),
-                unitId = rs.getUUID("unit_id"),
+                unitId = DaycareId(rs.getUUID("unit_id")),
                 unitName = rs.getString("unit_name"),
                 unitType = (rs.getArray("unit_type").array as Array<out Any>).map { it.toString() }.toSet().let(::getPrimaryUnitType),
                 unitProviderType = rs.getString("unit_provider_type"),
@@ -133,7 +133,7 @@ private fun Database.Read.getChildAgeLanguageRows(date: LocalDate, authorizedUni
 
 data class ChildAgeLanguageReportRow(
     val careAreaName: String,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val unitType: UnitType?,
     val unitProviderType: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -75,7 +76,7 @@ private fun Database.Read.getChildrenInDifferentAddressRows(authorizedUnits: Acl
         .map { rs, _ ->
             ChildrenInDifferentAddressReportRow(
                 careAreaName = rs.getString("care_area_name"),
-                unitId = rs.getUUID("unit_id"),
+                unitId = DaycareId(rs.getUUID("unit_id")),
                 unitName = rs.getString("unit_name"),
                 parentId = rs.getUUID("person_id_parent"),
                 firstNameParent = rs.getString("first_name_parent"),
@@ -92,7 +93,7 @@ private fun Database.Read.getChildrenInDifferentAddressRows(authorizedUnits: Acl
 
 data class ChildrenInDifferentAddressReportRow(
     val careAreaName: String,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val parentId: UUID,
     val firstNameParent: String?,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DecisionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DecisionsReport.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.util.UUID
 
 @RestController
 class DecisionsReportController {
@@ -92,7 +92,7 @@ private fun Database.Read.getDecisionsRows(from: LocalDate, to: LocalDate): List
 
 data class DecisionsReportRow(
     val careAreaName: String,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val providerType: String,
     val daycareUnder3: Int,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -77,7 +78,7 @@ private fun Database.Read.getFamilyConflicts(authorizedUnits: AclAuthorization):
         .map { rs, _ ->
             FamilyConflictReportRow(
                 careAreaName = rs.getString("care_area_name"),
-                unitId = rs.getUUID("unit_id"),
+                unitId = DaycareId(rs.getUUID("unit_id")),
                 unitName = rs.getString("unit_name"),
                 id = rs.getUUID("id"),
                 firstName = rs.getString("first_name"),
@@ -92,7 +93,7 @@ private fun Database.Read.getFamilyConflicts(authorizedUnits: AclAuthorization):
 
 data class FamilyConflictReportRow(
     val careAreaName: String,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val id: UUID,
     val firstName: String?,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -23,7 +24,7 @@ class FamilyContactReportController(private val acl: AccessControlList) {
     fun getFamilyContactsReport(
         db: Database,
         user: AuthenticatedUser,
-        @RequestParam unitId: UUID
+        @RequestParam unitId: DaycareId
     ): ResponseEntity<List<FamilyContactReportRow>> {
         Audit.FamilyContactReportRead.log()
         acl.getRolesForUnit(user, unitId).requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)
@@ -31,7 +32,7 @@ class FamilyContactReportController(private val acl: AccessControlList) {
     }
 }
 
-private fun Database.Read.getFamilyContacts(unitId: UUID): List<FamilyContactReportRow> {
+private fun Database.Read.getFamilyContacts(unitId: DaycareId): List<FamilyContactReportRow> {
     // language=sql
     val sql =
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -86,7 +87,7 @@ private fun Database.Read.getMissingHeadOfFamilyRows(
         .map { rs, _ ->
             MissingHeadOfFamilyReportRow(
                 careAreaName = rs.getString("care_area_name"),
-                unitId = rs.getUUID("unit_id"),
+                unitId = DaycareId(rs.getUUID("unit_id")),
                 unitName = rs.getString("unit_name"),
                 childId = rs.getUUID("child_id"),
                 firstName = rs.getString("first_name"),
@@ -98,7 +99,7 @@ private fun Database.Read.getMissingHeadOfFamilyRows(
 
 data class MissingHeadOfFamilyReportRow(
     val careAreaName: String,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val childId: UUID,
     val firstName: String?,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -87,7 +88,7 @@ private fun Database.Read.getMissingServiceNeedRows(
         .map { rs, _ ->
             MissingServiceNeedReportRow(
                 careAreaName = rs.getString("care_area_name"),
-                unitId = rs.getUUID("unit_id"),
+                unitId = DaycareId(rs.getUUID("unit_id")),
                 unitName = rs.getString("unit_name"),
                 childId = rs.getUUID("child_id"),
                 firstName = rs.getString("first_name"),
@@ -99,7 +100,7 @@ private fun Database.Read.getMissingServiceNeedRows(
 
 data class MissingServiceNeedReportRow(
     val careAreaName: String,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val childId: UUID,
     val firstName: String?,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.occupancy.OccupancyType
 import fi.espoo.evaka.occupancy.OccupancyValues
 import fi.espoo.evaka.occupancy.calculateDailyGroupOccupancyValues
 import fi.espoo.evaka.occupancy.calculateDailyUnitOccupancyValues
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -21,7 +22,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.util.UUID
 
 @RestController
 class OccupancyReportController {
@@ -30,7 +30,7 @@ class OccupancyReportController {
         db: Database,
         user: AuthenticatedUser,
         @RequestParam type: OccupancyType,
-        @RequestParam careAreaId: UUID,
+        @RequestParam careAreaId: AreaId,
         @RequestParam year: Int,
         @RequestParam month: Int
     ): ResponseEntity<List<OccupancyUnitReportResultRow>> {
@@ -56,7 +56,7 @@ class OccupancyReportController {
         db: Database,
         user: AuthenticatedUser,
         @RequestParam type: OccupancyType,
-        @RequestParam careAreaId: UUID,
+        @RequestParam careAreaId: AreaId,
         @RequestParam year: Int,
         @RequestParam month: Int
     ): ResponseEntity<List<OccupancyGroupReportResultRow>> {
@@ -94,7 +94,7 @@ data class OccupancyGroupReportResultRow(
 
 private fun Database.Read.calculateUnitOccupancyReport(
     today: LocalDate,
-    areaId: UUID,
+    areaId: AreaId,
     queryPeriod: FiniteDateRange,
     type: OccupancyType
 ): List<OccupancyUnitReportResultRow> {
@@ -111,7 +111,7 @@ private fun Database.Read.calculateUnitOccupancyReport(
 
 private fun Database.Read.calculateGroupOccupancyReport(
     today: LocalDate,
-    areaId: UUID,
+    areaId: AreaId,
     queryPeriod: FiniteDateRange,
     type: OccupancyType
 ): List<OccupancyGroupReportResultRow> {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.occupancy.OccupancyType
 import fi.espoo.evaka.occupancy.OccupancyValues
 import fi.espoo.evaka.occupancy.calculateDailyGroupOccupancyValues
 import fi.espoo.evaka.occupancy.calculateDailyUnitOccupancyValues
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -85,7 +86,7 @@ data class OccupancyUnitReportResultRow(
 data class OccupancyGroupReportResultRow(
     val unitId: UUID,
     val unitName: String,
-    val groupId: UUID,
+    val groupId: GroupId,
     val groupName: String,
     val occupancies: Map<LocalDate, OccupancyValues>
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.occupancy.OccupancyType
 import fi.espoo.evaka.occupancy.OccupancyValues
 import fi.espoo.evaka.occupancy.calculateDailyGroupOccupancyValues
 import fi.espoo.evaka.occupancy.calculateDailyUnitOccupancyValues
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -78,13 +79,13 @@ class OccupancyReportController {
 }
 
 data class OccupancyUnitReportResultRow(
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val occupancies: Map<LocalDate, OccupancyValues>
 )
 
 data class OccupancyGroupReportResultRow(
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val groupId: GroupId,
     val groupName: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -74,7 +75,7 @@ private fun Database.Read.getPartnersInDifferentAddressRows(authorizedUnits: Acl
         .map { rs, _ ->
             PartnersInDifferentAddressReportRow(
                 careAreaName = rs.getString("care_area_name"),
-                unitId = rs.getUUID("unit_id"),
+                unitId = DaycareId(rs.getUUID("unit_id")),
                 unitName = rs.getString("unit_name"),
                 personId1 = rs.getUUID("person_id_1"),
                 firstName1 = rs.getString("first_name_1"),
@@ -91,7 +92,7 @@ private fun Database.Read.getPartnersInDifferentAddressRows(authorizedUnits: Acl
 
 data class PartnersInDifferentAddressReportRow(
     val careAreaName: String,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val personId1: UUID,
     val firstName1: String?,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -110,7 +111,7 @@ data class PlacementSketchingReportRow(
     val childLastName: String?,
     val childDob: String?,
     val childStreetAddr: String?,
-    val applicationId: UUID?,
+    val applicationId: ApplicationId?,
     val currentUnitName: String?,
     val currentUnitId: DaycareId?,
     val assistanceNeeded: Boolean?,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -102,7 +103,7 @@ ORDER BY
 
 data class PlacementSketchingReportRow(
     val areaName: String,
-    val requestedUnitId: UUID,
+    val requestedUnitId: DaycareId,
     val requestedUnitName: String,
     val childId: UUID,
     val childFirstName: String?,
@@ -111,7 +112,7 @@ data class PlacementSketchingReportRow(
     val childStreetAddr: String?,
     val applicationId: UUID?,
     val currentUnitName: String?,
-    val currentUnitId: UUID?,
+    val currentUnitId: DaycareId?,
     val assistanceNeeded: Boolean?,
     val preparatoryEducation: Boolean?,
     val siblingBasis: Boolean?,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
@@ -6,9 +6,11 @@ package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.controllers.utils.ok
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.db.getNullableUUID
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
@@ -16,7 +18,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.util.UUID
 
 const val MAX_NUMBER_OF_DAYS = 14
 
@@ -71,7 +72,7 @@ private fun Database.Read.getPresenceRows(from: LocalDate, to: LocalDate): List<
             PresenceReportRow(
                 date = rs.getDate("date").toLocalDate(),
                 socialSecurityNumber = rs.getString("social_security_number"),
-                daycareId = rs.getString("daycare_id")?.let { UUID.fromString(it) },
+                daycareId = rs.getNullableUUID("daycare_id")?.let(::DaycareId),
                 daycareGroupName = rs.getString("name"),
                 present = rs.getBoolean("present").takeIf { rs.getString("daycare_id") != null }
             )
@@ -82,7 +83,7 @@ private fun Database.Read.getPresenceRows(from: LocalDate, to: LocalDate): List<
 data class PresenceReportRow(
     val date: LocalDate,
     val socialSecurityNumber: String?,
-    val daycareId: UUID?,
+    val daycareId: DaycareId?,
     val daycareGroupName: String?,
     val present: Boolean?
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.occupancy.youngChildOccupancyCoefficient
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -125,7 +126,7 @@ ORDER BY p.id, t
                 language = rs.getString("language"),
                 postOffice = rs.getString("post_office"),
                 placementType = rs.getEnum("placement_type"),
-                unitId = rs.getUUID("unit_id"),
+                unitId = DaycareId(rs.getUUID("unit_id")),
                 unitName = rs.getString("unit_name"),
                 careArea = rs.getString("care_area"),
                 unitType = (rs.getArray("unit_type").array as Array<out Any>).map { it.toString() }.toSet().let(::getPrimaryUnitType),
@@ -134,7 +135,7 @@ ORDER BY p.id, t
                 groupName = rs.getString("group_name"),
                 caretakersPlanned = rs.getBigDecimal("caretakers_planned")?.toDouble(),
                 caretakersRealized = rs.getBigDecimal("caretakers_realized")?.toDouble(),
-                backupUnitId = rs.getNullableUUID("backup_unit_id"),
+                backupUnitId = rs.getNullableUUID("backup_unit_id")?.let(::DaycareId),
                 backupGroupId = rs.getNullableUUID("backup_group_id")?.let(::GroupId),
                 hasServiceNeed = rs.getBoolean("has_service_need"),
                 partDay = rs.getBoolean("part_day"),
@@ -159,7 +160,7 @@ data class RawReportRow(
     val age: Int,
     val language: String?,
     val placementType: PlacementType,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val careArea: String,
     val unitType: UnitType?,
@@ -168,7 +169,7 @@ data class RawReportRow(
     val groupName: String?,
     val caretakersPlanned: Double?,
     val caretakersRealized: Double?,
-    val backupUnitId: UUID?,
+    val backupUnitId: DaycareId?,
     val backupGroupId: GroupId?,
     val hasServiceNeed: Boolean,
     val partDay: Boolean?,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.occupancy.youngChildOccupancyCoefficient
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -129,12 +130,12 @@ ORDER BY p.id, t
                 careArea = rs.getString("care_area"),
                 unitType = (rs.getArray("unit_type").array as Array<out Any>).map { it.toString() }.toSet().let(::getPrimaryUnitType),
                 unitProviderType = rs.getString("unit_provider_type"),
-                daycareGroupId = rs.getNullableUUID("daycare_group_id"),
+                daycareGroupId = rs.getNullableUUID("daycare_group_id")?.let(::GroupId),
                 groupName = rs.getString("group_name"),
                 caretakersPlanned = rs.getBigDecimal("caretakers_planned")?.toDouble(),
                 caretakersRealized = rs.getBigDecimal("caretakers_realized")?.toDouble(),
                 backupUnitId = rs.getNullableUUID("backup_unit_id"),
-                backupGroupId = rs.getNullableUUID("backup_group_id"),
+                backupGroupId = rs.getNullableUUID("backup_group_id")?.let(::GroupId),
                 hasServiceNeed = rs.getBoolean("has_service_need"),
                 partDay = rs.getBoolean("part_day"),
                 partWeek = rs.getBoolean("part_week"),
@@ -163,12 +164,12 @@ data class RawReportRow(
     val careArea: String,
     val unitType: UnitType?,
     val unitProviderType: String,
-    val daycareGroupId: UUID?,
+    val daycareGroupId: GroupId?,
     val groupName: String?,
     val caretakersPlanned: Double?,
     val caretakersRealized: Double?,
     val backupUnitId: UUID?,
-    val backupGroupId: UUID?,
+    val backupGroupId: GroupId?,
     val hasServiceNeed: Boolean,
     val partDay: Boolean?,
     val partWeek: Boolean?,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.reports
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -79,7 +80,7 @@ class ServiceVoucherValueReportController(private val acl: AccessControlList) {
     fun getServiceVoucherValuesForUnit(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable("unitId") unitId: UUID,
+        @PathVariable("unitId") unitId: DaycareId,
         @RequestParam year: Int,
         @RequestParam month: Int
     ): ResponseEntity<ServiceVoucherUnitReport> {
@@ -143,7 +144,7 @@ data class ServiceVoucherValueUnitAggregate(
     val monthlyPaymentSum: Int
 ) {
     data class UnitData(
-        val id: UUID,
+        val id: DaycareId,
         val name: String,
         val areaId: UUID,
         val areaName: String
@@ -162,7 +163,7 @@ data class ServiceVoucherValueRow(
     val childLastName: String,
     val childDateOfBirth: LocalDate,
     val childGroupName: String?,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val unitName: String,
     val areaId: UUID,
     val areaName: String,
@@ -182,7 +183,7 @@ private fun Database.Read.getServiceVoucherValues(
     year: Int,
     month: Int,
     areaId: UUID? = null,
-    unitIds: Set<UUID>? = null
+    unitIds: Set<DaycareId>? = null
 ): List<ServiceVoucherValueRow> {
     // language=sql
     val sql = """
@@ -335,7 +336,7 @@ private fun Database.Read.getSnapshotVoucherValues(
     year: Int,
     month: Int,
     areaId: UUID? = null,
-    unitIds: Set<UUID>? = null
+    unitIds: Set<DaycareId>? = null
 ): List<ServiceVoucherValueRow> {
     // language=sql
     val sql =

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -168,7 +169,7 @@ data class ServiceVoucherValueRow(
     val unitName: String,
     val areaId: AreaId,
     val areaName: String,
-    val serviceVoucherDecisionId: UUID,
+    val serviceVoucherDecisionId: VoucherValueDecisionId,
     val serviceVoucherValue: Int,
     val serviceVoucherCoPayment: Int,
     val serviceNeedDescription: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.reports
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -40,7 +41,7 @@ class ServiceVoucherValueReportController(private val acl: AccessControlList) {
         user: AuthenticatedUser,
         @RequestParam year: Int,
         @RequestParam month: Int,
-        @RequestParam(required = false) areaId: UUID?
+        @RequestParam(required = false) areaId: AreaId?
     ): ResponseEntity<ServiceVoucherReport> {
         val authorization = acl.getAuthorizedUnits(user, setOf(UserRole.UNIT_SUPERVISOR))
 
@@ -146,7 +147,7 @@ data class ServiceVoucherValueUnitAggregate(
     data class UnitData(
         val id: DaycareId,
         val name: String,
-        val areaId: UUID,
+        val areaId: AreaId,
         val areaName: String
     )
 }
@@ -165,7 +166,7 @@ data class ServiceVoucherValueRow(
     val childGroupName: String?,
     val unitId: DaycareId,
     val unitName: String,
-    val areaId: UUID,
+    val areaId: AreaId,
     val areaName: String,
     val serviceVoucherDecisionId: UUID,
     val serviceVoucherValue: Int,
@@ -182,7 +183,7 @@ data class ServiceVoucherValueRow(
 private fun Database.Read.getServiceVoucherValues(
     year: Int,
     month: Int,
-    areaId: UUID? = null,
+    areaId: AreaId? = null,
     unitIds: Set<DaycareId>? = null
 ): List<ServiceVoucherValueRow> {
     // language=sql
@@ -335,7 +336,7 @@ private fun Database.Read.getSnapshotDate(year: Int, month: Int): LocalDate? {
 private fun Database.Read.getSnapshotVoucherValues(
     year: Int,
     month: Int,
-    areaId: UUID? = null,
+    areaId: AreaId? = null,
     unitIds: Set<DaycareId>? = null
 ): List<ServiceVoucherValueRow> {
     // language=sql

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.serviceneed
 
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -21,7 +22,7 @@ import java.util.UUID
 
 data class ServiceNeed(
     val id: UUID,
-    val placementId: UUID,
+    val placementId: PlacementId,
     val startDate: LocalDate,
     val endDate: LocalDate,
     @Nested("option")
@@ -76,7 +77,7 @@ data class ServiceNeedOption(
 
 fun validateServiceNeed(
     db: Database.Read,
-    placementId: UUID,
+    placementId: PlacementId,
     startDate: LocalDate,
     endDate: LocalDate,
     optionId: UUID
@@ -117,7 +118,7 @@ fun validateServiceNeed(
 fun createServiceNeed(
     tx: Database.Transaction,
     user: AuthenticatedUser,
-    placementId: UUID,
+    placementId: PlacementId,
     startDate: LocalDate,
     endDate: LocalDate,
     optionId: UUID,
@@ -167,7 +168,7 @@ fun updateServiceNeed(
     )
 }
 
-fun clearServiceNeedsFromPeriod(tx: Database.Transaction, placementId: UUID, periodToClear: FiniteDateRange, excluding: UUID? = null) {
+fun clearServiceNeedsFromPeriod(tx: Database.Transaction, placementId: PlacementId, periodToClear: FiniteDateRange, excluding: UUID? = null) {
     tx.getOverlappingServiceNeeds(placementId, periodToClear.start, periodToClear.end, excluding).forEach { old ->
         val oldPeriod = FiniteDateRange(old.startDate, old.endDate)
         when {

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.serviceneed
 
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -21,7 +22,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class ServiceNeed(
-    val id: UUID,
+    val id: ServiceNeedId,
     val placementId: PlacementId,
     val startDate: LocalDate,
     val endDate: LocalDate,
@@ -124,7 +125,7 @@ fun createServiceNeed(
     optionId: UUID,
     shiftCare: Boolean,
     confirmedAt: HelsinkiDateTime
-): UUID {
+): ServiceNeedId {
     validateServiceNeed(tx, placementId, startDate, endDate, optionId)
     clearServiceNeedsFromPeriod(tx, placementId, FiniteDateRange(startDate, endDate))
     return tx.insertServiceNeed(
@@ -141,7 +142,7 @@ fun createServiceNeed(
 fun updateServiceNeed(
     tx: Database.Transaction,
     user: AuthenticatedUser,
-    id: UUID,
+    id: ServiceNeedId,
     startDate: LocalDate,
     endDate: LocalDate,
     optionId: UUID,
@@ -168,7 +169,7 @@ fun updateServiceNeed(
     )
 }
 
-fun clearServiceNeedsFromPeriod(tx: Database.Transaction, placementId: PlacementId, periodToClear: FiniteDateRange, excluding: UUID? = null) {
+fun clearServiceNeedsFromPeriod(tx: Database.Transaction, placementId: PlacementId, periodToClear: FiniteDateRange, excluding: ServiceNeedId? = null) {
     tx.getOverlappingServiceNeeds(placementId, periodToClear.start, periodToClear.end, excluding).forEach { old ->
         val oldPeriod = FiniteDateRange(old.startDate, old.endDate)
         when {

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.serviceneed
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -40,7 +41,7 @@ data class ServiceNeedChildRange(
 )
 
 data class ServiceNeedOptionSummary(
-    val id: UUID,
+    val id: ServiceNeedOptionId,
     val name: String,
     val updated: Instant
 )
@@ -53,13 +54,13 @@ data class ServiceNeedConfirmation(
 )
 
 data class ServiceNeedOptionPublicInfo(
-    val id: UUID,
+    val id: ServiceNeedOptionId,
     val name: String,
     val validPlacementType: PlacementType
 )
 
 data class ServiceNeedOption(
-    val id: UUID,
+    val id: ServiceNeedOptionId,
     val name: String,
     val validPlacementType: PlacementType,
     val defaultOption: Boolean,
@@ -81,7 +82,7 @@ fun validateServiceNeed(
     placementId: PlacementId,
     startDate: LocalDate,
     endDate: LocalDate,
-    optionId: UUID
+    optionId: ServiceNeedOptionId
 ) {
     if (endDate.isBefore(startDate)) {
         throw BadRequest("Start date cannot be before end date.")
@@ -122,7 +123,7 @@ fun createServiceNeed(
     placementId: PlacementId,
     startDate: LocalDate,
     endDate: LocalDate,
-    optionId: UUID,
+    optionId: ServiceNeedOptionId,
     shiftCare: Boolean,
     confirmedAt: HelsinkiDateTime
 ): ServiceNeedId {
@@ -145,7 +146,7 @@ fun updateServiceNeed(
     id: ServiceNeedId,
     startDate: LocalDate,
     endDate: LocalDate,
-    optionId: UUID,
+    optionId: ServiceNeedOptionId,
     shiftCare: Boolean,
     confirmedAt: HelsinkiDateTime
 ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.serviceneed
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -79,7 +80,7 @@ class ServiceNeedController(
     fun putServiceNeed(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable id: UUID,
+        @PathVariable id: ServiceNeedId,
         @RequestBody body: ServiceNeedUpdateRequest
     ): ResponseEntity<Unit> {
         Audit.PlacementServiceNeedUpdate.log(targetId = id)
@@ -118,7 +119,7 @@ class ServiceNeedController(
     fun deleteServiceNeed(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable id: UUID
+        @PathVariable id: ServiceNeedId
     ): ResponseEntity<Unit> {
         Audit.PlacementServiceNeedDelete.log(targetId = id)
         acl.getRolesForServiceNeed(user, id).requireOneOfRoles(UserRole.ADMIN, UserRole.UNIT_SUPERVISOR)

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.serviceneed
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -32,7 +33,7 @@ class ServiceNeedController(
 ) {
 
     data class ServiceNeedCreateRequest(
-        val placementId: UUID,
+        val placementId: PlacementId,
         val startDate: LocalDate,
         val endDate: LocalDate,
         val optionId: UUID,

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -25,7 +26,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.util.UUID
 
 @RestController
 class ServiceNeedController(
@@ -37,7 +37,7 @@ class ServiceNeedController(
         val placementId: PlacementId,
         val startDate: LocalDate,
         val endDate: LocalDate,
-        val optionId: UUID,
+        val optionId: ServiceNeedOptionId,
         val shiftCare: Boolean
     )
 
@@ -72,7 +72,7 @@ class ServiceNeedController(
     data class ServiceNeedUpdateRequest(
         val startDate: LocalDate,
         val endDate: LocalDate,
-        val optionId: UUID,
+        val optionId: ServiceNeedOptionId,
         val shiftCare: Boolean
     )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.serviceneed
 
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
@@ -38,7 +39,7 @@ fun Database.Read.getServiceNeedsByChild(
 }
 
 fun Database.Read.getServiceNeedsByUnit(
-    unitId: UUID,
+    unitId: DaycareId,
     startDate: LocalDate?,
     endDate: LocalDate?
 ): List<ServiceNeed> {

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -104,7 +105,7 @@ fun Database.Transaction.insertServiceNeed(
     placementId: PlacementId,
     startDate: LocalDate,
     endDate: LocalDate,
-    optionId: UUID,
+    optionId: ServiceNeedOptionId,
     shiftCare: Boolean,
     confirmedBy: UUID,
     confirmedAt: HelsinkiDateTime
@@ -131,7 +132,7 @@ fun Database.Transaction.updateServiceNeed(
     id: ServiceNeedId,
     startDate: LocalDate,
     endDate: LocalDate,
-    optionId: UUID,
+    optionId: ServiceNeedOptionId,
     shiftCare: Boolean,
     confirmedBy: UUID,
     confirmedAt: HelsinkiDateTime

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.serviceneed
 
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -98,7 +99,7 @@ fun Database.Read.getServiceNeedChildRange(id: UUID): ServiceNeedChildRange {
 }
 
 fun Database.Transaction.insertServiceNeed(
-    placementId: UUID,
+    placementId: PlacementId,
     startDate: LocalDate,
     endDate: LocalDate,
     optionId: UUID,
@@ -160,7 +161,7 @@ fun Database.Transaction.deleteServiceNeed(
 }
 
 fun Database.Read.getOverlappingServiceNeeds(
-    placementId: UUID,
+    placementId: PlacementId,
     startDate: LocalDate,
     endDate: LocalDate,
     excluding: UUID?

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.serviceneed
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -65,7 +66,7 @@ fun Database.Read.getServiceNeedsByUnit(
         .toList()
 }
 
-fun Database.Read.getServiceNeed(id: UUID): ServiceNeed {
+fun Database.Read.getServiceNeed(id: ServiceNeedId): ServiceNeed {
     // language=sql
     val sql = """
         SELECT 
@@ -84,7 +85,7 @@ fun Database.Read.getServiceNeed(id: UUID): ServiceNeed {
         .firstOrNull() ?: throw NotFound("Service need $id not found")
 }
 
-fun Database.Read.getServiceNeedChildRange(id: UUID): ServiceNeedChildRange {
+fun Database.Read.getServiceNeedChildRange(id: ServiceNeedId): ServiceNeedChildRange {
     // language=sql
     val sql = """
         SELECT p.child_id, daterange(sn.start_date, sn.end_date, '[]')
@@ -107,7 +108,7 @@ fun Database.Transaction.insertServiceNeed(
     shiftCare: Boolean,
     confirmedBy: UUID,
     confirmedAt: HelsinkiDateTime
-): UUID {
+): ServiceNeedId {
     // language=sql
     val sql = """
         INSERT INTO service_need (placement_id, start_date, end_date, option_id, shift_care, confirmed_by, confirmed_at) 
@@ -122,12 +123,12 @@ fun Database.Transaction.insertServiceNeed(
         .bind("shiftCare", shiftCare)
         .bind("confirmedBy", confirmedBy)
         .bind("confirmedAt", confirmedAt)
-        .mapTo<UUID>()
+        .mapTo<ServiceNeedId>()
         .one()
 }
 
 fun Database.Transaction.updateServiceNeed(
-    id: UUID,
+    id: ServiceNeedId,
     startDate: LocalDate,
     endDate: LocalDate,
     optionId: UUID,
@@ -154,7 +155,7 @@ fun Database.Transaction.updateServiceNeed(
 }
 
 fun Database.Transaction.deleteServiceNeed(
-    id: UUID
+    id: ServiceNeedId
 ) {
     createUpdate("DELETE FROM service_need WHERE id = :id")
         .bind("id", id)
@@ -165,7 +166,7 @@ fun Database.Read.getOverlappingServiceNeeds(
     placementId: PlacementId,
     startDate: LocalDate,
     endDate: LocalDate,
-    excluding: UUID?
+    excluding: ServiceNeedId?
 ): List<ServiceNeed> {
     // language=sql
     val sql = """

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -16,6 +16,7 @@ sealed interface DatabaseTable {
     sealed class ApplicationNote : DatabaseTable
     sealed class Area : DatabaseTable
     sealed class AssistanceAction : DatabaseTable
+    sealed class AssistanceNeed : DatabaseTable
     sealed class Attachment : DatabaseTable
     sealed class Daycare : DatabaseTable
     sealed class Decision : DatabaseTable
@@ -42,6 +43,7 @@ typealias ApplicationId = Id<DatabaseTable.Application>
 typealias ApplicationNoteId = Id<DatabaseTable.ApplicationNote>
 typealias AreaId = Id<DatabaseTable.Area>
 typealias AssistanceActionId = Id<DatabaseTable.AssistanceAction>
+typealias AssistanceNeedId = Id<DatabaseTable.AssistanceNeed>
 typealias AttachmentId = Id<DatabaseTable.Attachment>
 typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -28,6 +28,7 @@ sealed interface DatabaseTable {
     sealed class Partnership : DatabaseTable
     sealed class Person : DatabaseTable
     sealed class Placement : DatabaseTable
+    sealed class PlacementPlan : DatabaseTable
     sealed class ServiceNeed : DatabaseTable
     sealed class ServiceNeedOption : DatabaseTable
     sealed class VardaDecision : DatabaseTable
@@ -52,6 +53,7 @@ typealias ParentshipId = Id<DatabaseTable.Parentship>
 typealias PartnershipId = Id<DatabaseTable.Partnership>
 typealias PersonId = Id<DatabaseTable.Person>
 typealias PlacementId = Id<DatabaseTable.Placement>
+typealias PlacementPlanId = Id<DatabaseTable.PlacementPlan>
 typealias ServiceNeedId = Id<DatabaseTable.ServiceNeed>
 typealias ServiceNeedOptionId = Id<DatabaseTable.ServiceNeedOption>
 typealias VardaDecisionId = Id<DatabaseTable.VardaDecision>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -22,6 +22,7 @@ sealed interface DatabaseTable {
     sealed class Partnership : DatabaseTable
     sealed class Person : DatabaseTable
     sealed class Placement : DatabaseTable
+    sealed class ServiceNeed : DatabaseTable
 }
 
 typealias ApplicationId = Id<DatabaseTable.Application>
@@ -35,6 +36,7 @@ typealias GroupPlacementId = Id<DatabaseTable.GroupPlacement>
 typealias PartnershipId = Id<DatabaseTable.Partnership>
 typealias PersonId = Id<DatabaseTable.Person>
 typealias PlacementId = Id<DatabaseTable.Placement>
+typealias ServiceNeedId = Id<DatabaseTable.ServiceNeed>
 
 @JsonSerialize(converter = Id.ToJson::class)
 @JsonDeserialize(converter = Id.FromJson::class, keyUsing = Id.KeyFromJson::class)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -15,6 +15,7 @@ sealed interface DatabaseTable {
     sealed class Application : DatabaseTable
     sealed class ApplicationNote : DatabaseTable
     sealed class Area : DatabaseTable
+    sealed class Attachment : DatabaseTable
     sealed class Daycare : DatabaseTable
     sealed class Decision : DatabaseTable
     sealed class Employee : DatabaseTable
@@ -35,6 +36,7 @@ sealed interface DatabaseTable {
 typealias ApplicationId = Id<DatabaseTable.Application>
 typealias ApplicationNoteId = Id<DatabaseTable.ApplicationNote>
 typealias AreaId = Id<DatabaseTable.Area>
+typealias AttachmentId = Id<DatabaseTable.Attachment>
 typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>
 typealias DecisionId = Id<DatabaseTable.Decision>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -16,6 +16,7 @@ sealed interface DatabaseTable {
     sealed class Employee : DatabaseTable
     sealed class Group : DatabaseTable
     sealed class Person : DatabaseTable
+    sealed class Placement : DatabaseTable
 }
 
 typealias ChildId = Id<DatabaseTable.Person>
@@ -23,6 +24,7 @@ typealias DaycareId = Id<DatabaseTable.Daycare>
 typealias EmployeeId = Id<DatabaseTable.Employee>
 typealias GroupId = Id<DatabaseTable.Group>
 typealias PersonId = Id<DatabaseTable.Person>
+typealias PlacementId = Id<DatabaseTable.Placement>
 
 @JsonSerialize(converter = Id.ToJson::class)
 @JsonDeserialize(converter = Id.FromJson::class, keyUsing = Id.KeyFromJson::class)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -4,6 +4,8 @@
 
 package fi.espoo.evaka.shared
 
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.KeyDeserializer
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.util.StdConverter
@@ -23,7 +25,7 @@ typealias GroupId = Id<DatabaseTable.Group>
 typealias PersonId = Id<DatabaseTable.Person>
 
 @JsonSerialize(converter = Id.ToJson::class)
-@JsonDeserialize(converter = Id.FromJson::class)
+@JsonDeserialize(converter = Id.FromJson::class, keyUsing = Id.KeyFromJson::class)
 data class Id<out T : DatabaseTable>(val raw: UUID) : Comparable<Id<*>> {
     override fun toString(): String = raw.toString()
     override fun hashCode(): Int = raw.hashCode()
@@ -35,5 +37,10 @@ data class Id<out T : DatabaseTable>(val raw: UUID) : Comparable<Id<*>> {
 
     class ToJson : StdConverter<Id<*>, UUID>() {
         override fun convert(value: Id<*>): UUID = value.raw
+    }
+
+    class KeyFromJson : KeyDeserializer() {
+        override fun deserializeKey(key: String, ctxt: DeserializationContext): Any =
+            Id<DatabaseTable>(UUID.fromString(key))
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -16,7 +16,9 @@ sealed interface DatabaseTable {
     sealed class ApplicationNote : DatabaseTable
     sealed class Area : DatabaseTable
     sealed class Daycare : DatabaseTable
+    sealed class Decision : DatabaseTable
     sealed class Employee : DatabaseTable
+    sealed class FeeDecision : DatabaseTable
     sealed class Group : DatabaseTable
     sealed class GroupPlacement : DatabaseTable
     sealed class Parentship : DatabaseTable
@@ -25,6 +27,9 @@ sealed interface DatabaseTable {
     sealed class Placement : DatabaseTable
     sealed class ServiceNeed : DatabaseTable
     sealed class ServiceNeedOption : DatabaseTable
+    sealed class VardaDecision : DatabaseTable
+    sealed class VardaPlacement : DatabaseTable
+    sealed class VoucherValueDecision : DatabaseTable
 }
 
 typealias ApplicationId = Id<DatabaseTable.Application>
@@ -32,7 +37,9 @@ typealias ApplicationNoteId = Id<DatabaseTable.ApplicationNote>
 typealias AreaId = Id<DatabaseTable.Area>
 typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>
+typealias DecisionId = Id<DatabaseTable.Decision>
 typealias EmployeeId = Id<DatabaseTable.Employee>
+typealias FeeDecisionId = Id<DatabaseTable.FeeDecision>
 typealias GroupId = Id<DatabaseTable.Group>
 typealias GroupPlacementId = Id<DatabaseTable.GroupPlacement>
 typealias ParentshipId = Id<DatabaseTable.Parentship>
@@ -41,6 +48,9 @@ typealias PersonId = Id<DatabaseTable.Person>
 typealias PlacementId = Id<DatabaseTable.Placement>
 typealias ServiceNeedId = Id<DatabaseTable.ServiceNeed>
 typealias ServiceNeedOptionId = Id<DatabaseTable.ServiceNeedOption>
+typealias VardaDecisionId = Id<DatabaseTable.VardaDecision>
+typealias VardaPlacementId = Id<DatabaseTable.VardaPlacement>
+typealias VoucherValueDecisionId = Id<DatabaseTable.VoucherValueDecision>
 
 @JsonSerialize(converter = Id.ToJson::class)
 @JsonDeserialize(converter = Id.FromJson::class, keyUsing = Id.KeyFromJson::class)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.util.StdConverter
 import java.util.UUID
 
 sealed interface DatabaseTable {
+    sealed class Area : DatabaseTable
     sealed class Daycare : DatabaseTable
     sealed class Employee : DatabaseTable
     sealed class Group : DatabaseTable
@@ -19,6 +20,7 @@ sealed interface DatabaseTable {
     sealed class Placement : DatabaseTable
 }
 
+typealias AreaId = Id<DatabaseTable.Area>
 typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>
 typealias EmployeeId = Id<DatabaseTable.Employee>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -18,6 +18,7 @@ sealed interface DatabaseTable {
     sealed class Daycare : DatabaseTable
     sealed class Employee : DatabaseTable
     sealed class Group : DatabaseTable
+    sealed class GroupPlacement : DatabaseTable
     sealed class Partnership : DatabaseTable
     sealed class Person : DatabaseTable
     sealed class Placement : DatabaseTable
@@ -30,6 +31,7 @@ typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>
 typealias EmployeeId = Id<DatabaseTable.Employee>
 typealias GroupId = Id<DatabaseTable.Group>
+typealias GroupPlacementId = Id<DatabaseTable.GroupPlacement>
 typealias PartnershipId = Id<DatabaseTable.Partnership>
 typealias PersonId = Id<DatabaseTable.Person>
 typealias PlacementId = Id<DatabaseTable.Placement>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -19,6 +19,7 @@ sealed interface DatabaseTable {
     sealed class Employee : DatabaseTable
     sealed class Group : DatabaseTable
     sealed class GroupPlacement : DatabaseTable
+    sealed class Parentship : DatabaseTable
     sealed class Partnership : DatabaseTable
     sealed class Person : DatabaseTable
     sealed class Placement : DatabaseTable
@@ -33,6 +34,7 @@ typealias DaycareId = Id<DatabaseTable.Daycare>
 typealias EmployeeId = Id<DatabaseTable.Employee>
 typealias GroupId = Id<DatabaseTable.Group>
 typealias GroupPlacementId = Id<DatabaseTable.GroupPlacement>
+typealias ParentshipId = Id<DatabaseTable.Parentship>
 typealias PartnershipId = Id<DatabaseTable.Partnership>
 typealias PersonId = Id<DatabaseTable.Person>
 typealias PlacementId = Id<DatabaseTable.Placement>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -22,6 +22,7 @@ sealed interface DatabaseTable {
     sealed class Attendance : DatabaseTable
     sealed class BackupCare : DatabaseTable
     sealed class Daycare : DatabaseTable
+    sealed class DaycareDailyNote : DatabaseTable
     sealed class Decision : DatabaseTable
     sealed class Employee : DatabaseTable
     sealed class FeeDecision : DatabaseTable
@@ -53,6 +54,7 @@ typealias AttendanceId = Id<DatabaseTable.Attendance>
 typealias BackupCareId = Id<DatabaseTable.BackupCare>
 typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>
+typealias DaycareDailyNoteId = Id<DatabaseTable.DaycareDailyNote>
 typealias DecisionId = Id<DatabaseTable.Decision>
 typealias EmployeeId = Id<DatabaseTable.Employee>
 typealias FeeDecisionId = Id<DatabaseTable.FeeDecision>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -12,12 +12,14 @@ import com.fasterxml.jackson.databind.util.StdConverter
 import java.util.UUID
 
 sealed interface DatabaseTable {
+    sealed class Absence : DatabaseTable
     sealed class Application : DatabaseTable
     sealed class ApplicationNote : DatabaseTable
     sealed class Area : DatabaseTable
     sealed class AssistanceAction : DatabaseTable
     sealed class AssistanceNeed : DatabaseTable
     sealed class Attachment : DatabaseTable
+    sealed class Attendance : DatabaseTable
     sealed class BackupCare : DatabaseTable
     sealed class Daycare : DatabaseTable
     sealed class Decision : DatabaseTable
@@ -40,12 +42,14 @@ sealed interface DatabaseTable {
     sealed class VoucherValueDecision : DatabaseTable
 }
 
+typealias AbsenceId = Id<DatabaseTable.Absence>
 typealias ApplicationId = Id<DatabaseTable.Application>
 typealias ApplicationNoteId = Id<DatabaseTable.ApplicationNote>
 typealias AreaId = Id<DatabaseTable.Area>
 typealias AssistanceActionId = Id<DatabaseTable.AssistanceAction>
 typealias AssistanceNeedId = Id<DatabaseTable.AssistanceNeed>
 typealias AttachmentId = Id<DatabaseTable.Attachment>
+typealias AttendanceId = Id<DatabaseTable.Attendance>
 typealias BackupCareId = Id<DatabaseTable.BackupCare>
 typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -24,6 +24,7 @@ sealed interface DatabaseTable {
     sealed class Person : DatabaseTable
     sealed class Placement : DatabaseTable
     sealed class ServiceNeed : DatabaseTable
+    sealed class ServiceNeedOption : DatabaseTable
 }
 
 typealias ApplicationId = Id<DatabaseTable.Application>
@@ -39,6 +40,7 @@ typealias PartnershipId = Id<DatabaseTable.Partnership>
 typealias PersonId = Id<DatabaseTable.Person>
 typealias PlacementId = Id<DatabaseTable.Placement>
 typealias ServiceNeedId = Id<DatabaseTable.ServiceNeed>
+typealias ServiceNeedOptionId = Id<DatabaseTable.ServiceNeedOption>
 
 @JsonSerialize(converter = Id.ToJson::class)
 @JsonDeserialize(converter = Id.FromJson::class, keyUsing = Id.KeyFromJson::class)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.util.StdConverter
+import java.util.UUID
+
+sealed interface DatabaseTable {
+    sealed class Daycare : DatabaseTable
+    sealed class Employee : DatabaseTable
+    sealed class Group : DatabaseTable
+    sealed class Person : DatabaseTable
+}
+
+typealias ChildId = Id<DatabaseTable.Person>
+typealias DaycareId = Id<DatabaseTable.Daycare>
+typealias EmployeeId = Id<DatabaseTable.Employee>
+typealias GroupId = Id<DatabaseTable.Group>
+typealias PersonId = Id<DatabaseTable.Person>
+
+@JsonSerialize(converter = Id.ToJson::class)
+@JsonDeserialize(converter = Id.FromJson::class)
+data class Id<out T : DatabaseTable>(val raw: UUID) : Comparable<Id<*>> {
+    override fun toString(): String = raw.toString()
+    override fun hashCode(): Int = raw.hashCode()
+    override fun compareTo(other: Id<*>): Int = this.raw.compareTo(other.raw)
+
+    class FromJson : StdConverter<UUID, Id<*>>() {
+        override fun convert(value: UUID): Id<DatabaseTable> = Id(value)
+    }
+
+    class ToJson : StdConverter<Id<*>, UUID>() {
+        override fun convert(value: Id<*>): UUID = value.raw
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -18,6 +18,7 @@ sealed interface DatabaseTable {
     sealed class AssistanceAction : DatabaseTable
     sealed class AssistanceNeed : DatabaseTable
     sealed class Attachment : DatabaseTable
+    sealed class BackupCare : DatabaseTable
     sealed class Daycare : DatabaseTable
     sealed class Decision : DatabaseTable
     sealed class Employee : DatabaseTable
@@ -45,6 +46,7 @@ typealias AreaId = Id<DatabaseTable.Area>
 typealias AssistanceActionId = Id<DatabaseTable.AssistanceAction>
 typealias AssistanceNeedId = Id<DatabaseTable.AssistanceNeed>
 typealias AttachmentId = Id<DatabaseTable.Attachment>
+typealias BackupCareId = Id<DatabaseTable.BackupCare>
 typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>
 typealias DecisionId = Id<DatabaseTable.Decision>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -18,6 +18,7 @@ sealed interface DatabaseTable {
     sealed class Daycare : DatabaseTable
     sealed class Employee : DatabaseTable
     sealed class Group : DatabaseTable
+    sealed class Partnership : DatabaseTable
     sealed class Person : DatabaseTable
     sealed class Placement : DatabaseTable
 }
@@ -29,6 +30,7 @@ typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>
 typealias EmployeeId = Id<DatabaseTable.Employee>
 typealias GroupId = Id<DatabaseTable.Group>
+typealias PartnershipId = Id<DatabaseTable.Partnership>
 typealias PersonId = Id<DatabaseTable.Person>
 typealias PlacementId = Id<DatabaseTable.Placement>
 
@@ -39,7 +41,7 @@ data class Id<out T : DatabaseTable>(val raw: UUID) : Comparable<Id<*>> {
     override fun hashCode(): Int = raw.hashCode()
     override fun compareTo(other: Id<*>): Int = this.raw.compareTo(other.raw)
 
-    class FromJson : StdConverter<UUID, Id<*>>() {
+    class FromJson<T> : StdConverter<UUID, Id<*>>() {
         override fun convert(value: UUID): Id<DatabaseTable> = Id(value)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -22,6 +22,7 @@ sealed interface DatabaseTable {
     sealed class FeeDecision : DatabaseTable
     sealed class Group : DatabaseTable
     sealed class GroupPlacement : DatabaseTable
+    sealed class MobileDevice : DatabaseTable
     sealed class Parentship : DatabaseTable
     sealed class Partnership : DatabaseTable
     sealed class Person : DatabaseTable
@@ -44,6 +45,7 @@ typealias EmployeeId = Id<DatabaseTable.Employee>
 typealias FeeDecisionId = Id<DatabaseTable.FeeDecision>
 typealias GroupId = Id<DatabaseTable.Group>
 typealias GroupPlacementId = Id<DatabaseTable.GroupPlacement>
+typealias MobileDeviceId = Id<DatabaseTable.MobileDevice>
 typealias ParentshipId = Id<DatabaseTable.Parentship>
 typealias PartnershipId = Id<DatabaseTable.Partnership>
 typealias PersonId = Id<DatabaseTable.Person>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -15,6 +15,7 @@ sealed interface DatabaseTable {
     sealed class Application : DatabaseTable
     sealed class ApplicationNote : DatabaseTable
     sealed class Area : DatabaseTable
+    sealed class AssistanceAction : DatabaseTable
     sealed class Attachment : DatabaseTable
     sealed class Daycare : DatabaseTable
     sealed class Decision : DatabaseTable
@@ -40,6 +41,7 @@ sealed interface DatabaseTable {
 typealias ApplicationId = Id<DatabaseTable.Application>
 typealias ApplicationNoteId = Id<DatabaseTable.ApplicationNote>
 typealias AreaId = Id<DatabaseTable.Area>
+typealias AssistanceActionId = Id<DatabaseTable.AssistanceAction>
 typealias AttachmentId = Id<DatabaseTable.Attachment>
 typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -22,6 +22,7 @@ sealed interface DatabaseTable {
     sealed class FeeDecision : DatabaseTable
     sealed class Group : DatabaseTable
     sealed class GroupPlacement : DatabaseTable
+    sealed class Income : DatabaseTable
     sealed class MobileDevice : DatabaseTable
     sealed class Pairing : DatabaseTable
     sealed class Parentship : DatabaseTable
@@ -47,6 +48,7 @@ typealias EmployeeId = Id<DatabaseTable.Employee>
 typealias FeeDecisionId = Id<DatabaseTable.FeeDecision>
 typealias GroupId = Id<DatabaseTable.Group>
 typealias GroupPlacementId = Id<DatabaseTable.GroupPlacement>
+typealias IncomeId = Id<DatabaseTable.Income>
 typealias MobileDeviceId = Id<DatabaseTable.MobileDevice>
 typealias PairingId = Id<DatabaseTable.Pairing>
 typealias ParentshipId = Id<DatabaseTable.Parentship>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -23,6 +23,7 @@ sealed interface DatabaseTable {
     sealed class Group : DatabaseTable
     sealed class GroupPlacement : DatabaseTable
     sealed class MobileDevice : DatabaseTable
+    sealed class Pairing : DatabaseTable
     sealed class Parentship : DatabaseTable
     sealed class Partnership : DatabaseTable
     sealed class Person : DatabaseTable
@@ -46,6 +47,7 @@ typealias FeeDecisionId = Id<DatabaseTable.FeeDecision>
 typealias GroupId = Id<DatabaseTable.Group>
 typealias GroupPlacementId = Id<DatabaseTable.GroupPlacement>
 typealias MobileDeviceId = Id<DatabaseTable.MobileDevice>
+typealias PairingId = Id<DatabaseTable.Pairing>
 typealias ParentshipId = Id<DatabaseTable.Parentship>
 typealias PartnershipId = Id<DatabaseTable.Partnership>
 typealias PersonId = Id<DatabaseTable.Person>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.util.StdConverter
 import java.util.UUID
 
 sealed interface DatabaseTable {
+    sealed class Application : DatabaseTable
     sealed class Area : DatabaseTable
     sealed class Daycare : DatabaseTable
     sealed class Employee : DatabaseTable
@@ -20,6 +21,7 @@ sealed interface DatabaseTable {
     sealed class Placement : DatabaseTable
 }
 
+typealias ApplicationId = Id<DatabaseTable.Application>
 typealias AreaId = Id<DatabaseTable.Area>
 typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -13,6 +13,7 @@ import java.util.UUID
 
 sealed interface DatabaseTable {
     sealed class Application : DatabaseTable
+    sealed class ApplicationNote : DatabaseTable
     sealed class Area : DatabaseTable
     sealed class Daycare : DatabaseTable
     sealed class Employee : DatabaseTable
@@ -22,6 +23,7 @@ sealed interface DatabaseTable {
 }
 
 typealias ApplicationId = Id<DatabaseTable.Application>
+typealias ApplicationNoteId = Id<DatabaseTable.ApplicationNote>
 typealias AreaId = Id<DatabaseTable.Area>
 typealias ChildId = Id<DatabaseTable.Person>
 typealias DaycareId = Id<DatabaseTable.Daycare>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.application.ApplicationType
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.koski.KoskiSearchParams
 import fi.espoo.evaka.koski.KoskiStudyRightKey
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -156,7 +157,7 @@ data class NotifyVoucherValueDecisionPdfGenerated(val decisionId: UUID) : AsyncJ
     override val user: AuthenticatedUser? = null
 }
 
-data class InitializeFamilyFromApplication(val applicationId: UUID, override val user: AuthenticatedUser) :
+data class InitializeFamilyFromApplication(val applicationId: ApplicationId, override val user: AuthenticatedUser) :
     AsyncJobPayload {
     override val asyncJobType = AsyncJobType.INITIALIZE_FAMILY_FROM_APPLICATION
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.koski.KoskiStudyRightKey
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.FeeDecisionId
+import fi.espoo.evaka.shared.PairingId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.domain.DateRange
@@ -54,7 +55,7 @@ interface AsyncJobPayload {
     val user: AuthenticatedUser?
 }
 
-data class GarbageCollectPairing(val pairingId: UUID) : AsyncJobPayload {
+data class GarbageCollectPairing(val pairingId: PairingId) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.GARBAGE_COLLECT_PAIRING
     override val user: AuthenticatedUser? = null
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -10,6 +10,9 @@ import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.koski.KoskiSearchParams
 import fi.espoo.evaka.koski.KoskiStudyRightKey
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.DecisionId
+import fi.espoo.evaka.shared.FeeDecisionId
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -125,34 +128,34 @@ data class NotifyIncomeUpdated(
     override val user: AuthenticatedUser? = null
 }
 
-data class NotifyDecisionCreated(val decisionId: UUID, override val user: AuthenticatedUser, val sendAsMessage: Boolean) : AsyncJobPayload {
+data class NotifyDecisionCreated(val decisionId: DecisionId, override val user: AuthenticatedUser, val sendAsMessage: Boolean) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.DECISION_CREATED
 }
 
 data class SendDecision(
-    val decisionId: UUID,
+    val decisionId: DecisionId,
     @Deprecated(message = "only for backwards compatibility")
     override val user: AuthenticatedUser? = null
 ) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.SEND_DECISION
 }
 
-data class NotifyFeeDecisionApproved(val decisionId: UUID) : AsyncJobPayload {
+data class NotifyFeeDecisionApproved(val decisionId: FeeDecisionId) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.FEE_DECISION_APPROVED
     override val user: AuthenticatedUser? = null
 }
 
-data class NotifyFeeDecisionPdfGenerated(val decisionId: UUID) : AsyncJobPayload {
+data class NotifyFeeDecisionPdfGenerated(val decisionId: FeeDecisionId) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.FEE_DECISION_PDF_GENERATED
     override val user: AuthenticatedUser? = null
 }
 
-data class NotifyVoucherValueDecisionApproved(val decisionId: UUID) : AsyncJobPayload {
+data class NotifyVoucherValueDecisionApproved(val decisionId: VoucherValueDecisionId) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.VOUCHER_VALUE_DECISION_APPROVED
     override val user: AuthenticatedUser? = null
 }
 
-data class NotifyVoucherValueDecisionPdfGenerated(val decisionId: UUID) : AsyncJobPayload {
+data class NotifyVoucherValueDecisionPdfGenerated(val decisionId: VoucherValueDecisionId) : AsyncJobPayload {
     override val asyncJobType = AsyncJobType.VOUCHER_VALUE_DECISION_PDF_GENERATED
     override val user: AuthenticatedUser? = null
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.shared.auth
 
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
@@ -125,7 +126,7 @@ WHERE employee_id = :userId AND child_id = :childId
         }
     )
 
-    fun getRolesForDecision(user: AuthenticatedUser, decisionId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForDecision(user: AuthenticatedUser, decisionId: DecisionId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.shared.auth
 
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import org.jdbi.v3.core.Jdbi
@@ -96,7 +97,7 @@ WHERE employee_id = :userId AND daycare_group_id = :groupId
         }
     )
 
-    fun getRolesForPlacement(user: AuthenticatedUser, placementId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForPlacement(user: AuthenticatedUser, placementId: PlacementId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AssistanceActionId
 import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.BackupCareId
+import fi.espoo.evaka.shared.DaycareDailyNoteId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
@@ -231,7 +232,7 @@ WHERE employee_id = :userId AND d.id = :deviceId
         }
     )
 
-    fun getRolesForDailyNote(user: AuthenticatedUser, noteId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForDailyNote(user: AuthenticatedUser, noteId: DaycareDailyNoteId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 """

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.auth
 
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
@@ -54,7 +55,7 @@ WHERE employee_id = :userId AND daycare_id = :daycareId
         }
     )
 
-    fun getRolesForApplication(user: AuthenticatedUser, applicationId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForApplication(user: AuthenticatedUser, applicationId: ApplicationId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read { it ->
             val assistanceNeeded = it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.shared.auth
 
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import org.jdbi.v3.core.Jdbi
@@ -82,7 +83,7 @@ WHERE employee_id = :userId AND av.id = :applicationId AND av.status = ANY ('{SE
         }
     )
 
-    fun getRolesForUnitGroup(user: AuthenticatedUser, groupId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForUnitGroup(user: AuthenticatedUser, groupId: GroupId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.shared.auth
 
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.AssistanceActionId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
@@ -156,7 +157,7 @@ WHERE an.id = :assistanceNeedId AND acl.employee_id = :userId
         }
     )
 
-    fun getRolesForAssistanceAction(user: AuthenticatedUser, assistanceActionId: UUID): AclAppliedRoles =
+    fun getRolesForAssistanceAction(user: AuthenticatedUser, assistanceActionId: AssistanceActionId): AclAppliedRoles =
         AclAppliedRoles(
             (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
                 it.createQuery(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import org.jdbi.v3.core.Jdbi
@@ -181,7 +182,7 @@ WHERE bc.id = :backupCareId AND acl.employee_id = :userId
         }
     )
 
-    fun getRolesForServiceNeed(user: AuthenticatedUser, serviceNeedId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForServiceNeed(user: AuthenticatedUser, serviceNeedId: ServiceNeedId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.db.Database
@@ -212,7 +213,7 @@ WHERE employee_id = :userId AND p.id = :pairingId
         }
     )
 
-    fun getRolesForMobileDevice(user: AuthenticatedUser, deviceId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForMobileDevice(user: AuthenticatedUser, deviceId: MobileDeviceId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.auth
 
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import org.jdbi.v3.core.Jdbi
@@ -38,7 +39,8 @@ class AccessControlList(private val jdbi: Jdbi) {
             AclAuthorization.Subset(Database(jdbi).read { it.selectAuthorizedDaycares(user, roles) })
         }
 
-    fun getRolesForUnit(user: AuthenticatedUser, daycareId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForUnit(user: AuthenticatedUser, daycareId: UUID): AclAppliedRoles = getRolesForUnit(user, DaycareId(daycareId))
+    fun getRolesForUnit(user: AuthenticatedUser, daycareId: DaycareId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.MobileDeviceId
+import fi.espoo.evaka.shared.PairingId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.db.Database
@@ -199,7 +200,7 @@ WHERE employee_id = :userId AND service_need.id = :serviceNeedId
         }
     )
 
-    fun getRolesForPairing(user: AuthenticatedUser, pairingId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForPairing(user: AuthenticatedUser, pairingId: PairingId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.shared.auth
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AssistanceActionId
 import fi.espoo.evaka.shared.AssistanceNeedId
+import fi.espoo.evaka.shared.BackupCareId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
@@ -173,7 +174,7 @@ WHERE ac.id = :assistanceActionId AND acl.employee_id = :userId
             }
         )
 
-    fun getRolesForBackupCare(user: AuthenticatedUser, backupCareId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForBackupCare(user: AuthenticatedUser, backupCareId: BackupCareId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/Acl.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.shared.auth
 
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AssistanceActionId
+import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
@@ -143,7 +144,7 @@ WHERE employee_id = :userId AND decision.id = :decisionId
         }
     )
 
-    fun getRolesForAssistanceNeed(user: AuthenticatedUser, assistanceNeedId: UUID): AclAppliedRoles = AclAppliedRoles(
+    fun getRolesForAssistanceNeed(user: AuthenticatedUser, assistanceNeedId: AssistanceNeedId): AclAppliedRoles = AclAppliedRoles(
         (user.roles - UserRole.SCOPED_ROLES) + Database(jdbi).read {
             it.createQuery(
                 // language=SQL

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AclQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AclQueries.kt
@@ -54,7 +54,7 @@ fun Database.Read.hasDaycareAclRowForAnyUnit(employeeId: EmployeeId, role: UserR
     .one()
 
 fun Database.Transaction.insertDaycareAclRow(
-    daycareId: UUID,
+    daycareId: DaycareId,
     employeeId: UUID,
     role: UserRole
 ) = createUpdate(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionDetailed
 import fi.espoo.evaka.invoicing.domain.FeeDecisionSummary
 import fi.espoo.evaka.shared.Id
 import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.array.SqlArrayType
 import org.jdbi.v3.core.generic.GenericType
 import org.jdbi.v3.core.generic.GenericTypes
 import org.jdbi.v3.core.kotlin.KotlinPlugin
@@ -97,6 +98,12 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
     }
     jdbi.register(helsinkiDateTimeColumnMapper)
     jdbi.registerArrayType(UUID::class.java, "uuid")
+    jdbi.registerArrayType { elementType, _ ->
+        Optional.ofNullable(
+            SqlArrayType.of<Id<*>>("uuid") { it.raw }
+                .takeIf { Id::class.java.isAssignableFrom(GenericTypes.getErasedType(elementType)) }
+        )
+    }
     jdbi.registerRowMapper(FeeDecision::class.java, feeDecisionRowMapper(objectMapper))
     jdbi.registerRowMapper(FeeDecisionDetailed::class.java, feeDecisionDetailedRowMapper(objectMapper))
     jdbi.registerRowMapper(FeeDecisionSummary::class.java, feeDecisionSummaryRowMapper)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
@@ -20,6 +20,8 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionSummary
 import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
+import fi.espoo.evaka.shared.DatabaseTable
+import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -72,6 +74,8 @@ val identityArgumentFactory = customArgumentFactory<ExternalIdentifier>(Types.VA
 
 val externalIdArgumentFactory = toStringArgumentFactory<ExternalId>()
 
+val idArgumentFactory = customArgumentFactory<Id<DatabaseTable>>(Types.OTHER) { CustomObjectArgument(it.raw) }
+
 val helsinkiDateTimeArgumentFactory = customArgumentFactory<HelsinkiDateTime>(Types.TIMESTAMP_WITH_TIMEZONE) {
     CustomObjectArgument(it.toZonedDateTime().toOffsetDateTime())
 }
@@ -107,6 +111,8 @@ val coordinateColumnMapper = PgObjectColumnMapper {
 
 val externalIdColumnMapper =
     ColumnMapper { r, columnNumber, _ -> r.getString(columnNumber)?.let { ExternalId.parse(it) } }
+
+val idColumnMapper = ColumnMapper<Id<*>> { r, columnNumber, _ -> r.getObject(columnNumber, UUID::class.java)?.let { Id<DatabaseTable>(it) } }
 
 val helsinkiDateTimeColumnMapper =
     ColumnMapper { r, columnNumber, _ -> r.getObject(columnNumber, OffsetDateTime::class.java)?.let { HelsinkiDateTime.from(it.toInstant()) } }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionSummary
 import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DatabaseTable
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.Id
@@ -263,7 +264,7 @@ fun feeDecisionDetailedRowMapper(mapper: ObjectMapper): RowMapper<FeeDecisionDet
                         id = DaycareId(rs.getUUID("placement_unit_id")),
                         name = rs.getString("placement_unit_name"),
                         language = rs.getString("placement_unit_lang"),
-                        areaId = UUID.fromString(rs.getString("placement_unit_area_id")),
+                        areaId = AreaId(rs.getUUID("placement_unit_area_id")),
                         areaName = rs.getString("placement_unit_area_name")
                     ),
                     serviceNeedFeeCoefficient = rs.getBigDecimal("service_need_fee_coefficient"),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
@@ -21,6 +21,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.shared.DatabaseTable
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
@@ -179,7 +180,7 @@ fun feeDecisionRowMapper(mapper: ObjectMapper): RowMapper<FeeDecision> = RowMapp
                         dateOfBirth = rs.getDate("child_date_of_birth").toLocalDate()
                     ),
                     placement = FeeDecisionPlacement(
-                        unit = UnitData.JustId(rs.getUUID("placement_unit_id")),
+                        unit = UnitData.JustId(DaycareId(rs.getUUID("placement_unit_id"))),
                         type = rs.getEnum("placement_type"),
                     ),
                     serviceNeed = FeeDecisionServiceNeed(
@@ -259,7 +260,7 @@ fun feeDecisionDetailedRowMapper(mapper: ObjectMapper): RowMapper<FeeDecisionDet
                     ),
                     placementType = rs.getEnum("placement_type"),
                     placementUnit = UnitData.Detailed(
-                        id = UUID.fromString(rs.getString("placement_unit_id")),
+                        id = DaycareId(rs.getUUID("placement_unit_id")),
                         name = rs.getString("placement_unit_name"),
                         language = rs.getString("placement_unit_lang"),
                         areaId = UUID.fromString(rs.getString("placement_unit_area_id")),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DatabaseTable
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
@@ -161,7 +162,7 @@ class PgObjectColumnMapper<T>(private inline val deserializer: (PGobject) -> T?)
 
 fun feeDecisionRowMapper(mapper: ObjectMapper): RowMapper<FeeDecision> = RowMapper { rs, ctx ->
     FeeDecision(
-        id = UUID.fromString(rs.getString("id")),
+        id = FeeDecisionId(rs.getUUID("id")),
         status = FeeDecisionStatus.valueOf(rs.getString("status")),
         decisionNumber = rs.getObject("decision_number") as Long?, // getLong returns 0 for null values
         decisionType = rs.getEnum("decision_type"),
@@ -209,7 +210,7 @@ fun feeDecisionRowMapper(mapper: ObjectMapper): RowMapper<FeeDecision> = RowMapp
 
 fun feeDecisionDetailedRowMapper(mapper: ObjectMapper): RowMapper<FeeDecisionDetailed> = RowMapper { rs, ctx ->
     FeeDecisionDetailed(
-        id = UUID.fromString(rs.getString("id")),
+        id = FeeDecisionId(rs.getUUID("id")),
         status = FeeDecisionStatus.valueOf(rs.getString("status")),
         decisionNumber = rs.getObject("decision_number") as Long?, // getLong returns 0 for null values
         decisionType = FeeDecisionType.valueOf(rs.getString("decision_type")),
@@ -297,7 +298,7 @@ fun feeDecisionDetailedRowMapper(mapper: ObjectMapper): RowMapper<FeeDecisionDet
 
 val feeDecisionSummaryRowMapper: RowMapper<FeeDecisionSummary> = RowMapper { rs, ctx ->
     FeeDecisionSummary(
-        id = rs.getUUID("id"),
+        id = FeeDecisionId(rs.getUUID("id")),
         status = rs.getEnum("status"),
         decisionNumber = rs.getObject("decision_number") as Long?, // getLong returns 0 for null values
         validDuring = ctx.mapColumn(rs, "valid_during"),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -24,6 +24,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValue
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -419,16 +420,16 @@ INSERT INTO placement (id, type, child_id, unit_id, start_date, end_date)
 VALUES (:id, :type, :childId, :unitId, :startDate, :endDate)
 RETURNING id
 """
-)
+).let(::PlacementId)
 
 fun Database.Transaction.insertTestPlacement(
-    id: UUID = UUID.randomUUID(),
+    id: PlacementId = PlacementId(UUID.randomUUID()),
     childId: UUID = UUID.randomUUID(),
     unitId: UUID = UUID.randomUUID(),
     type: PlacementType = PlacementType.DAYCARE,
     startDate: LocalDate = LocalDate.of(2019, 1, 1),
     endDate: LocalDate = LocalDate.of(2019, 12, 31)
-): UUID {
+): PlacementId {
     createUpdate(
         """
             INSERT INTO placement (id, child_id, unit_id, type, start_date, end_date)
@@ -451,7 +452,7 @@ fun Database.Transaction.insertTestPlacement(
 
 fun Database.Transaction.insertTestServiceNeed(
     confirmedBy: UUID,
-    placementId: UUID,
+    placementId: PlacementId,
     period: FiniteDateRange,
     optionId: UUID,
     shiftCare: Boolean = false,
@@ -590,7 +591,7 @@ VALUES (:id, :daycareId, :name, :startDate)
 ).let(::GroupId)
 
 fun Database.Transaction.insertTestDaycareGroupPlacement(
-    daycarePlacementId: UUID = UUID.randomUUID(),
+    daycarePlacementId: PlacementId = PlacementId(UUID.randomUUID()),
     groupId: GroupId = GroupId(UUID.randomUUID()),
     id: UUID = UUID.randomUUID(),
     startDate: LocalDate = LocalDate.of(2019, 1, 1),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.invoicing.domain.VoucherValue
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
@@ -139,14 +140,14 @@ private fun Database.Transaction.insertTestDataRow(row: Any, @Language("sql") sq
     .asSequence()
     .single()
 
-fun Database.Transaction.insertTestCareArea(area: DevCareArea): UUID = insertTestDataRow(
+fun Database.Transaction.insertTestCareArea(area: DevCareArea): AreaId = insertTestDataRow(
     area,
     """
 INSERT INTO care_area (id, name, short_name, area_code, sub_cost_center)
 VALUES (:id, :name, :shortName, :areaCode, :subCostCenter)
 RETURNING id
 """
-)
+).let(::AreaId)
 
 fun Database.Transaction.insertTestDaycare(daycare: DevDaycare): DaycareId = insertTestDataRow(
     daycare,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.invoicing.domain.VoucherValue
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -586,11 +587,11 @@ fun Database.Transaction.insertTestDaycareGroup(group: DevDaycareGroup) = insert
 INSERT INTO daycare_group (id, daycare_id, name, start_date)
 VALUES (:id, :daycareId, :name, :startDate)
 """
-)
+).let(::GroupId)
 
 fun Database.Transaction.insertTestDaycareGroupPlacement(
     daycarePlacementId: UUID = UUID.randomUUID(),
-    groupId: UUID = UUID.randomUUID(),
+    groupId: GroupId = GroupId(UUID.randomUUID()),
     id: UUID = UUID.randomUUID(),
     startDate: LocalDate = LocalDate.of(2019, 1, 1),
     endDate: LocalDate = LocalDate.of(2019, 12, 31)
@@ -699,7 +700,7 @@ RETURNING id
 }
 
 fun Database.Transaction.insertTestCaretakers(
-    groupId: UUID,
+    groupId: GroupId,
     id: UUID = UUID.randomUUID(),
     amount: Double = 3.0,
     startDate: LocalDate = LocalDate.of(2019, 1, 1),
@@ -725,7 +726,7 @@ fun Database.Transaction.insertTestCaretakers(
 
 fun Database.Transaction.insertTestStaffAttendance(
     id: UUID = UUID.randomUUID(),
-    groupId: UUID,
+    groupId: GroupId,
     date: LocalDate,
     count: Double
 ) {
@@ -806,7 +807,7 @@ fun Database.Transaction.insertTestBackUpCare(
     unitId: UUID,
     startDate: LocalDate,
     endDate: LocalDate,
-    groupId: UUID? = null,
+    groupId: GroupId? = null,
     id: UUID = UUID.randomUUID()
 ) {
     //language=sql

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -25,6 +25,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
+import fi.espoo.evaka.shared.AssistanceActionId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
@@ -695,7 +696,7 @@ RETURNING id
 """
 )
 
-fun Database.Transaction.insertTestAssistanceAction(assistanceAction: DevAssistanceAction): UUID {
+fun Database.Transaction.insertTestAssistanceAction(assistanceAction: DevAssistanceAction): AssistanceActionId {
     val id = insertTestDataRow(
         assistanceAction,
         """
@@ -703,7 +704,7 @@ INSERT INTO assistance_action (id, updated_by, child_id, start_date, end_date, o
 VALUES (:id, :updatedBy, :childId, :startDate, :endDate, :otherAction, :measures::assistance_measure[])
 RETURNING id
 """
-    )
+    ).let(::AssistanceActionId)
     val counts = insertAssistanceActionOptionRefs(id, assistanceAction.actions)
     assert(counts.size == assistanceAction.actions.size)
     return id

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -27,6 +27,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PartnershipId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.UserRole
@@ -597,10 +598,10 @@ VALUES (:id, :daycareId, :name, :startDate)
 fun Database.Transaction.insertTestDaycareGroupPlacement(
     daycarePlacementId: PlacementId = PlacementId(UUID.randomUUID()),
     groupId: GroupId = GroupId(UUID.randomUUID()),
-    id: UUID = UUID.randomUUID(),
+    id: GroupPlacementId = GroupPlacementId(UUID.randomUUID()),
     startDate: LocalDate = LocalDate.of(2019, 1, 1),
     endDate: LocalDate = LocalDate.of(2019, 12, 31)
-): UUID {
+): GroupPlacementId {
     createUpdate(
         """
                 INSERT INTO daycare_group_placement (id, daycare_placement_id, daycare_group_id, start_date, end_date)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -26,6 +26,7 @@ import fi.espoo.evaka.serviceneed.ServiceNeedOption
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.AssistanceActionId
+import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
@@ -694,7 +695,7 @@ INSERT INTO assistance_need (id, updated_by, child_id, start_date, end_date, cap
 VALUES (:id, :updatedBy, :childId, :startDate, :endDate, :capacityFactor, :description, :bases::assistance_basis[], :otherBasis)
 RETURNING id
 """
-)
+).let(::AssistanceNeedId)
 
 fun Database.Transaction.insertTestAssistanceAction(assistanceAction: DevAssistanceAction): AssistanceActionId {
     val id = insertTestDataRow(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -28,6 +28,7 @@ import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
+import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.PartnershipId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
@@ -253,10 +254,10 @@ RETURNING id
 fun Database.Transaction.insertTestParentship(
     headOfChild: UUID,
     childId: UUID,
-    id: UUID = UUID.randomUUID(),
+    id: ParentshipId = ParentshipId(UUID.randomUUID()),
     startDate: LocalDate = LocalDate.of(2019, 1, 1),
     endDate: LocalDate = LocalDate.of(2019, 12, 31)
-): UUID {
+): ParentshipId {
     createUpdate(
         """
             INSERT INTO fridge_child (id, head_of_child, child_id, start_date, end_date)
@@ -277,7 +278,7 @@ fun Database.Transaction.insertTestParentship(
 }
 
 fun Database.Transaction.insertTestParentship(parentship: DevParentship): DevParentship {
-    val withId = if (parentship.id == null) parentship.copy(id = UUID.randomUUID()) else parentship
+    val withId = if (parentship.id == null) parentship.copy(id = ParentshipId(UUID.randomUUID())) else parentship
     // language=sql
     val sql =
         """
@@ -944,7 +945,7 @@ RETURNING id
 )
 
 data class DevFridgeChild(
-    val id: UUID,
+    val id: ParentshipId,
     val childId: UUID,
     val headOfChild: UUID,
     val startDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -30,6 +30,7 @@ import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PartnershipId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -462,9 +463,9 @@ fun Database.Transaction.insertTestServiceNeed(
     optionId: UUID,
     shiftCare: Boolean = false,
     confirmedAt: HelsinkiDateTime = HelsinkiDateTime.now(),
-    id: UUID = UUID.randomUUID(),
+    id: ServiceNeedId = ServiceNeedId(UUID.randomUUID()),
     updated: HelsinkiDateTime = HelsinkiDateTime.now()
-): UUID {
+): ServiceNeedId {
     createUpdate(
         """
 ALTER TABLE service_need DISABLE TRIGGER set_timestamp;

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -26,6 +26,7 @@ import fi.espoo.evaka.serviceneed.ServiceNeedOption
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.ParentshipId
@@ -683,7 +684,7 @@ INSERT INTO decision (created_by, sent_date, unit_id, application_id, type, star
 VALUES (:createdBy, :sentDate, :unitId, :applicationId, :type, :startDate, :endDate, :status, :requestedStartDate, :resolved, :resolvedBy, :pendingDecisionEmailsSentCount, :pendingDecisionEmailSent)
 RETURNING id
 """
-)
+).let(::DecisionId)
 
 fun Database.Transaction.insertTestAssistanceNeed(assistanceNeed: DevAssistanceNeed) = insertTestDataRow(
     assistanceNeed,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.invoicing.domain.VoucherValue
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
@@ -327,7 +328,7 @@ fun Database.Transaction.insertTestPartnership(
 }
 
 fun Database.Transaction.insertTestApplication(
-    id: UUID = UUID.randomUUID(),
+    id: ApplicationId = ApplicationId(UUID.randomUUID()),
     sentDate: LocalDate? = LocalDate.of(2019, 1, 1),
     dueDate: LocalDate? = LocalDate.of(2019, 5, 1),
     status: ApplicationStatus = ApplicationStatus.SENT,
@@ -336,7 +337,7 @@ fun Database.Transaction.insertTestApplication(
     otherGuardianId: UUID? = null,
     hideFromGuardian: Boolean = false,
     transferApplication: Boolean = false
-): UUID {
+): ApplicationId {
     createUpdate(
         """
             INSERT INTO application (id, sentdate, duedate, status, guardian_id, child_id, other_guardian_id, origin, hidefromguardian, transferApplication)
@@ -360,7 +361,7 @@ fun Database.Transaction.insertTestApplication(
     return id
 }
 
-fun Database.Transaction.insertTestApplicationForm(applicationId: UUID, document: DaycareFormV0, revision: Int = 1) {
+fun Database.Transaction.insertTestApplicationForm(applicationId: ApplicationId, document: DaycareFormV0, revision: Int = 1) {
     createUpdate(
         """
 UPDATE application_form SET latest = FALSE
@@ -382,7 +383,7 @@ VALUES (:applicationId, :revision, :document, TRUE)
         .execute()
 }
 
-fun Database.Transaction.insertTestClubApplicationForm(applicationId: UUID, document: ClubFormV0, revision: Int = 1) {
+fun Database.Transaction.insertTestClubApplicationForm(applicationId: ApplicationId, document: ClubFormV0, revision: Int = 1) {
     createUpdate(
         """
 UPDATE application_form SET latest = FALSE
@@ -619,7 +620,7 @@ fun Database.Transaction.insertTestDaycareGroupPlacement(
 }
 
 fun Database.Transaction.insertTestPlacementPlan(
-    applicationId: UUID,
+    applicationId: ApplicationId,
     unitId: DaycareId,
     id: UUID = UUID.randomUUID(),
     type: PlacementType = PlacementType.DAYCARE,
@@ -658,7 +659,7 @@ data class TestDecision(
     val createdBy: UUID,
     val sentDate: LocalDate = LocalDate.now(),
     val unitId: DaycareId,
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val type: DecisionType,
     val startDate: LocalDate,
     val endDate: LocalDate,
@@ -850,8 +851,8 @@ VALUES (:id, :childId, :unitId, :groupId, :startDate, :endDate)
     .bind("endDate", backupCare.period.end)
     .execute()
 
-fun Database.Transaction.insertApplication(application: ApplicationWithForm): UUID {
-    val id = application.id ?: UUID.randomUUID()
+fun Database.Transaction.insertApplication(application: ApplicationWithForm): ApplicationId {
+    val id = application.id ?: ApplicationId(UUID.randomUUID())
 
     //language=sql
     val sql =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -27,6 +27,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PartnershipId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -288,10 +289,10 @@ fun Database.Transaction.insertTestParentship(parentship: DevParentship): DevPar
 fun Database.Transaction.insertTestPartnership(
     adult1: UUID,
     adult2: UUID,
-    id: UUID = UUID.randomUUID(),
+    id: PartnershipId = PartnershipId(UUID.randomUUID()),
     startDate: LocalDate = LocalDate.of(2019, 1, 1),
     endDate: LocalDate = LocalDate.of(2019, 12, 31)
-): UUID {
+): PartnershipId {
     createUpdate(
         """
             INSERT INTO fridge_partner (partnership_id, indx, person_id, start_date, end_date)
@@ -958,7 +959,7 @@ RETURNING id
 )
 
 data class DevFridgePartner(
-    val partnershipId: UUID,
+    val partnershipId: PartnershipId,
     val indx: Int,
     val personId: UUID,
     val startDate: LocalDate,
@@ -972,7 +973,7 @@ INSERT INTO fridge_partner (partnership_id, indx, person_id, start_date, end_dat
 VALUES (:partnershipId, :indx, :personId, :startDate, :endDate)
 RETURNING partnership_id
 """
-)
+).let(::PartnershipId)
 
 data class DevEmployeePin(
     val id: UUID,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -32,6 +32,7 @@ import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.PartnershipId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -461,7 +462,7 @@ fun Database.Transaction.insertTestServiceNeed(
     confirmedBy: UUID,
     placementId: PlacementId,
     period: FiniteDateRange,
-    optionId: UUID,
+    optionId: ServiceNeedOptionId,
     shiftCare: Boolean = false,
     confirmedAt: HelsinkiDateTime = HelsinkiDateTime.now(),
     id: ServiceNeedId = ServiceNeedId(UUID.randomUUID()),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -56,6 +56,7 @@ import fi.espoo.evaka.pis.updatePersonFromVtj
 import fi.espoo.evaka.placement.PlacementPlanService
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -837,7 +838,7 @@ data class DevDaycareGroup(
 
 data class DevDaycareGroupPlacement(
     val id: UUID = UUID.randomUUID(),
-    val daycarePlacementId: UUID,
+    val daycarePlacementId: PlacementId,
     val daycareGroupId: GroupId,
     val startDate: LocalDate,
     val endDate: LocalDate
@@ -867,7 +868,7 @@ data class DevAssistanceAction(
 )
 
 data class DevPlacement(
-    val id: UUID = UUID.randomUUID(),
+    val id: PlacementId = PlacementId(UUID.randomUUID()),
     val type: PlacementType = PlacementType.DAYCARE,
     val childId: UUID,
     val unitId: UUID,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -55,6 +55,7 @@ import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.pis.updatePersonFromVtj
 import fi.espoo.evaka.placement.PlacementPlanService
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -149,7 +150,7 @@ class DevApi(
     @PutMapping("/daycares/{daycareId}/acl")
     fun addAclRoleForDaycare(
         db: Database,
-        @PathVariable daycareId: UUID,
+        @PathVariable daycareId: DaycareId,
         @RequestBody body: DaycareAclInsert
     ): ResponseEntity<Unit> {
         db.transaction { tx ->
@@ -232,7 +233,7 @@ class DevApi(
         val id: UUID,
         val employeeId: UUID,
         val applicationId: UUID,
-        val unitId: UUID,
+        val unitId: DaycareId,
         val type: DecisionType,
         val startDate: LocalDate,
         val endDate: LocalDate
@@ -611,7 +612,7 @@ RETURNING id
 
     data class MobileDeviceReq(
         val id: UUID,
-        val unitId: UUID,
+        val unitId: DaycareId,
         val name: String,
         val deleted: Boolean,
         val longTermToken: UUID
@@ -768,7 +769,7 @@ data class DevCareArea(
 data class DevBackupCare(
     val id: UUID? = null,
     val childId: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val groupId: GroupId?,
     val period: FiniteDateRange
 )
@@ -783,7 +784,7 @@ data class DevChild(
 )
 
 data class DevDaycare(
-    val id: UUID? = UUID.randomUUID(),
+    val id: DaycareId? = DaycareId(UUID.randomUUID()),
     val name: String = "Test Daycare",
     val openingDate: LocalDate? = null,
     val closingDate: LocalDate? = null,
@@ -831,7 +832,7 @@ data class DevDaycare(
 
 data class DevDaycareGroup(
     val id: GroupId = GroupId(UUID.randomUUID()),
-    val daycareId: UUID,
+    val daycareId: DaycareId,
     val name: String = "Testiläiset",
     val startDate: LocalDate = LocalDate.of(2019, 1, 1)
 )
@@ -871,7 +872,7 @@ data class DevPlacement(
     val id: PlacementId = PlacementId(UUID.randomUUID()),
     val type: PlacementType = PlacementType.DAYCARE,
     val childId: UUID,
-    val unitId: UUID,
+    val unitId: DaycareId,
     val startDate: LocalDate = LocalDate.of(2019, 1, 1),
     val endDate: LocalDate = LocalDate.of(2019, 12, 31)
 )
@@ -944,7 +945,7 @@ data class DevEmployee(
 
 data class DevMobileDevice(
     val id: UUID = UUID.randomUUID(),
-    val unitId: UUID,
+    val unitId: DaycareId,
     val name: String = "Laite",
     val deleted: Boolean = false,
     val longTermToken: UUID? = null
@@ -956,7 +957,7 @@ data class DaycareAclInsert(
 )
 
 data class PlacementPlan(
-    val unitId: UUID,
+    val unitId: DaycareId,
     val periodStart: LocalDate,
     val periodEnd: LocalDate,
     val preschoolDaycarePeriodStart: LocalDate?,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -58,6 +58,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.AssistanceActionId
+import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
@@ -854,7 +855,7 @@ data class DevDaycareGroupPlacement(
 )
 
 data class DevAssistanceNeed(
-    val id: UUID = UUID.randomUUID(),
+    val id: AssistanceNeedId = AssistanceNeedId(UUID.randomUUID()),
     val childId: UUID,
     val updatedBy: UUID,
     val startDate: LocalDate = LocalDate.of(2019, 1, 1),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -57,6 +57,7 @@ import fi.espoo.evaka.placement.PlacementPlanService
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
+import fi.espoo.evaka.shared.AssistanceActionId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
@@ -865,7 +866,7 @@ data class DevAssistanceNeed(
 )
 
 data class DevAssistanceAction(
-    val id: UUID = UUID.randomUUID(),
+    val id: AssistanceActionId = AssistanceActionId(UUID.randomUUID()),
     val childId: UUID,
     val updatedBy: UUID,
     val startDate: LocalDate = LocalDate.of(2019, 1, 1),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -58,6 +58,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.ParentshipId
@@ -234,7 +235,7 @@ class DevApi(
     }
 
     data class DecisionRequest(
-        val id: UUID,
+        val id: DecisionId,
         val employeeId: UUID,
         val applicationId: ApplicationId,
         val unitId: DaycareId,
@@ -263,7 +264,7 @@ class DevApi(
     }
 
     @PostMapping("/decisions/{id}/actions/create-pdf")
-    fun createDecisionPdf(db: Database, @PathVariable id: UUID): ResponseEntity<Unit> {
+    fun createDecisionPdf(db: Database, @PathVariable id: DecisionId): ResponseEntity<Unit> {
         db.transaction { decisionService.createDecisionPdfs(it, fakeAdmin, id) }
         return ResponseEntity.noContent().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -62,6 +62,7 @@ import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.MobileDeviceId
+import fi.espoo.evaka.shared.PairingId
 import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -594,7 +595,7 @@ RETURNING id
     @PostMapping("/mobile/pairings/{id}/response")
     fun postPairingResponse(
         db: Database.Connection,
-        @PathVariable id: UUID,
+        @PathVariable id: PairingId,
         @RequestBody body: PairingsController.PostPairingResponseReq
     ): ResponseEntity<Pairing> {
         db.transaction { it.incrementAttempts(id, body.challengeKey) }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -55,6 +55,7 @@ import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.pis.updatePersonFromVtj
 import fi.espoo.evaka.placement.PlacementPlanService
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -189,7 +190,7 @@ class DevApi(
     }
 
     data class Caretaker(
-        val groupId: UUID,
+        val groupId: GroupId,
         val amount: Double,
         val startDate: LocalDate,
         val endDate: LocalDate?
@@ -767,7 +768,7 @@ data class DevBackupCare(
     val id: UUID? = null,
     val childId: UUID,
     val unitId: UUID,
-    val groupId: UUID?,
+    val groupId: GroupId?,
     val period: FiniteDateRange
 )
 
@@ -828,7 +829,7 @@ data class DevDaycare(
 )
 
 data class DevDaycareGroup(
-    val id: UUID = UUID.randomUUID(),
+    val id: GroupId = GroupId(UUID.randomUUID()),
     val daycareId: UUID,
     val name: String = "Testiläiset",
     val startDate: LocalDate = LocalDate.of(2019, 1, 1)
@@ -837,7 +838,7 @@ data class DevDaycareGroup(
 data class DevDaycareGroupPlacement(
     val id: UUID = UUID.randomUUID(),
     val daycarePlacementId: UUID,
-    val daycareGroupId: UUID,
+    val daycareGroupId: GroupId,
     val startDate: LocalDate,
     val endDate: LocalDate
 )
@@ -987,4 +988,4 @@ data class ApplicationForm(
     val updated: OffsetDateTime? = OffsetDateTime.now()
 )
 
-data class DevDaycareGroupAcl(val groupId: UUID, val employeeId: UUID)
+data class DevDaycareGroupAcl(val groupId: GroupId, val employeeId: UUID)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -60,6 +60,7 @@ import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
+import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AclAuthorization
@@ -930,7 +931,7 @@ data class DevPerson(
 }
 
 data class DevParentship(
-    val id: UUID?,
+    val id: ParentshipId?,
     val childId: UUID,
     val headOfChildId: UUID,
     val startDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -59,6 +59,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AclAuthorization
@@ -840,7 +841,7 @@ data class DevDaycareGroup(
 )
 
 data class DevDaycareGroupPlacement(
-    val id: UUID = UUID.randomUUID(),
+    val id: GroupPlacementId = GroupPlacementId(UUID.randomUUID()),
     val daycarePlacementId: PlacementId,
     val daycareGroupId: GroupId,
     val startDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -61,6 +61,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
+import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -616,7 +617,7 @@ RETURNING id
     }
 
     data class MobileDeviceReq(
-        val id: UUID,
+        val id: MobileDeviceId,
         val unitId: DaycareId,
         val name: String,
         val deleted: Boolean,
@@ -949,7 +950,7 @@ data class DevEmployee(
 )
 
 data class DevMobileDevice(
-    val id: UUID = UUID.randomUUID(),
+    val id: MobileDeviceId = MobileDeviceId(UUID.randomUUID()),
     val unitId: DaycareId,
     val name: String = "Laite",
     val deleted: Boolean = false,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -55,6 +55,7 @@ import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.pis.updatePersonFromVtj
 import fi.espoo.evaka.placement.PlacementPlanService
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
@@ -233,7 +234,7 @@ class DevApi(
     data class DecisionRequest(
         val id: UUID,
         val employeeId: UUID,
-        val applicationId: UUID,
+        val applicationId: ApplicationId,
         val unitId: DaycareId,
         val type: DecisionType,
         val startDate: LocalDate,
@@ -268,7 +269,7 @@ class DevApi(
     @GetMapping("/applications/{applicationId}")
     fun getApplication(
         db: Database.Connection,
-        @PathVariable applicationId: UUID
+        @PathVariable applicationId: ApplicationId
     ): ResponseEntity<ApplicationDetails> {
         return db.read { tx ->
             tx.fetchApplicationDetails(applicationId)
@@ -278,7 +279,7 @@ class DevApi(
     @GetMapping("/applications/{applicationId}/decisions")
     fun getApplicationDecisions(
         db: Database.Connection,
-        @PathVariable applicationId: UUID
+        @PathVariable applicationId: ApplicationId
     ): ResponseEntity<List<Decision>> {
         return db.read { tx ->
             tx.getDecisionsByApplication(applicationId, AclAuthorization.All)
@@ -426,7 +427,7 @@ RETURNING id
     fun createApplications(
         db: Database,
         @RequestBody applications: List<ApplicationWithForm>
-    ): ResponseEntity<List<UUID>> {
+    ): ResponseEntity<List<ApplicationId>> {
         val uuids =
             db.transaction { tx ->
                 applications.map { application ->
@@ -454,7 +455,7 @@ RETURNING id
     @PostMapping("/placement-plan/{application-id}")
     fun createPlacementPlan(
         db: Database,
-        @PathVariable("application-id") applicationId: UUID,
+        @PathVariable("application-id") applicationId: ApplicationId,
         @RequestBody placementPlan: PlacementPlan
     ): ResponseEntity<Unit> {
         db.transaction { tx ->
@@ -521,7 +522,7 @@ RETURNING id
     @PostMapping("/applications/{applicationId}/actions/{action}")
     fun simpleAction(
         db: Database,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @PathVariable action: String
     ): ResponseEntity<Unit> {
         val simpleActions = mapOf(
@@ -545,7 +546,7 @@ RETURNING id
     @PostMapping("/applications/{applicationId}/actions/create-placement-plan")
     fun createPlacementPlan(
         db: Database,
-        @PathVariable applicationId: UUID,
+        @PathVariable applicationId: ApplicationId,
         @RequestBody body: DaycarePlacementPlan
     ): ResponseEntity<Unit> {
         db.transaction { tx ->
@@ -558,7 +559,7 @@ RETURNING id
     @PostMapping("/applications/{applicationId}/actions/create-default-placement-plan")
     fun createDefaultPlacementPlan(
         db: Database,
-        @PathVariable applicationId: UUID
+        @PathVariable applicationId: ApplicationId
     ): ResponseEntity<Unit> {
         db.transaction { tx ->
             tx.ensureFakeAdminExists()
@@ -966,7 +967,7 @@ data class PlacementPlan(
 )
 
 data class ApplicationWithForm(
-    val id: UUID?,
+    val id: ApplicationId?,
     val createdDate: OffsetDateTime?,
     val modifiedDate: OffsetDateTime?,
     var sentDate: LocalDate?,
@@ -984,7 +985,7 @@ data class ApplicationWithForm(
 
 data class ApplicationForm(
     val id: UUID? = UUID.randomUUID(),
-    val applicationId: UUID,
+    val applicationId: ApplicationId,
     val createdDate: OffsetDateTime? = OffsetDateTime.now(),
     val revision: Int,
     val document: DaycareFormV0,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -55,6 +55,7 @@ import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.pis.updatePersonFromVtj
 import fi.espoo.evaka.placement.PlacementPlanService
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
@@ -759,7 +760,7 @@ INSERT INTO voucher_value (id, validity, voucher_value) VALUES ('084314dc-ed7f-4
 }
 
 data class DevCareArea(
-    val id: UUID = UUID.randomUUID(),
+    val id: AreaId = AreaId(UUID.randomUUID()),
     val name: String = "Test Care Area",
     val shortName: String = "test_area",
     val areaCode: Int? = 200,
@@ -788,7 +789,7 @@ data class DevDaycare(
     val name: String = "Test Daycare",
     val openingDate: LocalDate? = null,
     val closingDate: LocalDate? = null,
-    val areaId: UUID,
+    val areaId: AreaId,
     val type: Set<CareType> = setOf(CareType.CENTRE, CareType.PRESCHOOL, CareType.PREPARATORY_EDUCATION),
     val daycareApplyPeriod: DateRange? = DateRange(LocalDate.of(2020, 3, 1), null),
     val preschoolApplyPeriod: DateRange? = DateRange(LocalDate.of(2020, 3, 1), null),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/LegacyEnduserDeserializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/LegacyEnduserDeserializer.kt
@@ -18,8 +18,8 @@ import fi.espoo.evaka.application.persistence.daycare.DEFAULT_CHILD_NATIONALITY
 import fi.espoo.evaka.application.persistence.daycare.DaycareAdditionalDetails
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.application.persistence.daycare.OtherPerson
+import fi.espoo.evaka.shared.DaycareId
 import java.time.LocalDate
-import java.util.UUID
 
 sealed class FormJson {
     abstract val type: ApplicationType
@@ -122,7 +122,7 @@ data class ChildJSON(
 )
 
 data class ApplyJSON(
-    val preferredUnits: List<UUID> = emptyList(),
+    val preferredUnits: List<DaycareId> = emptyList(),
     val siblingBasis: Boolean = false,
     val siblingName: String = "",
     val siblingSsn: String = ""

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/utils/SpringMvc.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/utils/SpringMvc.kt
@@ -35,11 +35,11 @@ fun runAfterCompletion(f: (request: WebRequest, ex: Exception?) -> Unit): WebReq
         override fun afterCompletion(request: WebRequest, ex: Exception?) = f(request, ex)
     }
 
-inline fun <reified T> convertFromString(crossinline f: (source: String) -> T): GenericConverter =
+inline fun <reified I, reified O> convertFrom(crossinline f: (source: I) -> O): GenericConverter =
     object : GenericConverter {
         override fun getConvertibleTypes(): Set<GenericConverter.ConvertiblePair> =
-            setOf(GenericConverter.ConvertiblePair(String::class.java, T::class.java))
+            setOf(GenericConverter.ConvertiblePair(I::class.java, O::class.java))
 
         override fun convert(source: Any?, sourceType: TypeDescriptor, targetType: TypeDescriptor): Any? =
-            source?.let { f(source as String) }
+            (source as? I)?.let(f)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -27,6 +27,7 @@ import fi.espoo.evaka.placement.PlacementPlanDetails
 import fi.espoo.evaka.placement.getDetailedDaycarePlacements
 import fi.espoo.evaka.placement.getMissingGroupPlacements
 import fi.espoo.evaka.placement.getPlacementPlans
+import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -119,7 +120,7 @@ data class UnitDataResponse(
 
 data class Caretakers(
     val unitCaretakers: Stats,
-    val groupCaretakers: Map<UUID, Stats>
+    val groupCaretakers: Map<GroupId, Stats>
 )
 
 data class UnitOccupancies(
@@ -149,8 +150,8 @@ private fun getOccupancyResponse(occupancies: List<OccupancyPeriod>): OccupancyR
 }
 
 data class GroupOccupancies(
-    val confirmed: Map<UUID, OccupancyResponse>,
-    val realized: Map<UUID, OccupancyResponse>
+    val confirmed: Map<GroupId, OccupancyResponse>,
+    val realized: Map<GroupId, OccupancyResponse>
 )
 
 private fun getGroupOccupancies(
@@ -176,7 +177,7 @@ private fun getGroupOccupancies(
     )
 }
 
-private fun getGroupOccupancyResponses(occupancies: List<OccupancyPeriodGroupLevel>): Map<UUID, OccupancyResponse> {
+private fun getGroupOccupancyResponses(occupancies: List<OccupancyPeriodGroupLevel>): Map<GroupId, OccupancyResponse> {
     return occupancies
         .groupBy { it.groupId }
         .mapValues { (_, value) ->

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -27,6 +27,7 @@ import fi.espoo.evaka.placement.PlacementPlanDetails
 import fi.espoo.evaka.placement.getDetailedDaycarePlacements
 import fi.espoo.evaka.placement.getMissingGroupPlacements
 import fi.espoo.evaka.placement.getPlacementPlans
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -41,7 +42,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import java.time.LocalDate
-import java.util.UUID
 
 val basicDataRoles = arrayOf(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR, UserRole.STAFF, UserRole.SPECIAL_EDUCATION_TEACHER)
 val detailedDataRoles = arrayOf(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.UNIT_SUPERVISOR)
@@ -53,7 +53,7 @@ class UnitsView(private val acl: AccessControlList) {
     fun getUnitViewData(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable unitId: UUID,
+        @PathVariable unitId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam(
             value = "to",
@@ -131,7 +131,7 @@ data class UnitOccupancies(
 
 private fun getUnitOccupancies(
     tx: Database.Read,
-    unitId: UUID,
+    unitId: DaycareId,
     period: FiniteDateRange
 ): UnitOccupancies {
     return UnitOccupancies(
@@ -156,7 +156,7 @@ data class GroupOccupancies(
 
 private fun getGroupOccupancies(
     tx: Database.Read,
-    unitId: UUID,
+    unitId: DaycareId,
     period: FiniteDateRange
 ): GroupOccupancies {
     return GroupOccupancies(

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaFeeData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaFeeData.kt
@@ -10,6 +10,8 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.FeeDecisionId
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
@@ -112,8 +114,8 @@ fun getMarkedFeeData(tx: Database.Read): List<Long> {
 private fun insertFeeDataUpload(
     tx: Database.Transaction,
     vardaId: Long,
-    feeDecisionId: UUID?,
-    voucherValueDecisionId: UUID?,
+    feeDecisionId: FeeDecisionId?,
+    voucherValueDecisionId: VoucherValueDecisionId?,
     vardaDecisionId: Long,
     vardaChildId: Long
 ) {
@@ -335,8 +337,8 @@ data class VardaGuardian(
 )
 
 data class VardaFeeDataBase(
-    val feeDecisionId: UUID?,
-    val voucherValueDecisionId: UUID?,
+    val feeDecisionId: FeeDecisionId?,
+    val voucherValueDecisionId: VoucherValueDecisionId?,
     val vardaChildId: Long,
     val vardaId: Long?,
     val startDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaPlacements.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaPlacements.kt
@@ -6,6 +6,8 @@ package fi.espoo.evaka.varda
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.VardaDecisionId
+import fi.espoo.evaka.shared.VardaPlacementId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.varda.integration.VardaClient
@@ -43,7 +45,7 @@ fun sendNewPlacements(db: Database.Connection, client: VardaClient) {
                 insertVardaPlacement(
                     it,
                     VardaPlacementTableRow(
-                        id = UUID.randomUUID(),
+                        id = VardaPlacementId(UUID.randomUUID()),
                         vardaPlacementId = vardaPlacementId,
                         evakaPlacementId = placementId,
                         decisionId = decisionId,
@@ -122,7 +124,7 @@ JOIN sent_decision d
     AND daterange(p.start_date, p.end_date, '[]') && daterange(d.start_date, d.end_date, '[]')
     """.trimIndent()
 
-fun getNewPlacements(tx: Database.Read, getDecisionUrl: (Long) -> String, sourceSystem: String): List<Triple<UUID, PlacementId, VardaPlacement>> {
+fun getNewPlacements(tx: Database.Read, getDecisionUrl: (Long) -> String, sourceSystem: String): List<Triple<VardaDecisionId, PlacementId, VardaPlacement>> {
     val sql =
         """
 $placementBaseQuery
@@ -170,7 +172,7 @@ private fun getUpdatedPlacements(
     tx: Database.Read,
     getDecisionUrl: (Long) -> String,
     sourceSystem: String
-): List<Triple<UUID, Long, VardaPlacement>> {
+): List<Triple<VardaPlacementId, Long, VardaPlacement>> {
     val sql =
         """
 $placementBaseQuery
@@ -184,7 +186,7 @@ WHERE vp.uploaded_at < GREATEST(p.updated, u.updated)
         .toList()
 }
 
-private fun updatePlacementUploadTimestamp(tx: Database.Transaction, id: UUID, uploadedAt: Instant = Instant.now()) {
+private fun updatePlacementUploadTimestamp(tx: Database.Transaction, id: VardaPlacementId, uploadedAt: Instant = Instant.now()) {
     val sql = "UPDATE varda_placement SET uploaded_at = :uploadedAt WHERE id = :id"
     tx.createUpdate(sql)
         .bind("id", id)
@@ -235,10 +237,10 @@ data class VardaPlacementResponse(
 )
 
 data class VardaPlacementTableRow(
-    val id: UUID,
+    val id: VardaPlacementId,
     val vardaPlacementId: Long,
     val evakaPlacementId: PlacementId,
-    val decisionId: UUID,
+    val decisionId: VardaDecisionId,
     val createdAt: Instant,
     val uploadedAt: Instant
 )
@@ -246,10 +248,10 @@ data class VardaPlacementTableRow(
 private fun toVardaPlacementWithDecisionAndPlacementId(
     getDecisionUrl: (Long) -> String,
     sourceSystem: String
-): (ResultSet, StatementContext) -> Triple<UUID, PlacementId, VardaPlacement> =
+): (ResultSet, StatementContext) -> Triple<VardaDecisionId, PlacementId, VardaPlacement> =
     { rs, _ ->
         Triple(
-            rs.getUUID("decision_id"),
+            VardaDecisionId(rs.getUUID("decision_id")),
             PlacementId(rs.getUUID("placement_id")),
             toVardaPlacement(rs, getDecisionUrl, sourceSystem)
         )
@@ -258,10 +260,10 @@ private fun toVardaPlacementWithDecisionAndPlacementId(
 private fun toVardaPlacementWithIdAndVardaId(
     getDecisionUrl: (Long) -> String,
     sourceSystem: String
-): (ResultSet, StatementContext) -> Triple<UUID, Long, VardaPlacement> =
+): (ResultSet, StatementContext) -> Triple<VardaPlacementId, Long, VardaPlacement> =
     { rs, _ ->
         Triple(
-            rs.getUUID("id"),
+            VardaPlacementId(rs.getUUID("id")),
             rs.getLong("varda_placement_id"),
             toVardaPlacement(rs, getDecisionUrl, sourceSystem)
         )
@@ -281,10 +283,10 @@ private fun toVardaPlacement(
 
 val toVardaPlacementRow: (ResultSet, StatementContext) -> VardaPlacementTableRow = { rs, _ ->
     VardaPlacementTableRow(
-        id = rs.getUUID("id"),
+        id = VardaPlacementId(rs.getUUID("id")),
         vardaPlacementId = rs.getLong("varda_placement_id"),
         evakaPlacementId = PlacementId(rs.getUUID("evaka_placement_id")),
-        decisionId = rs.getUUID("decision_id"),
+        decisionId = VardaDecisionId(rs.getUUID("decision_id")),
         createdAt = rs.getTimestamp("created_at").toInstant(),
         uploadedAt = rs.getTimestamp("uploaded_at").toInstant()
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUnits.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUnits.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.varda.integration.VardaClient
 import mu.KotlinLogging
@@ -164,7 +165,7 @@ data class VardaUnit(
     @JsonProperty("organisaatio_oid")
     val ophUnitOid: String?,
     @JsonIgnore
-    val evakaDaycareId: UUID?,
+    val evakaDaycareId: DaycareId?,
     @JsonProperty("vakajarjestaja")
     var organizer: String?,
     @JsonProperty("nimi")

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
 import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.VardaUpdateV2
 import fi.espoo.evaka.shared.db.Database
@@ -680,7 +681,7 @@ GROUP BY evaka_child_id"""
 data class VardaServiceNeed(
     val evakaChildId: UUID,
     val evakaServiceNeedId: ServiceNeedId,
-    val evakaServiceNeedOptionId: UUID,
+    val evakaServiceNeedOptionId: ServiceNeedOptionId,
     val evakaServiceNeedUpdated: HelsinkiDateTime,
     val evakaServiceNeedOptionUpdated: HelsinkiDateTime,
     var vardaChildId: Long? = null,
@@ -812,7 +813,7 @@ private fun evakaServiceNeedToVardaServiceNeed(childId: UUID, evakaServiceNeed: 
 
 data class EvakaServiceNeedInfoForVarda(
     val id: ServiceNeedId,
-    val optionId: UUID,
+    val optionId: ServiceNeedOptionId,
     val serviceNeedUpdated: Instant,
     val serviceNeedOptionUpdated: Instant,
     val childId: UUID,

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
@@ -15,8 +15,10 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
+import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.VardaUpdateV2
 import fi.espoo.evaka.shared.db.Database
@@ -413,7 +415,7 @@ fun createFeeDataToVardaFromFeeDecision(
     client: VardaClient,
     vardaChildId: Long,
     evakaServiceNeedInfoForVarda: EvakaServiceNeedInfoForVarda,
-    decisionId: UUID
+    decisionId: FeeDecisionId
 ): Long? {
     val decision = db.read { it.getFeeDecisionsByIds(listOf(decisionId)) }.first()
     val childPart = decision.children.find { part -> part.child.id == evakaServiceNeedInfoForVarda.childId }
@@ -486,7 +488,7 @@ fun createFeeDataToVardaFromVoucherValueDecision(
     client: VardaClient,
     vardaChildId: Long,
     evakaServiceNeedInfoForVarda: EvakaServiceNeedInfoForVarda,
-    id: UUID
+    id: VoucherValueDecisionId
 ): Long {
     val decision = db.read { it.getVoucherValueDecision(id) }
         ?: throw Exception("VardaUpdate: cannot create voucher fee data: voucher $id not found")
@@ -798,8 +800,8 @@ ${ if (serviceNeedId != null) "WHERE COALESCE(service_need_fees.service_need_id,
 data class FeeDataByServiceNeed(
     val evakaChildId: UUID,
     val serviceNeedId: ServiceNeedId,
-    val feeDecisionIds: List<UUID> = emptyList(),
-    val voucherValueDecisionIds: List<UUID> = emptyList()
+    val feeDecisionIds: List<FeeDecisionId> = emptyList(),
+    val voucherValueDecisionIds: List<VoucherValueDecisionId> = emptyList()
 )
 
 private fun evakaServiceNeedToVardaServiceNeed(childId: UUID, evakaServiceNeed: EvakaServiceNeedInfoForVarda): VardaServiceNeed =

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
@@ -29,6 +29,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionPlacement
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionServiceNeed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.domain.DateRange
 import java.math.BigDecimal
 import java.time.Instant
@@ -98,7 +99,7 @@ val testFeeThresholds = FeeThresholds(
 val testDecisionChild1 =
     FeeDecisionChild(
         child = testChild1,
-        placement = FeeDecisionPlacement(UnitData.JustId(UUID.randomUUID()), PlacementType.DAYCARE),
+        placement = FeeDecisionPlacement(UnitData.JustId(DaycareId(UUID.randomUUID())), PlacementType.DAYCARE),
         serviceNeed = FeeDecisionServiceNeed(BigDecimal("1.00"), "palveluntarve", "vårdbehövet", false),
         baseFee = 28900,
         siblingDiscount = 0,
@@ -109,7 +110,7 @@ val testDecisionChild1 =
 val testDecisionChild2 =
     FeeDecisionChild(
         child = testChild2,
-        placement = FeeDecisionPlacement(UnitData.JustId(UUID.randomUUID()), PlacementType.DAYCARE),
+        placement = FeeDecisionPlacement(UnitData.JustId(DaycareId(UUID.randomUUID())), PlacementType.DAYCARE),
         serviceNeed = FeeDecisionServiceNeed(BigDecimal("1.00"), "palveluntarve", "vårdbehövet", false),
         baseFee = 28900,
         siblingDiscount = 0,
@@ -187,7 +188,7 @@ fun createFeeDecisionAlterationFixture(
 fun createFeeDecisionChildFixture(
     childId: UUID,
     dateOfBirth: LocalDate,
-    placementUnitId: UUID,
+    placementUnitId: DaycareId,
     placementType: PlacementType,
     serviceNeed: FeeDecisionServiceNeed,
     baseFee: Int = 28900,
@@ -234,7 +235,7 @@ fun createVoucherValueDecisionFixture(
     headOfFamilyId: UUID,
     childId: UUID,
     dateOfBirth: LocalDate,
-    unitId: UUID,
+    unitId: DaycareId,
     familySize: Int = 2,
     placementType: PlacementType,
     serviceNeed: VoucherValueDecisionServiceNeed,

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
@@ -30,6 +30,8 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionServiceNeed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.FeeDecisionId
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.domain.DateRange
 import java.math.BigDecimal
 import java.time.Instant
@@ -120,7 +122,7 @@ val testDecisionChild2 =
     )
 
 val testDecision1 = FeeDecision(
-    id = uuid1,
+    id = FeeDecisionId(uuid1),
     status = FeeDecisionStatus.DRAFT,
     decisionNumber = 1010101010L,
     decisionType = FeeDecisionType.NORMAL,
@@ -215,7 +217,7 @@ fun createFeeDecisionFixture(
     feeThresholds: FeeDecisionThresholds = testFeeThresholds.getFeeDecisionThresholds(children.size + 1),
     headOfFamilyIncome: DecisionIncome? = null
 ) = FeeDecision(
-    id = UUID.randomUUID(),
+    id = FeeDecisionId(UUID.randomUUID()),
     status = status,
     decisionType = decisionType,
     validDuring = period,
@@ -247,7 +249,7 @@ fun createVoucherValueDecisionFixture(
     coPayment: Int = 28900,
     feeAlterations: List<FeeAlterationWithEffect> = listOf()
 ) = VoucherValueDecision(
-    id = UUID.randomUUID(),
+    id = VoucherValueDecisionId(UUID.randomUUID()),
     status = status,
     validFrom = validFrom,
     validTo = validTo,

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
@@ -31,6 +31,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.FeeDecisionId
+import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.domain.DateRange
 import java.math.BigDecimal
@@ -162,7 +163,7 @@ val testInvoice = Invoice(
 val testPisFridgeParentId = UUID.randomUUID()
 
 val testIncome = Income(
-    id = UUID.randomUUID(),
+    id = IncomeId(UUID.randomUUID()),
     personId = UUID.randomUUID(),
     validFrom = LocalDate.of(2000, 1, 1),
     validTo = null,

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/service/PdfServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/service/PdfServiceTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.invoicing.testDecision1
 import fi.espoo.evaka.invoicing.testDecisionIncome
 import fi.espoo.evaka.invoicing.testFeeThresholds
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.config.PDFConfig
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.template.EvakaTemplateProvider
@@ -81,7 +82,7 @@ class PdfServiceTest {
                 ),
                 placementType = it.placement.type,
                 placementUnit = UnitData.Detailed(
-                    id = UUID.randomUUID(),
+                    id = DaycareId(UUID.randomUUID()),
                     name = "Leppäkerttu-konserni, päiväkoti Pupu Tupuna",
                     language = "fi",
                     areaId = UUID.randomUUID(),
@@ -152,7 +153,7 @@ class PdfServiceTest {
         childAge = 3,
         placement = VoucherValueDecisionPlacementDetailed(
             UnitData.Detailed(
-                id = UUID.randomUUID(),
+                id = DaycareId(UUID.randomUUID()),
                 name = "Test Daycare",
                 language = "fi",
                 areaId = UUID.randomUUID(),

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/service/PdfServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/service/PdfServiceTest.kt
@@ -21,6 +21,7 @@ import fi.espoo.evaka.invoicing.testFeeThresholds
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.config.PDFConfig
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.template.EvakaTemplateProvider
@@ -107,7 +108,7 @@ class PdfServiceTest {
     private val reliefDecision = normalDecision.copy(decisionType = FeeDecisionType.RELIEF_ACCEPTED)
 
     private val normalVoucherValueDecision = VoucherValueDecisionDetailed(
-        id = testDecision1.id,
+        id = VoucherValueDecisionId(testDecision1.id.raw),
         approvedAt = Instant.parse("2019-04-15T10:15:30.00Z"),
         approvedBy = PersonData.WithName(
             UUID.randomUUID(),

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/service/PdfServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/service/PdfServiceTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.invoicing.testDecision1
 import fi.espoo.evaka.invoicing.testDecisionIncome
 import fi.espoo.evaka.invoicing.testFeeThresholds
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.config.PDFConfig
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
@@ -85,7 +86,7 @@ class PdfServiceTest {
                     id = DaycareId(UUID.randomUUID()),
                     name = "Leppäkerttu-konserni, päiväkoti Pupu Tupuna",
                     language = "fi",
-                    areaId = UUID.randomUUID(),
+                    areaId = AreaId(UUID.randomUUID()),
                     areaName = "Test Area"
                 ),
                 serviceNeedFeeCoefficient = it.serviceNeed.feeCoefficient,
@@ -156,7 +157,7 @@ class PdfServiceTest {
                 id = DaycareId(UUID.randomUUID()),
                 name = "Test Daycare",
                 language = "fi",
-                areaId = UUID.randomUUID(),
+                areaId = AreaId(UUID.randomUUID()),
                 areaName = "Test Area"
             ),
             PlacementType.DAYCARE


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- a minimal wrapper for UUIDs with more type-safety
- `@JvmInline` + `value class` would be optimal, but Java libraries that use reflection have some problems with it -> use normal `data class` instead
- handle `Id<*>` transparently in REST endpoint parameters (Spring MVC / Jackson), JSON serialization (Jackson), and database parameters / return values (JDBI)
- convert ~55% of raw UUIDs to typesafe IDs.
  Before:

  ```
  $ rg -i "id: UUID" | wc -l
  1470
  ```

  After:
  ```
  $ rg -i "id: UUID" | wc -l
  650
  ```
  
  - `PersonId` / `ChildId` / `EmployeeId` are not fully utilized, because some existing code mixes them and needs refactoring