### PR TITLE
Wait until message has actually been sent

### DIFF
--- a/frontend/src/e2e-playwright/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-playwright/pages/employee/messages/messages-page.ts
@@ -44,6 +44,8 @@ export default class MessagesPage {
     await this.#receiverSelection.click()
     await this.page.keyboard.press('Enter')
     await this.#sendMessageButton.click()
+    await waitUntilEqual(() => this.isEditorVisible(), false)
+
     await this.#sentMessagesBoxRow.click()
     await waitUntilEqual(() => this.existsSentMessage(), true)
   }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Potential fix for flaky E2E: after pressing send, actually wait for the message editor to close. Previously we went immediately to the "sent messages" page and assumed the message was there, but there was no guarantee the REST request for sending the message had completed.
