### PR TITLE
Ensure applications are sorted in predictable order

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -325,11 +325,11 @@ fun Database.Read.fetchApplicationSummaries(
         """.trimIndent()
 
     val orderedSql = when (sortBy) {
-        ApplicationSortColumn.APPLICATION_TYPE -> "$sql ORDER BY type $sortDir"
+        ApplicationSortColumn.APPLICATION_TYPE -> "$sql ORDER BY type $sortDir, last_name, first_name"
         ApplicationSortColumn.CHILD_NAME -> "$sql ORDER BY last_name, first_name $sortDir"
-        ApplicationSortColumn.DUE_DATE -> "$sql ORDER BY duedate $sortDir"
-        ApplicationSortColumn.START_DATE -> "$sql ORDER BY preferredStartDate $sortDir"
-        ApplicationSortColumn.STATUS -> "$sql ORDER BY application_status $sortDir"
+        ApplicationSortColumn.DUE_DATE -> "$sql ORDER BY duedate $sortDir, last_name, first_name"
+        ApplicationSortColumn.START_DATE -> "$sql ORDER BY preferredStartDate $sortDir, last_name, first_name"
+        ApplicationSortColumn.STATUS -> "$sql ORDER BY application_status $sortDir, last_name, first_name"
     }.exhaust()
 
     val paginatedSql = "$orderedSql LIMIT $pageSize OFFSET ${(page - 1) * pageSize}"


### PR DESCRIPTION
#### Summary

- Sorted applications should be in same order (see that state sorted application here are ordered based on the first name of the child even though applications are identical otherwise)

<img width="1422" alt="Screenshot 2021-07-07 at 14 27 28" src="https://user-images.githubusercontent.com/158767/124751670-94553080-df2f-11eb-96f0-0050e7f425da.png">


