### PR TITLE
[EVAKA-HOTFIX] Adjust DVV update schedule to avoid downtime

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -54,7 +54,7 @@ data class ScheduledJobSettings(val enabled: Boolean, val schedule: Schedule) {
             )
             ScheduledJob.DvvUpdate -> ScheduledJobSettings(
                 enabled = false,
-                schedule = JobSchedule.daily(LocalTime.of(6, 0))
+                schedule = JobSchedule.daily(LocalTime.of(4, 0))
             )
             ScheduledJob.RemoveOldDaycareDailyNotes -> ScheduledJobSettings(
                 enabled = true,


### PR DESCRIPTION
#### Summary
- Espoo's X-Road instance has a daily downtime at 03:00 UTC which is 06:00 Helsinki time -> adjust schedule to never collide with the downtime
- DVV update goes through X-Road

