### PR TITLE
MVP of action-based permission checks

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/SecurityConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/SecurityConfig.kt
@@ -5,6 +5,9 @@
 package fi.espoo.evaka.shared.config
 
 import fi.espoo.evaka.shared.auth.AccessControlList
+import fi.espoo.evaka.shared.security.AccessControl
+import fi.espoo.evaka.shared.security.PermittedRoleActions
+import fi.espoo.evaka.shared.security.StaticPermittedRoleActions
 import org.jdbi.v3.core.Jdbi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -13,4 +16,11 @@ import org.springframework.context.annotation.Configuration
 class SecurityConfig {
     @Bean
     fun accessControlList(jdbi: Jdbi): AccessControlList = AccessControlList(jdbi)
+
+    @Bean
+    fun permittedRoleActions(): PermittedRoleActions = StaticPermittedRoleActions()
+
+    @Bean
+    fun accessControl(permittedRoleActions: PermittedRoleActions, acl: AccessControlList): AccessControl =
+        AccessControl(permittedRoleActions, acl)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.security
+
+import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.AssistanceActionId
+import fi.espoo.evaka.shared.AssistanceNeedId
+import fi.espoo.evaka.shared.BackupCareId
+import fi.espoo.evaka.shared.DaycareDailyNoteId
+import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.DecisionId
+import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.MobileDeviceId
+import fi.espoo.evaka.shared.PairingId
+import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.auth.AccessControlList
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.domain.Forbidden
+import java.util.UUID
+
+class AccessControl(private val permittedRoleActions: PermittedRoleActions, private val acl: AccessControlList) {
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.Application, id: ApplicationId) {
+        val roles = acl.getRolesForApplication(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::applicationActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.AssistanceAction, id: AssistanceActionId) {
+        val roles = acl.getRolesForAssistanceAction(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::assistanceActionActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.AssistanceNeed, id: AssistanceNeedId) {
+        val roles = acl.getRolesForAssistanceNeed(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::assistanceNeedActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.BackupCare, id: BackupCareId) {
+        val roles = acl.getRolesForBackupCare(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::backupCareActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.Child, id: UUID) {
+        val roles = acl.getRolesForChild(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::childActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.DailyNote, id: DaycareDailyNoteId) {
+        val roles = acl.getRolesForDailyNote(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::dailyNoteActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.Decision, id: DecisionId) {
+        val roles = acl.getRolesForDecision(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::decisionActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.Group, id: GroupId) {
+        val roles = acl.getRolesForUnitGroup(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::groupActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.MobileDevice, id: MobileDeviceId) {
+        val roles = acl.getRolesForMobileDevice(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::mobileDeviceActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.Pairing, id: PairingId) {
+        val roles = acl.getRolesForPairing(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::pairingActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.Placement, id: PlacementId) {
+        val roles = acl.getRolesForPlacement(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::placementActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.ServiceNeed, id: ServiceNeedId) {
+        val roles = acl.getRolesForServiceNeed(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::serviceNeedActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.Unit, id: DaycareId) {
+        val roles = acl.getRolesForUnit(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::unitActions)
+    }
+
+    fun requirePermissionFor(user: AuthenticatedUser, action: Action.VasuDocument, id: UUID) {
+        val roles = acl.getRolesForVasuDocument(user, id).roles
+        assertPermission(roles, action, permittedRoleActions::vasuDocumentActions)
+    }
+
+    private inline fun <reified A> assertPermission(
+        roles: Set<UserRole>,
+        action: A,
+        crossinline mapping: (role: UserRole) -> Set<A>
+    ) where A : Action, A : Enum<A> {
+        if (!roles.any { it == UserRole.ADMIN || mapping(it).contains(action) }) {
+            throw Forbidden("Permission denied")
+        }
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.security
+
+import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.auth.UserRole.FINANCE_ADMIN
+import fi.espoo.evaka.shared.auth.UserRole.SERVICE_WORKER
+import fi.espoo.evaka.shared.auth.UserRole.SPECIAL_EDUCATION_TEACHER
+import fi.espoo.evaka.shared.auth.UserRole.STAFF
+import fi.espoo.evaka.shared.auth.UserRole.UNIT_SUPERVISOR
+import java.util.EnumSet
+
+sealed interface Action {
+    enum class Application(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class AssistanceAction(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class AssistanceNeed(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class BackupCare(private val roles: EnumSet<UserRole>) : Action {
+        UPDATE(SERVICE_WORKER, UNIT_SUPERVISOR),
+        DELETE(SERVICE_WORKER, UNIT_SUPERVISOR);
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class Child(private val roles: EnumSet<UserRole>) : Action {
+        CREATE_BACKUP_CARE(SERVICE_WORKER, UNIT_SUPERVISOR),
+        READ_BACKUP_CARE(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN, STAFF, SPECIAL_EDUCATION_TEACHER);
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class DailyNote(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class Decision(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class Group(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class MobileDevice(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class Pairing(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class Placement(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class ServiceNeed(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class Unit(private val roles: EnumSet<UserRole>) : Action {
+        READ_BACKUP_CARE(SERVICE_WORKER, UNIT_SUPERVISOR, FINANCE_ADMIN, STAFF);
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+    enum class VasuDocument(private val roles: EnumSet<UserRole>) : Action {
+        ;
+
+        constructor(vararg roles: UserRole) : this(roles.toEnumSet())
+        override fun toString(): String = "${javaClass.name}.$name"
+        override fun defaultRoles(): Set<UserRole> = roles
+    }
+
+    /**
+     * Roles allowed to perform this action by default.
+     *
+     * Can be empty if permission checks for this action are not based on roles.
+     */
+    fun defaultRoles(): Set<UserRole>
+}
+
+private fun Array<out UserRole>.toEnumSet() = EnumSet.noneOf(UserRole::class.java).also {
+    it.addAll(this)
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/PermittedRoleActions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/PermittedRoleActions.kt
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.security
+
+import fi.espoo.evaka.shared.auth.UserRole
+import java.util.EnumMap
+import java.util.EnumSet
+
+/**
+ * Role → action mapping
+ */
+interface PermittedRoleActions {
+    fun applicationActions(role: UserRole): Set<Action.Application>
+    fun assistanceActionActions(role: UserRole): Set<Action.AssistanceAction>
+    fun assistanceNeedActions(role: UserRole): Set<Action.AssistanceNeed>
+    fun backupCareActions(role: UserRole): Set<Action.BackupCare>
+    fun childActions(role: UserRole): Set<Action.Child>
+    fun dailyNoteActions(role: UserRole): Set<Action.DailyNote>
+    fun decisionActions(role: UserRole): Set<Action.Decision>
+    fun groupActions(role: UserRole): Set<Action.Group>
+    fun mobileDeviceActions(role: UserRole): Set<Action.MobileDevice>
+    fun pairingActions(role: UserRole): Set<Action.Pairing>
+    fun placementActions(role: UserRole): Set<Action.Placement>
+    fun serviceNeedActions(role: UserRole): Set<Action.ServiceNeed>
+    fun unitActions(role: UserRole): Set<Action.Unit>
+    fun vasuDocumentActions(role: UserRole): Set<Action.VasuDocument>
+}
+
+/**
+ * Role → action mapping based on static data.
+ *
+ * Uses system defaults, unless some mappings are overridden using constructor parameters
+ */
+class StaticPermittedRoleActions(
+    val application: ActionsByRole<Action.Application> = getDefaults(),
+    val assistanceAction: ActionsByRole<Action.AssistanceAction> = getDefaults(),
+    val assistanceNeed: ActionsByRole<Action.AssistanceNeed> = getDefaults(),
+    val backupCare: ActionsByRole<Action.BackupCare> = getDefaults(),
+    val child: ActionsByRole<Action.Child> = getDefaults(),
+    val dailyNote: ActionsByRole<Action.DailyNote> = getDefaults(),
+    val decision: ActionsByRole<Action.Decision> = getDefaults(),
+    val group: ActionsByRole<Action.Group> = getDefaults(),
+    val mobileDevice: ActionsByRole<Action.MobileDevice> = getDefaults(),
+    val pairing: ActionsByRole<Action.Pairing> = getDefaults(),
+    val placement: ActionsByRole<Action.Placement> = getDefaults(),
+    val serviceNeed: ActionsByRole<Action.ServiceNeed> = getDefaults(),
+    val unit: ActionsByRole<Action.Unit> = getDefaults(),
+    val vasuDocument: ActionsByRole<Action.VasuDocument> = getDefaults(),
+) : PermittedRoleActions {
+    override fun applicationActions(role: UserRole): Set<Action.Application> = application[role] ?: emptySet()
+    override fun assistanceActionActions(role: UserRole): Set<Action.AssistanceAction> = assistanceAction[role] ?: emptySet()
+    override fun assistanceNeedActions(role: UserRole): Set<Action.AssistanceNeed> = assistanceNeed[role] ?: emptySet()
+    override fun backupCareActions(role: UserRole): Set<Action.BackupCare> = backupCare[role] ?: emptySet()
+    override fun childActions(role: UserRole): Set<Action.Child> = child[role] ?: emptySet()
+    override fun dailyNoteActions(role: UserRole): Set<Action.DailyNote> = dailyNote[role] ?: emptySet()
+    override fun decisionActions(role: UserRole): Set<Action.Decision> = decision[role] ?: emptySet()
+    override fun groupActions(role: UserRole): Set<Action.Group> = group[role] ?: emptySet()
+    override fun mobileDeviceActions(role: UserRole): Set<Action.MobileDevice> = mobileDevice[role] ?: emptySet()
+    override fun pairingActions(role: UserRole): Set<Action.Pairing> = pairing[role] ?: emptySet()
+    override fun placementActions(role: UserRole): Set<Action.Placement> = placement[role] ?: emptySet()
+    override fun serviceNeedActions(role: UserRole): Set<Action.ServiceNeed> = serviceNeed[role] ?: emptySet()
+    override fun unitActions(role: UserRole): Set<Action.Unit> = unit[role] ?: emptySet()
+    override fun vasuDocumentActions(role: UserRole): Set<Action.VasuDocument> = vasuDocument[role] ?: emptySet()
+}
+
+typealias ActionsByRole<A> = Map<UserRole, Set<A>>
+typealias RolesByAction<A> = Map<A, Set<UserRole>>
+
+private inline fun <reified A> RolesByAction<A>.invert(): ActionsByRole<A> where A : Action, A : Enum<A> {
+    val result = EnumMap<UserRole, EnumSet<A>>(UserRole::class.java)
+    this.entries.forEach { (action, roles) ->
+        roles.forEach { role ->
+            result[role] = EnumSet.copyOf(result[role] ?: EnumSet.noneOf(A::class.java)).apply {
+                add(action)
+            }
+        }
+    }
+    return result
+}
+
+private inline fun <reified A> getDefaults() where A : Action, A : Enum<A> =
+    enumValues<A>().associateWith { it.defaultRoles() }.invert()


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- introduce an API for checking permissions based on the intended *action*, instead of hard-coding a list of roles in the REST controller code. Roles will become customizable in the near future, so we can't have `UserRole` lists scattered in controller code anymore
- convert `BackupCareController` to use the new API as an example
- actions are defined in multiple enums, one per "scope"
- prepare action enums and other boilerplate for all scopes currently used in `AccessControlList`
- `ADMIN` role gets permission for all actions *implicitly*. If necessary, this can be overridden in more complicated action permission checks by not calling `assertPermission`