### PR TITLE
Fix Combobox toggle button

### DIFF
--- a/frontend/src/lib-components/atoms/form/Combobox.tsx
+++ b/frontend/src/lib-components/atoms/form/Combobox.tsx
@@ -149,10 +149,6 @@ function stopPropagation(e: React.SyntheticEvent) {
   e.stopPropagation()
 }
 
-function preventDefault(e: React.SyntheticEvent) {
-  e.preventDefault()
-}
-
 function ensureElementIsInView(element: HTMLElement) {
   computeScrollIntoView(element, {
     block: 'end',
@@ -317,7 +313,7 @@ export default function Combobox<T>(props: Props<T>) {
           {...getToggleButtonProps({
             disabled,
             // avoid toggling the menu twice
-            onClick: preventDefault
+            onClick: stopPropagation
           })}
         >
           <FontAwesomeIcon icon={faChevronDown} />


### PR DESCRIPTION
#### Summary

Fix Combobox toggle button.

`getToggleButtonProps` applies toggling logic to the toggle button. The click event was propagated to `Root` component which was also toggling the menu. `stopPropagation` correctly prevents the double toggle no-op.