### PR TITLE
[EVAKA-HOTFIX] Less SAML authn failure noise in logs

### DIFF
--- a/apigw/package.json
+++ b/apigw/package.json
@@ -35,7 +35,7 @@
     "nocache": "^2.1.0",
     "passport": "^0.4.1",
     "passport-dummy": "0.0.1",
-    "passport-saml": "1.3.5",
+    "passport-saml": "1.5.0",
     "pino": "^6.7.0",
     "pino-http": "^5.3.0",
     "pino-pretty": "^4.3.0",

--- a/apigw/package.json
+++ b/apigw/package.json
@@ -95,8 +95,7 @@
     "xmldom": "^0.6.0"
   },
   "resolutions": {
-    "@types/node": "^14.14.6",
-    "xml-crypto": "2.1.2"
+    "@types/node": "^14.14.6"
   },
   "jest": {
     "preset": "ts-jest",

--- a/apigw/src/shared/routes/auth/saml/index.ts
+++ b/apigw/src/shared/routes/auth/saml/index.ts
@@ -74,11 +74,11 @@ function createLoginHandler({
         if (err || !user) {
           const description =
             parseDescriptionFromSamlError(err, req) ||
-            'Could not parse SAML error'
+            'Could not parse SAML message'
           logAuditEvent(
             `evaka.saml.${strategyName}.sign_in_failed`,
             req,
-            `Error authenticating user. Description: ${description}. Error: ${err}`
+            `Failed to authenticate user. Description: ${description}. Details: ${err}`
           )
           return res.redirect(`${getDefaultPageUrl(req)}?loginError=true`)
         }

--- a/apigw/yarn.lock
+++ b/apigw/yarn.lock
@@ -8065,7 +8065,7 @@ typescript@^4.1.3:
   languageName: node
   linkType: hard
 
-"xml-crypto@npm:2.1.2":
+"xml-crypto@npm:2.1.2, xml-crypto@npm:^2.0.0":
   version: 2.1.2
   resolution: "xml-crypto@npm:2.1.2"
   dependencies:

--- a/apigw/yarn.lock
+++ b/apigw/yarn.lock
@@ -2920,7 +2920,7 @@ __metadata:
     nodemon: ^2.0.7
     passport: ^0.4.1
     passport-dummy: 0.0.1
-    passport-saml: 1.3.5
+    passport-saml: 1.5.0
     pino: ^6.7.0
     pino-http: ^5.3.0
     pino-pretty: ^4.3.0
@@ -5865,19 +5865,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"passport-saml@npm:1.3.5":
-  version: 1.3.5
-  resolution: "passport-saml@npm:1.3.5"
+"passport-saml@npm:1.5.0":
+  version: 1.5.0
+  resolution: "passport-saml@npm:1.5.0"
   dependencies:
     debug: ^3.1.0
     passport-strategy: "*"
-    q: ^1.5.0
-    xml-crypto: ^1.4.0
+    xml-crypto: ^2.0.0
     xml-encryption: 1.2.1
     xml2js: 0.4.x
     xmlbuilder: ^11.0.0
     xmldom: 0.1.x
-  checksum: a435d3a65cf8c4ad816fe067d1cb6572d9cf126d08bca7d32ef40b08e22d7bae9022442e66c8998e128f443ab8cc08ecbdf36c45bcdbb363d4a19d52e661cb9e
+  checksum: 54c81ec5ecd86e75e953aeffe4812f5dc995bf235aadcd5fbdfc760331b7f4271532a53c875df6e147f64cc88a93fbd61c83aadce7c97db7897cf720d7f03dab
   languageName: node
   linkType: hard
 
@@ -6205,13 +6204,6 @@ __metadata:
   dependencies:
     escape-goat: ^2.0.0
   checksum: b300d979e1bcc388b0aabe723e9bd7f6598f02a10e66b693b9dde6249f68ad95e93804a1511dbbafd172e404b837d60c49ebdd152e3e94909dc282ca4ba285e8
-  languageName: node
-  linkType: hard
-
-"q@npm:^1.5.0":
-  version: 1.5.1
-  resolution: "q@npm:1.5.1"
-  checksum: f610c1295a4f1b334affbe5333bc8c6160b907d011a62f1c6d05d4ca985535ea271fd8684e1e655b4659cc5b71f5be9ac4ccc84482d869b5a0576955598a7dca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Summary
- Slightly less aggressive SAML error logging (will also need adjustments in alerting logic)
    - Adjust SAML authentication failure logging to avoid triggering unnecessary error log alerting with the word "error"
    - Also, authentication errors are completely normal and not usually something to alert about (at least for each event)
- Update passport-saml to 1.5.0
    - Latest release in the 1.x.x major version
    - 2.x.x and 3.x.x still aren't ready for prime time with their broken typings (mainly related to extended request/response types)
- Drop xml-crypto resolution
    - passport-saml@1.5.0 resolves xml-crypto to 2.1.2, so no longer necessary to override it

