### PR TITLE
EVAKA-4203 Validate vasu content when saving

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuTest.kt
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.vasu
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class VasuTest {
+
+    @Test
+    fun `matchesStructurally returns true for equal objects`() {
+        val content = getDefaultTemplateContent(VasuLanguage.FI)
+        assertTrue { content.matchesStructurally(content) }
+    }
+
+    @Test
+    fun `matchesStructurally returns true with equal sections`() {
+        assertTrue {
+            getSampleContent().matchesStructurally(VasuContent(sections = getSampleSections()))
+        }
+    }
+
+    @Test
+    fun `matchesStructurally returns false if there are extra sections`() {
+        assertFalse {
+            getSampleContent().matchesStructurally(VasuContent(sections = getSampleSections() + getSampleSections()))
+        }
+    }
+
+    @Test
+    fun `matchesStructurally returns true for structurally equal objects where value does not match`() {
+        assertTrue { getSampleContent().matchesStructurally(getSampleContent(listOf("1", "2"))) }
+    }
+
+    @Test
+    fun `matchesStructurally returns false for non-equal content`() {
+        assertFalse {
+            getSampleContent().matchesStructurally(
+                VasuContent(
+                    sections = listOf(
+                        VasuSection(
+                            name = "foo",
+                            questions = listOf(getSampleQuestion().copy(name = "babar"))
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    private fun getSampleContent(value: List<String> = listOf()) = VasuContent(
+        sections = getSampleSections(value)
+    )
+
+    private fun getSampleSections(value: List<String> = listOf()) = listOf(
+        VasuSection(
+            name = "foo",
+            questions = listOf(
+                getSampleQuestion(value)
+            )
+        )
+    )
+
+    private fun getSampleQuestion(value: List<String> = listOf()) = VasuQuestion.MultiSelectQuestion(
+        ophKey = OphQuestionKey.PEDAGOGIC_ACTIVITY_GOALS,
+        name = "Q1",
+        options = listOf(
+            QuestionOption(
+                key = "1",
+                name = "Kyllä"
+            ),
+            QuestionOption(
+                key = "2",
+                name = "Ei"
+            )
+        ),
+        minSelections = 1,
+        maxSelections = null,
+        value = value
+    )
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/Vasu.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/Vasu.kt
@@ -85,26 +85,20 @@ data class VasuDocumentChild(
 data class VasuContent(
     val sections: List<VasuSection>
 ) {
-    fun matchesStructurally(content: VasuContent): Boolean {
-        if (this.sections.size != content.sections.size) return false
-        for ((index, section) in this.sections.withIndex()) {
-            if (!section.matchesStructurally(content.sections.getOrNull(index))) return false
+    fun matchesStructurally(content: VasuContent): Boolean =
+        this.sections.size == content.sections.size && this.sections.withIndex().all { (index, section) ->
+            section.matchesStructurally(content.sections.getOrNull(index))
         }
-        return true
-    }
 }
 
 data class VasuSection(
     val name: String,
     val questions: List<VasuQuestion>
 ) {
-    fun matchesStructurally(section: VasuSection?): Boolean {
-        if (section == null || section.name != this.name || section.questions.size != this.questions.size) return false
-        for ((index, question) in this.questions.withIndex()) {
-            if (!question.equalsIgnoringValue(section.questions.getOrNull(index))) return false
-        }
-        return true
-    }
+    fun matchesStructurally(section: VasuSection?): Boolean =
+        section != null && section.name == this.name && section.questions.size == this.questions.size &&
+            this.questions.withIndex()
+                .all { (index, question) -> question.equalsIgnoringValue(section.questions.getOrNull(index)) }
 }
 
 @JsonTypeInfo(

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/Vasu.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/Vasu.kt
@@ -84,12 +84,28 @@ data class VasuDocumentChild(
 @Json
 data class VasuContent(
     val sections: List<VasuSection>
-)
+) {
+    fun matchesStructurally(content: VasuContent): Boolean {
+        if (this.sections.size != content.sections.size) return false
+        for ((index, section) in this.sections.withIndex()) {
+            if (!section.matchesStructurally(content.sections.getOrNull(index))) return false
+        }
+        return true
+    }
+}
 
 data class VasuSection(
     val name: String,
     val questions: List<VasuQuestion>
-)
+) {
+    fun matchesStructurally(section: VasuSection?): Boolean {
+        if (section == null || section.name != this.name || section.questions.size != this.questions.size) return false
+        for ((index, question) in this.questions.withIndex()) {
+            if (!question.equalsIgnoringValue(section.questions.getOrNull(index))) return false
+        }
+        return true
+    }
+}
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -107,26 +123,39 @@ sealed class VasuQuestion(
 ) {
     abstract val name: String
     abstract val ophKey: OphQuestionKey?
+    abstract fun equalsIgnoringValue(question: VasuQuestion?): Boolean
 
     data class TextQuestion(
         override val name: String,
         override val ophKey: OphQuestionKey? = null,
         val multiline: Boolean,
         val value: String
-    ) : VasuQuestion(VasuQuestionType.TEXT)
+    ) : VasuQuestion(VasuQuestionType.TEXT) {
+        override fun equalsIgnoringValue(question: VasuQuestion?): Boolean {
+            return question is TextQuestion && question.copy(value = this.value) == this
+        }
+    }
 
     data class CheckboxQuestion(
         override val name: String,
         override val ophKey: OphQuestionKey? = null,
         val value: Boolean
-    ) : VasuQuestion(VasuQuestionType.CHECKBOX)
+    ) : VasuQuestion(VasuQuestionType.CHECKBOX) {
+        override fun equalsIgnoringValue(question: VasuQuestion?): Boolean {
+            return question is CheckboxQuestion && question.copy(value = this.value) == this
+        }
+    }
 
     data class RadioGroupQuestion(
         override val name: String,
         override val ophKey: OphQuestionKey? = null,
         val options: List<QuestionOption>,
         val value: String?
-    ) : VasuQuestion(VasuQuestionType.RADIO_GROUP)
+    ) : VasuQuestion(VasuQuestionType.RADIO_GROUP) {
+        override fun equalsIgnoringValue(question: VasuQuestion?): Boolean {
+            return question is RadioGroupQuestion && question.copy(value = this.value) == this
+        }
+    }
 
     data class MultiSelectQuestion(
         override val name: String,
@@ -135,7 +164,11 @@ sealed class VasuQuestion(
         val minSelections: Int,
         val maxSelections: Int?,
         val value: List<String>
-    ) : VasuQuestion(VasuQuestionType.MULTISELECT)
+    ) : VasuQuestion(VasuQuestionType.MULTISELECT) {
+        override fun equalsIgnoringValue(question: VasuQuestion?): Boolean {
+            return question is MultiSelectQuestion && question.copy(value = this.value) == this
+        }
+    }
 }
 
 data class QuestionOption(

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
@@ -93,6 +93,8 @@ class VasuController(
         )
 
         db.transaction { tx ->
+            val vasu = tx.getVasuDocumentMaster(id) ?: throw NotFound("vasu $id not found")
+            validateVasuDocumentUpdate(vasu, body)
             tx.updateVasuDocumentMaster(
                 id,
                 body.content,
@@ -101,6 +103,11 @@ class VasuController(
                 body.evaluationDiscussionContent
             )
         }
+    }
+
+    private fun validateVasuDocumentUpdate(vasu: VasuDocument, body: UpdateDocumentRequest) {
+        if (!vasu.content.matchesStructurally(body.content))
+            throw BadRequest("Vasu document structure does not match template", "DOCUMENT_DOES_NOT_MATCH_TEMPLATE")
     }
 
     @GetMapping("/children/{childId}/vasu-summaries")


### PR DESCRIPTION
#### Summary

- Prevent updating template content if template is already in use 
- Validate that vasu content structurally matches the template content when saving

