### PR TITLE
[EVAKA] Remove remains of Google Maps, update CSP

### DIFF
--- a/apigw/README.md
+++ b/apigw/README.md
@@ -16,8 +16,6 @@ Gateway between eVaka frontends and backend services
 - [Node.js](https://nodejs.org/en/) – a JavaScript runtime built on Chrome's V8 JavaScript engine, version  14.15+
   - Install correct version automatically with [nvm](https://github.com/nvm-sh/nvm): `nvm install` (see [`.nvmrc`](../.nvmrc))
 - [Yarn](https://yarnpkg.com/getting-started/install) – Package manager for Node, version 1.22+
-- (OPTIONAL) [Google Maps JavaScript API key](#google-maps-api-key)
-  - If you want to use the geocoding & autocomplete endpoints
 
 The service requires redis running on port 6379. Easiest way is to run it with [compose](../compose/README.md) command
 
@@ -50,30 +48,6 @@ Lint with auto-fix
 ```bash
 yarn lint
 yarn lint:fix
-```
-
-### Google Maps API key
-
-If you want to use the Google Maps geocoding and autocomplete endpoints,
-a [Google Maps JavaScript API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
-must be configured for the application. Unfortunately none can be provided for local development by default as backend
-API keys can only be restricted by IP addresses.
-
-The application can be run locally without an API key but the endpoints will respond with an error.
-
-When creating your own key, restrict it to the following APIs:
-
-- Geocoding API
-- Places API
-
-#### Instructions for Voltti Developers
-
-Fetch and export the **secret** API key from Parameter Store with:
-
-```sh
-aws --profile voltti-local ssm get-parameter \
-  --name /local/evaka/google/maps_backend_api_key \
-  --query 'Parameter.Value' --with-decryption --output text
 ```
 
 ## Generated JWTs for local testing

--- a/compose/proxy/nginx.conf
+++ b/compose/proxy/nginx.conf
@@ -41,8 +41,8 @@ server {
   add_header X-Content-Type-Options nosniff;
   add_header X-XSS-Protection '1; mode=block';
   add_header X-DNS-Prefetch-Control off;
-  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://maps.gstatic.com https://maps.googleapis.com https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
-  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' https://maps.googleapis.com; frame-ancestors 'none'; form-action 'self';";
+  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
+  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self'; frame-ancestors 'none'; form-action 'self';";
 
   # Tracing
   add_header X-Request-ID $request_id always;

--- a/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -144,8 +144,8 @@ server {
   add_header X-DNS-Prefetch-Control off;
   add_header Report-To '{"group","csp-endpoint","max_age":31536000,"endpoints":[{"url":"https://$host/api/csp"}]}';
 
-  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://maps.gstatic.com https://maps.googleapis.com https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
-  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' https://maps.googleapis.com; frame-ancestors 'none'; form-action 'self';";
+  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
+  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self'; frame-ancestors 'none'; form-action 'self';";
 
   # Tracing
   # Return the request ID to the client to make tracing of test requests very easy


### PR DESCRIPTION
#### Summary
- Google Maps has been fully replaced by OpenStreetMaps in eVaka, remove all mentions of it
    - Well, except that one _link_ in employee-frontend but that doesn't need anything loaded/allowed in eVaka
- Remove all remaining Google URLs from CSPs accordingly
- Secret already removed from infra configs

