### PR TITLE
Upgrade Spring Boot to 2.5.2

### DIFF
--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     api(platform("org.jdbi:jdbi3-bom:3.20.1"))
     api(platform("org.jetbrains.kotlin:kotlin-bom:1.5.10"))
     api(platform("org.junit:junit-bom:5.7.2"))
-    api(platform("org.springframework.boot:spring-boot-dependencies:2.5.1"))
+    api(platform("org.springframework.boot:spring-boot-dependencies:2.5.2"))
     api(platform("org.testcontainers:testcontainers-bom:1.15.3"))
     api(platform("software.amazon.awssdk:bom:2.16.88"))
 }

--- a/frontend/src/e2e-test-common/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test-common/dev-api/fixtures.ts
@@ -517,6 +517,12 @@ const applicationForm = (
     // => Sep
     startDate = setMonth(startDate, 8)
   }
+
+  // Move daycare application start date to August if current date is in July
+  if (type === 'DAYCARE' && 6 === getMonth(startDate)) {
+    startDate = setMonth(startDate, 7)
+  }
+
   return {
     type,
     additionalDetails: {

--- a/frontend/src/e2e-test/specs/2_employee-2/application-transitions.spec.ts
+++ b/frontend/src/e2e-test/specs/2_employee-2/application-transitions.spec.ts
@@ -116,7 +116,7 @@ test('Supervisor accepts decision on behalf of the enduser and forwards start da
   await applicationReadView.openApplicationByLink(applicationId)
   await applicationReadView.setDecisionStartDate(
     'DAYCARE',
-    format(addWeeks(new Date(), 2), 'dd.MM.yyyy')
+    format(addWeeks(new Date(fixture.form.preferredStartDate), 2), 'dd.MM.yyyy')
   )
 
   await applicationReadView.acceptDecision('DAYCARE')

--- a/message-service/buildSrc/src/main/kotlin/Version.kt
+++ b/message-service/buildSrc/src/main/kotlin/Version.kt
@@ -11,7 +11,7 @@ object Version {
         const val kotlin = "1.5.10"
         const val kotlinter = "3.4.5"
         const val owasp = "6.2.2"
-        const val springBoot = "2.5.1"
+        const val springBoot = "2.5.2"
         const val versions = "0.39.0"
     }
 }

--- a/service/buildSrc/src/main/kotlin/Version.kt
+++ b/service/buildSrc/src/main/kotlin/Version.kt
@@ -11,7 +11,7 @@ object Version {
         const val kotlin = "1.5.10"
         const val kotlinter = "3.4.5"
         const val owasp = "6.2.2"
-        const val springBoot = "2.5.1"
+        const val springBoot = "2.5.2"
         const val versions = "0.39.0"
     }
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Spring Boot 2.5.2 upgrades Tomcat to a version that doesn't have CVE-2021-33037 vulnerability.

