### PR TITLE
[EVAKA-HOTFIX] Add cache busting capability to base Docker image

### DIFF
--- a/evaka-base/Dockerfile
+++ b/evaka-base/Dockerfile
@@ -6,6 +6,9 @@ FROM ubuntu:20.04
 
 LABEL maintainer="https://github.com/espoon-voltti/evaka"
 
+# Increment this if we ever explicitly want to e.g. run apt-get upgrade
+ARG CACHE_BUST=2021-07-22
+
 # Use bash instead of dash
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
#### Summary
- In case we ever explicitly need to run e.g. apt-get dist-upgrade to update some vulnerable dependencies instead of just allowing cached base layers to be used, now the argument can be incremented and caches busted
- For example, now we want to update to at least systemd@245.4-4ubuntu3.10 instead of 3.6 included in ubuntu:20.04 (as of the time of this commit) to fix [CVE-2021-33910](https://ubuntu.com/security/CVE-2021-33910), we would increment the ARG value
    - And obviously in this case, creating the new layer _before_ apt-get dist-ugprade, the result is the same

#### Testing instructions

1. `cd evaka-base`
1. Initial build: `docker build .`
1. Next build w/ cache: `docker build .` -> should re-use all existing layers
1. Increment the new `ARG` value in `Dockerfile`
1. `docker build .` -> should **not** re-use layers below the `ARG` layer (i.e. just use the first two existing layers)

