### PR TITLE
[EVAKA-HOTFIX] Add missing nameID for AD mock user, rename DEV_LOGIN to AD_MOCK

### DIFF
--- a/apigw/src/shared/auth/ad-saml.ts
+++ b/apigw/src/shared/auth/ad-saml.ts
@@ -10,7 +10,7 @@ import {
 } from 'passport-saml'
 import DevPassportStrategy from './dev-passport-strategy'
 import { SamlUser } from '../routes/auth/saml/types'
-import { devLoginEnabled, adConfig, adExternalIdPrefix } from '../config'
+import { adMock, adConfig, adExternalIdPrefix } from '../config'
 import certificates from '../certificates'
 import { readFileSync } from 'fs'
 import { upsertEmployee } from '../dev-api'
@@ -65,7 +65,7 @@ async function verifyProfile(profile: AdProfile): Promise<SamlUser> {
 }
 
 export function createSamlConfig(redisClient?: RedisClient): SamlConfig {
-  if (devLoginEnabled) return {}
+  if (adMock) return {}
   if (!adConfig) throw Error('Missing AD SAML configuration')
   return {
     acceptedClockSkewMs: 0,
@@ -93,7 +93,7 @@ export function createSamlConfig(redisClient?: RedisClient): SamlConfig {
 export default function createAdStrategy(
   config: SamlConfig
 ): SamlStrategy | DevPassportStrategy {
-  if (devLoginEnabled) {
+  if (adMock) {
     const getter = async (userId: string) =>
       verifyProfile({
         nameID: 'dummyid',

--- a/apigw/src/shared/auth/ad-saml.ts
+++ b/apigw/src/shared/auth/ad-saml.ts
@@ -96,6 +96,7 @@ export default function createAdStrategy(
   if (devLoginEnabled) {
     const getter = async (userId: string) =>
       verifyProfile({
+        nameID: 'dummyid',
         [AD_USER_ID_KEY]: userId,
         [AD_ROLES_KEY]: [],
         [AD_GIVEN_NAME_KEY]: '',
@@ -119,6 +120,7 @@ export default function createAdStrategy(
         roles: roles as UserRole[]
       })
       return verifyProfile({
+        nameID: 'dummyid',
         [AD_USER_ID_KEY]: userId,
         [AD_ROLES_KEY]: roles,
         [AD_GIVEN_NAME_KEY]: firstName,

--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -146,15 +146,18 @@ const certificateNames = Object.keys(
   certificates
 ) as ReadonlyArray<TrustedCertificates>
 
-export const devLoginEnabled =
-  env('DEV_LOGIN', parseBoolean) ?? ifNodeEnv(['local', 'test'], true) ?? false
+export const adMock =
+  env('AD_MOCK', parseBoolean) ??
+  env('DEV_LOGIN', parseBoolean) ??
+  ifNodeEnv(['local', 'test'], true) ??
+  false
 
 const adCallbackUrl = process.env.AD_SAML_CALLBACK_URL
 const adEntryPointUrl = process.env.AD_SAML_ENTRYPOINT_URL
 const adLogoutUrl = process.env.AD_SAML_LOGOUT_URL
 
 export const adConfig: EvakaSamlConfig | undefined =
-  adCallbackUrl && !devLoginEnabled
+  adCallbackUrl && !adMock
     ? {
         callbackUrl: required(adCallbackUrl),
         entryPoint: required(adEntryPointUrl),

--- a/apigw/src/shared/routes/auth/saml/index.ts
+++ b/apigw/src/shared/routes/auth/saml/index.ts
@@ -7,7 +7,7 @@ import _ from 'lodash'
 import passport from 'passport'
 import { AuthenticateOptions, SAML } from 'passport-saml'
 import { createLogoutToken, tryParseProfile } from '../../../auth'
-import { devLoginEnabled, gatewayRole, nodeEnv } from '../../../config'
+import { adMock, gatewayRole, nodeEnv } from '../../../config'
 import { getEmployees } from '../../../dev-api'
 import { toMiddleware, toRequestHandler } from '../../../express'
 import { logAuditEvent, logDebug } from '../../../logging'
@@ -205,7 +205,7 @@ export default function createSamlRouter(config: SamlEndpointConfig): Router {
     loginHandler
   )
 
-  if (devLoginEnabled) {
+  if (adMock) {
     configureDevLogin(router)
   }
 


### PR DESCRIPTION
#### Summary

- Add `nameID` property for AD mock user
    - Fixes "User unexpectedly missing nameID property" error (which just failed to create the 3rd party logout token but still created a valid session)
    - AD mock (i.e. "dev login") doesn't use a proper SAML message but our 3rd party logout token system requires users to have a `nameID` property in order to generate the token -> add a dummy ID like already exists with the Suomi.fi mock user
    - The alternative would be to disable logout tokens altogether for mock logins but as both internal-gw and enduser-gw share _default_ configs we cannot assume that AD mocking is enabled (default is `false`) on enduser-gw or vice versa -> would need to add knowledge about the active strategy to ther otherwise strategy-agnostic router or make a breaking change to defaults
        - This is also reflected in unit SAML unit tests which need the 3rd party token enabled (in order to test it) but should not touch AD mocking unnecessarily
- Rename `DEV_LOGIN` to `AD_MOCK`, match `SFI_MOCK`
    - There's no separate global dev login -- it's just an AD mock, so name the config and matching environment variable appropriately
    - Keeping `DEV_LOGIN` supported for backwards compatibility but prefering `AD_MOCK` if both are set

#### Testing instructions

**NOTE:** This change has been manually deployed to dev, so test & dev can be compared:

1. Log in using dev auth in **test** environment -> redirects with `?loginError=true` (but still sets session cookie) and causes an error in logs (->alert)
1. Log in using dev auth in **dev** environment -> no error in redirect URL or logs, and still has a valid session

This change doesn't affect logouts in 1st party contexts, so using the logout-button in eVaka will continue to function identically in dev & test -- as it did before.

