### PR TITLE
Option to disable async job runner

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -10,12 +10,15 @@ import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.event.EventListener
+import org.springframework.core.env.Environment
+import org.springframework.core.env.getProperty
 import java.time.Duration
 
 @Configuration
 class AsyncJobConfig {
     @Bean
-    fun asyncJobRunner(jdbi: Jdbi) = AsyncJobRunner(jdbi)
+    fun asyncJobRunner(jdbi: Jdbi, env: Environment) =
+        AsyncJobRunner(jdbi, disableRunner = env.getProperty<Boolean>("evaka.async_job_runner.disable_runner") ?: false)
 
     @Bean
     fun asyncJobRunnerSchedule(asyncJobRunner: AsyncJobRunner) = object {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add an env variable that can be used to disable async job runner. Useful when eg. enabling maintenance mode.

Also, see https://github.com/espoon-voltti/evaka-infra/pull/452
