### PR TITLE
[EVAKA] CI: wait for ECS deploy to succeed, or fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,14 +643,26 @@ commands:
             - *ci_evaka_fingerprint
       - attach_root_workspace
       - run:
-          name: Deploy ECS services to << parameters.env >>
+          name: Initialize Terraform workspace
+          working_directory: evaka-infra/terraform/evaka-ecs
           command: |
-            cd evaka-infra/terraform/evaka-ecs
-
             . replace-credentials
 
             terraform init
             terraform workspace select << parameters.env >>
+      - run:
+          name: Log current ECS service versions
+          working_directory: evaka-infra/terraform/evaka-ecs
+          command: |
+            . replace-credentials
+
+            terraform output | grep _version
+      - run:
+          name: Deploy ECS services to << parameters.env >>
+          working_directory: evaka-infra/terraform/evaka-ecs
+          command: |
+            . replace-credentials
+
             terraform apply -auto-approve -lock-timeout=300s \
               -var enduser-api-gw_version="${CIRCLE_SHA1}" \
               -var internal-api-gw_version="${CIRCLE_SHA1}" \
@@ -658,6 +670,26 @@ commands:
               -var message-srv_version="${CIRCLE_SHA1}" \
               -var proxy_version="${CIRCLE_SHA1}" \
               -var ses-notification-processor_version="${CIRCLE_SHA1}"
+      - run:
+          name: Wait for ECS deploy to finish
+          environment:
+            AWS_PROFILE: voltti-<< parameters.env >>
+          command: |
+            . replace-credentials
+
+            aws ecs wait services-stable \
+              --cluster voltti-ecs-cluster-<< parameters.env >> \
+              --services \
+                  evaka-enduser-gw \
+                  evaka-internal-gw \
+                  evaka-srv \
+                  evaka-message-srv \
+                  evaka-proxy || {
+              echo 'ERROR: Deployment failed! At least one of the ECS tasks failed to stabilize in 10 minutes with the new versions.' &&
+              echo 'INFO: See output above for previous versions' &&
+              echo "WARN: Generally rollbacks aren't recommended as they can cause issues with DB migrations" &&
+              exit 1
+            }
 
   # Must be the last step in a job
   notify_slack:


### PR DESCRIPTION
#### Summary
- CI: ensure ECS deploys are successful
    - Wait until all ECS services in the target environment's cluster have stabilized after deployed (meaning that new tasks have successfully replaced the old tasks within 10 minutes
    - Log previous versions before deploying new versions so that developers can manually do a rollback if necessary
- In the longer term, we probably would like to drop deploys from CircleCI altogether (and maybe move the Espoo customized version to another repo) and/or use the Espoo deploy tool for deploys but this is the MVP setup to faster feedback loops on working eVaka versions:
    - This will alert a lot quicker than Datadog (with its 15 min AWS metric delays)
    - Prevents going forward to staging/prod with a broken version as a broken deploy job will block staging approvals
        - Of course, as staging & prod _ECS_ deploys are decoupled from this repo's CircleCI workflows, someone can still accidentally make the deployment to staging but it should be much more unlikely as the feedback should come a bit quicker now

