### PR TITLE
Add suppressions for irrelevant vulnerabilities

### DIFF
--- a/message-service/owasp-suppressions.xml
+++ b/message-service/owasp-suppressions.xml
@@ -66,4 +66,28 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         ]]></notes>
         <cve>CVE-2021-22118</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Not relevant for us as we do not use Compress to read untrusted 7Z files
+        ]]></notes>
+        <cve>CVE-2021-35515</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Not relevant for us as we do not use Compress to read untrusted 7Z files
+        ]]></notes>
+        <cve>CVE-2021-35516</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Not relevant for us as we do not use Compress to read untrusted TAR files
+        ]]></notes>
+        <cve>CVE-2021-35517</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Not relevant for us as we do not use Compress to read untrusted ZIP files
+        ]]></notes>
+        <cve>CVE-2021-36090</cve>
+    </suppress>
 </suppressions>

--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -53,4 +53,28 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         ]]></notes>
         <cve>CVE-2021-22118</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Not relevant for us as we do not use Compress to read untrusted 7Z files
+        ]]></notes>
+        <cve>CVE-2021-35515</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Not relevant for us as we do not use Compress to read untrusted 7Z files
+        ]]></notes>
+        <cve>CVE-2021-35516</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Not relevant for us as we do not use Compress to read untrusted TAR files
+        ]]></notes>
+        <cve>CVE-2021-35517</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Not relevant for us as we do not use Compress to read untrusted ZIP files
+        ]]></notes>
+        <cve>CVE-2021-36090</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
These vulnerabilities should not be relevant for us since we do not use Apache Commons Compress to read untrusted 7z/zip/tar files.

https://nvd.nist.gov/vuln/detail/CVE-2021-35515
https://nvd.nist.gov/vuln/detail/CVE-2021-35516
https://nvd.nist.gov/vuln/detail/CVE-2021-35517
https://nvd.nist.gov/vuln/detail/CVE-2021-36090

