### PR TITLE
Update spring boot to 2.5.3

### DIFF
--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     api(platform("org.jdbi:jdbi3-bom:3.20.1"))
     api(platform("org.jetbrains.kotlin:kotlin-bom:1.5.10"))
     api(platform("org.junit:junit-bom:5.7.2"))
-    api(platform("org.springframework.boot:spring-boot-dependencies:2.5.2"))
+    api(platform("org.springframework.boot:spring-boot-dependencies:2.5.3"))
     api(platform("org.testcontainers:testcontainers-bom:1.15.3"))
     api(platform("software.amazon.awssdk:bom:2.16.88"))
 }

--- a/message-service/buildSrc/src/main/kotlin/Version.kt
+++ b/message-service/buildSrc/src/main/kotlin/Version.kt
@@ -11,7 +11,7 @@ object Version {
         const val kotlin = "1.5.10"
         const val kotlinter = "3.4.5"
         const val owasp = "6.2.2"
-        const val springBoot = "2.5.2"
+        const val springBoot = "2.5.3"
         const val versions = "0.39.0"
     }
 }

--- a/service/buildSrc/src/main/kotlin/Version.kt
+++ b/service/buildSrc/src/main/kotlin/Version.kt
@@ -11,7 +11,7 @@ object Version {
         const val kotlin = "1.5.10"
         const val kotlinter = "3.4.5"
         const val owasp = "6.2.2"
-        const val springBoot = "2.5.2"
+        const val springBoot = "2.5.3"
         const val versions = "0.39.0"
     }
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Spring boot 3.5.3 has an upgraded version of Jetty without the CVE-2021-34429 vulnerability.

