### PR TITLE
Flaky e2e test logins

### DIFF
--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-applications-list.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-applications-list.spec.ts
@@ -32,6 +32,7 @@ beforeEach(async () => {
 
   page = await (await newBrowserContext()).newPage()
   await page.goto(config.enduserUrl)
+  await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)
 })
@@ -52,7 +53,6 @@ describe('Citizen applications list', () => {
     )
     await insertApplications([application])
 
-    await enduserLogin(page)
     await header.applicationsTab.click()
 
     const child = fixtures.enduserChildFixtureJari
@@ -87,7 +87,6 @@ describe('Citizen applications list', () => {
     ])
     await runPendingAsyncJobs()
 
-    await enduserLogin(page)
     await header.applicationsTab.click()
     await applicationsPage.assertApplicationIsListed(
       application.id,
@@ -111,7 +110,6 @@ describe('Citizen applications list', () => {
     )
     await insertApplications([application])
 
-    await enduserLogin(page)
     await header.applicationsTab.click()
     await applicationsPage.cancelApplication(application.id)
     await applicationsPage.assertApplicationDoesNotExist(application.id)
@@ -130,7 +128,6 @@ describe('Citizen applications list', () => {
     )
     await insertApplications([application])
 
-    await enduserLogin(page)
     await header.applicationsTab.click()
     await applicationsPage.cancelApplication(application.id)
     await applicationsPage.assertApplicationDoesNotExist(application.id)

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-club-application.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-club-application.spec.ts
@@ -29,6 +29,7 @@ beforeEach(async () => {
 
   page = await (await newBrowserContext()).newPage()
   await page.goto(config.enduserUrl)
+  await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)
 })
@@ -38,7 +39,6 @@ afterEach(async () => {
 
 describe('Citizen club applications', () => {
   test('Sending incomplete club application gives validation error', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,
@@ -49,7 +49,6 @@ describe('Citizen club applications', () => {
   })
 
   test('Minimal valid club application can be sent', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,
@@ -65,7 +64,6 @@ describe('Citizen club applications', () => {
   })
 
   test('Full valid club application can be sent', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -41,6 +41,7 @@ beforeEach(async () => {
 
   page = await (await newBrowserContext()).newPage()
   await page.goto(config.enduserUrl)
+  await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)
 })
@@ -50,7 +51,6 @@ afterEach(async () => {
 
 describe('Citizen daycare applications', () => {
   test('Sending incomplete daycare application gives validation error', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,
@@ -61,7 +61,6 @@ describe('Citizen daycare applications', () => {
   })
 
   test('Minimal valid daycare application can be sent', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,
@@ -78,7 +77,6 @@ describe('Citizen daycare applications', () => {
   })
 
   test('Full valid daycare application can be sent', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,
@@ -110,7 +108,6 @@ describe('Citizen daycare applications', () => {
     ])
     await runPendingAsyncJobs()
 
-    await enduserLogin(page)
     await header.applicationsTab.click()
     await applicationsPage.assertDuplicateWarningIsShown(
       fixtures.enduserChildFixtureJari.id,
@@ -130,7 +127,6 @@ describe('Citizen daycare applications', () => {
       }
     ])
 
-    await enduserLogin(page)
     await header.applicationsTab.click()
     await applicationsPage.assertTransferNotificationIsShown(
       fixtures.enduserChildFixtureJari.id,
@@ -139,7 +135,6 @@ describe('Citizen daycare applications', () => {
   })
 
   test('A warning is shown if preferred start date is very soon', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,
@@ -152,7 +147,6 @@ describe('Citizen daycare applications', () => {
   })
 
   test('A validation error message is shown if preferred start date is not valid', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,
@@ -173,7 +167,6 @@ describe('Citizen daycare applications', () => {
   })
 
   test('Citizen cannot move preferred start date before a previously selected date', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,
@@ -197,7 +190,6 @@ describe('Citizen daycare applications', () => {
   })
 
   test('Application can be made for restricted child', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixturePorriHatterRestricted.id,
@@ -209,7 +201,6 @@ describe('Citizen daycare applications', () => {
   })
 
   test('Urgent application attachment can be uploaded and downloaded by citizen', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixturePorriHatterRestricted.id,

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-header.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-header.spec.ts
@@ -20,6 +20,7 @@ beforeEach(async () => {
 
   page = await (await newBrowserContext()).newPage()
   await page.goto(config.enduserUrl)
+  await enduserLogin(page)
   header = new CitizenHeader(page)
 })
 afterEach(async () => {
@@ -28,7 +29,6 @@ afterEach(async () => {
 
 describe('Citizen page', () => {
   test('UI language can be changed', async () => {
-    await enduserLogin(page)
     await header.selectLanguage('fi')
     await waitUntilEqual(
       async () => (await header.applicationsTab.innerText).toLowerCase(),

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-preschool-application.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-preschool-application.spec.ts
@@ -29,6 +29,7 @@ beforeEach(async () => {
 
   page = await (await newBrowserContext()).newPage()
   await page.goto(config.enduserUrl)
+  await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)
 })
@@ -38,7 +39,6 @@ afterEach(async () => {
 
 describe('Citizen preschool applications', () => {
   test('Sending incomplete preschool application gives validation error', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,
@@ -49,7 +49,6 @@ describe('Citizen preschool applications', () => {
   })
 
   test('Minimal valid preschool application can be sent', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,
@@ -65,7 +64,6 @@ describe('Citizen preschool applications', () => {
   })
 
   test('Full valid preschool application can be sent', async () => {
-    await enduserLogin(page)
     await header.applicationsTab.click()
     const editorPage = await applicationsPage.createApplication(
       fixtures.enduserChildFixtureJari.id,

--- a/frontend/src/e2e-playwright/utils/user.ts
+++ b/frontend/src/e2e-playwright/utils/user.ts
@@ -59,6 +59,7 @@ function getLoginUser(role: UserRole): DevLoginUser | string {
 export async function enduserLogin(page: Page) {
   await page.goto(config.enduserUrl)
   await page.click('[data-qa="login-btn"]')
+  await page.waitForSelector('[data-qa="logout-btn"]', { state: 'visible' })
 }
 
 export async function employeeLogin(page: Page, role: UserRole) {

--- a/frontend/src/e2e-playwright/utils/user.ts
+++ b/frontend/src/e2e-playwright/utils/user.ts
@@ -66,7 +66,10 @@ export async function employeeLogin(page: Page, role: UserRole) {
   const authUrl = `${config.apiUrl}/auth/saml/login/callback?RelayState=%2Femployee`
   const user = getLoginUser(role)
 
-  await page.goto(config.employeeLoginUrl)
+  if (!page.url().startsWith(config.employeeUrl)) {
+    // We must be in the correct domain to be able to fetch()
+    await page.goto(config.employeeLoginUrl)
+  }
 
   await page.evaluate(
     ({ user, authUrl }: { user: DevLoginUser | string; authUrl: string }) => {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Attempt to make logins in e2e tests more reliable:
* Wait for logout button to appear on enduser login
* Skip unnecessary navigations to login page on employee login
* Use separate browser contexts when logging in with different roles
* Do login in beforeEach hook in every citizen test so that individual tests don't have to care about logins

