### PR TITLE
EVAKA-4208 remove roles from inactive employees

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
@@ -1,0 +1,150 @@
+package fi.espoo.evaka.pis
+
+import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.auth.insertDaycareAclRow
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.insertTestCareArea
+import fi.espoo.evaka.shared.dev.insertTestDaycare
+import fi.espoo.evaka.shared.dev.insertTestEmployee
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InactiveEmployeesRoleResetIntegrationTest : PureJdbiTest() {
+    private val firstOfAugust2021 = HelsinkiDateTime.of(LocalDate.of(2021, 8, 1), LocalTime.of(3, 15)).toInstant()
+
+    @BeforeEach
+    fun beforeEach() {
+        db.transaction {
+            it.resetDatabase()
+        }
+    }
+
+    @Test
+    fun `global roles are not reset when last_login is now`() {
+        val employeeId = db.transaction {
+            it.insertTestEmployee(DevEmployee(lastLogin = firstOfAugust2021, roles = setOf(UserRole.ADMIN)))
+        }
+
+        db.transaction { it.clearRolesForInactiveEmployees(firstOfAugust2021) }
+
+        val globalRoles = db.read { it.getEmployeeWithRoles(employeeId) }!!.globalRoles
+        assertEquals(setOf(UserRole.ADMIN), globalRoles.toSet())
+    }
+
+    @Test
+    fun `global roles are not reset when last_login is null and now is before first of Sep`() {
+        val employeeId = db.transaction {
+            it.insertTestEmployee(DevEmployee(lastLogin = null, roles = setOf(UserRole.ADMIN)))
+        }
+
+        db.transaction { it.clearRolesForInactiveEmployees(firstOfAugust2021) }
+
+        val globalRoles = db.read { it.getEmployeeWithRoles(employeeId) }!!.globalRoles
+        assertEquals(setOf(UserRole.ADMIN), globalRoles.toSet())
+    }
+
+    @Test
+    fun `global roles are reset when last_login is over 3 months ago`() {
+        val employeeId = db.transaction {
+            it.insertTestEmployee(
+                DevEmployee(
+                    lastLogin = firstOfAugust2021.minus(31 + 30 + 31 + 1, ChronoUnit.DAYS),
+                    roles = setOf(UserRole.ADMIN)
+                )
+            )
+        }
+
+        db.transaction { it.clearRolesForInactiveEmployees(firstOfAugust2021) }
+
+        val globalRoles = db.read { it.getEmployeeWithRoles(employeeId) }!!.globalRoles
+        assertTrue(globalRoles.isEmpty())
+    }
+
+    @Test
+    fun `global roles are reset when last_login is null and now is after first of Sep`() {
+        val employeeId = db.transaction {
+            it.insertTestEmployee(DevEmployee(lastLogin = null, roles = setOf(UserRole.ADMIN)))
+        }
+
+        db.transaction { it.clearRolesForInactiveEmployees(firstOfAugust2021.plus(31, ChronoUnit.DAYS)) }
+
+        val globalRoles = db.read { it.getEmployeeWithRoles(employeeId) }!!.globalRoles
+        assertTrue(globalRoles.isEmpty())
+    }
+
+    @Test
+    fun `scoped roles are not reset when last_login is now`() {
+        val employeeId = db.transaction {
+            val employeeId = it.insertTestEmployee(DevEmployee(lastLogin = firstOfAugust2021))
+            val areaId = it.insertTestCareArea(DevCareArea())
+            val unitId = it.insertTestDaycare(DevDaycare(areaId = areaId))
+            it.insertDaycareAclRow(daycareId = unitId, employeeId = employeeId, role = UserRole.STAFF)
+            employeeId
+        }
+
+        db.transaction { it.clearRolesForInactiveEmployees(firstOfAugust2021) }
+
+        val scopedRoles = db.read { it.getEmployeeWithRoles(employeeId) }!!.daycareRoles.map { it.role }
+        assertEquals(setOf(UserRole.STAFF), scopedRoles.toSet())
+    }
+
+    @Test
+    fun `scoped roles are not reset when last_login is null and now is before first of Sep`() {
+        val employeeId = db.transaction {
+            val employeeId = it.insertTestEmployee(DevEmployee(lastLogin = null))
+            val areaId = it.insertTestCareArea(DevCareArea())
+            val unitId = it.insertTestDaycare(DevDaycare(areaId = areaId))
+            it.insertDaycareAclRow(daycareId = unitId, employeeId = employeeId, role = UserRole.STAFF)
+            employeeId
+        }
+
+        db.transaction { it.clearRolesForInactiveEmployees(firstOfAugust2021) }
+
+        val scopedRoles = db.read { it.getEmployeeWithRoles(employeeId) }!!.daycareRoles.map { it.role }
+        assertEquals(setOf(UserRole.STAFF), scopedRoles.toSet())
+    }
+
+    @Test
+    fun `scoped roles are reset when last_login is over 3 months ago`() {
+        val employeeId = db.transaction {
+            val employeeId = it.insertTestEmployee(
+                DevEmployee(lastLogin = firstOfAugust2021.minus(31 + 30 + 31 + 1, ChronoUnit.DAYS))
+            )
+            val areaId = it.insertTestCareArea(DevCareArea())
+            val unitId = it.insertTestDaycare(DevDaycare(areaId = areaId))
+            it.insertDaycareAclRow(daycareId = unitId, employeeId = employeeId, role = UserRole.STAFF)
+            employeeId
+        }
+
+        db.transaction { it.clearRolesForInactiveEmployees(firstOfAugust2021) }
+
+        val scopedRoles = db.read { it.getEmployeeWithRoles(employeeId) }!!.daycareRoles.map { it.role }
+        assertTrue(scopedRoles.isEmpty())
+    }
+
+    @Test
+    fun `scoped roles are reset when last_login is null and now is after first of Sep`() {
+        val employeeId = db.transaction {
+            val employeeId = it.insertTestEmployee(DevEmployee(lastLogin = null))
+            val areaId = it.insertTestCareArea(DevCareArea())
+            val unitId = it.insertTestDaycare(DevDaycare(areaId = areaId))
+            it.insertDaycareAclRow(daycareId = unitId, employeeId = employeeId, role = UserRole.STAFF)
+            employeeId
+        }
+
+        db.transaction { it.clearRolesForInactiveEmployees(firstOfAugust2021.plus(31, ChronoUnit.DAYS)) }
+
+        val scopedRoles = db.read { it.getEmployeeWithRoles(employeeId) }!!.daycareRoles.map { it.role }
+        assertTrue(scopedRoles.isEmpty())
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemIdentityController.kt
@@ -98,7 +98,8 @@ class SystemIdentityController {
         val lastName: String,
         val email: String?
     ) {
-        fun toNewEmployee(): NewEmployee = NewEmployee(firstName = firstName, lastName = lastName, email = email, externalId = externalId)
+        fun toNewEmployee(): NewEmployee =
+            NewEmployee(firstName = firstName, lastName = lastName, email = email, externalId = externalId)
     }
 
     data class PersonIdentityRequest(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -224,8 +224,8 @@ fun Database.Transaction.createMobileDeviceToUnit(id: UUID, unitId: DaycareId, n
 fun Database.Transaction.insertTestEmployee(employee: DevEmployee) = insertTestDataRow(
     employee,
     """
-INSERT INTO employee (id, first_name, last_name, email, external_id, roles)
-VALUES (:id, :firstName, :lastName, :email, :externalId, :roles::user_role[])
+INSERT INTO employee (id, first_name, last_name, email, external_id, roles, last_login)
+VALUES (:id, :firstName, :lastName, :email, :externalId, :roles::user_role[], :lastLogin)
 RETURNING id
 """
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -94,6 +94,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.Duration
+import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneId
@@ -949,7 +950,8 @@ data class DevEmployee(
     val lastName: String = "Person",
     val email: String? = "test.person@espoo.fi",
     val externalId: ExternalId? = null,
-    val roles: Set<UserRole> = setOf()
+    val roles: Set<UserRole> = setOf(),
+    val lastLogin: Instant? = Instant.now()
 )
 
 data class DevMobileDevice(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -72,6 +72,10 @@ data class ScheduledJobSettings(val enabled: Boolean, val schedule: Schedule) {
                 enabled = true,
                 schedule = JobSchedule.daily(LocalTime.of(3, 30))
             )
+            ScheduledJob.InactiveEmployeesRoleReset -> ScheduledJobSettings(
+                enabled = true,
+                schedule = JobSchedule.daily(LocalTime.of(3, 15))
+            )
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.koski.KoskiSearchParams
 import fi.espoo.evaka.koski.KoskiUpdateService
 import fi.espoo.evaka.messaging.daycarydailynote.deleteExpiredDaycareDailyNotes
 import fi.espoo.evaka.pis.cleanUpInactivePeople
+import fi.espoo.evaka.pis.clearRolesForInactiveEmployees
 import fi.espoo.evaka.placement.deletePlacementPlans
 import fi.espoo.evaka.reports.freezeVoucherValueReportRows
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -42,6 +43,7 @@ enum class ScheduledJob(val fn: (ScheduledJobs, Database.Connection) -> Unit) {
     SendPendingDecisionReminderEmails(ScheduledJobs::sendPendingDecisionReminderEmails),
     VardaUpdate(ScheduledJobs::vardaUpdate),
     InactivePeopleCleanup(ScheduledJobs::inactivePeopleCleanup),
+    InactiveEmployeesRoleReset(ScheduledJobs::inactiveEmployeesRoleReset)
 }
 
 private val logger = KotlinLogging.logger { }
@@ -137,5 +139,9 @@ class ScheduledJobs(
 
     fun inactivePeopleCleanup(db: Database.Connection) {
         db.transaction { cleanUpInactivePeople(it, LocalDate.now()) }
+    }
+
+    fun inactiveEmployeesRoleReset(db: Database.Connection) {
+        db.transaction { it.clearRolesForInactiveEmployees(Instant.now()) }
     }
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add a scheduled job that removes all roles from employees that haven't logged in last 3 months. For employees that do not have `last_login` data, use 1.6.2021 as a default since `last_login` has been tracked since May.
