### PR TITLE
Remove MaxPermSize option

### DIFF
--- a/message-service/gradle.properties
+++ b/message-service/gradle.properties
@@ -11,5 +11,5 @@ flyway.password=message-flyway
 flyway.placeholders.application_user=evaka_message_application_local
 flyway.placeholders.migration_user=evaka_message_migration_local
 
-org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.vfs.watch=true

--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -19,5 +19,5 @@ flyway.placeholders.migration_user=evaka_migration_local
 #flyway.placeholders.migration_user=evaka_it
 #flyway.placeholders.application_user=evaka_it
 
-org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.vfs.watch=true


### PR DESCRIPTION
#### Summary

MaxPermSize option is already deprecated in Java 8 and removed in latest versions.