### PR TITLE
Refactor assistance basis options to database

### DIFF
--- a/frontend/src/employee-frontend/api/child/assistance-needs.ts
+++ b/frontend/src/employee-frontend/api/child/assistance-needs.ts
@@ -4,7 +4,7 @@
 
 import { UUID } from '../../types'
 import { Failure, Result, Success } from 'lib-common/api'
-import { AssistanceBasis, AssistanceNeed } from '../../types/child'
+import { AssistanceBasisOption, AssistanceNeed } from '../../types/child'
 import { client } from '../client'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
@@ -14,7 +14,7 @@ export interface AssistanceNeedRequest {
   endDate: LocalDate
   capacityFactor: number
   description: string
-  bases: AssistanceBasis[]
+  bases: string[]
   otherBasis: string
 }
 
@@ -83,5 +83,14 @@ export async function removeAssistanceNeed(
   return client
     .delete(`/assistance-needs/${assistanceNeedId}`)
     .then(() => Success.of(null))
+    .catch((e) => Failure.fromError(e))
+}
+
+export async function getAssistanceBasisOptions(): Promise<
+  Result<AssistanceBasisOption[]>
+> {
+  return client
+    .get<JsonOf<AssistanceBasisOption[]>>('/assistance-basis-options')
+    .then((res) => Success.of(res.data))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
@@ -12,7 +12,7 @@ import { Gap } from 'lib-components/white-space'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import InputField from 'lib-components/atoms/form/InputField'
 import TextArea from 'lib-components/atoms/form/TextArea'
-import { AssistanceBasis, AssistanceNeed } from '../../../types/child'
+import { AssistanceBasisOption, AssistanceNeed } from '../../../types/child'
 import { UUID } from '../../../types'
 import { formatDecimal } from 'lib-common/utils/number'
 import { textAreaRows } from '../../utils'
@@ -24,7 +24,6 @@ import {
   isDateRangeInverted
 } from '../../../utils/validation/validations'
 import LabelValueList from '../../../components/common/LabelValueList'
-import { ASSISTANCE_BASIS_LIST } from '../../../constants'
 import FormActions from '../../../components/common/FormActions'
 import { ChildContext } from '../../../state'
 import { DateRange, rangeContainsDate } from '../../../utils/date'
@@ -36,6 +35,7 @@ import {
   updateAssistanceNeed
 } from '../../../api/child/assistance-needs'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
+import { featureFlags } from 'lib-customizations/employee'
 
 const CheckboxRow = styled.div`
   display: flex;
@@ -65,7 +65,8 @@ interface FormState {
   endDate: LocalDate
   capacityFactor: string
   description: string
-  bases: Set<AssistanceBasis>
+  bases: Set<string>
+  otherSelected: boolean
   otherBasis: string
 }
 
@@ -73,6 +74,7 @@ const coefficientRegex = /^\d(([.,])(\d){1,2})?$/
 
 interface CommonProps {
   onReload: () => undefined | void
+  assistanceBasisOptions: AssistanceBasisOption[]
 }
 
 interface CreateProps extends CommonProps {
@@ -128,11 +130,13 @@ function AssistanceNeedForm(props: Props) {
           capacityFactor: '1',
           description: '',
           bases: new Set(),
+          otherSelected: false,
           otherBasis: ''
         }
       : {
           ...props.assistanceNeed,
-          capacityFactor: formatDecimal(props.assistanceNeed.capacityFactor)
+          capacityFactor: formatDecimal(props.assistanceNeed.capacityFactor),
+          otherSelected: props.assistanceNeed.otherBasis !== ''
         }
   const [form, setForm] = useState<FormState>(initialFormState)
 
@@ -196,7 +200,7 @@ function AssistanceNeedForm(props: Props) {
       ...form,
       capacityFactor: Number(form.capacityFactor.replace(',', '.')),
       bases: [...form.bases],
-      otherBasis: form.bases.has('OTHER') ? form.otherBasis : ''
+      otherBasis: form.otherSelected ? form.otherBasis : ''
     }
 
     const apiCall = isCreate(props)
@@ -326,55 +330,60 @@ function AssistanceNeedForm(props: Props) {
             label: i18n.childInformation.assistanceNeed.fields.bases,
             value: (
               <div>
-                {ASSISTANCE_BASIS_LIST.map((basis) =>
-                  i18n.childInformation.assistanceNeed.fields.basisTypes[
-                    `${basis}_INFO`
-                  ] ? (
+                {props.assistanceBasisOptions.map((basis) =>
+                  basis.descriptionFi ? (
                     <ExpandingInfo
-                      key={basis}
-                      info={String(
-                        i18n.childInformation.assistanceNeed.fields.basisTypes[
-                          `${basis}_INFO`
-                        ]
-                      )}
+                      key={basis.value}
+                      info={basis.descriptionFi}
                       ariaLabel={''}
                       fullWidth={true}
                     >
-                      <CheckboxRow key={basis}>
+                      <CheckboxRow key={basis.value}>
                         <Checkbox
-                          label={
-                            i18n.childInformation.assistanceNeed.fields
-                              .basisTypes[basis]
-                          }
-                          checked={form.bases.has(basis)}
+                          label={basis.nameFi}
+                          checked={form.bases.has(basis.value)}
                           onChange={(value) => {
                             const bases = new Set([...form.bases])
-                            if (value) bases.add(basis)
-                            else bases.delete(basis)
+                            if (value) bases.add(basis.value)
+                            else bases.delete(basis.value)
                             updateFormState({ bases: bases })
                           }}
                         />
                       </CheckboxRow>
                     </ExpandingInfo>
                   ) : (
-                    <CheckboxRow key={basis}>
+                    <CheckboxRow key={basis.value}>
                       <Checkbox
-                        label={
-                          i18n.childInformation.assistanceNeed.fields
-                            .basisTypes[basis]
-                        }
-                        checked={form.bases.has(basis)}
+                        label={basis.nameFi}
+                        checked={form.bases.has(basis.value)}
                         onChange={(value) => {
                           const bases = new Set([...form.bases])
-                          if (value) bases.add(basis)
-                          else bases.delete(basis)
+                          if (value) bases.add(basis.value)
+                          else bases.delete(basis.value)
                           updateFormState({ bases: bases })
                         }}
                       />
                     </CheckboxRow>
                   )
                 )}
-                {form.bases.has('OTHER') && (
+                {featureFlags.assistanceBasisOtherEnabled ? (
+                  <CheckboxRow>
+                    <Checkbox
+                      label={
+                        i18n.childInformation.assistanceNeed.fields.basisTypes
+                          .OTHER
+                      }
+                      checked={form.otherSelected}
+                      onChange={(value) =>
+                        updateFormState({
+                          otherSelected: value,
+                          otherBasis: ''
+                        })
+                      }
+                    ></Checkbox>
+                  </CheckboxRow>
+                ) : null}
+                {form.otherSelected && (
                   <div style={{ width: '100%' }}>
                     <InputField
                       value={form.otherBasis}

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
@@ -4,7 +4,7 @@
 
 import React, { MutableRefObject, useContext, useRef, useState } from 'react'
 import { useTranslation } from '../../../state/i18n'
-import { AssistanceNeed } from '../../../types/child'
+import { AssistanceBasisOption, AssistanceNeed } from '../../../types/child'
 import { UIContext } from '../../../state/ui'
 import InfoBall from '../../../components/common/InfoBall'
 import AssistanceNeedForm from '../../../components/child-information/assistance-need/AssistanceNeedForm'
@@ -16,18 +16,24 @@ import { formatDecimal } from 'lib-common/utils/number'
 
 import { formatParagraphs } from '../../../utils/html-utils'
 import LabelValueList from '../../../components/common/LabelValueList'
-import { ASSISTANCE_BASIS_LIST } from '../../../constants'
 import Toolbar from '../../../components/common/Toolbar'
 import { scrollToRef } from '../../../utils'
 import { removeAssistanceNeed } from '../../../api/child/assistance-needs'
+import { featureFlags } from 'lib-customizations/employee'
 
 export interface Props {
   assistanceNeed: AssistanceNeed
   onReload: () => undefined | void
+  assistanceBasisOptions: AssistanceBasisOption[]
   refSectionTop: MutableRefObject<HTMLElement | null>
 }
 
-function AssistanceNeedRow({ assistanceNeed, onReload, refSectionTop }: Props) {
+function AssistanceNeedRow({
+  assistanceNeed,
+  onReload,
+  assistanceBasisOptions,
+  refSectionTop
+}: Props) {
   const { i18n } = useTranslation()
   const expandedAtStart = isActiveDateRange(
     assistanceNeed.startDate,
@@ -92,6 +98,7 @@ function AssistanceNeedRow({ assistanceNeed, onReload, refSectionTop }: Props) {
             <AssistanceNeedForm
               assistanceNeed={assistanceNeed}
               onReload={onReload}
+              assistanceBasisOptions={assistanceBasisOptions}
             />
           </div>
         ) : (
@@ -126,28 +133,22 @@ function AssistanceNeedRow({ assistanceNeed, onReload, refSectionTop }: Props) {
                 label: i18n.childInformation.assistanceNeed.fields.bases,
                 value: (
                   <ul>
-                    {ASSISTANCE_BASIS_LIST.filter(
-                      (basis) => basis != 'OTHER'
-                    ).map(
+                    {assistanceBasisOptions.map(
                       (basis) =>
-                        assistanceNeed.bases.has(basis) && (
-                          <li key={basis}>
-                            {
-                              i18n.childInformation.assistanceNeed.fields
-                                .basisTypes[basis]
-                            }
-                          </li>
+                        assistanceNeed.bases.has(basis.value) && (
+                          <li key={basis.value}>{basis.nameFi}</li>
                         )
                     )}
-                    {assistanceNeed.bases.has('OTHER') && (
-                      <li>
-                        {
-                          i18n.childInformation.assistanceNeed.fields.basisTypes
-                            .OTHER
-                        }
-                        : {assistanceNeed.otherBasis}
-                      </li>
-                    )}
+                    {featureFlags.assistanceBasisOtherEnabled &&
+                      assistanceNeed.otherBasis !== '' && (
+                        <li>
+                          {
+                            i18n.childInformation.assistanceNeed.fields
+                              .basisTypes.OTHER
+                          }
+                          : {assistanceNeed.otherBasis}
+                        </li>
+                      )}
                   </ul>
                 )
               }

--- a/frontend/src/employee-frontend/constants.ts
+++ b/frontend/src/employee-frontend/constants.ts
@@ -4,7 +4,6 @@
 
 import LocalDate from 'lib-common/local-date'
 import { UUID } from './types'
-import { AssistanceBasis } from './types/child'
 
 export const EVAKA_START = LocalDate.of(2020, 3, 1)
 
@@ -48,18 +47,3 @@ export function isPilotUnit(unitId: UUID): boolean {
 
   return pilotUnitIds.includes(unitId)
 }
-
-export const ASSISTANCE_BASIS_LIST: AssistanceBasis[] = [
-  'AUTISM',
-  'DEVELOPMENTAL_DISABILITY_1',
-  'DEVELOPMENTAL_DISABILITY_2',
-  'FOCUS_CHALLENGE',
-  'LINGUISTIC_CHALLENGE',
-  'DEVELOPMENT_MONITORING',
-  'DEVELOPMENT_MONITORING_PENDING',
-  'MULTI_DISABILITY',
-  'LONG_TERM_CONDITION',
-  'REGULATION_SKILL_CHALLENGE',
-  'DISABILITY',
-  'OTHER'
-]

--- a/frontend/src/employee-frontend/types/child.ts
+++ b/frontend/src/employee-frontend/types/child.ts
@@ -12,20 +12,6 @@ import {
   PlacementType
 } from 'lib-common/api-types/serviceNeed/common'
 
-export type AssistanceBasis =
-  | 'AUTISM'
-  | 'DEVELOPMENTAL_DISABILITY_1'
-  | 'DEVELOPMENTAL_DISABILITY_2'
-  | 'FOCUS_CHALLENGE'
-  | 'LINGUISTIC_CHALLENGE'
-  | 'DEVELOPMENT_MONITORING'
-  | 'DEVELOPMENT_MONITORING_PENDING'
-  | 'MULTI_DISABILITY'
-  | 'LONG_TERM_CONDITION'
-  | 'REGULATION_SKILL_CHALLENGE'
-  | 'DISABILITY'
-  | 'OTHER'
-
 export interface AssistanceNeed {
   id: UUID
   childId: UUID
@@ -33,7 +19,7 @@ export interface AssistanceNeed {
   endDate: LocalDate
   capacityFactor: number
   description: string
-  bases: Set<AssistanceBasis>
+  bases: Set<string>
   otherBasis: string
 }
 
@@ -52,6 +38,12 @@ export interface AssistanceAction {
 export interface AssistanceActionOption {
   value: string
   nameFi: string
+}
+
+export interface AssistanceBasisOption {
+  value: string
+  nameFi: string
+  descriptionFi: string | null
 }
 
 export interface AdditionalInformation {

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -14,6 +14,7 @@ type Features = {
 const features: Features = {
   default: {
     assistanceActionOtherEnabled: true,
+    assistanceBasisOtherEnabled: true,
     daycareApplication: {
       dailyTimesEnabled: true,
       serviceNeedOptionsEnabled: false
@@ -31,6 +32,7 @@ const features: Features = {
   },
   staging: {
     assistanceActionOtherEnabled: true,
+    assistanceBasisOtherEnabled: true,
     daycareApplication: {
       dailyTimesEnabled: true,
       serviceNeedOptionsEnabled: false
@@ -48,6 +50,7 @@ const features: Features = {
   },
   prod: {
     assistanceActionOtherEnabled: true,
+    assistanceBasisOtherEnabled: true,
     daycareApplication: {
       dailyTimesEnabled: true,
       serviceNeedOptionsEnabled: false

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -85,6 +85,7 @@ interface MapConfig {
  */
 interface BaseFeatureFlags {
   assistanceActionOtherEnabled: boolean
+  assistanceBasisOtherEnabled: boolean
   daycareApplication: {
     dailyTimesEnabled: boolean
     serviceNeedOptionsEnabled: boolean

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -562,6 +562,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
 
     insertServiceNeedOptions()
     insertAssistanceActionOptions()
+    insertAssistanceBasisOptions()
 }
 
 fun Database.Transaction.resetDatabase() = execute("SELECT reset_database()")
@@ -649,6 +650,26 @@ INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
     ('RESOURCE_PERSON', 'Resurssihenkilö', 60),
     ('RATIO_DECREASE', 'Suhdeluvun väljennys', 70),
     ('PERIODICAL_VEO_SUPPORT', 'Jaksottainen veon tuki (2–6 kk)', 80);
+"""
+
+    createUpdate(sql).execute()
+}
+
+fun Database.Transaction.insertAssistanceBasisOptions() {
+    // language=sql
+    val sql = """
+INSERT INTO assistance_basis_option (value, name_fi, description_fi, display_order) VALUES
+    ('AUTISM', 'Autismin kirjo', NULL, 10),
+    ('DEVELOPMENTAL_DISABILITY_1', 'Kehitysvamma 1', NULL, 15),
+    ('DEVELOPMENTAL_DISABILITY_2', 'Kehitysvamma 2', 'Käytetään silloin, kun esiopetuksessa oleva lapsi on vaikeasti kehitysvammainen.', 20),
+    ('FOCUS_CHALLENGE', 'Keskittymisen / tarkkaavaisuuden vaikeus', NULL, 25),
+    ('LINGUISTIC_CHALLENGE', 'Kielellinen vaikeus', NULL, 30),
+    ('DEVELOPMENT_MONITORING', 'Lapsen kehityksen seuranta', NULL, 35),
+    ('DEVELOPMENT_MONITORING_PENDING', 'Lapsen kehityksen seuranta, tutkimukset kesken', 'Lapsi on terveydenhuollon tutkimuksissa, diagnoosi ei ole vielä varmistunut.', 40),
+    ('MULTI_DISABILITY', 'Monivammaisuus', NULL, 45),
+    ('LONG_TERM_CONDITION', 'Pitkäaikaissairaus', NULL, 50),
+    ('REGULATION_SKILL_CHALLENGE', 'Säätelytaitojen vaikeus', NULL, 55),
+    ('DISABILITY', 'Vamma (näkö, kuulo, liikunta, muu)', NULL, 60);
 """
 
     createUpdate(sql).execute()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
@@ -63,20 +63,7 @@ class AssistanceNeedIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `post first assistance need, with bases`() {
-        val allBases = setOf(
-            AssistanceBasis.AUTISM,
-            AssistanceBasis.DEVELOPMENTAL_DISABILITY_1,
-            AssistanceBasis.DEVELOPMENTAL_DISABILITY_2,
-            AssistanceBasis.FOCUS_CHALLENGE,
-            AssistanceBasis.LINGUISTIC_CHALLENGE,
-            AssistanceBasis.DEVELOPMENT_MONITORING,
-            AssistanceBasis.DEVELOPMENT_MONITORING_PENDING,
-            AssistanceBasis.MULTI_DISABILITY,
-            AssistanceBasis.LONG_TERM_CONDITION,
-            AssistanceBasis.REGULATION_SKILL_CHALLENGE,
-            AssistanceBasis.DISABILITY,
-            AssistanceBasis.OTHER
-        )
+        val allBases = db.transaction { it.getAssistanceBasisOptions() }.map { it.value }.toSet()
 
         val assistanceNeed = whenPostAssistanceNeedThenExpectSuccess(
             AssistanceNeedRequest(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -6,7 +6,6 @@ package fi.espoo.evaka.koski
 
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.assistanceaction.AssistanceMeasure
-import fi.espoo.evaka.assistanceneed.AssistanceBasis
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.daycare.service.CareType
@@ -329,12 +328,12 @@ class KoskiIntegrationTest : FullApplicationTest() {
     fun `assistance needs are converted to Koski extra information`() {
         data class TestCase(
             val period: FiniteDateRange,
-            val basis: AssistanceBasis
+            val basis: String
         )
         insertPlacement(testChild_1)
         val testCases = listOf(
-            TestCase(testPeriod(0L to 1L), AssistanceBasis.DEVELOPMENTAL_DISABILITY_1),
-            TestCase(testPeriod(2L to 3L), AssistanceBasis.DEVELOPMENTAL_DISABILITY_2)
+            TestCase(testPeriod(0L to 1L), "DEVELOPMENTAL_DISABILITY_1"),
+            TestCase(testPeriod(2L to 3L), "DEVELOPMENTAL_DISABILITY_2")
         )
         db.transaction { tx ->
             testCases.forEach {

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeed.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeed.kt
@@ -15,7 +15,7 @@ data class AssistanceNeed(
     val endDate: LocalDate,
     val capacityFactor: Double,
     val description: String,
-    val bases: Set<AssistanceBasis>,
+    val bases: Set<String>,
     val otherBasis: String
 )
 
@@ -24,21 +24,12 @@ data class AssistanceNeedRequest(
     val endDate: LocalDate,
     val capacityFactor: Double,
     val description: String = "",
-    val bases: Set<AssistanceBasis> = emptySet(),
+    val bases: Set<String> = emptySet(),
     val otherBasis: String = ""
 )
 
-enum class AssistanceBasis {
-    AUTISM,
-    DEVELOPMENTAL_DISABILITY_1,
-    DEVELOPMENTAL_DISABILITY_2,
-    FOCUS_CHALLENGE,
-    LINGUISTIC_CHALLENGE,
-    DEVELOPMENT_MONITORING,
-    DEVELOPMENT_MONITORING_PENDING,
-    MULTI_DISABILITY,
-    LONG_TERM_CONDITION,
-    REGULATION_SKILL_CHALLENGE,
-    DISABILITY,
-    OTHER
-}
+data class AssistanceBasisOption(
+    val value: String,
+    val nameFi: String,
+    val descriptionFi: String?
+)

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -85,4 +85,10 @@ class AssistanceNeedController(
         assistanceNeedService.deleteAssistanceNeed(db, assistanceNeedId)
         return noContent()
     }
+
+    @GetMapping("/assistance-basis-options")
+    fun getAssistanceBasisOptions(db: Database.Connection, user: AuthenticatedUser): List<AssistanceBasisOption> {
+        user.requireAnyEmployee()
+        return assistanceNeedService.getAssistanceBasisOptions(db)
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedQueries.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.NotFound
+import org.jdbi.v3.core.kotlin.mapTo
 import java.time.LocalDate
 import java.util.UUID
 
@@ -22,7 +23,6 @@ fun Database.Transaction.insertAssistanceNeed(user: AuthenticatedUser, childId: 
             updated_by, 
             capacity_factor, 
             description, 
-            bases,          
             other_basis                   
         )
         VALUES (
@@ -32,28 +32,66 @@ fun Database.Transaction.insertAssistanceNeed(user: AuthenticatedUser, childId: 
             :updatedBy, 
             :capacityFactor, 
             :description,
-            :bases::assistance_basis[],
             :otherBasis
         )
-        RETURNING *
+        RETURNING id
         """.trimIndent()
 
-    return createQuery(sql)
+    val id = createQuery(sql)
         .bind("childId", childId)
         .bind("startDate", data.startDate)
         .bind("endDate", data.endDate)
         .bind("updatedBy", user.id)
         .bind("capacityFactor", data.capacityFactor)
         .bind("description", data.description)
-        .bind("bases", data.bases.map { it.toString() }.toTypedArray())
         .bind("otherBasis", data.otherBasis)
-        .mapTo(AssistanceNeed::class.java)
+        .mapTo<AssistanceNeedId>()
         .first()
+
+    insertAssistanceBasisOptionRefs(id, data.bases)
+
+    return getAssistanceNeedById(id)
+}
+
+fun Database.Transaction.insertAssistanceBasisOptionRefs(needId: AssistanceNeedId, options: Set<String>): IntArray {
+    //language=sql
+    val sql =
+        """
+        INSERT INTO assistance_basis_option_ref (need_id, option_id)
+        VALUES (:need_id, (SELECT id FROM assistance_basis_option WHERE value = :option))
+        ON CONFLICT DO NOTHING
+        """.trimIndent()
+    val batch = prepareBatch(sql)
+    options.forEach { option -> batch.bind("need_id", needId).bind("option", option).add() }
+    return batch.execute()
+}
+
+fun Database.Read.getAssistanceNeedById(id: AssistanceNeedId): AssistanceNeed {
+    //language=sql
+    val sql =
+        """
+        SELECT an.id, child_id, start_date, end_date, capacity_factor, description, array_remove(array_agg(value), null) AS bases, other_basis
+        FROM assistance_need an
+        LEFT JOIN assistance_basis_option_ref abor ON abor.need_id = an.id
+        LEFT JOIN assistance_basis_option abo ON abo.id = abor.option_id
+        WHERE an.id = :id
+        GROUP BY an.id, child_id, start_date, end_date, capacity_factor, description, other_basis
+        """.trimIndent()
+    return createQuery(sql).bind("id", id).mapTo(AssistanceNeed::class.java).first()
 }
 
 fun Database.Read.getAssistanceNeedsByChild(childId: UUID): List<AssistanceNeed> {
     //language=sql
-    val sql = "SELECT * FROM assistance_need WHERE child_id = :childId ORDER BY start_date DESC "
+    val sql =
+        """
+        SELECT an.id, child_id, start_date, end_date, capacity_factor, description, array_remove(array_agg(value), null) AS bases, other_basis
+        FROM assistance_need an
+        LEFT JOIN assistance_basis_option_ref abor ON abor.need_id = an.id
+        LEFT JOIN assistance_basis_option abo ON abo.id = abor.option_id
+        WHERE child_id = :childId
+        GROUP BY an.id, child_id, start_date, end_date, capacity_factor, description, other_basis
+        ORDER BY start_date DESC
+        """.trimIndent()
     return createQuery(sql)
         .bind("childId", childId)
         .mapTo(AssistanceNeed::class.java)
@@ -70,23 +108,26 @@ fun Database.Transaction.updateAssistanceNeed(user: AuthenticatedUser, id: Assis
             updated_by = :updatedBy,
             capacity_factor = :capacityFactor,
             description = :description,
-            bases = :bases::assistance_basis[],
             other_basis = :otherBasis
         WHERE id = :id
-        RETURNING *
+        RETURNING id
         """.trimIndent()
 
-    return createQuery(sql)
+    createQuery(sql)
         .bind("id", id)
         .bind("startDate", data.startDate)
         .bind("endDate", data.endDate)
         .bind("updatedBy", user.id)
         .bind("capacityFactor", data.capacityFactor)
         .bind("description", data.description)
-        .bind("bases", data.bases.map { it.toString() }.toTypedArray())
         .bind("otherBasis", data.otherBasis)
-        .mapTo(AssistanceNeed::class.java)
+        .mapTo<AssistanceNeedId>()
         .firstOrNull() ?: throw NotFound("Assistance need $id not found")
+
+    deleteAssistanceBasisOptionRefsByNeedId(id, data.bases)
+    insertAssistanceBasisOptionRefs(id, data.bases)
+
+    return getAssistanceNeedById(id)
 }
 
 fun Database.Transaction.shortenOverlappingAssistanceNeed(user: AuthenticatedUser, childId: UUID, startDate: LocalDate, endDate: LocalDate) {
@@ -112,4 +153,24 @@ fun Database.Transaction.deleteAssistanceNeed(id: AssistanceNeedId) {
     val sql = "DELETE FROM assistance_need WHERE id = :id"
     val deleted = createUpdate(sql).bind("id", id).execute()
     if (deleted == 0) throw NotFound("Assistance need $id not found")
+}
+
+fun Database.Transaction.deleteAssistanceBasisOptionRefsByNeedId(needId: AssistanceNeedId, excluded: Set<String>): Int {
+    //language=sql
+    val sql =
+        """
+        DELETE FROM assistance_basis_option_ref
+        WHERE need_id = :need_id
+        AND option_id NOT IN (SELECT id FROM assistance_basis_option WHERE value = ANY(:excluded))
+        """.trimIndent()
+    return createUpdate(sql)
+        .bind("need_id", needId)
+        .bind("excluded", excluded.toTypedArray())
+        .execute()
+}
+
+fun Database.Transaction.getAssistanceBasisOptions(): List<AssistanceBasisOption> {
+    //language=sql
+    val sql = "SELECT value, name_fi, description_fi FROM assistance_basis_option ORDER BY display_order"
+    return createQuery(sql).mapTo(AssistanceBasisOption::class.java).list()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
+import fi.espoo.evaka.shared.domain.BadRequest
 import org.jdbi.v3.core.JdbiException
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -17,6 +18,7 @@ class AssistanceNeedService {
     fun createAssistanceNeed(db: Database.Connection, user: AuthenticatedUser, childId: UUID, data: AssistanceNeedRequest): AssistanceNeed {
         try {
             return db.transaction {
+                validateBases(data, it.getAssistanceBasisOptions().map { it.value } )
                 it.shortenOverlappingAssistanceNeed(user, childId, data.startDate, data.endDate)
                 it.insertAssistanceNeed(user, childId, data)
             }
@@ -31,7 +33,10 @@ class AssistanceNeedService {
 
     fun updateAssistanceNeed(db: Database.Connection, user: AuthenticatedUser, id: AssistanceNeedId, data: AssistanceNeedRequest): AssistanceNeed {
         try {
-            return db.transaction { it.updateAssistanceNeed(user, id, data) }
+            return db.transaction {
+                validateBases(data, it.getAssistanceBasisOptions().map { it.value })
+                it.updateAssistanceNeed(user, id, data)
+            }
         } catch (e: JdbiException) {
             throw mapPSQLException(e)
         }
@@ -39,5 +44,17 @@ class AssistanceNeedService {
 
     fun deleteAssistanceNeed(db: Database.Connection, id: AssistanceNeedId) {
         db.transaction { it.deleteAssistanceNeed(id) }
+    }
+
+    fun getAssistanceBasisOptions(db: Database.Connection): List<AssistanceBasisOption> {
+        return db.transaction { it.getAssistanceBasisOptions() }
+    }
+
+    private fun validateBases(data: AssistanceNeedRequest, options: List<String>) {
+        data.bases.forEach { basis ->
+            if (!options.contains(basis)) {
+                throw BadRequest("Basis $basis is not valid option, all options: $options")
+            }
+        }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedService.kt
@@ -18,7 +18,7 @@ class AssistanceNeedService {
     fun createAssistanceNeed(db: Database.Connection, user: AuthenticatedUser, childId: UUID, data: AssistanceNeedRequest): AssistanceNeed {
         try {
             return db.transaction {
-                validateBases(data, it.getAssistanceBasisOptions().map { it.value } )
+                validateBases(data, it.getAssistanceBasisOptions().map { it.value })
                 it.shortenOverlappingAssistanceNeed(user, childId, data.startDate, data.endDate)
                 it.insertAssistanceNeed(user, childId, data)
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
@@ -48,19 +48,19 @@ fun Database.Read.getAssistanceNeedsAndActionsReportRows(date: LocalDate, author
             u.type as unit_type,
             u.provider_type as unit_provider_type,
             
-            count(DISTINCT pl.child_id) FILTER (WHERE 'AUTISM'::assistance_basis = ANY(an.bases)) AS autism,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENTAL_DISABILITY_1'::assistance_basis = ANY(an.bases)) AS developmental_disability_1,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENTAL_DISABILITY_2'::assistance_basis = ANY(an.bases)) AS developmental_disability_2,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'FOCUS_CHALLENGE'::assistance_basis = ANY(an.bases)) AS focus_challenge,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'LINGUISTIC_CHALLENGE'::assistance_basis = ANY(an.bases)) AS linguistic_challenge,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENT_MONITORING'::assistance_basis = ANY(an.bases)) AS development_monitoring,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENT_MONITORING_PENDING'::assistance_basis = ANY(an.bases)) AS development_monitoring_pending,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'MULTI_DISABILITY'::assistance_basis = ANY(an.bases)) AS multi_disability,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'LONG_TERM_CONDITION'::assistance_basis = ANY(an.bases)) AS long_term_condition,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'REGULATION_SKILL_CHALLENGE'::assistance_basis = ANY(an.bases)) AS regulation_skill_challenge,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'DISABILITY'::assistance_basis = ANY(an.bases)) AS disability,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'OTHER'::assistance_basis = ANY(an.bases)) AS other_assistance_need,
-            count(DISTINCT pl.child_id) FILTER (WHERE cardinality(an.bases) = 0) AS no_assistance_needs,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'AUTISM' = ANY(abo.bases)) AS autism,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENTAL_DISABILITY_1' = ANY(abo.bases)) AS developmental_disability_1,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENTAL_DISABILITY_2' = ANY(abo.bases)) AS developmental_disability_2,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'FOCUS_CHALLENGE' = ANY(abo.bases)) AS focus_challenge,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'LINGUISTIC_CHALLENGE' = ANY(abo.bases)) AS linguistic_challenge,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENT_MONITORING' = ANY(abo.bases)) AS development_monitoring,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENT_MONITORING_PENDING' = ANY(abo.bases)) AS development_monitoring_pending,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'MULTI_DISABILITY' = ANY(abo.bases)) AS multi_disability,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'LONG_TERM_CONDITION' = ANY(abo.bases)) AS long_term_condition,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'REGULATION_SKILL_CHALLENGE' = ANY(abo.bases)) AS regulation_skill_challenge,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'DISABILITY' = ANY(abo.bases)) AS disability,
+            count(DISTINCT pl.child_id) FILTER (WHERE 'OTHER' = ANY(abo.bases)) AS other_assistance_need,
+            count(DISTINCT pl.child_id) FILTER (WHERE cardinality(abo.bases) = 0) AS no_assistance_needs,
             
             count(DISTINCT pl.child_id) FILTER (WHERE 'ASSISTANCE_SERVICE_CHILD' = ANY(aao.actions)) AS assistance_service_child,
             count(DISTINCT pl.child_id) FILTER (WHERE 'ASSISTANCE_SERVICE_UNIT' = ANY(aao.actions)) AS assistance_service_unit,
@@ -78,6 +78,12 @@ fun Database.Read.getAssistanceNeedsAndActionsReportRows(date: LocalDate, author
         LEFT JOIN daycare_group_placement gpl ON gpl.daycare_group_id = g.id AND daterange(gpl.start_date, gpl.end_date, '[]') @> :target_date
         LEFT JOIN placement pl ON pl.id = gpl.daycare_placement_id
         LEFT JOIN assistance_need an on an.child_id = pl.child_id AND daterange(an.start_date, an.end_date, '[]') @> :target_date
+        LEFT JOIN (
+            SELECT r.need_id, array_remove(array_agg(o.value), null) AS bases
+            FROM assistance_basis_option_ref r
+            JOIN assistance_basis_option o ON o.id = r.option_id
+            GROUP BY r.need_id
+        ) abo ON abo.need_id = an.id
         LEFT JOIN assistance_action aa on aa.child_id = pl.child_id AND daterange(aa.start_date, aa.end_date, '[]') @> :target_date
         LEFT JOIN (
             SELECT r.action_id, array_remove(array_agg(o.value), null) AS actions

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.application.fetchApplicationDetails
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.application.persistence.objectMapper
 import fi.espoo.evaka.assistanceaction.AssistanceMeasure
-import fi.espoo.evaka.assistanceneed.AssistanceBasis
 import fi.espoo.evaka.daycare.CareType
 import fi.espoo.evaka.daycare.DaycareDecisionCustomization
 import fi.espoo.evaka.daycare.MailingAddress
@@ -862,7 +861,7 @@ data class DevAssistanceNeed(
     val startDate: LocalDate = LocalDate.of(2019, 1, 1),
     val endDate: LocalDate = LocalDate.of(2019, 12, 31),
     val capacityFactor: Double = 1.0,
-    val bases: Set<AssistanceBasis> = emptySet(),
+    val bases: Set<String> = emptySet(),
     val otherBasis: String = "",
     val description: String = ""
 )

--- a/service/src/main/resources/db/migration/R__koski_views.sql
+++ b/service/src/main/resources/db/migration/R__koski_views.sql
@@ -69,11 +69,15 @@ TABLE (
             array_agg(date_interval) FILTER (WHERE 'DEVELOPMENTAL_DISABILITY_2' = ANY(bases)) AS developmental_disability_2
         FROM (
             SELECT
+                an.id,
                 daterange(an.start_date, an.end_date, '[]') AS date_interval,
-                an.bases
+                array_remove(array_agg(abo.value), null) AS bases
             FROM assistance_need an
+            LEFT JOIN assistance_basis_option_ref abor ON abor.need_id = an.id
+            LEFT JOIN assistance_basis_option abo ON abo.id = abor.option_id
             WHERE an.child_id = p.child_id
             AND daterange(an.start_date, an.end_date, '[]') && full_range
+            GROUP BY an.id, daterange(an.start_date, an.end_date, '[]')
             ORDER BY an.id
         ) matching_assistance_need
     ) an ON true

--- a/service/src/main/resources/db/migration/V124__assistance_basis_option.sql
+++ b/service/src/main/resources/db/migration/V124__assistance_basis_option.sql
@@ -1,0 +1,60 @@
+CREATE TABLE assistance_basis_option (
+    id uuid PRIMARY KEY DEFAULT ext.uuid_generate_v1mc(),
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    updated timestamp with time zone DEFAULT now() NOT NULL,
+    value text NOT NULL,
+    name_fi text NOT NULL,
+    description_fi text,
+    display_order int
+);
+
+CREATE UNIQUE INDEX uniq$assistance_basis_option_value ON assistance_basis_option (value);
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON assistance_basis_option FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();
+
+INSERT INTO assistance_basis_option (value, name_fi, description_fi, display_order)
+SELECT basis, CASE basis
+    WHEN 'AUTISM'::assistance_basis THEN 'Autismin kirjo'
+    WHEN 'DEVELOPMENTAL_DISABILITY_1'::assistance_basis THEN 'Kehitysvamma 1'
+    WHEN 'DEVELOPMENTAL_DISABILITY_2'::assistance_basis THEN 'Kehitysvamma 2'
+    WHEN 'FOCUS_CHALLENGE'::assistance_basis THEN 'Keskittymisen / tarkkaavaisuuden vaikeus'
+    WHEN 'LINGUISTIC_CHALLENGE'::assistance_basis THEN 'Kielellinen vaikeus'
+    WHEN 'DEVELOPMENT_MONITORING'::assistance_basis THEN 'Lapsen kehityksen seuranta'
+    WHEN 'DEVELOPMENT_MONITORING_PENDING'::assistance_basis THEN 'Lapsen kehityksen seuranta, tutkimukset kesken'
+    WHEN 'MULTI_DISABILITY'::assistance_basis THEN 'Monivammaisuus'
+    WHEN 'LONG_TERM_CONDITION'::assistance_basis THEN 'Pitkäaikaissairaus'
+    WHEN 'REGULATION_SKILL_CHALLENGE'::assistance_basis THEN 'Säätelytaitojen vaikeus'
+    WHEN 'DISABILITY'::assistance_basis THEN 'Vamma (näkö, kuulo, liikunta, muu)'
+END, CASE basis
+    WHEN 'DEVELOPMENTAL_DISABILITY_2'::assistance_basis THEN 'Käytetään silloin, kun esiopetuksessa oleva lapsi on vaikeasti kehitysvammainen.'
+    WHEN 'DEVELOPMENT_MONITORING_PENDING'::assistance_basis THEN 'Lapsi on terveydenhuollon tutkimuksissa, diagnoosi ei ole vielä varmistunut.'
+END, CASE basis
+    WHEN 'AUTISM'::assistance_basis THEN 10
+    WHEN 'DEVELOPMENTAL_DISABILITY_1'::assistance_basis THEN 15
+    WHEN 'DEVELOPMENTAL_DISABILITY_2'::assistance_basis THEN 20
+    WHEN 'FOCUS_CHALLENGE'::assistance_basis THEN 25
+    WHEN 'LINGUISTIC_CHALLENGE'::assistance_basis THEN 30
+    WHEN 'DEVELOPMENT_MONITORING'::assistance_basis THEN 35
+    WHEN 'DEVELOPMENT_MONITORING_PENDING'::assistance_basis THEN 40
+    WHEN 'MULTI_DISABILITY'::assistance_basis THEN 45
+    WHEN 'LONG_TERM_CONDITION'::assistance_basis THEN 50
+    WHEN 'REGULATION_SKILL_CHALLENGE'::assistance_basis THEN 55
+    WHEN 'DISABILITY'::assistance_basis THEN 60
+END
+FROM (SELECT DISTINCT unnest(bases) AS basis FROM assistance_need) ab WHERE basis <> 'OTHER';
+
+CREATE TABLE assistance_basis_option_ref (
+    need_id uuid NOT NULL REFERENCES assistance_need ON DELETE CASCADE,
+    option_id uuid NOT NULL REFERENCES assistance_basis_option,
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY (need_id, option_id)
+);
+
+INSERT INTO assistance_basis_option_ref (need_id, option_id, created)
+SELECT ab.id, abo.id, ab.updated
+FROM (SELECT id, updated, unnest(bases) AS basis FROM assistance_need) ab
+LEFT JOIN assistance_basis_option abo ON abo.value::assistance_basis = ab.basis
+WHERE basis <> 'OTHER'
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE assistance_need DROP COLUMN bases;
+DROP TYPE assistance_basis;

--- a/service/src/main/resources/dev-data/espoo-dev-data.sql
+++ b/service/src/main/resources/dev-data/espoo-dev-data.sql
@@ -1921,3 +1921,16 @@ INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
     ('RESOURCE_PERSON', 'Resurssihenkilö', 60),
     ('RATIO_DECREASE', 'Suhdeluvun väljennys', 70),
     ('PERIODICAL_VEO_SUPPORT', 'Jaksottainen veon tuki (2–6 kk)', 80);
+
+INSERT INTO assistance_basis_option (value, name_fi, description_fi, display_order) VALUES
+    ('AUTISM', 'Autismin kirjo', NULL, 10),
+    ('DEVELOPMENTAL_DISABILITY_1', 'Kehitysvamma 1', NULL, 15),
+    ('DEVELOPMENTAL_DISABILITY_2', 'Kehitysvamma 2', 'Käytetään silloin, kun esiopetuksessa oleva lapsi on vaikeasti kehitysvammainen.', 20),
+    ('FOCUS_CHALLENGE', 'Keskittymisen / tarkkaavaisuuden vaikeus', NULL, 25),
+    ('LINGUISTIC_CHALLENGE', 'Kielellinen vaikeus', NULL, 30),
+    ('DEVELOPMENT_MONITORING', 'Lapsen kehityksen seuranta', NULL, 35),
+    ('DEVELOPMENT_MONITORING_PENDING', 'Lapsen kehityksen seuranta, tutkimukset kesken', 'Lapsi on terveydenhuollon tutkimuksissa, diagnoosi ei ole vielä varmistunut.', 40),
+    ('MULTI_DISABILITY', 'Monivammaisuus', NULL, 45),
+    ('LONG_TERM_CONDITION', 'Pitkäaikaissairaus', NULL, 50),
+    ('REGULATION_SKILL_CHALLENGE', 'Säätelytaitojen vaikeus', NULL, 55),
+    ('DISABILITY', 'Vamma (näkö, kuulo, liikunta, muu)', NULL, 60);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -121,3 +121,4 @@ V120__varda_reset_child.sql
 V121__add_person_oid.sql
 V122__person_foreign_key_cascades.sql
 V123__voucher_value_age_coefficient.sql
+V124__assistance_basis_option.sql


### PR DESCRIPTION
#### Summary

See https://github.com/espoon-voltti/evaka/pull/926 for a very similar pull request.

After installing this change, you want to execute following SQL-script to make sure every option is still available in the UI:

```
INSERT INTO assistance_basis_option (value, name_fi, description_fi, display_order) VALUES
    ('AUTISM', 'Autismin kirjo', NULL, 10),
    ('DEVELOPMENTAL_DISABILITY_1', 'Kehitysvamma 1', NULL, 15),
    ('DEVELOPMENTAL_DISABILITY_2', 'Kehitysvamma 2', 'Käytetään silloin, kun esiopetuksessa oleva lapsi on vaikeasti kehitysvammainen.', 20),
    ('FOCUS_CHALLENGE', 'Keskittymisen / tarkkaavaisuuden vaikeus', NULL, 25),
    ('LINGUISTIC_CHALLENGE', 'Kielellinen vaikeus', NULL, 30),
    ('DEVELOPMENT_MONITORING', 'Lapsen kehityksen seuranta', NULL, 35),
    ('DEVELOPMENT_MONITORING_PENDING', 'Lapsen kehityksen seuranta, tutkimukset kesken', 'Lapsi on terveydenhuollon tutkimuksissa, diagnoosi ei ole vielä varmistunut.', 40),
    ('MULTI_DISABILITY', 'Monivammaisuus', NULL, 45),
    ('LONG_TERM_CONDITION', 'Pitkäaikaissairaus', NULL, 50),
    ('REGULATION_SKILL_CHALLENGE', 'Säätelytaitojen vaikeus', NULL, 55),
    ('DISABILITY', 'Vamma (näkö, kuulo, liikunta, muu)', NULL, 60)
    ON CONFLICT (value) DO NOTHING;
```