### PR TITLE
Make id column of fee_thresholds primary key

### DIFF
--- a/service/src/main/resources/db/migration/V125__fee_thresholds_primary_key.sql
+++ b/service/src/main/resources/db/migration/V125__fee_thresholds_primary_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE fee_thresholds ADD CONSTRAINT fee_thresholds_pkey PRIMARY KEY (id);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -122,3 +122,4 @@ V121__add_person_oid.sql
 V122__person_foreign_key_cascades.sql
 V123__voucher_value_age_coefficient.sql
 V124__assistance_basis_option.sql
+V125__fee_thresholds_primary_key.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Primary key constraint was probably accidentally left off the original migration.

