### PR TITLE
Minor E2E fixes

### DIFF
--- a/frontend/src/e2e-playwright/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-playwright/pages/citizen/citizen-applications.ts
@@ -2,6 +2,7 @@ import { Page } from 'playwright'
 import {
   waitUntilEqual,
   waitUntilFalse,
+  waitUntilDefined,
   waitUntilTrue
 } from 'e2e-playwright/utils'
 import {
@@ -191,7 +192,10 @@ class CitizenApplicationEditor {
   }
 
   async openSection(section: string) {
-    if ((await this.#section(section).getAttribute('data-status')) !== 'open') {
+    const status = await waitUntilDefined(() =>
+      this.#section(section).getAttribute('data-status')
+    )
+    if (status !== 'open') {
       await this.#sectionHeader(section).click()
     }
   }
@@ -315,7 +319,8 @@ class CitizenApplicationEditor {
 
   async assertPreferredStartDateInfo(infoText: string | undefined) {
     if (infoText === undefined) {
-      return await waitUntilFalse(() => this.#preferredStartDateInfo.visible)
+      await waitUntilFalse(() => this.#preferredStartDateInfo.visible)
+      return
     }
     await waitUntilEqual(() => this.#preferredStartDateInfo.innerText, infoText)
   }

--- a/frontend/src/e2e-playwright/utils/element.ts
+++ b/frontend/src/e2e-playwright/utils/element.ts
@@ -3,7 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Page } from 'playwright'
-import { BoundingBox, toCssString, waitUntilEqual, waitUntilDefined } from '.'
+import {
+  BoundingBox,
+  toCssString,
+  waitUntilEqual,
+  waitUntilDefined,
+  waitUntilTrue
+} from '.'
 
 export class RawElement {
   constructor(public page: Page, public selector: string) {}
@@ -120,8 +126,12 @@ export class Collapsible extends RawElement {
   }
 
   async open() {
-    if (await this.isOpen()) return
-    await this.#trigger.click()
+    await waitUntilTrue(async () => {
+      if (!(await this.isOpen())) {
+        await this.#trigger.click()
+      }
+      return this.isOpen()
+    })
   }
 }
 

--- a/frontend/src/e2e-playwright/utils/element.ts
+++ b/frontend/src/e2e-playwright/utils/element.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Page } from 'playwright'
-import { BoundingBox, toCssString, waitUntilEqual } from '.'
+import { BoundingBox, toCssString, waitUntilEqual, waitUntilDefined } from '.'
 
 export class RawElement {
   constructor(public page: Page, public selector: string) {}
@@ -113,7 +113,10 @@ export class Collapsible extends RawElement {
   #trigger = this.find('[data-qa="collapsible-trigger"]')
 
   async isOpen() {
-    return (await this.getAttribute('data-status')) !== 'closed'
+    const status = await waitUntilDefined(() =>
+      this.getAttribute('data-status')
+    )
+    return status !== 'closed'
   }
 
   async open() {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- return last seen value in wait APIs
- implement a more low-level `waitForCondition` function that others use
- make sure attribute value is defined before comparing `!== 'someactualvalue'`
- try to remove collapsible click flakiness