### PR TITLE
Prepare service for new version of dvv modifications url env variable

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTestBase.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTestBase.kt
@@ -50,7 +50,7 @@ class DvvModificationsServiceIntegrationTestBase : FullApplicationTest() {
         assert(httpPort > 0)
 
         fridgeFamilyService = FridgeFamilyService(personService, parentshipService, asyncJobRunner)
-        val mockDvvBaseUrl = "http://localhost:$httpPort/mock-integration/dvv"
+        val mockDvvBaseUrl = "http://localhost:$httpPort/mock-integration/dvv/api/v1"
         requestCustomizerMock = mock()
         dvvModificationsServiceClient = DvvModificationsServiceClient(objectMapper, noCertCheckFuelManager(), listOf(requestCustomizerMock), DvvModificationsEnv.fromEnvironment(env).copy(url = mockDvvBaseUrl))
         dvvModificationsService = DvvModificationsService(dvvModificationsServiceClient, personService, fridgeFamilyService, asyncJobRunner)

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -230,10 +230,8 @@ data class DvvModificationsEnv(
 ) {
     companion object {
         fun fromEnvironment(env: Environment) = DvvModificationsEnv(
-            url = env.lookup(
-                "evaka.integration.dvv_modifications.url",
-                "fi.espoo.integration.dvv-modifications-service.url"
-            ),
+            url = env.lookup("evaka.integration.dvv_modifications.url")
+                ?: env.lookup("fi.espoo.integration.dvv-modifications-service.url"),
             userId = env.lookup(
                 "evaka.integration.dvv_modifications.user_id",
                 "fi.espoo.integration.dvv-modifications-service.userId"

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceClient.kt
@@ -38,8 +38,8 @@ class DvvModificationsServiceClient(
 
     // Fetch the first modification token of the given date
     fun getFirstModificationToken(date: LocalDate): DvvModificationServiceModificationTokenResponse? {
-        logger.info { "Fetching the first modification token of $date from DVV modification service from $serviceUrl/api/v1/kirjausavain/$date" }
-        val (_, _, result) = fuel.get("$serviceUrl/api/v1/kirjausavain/$date")
+        logger.info { "Fetching the first modification token of $date from DVV modification service from $serviceUrl/kirjausavain/$date" }
+        val (_, _, result) = fuel.get("$serviceUrl/kirjausavain/$date")
             .header(Headers.ACCEPT, "application/json")
             .header("MUTP-Tunnus", dvvUserId)
             .header("MUTP-Salasana", dvvPassword.value)
@@ -64,8 +64,8 @@ class DvvModificationsServiceClient(
     }
 
     fun getModifications(updateToken: String, ssns: List<String>): DvvModificationsResponse {
-        logger.info { "Fetching modifications with token $updateToken from DVV modifications service from $serviceUrl/api/v1/muutokset" }
-        val (_, _, result) = fuel.post("$serviceUrl/api/v1/muutokset")
+        logger.info { "Fetching modifications with token $updateToken from DVV modifications service from $serviceUrl/muutokset" }
+        val (_, _, result) = fuel.post("$serviceUrl/muutokset")
             .header(Headers.ACCEPT, "application/json")
             .header("MUTP-Tunnus", dvvUserId)
             .header("MUTP-Salasana", dvvPassword.value)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Since we are still using the old env variable for dvv modifications url, I decide to use the new variable name for the new format. This PR needs to be merged into master before the new url is used.

