### PR TITLE
Hotfix: Hide new message button

### DIFF
--- a/frontend/src/citizen-frontend/messages/ThreadList.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadList.tsx
@@ -57,13 +57,15 @@ export default React.memo(function ThreadList({
       <Container className={selectedThread ? 'desktop-only' : undefined}>
         <HeaderContainer>
           <H1 noMargin>{t.messages.inboxTitle}</H1>
-          <Button
-            text={t.messages.messageEditor.newMessage}
-            onClick={() => setEditorVisible(true)}
-            primary
-            data-qa="new-message-btn"
-            disabled={!newMessageButtonEnabled}
-          />
+          <div style={{ display: 'none' }}>
+            <Button
+              text={t.messages.messageEditor.newMessage}
+              onClick={() => setEditorVisible(true)}
+              primary
+              data-qa="new-message-btn"
+              disabled={!newMessageButtonEnabled}
+            />
+          </div>
           {threadLoadingResult.isSuccess && threads.length === 0 && (
             <span>{t.messages.noMessages}</span>
           )}

--- a/frontend/src/e2e-playwright/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-playwright/specs/7_messaging/messaging.spec.ts
@@ -168,6 +168,7 @@ describe('Sending and receiving messages', () => {
     await messagesPage.assertNoDrafts()
   })
 
+  /*
   test('Citizen sends a message to the unit supervisor', async () => {
     const title = 'Otsikko'
     const content = 'Testiviestin sisältö'
@@ -199,4 +200,5 @@ describe('Sending and receiving messages', () => {
     await messagesPage.openInbox(2)
     await waitUntilEqual(() => messagesPage.getReceivedMessageCount(), 1)
   })
+  */
 })


### PR DESCRIPTION
#### Summary

New message button caused problems with features available to non-pilot daycares. Temporarily hide new message button to buy some time to introduce a proper fix.