### PR TITLE
Varda improvements

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2IntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2IntegrationTest.kt
@@ -40,6 +40,7 @@ import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
 import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.testDaycareNotInvoiced
 import fi.espoo.evaka.testDecisionMaker_1
 import fi.espoo.evaka.varda.integration.MockVardaIntegrationEndpoint
 import org.jdbi.v3.core.kotlin.mapTo
@@ -356,6 +357,17 @@ class VardaUpdateServiceV2IntegrationTest : FullApplicationTest() {
         val since = HelsinkiDateTime.now()
         val serviceNeedPeriod = DateRange(since.minusDays(100).toLocalDate(), since.toLocalDate())
         createServiceNeed(db, since, snDefaultDaycare, testChild_1, serviceNeedPeriod.start, serviceNeedPeriod.end!!, PlacementType.PRESCHOOL)
+
+        updateChildData(db, vardaClient, since, feeDecisionMinDate)
+        assertVardaElementCounts(0, 0, 0)
+    }
+
+    @Test
+    fun `updateChildData does not react to new evaka service for non varda unit`() {
+        insertVardaChild(db, testChild_1.id)
+        val since = HelsinkiDateTime.now()
+        val serviceNeedPeriod = DateRange(since.minusDays(100).toLocalDate(), since.toLocalDate())
+        createServiceNeed(db, since, snDefaultDaycare, testChild_1, serviceNeedPeriod.start, serviceNeedPeriod.end!!, PlacementType.DAYCARE, testDaycareNotInvoiced.id)
 
         updateChildData(db, vardaClient, since, feeDecisionMinDate)
         assertVardaElementCounts(0, 0, 0)
@@ -751,12 +763,12 @@ class VardaUpdateServiceV2IntegrationTest : FullApplicationTest() {
         assertEquals(expectedDeletes, diff.deletes.size)
     }
 
-    private fun createServiceNeed(db: Database.Connection, updated: HelsinkiDateTime, option: ServiceNeedOption, child: PersonData.Detailed = testChild_1, fromDays: LocalDate = HelsinkiDateTime.now().minusDays(100).toLocalDate(), toDays: LocalDate = HelsinkiDateTime.now().toLocalDate(), placementType: PlacementType = PlacementType.DAYCARE): ServiceNeedId {
+    private fun createServiceNeed(db: Database.Connection, updated: HelsinkiDateTime, option: ServiceNeedOption, child: PersonData.Detailed = testChild_1, fromDays: LocalDate = HelsinkiDateTime.now().minusDays(100).toLocalDate(), toDays: LocalDate = HelsinkiDateTime.now().toLocalDate(), placementType: PlacementType = PlacementType.DAYCARE, unitId: DaycareId = testDaycare.id): ServiceNeedId {
         var serviceNeedId = ServiceNeedId(UUID.randomUUID())
         db.transaction { tx ->
             FixtureBuilder(tx, HelsinkiDateTime.now().toLocalDate())
                 .addChild().usePerson(child).saveAnd {
-                    addPlacement().ofType(placementType).toUnit(testDaycare.id).fromDay(fromDays).toDay(toDays).saveAnd {
+                    addPlacement().ofType(placementType).toUnit(unitId).fromDay(fromDays).toDay(toDays).saveAnd {
                         addServiceNeed()
                             .withId(serviceNeedId)
                             .withUpdated(updated)

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
@@ -741,8 +741,10 @@ SELECT
 FROM service_need sn
 LEFT JOIN service_need_option option ON sn.option_id = option.id
 LEFT JOIN placement ON sn.placement_id = placement.id
+LEFT JOIN daycare ON daycare.id = placement.unit_id
 WHERE (sn.updated >= :startingFrom OR option.updated >= :startingFrom)
 AND placement.type = ANY(:vardaPlacementTypes::placement_type[])
+AND daycare.invoiced_by_municipality = true
 """
     )
         .bind("startingFrom", startingFrom)
@@ -921,6 +923,7 @@ fun Database.Read.getEvakaServiceNeedInfoForVarda(id: ServiceNeedId): EvakaServi
         LEFT JOIN application_view a ON daterange(sn.start_date, sn.end_date, '[]') @> a.preferredstartdate AND a.preferredstartdate=(select max(preferredstartdate) from application_view a where daterange(sn.start_date, sn.end_date, '[]') @> a.preferredstartdate)
         WHERE sn.id = :id
         AND p.type = ANY(:vardaPlacementTypes::placement_type[])
+        AND d.invoiced_by_municipality = true
     """.trimIndent()
 
     return createQuery(sql)

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
@@ -177,11 +177,11 @@ fun getVardaChildIdsByEvakaChildId(db: Database.Connection, evakaChildId: UUID):
     return db.read {
         it.createQuery(
             """
-            select varda_child_id from varda_service_need where evaka_child_id = :evakaChildId
+            select varda_child_id from varda_service_need where evaka_child_id = :evakaChildId and varda_child_id is not null 
             union
             select varda_child_id from varda_organizer_child where evaka_person_id = :evakaChildId
             union
-            select varda_child_id from varda_child where person_id = :evakaChildId
+            select varda_child_id from varda_child where person_id = :evakaChildId and varda_child_id is not null
             """.trimIndent()
         )
             .bind("evakaChildId", evakaChildId)


### PR DESCRIPTION
- Varda seems to send http 429 RETRY_AFTER values exceeding several hours. In those cases it is better to abort to avoid running out of threads.
- On some tables the varda_child_id is nullable so check for those
- Non invoiced units are not included in varda updates