### PR TITLE
EVAKA-HOTFIX do not throw when person not found in VTJ

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/service/vtjclient/VtjClientService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/service/vtjclient/VtjClientService.kt
@@ -76,7 +76,6 @@ class VtjClientService(
             ) {
                 "Did not receive VTJ results"
             }
-            throw IllegalStateException("No results received")
         } else {
             logger.auditVTJ(
                 toLogParamsMap(

--- a/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/VtjClientServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/VtjClientServiceTest.kt
@@ -133,27 +133,21 @@ class VtjClientServiceTest {
         whenever(mockWSTemplate.marshalSendAndReceive(any<Any>(), eq(mockCallback))).thenReturn(response)
         whenever(responseMapper.mapResponseToHenkilo(response)).thenReturn(null)
 
-        try {
-            service.query(query)
-            fail<Exception>("Exception not thrown")
-        } catch (ex: IllegalStateException) {
+        service.query(query)
 
-            assertThat(ex.message).isEqualTo("No results received")
+        argumentCaptor<ILoggingEvent>().apply {
+            verify(mockAppender, times(2)).doAppend(capture())
 
-            argumentCaptor<ILoggingEvent>().apply {
-                verify(mockAppender, times(2)).doAppend(capture())
+            val queryLogEvent = firstValue
 
-                val queryLogEvent = firstValue
+            queryLogEvent.assertCreateQueryLogMessage(query)
+            queryLogEvent.assertLogArgumentsContain(query = query, status = STATUS_CREATE_QUERY)
 
-                queryLogEvent.assertCreateQueryLogMessage(query)
-                queryLogEvent.assertLogArgumentsContain(query = query, status = STATUS_CREATE_QUERY)
-
-                val responseLogEvent = secondValue
-                assertThat(responseLogEvent.message).isEqualTo(
-                    "Did not receive VTJ results"
-                )
-                responseLogEvent.assertLogArgumentsContain(query = query, status = STATUS_NO_RESPONSE_OR_PARSING_ERROR)
-            }
+            val responseLogEvent = secondValue
+            assertThat(responseLogEvent.message).isEqualTo(
+                "Did not receive VTJ results"
+            )
+            responseLogEvent.assertLogArgumentsContain(query = query, status = STATUS_NO_RESPONSE_OR_PARSING_ERROR)
         }
     }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
It's completely expected that sometimes people are not found in VTJ when users input wrong SSNs. Other code handles the `null`s.

