### PR TITLE
[EVAKA-HOTFIX] Base: update openssl to fix SM2 vulnerability

### DIFF
--- a/evaka-base/Dockerfile
+++ b/evaka-base/Dockerfile
@@ -7,7 +7,7 @@ FROM ubuntu:20.04
 LABEL maintainer="https://github.com/espoon-voltti/evaka"
 
 # Increment this if we ever explicitly want to e.g. run apt-get upgrade
-ARG CACHE_BUST=2021-07-22
+ARG CACHE_BUST=2021-08-25
 
 # Use bash instead of dash
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
#### Summary
- Not at all relevant for us but might as well update (i.e. cache bust Docker image) to appease ECR security scanners
    - Fixed version of openssl (1.1.1f-1ubuntu2.8) has already been released for Ubuntu 20.04 (base image's base image)

