### PR TITLE
Search people using POST methods instead GET

### DIFF
--- a/frontend/src/employee-frontend/api/applications.ts
+++ b/frontend/src/employee-frontend/api/applications.ts
@@ -78,8 +78,12 @@ export async function getApplications(
   params: ApplicationSearchParams
 ): Promise<Result<Paged<ApplicationListSummary>>> {
   return client
-    .get<JsonOf<Paged<ApplicationListSummary>>>('v2/applications', {
-      params: { page: page, pageSize, sortBy, sortDir, ...params }
+    .post<JsonOf<Paged<ApplicationListSummary>>>('v2/applications/search', {
+      page: page,
+      pageSize,
+      sortBy,
+      sortDir,
+      ...params
     })
     .then(({ data }) => ({
       ...data,

--- a/frontend/src/employee-frontend/api/employees.ts
+++ b/frontend/src/employee-frontend/api/employees.ts
@@ -59,8 +59,10 @@ export function searchEmployees(
   searchTerm?: string
 ): Promise<Result<Paged<EmployeeUser>>> {
   return client
-    .get<JsonOf<Paged<EmployeeUser>>>('/employee/search', {
-      params: { page, pageSize, searchTerm }
+    .post<JsonOf<Paged<EmployeeUser>>>('/employee/search', {
+      page,
+      pageSize,
+      searchTerm
     })
     .then(({ data }) => Success.of(data))
     .catch((e) => Failure.fromError(e))

--- a/frontend/src/employee-frontend/api/invoicing.ts
+++ b/frontend/src/employee-frontend/api/invoicing.ts
@@ -241,8 +241,12 @@ export async function getFeeDecisions(
   params: FeeDecisionSearchParams
 ): Promise<Result<Paged<FeeDecisionSummary>>> {
   return client
-    .get<JsonOf<Paged<FeeDecisionSummary>>>('/fee-decisions/search', {
-      params: { page: page - 1, pageSize, sortBy, sortDirection, ...params }
+    .post<JsonOf<Paged<FeeDecisionSummary>>>('/fee-decisions/search', {
+      page: page - 1,
+      pageSize,
+      sortBy,
+      sortDirection,
+      ...params
     })
     .then(({ data }) => ({
       ...data,
@@ -289,10 +293,14 @@ export async function getVoucherValueDecisions(
   params: VoucherValueDecisionSearchParams
 ): Promise<Result<Paged<VoucherValueDecisionSummary>>> {
   return client
-    .get<JsonOf<Paged<VoucherValueDecisionSummary>>>(
+    .post<JsonOf<Paged<VoucherValueDecisionSummary>>>(
       '/value-decisions/search',
       {
-        params: { page: page - 1, pageSize, sortBy, sortDirection, ...params }
+        page: page - 1,
+        pageSize,
+        sortBy,
+        sortDirection,
+        ...params
       }
     )
     .then(({ data }) => ({
@@ -377,8 +385,12 @@ export async function getInvoices(
   params: InvoiceSearchParams
 ): Promise<Result<Paged<InvoiceSummary>>> {
   return client
-    .get<JsonOf<Paged<InvoiceSummary>>>('/invoices/search', {
-      params: { page, pageSize, sortBy, sortDirection, ...params }
+    .post<JsonOf<Paged<InvoiceSummary>>>('/invoices/search', {
+      page,
+      pageSize,
+      sortBy,
+      sortDirection,
+      ...params
     })
     .then(({ data }) => ({
       ...data,

--- a/frontend/src/employee-frontend/api/person.ts
+++ b/frontend/src/employee-frontend/api/person.ts
@@ -69,10 +69,9 @@ export async function getOrCreatePersonBySsn(
   readonly = false
 ): Promise<Result<PersonDetails>> {
   return client
-    .get<JsonOf<PersonDetails>>(`/person/details/ssn/${ssn}`, {
-      params: {
-        readonly
-      }
+    .post<JsonOf<PersonDetails>>(`/person/details/ssn`, {
+      ssn,
+      readonly
     })
     .then(({ data }) => deserializePersonDetails(data))
     .then((v) => Success.of(v))
@@ -85,12 +84,10 @@ export async function findByNameOrAddress(
   sortDirection: SearchOrder
 ): Promise<Result<PersonDetails[]>> {
   return client
-    .get<JsonOf<PersonDetails[]>>('/person/search', {
-      params: {
-        searchTerm,
-        orderBy,
-        sortDirection
-      }
+    .post<JsonOf<PersonDetails[]>>('/person/search', {
+      searchTerm,
+      orderBy,
+      sortDirection
     })
     .then((res) => res.data)
     .then((results) => results.map(deserializePersonDetails))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.application
 
+import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
@@ -42,26 +43,27 @@ class GetApplicationSummaryIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `application summary with minimal parameters returns data`() {
-        val summary = getSummary(listOf("type" to "ALL", "status" to "SENT"))
+        val summary = getSummary("""{"type": "ALL", "status": "SENT"}""")
         assertEquals(3, summary.total)
     }
 
     @Test
     fun `application summary can be be filtered by attachments`() {
-        val summary = getSummary(listOf("type" to "ALL", "status" to "SENT", "basis" to "HAS_ATTACHMENTS"))
+        val summary = getSummary("""{"type": "ALL", "status": "SENT", "basis": "HAS_ATTACHMENTS"}""")
         assertEquals(1, summary.total)
         assertEquals(1, summary.data[0].attachmentCount)
     }
 
     @Test
     fun `application summary can be be filtered by urgency`() {
-        val summary = getSummary(listOf("type" to "ALL", "status" to "SENT", "basis" to "URGENT"))
+        val summary = getSummary("""{"type": "ALL", "status": "SENT", "basis": "URGENT"}""")
         assertEquals(1, summary.total)
         assertEquals(true, summary.data[0].urgent)
     }
 
-    private fun getSummary(params: List<Pair<String, String>>): Paged<ApplicationSummary> {
-        val (_, res, result) = http.get("/v2/applications", params)
+    private fun getSummary(payload: String): Paged<ApplicationSummary> {
+        val (_, res, result) = http.post("/v2/applications/search")
+            .jsonBody(payload)
             .asUser(serviceWorker)
             .responseObject<Paged<ApplicationSummary>>(objectMapper)
         assertEquals(200, res.statusCode)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -176,7 +176,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
         val drafts = testInvoices.filter { it.status === InvoiceStatus.DRAFT }.sortedBy { it.dueDate }
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&status=DRAFT")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "status": "DRAFT"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -192,7 +193,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
         val sent = testInvoices.filter { it.status === InvoiceStatus.SENT }
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&status=SENT")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "status": "SENT"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -208,7 +210,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
         val canceled = testInvoices.filter { it.status === InvoiceStatus.CANCELED }
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&status=CANCELED")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "status": "CANCELED"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -225,7 +228,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         val sentAndCanceled =
             testInvoices.filter { it.status == InvoiceStatus.SENT || it.status == InvoiceStatus.CANCELED }
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&status=SENT,CANCELED")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "status": "SENT,CANCELED"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -242,9 +246,11 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         db.transaction { tx -> tx.upsertInvoices(testInvoiceSubset) }
         val invoices = testInvoiceSubset.sortedBy { it.status }.reversed()
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&status=DRAFT,SENT,CANCELED")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "status": "DRAFT,SENT,CANCELED"}""")
             .asUser(testUser)
             .responseString()
+
         assertEquals(200, response.statusCode)
 
         assertEqualEnough(
@@ -258,7 +264,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
         val invoices = testInvoices.sortedBy { it.status }.reversed()
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&area=test_area")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "area": "test_area"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -274,7 +281,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
         val invoices = testInvoices.sortedBy { it.status }.reversed()
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&area=test_area&status=DRAFT")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "area": "test_area", "status": "DRAFT"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -289,7 +297,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     fun `search works as expected with non-existent area param`() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&area=non_existent")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "area": "non_existent"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -304,12 +313,11 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     fun `search works as expected with multiple partial search terms`() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
 
-        val (_, response, result) = http.get(
-            "/invoices/search?page=1&pageSize=200&searchTerms=${testAdult_1.streetAddress} ${testAdult_1.firstName.substring(
-                0,
-                2
-            )}"
-        )
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody(
+                """{"page": 1, "pageSize": 200,
+                          "searchTerms": "${testAdult_1.streetAddress} ${testAdult_1.firstName.substring(0, 2)}"}"""
+            )
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -324,12 +332,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     fun `search works as expected with multiple more specific search terms`() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
 
-        val (_, response, result) = http.get(
-            "/invoices/search?page=1&pageSize=200&searchTerms=${testAdult_1.lastName.substring(
-                0,
-                2
-            )} ${testAdult_1.firstName}"
-        )
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "searchTerms": "${testAdult_1.lastName.substring(0, 2)} ${testAdult_1.firstName}"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -344,7 +348,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     fun `search works as expected with multiple search terms where one does not match anything`() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&searchTerms=${testAdult_1.lastName} ${testAdult_1.streetAddress} nomatch")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "searchTerms": "${testAdult_1.lastName} ${testAdult_1.streetAddress} nomatch"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -359,7 +364,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     fun `search works as expected with child name as search term`() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&searchTerms=${testChild_2.firstName}")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "searchTerms": "${testChild_2.firstName}"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -374,7 +380,11 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     fun `search works as expected with ssn as search term`() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=200&searchTerms=${testAdult_1.ssn}")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody(
+                """{"page": 1, "pageSize": 200,
+                          "searchTerms": "${testAdult_1.ssn}"}"""
+            )
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -389,12 +399,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
     fun `search works as expected with date of birth as search term`() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
 
-        val (_, response, result) = http.get(
-            "/invoices/search?page=1&pageSize=200&searchTerms=${testAdult_1.ssn!!.substring(
-                0,
-                6
-            )}"
-        )
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 200, "searchTerms": "${testAdult_1.ssn!!.substring(0, 6)}"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -410,7 +416,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
         val sent = listOf(testInvoices.sortedWith(compareBy({ it.periodStart }, { it.id })).first())
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=1&sortBy=START&sortDirection=ASC")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 1, "sortBy": "START", "sortDirection": "ASC"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -426,7 +433,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
         val sent = listOf(testInvoices.sortedWith(compareBy({ it.periodStart }, { it.id }))[1])
 
-        val (_, response, result) = http.get("/invoices/search?page=2&pageSize=1&sortBy=START&sortDirection=ASC")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 2, "pageSize": 1, "sortBy": "START", "sortDirection": "ASC"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -442,7 +450,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
         val sent = testInvoices.sortedWith(compareBy({ it.periodStart }, { it.id })).subList(0, 2)
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=2&sortBy=START&sortDirection=ASC")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 2, "sortBy": "START", "sortDirection": "ASC"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -461,7 +470,8 @@ class InvoiceIntegrationTest : FullApplicationTest() {
             .sortedBy { it.periodStart }
             .reversed()
 
-        val (_, response, result) = http.get("/invoices/search?page=1&pageSize=2&status=DRAFT&sortBy=START&sortDirection=DESC")
+        val (_, response, result) = http.post("/invoices/search")
+            .jsonBody("""{"page": 1, "pageSize": 2, "status": "DRAFT", "sortBy": "START", "sortDirection": "DESC"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.invoicing
 
+import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.jackson.objectBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
@@ -291,16 +292,16 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest() {
     }
 
     private fun searchValueDecisions(status: String, searchTerms: String = ""): Paged<VoucherValueDecisionSummary> {
-        val searchParams = listOf("page" to 0, "pageSize" to 100, "status" to status, "searchTerms" to searchTerms)
-        val (_, _, data) = http.get("/value-decisions/search", searchParams)
+        val (_, _, data) = http.post("/value-decisions/search")
+            .jsonBody("""{"page": 0, "pageSize": 100, "status": "$status", "searchTerms": "$searchTerms"}""")
             .asUser(financeWorker)
             .responseObject<Paged<VoucherValueDecisionSummary>>(objectMapper)
         return data.get()
     }
 
     private fun sendAllValueDecisions() {
-        val searchParams = listOf("page" to 0, "pageSize" to 100, "status" to "DRAFT")
-        val (_, _, data) = http.get("/value-decisions/search", searchParams)
+        val (_, _, data) = http.post("/value-decisions/search")
+            .jsonBody("""{"page": 0, "pageSize": 100, "status": "DRAFT"}""")
             .asUser(financeWorker)
             .responseObject<Paged<VoucherValueDecisionSummary>>(objectMapper)
             .also { (_, res, _) ->

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerSearchIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerSearchIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.AbstractIntegrationTest
 import fi.espoo.evaka.pis.DaycareRole
 import fi.espoo.evaka.pis.controllers.EmployeeController
+import fi.espoo.evaka.pis.controllers.SearchEmployeeRequest
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.testDaycare
@@ -36,7 +37,7 @@ class EmployeeControllerSearchIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `admin searches employees`() {
         val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
-        val response = controller.searchEmployees(db, user, page = 1, pageSize = 3, searchTerm = null)
+        val response = controller.searchEmployees(db, user, SearchEmployeeRequest(page = 1, pageSize = 3, searchTerm = null))
         assertEquals(HttpStatus.OK, response.statusCode)
         val body = response.body ?: fail("missing body")
         assertEquals(3, body.total)
@@ -57,7 +58,7 @@ class EmployeeControllerSearchIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `admin searches employees with free text`() {
         val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
-        val response = controller.searchEmployees(db, user, page = 1, pageSize = 10, searchTerm = "super")
+        val response = controller.searchEmployees(db, user, SearchEmployeeRequest(page = 1, pageSize = 10, searchTerm = "super"))
         assertEquals(HttpStatus.OK, response.statusCode)
         val body = response.body ?: fail("missing body")
         assertEquals(1, body.data.size)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.pis.controller
 import fi.espoo.evaka.identity.getDobFromSsn
 import fi.espoo.evaka.pis.AbstractIntegrationTest
 import fi.espoo.evaka.pis.controllers.PersonController
+import fi.espoo.evaka.pis.controllers.SearchPersonBody
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.pis.service.ContactInfo
 import fi.espoo.evaka.pis.service.PersonDTO
@@ -68,9 +69,11 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         val response = controller.findBySearchTerms(
             db,
             user,
-            searchTerm = "${person.firstName} ${person.lastName}",
-            orderBy = "first_name",
-            sortDirection = "DESC"
+            SearchPersonBody(
+                searchTerm = "${person.firstName} ${person.lastName}",
+                orderBy = "first_name",
+                sortDirection = "DESC"
+            )
         )
 
         assertEquals(HttpStatus.OK, response?.statusCode)
@@ -88,9 +91,11 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         val response = controller.findBySearchTerms(
             db,
             user,
-            searchTerm = "${person.firstName}\t${person.lastName}",
-            orderBy = "first_name",
-            sortDirection = "DESC"
+            SearchPersonBody(
+                searchTerm = "${person.firstName}\t${person.lastName}",
+                orderBy = "first_name",
+                sortDirection = "DESC"
+            )
         )
 
         assertEquals(HttpStatus.OK, response?.statusCode)
@@ -108,9 +113,11 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         val response = controller.findBySearchTerms(
             db,
             user,
-            searchTerm = "${person.firstName}\u00A0${person.lastName}",
-            orderBy = "first_name",
-            sortDirection = "DESC"
+            SearchPersonBody(
+                searchTerm = "${person.firstName}\u00A0${person.lastName}",
+                orderBy = "first_name",
+                sortDirection = "DESC"
+            )
         )
 
         assertEquals(HttpStatus.OK, response?.statusCode)
@@ -130,9 +137,11 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         val response = controller.findBySearchTerms(
             db,
             user,
-            searchTerm = "${person.firstName}\u3000${person.lastName}",
-            orderBy = "first_name",
-            sortDirection = "DESC"
+            SearchPersonBody(
+                searchTerm = "${person.firstName}\u3000${person.lastName}",
+                orderBy = "first_name",
+                sortDirection = "DESC"
+            )
         )
 
         assertEquals(HttpStatus.OK, response?.statusCode)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -33,7 +33,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.Instant
 import java.time.LocalDate
@@ -68,46 +67,34 @@ class FeeDecisionController(
     private val generator: FinanceDecisionGenerator,
     private val asyncJobRunner: AsyncJobRunner
 ) {
-    @GetMapping("/search")
+    @PostMapping("/search")
     fun search(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @RequestParam(required = true) page: Int,
-        @RequestParam(required = true) pageSize: Int,
-        @RequestParam(required = false) sortBy: FeeDecisionSortParam?,
-        @RequestParam(required = false) sortDirection: SortDirection?,
-        @RequestParam(required = false) status: String?,
-        @RequestParam(required = false) area: String?,
-        @RequestParam(required = false) unit: String?,
-        @RequestParam(required = false) distinctions: String?,
-        @RequestParam(required = false) searchTerms: String?,
-        @RequestParam(required = false) startDate: String?,
-        @RequestParam(required = false) endDate: String?,
-        @RequestParam(required = false) searchByStartDate: Boolean = false,
-        @RequestParam(required = false) financeDecisionHandlerId: UUID?
+        @RequestBody body: SearchFeeDecisionRequest
     ): ResponseEntity<Paged<FeeDecisionSummary>> {
         Audit.FeeDecisionSearch.log()
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         val maxPageSize = 5000
-        if (pageSize > maxPageSize) throw BadRequest("Maximum page size is $maxPageSize")
-        if (startDate != null && endDate != null && endDate < startDate)
+        if (body.pageSize > maxPageSize) throw BadRequest("Maximum page size is $maxPageSize")
+        if (body.startDate != null && body.endDate != null && body.endDate < body.startDate)
             throw BadRequest("End date cannot be before start date")
         return db
             .read { tx ->
                 tx.searchFeeDecisions(
-                    page,
-                    pageSize,
-                    sortBy ?: FeeDecisionSortParam.STATUS,
-                    sortDirection ?: SortDirection.DESC,
-                    status?.split(",")?.mapNotNull { parseEnum<FeeDecisionStatus>(it) } ?: listOf(),
-                    area?.split(",") ?: listOf(),
-                    unit?.let { parseUUID(it) },
-                    distinctions?.split(",")?.mapNotNull { parseEnum<DistinctiveParams>(it) } ?: listOf(),
-                    searchTerms ?: "",
-                    startDate?.let { LocalDate.parse(startDate, DateTimeFormatter.ISO_DATE) },
-                    endDate?.let { LocalDate.parse(endDate, DateTimeFormatter.ISO_DATE) },
-                    searchByStartDate,
-                    financeDecisionHandlerId
+                    body.page,
+                    body.pageSize,
+                    body.sortBy ?: FeeDecisionSortParam.STATUS,
+                    body.sortDirection ?: SortDirection.DESC,
+                    body.status?.split(",")?.mapNotNull { parseEnum<FeeDecisionStatus>(it) } ?: listOf(),
+                    body.area?.split(",") ?: listOf(),
+                    body.unit?.let { parseUUID(it) },
+                    body.distinctions?.split(",")?.mapNotNull { parseEnum<DistinctiveParams>(it) } ?: listOf(),
+                    body.searchTerms ?: "",
+                    body.startDate?.let { LocalDate.parse(body.startDate, DateTimeFormatter.ISO_DATE) },
+                    body.endDate?.let { LocalDate.parse(body.endDate, DateTimeFormatter.ISO_DATE) },
+                    body.searchByStartDate,
+                    body.financeDecisionHandlerId
                 )
             }
             .let { ResponseEntity.ok(it) }
@@ -199,6 +186,22 @@ class FeeDecisionController(
 }
 
 data class CreateRetroactiveFeeDecisionsBody(val from: LocalDate)
+
+data class SearchFeeDecisionRequest(
+    val page: Int,
+    val pageSize: Int,
+    val sortBy: FeeDecisionSortParam?,
+    val sortDirection: SortDirection?,
+    val status: String?,
+    val area: String?,
+    val unit: String?,
+    val distinctions: String?,
+    val searchTerms: String?,
+    val startDate: String?,
+    val endDate: String?,
+    val searchByStartDate: Boolean = false,
+    val financeDecisionHandlerId: UUID?
+)
 
 data class FeeDecisionTypeRequest(
     val type: FeeDecisionType

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -149,20 +148,24 @@ class EmployeeController {
         }
     }
 
-    @GetMapping("/search")
+    @PostMapping("/search")
     fun searchEmployees(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @RequestParam(required = false) page: Int?,
-        @RequestParam(required = false) pageSize: Int?,
-        @RequestParam(required = false) searchTerm: String?,
+        @RequestBody body: SearchEmployeeRequest
     ): ResponseEntity<Paged<EmployeeWithDaycareRoles>> {
         Audit.EmployeesRead.log()
         user.requireOneOfRoles(UserRole.ADMIN)
         return db.read { tx ->
-            getEmployeesPaged(tx, page ?: 1, (pageSize ?: 50).coerceAtMost(100), searchTerm ?: "")
+            getEmployeesPaged(tx, body.page ?: 1, (body.pageSize ?: 50).coerceAtMost(100), body.searchTerm ?: "")
         }.let { ResponseEntity.ok(it) }
     }
 }
 
 data class PinCode(val pin: String)
+
+data class SearchEmployeeRequest(
+    val page: Int?,
+    val pageSize: Int?,
+    val searchTerm: String?,
+)


### PR DESCRIPTION
#### Summary

Using POST methods in person searches so we do not get problematic entries into logs. The GET methods are replaced with POST-JSON equivalents.

This will change the internal API. 