### PR TITLE
HOTFIX: Make sure we fetch permitted actions for all placement/backupcare ids

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -73,6 +73,10 @@ class UnitsView(private val accessControl: AccessControl) {
                 unitCaretakers = tx.getUnitStats(unitId, from, to),
                 groupCaretakers = tx.getGroupStats(unitId, from, to)
             )
+            val backupCareIds = backupCares.map { it.id }.toSet() +
+                missingGroupPlacements.mapNotNull { if (it.backup) { BackupCareId(it.placementId.raw) } else null }.toSet()
+            val placementIds = placements.map { it.id }.toSet() +
+                missingGroupPlacements.mapNotNull { if (!it.backup) { it.placementId } else null }.toSet()
 
             val basicData = UnitDataResponse(
                 groups = groups,
@@ -80,11 +84,8 @@ class UnitsView(private val accessControl: AccessControl) {
                 backupCares = backupCares,
                 missingGroupPlacements = missingGroupPlacements,
                 caretakers = caretakers,
-                permittedBackupCareActions = accessControl.getPermittedBackupCareActions(
-                    user,
-                    backupCares.map { it.id }
-                ),
-                permittedPlacementActions = accessControl.getPermittedPlacementActions(user, placements.map { it.id }),
+                permittedBackupCareActions = accessControl.getPermittedBackupCareActions(user, backupCareIds),
+                permittedPlacementActions = accessControl.getPermittedPlacementActions(user, placementIds),
                 permittedGroupPlacementActions = accessControl.getPermittedGroupPlacementActions(
                     user,
                     placements.flatMap { placement ->


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Missing group placements did not always get permitted actions.
Backup care / placement fetches are affected by the date filter in the REST request, but missing group placement fetch is not
→ in order to get all backup care / placement ids for the permitted actions fetch, we need to look at missing group placement data too

