### PR TITLE
Try to fix flaky value decision test

### DIFF
--- a/frontend/src/e2e-playwright/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-playwright/pages/employee/finance/finance-page.ts
@@ -179,13 +179,8 @@ export class ValueDecisionsPage {
     await this.#dateCheckbox.click()
   }
 
-  async toggleAllValueDecisions(toggledOn: boolean) {
-    await waitUntilEqual(
-      () => this.#allValueDecisionsToggle.checked,
-      !toggledOn
-    )
-    await this.#allValueDecisionsToggle.click()
-    await waitUntilEqual(() => this.#allValueDecisionsToggle.checked, toggledOn)
+  async toggleAllValueDecisions() {
+    await this.#allValueDecisionsToggle.check()
   }
 
   async sendValueDecisions() {

--- a/frontend/src/e2e-playwright/specs/4_finance/value-decisions.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/value-decisions.spec.ts
@@ -120,7 +120,7 @@ describe('Value decisions', () => {
   })
 
   test('Voucher value decisions are toggled and sent', async () => {
-    await valueDecisionsPage.toggleAllValueDecisions(true)
+    await valueDecisionsPage.toggleAllValueDecisions()
     await valueDecisionsPage.sendValueDecisions()
     await valueDecisionsPage.assertSentDecisionsCount(2)
   })

--- a/frontend/src/e2e-playwright/utils/element.ts
+++ b/frontend/src/e2e-playwright/utils/element.ts
@@ -78,6 +78,14 @@ export const WithChecked = <T extends Constructor<RawElement>>(
     get checked(): Promise<boolean> {
       return this.page.isChecked(this.#input)
     }
+
+    check(): Promise<void> {
+      return this.page.check(this.#input)
+    }
+
+    uncheck(): Promise<void> {
+      return this.page.uncheck(this.#input)
+    }
   }
 
 export const WithTextInput = <T extends Constructor<RawElement>>(


### PR DESCRIPTION
#### Summary

Use built-in [`check`](https://playwright.dev/docs/api/class-frame/#frame-check) function instead of manual assertions and click().
The `check` function ensures that the element is actionable and verifies that the operation succeeded.

