### PR TITLE
EVAKA-4240 citizen reservation inline editor

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarModal.tsx
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { ReactNode, useCallback } from 'react'
-import { useHistory } from 'react-router-dom'
+import React, { ReactNode } from 'react'
 import styled from 'styled-components'
 import { faTimes } from 'lib-icons'
 import { defaultMargins } from 'lib-components/white-space'
@@ -12,16 +11,15 @@ import { desktopMin, tabletMin } from 'lib-components/breakpoints'
 
 interface Props {
   highlight: boolean
+  close: () => void
   children: ReactNode | ReactNode[]
 }
 
 export default React.memo(function CalendarModal({
   highlight,
+  close,
   children
 }: Props) {
-  const history = useHistory()
-  const close = useCallback(() => void history.replace('/calendar'), [history])
-
   return (
     <Modal>
       <TopBar>

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -45,6 +45,10 @@ export default React.memo(function CalendarPage() {
       void history.replace(`calendar?day=${date.formatIso()}`),
     [history]
   )
+  const closeDayView = useCallback(
+    () => void history.replace('/calendar'),
+    [history]
+  )
 
   if (!user || !user.accessibleFeatures.reservations) return null
 
@@ -55,6 +59,8 @@ export default React.memo(function CalendarPage() {
           date={selectedDate}
           data={data.value}
           selectDate={selectDate}
+          reloadData={loadDefaultRange}
+          close={closeDayView}
         />
       ) : null}
       <Container>

--- a/frontend/src/citizen-frontend/calendar/DayElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayElem.tsx
@@ -8,7 +8,7 @@ import {
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
 import { useTranslation } from '../localization'
-import { DailyReservationData } from './api'
+import { DailyReservationData, Reservation } from './api'
 import { defaultMargins } from 'lib-components/white-space'
 
 export interface DayProps {
@@ -38,7 +38,7 @@ export default React.memo(function DayElem({
         {reservations.length === 0 && isHoliday && (
           <HolidayNote>{i18n.calendar.holiday}</HolidayNote>
         )}
-        {reservations
+        {uniqueReservations(reservations)
           .map(
             (reservation) =>
               `${formatDate(reservation.startTime, 'HH:mm')} - ${formatDate(
@@ -52,6 +52,21 @@ export default React.memo(function DayElem({
     </DayDiv>
   )
 })
+
+const uniqueReservations = (reservations: Reservation[]) =>
+  reservations.reduce<Reservation[]>(
+    (uniq, reservation) =>
+      uniq.some(
+        ({ startTime, endTime }) =>
+          formatDate(startTime, 'HH:mm') ===
+            formatDate(reservation.startTime, 'HH:mm') &&
+          formatDate(endTime, 'HH:mm') ===
+            formatDate(reservation.endTime, 'HH:mm')
+      )
+        ? uniq
+        : [...uniq, reservation],
+    []
+  )
 
 const DayDiv = styled(FixedSpaceRow)<{ today: boolean }>`
   position: relative;

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -2,25 +2,45 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { Fragment, useMemo } from 'react'
+import React, { Fragment, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
-import { faChevronLeft, faChevronRight } from 'lib-icons'
+import { faCheck, faChevronLeft, faChevronRight, faPen } from 'lib-icons'
 import { DATE_FORMAT_TIME_ONLY, formatDate } from 'lib-common/date'
 import LocalDate from 'lib-common/local-date'
 import { H1, H2, H3, Label } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
+import InputField from 'lib-components/atoms/form/InputField'
+import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { useTranslation } from 'citizen-frontend/localization'
-import { ReservationsResponse } from './api'
+import {
+  TIME_REGEXP,
+  regexp,
+  errorToInputInfo
+} from 'citizen-frontend/form-validation'
+import {
+  postReservations,
+  Reservation,
+  ReservationChild,
+  ReservationsResponse
+} from './api'
 import CalendarModal from './CalendarModal'
 
 interface Props {
   date: LocalDate
   data: ReservationsResponse
   selectDate: (date: LocalDate) => void
+  reloadData: () => void
+  close: () => void
 }
 
-export default React.memo(function DayView({ date, data, selectDate }: Props) {
+export default React.memo(function DayView({
+  date,
+  data,
+  selectDate,
+  reloadData,
+  close
+}: Props) {
   const i18n = useTranslation()
 
   const childrenWithReservations = useMemo(() => {
@@ -40,52 +60,255 @@ export default React.memo(function DayView({ date, data, selectDate }: Props) {
     })
   }, [date, data])
 
+  const {
+    editable,
+    editing,
+    startEditing,
+    editorState,
+    editorStateSetter,
+    saving,
+    save,
+    navigate,
+    confirmationModal
+  } = useEditState(date, data, reloadData, childrenWithReservations)
+
   return (
-    <CalendarModal highlight={date.isEqual(LocalDate.today())}>
+    <CalendarModal
+      highlight={date.isEqual(LocalDate.today())}
+      close={navigate(close)}
+    >
       <DayPicker>
         <IconButton
           icon={faChevronLeft}
-          onClick={() => selectDate(date.subDays(1))}
+          onClick={navigate(() => selectDate(date.subDays(1)))}
         />
         <DayOfWeek>{`${
           i18n.common.datetime.weekdays[date.getIsoDayOfWeek() - 1]
         } ${date.format()}`}</DayOfWeek>
         <IconButton
           icon={faChevronRight}
-          onClick={() => selectDate(date.addDays(1))}
+          onClick={navigate(() => selectDate(date.addDays(1)))}
         />
       </DayPicker>
       <Gap size="m" />
-      <H2 noMargin>Varaukset ja toteuma</H2>
+      <ReservationTitle>
+        <H2 noMargin>Varaukset ja toteuma</H2>
+        {editable ? (
+          editing ? (
+            <IconButton icon={faCheck} disabled={saving} onClick={save} />
+          ) : (
+            <IconButton icon={faPen} onClick={startEditing} />
+          )
+        ) : null}
+      </ReservationTitle>
       <Gap size="s" />
-      {childrenWithReservations.map(({ child, reservation }, index) => (
-        <Fragment key={child.id}>
-          {index !== 0 ? <Separator /> : null}
-          <H3 noMargin>
-            {child.preferredName || child.firstName.split(' ')[0]}
-          </H3>
-          <Gap size="s" />
-          <Grid>
-            <Label>Varaus</Label>
-            {reservation === undefined ? (
-              <NoReservation>Ei varausta</NoReservation>
-            ) : (
-              <span>{`${formatDate(
-                reservation.startTime,
-                DATE_FORMAT_TIME_ONLY
-              )} – ${formatDate(
-                reservation.endTime,
-                DATE_FORMAT_TIME_ONLY
-              )}`}</span>
-            )}
-            <Label>Toteuma</Label>
-            <span>–</span>
-          </Grid>
-        </Fragment>
-      ))}
+      {editing
+        ? editorState.map(({ child, startTime, endTime, errors }, index) => (
+            <Fragment key={child.id}>
+              {index !== 0 ? <Separator /> : null}
+              <H3 noMargin>
+                {child.preferredName || child.firstName.split(' ')[0]}
+              </H3>
+              <Gap size="s" />
+              <Grid>
+                <Label>Varaus</Label>
+                <InputWrapper>
+                  <InputField
+                    type="time"
+                    onChange={editorStateSetter(index, 'startTime')}
+                    value={startTime}
+                    info={errorToInputInfo(
+                      errors.startTime,
+                      i18n.validationErrors
+                    )}
+                    readonly={saving}
+                  />
+                  –
+                  <InputField
+                    type="time"
+                    onChange={editorStateSetter(index, 'endTime')}
+                    value={endTime}
+                    info={errorToInputInfo(
+                      errors.endTime,
+                      i18n.validationErrors
+                    )}
+                    readonly={saving}
+                  />
+                </InputWrapper>
+                <Label>Toteuma</Label>
+                <span>–</span>
+              </Grid>
+            </Fragment>
+          ))
+        : childrenWithReservations.map(({ child, reservation }, index) => (
+            <Fragment key={child.id}>
+              {index !== 0 ? <Separator /> : null}
+              <H3 noMargin>
+                {child.preferredName || child.firstName.split(' ')[0]}
+              </H3>
+              <Gap size="s" />
+              <Grid>
+                <Label>Varaus</Label>
+                {reservation === undefined ? (
+                  <NoReservation>Ei varausta</NoReservation>
+                ) : (
+                  <span>{`${formatDate(
+                    reservation.startTime,
+                    DATE_FORMAT_TIME_ONLY
+                  )} – ${formatDate(
+                    reservation.endTime,
+                    DATE_FORMAT_TIME_ONLY
+                  )}`}</span>
+                )}
+                <Label>Toteuma</Label>
+                <span>–</span>
+              </Grid>
+            </Fragment>
+          ))}
+      {confirmationModal ? (
+        <InfoModal
+          title="Haluatko tallentaa muutokset?"
+          close={confirmationModal.close}
+          resolve={{
+            action: confirmationModal.resolve,
+            label: 'Tallenna'
+          }}
+          reject={{
+            action: confirmationModal.reject,
+            label: 'Älä tallenna'
+          }}
+        />
+      ) : null}
     </CalendarModal>
   )
 })
+
+function useEditState(
+  date: LocalDate,
+  data: ReservationsResponse,
+  reloadData: () => void,
+  childrenWithReservations: {
+    child: ReservationChild
+    reservation: Reservation | undefined
+  }[]
+) {
+  const editable = data.reservableDays.includes(date)
+
+  const [editing, setEditing] = useState(false)
+  const startEditing = () => setEditing(true)
+
+  const editorStateFromProps = useMemo(
+    () =>
+      childrenWithReservations.map(({ child, reservation }) => ({
+        child,
+        startTime: reservation
+          ? formatDate(reservation.startTime, DATE_FORMAT_TIME_ONLY)
+          : '',
+        endTime: reservation
+          ? formatDate(reservation.endTime, DATE_FORMAT_TIME_ONLY)
+          : '',
+        errors: {
+          startTime: undefined,
+          endTime: undefined
+        }
+      })),
+    [childrenWithReservations]
+  )
+  const [editorState, setEditorState] = useState(editorStateFromProps)
+  useEffect(() => setEditorState(editorStateFromProps), [editorStateFromProps])
+
+  const editorStateSetter =
+    (index: number, field: 'startTime' | 'endTime') => (value: string) =>
+      setEditorState((state) =>
+        state.map((child, i) =>
+          i === index
+            ? {
+                ...child,
+                [field]: value,
+                errors: {
+                  ...child.errors,
+                  [field]:
+                    value === '' &&
+                    child[field === 'startTime' ? 'endTime' : 'startTime'] !==
+                      ''
+                      ? 'required'
+                      : regexp(value, TIME_REGEXP, 'timeFormat')
+                }
+              }
+            : child
+        )
+      )
+
+  const stateIsValid = editorState.every(
+    ({ errors }) =>
+      errors.startTime === undefined && errors.endTime === undefined
+  )
+
+  const [saving, setSaving] = useState(false)
+  const save = () => {
+    if (!stateIsValid) return Promise.resolve()
+
+    setSaving(true)
+    return postReservations(
+      editorState
+        .filter(({ startTime, endTime }) => startTime !== '' && endTime !== '')
+        .map(({ child, startTime, endTime }) => ({
+          childId: child.id,
+          date: date,
+          startTime,
+          endTime
+        }))
+    )
+      .then(() => setEditing(false))
+      .then(() => reloadData())
+      .finally(() => setSaving(false))
+  }
+
+  const [confirmationModal, setConfirmationModal] =
+    useState<{ close: () => void; resolve: () => void; reject: () => void }>()
+
+  const navigate = (callback: () => void) => () => {
+    const stateHasBeenModified = editorStateFromProps.some((childFromProps) => {
+      const editorData = editorState.find(
+        (child) => child.child.id === childFromProps.child.id
+      )
+
+      return (
+        !editorData ||
+        childFromProps.startTime !== editorData.startTime ||
+        childFromProps.endTime !== editorData.endTime
+      )
+    })
+
+    if (!editing || !stateHasBeenModified) return callback()
+
+    setConfirmationModal({
+      close: () => setConfirmationModal(undefined),
+      resolve: () => {
+        setConfirmationModal(undefined)
+        void save().then(() => callback())
+      },
+      reject: () => {
+        setEditing(false)
+        setConfirmationModal(undefined)
+        callback()
+      }
+    })
+  }
+
+  return {
+    editable,
+    editing,
+    startEditing,
+    editorState,
+    editorStateSetter,
+    stateIsValid,
+    saving,
+    save,
+    navigate,
+    confirmationModal
+  }
+}
 
 const DayPicker = styled.div`
   display: flex;
@@ -98,6 +321,14 @@ const DayPicker = styled.div`
 const DayOfWeek = styled(H1)`
   margin: 0 ${defaultMargins.s};
   text-align: center;
+`
+
+const ReservationTitle = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: center;
 `
 
 const Grid = styled.div`
@@ -114,4 +345,12 @@ const NoReservation = styled.span`
 const Separator = styled.div`
   border-top: 2px dotted ${(p) => p.theme.colors.greyscale.lighter};
   margin: ${defaultMargins.s} 0;
+`
+
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-items: center;
 `

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -169,20 +169,26 @@ export default React.memo(function ReservationModal({
     )
     switch (formData.repetition) {
       case 'DAILY':
-        return [...range.dates()].map((date) => ({
-          date,
-          startTime: formData.startTime,
-          endTime: formData.endTime
-        }))
+        return [...range.dates()].flatMap((date) =>
+          formData.selectedChildren.map((childId) => ({
+            childId,
+            date,
+            startTime: formData.startTime,
+            endTime: formData.endTime
+          }))
+        )
       case 'WEEKLY':
         return [...range.dates()]
           .filter((d) => !d.isWeekend())
-          .map((date) => ({
-            date,
-            startTime:
-              formData.weeklyTimes[date.getIsoDayOfWeek() - 1].startTime,
-            endTime: formData.weeklyTimes[date.getIsoDayOfWeek() - 1].endTime
-          }))
+          .flatMap((date) =>
+            formData.selectedChildren.map((childId) => ({
+              childId,
+              date,
+              startTime:
+                formData.weeklyTimes[date.getIsoDayOfWeek() - 1].startTime,
+              endTime: formData.weeklyTimes[date.getIsoDayOfWeek() - 1].endTime
+            }))
+          )
     }
   }
 
@@ -196,10 +202,9 @@ export default React.memo(function ReservationModal({
             setShowAllErrors(true)
             return
           }
-          void postReservations(
-            formData.selectedChildren,
-            getDailyReservations()
-          ).then((result) => setPostResult(result))
+          void postReservations(getDailyReservations()).then((result) =>
+            setPostResult(result)
+          )
         },
         label: i18n.common.confirm,
         disabled:

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -253,6 +253,7 @@ export default React.memo(function ReservationModal({
           isValidDate={(date) => reservableDays.includes(date)}
           info={errorToInputInfo(errors.endDate, i18n.validationErrors)}
           hideErrorsBeforeTouched={!showAllErrors}
+          initialMonth={reservableDays.start}
         />
       </FixedSpaceRow>
 

--- a/frontend/src/citizen-frontend/calendar/api.ts
+++ b/frontend/src/citizen-frontend/calendar/api.ts
@@ -56,23 +56,17 @@ export async function getReservations(
 }
 
 export interface DailyReservationRequest {
+  childId: string
   date: LocalDate
   startTime: string
   endTime: string
 }
 
-interface ReservationRequest {
-  children: UUID[]
-  reservations: DailyReservationRequest[]
-}
-
 export async function postReservations(
-  children: UUID[],
   reservations: DailyReservationRequest[]
 ): Promise<Result<null>> {
-  const body: ReservationRequest = { children, reservations }
   return client
-    .post('/citizen/reservations', body)
+    .post('/citizen/reservations', reservations)
     .then(() => Success.of(null))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
@@ -56,6 +56,7 @@ type DatePickerProps = {
   'data-qa'?: string
   id?: string
   required?: boolean
+  initialMonth?: LocalDate
 }
 
 function DatePicker({
@@ -70,6 +71,7 @@ function DatePicker({
   isValidDate,
   id,
   required,
+  initialMonth,
   ...props
 }: DatePickerProps) {
   const [show, setShow] = useState<boolean>(false)
@@ -162,6 +164,7 @@ function DatePicker({
             inputValue={date}
             handleDayClick={handleDayClick}
             isValidDate={isValidDate}
+            initialMonth={initialMonth}
           />
         </DayPickerDiv>
       </DayPickerPositioner>

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
@@ -18,13 +18,15 @@ interface Props {
   inputValue: string
   locale: 'fi' | 'sv' | 'en'
   isValidDate?: (date: LocalDate) => boolean
+  initialMonth?: LocalDate
 }
 
 function DatePickerDay({
   handleDayClick,
   inputValue,
   locale,
-  isValidDate
+  isValidDate,
+  initialMonth
 }: Props) {
   const dateI18n = locale === 'sv' ? sv : locale === 'en' ? enGB : fi
 
@@ -61,7 +63,7 @@ function DatePickerDay({
         const localDate = LocalDate.fromSystemTzDate(date)
         return isValidDate ? !isValidDate(localDate) : false
       }}
-      initialMonth={convertToDate(inputValue) ?? undefined}
+      initialMonth={convertToDate(inputValue) ?? initialMonth?.toSystemTzDate()}
     />
   )
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
@@ -42,14 +42,13 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
 
     @Test
     fun `adding reservations works in a basic case`() {
-        postReservatios(
-            ReservationRequest(
-                children = setOf(testChild_1.id, testChild_2.id),
-                reservations = listOf(
-                    DailyReservationRequest(monday, startTime, endTime),
-                    DailyReservationRequest(monday.plusDays(1), startTime, endTime)
+        postReservations(
+            listOf(testChild_1.id, testChild_2.id).flatMap { child ->
+                listOf(
+                    DailyReservationRequest(child, monday, startTime, endTime),
+                    DailyReservationRequest(child, monday.plusDays(1), startTime, endTime)
                 )
-            )
+            },
         )
 
         val res = getReservations(FiniteDateRange(monday, monday.plusDays(2)))
@@ -87,7 +86,7 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
         assertEquals(0, dailyData[2].reservations.size)
     }
 
-    private fun postReservatios(request: ReservationRequest) {
+    private fun postReservations(request: List<DailyReservationRequest>) {
         val (_, res, _) = http.post("/citizen/reservations")
             .jsonBody(objectMapper.writeValueAsString(request))
             .asUser(AuthenticatedUser.Citizen(testAdult_1.id))

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -94,6 +94,7 @@ fun Database.Transaction.clearOldCitizenReservations(reservations: List<Reservat
         batch
             .bind("childId", res.childId)
             .bind("date", res.startTime.toLocalDate())
+            .add()
     }
 
     batch.execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -50,26 +50,24 @@ class ReservationControllerCitizen(
     fun postReservations(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @RequestBody body: ReservationRequest
+        @RequestBody body: List<DailyReservationRequest>
     ) {
-        Audit.AttendanceReservationCitizenCreate.log(targetId = body.children.joinToString())
+        Audit.AttendanceReservationCitizenCreate.log(targetId = body.map { it.childId }.joinToString())
         user.requireOneOfRoles(UserRole.CITIZEN_WEAK, UserRole.END_USER)
-        accessControl.requireGuardian(user, body.children)
+        accessControl.requireGuardian(user, body.map { it.childId }.toSet())
 
-        val reservations = body.children.flatMap { childId ->
-            body.reservations.map { res ->
-                Reservation(
-                    childId = childId,
-                    startTime = HelsinkiDateTime.of(
-                        date = res.date,
-                        time = res.startTime
-                    ),
-                    endTime = HelsinkiDateTime.of(
-                        date = if (res.endTime.isAfter(res.startTime)) res.date else res.date.plusDays(1),
-                        time = res.endTime
-                    )
+        val reservations = body.map { res ->
+            Reservation(
+                childId = res.childId,
+                startTime = HelsinkiDateTime.of(
+                    date = res.date,
+                    time = res.startTime
+                ),
+                endTime = HelsinkiDateTime.of(
+                    date = if (res.endTime.isAfter(res.startTime)) res.date else res.date.plusDays(1),
+                    time = res.endTime
                 )
-            }
+            )
         }
 
         db.transaction { createReservations(it, user.id, reservations) }
@@ -131,12 +129,8 @@ fun Database.Transaction.insertValidReservations(userId: UUID, reservations: Lis
     batch.execute()
 }
 
-data class ReservationRequest(
-    val children: Set<UUID>,
-    val reservations: List<DailyReservationRequest>
-)
-
 data class DailyReservationRequest(
+    val childId: UUID,
     val date: LocalDate,
     val startTime: LocalTime,
     val endTime: LocalTime,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add inline editor to citizen reservation day view where single day reservations can be updated quickly.
Also,
* Show month with first available end date when opening date picker in reservation modal
* Fix a bug in citizen reservation overwrite
* Show same reservations only once

