### PR TITLE
Fix withMonth method

### DIFF
--- a/frontend/src/lib-common/local-date.ts
+++ b/frontend/src/lib-common/local-date.ts
@@ -17,6 +17,7 @@ import {
   isValid,
   isWeekend,
   lastDayOfMonth,
+  setMonth,
   startOfToday,
   subDays,
   subMonths,
@@ -55,7 +56,9 @@ export default class LocalDate {
     return LocalDate.of(year, this.month, this.date)
   }
   withMonth(month: number): LocalDate {
-    return LocalDate.of(this.year, month, this.date)
+    return LocalDate.fromSystemTzDate(
+      setMonth(this.toSystemTzDate(), month - 1)
+    )
   }
   withDate(date: number): LocalDate {
     return LocalDate.of(this.year, this.month, date)


### PR DESCRIPTION
#### Summary

The withMonth method blindly replaces month from date, so if created date is invalid it will break example e2e tests. This will change date to use date-fns setMonth so if day overflows we get last day of given month.