### PR TITLE
Make AsyncJobRunner parameterizable by job type

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -41,7 +42,7 @@ import kotlin.test.assertNotNull
 
 class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     @Autowired
-    lateinit var asyncJobRunner: AsyncJobRunner
+    lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     @Autowired
     lateinit var applicationReceivedEmailService: ApplicationReceivedEmailService

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -33,6 +33,7 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.IncomeId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -81,7 +82,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
     private lateinit var decisionDraftService: DecisionDraftService
 
     @Autowired
-    private lateinit var asyncJobRunner: AsyncJobRunner
+    private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     @Autowired
     lateinit var mapper: ObjectMapper

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.emailclient.MockEmailClient
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -36,7 +37,7 @@ import kotlin.test.assertNotNull
 
 class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest() {
     @Autowired
-    lateinit var asyncJobRunner: AsyncJobRunner
+    lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     @Autowired
     lateinit var scheduledJobs: ScheduledJobs

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -55,7 +56,7 @@ class DecisionCreationIntegrationTest : FullApplicationTest() {
     private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER))
 
     @Autowired
-    private lateinit var asyncJobRunner: AsyncJobRunner
+    private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     @Autowired
     private lateinit var applicationStateService: ApplicationStateService

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTestBase.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTestBase.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.pis.service.ParentshipService
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.pis.service.PersonWithChildrenDTO
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
@@ -37,7 +38,7 @@ class DvvModificationsServiceIntegrationTestBase : FullApplicationTest() {
     protected lateinit var parentshipService: ParentshipService
 
     @Autowired
-    protected lateinit var asyncJobRunner: AsyncJobRunner
+    protected lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     protected lateinit var fridgeFamilyService: FridgeFamilyService
     protected lateinit var dvvModificationsServiceClient: DvvModificationsServiceClient

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.Paged
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -54,7 +55,7 @@ import kotlin.test.assertNotNull
 
 class FeeDecisionIntegrationTest : FullApplicationTest() {
     @Autowired
-    lateinit var asyncJobRunner: AsyncJobRunner
+    lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     private val user = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -22,6 +22,7 @@ import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -44,7 +45,7 @@ import kotlin.test.assertEquals
 
 class VoucherValueDecisionIntegrationTest : FullApplicationTest() {
     @Autowired
-    lateinit var asyncJobRunner: AsyncJobRunner
+    lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     @Autowired
     lateinit var voucherValueDecisionService: VoucherValueDecisionService

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTestHelpers.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTestHelpers.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.koski
 
 import fi.espoo.evaka.shared.DaycareId
-import fi.espoo.evaka.shared.async.UploadToKoski
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDaycare2
@@ -45,7 +45,7 @@ internal class KoskiTester(private val jdbi: Jdbi, private val client: KoskiClie
     fun triggerUploads(today: LocalDate, params: KoskiSearchParams = KoskiSearchParams()) {
         val db = Database(jdbi)
         db.read { it.getPendingStudyRights(today, params) }.forEach { request ->
-            client.uploadToKoski(db, UploadToKoski(request), today)
+            client.uploadToKoski(db, AsyncJob.UploadToKoski(request), today)
         }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -45,7 +46,7 @@ import kotlin.test.assertTrue
 
 class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest() {
     @Autowired
-    lateinit var asyncJobRunner: AsyncJobRunner
+    lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     private val testPersonFi = DevPerson(email = "fi@example.com", language = "fi")
     private val testPersonSv = DevPerson(email = "sv@example.com", language = "sv")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.pis.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import fi.espoo.evaka.PureJdbiTest
@@ -19,8 +20,8 @@ import fi.espoo.evaka.messaging.message.getMessagesReceivedByAccount
 import fi.espoo.evaka.messaging.message.getMessagesSentByAccount
 import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.config.defaultObjectMapper
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevEmployee
@@ -47,7 +48,7 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
     lateinit var mergeService: MergeService
 
     private val objectMapper: ObjectMapper = defaultObjectMapper()
-    private val asyncJobRunnerMock = Mockito.mock(AsyncJobRunner::class.java)
+    private val asyncJobRunnerMock: AsyncJobRunner<AsyncJob> = mock { }
     private val messageNotificationEmailService = Mockito.mock(MessageNotificationEmailService::class.java)
     private val messageService: MessageService = MessageService(messageNotificationEmailService)
 
@@ -138,7 +139,7 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
 
         verify(asyncJobRunnerMock).plan(
             any(),
-            eq(listOf(GenerateFinanceDecisions.forAdult(adultId, DateRange(validFrom, validTo)))),
+            eq(listOf(AsyncJob.GenerateFinanceDecisions.forAdult(adultId, DateRange(validFrom, validTo)))),
             any(),
             any(),
             any()
@@ -317,7 +318,7 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
 
         verify(asyncJobRunnerMock).plan(
             any(),
-            eq(listOf(GenerateFinanceDecisions.forAdult(adultId, DateRange(placementStart, placementEnd)))),
+            eq(listOf(AsyncJob.GenerateFinanceDecisions.forAdult(adultId, DateRange(placementStart, placementEnd)))),
             any(),
             any(),
             any()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -13,8 +13,8 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.VTJRefresh
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
@@ -38,7 +38,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
     lateinit var fridgeFamilyService: FridgeFamilyService
 
     @MockBean
-    protected lateinit var asyncJobRunner: AsyncJobRunner
+    protected lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     lateinit var service: VTJBatchRefreshService
 
@@ -87,7 +87,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         )
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_1.id), any())).thenReturn(dto)
 
-        service.doVTJRefresh(dbInstance(), VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(dbInstance(), AsyncJob.VTJRefresh(testAdult_1.id, user.id))
         verify(parentshipService).createParentship(
             any(),
             eq(testChild_1.id),
@@ -112,7 +112,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
             )
         )
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_1.id), any())).thenReturn(dto)
-        service.doVTJRefresh(dbInstance(), VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(dbInstance(), AsyncJob.VTJRefresh(testAdult_1.id, user.id))
         verifyZeroInteractions(parentshipService)
     }
 
@@ -148,7 +148,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_1.id), any())).thenReturn(dto1)
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_2.id), any())).thenReturn(dto2)
 
-        service.doVTJRefresh(dbInstance(), VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(dbInstance(), AsyncJob.VTJRefresh(testAdult_1.id, user.id))
         verify(parentshipService).createParentship(
             any(),
             eq(testChild_1.id),
@@ -192,7 +192,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest() {
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_1.id), any())).thenReturn(dto1)
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_2.id), any())).thenReturn(dto2)
 
-        service.doVTJRefresh(dbInstance(), VTJRefresh(testAdult_1.id, user.id))
+        service.doVTJRefresh(dbInstance(), AsyncJob.VTJRefresh(testAdult_1.id, user.id))
         verifyZeroInteractions(parentshipService)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -50,7 +51,7 @@ import kotlin.test.assertNotNull
 
 class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
     @Autowired
-    private lateinit var asyncJobRunner: AsyncJobRunner
+    private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     @BeforeEach
     fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.reports.VoucherReportRowType.ORIGINAL
 import fi.espoo.evaka.reports.VoucherReportRowType.REFUND
 import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -45,7 +46,7 @@ import kotlin.test.assertTrue
 
 class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
     @Autowired
-    private lateinit var asyncJobRunner: AsyncJobRunner
+    private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     @BeforeEach
     fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.shared.async
 
 import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
@@ -18,6 +19,7 @@ import java.time.LocalTime
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -136,6 +138,27 @@ class AsyncJobQueriesTest : PureJdbiTest() {
             ),
             remainingJobs
         )
+    }
+
+    @Test
+    fun `legacy jobs with asyncJobType fields are supported`() {
+        val id = UUID.fromString("d9a88d89-b8d6-4245-a921-b9f5baafc863")
+        db.transaction {
+            it.createUpdate(
+                """
+                INSERT INTO async_job (type, retry_count, retry_interval, run_at, payload)
+                VALUES ('SEND_DECISION', 20, 'PT20S', now(), '{"asyncJobType": "SEND_DECISION", "decisionId": "$id"}')
+                """.trimIndent()
+            ).execute()
+        }
+        db.transaction {
+            val jobType = AsyncJobType(AsyncJob.SendDecision::class)
+            val jobRef = it.claimJob(listOf(jobType))
+            assertNotNull(jobRef)
+            assertEquals(jobType, jobRef.jobType)
+            val job = it.startJob(jobRef)
+            assertEquals(AsyncJob.SendDecision(decisionId = DecisionId(id)), job)
+        }
     }
 
     private data class Retry(val runAt: HelsinkiDateTime, val retryCount: Long)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.config.getTestDataSource
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
+import fi.espoo.voltti.logging.MdcKey
 import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
@@ -23,13 +24,17 @@ import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AsyncJobRunnerTest {
-    private data class TestJob(val data: UUID) : AsyncJobPayload {
+    private data class TestJob(
+        val data: UUID = UUID.randomUUID(),
         override val user: AuthenticatedUser? = null
-    }
+    ) : AsyncJobPayload
+
+    private class LetsRollbackException : RuntimeException()
 
     private lateinit var asyncJobRunner: AsyncJobRunner<TestJob>
     private lateinit var jdbi: Jdbi
@@ -59,7 +64,7 @@ class AsyncJobRunnerTest {
     }
 
     @Test
-    fun testPlanRollback() {
+    fun `planned jobs are not saved if the transaction gets rolled back`() {
         assertThrows<LetsRollbackException> {
             db.transaction { tx ->
                 asyncJobRunner.plan(tx, listOf(TestJob(UUID.randomUUID())))
@@ -70,27 +75,62 @@ class AsyncJobRunnerTest {
     }
 
     @Test
-    fun testCompleteHappyCase() {
-        val id = UUID.randomUUID()
-        val future = this.setAsyncJobCallback { msg -> msg }
-        db.transaction { asyncJobRunner.plan(it, listOf(TestJob(id))) }
-        asyncJobRunner.runPendingJobsSync()
-        val result = future.get(10, TimeUnit.SECONDS)
-        assertEquals(id, result.data)
+    fun `logging MDC keys are set during job execution`() {
+        val job = TestJob(user = AuthenticatedUser.SystemInternalUser)
+        val future = this.setAsyncJobCallback {
+            assertEquals(job, it)
+            val traceId = MdcKey.TRACE_ID.get()
+            val spanId = MdcKey.SPAN_ID.get()
+            assertNotNull(traceId)
+            assertEquals(traceId, spanId)
+            assertEquals(AuthenticatedUser.SystemInternalUser.id.toString(), MdcKey.USER_ID.get())
+            assertEquals(AuthenticatedUser.SystemInternalUser.idHash.toString(), MdcKey.USER_ID_HASH.get())
+        }
+        db.transaction { asyncJobRunner.plan(it, listOf(job)) }
+        asyncJobRunner.runPendingJobsSync(1)
+        future.get(0, TimeUnit.SECONDS)
     }
 
     @Test
-    fun testCompleteRetry() {
-        val id = UUID.randomUUID()
+    fun `pending jobs can be executed manually`() {
+        val job = TestJob()
+        val future = this.setAsyncJobCallback { assertEquals(job, it) }
+        db.transaction { asyncJobRunner.plan(it, listOf(job)) }
+        asyncJobRunner.runPendingJobsSync()
+        future.get(0, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `pending jobs are executed in the background if AsyncJobRunner has been started`() {
+        val job = TestJob()
+        val future = this.setAsyncJobCallback { assertEquals(job, it) }
+        db.transaction { asyncJobRunner.plan(it, listOf(job)) }
+        asyncJobRunner.start(pollingInterval = Duration.ofSeconds(1))
+        future.get(10, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `AsyncJobRunner wakes up automatically after a transaction plans jobs`() {
+        val job = TestJob()
+        val future = this.setAsyncJobCallback { assertEquals(job, it) }
+        asyncJobRunner.start(pollingInterval = Duration.ofDays(1))
+        TimeUnit.MILLISECONDS.sleep(100)
+        db.transaction { asyncJobRunner.plan(it, listOf(job)) }
+        future.get(10, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `failed jobs get retried`() {
+        val job = TestJob()
         val failingFuture = this.setAsyncJobCallback { throw LetsRollbackException() }
-        db.transaction { asyncJobRunner.plan(it, listOf(TestJob(id)), 20, Duration.ZERO) }
+        db.transaction { asyncJobRunner.plan(it, listOf(job), 20, Duration.ZERO) }
         asyncJobRunner.runPendingJobsSync(1)
 
         val exception = assertThrows<ExecutionException> { failingFuture.get(10, TimeUnit.SECONDS) }
         assertTrue(exception.cause is LetsRollbackException)
         assertEquals(1, asyncJobRunner.getPendingJobCount())
 
-        val future = this.setAsyncJobCallback { msg -> msg }
+        val future = this.setAsyncJobCallback { assertEquals(job, it) }
         asyncJobRunner.runPendingJobsSync(1)
         future.get(10, TimeUnit.SECONDS)
         assertEquals(0, asyncJobRunner.getPendingJobCount())
@@ -100,7 +140,8 @@ class AsyncJobRunnerTest {
         val future = CompletableFuture<R>()
         currentCallback.set { msg: TestJob ->
             try {
-                future.complete(f(msg))
+                val completed = future.complete(f(msg))
+                assertTrue(completed)
             } catch (t: Throwable) {
                 future.completeExceptionally(t)
                 throw t
@@ -109,5 +150,3 @@ class AsyncJobRunnerTest {
         return future
     }
 }
-
-class LetsRollbackException : RuntimeException()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.BucketEnv
 import fi.espoo.evaka.emailclient.EvakaEmailMessageProvider
 import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
@@ -91,7 +92,7 @@ class SharedIntegrationTestConfig {
     fun jdbi(dataSource: DataSource) = configureJdbi(Jdbi.create(dataSource))
 
     @Bean
-    fun asyncJobRunner(jdbi: Jdbi, dataSource: DataSource) = AsyncJobRunner(jdbi, syncMode = true)
+    fun asyncJobRunner(jdbi: Jdbi, dataSource: DataSource): AsyncJobRunner<AsyncJob> = AsyncJobRunner(jdbi, syncMode = true)
 
     @Bean
     fun dataSource(): DataSource = getTestDataSource()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -12,8 +12,6 @@ import fi.espoo.evaka.BucketEnv
 import fi.espoo.evaka.emailclient.EvakaEmailMessageProvider
 import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
-import fi.espoo.evaka.shared.async.AsyncJob
-import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
 import fi.espoo.evaka.shared.dev.resetDatabase
@@ -90,9 +88,6 @@ fun getTestDataSource(): TestDataSource = synchronized(globalLock) {
 class SharedIntegrationTestConfig {
     @Bean
     fun jdbi(dataSource: DataSource) = configureJdbi(Jdbi.create(dataSource))
-
-    @Bean
-    fun asyncJobRunner(jdbi: Jdbi, dataSource: DataSource): AsyncJobRunner<AsyncJob> = AsyncJobRunner(jdbi, syncMode = true)
 
     @Bean
     fun dataSource(): DataSource = getTestDataSource()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
@@ -32,7 +32,7 @@ class ScheduledJobRunnerTest : PureJdbiTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { it.resetDatabase() }
-        asyncJobRunner = AsyncJobRunner(jdbi, syncMode = true)
+        asyncJobRunner = AsyncJobRunner(jdbi)
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
@@ -8,8 +8,8 @@ import com.github.kagkarlsson.scheduler.task.schedule.Schedule
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.application.utils.helsinkiZone
 import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.RunScheduledJob
 import fi.espoo.evaka.shared.config.getTestDataSource
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -21,7 +21,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class ScheduledJobRunnerTest : PureJdbiTest() {
-    private lateinit var asyncJobRunner: AsyncJobRunner
+    private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
     private val testTime = LocalTime.of(1, 0)
     private val testSchedule = object : JobSchedule {
         override fun getScheduleForJob(job: ScheduledJob): Schedule? = if (job == ScheduledJob.EndOfDayAttendanceUpkeep) {
@@ -38,7 +38,7 @@ class ScheduledJobRunnerTest : PureJdbiTest() {
     @Test
     fun `a job specified by DailySchedule is scheduled and executed correctly`() {
         val executedJob = AtomicReference<ScheduledJob?>(null)
-        asyncJobRunner.registerHandler { _, msg: RunScheduledJob ->
+        asyncJobRunner.registerHandler { _, msg: AsyncJob.RunScheduledJob ->
             val previous = executedJob.getAndSet(msg.job)
             assertNull(previous)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaFeeDataIntegrationTest.kt
@@ -28,6 +28,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.VardaDecisionId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -70,7 +71,7 @@ class VardaFeeDataIntegrationTest : FullApplicationTest() {
     lateinit var mockEndpoint: MockVardaIntegrationEndpoint
 
     @Autowired
-    lateinit var asyncJobRunner: AsyncJobRunner
+    lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     @BeforeEach
     fun beforeEach() {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
@@ -20,8 +20,8 @@ class DecisionMessageProcessor(
     private val decisionService: DecisionService
 ) {
     init {
-        asyncJobRunner.notifyDecisionCreated = ::runCreateJob
-        asyncJobRunner.sendDecision = ::runSendJob
+        asyncJobRunner.registerHandler(::runCreateJob)
+        asyncJobRunner.registerHandler(::runSendJob)
     }
 
     fun runCreateJob(db: Database, msg: NotifyDecisionCreated) = db.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -29,7 +29,7 @@ class PendingDecisionEmailService(
     env: EmailEnv
 ) {
     init {
-        asyncJobRunner.sendPendingDecisionEmail = ::doSendPendingDecisionsEmail
+        asyncJobRunner.registerHandler(::doSendPendingDecisionsEmail)
     }
 
     val senderAddress: String = env.senderAddress

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -103,8 +103,6 @@ GROUP BY application.guardian_id
             createdJobCount
         }
 
-        asyncJobRunner.scheduleImmediateRun()
-
         return jobCount
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -9,8 +9,8 @@ import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.emailclient.IEmailClient
 import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.pis.getPersonById
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.SendPendingDecisionEmail
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import mu.KotlinLogging
@@ -23,7 +23,7 @@ private val logger = KotlinLogging.logger { }
 
 @Service
 class PendingDecisionEmailService(
-    private val asyncJobRunner: AsyncJobRunner,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val emailClient: IEmailClient,
     private val emailMessageProvider: IEmailMessageProvider,
     env: EmailEnv
@@ -41,7 +41,7 @@ class PendingDecisionEmailService(
         else -> "$senderNameFi <$senderAddress>"
     }
 
-    fun doSendPendingDecisionsEmail(db: Database, msg: SendPendingDecisionEmail) {
+    fun doSendPendingDecisionsEmail(db: Database, msg: AsyncJob.SendPendingDecisionEmail) {
         logger.info("Sending pending decision reminder email to guardian ${msg.guardianId}")
         sendPendingDecisionEmail(db, msg)
     }
@@ -81,7 +81,7 @@ GROUP BY application.guardian_id
                         asyncJobRunner.plan(
                             tx,
                             payloads = listOf(
-                                SendPendingDecisionEmail(
+                                AsyncJob.SendPendingDecisionEmail(
                                     guardianId = pendingDecision.guardianId,
                                     email = guardian.email,
                                     language = guardian.language,
@@ -108,7 +108,7 @@ GROUP BY application.guardian_id
         return jobCount
     }
 
-    fun sendPendingDecisionEmail(db: Database, pendingDecision: SendPendingDecisionEmail) {
+    fun sendPendingDecisionEmail(db: Database, pendingDecision: AsyncJob.SendPendingDecisionEmail) {
         db.transaction { tx ->
             logger.info("Sending pending decision email to guardian ${pendingDecision.guardianId}")
             val lang = getLanguage(pendingDecision.language)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/SendApplicationReceivedEmailAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/SendApplicationReceivedEmailAsyncJobs.kt
@@ -20,7 +20,7 @@ class SendApplicationReceivedEmailAsyncJobs(
 ) {
 
     init {
-        asyncJobRunner.sendApplicationEmail = ::runSendApplicationEmail
+        asyncJobRunner.registerHandler(::runSendApplicationEmail)
     }
 
     private fun runSendApplicationEmail(db: Database, msg: SendApplicationEmail) {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/SendApplicationReceivedEmailAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/SendApplicationReceivedEmailAsyncJobs.kt
@@ -5,8 +5,8 @@
 package fi.espoo.evaka.application
 
 import fi.espoo.evaka.pis.getPersonById
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.SendApplicationEmail
 import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
@@ -15,7 +15,7 @@ private val logger = KotlinLogging.logger { }
 
 @Component
 class SendApplicationReceivedEmailAsyncJobs(
-    asyncJobRunner: AsyncJobRunner,
+    asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val applicationReceivedEmailService: ApplicationReceivedEmailService
 ) {
 
@@ -23,7 +23,7 @@ class SendApplicationReceivedEmailAsyncJobs(
         asyncJobRunner.registerHandler(::runSendApplicationEmail)
     }
 
-    private fun runSendApplicationEmail(db: Database, msg: SendApplicationEmail) {
+    private fun runSendApplicationEmail(db: Database, msg: AsyncJob.SendApplicationEmail) {
         val guardian = db.read { it.getPersonById(msg.guardianId) }
             ?: throw Exception("Didn't find guardian when sending application email (guardianId: ${msg.guardianId})")
 

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -20,8 +20,8 @@ import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.s3.DocumentWrapper
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DecisionId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.NotifyDecisionCreated
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.NotFound
@@ -48,7 +48,7 @@ class DecisionService(
     private val pdfService: PDFService,
     private val messageProvider: IMessageProvider,
     private val evakaMessageClient: IEvakaMessageClient,
-    private val asyncJobRunner: AsyncJobRunner,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     env: BucketEnv,
 ) {
     private val decisionBucket = env.decisions
@@ -60,7 +60,7 @@ class DecisionService(
         sendAsMessage: Boolean
     ): List<DecisionId> {
         val decisionIds = tx.finalizeDecisions(applicationId)
-        asyncJobRunner.plan(tx, decisionIds.map { NotifyDecisionCreated(it, user, sendAsMessage) })
+        asyncJobRunner.plan(tx, decisionIds.map { AsyncJob.NotifyDecisionCreated(it, user, sendAsMessage) })
         return decisionIds
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -51,8 +51,6 @@ class DvvModificationsBatchRefreshService(
             ssns.size
         }
 
-        asyncJobRunner.scheduleImmediateRun()
-
         return jobCount
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -4,10 +4,8 @@
 
 package fi.espoo.evaka.dvv
 
-import fi.espoo.evaka.shared.async.AsyncJobPayload
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.AsyncJobType
-import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.async.DvvModificationsRefresh
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import mu.KotlinLogging
@@ -23,7 +21,7 @@ class DvvModificationsBatchRefreshService(
     private val dvvModificationsService: DvvModificationsService
 ) {
     init {
-        asyncJobRunner.dvvModificationsRefresh = ::doDvvModificationsRefresh
+        asyncJobRunner.registerHandler(::doDvvModificationsRefresh)
     }
 
     fun doDvvModificationsRefresh(db: Database, msg: DvvModificationsRefresh) {
@@ -71,8 +69,3 @@ SELECT DISTINCT(social_security_number) FROM person
 )
     .mapTo<String>()
     .toList()
-
-data class DvvModificationsRefresh(val ssns: List<String>, val requestingUserId: UUID) : AsyncJobPayload {
-    override val asyncJobType = AsyncJobType.DVV_MODIFICATIONS_REFRESH
-    override val user: AuthenticatedUser? = null
-}

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
@@ -60,7 +60,6 @@ class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner<AsyncJo
             )
         }
 
-        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()
     }
 
@@ -80,7 +79,6 @@ class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner<AsyncJo
             asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forChild(feeAlteration.personId, expandedPeriod)))
         }
 
-        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()
     }
 
@@ -106,7 +104,6 @@ class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner<AsyncJo
             }
         }
 
-        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -17,8 +17,8 @@ import fi.espoo.evaka.invoicing.service.FeeDecisionService
 import fi.espoo.evaka.invoicing.service.FinanceDecisionGenerator
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.Paged
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.NotifyFeeDecisionApproved
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -65,7 +65,7 @@ enum class DistinctiveParams {
 class FeeDecisionController(
     private val service: FeeDecisionService,
     private val generator: FinanceDecisionGenerator,
-    private val asyncJobRunner: AsyncJobRunner
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     @PostMapping("/search")
     fun search(
@@ -106,7 +106,7 @@ class FeeDecisionController(
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         db.transaction { tx ->
             val confirmedDecisions = service.confirmDrafts(tx, user, feeDecisionIds, Instant.now())
-            asyncJobRunner.plan(tx, confirmedDecisions.map { NotifyFeeDecisionApproved(it) })
+            asyncJobRunner.plan(tx, confirmedDecisions.map { AsyncJob.NotifyFeeDecisionApproved(it) })
         }
         asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -108,7 +108,6 @@ class FeeDecisionController(
             val confirmedDecisions = service.confirmDrafts(tx, user, feeDecisionIds, Instant.now())
             asyncJobRunner.plan(tx, confirmedDecisions.map { AsyncJob.NotifyFeeDecisionApproved(it) })
         }
-        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
@@ -43,6 +43,5 @@ class FeeDecisionGeneratorController(private val asyncJobRunner: AsyncJobRunner<
 
     private fun generateAllStartingFrom(db: Database.Connection, starting: LocalDate, targetHeads: List<UUID>) {
         db.transaction { planFinanceDecisionGeneration(it, asyncJobRunner, DateRange(starting, null), targetHeads) }
-        asyncJobRunner.scheduleImmediateRun()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.invoicing.controller
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.invoicing.messaging.planFinanceDecisionGeneration
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -27,7 +28,7 @@ data class GenerateDecisionsBody(
 
 @RestController
 @RequestMapping("/fee-decision-generator")
-class FeeDecisionGeneratorController(private val asyncJobRunner: AsyncJobRunner) {
+class FeeDecisionGeneratorController(private val asyncJobRunner: AsyncJobRunner<AsyncJob>) {
     @PostMapping("/generate")
     fun generateDecisions(db: Database.Connection, user: AuthenticatedUser, @RequestBody data: GenerateDecisionsBody): ResponseEntity<Unit> {
         Audit.FeeDecisionGenerate.log(targetId = data.targetHeads)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
@@ -68,7 +68,6 @@ class FinanceBasicsController(private val asyncJobRunner: AsyncJobRunner<AsyncJo
             mapConstraintExceptions { tx.insertNewFeeThresholds(body) }
             asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyFeeThresholdsUpdated(body.validDuring)))
         }
-        asyncJobRunner.scheduleImmediateRun()
     }
 
     @PutMapping("/fee-thresholds/{id}")
@@ -86,7 +85,6 @@ class FinanceBasicsController(private val asyncJobRunner: AsyncJobRunner<AsyncJo
             mapConstraintExceptions { tx.updateFeeThresholds(id, thresholds) }
             asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyFeeThresholdsUpdated(thresholds.validDuring)))
         }
-        asyncJobRunner.scheduleImmediateRun()
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -16,8 +16,8 @@ import fi.espoo.evaka.invoicing.domain.IncomeCoefficient
 import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.invoicing.domain.IncomeType
 import fi.espoo.evaka.shared.IncomeId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -40,7 +40,7 @@ import java.util.UUID
 @RequestMapping("/incomes")
 class IncomeController(
     private val mapper: ObjectMapper,
-    private val asyncJobRunner: AsyncJobRunner
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     @GetMapping
     fun getIncome(db: Database.Connection, user: AuthenticatedUser, @RequestParam personId: String?): ResponseEntity<Wrapper<List<Income>>> {
@@ -70,7 +70,7 @@ class IncomeController(
             val validIncome = income.copy(id = id).let(::validateIncome)
             tx.splitEarlierIncome(validIncome.personId, period)
             tx.upsertIncome(mapper, validIncome, user.id)
-            asyncJobRunner.plan(tx, listOf(GenerateFinanceDecisions.forAdult(validIncome.personId, period)))
+            asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forAdult(validIncome.personId, period)))
             id
         }
 
@@ -97,7 +97,7 @@ class IncomeController(
                 DateRange(minOf(it.validFrom, income.validFrom), maxEndDate(it.validTo, income.validTo))
             } ?: DateRange(income.validFrom, income.validTo)
 
-            asyncJobRunner.plan(tx, listOf(GenerateFinanceDecisions.forAdult(validIncome.personId, expandedPeriod)))
+            asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forAdult(validIncome.personId, expandedPeriod)))
         }
 
         asyncJobRunner.scheduleImmediateRun()
@@ -116,7 +116,7 @@ class IncomeController(
 
             tx.deleteIncome(incomeId)
 
-            asyncJobRunner.plan(tx, listOf(GenerateFinanceDecisions.forAdult(existing.personId, period)))
+            asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forAdult(existing.personId, period)))
         }
 
         asyncJobRunner.scheduleImmediateRun()

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -74,7 +74,6 @@ class IncomeController(
             id
         }
 
-        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.ok(id)
     }
 
@@ -100,7 +99,6 @@ class IncomeController(
             asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forAdult(validIncome.personId, expandedPeriod)))
         }
 
-        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()
     }
 
@@ -119,7 +117,6 @@ class IncomeController(
             asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forAdult(existing.personId, period)))
         }
 
-        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -122,7 +122,6 @@ class VoucherValueDecisionController(
                 ids = decisionIds
             )
         }
-        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
@@ -23,8 +23,8 @@ class FeeDecisionGenerationJobProcessor(
     private val asyncJobRunner: AsyncJobRunner
 ) {
     init {
-        asyncJobRunner.notifyFeeThresholdsUpdated = ::runJob
-        asyncJobRunner.generateFinanceDecisions = ::runJob
+        asyncJobRunner.registerHandler<NotifyFeeThresholdsUpdated>(::runJob)
+        asyncJobRunner.registerHandler<GenerateFinanceDecisions>(::runJob)
     }
 
     fun runJob(db: Database, msg: NotifyFeeThresholdsUpdated) {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
@@ -29,7 +29,6 @@ class FeeDecisionGenerationJobProcessor(
     fun runJob(db: Database, msg: AsyncJob.NotifyFeeThresholdsUpdated) {
         logger.info { "Handling fee thresholds update event for date range (id: ${msg.dateRange})" }
         db.transaction { planFinanceDecisionGeneration(it, asyncJobRunner, msg.dateRange, listOf()) }
-        asyncJobRunner.scheduleImmediateRun()
     }
 
     fun runJob(db: Database, msg: AsyncJob.GenerateFinanceDecisions) {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
@@ -5,9 +5,8 @@
 package fi.espoo.evaka.invoicing.messaging
 
 import fi.espoo.evaka.invoicing.service.FinanceDecisionGenerator
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
-import fi.espoo.evaka.shared.async.NotifyFeeThresholdsUpdated
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
 import mu.KotlinLogging
@@ -20,26 +19,26 @@ private val logger = KotlinLogging.logger {}
 @Component
 class FeeDecisionGenerationJobProcessor(
     private val generator: FinanceDecisionGenerator,
-    private val asyncJobRunner: AsyncJobRunner
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     init {
-        asyncJobRunner.registerHandler<NotifyFeeThresholdsUpdated>(::runJob)
-        asyncJobRunner.registerHandler<GenerateFinanceDecisions>(::runJob)
+        asyncJobRunner.registerHandler<AsyncJob.NotifyFeeThresholdsUpdated>(::runJob)
+        asyncJobRunner.registerHandler<AsyncJob.GenerateFinanceDecisions>(::runJob)
     }
 
-    fun runJob(db: Database, msg: NotifyFeeThresholdsUpdated) {
+    fun runJob(db: Database, msg: AsyncJob.NotifyFeeThresholdsUpdated) {
         logger.info { "Handling fee thresholds update event for date range (id: ${msg.dateRange})" }
         db.transaction { planFinanceDecisionGeneration(it, asyncJobRunner, msg.dateRange, listOf()) }
         asyncJobRunner.scheduleImmediateRun()
     }
 
-    fun runJob(db: Database, msg: GenerateFinanceDecisions) {
+    fun runJob(db: Database, msg: AsyncJob.GenerateFinanceDecisions) {
         logger.info { "Generating finance decisions with parameters $msg" }
         db.transaction { tx ->
             when (msg.person) {
-                is GenerateFinanceDecisions.Person.Adult ->
+                is AsyncJob.GenerateFinanceDecisions.Person.Adult ->
                     generator.generateNewDecisionsForAdult(tx, msg.person.adultId, msg.dateRange)
-                is GenerateFinanceDecisions.Person.Child ->
+                is AsyncJob.GenerateFinanceDecisions.Person.Child ->
                     generator.generateNewDecisionsForChild(tx, msg.person.childId, msg.dateRange)
             }
         }
@@ -48,7 +47,7 @@ class FeeDecisionGenerationJobProcessor(
 
 fun planFinanceDecisionGeneration(
     tx: Database.Transaction,
-    asyncJobRunner: AsyncJobRunner,
+    asyncJobRunner: AsyncJobRunner<AsyncJob>,
     dateRange: DateRange,
     targetHeadsOfFamily: List<UUID>
 ) {
@@ -61,5 +60,5 @@ fun planFinanceDecisionGeneration(
             .list()
     }
 
-    asyncJobRunner.plan(tx, heads.distinct().map { GenerateFinanceDecisions.forAdult(it, dateRange) })
+    asyncJobRunner.plan(tx, heads.distinct().map { AsyncJob.GenerateFinanceDecisions.forAdult(it, dateRange) })
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
@@ -6,11 +6,8 @@ package fi.espoo.evaka.invoicing.messaging
 
 import fi.espoo.evaka.invoicing.service.FeeDecisionService
 import fi.espoo.evaka.invoicing.service.VoucherValueDecisionService
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.NotifyFeeDecisionApproved
-import fi.espoo.evaka.shared.async.NotifyFeeDecisionPdfGenerated
-import fi.espoo.evaka.shared.async.NotifyVoucherValueDecisionApproved
-import fi.espoo.evaka.shared.async.NotifyVoucherValueDecisionPdfGenerated
 import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
@@ -21,7 +18,7 @@ private val logger = KotlinLogging.logger {}
 class InvoicingAsyncJobs(
     private val feeService: FeeDecisionService,
     private val valueDecisionService: VoucherValueDecisionService,
-    private val asyncJobRunner: AsyncJobRunner
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     init {
         asyncJobRunner.registerHandler(::runCreateFeeDecisionPdf)
@@ -30,27 +27,27 @@ class InvoicingAsyncJobs(
         asyncJobRunner.registerHandler(::runSendVoucherValueDecisionPdf)
     }
 
-    fun runCreateFeeDecisionPdf(db: Database, msg: NotifyFeeDecisionApproved) = db.transaction { tx ->
+    fun runCreateFeeDecisionPdf(db: Database, msg: AsyncJob.NotifyFeeDecisionApproved) = db.transaction { tx ->
         val decisionId = msg.decisionId
         feeService.createFeeDecisionPdf(tx, decisionId)
         logger.info { "Successfully created fee decision pdf (id: $decisionId)." }
-        asyncJobRunner.plan(tx, listOf(NotifyFeeDecisionPdfGenerated(decisionId)))
+        asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyFeeDecisionPdfGenerated(decisionId)))
     }
 
-    fun runSendFeeDecisionPdf(db: Database, msg: NotifyFeeDecisionPdfGenerated) = db.transaction { tx ->
+    fun runSendFeeDecisionPdf(db: Database, msg: AsyncJob.NotifyFeeDecisionPdfGenerated) = db.transaction { tx ->
         val decisionId = msg.decisionId
         feeService.sendDecision(tx, decisionId)
         logger.info { "Successfully sent fee decision msg to suomi.fi (id: $decisionId)." }
     }
 
-    fun runCreateVoucherValueDecisionPdf(db: Database, msg: NotifyVoucherValueDecisionApproved) = db.transaction { tx ->
+    fun runCreateVoucherValueDecisionPdf(db: Database, msg: AsyncJob.NotifyVoucherValueDecisionApproved) = db.transaction { tx ->
         val decisionId = msg.decisionId
         valueDecisionService.createDecisionPdf(tx, decisionId)
         logger.info { "Successfully created voucher value decision pdf (id: $decisionId)." }
-        asyncJobRunner.plan(tx, listOf(NotifyVoucherValueDecisionPdfGenerated(decisionId)))
+        asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyVoucherValueDecisionPdfGenerated(decisionId)))
     }
 
-    fun runSendVoucherValueDecisionPdf(db: Database, msg: NotifyVoucherValueDecisionPdfGenerated) = db.transaction { tx ->
+    fun runSendVoucherValueDecisionPdf(db: Database, msg: AsyncJob.NotifyVoucherValueDecisionPdfGenerated) = db.transaction { tx ->
         val decisionId = msg.decisionId
         valueDecisionService.sendDecision(tx, decisionId)
         logger.info { "Successfully sent fee decision msg to suomi.fi (id: $decisionId)." }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
@@ -24,10 +24,10 @@ class InvoicingAsyncJobs(
     private val asyncJobRunner: AsyncJobRunner
 ) {
     init {
-        asyncJobRunner.notifyFeeDecisionApproved = ::runCreateFeeDecisionPdf
-        asyncJobRunner.notifyFeeDecisionPdfGenerated = ::runSendFeeDecisionPdf
-        asyncJobRunner.notifyVoucherValueDecisionApproved = ::runCreateVoucherValueDecisionPdf
-        asyncJobRunner.notifyVoucherValueDecisionPdfGenerated = ::runSendVoucherValueDecisionPdf
+        asyncJobRunner.registerHandler(::runCreateFeeDecisionPdf)
+        asyncJobRunner.registerHandler(::runSendFeeDecisionPdf)
+        asyncJobRunner.registerHandler(::runCreateVoucherValueDecisionPdf)
+        asyncJobRunner.registerHandler(::runSendVoucherValueDecisionPdf)
     }
 
     fun runCreateFeeDecisionPdf(db: Database, msg: NotifyFeeDecisionApproved) = db.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -44,7 +44,7 @@ class KoskiClient(
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     init {
-        asyncJobRunner?.uploadToKoski = { db, msg -> uploadToKoski(db, msg, today = LocalDate.now()) }
+        asyncJobRunner?.registerHandler { db, msg: UploadToKoski -> uploadToKoski(db, msg, today = LocalDate.now()) }
     }
 
     fun uploadToKoski(db: Database, msg: UploadToKoski, today: LocalDate) = db.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -19,8 +19,8 @@ import com.github.kittinunf.fuel.core.Method
 import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import fi.espoo.evaka.KoskiEnv
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.UploadToKoski
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.voltti.logging.loggers.error
 import mu.KotlinLogging
@@ -31,7 +31,7 @@ private val logger = KotlinLogging.logger { }
 class KoskiClient(
     private val env: KoskiEnv,
     private val fuel: FuelManager,
-    asyncJobRunner: AsyncJobRunner?
+    asyncJobRunner: AsyncJobRunner<AsyncJob>?
 ) {
     // Use a local Jackson instance so the configuration doesn't get changed accidentally if the global defaults change.
     // This is important, because our payload diffing mechanism relies on the serialization format
@@ -44,10 +44,10 @@ class KoskiClient(
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     init {
-        asyncJobRunner?.registerHandler { db, msg: UploadToKoski -> uploadToKoski(db, msg, today = LocalDate.now()) }
+        asyncJobRunner?.registerHandler { db, msg: AsyncJob.UploadToKoski -> uploadToKoski(db, msg, today = LocalDate.now()) }
     }
 
-    fun uploadToKoski(db: Database, msg: UploadToKoski, today: LocalDate) = db.transaction { tx ->
+    fun uploadToKoski(db: Database, msg: AsyncJob.UploadToKoski, today: LocalDate) = db.transaction { tx ->
         logger.info { "Koski upload ${msg.key}: starting" }
         val data = tx.beginKoskiUpload(env.sourceSystem, msg.key, today)
         if (data == null) {

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.koski
 import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.async.ScheduleKoskiUploads
 import fi.espoo.evaka.shared.async.UploadToKoski
 import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
@@ -27,7 +28,7 @@ class KoskiUpdateService(
     private val env: EvakaEnv
 ) {
     init {
-        asyncJobRunner.scheduleKoskiUploads = { db, msg -> scheduleKoskiUploads(db, msg.params) }
+        asyncJobRunner.registerHandler { db, msg: ScheduleKoskiUploads -> scheduleKoskiUploads(db, msg.params) }
     }
 
     fun scheduleKoskiUploads(db: Database, params: KoskiSearchParams) = db.connect {

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
@@ -6,9 +6,8 @@ package fi.espoo.evaka.koski
 
 import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.ScheduleKoskiUploads
-import fi.espoo.evaka.shared.async.UploadToKoski
 import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
@@ -24,11 +23,11 @@ data class KoskiSearchParams(
 
 @Service
 class KoskiUpdateService(
-    private val asyncJobRunner: AsyncJobRunner,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val env: EvakaEnv
 ) {
     init {
-        asyncJobRunner.registerHandler { db, msg: ScheduleKoskiUploads -> scheduleKoskiUploads(db, msg.params) }
+        asyncJobRunner.registerHandler { db, msg: AsyncJob.ScheduleKoskiUploads -> scheduleKoskiUploads(db, msg.params) }
     }
 
     fun scheduleKoskiUploads(db: Database, params: KoskiSearchParams) = db.connect {
@@ -39,7 +38,7 @@ class KoskiUpdateService(
             db.transaction { tx ->
                 val requests = tx.getPendingStudyRights(LocalDate.now(), params)
                 logger.info { "Scheduling ${requests.size} Koski upload requests" }
-                asyncJobRunner.plan(tx, requests.map { UploadToKoski(it) }, retryCount = 1)
+                asyncJobRunner.plan(tx, requests.map { AsyncJob.UploadToKoski(it) }, retryCount = 1)
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageNotificationEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageNotificationEmailService.kt
@@ -24,7 +24,7 @@ class MessageNotificationEmailService(
     emailEnv: EmailEnv
 ) {
     init {
-        asyncJobRunner.sendMessageNotificationEmail = ::sendMessageNotification
+        asyncJobRunner.registerHandler(::sendMessageNotification)
     }
 
     val baseUrl: String = env.frontendBaseUrlFi

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingAsyncJobs.kt
@@ -4,20 +4,20 @@
 
 package fi.espoo.evaka.pairing
 
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GarbageCollectPairing
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.stereotype.Component
 
 @Component
 class PairingAsyncJobs(
-    asyncJobRunner: AsyncJobRunner
+    asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     init {
         asyncJobRunner.registerHandler(::runGarbageCollectPairing)
     }
 
-    private fun runGarbageCollectPairing(db: Database, msg: GarbageCollectPairing) {
+    private fun runGarbageCollectPairing(db: Database, msg: AsyncJob.GarbageCollectPairing) {
         db.transaction {
             it.createUpdate("DELETE FROM pairing WHERE id = :id")
                 .bind("id", msg.pairingId)

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingAsyncJobs.kt
@@ -14,7 +14,7 @@ class PairingAsyncJobs(
     asyncJobRunner: AsyncJobRunner
 ) {
     init {
-        asyncJobRunner.garbageCollectPairing = ::runGarbageCollectPairing
+        asyncJobRunner.registerHandler(::runGarbageCollectPairing)
     }
 
     private fun runGarbageCollectPairing(db: Database, msg: GarbageCollectPairing) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -7,8 +7,8 @@ package fi.espoo.evaka.pairing
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PairingId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GarbageCollectPairing
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class PairingsController(
     private val acl: AccessControlList,
-    private val asyncJobRunner: AsyncJobRunner
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     /**
      * Unit supervisor calls this endpoint as an authorized desktop user to start a new pairing process.
@@ -51,7 +51,7 @@ class PairingsController(
 
             asyncJobRunner.plan(
                 tx = tx,
-                payloads = listOf(GarbageCollectPairing(pairingId = pairing.id)),
+                payloads = listOf(AsyncJob.GarbageCollectPairing(pairingId = pairing.id)),
                 runAt = pairing.expires.plusDays(1)
             )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.pis.getParentships
 import fi.espoo.evaka.pis.service.Parentship
 import fi.espoo.evaka.pis.service.ParentshipService
 import fi.espoo.evaka.shared.ParentshipId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -33,7 +34,7 @@ import java.util.UUID
 @RequestMapping("/parentships")
 class ParentshipController(
     private val parentshipService: ParentshipService,
-    private val asyncJobRunner: AsyncJobRunner
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     @PostMapping
     fun createParentship(

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -54,7 +54,6 @@ class ParentshipController(
             return db.transaction {
                 parentshipService.createParentship(it, childId, headOfChildId, startDate, endDate)
             }
-                .also { asyncJobRunner.scheduleImmediateRun() }
                 .let { ResponseEntity.created(URI.create("/parentships/${it.id}")).body(it) }
         }
     }
@@ -118,7 +117,6 @@ class ParentshipController(
         return db.transaction {
             parentshipService.updateParentshipDuration(it, id, body.startDate, body.endDate)
         }
-            .also { asyncJobRunner.scheduleImmediateRun() }
             .let { ResponseEntity.ok().body(it) }
     }
 
@@ -137,7 +135,6 @@ class ParentshipController(
         )
 
         db.transaction { parentshipService.retryParentship(it, parentshipId) }
-        asyncJobRunner.scheduleImmediateRun()
         return noContent()
     }
 
@@ -157,8 +154,6 @@ class ParentshipController(
 
             parentshipService.deleteParentship(it, id)
         }
-
-        asyncJobRunner.scheduleImmediateRun()
 
         return ResponseEntity.noContent().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
@@ -11,8 +11,8 @@ import fi.espoo.evaka.pis.getPartnershipsForPerson
 import fi.espoo.evaka.pis.service.Partnership
 import fi.espoo.evaka.pis.service.PartnershipService
 import fi.espoo.evaka.shared.PartnershipId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -34,7 +34,7 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/partnerships")
-class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private val partnershipService: PartnershipService) {
+class PartnershipsController(private val asyncJobRunner: AsyncJobRunner<AsyncJob>, private val partnershipService: PartnershipService) {
     @PostMapping
     fun createPartnership(
         db: Database.Connection,
@@ -52,7 +52,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
                     val partnership = partnershipService.createPartnership(tx, personId1, personId2, startDate, endDate)
                     asyncJobRunner.plan(
                         tx,
-                        listOf(GenerateFinanceDecisions.forAdult(personId2, DateRange(startDate, endDate)))
+                        listOf(AsyncJob.GenerateFinanceDecisions.forAdult(personId2, DateRange(startDate, endDate)))
                     )
                     partnership
                 }
@@ -104,7 +104,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
                 asyncJobRunner.plan(
                     tx,
                     listOf(
-                        GenerateFinanceDecisions.forAdult(
+                        AsyncJob.GenerateFinanceDecisions.forAdult(
                             partnership.partners.last().id,
                             DateRange(partnership.startDate, partnership.endDate)
                         )
@@ -130,7 +130,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
                 asyncJobRunner.plan(
                     tx,
                     listOf(
-                        GenerateFinanceDecisions.forAdult(it.partners.first().id, DateRange(it.startDate, it.endDate))
+                        AsyncJob.GenerateFinanceDecisions.forAdult(it.partners.first().id, DateRange(it.startDate, it.endDate))
                     )
                 )
             }
@@ -153,7 +153,7 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner, private
                 asyncJobRunner.plan(
                     tx,
                     partnership.partners.map {
-                        GenerateFinanceDecisions.forAdult(it.id, DateRange(partnership.startDate, partnership.endDate))
+                        AsyncJob.GenerateFinanceDecisions.forAdult(it.id, DateRange(partnership.startDate, partnership.endDate))
                     }
                 )
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
@@ -56,7 +56,6 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner<AsyncJob
                     )
                     partnership
                 }
-                .also { asyncJobRunner.scheduleImmediateRun() }
                 .let { ResponseEntity.created(URI.create("/partnerships/${it.id}")).body(it) }
         }
     }
@@ -112,7 +111,6 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner<AsyncJob
                 )
                 partnership
             }
-            .also { asyncJobRunner.scheduleImmediateRun() }
             .let { ResponseEntity.ok().body(it) }
     }
 
@@ -135,7 +133,6 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner<AsyncJob
                 )
             }
         }
-        asyncJobRunner.scheduleImmediateRun()
         return noContent()
     }
 
@@ -158,7 +155,6 @@ class PartnershipsController(private val asyncJobRunner: AsyncJobRunner<AsyncJob
                 )
             }
         }
-        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.noContent().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.pis.service.PersonPatch
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.pis.service.PersonWithChildrenDTO
 import fi.espoo.evaka.pis.updatePersonContactInfo
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -47,7 +48,7 @@ import java.util.UUID
 class PersonController(
     private val personService: PersonService,
     private val mergeService: MergeService,
-    private val asyncJobRunner: AsyncJobRunner,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val accessControl: AccessControl
 ) {
     @PostMapping

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -228,7 +228,6 @@ class PersonController(
         db.transaction { tx ->
             mergeService.mergePeople(tx, master = body.master, duplicate = body.duplicate)
         }
-        asyncJobRunner.scheduleImmediateRun()
         return ResponseEntity.ok().build()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -32,7 +32,7 @@ class FamilyInitializerService(
     private val logger = KotlinLogging.logger {}
 
     init {
-        asyncJobRunner.initializeFamilyFromApplication = ::handleInitializeFamilyFromApplication
+        asyncJobRunner.registerHandler(::handleInitializeFamilyFromApplication)
     }
 
     fun handleInitializeFamilyFromApplication(db: Database, msg: InitializeFamilyFromApplication) =

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -12,8 +12,8 @@ import fi.espoo.evaka.pis.createPartnership
 import fi.espoo.evaka.pis.getParentships
 import fi.espoo.evaka.pis.getPartnershipsForPerson
 import fi.espoo.evaka.pis.getPersonById
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.InitializeFamilyFromApplication
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.psqlCause
@@ -27,7 +27,7 @@ import java.util.UUID
 @Service
 class FamilyInitializerService(
     private val personService: PersonService,
-    asyncJobRunner: AsyncJobRunner
+    asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -35,10 +35,10 @@ class FamilyInitializerService(
         asyncJobRunner.registerHandler(::handleInitializeFamilyFromApplication)
     }
 
-    fun handleInitializeFamilyFromApplication(db: Database, msg: InitializeFamilyFromApplication) =
+    fun handleInitializeFamilyFromApplication(db: Database, msg: AsyncJob.InitializeFamilyFromApplication) =
         db.connect { handleInitializeFamilyFromApplication(it, msg) }
 
-    fun handleInitializeFamilyFromApplication(db: Database.Connection, msg: InitializeFamilyFromApplication) {
+    fun handleInitializeFamilyFromApplication(db: Database.Connection, msg: AsyncJob.InitializeFamilyFromApplication) {
         val user = msg.user
         val application = db.read { it.fetchApplicationDetails(msg.applicationId) }
         if (application != null) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
@@ -4,8 +4,8 @@
 
 package fi.espoo.evaka.pis.service
 
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.VTJRefresh
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
@@ -20,10 +20,10 @@ private val logger = KotlinLogging.logger {}
 class FridgeFamilyService(
     private val personService: PersonService,
     private val parentshipService: ParentshipService,
-    private val asyncJobRunner: AsyncJobRunner
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
 
-    fun doVTJRefresh(db: Database, msg: VTJRefresh) {
+    fun doVTJRefresh(db: Database, msg: AsyncJob.VTJRefresh) {
         logger.info("Refreshing ${msg.personId} from VTJ")
         val head = db.transaction {
             personService.getPersonWithChildren(

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
@@ -77,7 +77,6 @@ class FridgeFamilyService(
                             endDate = child.dateOfBirth.plusYears(18).minusDays(1)
                         )
                     }
-                    asyncJobRunner.scheduleImmediateRun()
                     logger.info("Child ${child.id} added")
                 } catch (e: Exception) {
                     logger.debug("Ignored the following:", e)

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/MergeService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/MergeService.kt
@@ -5,8 +5,8 @@
 package fi.espoo.evaka.pis.service
 
 import fi.espoo.evaka.pis.getTransferablePersonReferences
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.db.mapPSQLException
@@ -18,7 +18,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 @Service
-class MergeService(private val asyncJobRunner: AsyncJobRunner) {
+class MergeService(private val asyncJobRunner: AsyncJobRunner<AsyncJob>) {
     fun mergePeople(tx: Database.Transaction, master: UUID, duplicate: UUID) {
         // language=sql
         val feeAffectingDatesSQL =
@@ -138,6 +138,6 @@ class MergeService(private val asyncJobRunner: AsyncJobRunner) {
     }
 
     private fun sendFamilyUpdatedMessage(tx: Database.Transaction, adultId: UUID, dateRange: DateRange) {
-        asyncJobRunner.plan(tx, listOf(GenerateFinanceDecisions.forAdult(adultId, dateRange)))
+        asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forAdult(adultId, dateRange)))
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/ParentshipService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/ParentshipService.kt
@@ -11,8 +11,8 @@ import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.pis.retryParentship
 import fi.espoo.evaka.pis.updateParentshipDuration
 import fi.espoo.evaka.shared.ParentshipId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -24,7 +24,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 @Service
-class ParentshipService(private val asyncJobRunner: AsyncJobRunner) {
+class ParentshipService(private val asyncJobRunner: AsyncJobRunner<AsyncJob>) {
     private val logger = KotlinLogging.logger { }
 
     fun createParentship(
@@ -91,7 +91,7 @@ class ParentshipService(private val asyncJobRunner: AsyncJobRunner) {
 
     private fun Database.Transaction.sendFamilyUpdatedMessage(adultId: UUID, startDate: LocalDate, endDate: LocalDate) {
         logger.info("Sending update family message with adult $adultId")
-        asyncJobRunner.plan(this, listOf(GenerateFinanceDecisions.forAdult(adultId, DateRange(startDate, endDate))))
+        asyncJobRunner.plan(this, listOf(AsyncJob.GenerateFinanceDecisions.forAdult(adultId, DateRange(startDate, endDate))))
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
@@ -16,7 +16,7 @@ class VTJBatchRefreshService(
 ) {
 
     init {
-        asyncJobRunner.vtjRefresh = ::doVTJRefresh
+        asyncJobRunner.registerHandler(::doVTJRefresh)
     }
 
     fun doVTJRefresh(db: Database, msg: VTJRefresh) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
@@ -4,22 +4,22 @@
 
 package fi.espoo.evaka.pis.service
 
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.VTJRefresh
 import fi.espoo.evaka.shared.db.Database
 import org.springframework.stereotype.Service
 
 @Service
 class VTJBatchRefreshService(
     private val fridgeFamilyService: FridgeFamilyService,
-    asyncJobRunner: AsyncJobRunner
+    asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
 
     init {
         asyncJobRunner.registerHandler(::doVTJRefresh)
     }
 
-    fun doVTJRefresh(db: Database, msg: VTJRefresh) {
+    fun doVTJRefresh(db: Database, msg: AsyncJob.VTJRefresh) {
         fridgeFamilyService.doVTJRefresh(db, msg)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -14,8 +14,8 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -40,7 +40,7 @@ import java.util.UUID
 class PlacementController(
     private val acl: AccessControlList,
     private val accessControl: AccessControl,
-    private val asyncJobRunner: AsyncJobRunner,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     env: EvakaEnv
 ) {
     private val useFiveYearsOldDaycare = env.fiveYearsOldDaycareEnabled
@@ -129,7 +129,7 @@ class PlacementController(
             )
             asyncJobRunner.plan(
                 tx,
-                listOf(GenerateFinanceDecisions.forChild(body.childId, DateRange(body.startDate, body.endDate)))
+                listOf(AsyncJob.GenerateFinanceDecisions.forChild(body.childId, DateRange(body.startDate, body.endDate)))
             )
         }
 
@@ -152,7 +152,7 @@ class PlacementController(
             asyncJobRunner.plan(
                 tx,
                 listOf(
-                    GenerateFinanceDecisions.forChild(
+                    AsyncJob.GenerateFinanceDecisions.forChild(
                         oldPlacement.childId,
                         DateRange(
                             minOf(body.startDate, oldPlacement.startDate),
@@ -179,7 +179,7 @@ class PlacementController(
             val (childId, startDate, endDate) = tx.cancelPlacement(placementId)
             asyncJobRunner.plan(
                 tx,
-                listOf(GenerateFinanceDecisions.forChild(childId, DateRange(startDate, endDate)))
+                listOf(AsyncJob.GenerateFinanceDecisions.forChild(childId, DateRange(startDate, endDate)))
             )
         }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -132,8 +132,6 @@ class PlacementController(
                 listOf(AsyncJob.GenerateFinanceDecisions.forChild(body.childId, DateRange(body.startDate, body.endDate)))
             )
         }
-
-        asyncJobRunner.scheduleImmediateRun()
     }
 
     @PutMapping("/placements/{placementId}")
@@ -162,8 +160,6 @@ class PlacementController(
                 )
             )
         }
-
-        asyncJobRunner.scheduleImmediateRun()
     }
 
     @DeleteMapping("/placements/{placementId}")
@@ -182,8 +178,6 @@ class PlacementController(
                 listOf(AsyncJob.GenerateFinanceDecisions.forChild(childId, DateRange(startDate, endDate)))
             )
         }
-
-        asyncJobRunner.scheduleImmediateRun()
     }
 
     @PostMapping("/placements/{placementId}/group-placements")

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -16,8 +16,8 @@ import fi.espoo.evaka.serviceneed.findServiceNeedOptionById
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -31,7 +31,7 @@ private val logger = KotlinLogging.logger {}
 
 @Service
 class PlacementPlanService(
-    private val asyncJobRunner: AsyncJobRunner,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     env: EvakaEnv
 ) {
     private val useFiveYearsOldDaycare = env.fiveYearsOldDaycareEnabled
@@ -216,7 +216,7 @@ class PlacementPlanService(
             effectivePeriod = period
         }
         effectivePeriod?.also {
-            asyncJobRunner.plan(tx, listOf(GenerateFinanceDecisions.forChild(childId, it.asDateRange())))
+            asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forChild(childId, it.asDateRange())))
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
@@ -9,8 +9,8 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.GenerateFinanceDecisions
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -227,9 +227,9 @@ fun clearServiceNeedsFromPeriod(tx: Database.Transaction, placementId: Placement
     }
 }
 
-fun notifyServiceNeedUpdated(tx: Database.Transaction, asyncJobRunner: AsyncJobRunner, childRange: ServiceNeedChildRange) {
+fun notifyServiceNeedUpdated(tx: Database.Transaction, asyncJobRunner: AsyncJobRunner<AsyncJob>, childRange: ServiceNeedChildRange) {
     asyncJobRunner.plan(
         tx,
-        listOf(GenerateFinanceDecisions.forChild(childRange.childId, childRange.dateRange.asDateRange()))
+        listOf(AsyncJob.GenerateFinanceDecisions.forChild(childRange.childId, childRange.dateRange.asDateRange()))
     )
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
@@ -30,7 +31,7 @@ import java.time.LocalDate
 @RestController
 class ServiceNeedController(
     private val accessControl: AccessControl,
-    private val asyncJobRunner: AsyncJobRunner
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
 
     data class ServiceNeedCreateRequest(

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -65,8 +65,6 @@ class ServiceNeedController(
                 .let { id -> tx.getServiceNeedChildRange(id) }
                 .let { notifyServiceNeedUpdated(tx, asyncJobRunner, it) }
         }
-        asyncJobRunner.scheduleImmediateRun()
-
         return ResponseEntity.noContent().build()
     }
 
@@ -111,8 +109,6 @@ class ServiceNeedController(
                 )
             )
         }
-        asyncJobRunner.scheduleImmediateRun()
-
         return ResponseEntity.noContent().build()
     }
 
@@ -130,7 +126,6 @@ class ServiceNeedController(
             tx.deleteServiceNeed(id)
             notifyServiceNeedUpdated(tx, asyncJobRunner, childRange)
         }
-        asyncJobRunner.scheduleImmediateRun()
 
         return ResponseEntity.noContent().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -29,31 +29,31 @@ data class AsyncJobType<T : AsyncJobPayload>(val payloadClass: KClass<T>) {
 
     @Suppress("DEPRECATION")
     fun getAllNames(): List<String> = listOf(name) + when (payloadClass) {
-        NotifyServiceNeedUpdated::class -> listOf("SERVICE_NEED_UPDATED")
-        NotifyFamilyUpdated::class -> listOf("FAMILY_UPDATED")
-        NotifyFeeAlterationUpdated::class -> listOf("FEE_ALTERATION_UPDATED")
-        NotifyIncomeUpdated::class -> listOf("INCOME_UPDATED")
-        NotifyDecisionCreated::class -> listOf("DECISION_CREATED")
-        SendDecision::class -> listOf("SEND_DECISION")
-        NotifyPlacementPlanApplied::class -> listOf("PLACEMENT_PLAN_APPLIED")
-        NotifyFeeDecisionApproved::class -> listOf("FEE_DECISION_APPROVED")
-        NotifyFeeDecisionPdfGenerated::class -> listOf("FEE_DECISION_PDF_GENERATED")
-        NotifyVoucherValueDecisionApproved::class -> listOf("VOUCHER_VALUE_DECISION_APPROVED")
-        NotifyVoucherValueDecisionPdfGenerated::class -> listOf("VOUCHER_VALUE_DECISION_PDF_GENERATED")
-        InitializeFamilyFromApplication::class -> listOf("INITIALIZE_FAMILY_FROM_APPLICATION")
-        VTJRefresh::class -> listOf("VTJ_REFRESH")
-        DvvModificationsRefresh::class -> listOf("DVV_MODIFICATIONS_REFRESH")
-        UploadToKoski::class -> listOf("UPLOAD_TO_KOSKI")
-        ScheduleKoskiUploads::class -> listOf("SCHEDULE_KOSKI_UPLOADS")
-        SendApplicationEmail::class -> listOf("SEND_APPLICATION_EMAIL")
-        GarbageCollectPairing::class -> listOf("GARBAGE_COLLECT_PAIRING")
-        VardaUpdate::class -> listOf("VARDA_UPDATE")
-        VardaUpdateV2::class -> listOf("VARDA_UPDATE_V2")
-        SendPendingDecisionEmail::class -> listOf("SEND_PENDING_DECISION_EMAIL")
-        SendMessageNotificationEmail::class -> listOf("SEND_UNREAD_MESSAGE_NOTIFICATION")
-        RunScheduledJob::class -> listOf("RUN_SCHEDULED_JOB")
-        NotifyFeeThresholdsUpdated::class -> listOf("FEE_THRESHOLDS_UPDATED")
-        GenerateFinanceDecisions::class -> listOf("GENERATE_FINANCE_DECISIONS")
+        AsyncJob.NotifyServiceNeedUpdated::class -> listOf("SERVICE_NEED_UPDATED")
+        AsyncJob.NotifyFamilyUpdated::class -> listOf("FAMILY_UPDATED")
+        AsyncJob.NotifyFeeAlterationUpdated::class -> listOf("FEE_ALTERATION_UPDATED")
+        AsyncJob.NotifyIncomeUpdated::class -> listOf("INCOME_UPDATED")
+        AsyncJob.NotifyDecisionCreated::class -> listOf("DECISION_CREATED")
+        AsyncJob.SendDecision::class -> listOf("SEND_DECISION")
+        AsyncJob.NotifyPlacementPlanApplied::class -> listOf("PLACEMENT_PLAN_APPLIED")
+        AsyncJob.NotifyFeeDecisionApproved::class -> listOf("FEE_DECISION_APPROVED")
+        AsyncJob.NotifyFeeDecisionPdfGenerated::class -> listOf("FEE_DECISION_PDF_GENERATED")
+        AsyncJob.NotifyVoucherValueDecisionApproved::class -> listOf("VOUCHER_VALUE_DECISION_APPROVED")
+        AsyncJob.NotifyVoucherValueDecisionPdfGenerated::class -> listOf("VOUCHER_VALUE_DECISION_PDF_GENERATED")
+        AsyncJob.InitializeFamilyFromApplication::class -> listOf("INITIALIZE_FAMILY_FROM_APPLICATION")
+        AsyncJob.VTJRefresh::class -> listOf("VTJ_REFRESH")
+        AsyncJob.DvvModificationsRefresh::class -> listOf("DVV_MODIFICATIONS_REFRESH")
+        AsyncJob.UploadToKoski::class -> listOf("UPLOAD_TO_KOSKI")
+        AsyncJob.ScheduleKoskiUploads::class -> listOf("SCHEDULE_KOSKI_UPLOADS")
+        AsyncJob.SendApplicationEmail::class -> listOf("SEND_APPLICATION_EMAIL")
+        AsyncJob.GarbageCollectPairing::class -> listOf("GARBAGE_COLLECT_PAIRING")
+        AsyncJob.VardaUpdate::class -> listOf("VARDA_UPDATE")
+        AsyncJob.VardaUpdateV2::class -> listOf("VARDA_UPDATE_V2")
+        AsyncJob.SendPendingDecisionEmail::class -> listOf("SEND_PENDING_DECISION_EMAIL")
+        AsyncJob.SendMessageNotificationEmail::class -> listOf("SEND_UNREAD_MESSAGE_NOTIFICATION")
+        AsyncJob.RunScheduledJob::class -> listOf("RUN_SCHEDULED_JOB")
+        AsyncJob.NotifyFeeThresholdsUpdated::class -> listOf("FEE_THRESHOLDS_UPDATED")
+        AsyncJob.GenerateFinanceDecisions::class -> listOf("GENERATE_FINANCE_DECISIONS")
         else -> emptyList()
     }
 
@@ -62,137 +62,139 @@ data class AsyncJobType<T : AsyncJobPayload>(val payloadClass: KClass<T>) {
     }
 }
 
-sealed interface AsyncJobPayload {
+interface AsyncJobPayload {
     val user: AuthenticatedUser?
 }
 
-data class DvvModificationsRefresh(val ssns: List<String>, val requestingUserId: UUID) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class GarbageCollectPairing(val pairingId: PairingId) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class SendApplicationEmail(val guardianId: UUID, val language: Language, val type: ApplicationType = ApplicationType.DAYCARE, val sentWithinPreschoolApplicationPeriod: Boolean? = null) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class SendPendingDecisionEmail(val guardianId: UUID, val email: String, val language: String?, val decisionIds: List<UUID>) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class SendMessageNotificationEmail(val messageRecipientId: UUID, val personEmail: String, val language: Language) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class ScheduleKoskiUploads(val params: KoskiSearchParams) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class UploadToKoski(val key: KoskiStudyRightKey) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-@Deprecated("Use GenerateFinanceDecisions instead")
-data class NotifyPlacementPlanApplied(val childId: UUID, val startDate: LocalDate, val endDate: LocalDate) :
-    AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-@Deprecated("Use GenerateFinanceDecisions instead")
-data class NotifyServiceNeedUpdated(val childId: UUID, val startDate: LocalDate, val endDate: LocalDate?) :
-    AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-@Deprecated("Use GenerateFinanceDecisions instead")
-data class NotifyFamilyUpdated(
-    val adultId: UUID,
-    val startDate: LocalDate,
-    val endDate: LocalDate?
-) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-@Deprecated("Use GenerateFinanceDecisions instead")
-data class NotifyFeeAlterationUpdated(
-    val personId: UUID,
-    val startDate: LocalDate,
-    val endDate: LocalDate?
-) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-@Deprecated("Use GenerateFinanceDecisions instead")
-data class NotifyIncomeUpdated(
-    val personId: UUID,
-    val startDate: LocalDate,
-    val endDate: LocalDate?
-) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class NotifyDecisionCreated(val decisionId: DecisionId, override val user: AuthenticatedUser, val sendAsMessage: Boolean) : AsyncJobPayload
-
-data class SendDecision(
-    val decisionId: DecisionId,
-    @Deprecated(message = "only for backwards compatibility")
-    override val user: AuthenticatedUser? = null
-) : AsyncJobPayload
-
-data class NotifyFeeDecisionApproved(val decisionId: FeeDecisionId) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class NotifyFeeDecisionPdfGenerated(val decisionId: FeeDecisionId) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class NotifyVoucherValueDecisionApproved(val decisionId: VoucherValueDecisionId) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class NotifyVoucherValueDecisionPdfGenerated(val decisionId: VoucherValueDecisionId) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class InitializeFamilyFromApplication(val applicationId: ApplicationId, override val user: AuthenticatedUser) :
-    AsyncJobPayload
-
-data class VTJRefresh(val personId: UUID, val requestingUserId: UUID) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-class VardaUpdate : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-class VardaUpdateV2 : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class RunScheduledJob(val job: ScheduledJob) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class NotifyFeeThresholdsUpdated(val dateRange: DateRange) : AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-}
-
-data class GenerateFinanceDecisions private constructor(val person: Person, val dateRange: DateRange) :
-    AsyncJobPayload {
-    override val user: AuthenticatedUser? = null
-
-    companion object {
-        fun forAdult(personId: UUID, dateRange: DateRange) = GenerateFinanceDecisions(Person.Adult(personId), dateRange)
-        fun forChild(personId: UUID, dateRange: DateRange) = GenerateFinanceDecisions(Person.Child(personId), dateRange)
+sealed interface AsyncJob : AsyncJobPayload {
+    data class DvvModificationsRefresh(val ssns: List<String>, val requestingUserId: UUID) : AsyncJob {
+        override val user: AuthenticatedUser? = null
     }
 
-    @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
-    sealed class Person {
-        data class Adult(val adultId: UUID) : Person()
-        data class Child(val childId: UUID) : Person()
+    data class GarbageCollectPairing(val pairingId: PairingId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class SendApplicationEmail(val guardianId: UUID, val language: Language, val type: ApplicationType = ApplicationType.DAYCARE, val sentWithinPreschoolApplicationPeriod: Boolean? = null) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class SendPendingDecisionEmail(val guardianId: UUID, val email: String, val language: String?, val decisionIds: List<UUID>) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class SendMessageNotificationEmail(val messageRecipientId: UUID, val personEmail: String, val language: Language) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class ScheduleKoskiUploads(val params: KoskiSearchParams) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class UploadToKoski(val key: KoskiStudyRightKey) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    @Deprecated("Use GenerateFinanceDecisions instead")
+    data class NotifyPlacementPlanApplied(val childId: UUID, val startDate: LocalDate, val endDate: LocalDate) :
+        AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    @Deprecated("Use GenerateFinanceDecisions instead")
+    data class NotifyServiceNeedUpdated(val childId: UUID, val startDate: LocalDate, val endDate: LocalDate?) :
+        AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    @Deprecated("Use GenerateFinanceDecisions instead")
+    data class NotifyFamilyUpdated(
+        val adultId: UUID,
+        val startDate: LocalDate,
+        val endDate: LocalDate?
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    @Deprecated("Use GenerateFinanceDecisions instead")
+    data class NotifyFeeAlterationUpdated(
+        val personId: UUID,
+        val startDate: LocalDate,
+        val endDate: LocalDate?
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    @Deprecated("Use GenerateFinanceDecisions instead")
+    data class NotifyIncomeUpdated(
+        val personId: UUID,
+        val startDate: LocalDate,
+        val endDate: LocalDate?
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class NotifyDecisionCreated(val decisionId: DecisionId, override val user: AuthenticatedUser, val sendAsMessage: Boolean) : AsyncJob
+
+    data class SendDecision(
+        val decisionId: DecisionId,
+        @Deprecated(message = "only for backwards compatibility")
+        override val user: AuthenticatedUser? = null
+    ) : AsyncJob
+
+    data class NotifyFeeDecisionApproved(val decisionId: FeeDecisionId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class NotifyFeeDecisionPdfGenerated(val decisionId: FeeDecisionId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class NotifyVoucherValueDecisionApproved(val decisionId: VoucherValueDecisionId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class NotifyVoucherValueDecisionPdfGenerated(val decisionId: VoucherValueDecisionId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class InitializeFamilyFromApplication(val applicationId: ApplicationId, override val user: AuthenticatedUser) :
+        AsyncJob
+
+    data class VTJRefresh(val personId: UUID, val requestingUserId: UUID) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    class VardaUpdate : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    class VardaUpdateV2 : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class RunScheduledJob(val job: ScheduledJob) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class NotifyFeeThresholdsUpdated(val dateRange: DateRange) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class GenerateFinanceDecisions private constructor(val person: Person, val dateRange: DateRange) :
+        AsyncJob {
+        override val user: AuthenticatedUser? = null
+
+        companion object {
+            fun forAdult(personId: UUID, dateRange: DateRange) = GenerateFinanceDecisions(Person.Adult(personId), dateRange)
+            fun forChild(personId: UUID, dateRange: DateRange) = GenerateFinanceDecisions(Person.Child(personId), dateRange)
+        }
+
+        @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+        sealed class Person {
+            data class Adult(val adultId: UUID) : Person()
+            data class Child(val childId: UUID) : Person()
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -19,7 +19,6 @@ import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.job.ScheduledJob
 import java.time.Duration
-import java.time.LocalDate
 import java.util.UUID
 import kotlin.reflect.KClass
 
@@ -29,13 +28,8 @@ data class AsyncJobType<T : AsyncJobPayload>(val payloadClass: KClass<T>) {
 
     @Suppress("DEPRECATION")
     fun getAllNames(): List<String> = listOf(name) + when (payloadClass) {
-        AsyncJob.NotifyServiceNeedUpdated::class -> listOf("SERVICE_NEED_UPDATED")
-        AsyncJob.NotifyFamilyUpdated::class -> listOf("FAMILY_UPDATED")
-        AsyncJob.NotifyFeeAlterationUpdated::class -> listOf("FEE_ALTERATION_UPDATED")
-        AsyncJob.NotifyIncomeUpdated::class -> listOf("INCOME_UPDATED")
         AsyncJob.NotifyDecisionCreated::class -> listOf("DECISION_CREATED")
         AsyncJob.SendDecision::class -> listOf("SEND_DECISION")
-        AsyncJob.NotifyPlacementPlanApplied::class -> listOf("PLACEMENT_PLAN_APPLIED")
         AsyncJob.NotifyFeeDecisionApproved::class -> listOf("FEE_DECISION_APPROVED")
         AsyncJob.NotifyFeeDecisionPdfGenerated::class -> listOf("FEE_DECISION_PDF_GENERATED")
         AsyncJob.NotifyVoucherValueDecisionApproved::class -> listOf("VOUCHER_VALUE_DECISION_APPROVED")
@@ -95,52 +89,11 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
-    @Deprecated("Use GenerateFinanceDecisions instead")
-    data class NotifyPlacementPlanApplied(val childId: UUID, val startDate: LocalDate, val endDate: LocalDate) :
-        AsyncJob {
-        override val user: AuthenticatedUser? = null
-    }
-
-    @Deprecated("Use GenerateFinanceDecisions instead")
-    data class NotifyServiceNeedUpdated(val childId: UUID, val startDate: LocalDate, val endDate: LocalDate?) :
-        AsyncJob {
-        override val user: AuthenticatedUser? = null
-    }
-
-    @Deprecated("Use GenerateFinanceDecisions instead")
-    data class NotifyFamilyUpdated(
-        val adultId: UUID,
-        val startDate: LocalDate,
-        val endDate: LocalDate?
-    ) : AsyncJob {
-        override val user: AuthenticatedUser? = null
-    }
-
-    @Deprecated("Use GenerateFinanceDecisions instead")
-    data class NotifyFeeAlterationUpdated(
-        val personId: UUID,
-        val startDate: LocalDate,
-        val endDate: LocalDate?
-    ) : AsyncJob {
-        override val user: AuthenticatedUser? = null
-    }
-
-    @Deprecated("Use GenerateFinanceDecisions instead")
-    data class NotifyIncomeUpdated(
-        val personId: UUID,
-        val startDate: LocalDate,
-        val endDate: LocalDate?
-    ) : AsyncJob {
-        override val user: AuthenticatedUser? = null
-    }
-
     data class NotifyDecisionCreated(val decisionId: DecisionId, override val user: AuthenticatedUser, val sendAsMessage: Boolean) : AsyncJob
 
-    data class SendDecision(
-        val decisionId: DecisionId,
-        @Deprecated(message = "only for backwards compatibility")
+    data class SendDecision(val decisionId: DecisionId) : AsyncJob {
         override val user: AuthenticatedUser? = null
-    ) : AsyncJob
+    }
 
     data class NotifyFeeDecisionApproved(val decisionId: FeeDecisionId) : AsyncJob {
         override val user: AuthenticatedUser? = null

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.async
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import fi.espoo.evaka.application.ApplicationType
 import fi.espoo.evaka.daycare.domain.Language
@@ -60,6 +61,7 @@ interface AsyncJobPayload {
     val user: AuthenticatedUser?
 }
 
+@JsonIgnoreProperties("asyncJobType") // only present in old jobs in db
 sealed interface AsyncJob : AsyncJobPayload {
     data class DvvModificationsRefresh(val ssns: List<String>, val requestingUserId: UUID) : AsyncJob {
         override val user: AuthenticatedUser? = null

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -126,7 +126,6 @@ class AsyncJobRunner<T : AsyncJobPayload>(private val jdbi: Jdbi) : AutoCloseabl
         }
     }
 
-    @Suppress("DEPRECATION")
     private fun runPendingJob(db: Database.Connection, job: ClaimedJobRef<out T>) {
         val logMeta = mapOf(
             "jobId" to job.jobId,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -7,24 +7,28 @@ package fi.espoo.evaka.shared.config
 import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
+import mu.KotlinLogging
 import org.jdbi.v3.core.Jdbi
 import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationListener
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.event.EventListener
 import java.time.Duration
 
 @Configuration
 class AsyncJobConfig {
     @Bean
-    fun asyncJobRunner(jdbi: Jdbi, evakaEnv: EvakaEnv): AsyncJobRunner<AsyncJob> =
-        AsyncJobRunner(jdbi, disableRunner = evakaEnv.asyncJobRunnerDisabled)
+    fun asyncJobRunner(jdbi: Jdbi): AsyncJobRunner<AsyncJob> = AsyncJobRunner(jdbi)
 
     @Bean
-    fun asyncJobRunnerSchedule(asyncJobRunner: AsyncJobRunner<AsyncJob>) = object {
-        @EventListener
-        fun onApplicationReady(@Suppress("UNUSED_PARAMETER") event: ApplicationReadyEvent) {
-            asyncJobRunner.schedulePeriodicRun(Duration.ofMinutes(1))
+    fun asyncJobRunnerStarter(asyncJobRunner: AsyncJobRunner<AsyncJob>, evakaEnv: EvakaEnv) =
+        ApplicationListener<ApplicationReadyEvent> {
+            val logger = KotlinLogging.logger { }
+            if (evakaEnv.asyncJobRunnerDisabled) {
+                asyncJobRunner.start(Duration.ofMinutes(1))
+                logger.info("Async job runner started")
+            } else {
+                logger.info("Async job runner disabled")
+            }
         }
-    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.shared.config
 
 import fi.espoo.evaka.EvakaEnv
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import org.jdbi.v3.core.Jdbi
 import org.springframework.boot.context.event.ApplicationReadyEvent
@@ -16,11 +17,11 @@ import java.time.Duration
 @Configuration
 class AsyncJobConfig {
     @Bean
-    fun asyncJobRunner(jdbi: Jdbi, evakaEnv: EvakaEnv) =
+    fun asyncJobRunner(jdbi: Jdbi, evakaEnv: EvakaEnv): AsyncJobRunner<AsyncJob> =
         AsyncJobRunner(jdbi, disableRunner = evakaEnv.asyncJobRunnerDisabled)
 
     @Bean
-    fun asyncJobRunnerSchedule(asyncJobRunner: AsyncJobRunner) = object {
+    fun asyncJobRunnerSchedule(asyncJobRunner: AsyncJobRunner<AsyncJob>) = object {
         @EventListener
         fun onApplicationReady(@Suppress("UNUSED_PARAMETER") event: ApplicationReadyEvent) {
             asyncJobRunner.schedulePeriodicRun(Duration.ofMinutes(1))

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/KoskiConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/KoskiConfig.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.shared.config
 import com.github.kittinunf.fuel.core.FuelManager
 import fi.espoo.evaka.KoskiEnv
 import fi.espoo.evaka.koski.KoskiClient
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.context.annotation.Bean
@@ -18,6 +19,6 @@ class KoskiConfig {
     fun koskiClient(
         koskiEnv: ObjectProvider<KoskiEnv>,
         fuel: FuelManager,
-        asyncJobRunner: AsyncJobRunner
+        asyncJobRunner: AsyncJobRunner<AsyncJob>
     ): KoskiClient? = koskiEnv.ifAvailable?.let { KoskiClient(it, fuel, asyncJobRunner) }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/ScheduledJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/ScheduledJobConfig.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.config
 
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.job.JobSchedule
 import fi.espoo.evaka.shared.job.ScheduledJobRunner
@@ -21,7 +22,7 @@ class ScheduledJobConfig {
     @Bean
     fun scheduledJobRunner(
         jdbi: Jdbi,
-        asyncJobRunner: AsyncJobRunner,
+        asyncJobRunner: AsyncJobRunner<AsyncJob>,
         dataSource: DataSource,
         schedule: JobSchedule
     ) = ScheduledJobRunner(jdbi, asyncJobRunner, dataSource, schedule)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledJobTriggerController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledJobTriggerController.kt
@@ -4,8 +4,8 @@
 
 package fi.espoo.evaka.shared.controllers
 
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.RunScheduledJob
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/scheduled")
-class ScheduledJobTriggerController(private val asyncJobRunner: AsyncJobRunner) {
+class ScheduledJobTriggerController(private val asyncJobRunner: AsyncJobRunner<AsyncJob>) {
     @GetMapping(produces = ["text/html"])
     fun form(user: AuthenticatedUser): String {
         user.requireOneOfRoles(UserRole.ADMIN)
@@ -65,7 +65,7 @@ class ScheduledJobTriggerController(private val asyncJobRunner: AsyncJobRunner) 
         user.requireOneOfRoles(UserRole.ADMIN)
 
         db.transaction { tx ->
-            asyncJobRunner.plan(tx, listOf(RunScheduledJob(body.type)), retryCount = 1)
+            asyncJobRunner.plan(tx, listOf(AsyncJob.RunScheduledJob(body.type)), retryCount = 1)
         }
         asyncJobRunner.scheduleImmediateRun()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledJobTriggerController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledJobTriggerController.kt
@@ -67,7 +67,6 @@ class ScheduledJobTriggerController(private val asyncJobRunner: AsyncJobRunner<A
         db.transaction { tx ->
             asyncJobRunner.plan(tx, listOf(AsyncJob.RunScheduledJob(body.type)), retryCount = 1)
         }
-        asyncJobRunner.scheduleImmediateRun()
     }
 
     data class TriggerBody(val type: ScheduledJob)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -66,6 +66,7 @@ import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.PairingId
 import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -111,7 +112,7 @@ private val fakeAdmin = AuthenticatedUser.Employee(
 @RequestMapping("/dev-api")
 class DevApi(
     private val personService: PersonService,
-    private val asyncJobRunner: AsyncJobRunner,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val placementPlanService: PlacementPlanService,
     private val applicationStateService: ApplicationStateService,
     private val decisionService: DecisionService

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunner.kt
@@ -50,7 +50,7 @@ class ScheduledJobRunner(
         db.transaction { tx ->
             asyncJobRunner.plan(tx, listOf(AsyncJob.RunScheduledJob(job)), retryCount = ASYNC_JOB_RETRY_COUNT)
         }
-        asyncJobRunner.scheduleImmediateRun()
+        asyncJobRunner.wakeUp()
     }
 
     fun getScheduledExecutionsForTask(job: ScheduledJob): List<ScheduledExecution<Unit>> =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunner.kt
@@ -7,8 +7,8 @@ package fi.espoo.evaka.shared.job
 import com.github.kagkarlsson.scheduler.ScheduledExecution
 import com.github.kagkarlsson.scheduler.Scheduler
 import com.github.kagkarlsson.scheduler.task.helper.Tasks
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.RunScheduledJob
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.voltti.logging.loggers.info
 import mu.KotlinLogging
@@ -24,7 +24,7 @@ private val logger = KotlinLogging.logger { }
 
 class ScheduledJobRunner(
     private val jdbi: Jdbi,
-    private val asyncJobRunner: AsyncJobRunner,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     dataSource: DataSource,
     schedule: JobSchedule
 ) : AutoCloseable {
@@ -48,7 +48,7 @@ class ScheduledJobRunner(
         val logMeta = mapOf("jobName" to job.name)
         logger.info(logMeta) { "Planning scheduled job ${job.name}" }
         db.transaction { tx ->
-            asyncJobRunner.plan(tx, listOf(RunScheduledJob(job)), retryCount = ASYNC_JOB_RETRY_COUNT)
+            asyncJobRunner.plan(tx, listOf(AsyncJob.RunScheduledJob(job)), retryCount = ASYNC_JOB_RETRY_COUNT)
         }
         asyncJobRunner.scheduleImmediateRun()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -18,8 +18,8 @@ import fi.espoo.evaka.pis.cleanUpInactivePeople
 import fi.espoo.evaka.pis.clearRolesForInactiveEmployees
 import fi.espoo.evaka.placement.deletePlacementPlans
 import fi.espoo.evaka.reports.freezeVoucherValueReportRows
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.RunScheduledJob
 import fi.espoo.evaka.shared.async.removeOldAsyncJobs
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -57,11 +57,11 @@ class ScheduledJobs(
     private val pendingDecisionEmailService: PendingDecisionEmailService,
     private val voucherValueDecisionService: VoucherValueDecisionService,
     private val koskiUpdateService: KoskiUpdateService,
-    asyncJobRunner: AsyncJobRunner
+    asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
 
     init {
-        asyncJobRunner.registerHandler { db, msg: RunScheduledJob ->
+        asyncJobRunner.registerHandler { db, msg: AsyncJob.RunScheduledJob ->
             val logMeta = mapOf("jobName" to msg.job.name)
             logger.info(logMeta) { "Running scheduled job ${msg.job.name}" }
             db.connect { msg.job.fn(this, it) }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.pis.clearRolesForInactiveEmployees
 import fi.espoo.evaka.placement.deletePlacementPlans
 import fi.espoo.evaka.reports.freezeVoucherValueReportRows
 import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.async.RunScheduledJob
 import fi.espoo.evaka.shared.async.removeOldAsyncJobs
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -60,7 +61,7 @@ class ScheduledJobs(
 ) {
 
     init {
-        asyncJobRunner.runScheduledJob = { db, msg ->
+        asyncJobRunner.registerHandler { db, msg: RunScheduledJob ->
             val logMeta = mapOf("jobName" to msg.job.name)
             logger.info(logMeta) { "Running scheduled job ${msg.job.name}" }
             db.connect { msg.job.fn(this, it) }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -10,8 +10,8 @@ import fi.espoo.evaka.VardaEnv
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.VardaUpdate
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.varda.integration.VardaClient
 import fi.espoo.evaka.varda.integration.VardaTokenProvider
@@ -42,7 +42,7 @@ private val logger = KotlinLogging.logger {}
 
 @Service
 class VardaUpdateService(
-    private val asyncJobRunner: AsyncJobRunner,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val tokenProvider: VardaTokenProvider,
     private val fuel: FuelManager,
     private val mapper: ObjectMapper,
@@ -60,11 +60,11 @@ class VardaUpdateService(
             val client = VardaClient(tokenProvider, fuel, mapper, env)
             updateAll(db, client, personService, organizer)
         } else {
-            db.transaction { asyncJobRunner.plan(it, listOf(VardaUpdate()), retryCount = 1) }
+            db.transaction { asyncJobRunner.plan(it, listOf(AsyncJob.VardaUpdate()), retryCount = 1) }
         }
     }
 
-    fun updateAll(db: Database, msg: VardaUpdate) {
+    fun updateAll(db: Database, msg: AsyncJob.VardaUpdate) {
         val client = VardaClient(tokenProvider, fuel, mapper, env)
         db.connect { updateAll(it, client, personService, organizer) }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -52,7 +52,7 @@ class VardaUpdateService(
     private val organizer = env.organizer
 
     init {
-        asyncJobRunner.vardaUpdate = ::updateAll
+        asyncJobRunner.registerHandler(::updateAll)
     }
 
     fun scheduleVardaUpdate(db: Database.Connection, runNow: Boolean = false) {

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
@@ -19,8 +19,8 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.VardaUpdateV2
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.DateRange
@@ -41,7 +41,7 @@ private val logger = KotlinLogging.logger {}
 
 @Service
 class VardaUpdateServiceV2(
-    private val asyncJobRunner: AsyncJobRunner,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val tokenProvider: VardaTokenProvider,
     private val fuel: FuelManager,
     private val mapper: ObjectMapper,
@@ -62,11 +62,11 @@ class VardaUpdateServiceV2(
             updateAllVardaData(db, client, organizer, feeDecisionMinDate)
         } else {
             logger.info("VardaUpdate: scheduling varda update")
-            db.transaction { asyncJobRunner.plan(it, listOf(VardaUpdateV2()), retryCount = 1) }
+            db.transaction { asyncJobRunner.plan(it, listOf(AsyncJob.VardaUpdateV2()), retryCount = 1) }
         }
     }
 
-    fun updateAll(db: Database, msg: VardaUpdateV2) {
+    fun updateAll(db: Database, msg: AsyncJob.VardaUpdateV2) {
         val client = VardaClient(tokenProvider, fuel, mapper, vardaEnv)
         db.connect { updateAllVardaData(it, client, organizer, feeDecisionMinDate) }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceV2.kt
@@ -52,7 +52,7 @@ class VardaUpdateServiceV2(
     private val feeDecisionMinDate = evakaEnv.feeDecisionMinDate
 
     init {
-        asyncJobRunner.vardaUpdateV2 = ::updateAll
+        asyncJobRunner.registerHandler(::updateAll)
     }
 
     fun scheduleVardaUpdate(db: Database.Connection, runNow: Boolean = false) {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- jobs are no longer hard-coded in the AsyncJobRunner implementation
- use payload class directly as "job type"
- move current jobs under sealed `AsyncJob` type