### PR TITLE
EVAKA-4213 Income statement tweaks

### DIFF
--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -531,16 +531,13 @@ function EntrepreneurIncomeSelection({
           }
         />
         <Gap size="L" />
-        <Label>{t.income.entrepreneurIncome.checkupLabel} *</Label>
+        <Label>{t.income.entrepreneurIncome.checkupLabel}</Label>
         <Gap size="s" />
         <Checkbox
           label={t.income.entrepreneurIncome.checkupConsent}
           checked={formData.checkupConsent}
           onChange={(value) => onChange({ ...formData, checkupConsent: value })}
         />
-        {showFormErrors && !formData.checkupConsent && (
-          <AlertBox message={t.income.errors.consentRequired} />
-        )}
         <Gap size="XL" />
         <H3 noMargin>{t.income.entrepreneurIncome.companyInfo}</H3>
         <Gap size="L" />

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -119,10 +119,13 @@ export default React.forwardRef(function IncomeStatementForm(
       <Container>
         <Gap size="s" />
         <ContentArea opaque paddingVertical="L">
-          <FixedSpaceColumn spacing="zero">
-            <H1 noMargin>{t.income.formTitle}</H1>
-            {t.income.formDescription}
-          </FixedSpaceColumn>
+          <ResponsiveFixedSpaceRow>
+            <FixedSpaceColumn spacing="zero">
+              <H1 noMargin>{t.income.formTitle}</H1>
+              {t.income.formDescription}
+            </FixedSpaceColumn>
+            <Confidential>{t.income.confidential}</Confidential>
+          </ResponsiveFixedSpaceRow>
         </ContentArea>
         <Gap size="s" />
         <IncomeTypeSelection
@@ -1034,6 +1037,16 @@ const Indent = styled.div`
 
 const OtherIncomeWrapper = styled.div`
   max-width: 480px;
+`
+
+const ResponsiveFixedSpaceRow = styled(FixedSpaceRow)`
+  @media (max-width: 900px) {
+    display: block;
+  }
+`
+
+const Confidential = styled.div`
+  flex: 0 0 auto;
 `
 
 const LabelError = styled(function ({

--- a/frontend/src/citizen-frontend/income-statements/types/body.ts
+++ b/frontend/src/citizen-frontend/income-statements/types/body.ts
@@ -96,7 +96,6 @@ function validateEntrepreneur(formData: Form.Entrepreneur) {
   const limitedCompany = validateLimitedCompany(formData.limitedCompany)
 
   if (
-    !checkupConsent ||
     fullTime === null ||
     startOfEntrepreneurship === invalid ||
     spouseWorksInCompany === null ||
@@ -120,6 +119,7 @@ function validateEntrepreneur(formData: Form.Entrepreneur) {
     startOfEntrepreneurship,
     spouseWorksInCompany,
     startupGrant,
+    checkupConsent,
     selfEmployed,
     limitedCompany,
     partnership,

--- a/frontend/src/citizen-frontend/income-statements/types/form.ts
+++ b/frontend/src/citizen-frontend/income-statements/types/form.ts
@@ -159,7 +159,7 @@ function mapEntrepreneur(
     startOfEntrepreneurship: entrepreneur.startOfEntrepreneurship.format(),
     spouseWorksInCompany: entrepreneur.spouseWorksInCompany,
     startupGrant: entrepreneur.startupGrant,
-    checkupConsent: true,
+    checkupConsent: entrepreneur.checkupConsent,
     selfEmployed: mapSelfEmployed(entrepreneur.selfEmployed),
     limitedCompany: mapLimitedCompany(entrepreneur.limitedCompany),
     partnership: entrepreneur.partnership,

--- a/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
+++ b/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
@@ -206,7 +206,7 @@ function EntrepreneurIncome({ entrepreneur }: { entrepreneur: Entrepreneur }) {
       />
       <Row
         label={i18n.incomeStatement.kelaInspectionConsent}
-        value={yesno(true)}
+        value={yesno(entrepreneur.checkupConsent)}
       />
       <H3>{i18n.incomeStatement.companyInfoTitle}</H3>
       <Row

--- a/frontend/src/lib-common/api-types/incomeStatement.ts
+++ b/frontend/src/lib-common/api-types/incomeStatement.ts
@@ -65,6 +65,7 @@ export interface Entrepreneur {
   startOfEntrepreneurship: LocalDate
   spouseWorksInCompany: boolean
   startupGrant: boolean
+  checkupConsent: boolean
   selfEmployed: SelfEmployed | null
   limitedCompany: LimitedCompany | null
   partnership: boolean

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1314,6 +1314,13 @@ const en: Translations = {
         <p>* Tähdellä merkityt tiedot ovat pakollisia</p>
       </>
     ),
+    confidential: (
+      <P>
+        <strong>Salassapidettävä</strong>
+        <br />
+        (JulkL 24.1 §:n 23 kohta.
+      </P>
+    ),
     addNew: 'Uusi tuloselvitys',
     incomeInfo: 'Tulotiedot',
     incomesRegisterConsent:

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1528,8 +1528,6 @@ const en: Translations = {
         'Lomakkeelta puuttuu joitakin tarvittavia tietoja tai tiedot ovat virheellisiä. Ole hyvä ja tarkista täyttämäsi tiedot.',
       choose: 'Valitse vaihtoehto',
       chooseAtLeastOne: 'Valitse vähintään yksi vaihtoehto',
-      consentRequired:
-        'Jos suostumusta tulotietojen tarkistamiseen joko kelasta tai tulorekisteristä ei anneta, määrätään maksu puuttuvilla tuloilla korkeimpaan maksuluokkaan',
       deleteFailed: 'Tuloselvitystä ei voitu poistaa'
     },
     table: {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1298,9 +1298,9 @@ const en: Translations = {
     formDescription: (
       <>
         <p>
-          Tuloselvitys liitteineen palautetaan kahden viikon kuluessa hoidon
-          aloittamisesta. Maksu voidaan määrätä puutteellisilla tulotiedoilla
-          korkeimpaan maksuun.
+          Tuloselvitys liitteineen palautetaan kahden viikon kuluessa
+          varhaiskasvatuksen aloittamisesta. Maksu voidaan määrätä
+          puutteellisilla tulotiedoilla korkeimpaan maksuun.
         </p>
         <p>
           Asiakasmaksu peritään päätöksen mukaisesta varhaiskasvatuksen

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1335,13 +1335,13 @@ const en: Translations = {
       <P>
         <strong>Salassapidettävä</strong>
         <br />
-        (JulkL 24.1 §:n 23 kohta.
+        (JulkL 24.1 §:n 23 kohta)
       </P>
     ),
     addNew: 'Uusi tuloselvitys',
     incomeInfo: 'Tulotiedot',
     incomesRegisterConsent:
-      'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan Kelasta sekä tulorekisteristä.',
+      'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan tulorekisteristä, sekä Kelasta tarvittaessa',
     incomeType: {
       description: (
         <>
@@ -1362,10 +1362,10 @@ const en: Translations = {
     grossIncome: {
       title: 'Bruttotulotietojen täyttäminen',
       description:
-        'Valitse alta haluatko toimittaat tulotietosi liitteinä, vai katsooko viranomainen tietosi suoraan Kelasta ja tulorekisteristä.',
+        'Valitse alta haluatko toimittaat tulotietosi liitteinä, vai katsooko viranomainen tietosi suoraan tulorekisteristä sekä Kelasta tarvittaessa.',
       incomeSource: 'Tulotietojen toimitus',
       provideAttachments:
-        'Toimitan tiedot liitteinä ja tietoni saa tarkastaa Kelasta',
+        'Toimitan tiedot liitteinä, ja tietoni saa tarkastaa Kelasta tarvittaessa',
       estimate: 'Arvio bruttotuloistani',
       otherIncome: 'Muut tulot',
       otherIncomeInfo:
@@ -1423,7 +1423,7 @@ const en: Translations = {
         'Yritykseni on saanut starttirahaa. Toimitan starttirahapäätöksen liitteenä.',
       checkupLabel: 'Tietojen tarkastus',
       checkupConsent:
-        'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan Kelasta sekä tulorekisteristä tarvittaessa.',
+        'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan tarvittaessa tulorekisteristä sekä Kelasta.',
       companyInfo: 'Yrityksen tiedot',
       companyForm: 'Yrityksen toimintamuoto',
       selfEmployed: 'Toiminimi',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -6,6 +6,8 @@ import { P } from 'lib-components/typography'
 import React from 'react'
 import { Translations } from 'lib-customizations/citizen'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
+import UnorderedList from 'lib-components/atoms/UnorderedList'
+import { Gap } from 'lib-components/white-space'
 
 const en: Translations = {
   common: {
@@ -1297,21 +1299,36 @@ const en: Translations = {
     formTitle: 'Tulotietojen ilmoitus',
     formDescription: (
       <>
-        <p>
+        <P>
           Tuloselvitys liitteineen palautetaan kahden viikon kuluessa
           varhaiskasvatuksen aloittamisesta. Maksu voidaan määrätä
           puutteellisilla tulotiedoilla korkeimpaan maksuun.
-        </p>
-        <p>
+        </P>
+        <P>
           Asiakasmaksu peritään päätöksen mukaisesta varhaiskasvatuksen
           alkamispäivästä lähtien.
-        </p>
-        <p>
+        </P>
+        <P>
           Asiakkaan on viipymättä ilmoitettava tulojen ja perhekoon muutoksista
           asiakasmaksuyksikköön. Viranomainen on tarvittaessa oikeutettu
           perimään varhaiskasvatusmaksuja myös takautuvasti.
-        </p>
-        <p>* Tähdellä merkityt tiedot ovat pakollisia</p>
+        </P>
+        <P>
+          <strong>Huomioitavaa:</strong>
+        </P>
+        <Gap size="xs" />
+        <UnorderedList>
+          <li>
+            Jos tulosi ylittävät perhekoon mukaisen tulorajan, hyväksy korkein
+            varhaiskasvatusmaksu. Tällöin sinun ei tarvitse selvittää tulojasi
+            lainkaan.
+          </li>
+          <li>
+            Jos perheeseesi kuuluu toinen aikuinen, myös hänen on toimitettava
+            tuloselvitys.
+          </li>
+        </UnorderedList>
+        <P>* Tähdellä merkityt tiedot ovat pakollisia</P>
       </>
     ),
     confidential: (

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1231,9 +1231,9 @@ export default {
     formDescription: (
       <>
         <p>
-          Tuloselvitys liitteineen palautetaan kahden viikon kuluessa hoidon
-          aloittamisesta. Maksu voidaan määrätä puutteellisilla tulotiedoilla
-          korkeimpaan maksuun.
+          Tuloselvitys liitteineen palautetaan kahden viikon kuluessa
+          varhaiskasvatuksen aloittamisesta. Maksu voidaan määrätä
+          puutteellisilla tulotiedoilla korkeimpaan maksuun.
         </p>
         <p>
           Asiakasmaksu peritään päätöksen mukaisesta varhaiskasvatuksen

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -4,7 +4,9 @@
 
 import React from 'react'
 import { P } from 'lib-components/typography'
+import { Gap } from 'lib-components/white-space'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
+import UnorderedList from 'lib-components/atoms/UnorderedList'
 
 export default {
   common: {
@@ -1230,21 +1232,36 @@ export default {
     formTitle: 'Tulotietojen ilmoitus',
     formDescription: (
       <>
-        <p>
+        <P>
           Tuloselvitys liitteineen palautetaan kahden viikon kuluessa
           varhaiskasvatuksen aloittamisesta. Maksu voidaan määrätä
           puutteellisilla tulotiedoilla korkeimpaan maksuun.
-        </p>
-        <p>
+        </P>
+        <P>
           Asiakasmaksu peritään päätöksen mukaisesta varhaiskasvatuksen
           alkamispäivästä lähtien.
-        </p>
-        <p>
+        </P>
+        <P>
           Asiakkaan on viipymättä ilmoitettava tulojen ja perhekoon muutoksista
           asiakasmaksuyksikköön. Viranomainen on tarvittaessa oikeutettu
           perimään varhaiskasvatusmaksuja myös takautuvasti.
-        </p>
-        <p>* Tähdellä merkityt tiedot ovat pakollisia</p>
+        </P>
+        <P>
+          <strong>Huomioitavaa:</strong>
+        </P>
+        <Gap size="xs" />
+        <UnorderedList>
+          <li>
+            Jos tulosi ylittävät perhekoon mukaisen tulorajan, hyväksy korkein
+            varhaiskasvatusmaksu. Tällöin sinun ei tarvitse selvittää tulojasi
+            lainkaan.
+          </li>
+          <li>
+            Jos perheeseesi kuuluu toinen aikuinen, myös hänen on toimitettava
+            tuloselvitys.
+          </li>
+        </UnorderedList>
+        <P>* Tähdellä merkityt tiedot ovat pakollisia</P>
       </>
     ),
     confidential: (

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1247,6 +1247,13 @@ export default {
         <p>* Tähdellä merkityt tiedot ovat pakollisia</p>
       </>
     ),
+    confidential: (
+      <P>
+        <strong>Salassapidettävä</strong>
+        <br />
+        (JulkL 24.1 §:n 23 kohta)
+      </P>
+    ),
     addNew: 'Uusi tuloselvitys',
     incomeInfo: 'Tulotiedot',
     incomesRegisterConsent:

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1461,8 +1461,6 @@ export default {
         'Lomakkeelta puuttuu joitakin tarvittavia tietoja tai tiedot ovat virheellisiä. Ole hyvä ja tarkista täyttämäsi tiedot.',
       choose: 'Valitse vaihtoehto',
       chooseAtLeastOne: 'Valitse vähintään yksi vaihtoehto',
-      consentRequired:
-        'Jos suostumusta tulotietojen tarkistamiseen joko kelasta tai tulorekisteristä ei anneta, määrätään maksu puuttuvilla tuloilla korkeimpaan maksuluokkaan',
       deleteFailed: 'Tuloselvitystä ei voitu poistaa'
     },
     table: {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1274,7 +1274,7 @@ export default {
     addNew: 'Uusi tuloselvitys',
     incomeInfo: 'Tulotiedot',
     incomesRegisterConsent:
-      'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan Kelasta sekä tulorekisteristä.',
+      'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan tulorekisteristä, sekä Kelasta tarvittaessa',
     incomeType: {
       description: (
         <>
@@ -1295,10 +1295,10 @@ export default {
     grossIncome: {
       title: 'Bruttotulotietojen täyttäminen',
       description:
-        'Valitse alta haluatko toimittaat tulotietosi liitteinä, vai katsooko viranomainen tietosi suoraan Kelasta ja tulorekisteristä.',
+        'Valitse alta haluatko toimittaat tulotietosi liitteinä, vai katsooko viranomainen tietosi suoraan tulorekisteristä sekä Kelasta tarvittaessa.',
       incomeSource: 'Tulotietojen toimitus',
       provideAttachments:
-        'Toimitan tiedot liitteinä ja tietoni saa tarkastaa Kelasta',
+        'Toimitan tiedot liitteinä, ja tietoni saa tarkastaa Kelasta tarvittaessa',
       estimate: 'Arvio bruttotuloistani',
       otherIncome: 'Muut tulot',
       otherIncomeInfo:
@@ -1356,7 +1356,7 @@ export default {
         'Yritykseni on saanut starttirahaa. Toimitan starttirahapäätöksen liitteenä.',
       checkupLabel: 'Tietojen tarkastus',
       checkupConsent:
-        'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan Kelasta sekä tulorekisteristä tarvittaessa.',
+        'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan tarvittaessa tulorekisteristä sekä Kelasta.',
       companyInfo: 'Yrityksen tiedot',
       companyForm: 'Yrityksen toimintamuoto',
       selfEmployed: 'Toiminimi',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1244,9 +1244,9 @@ const sv: Translations = {
     formDescription: (
       <>
         <p>
-          Tuloselvitys liitteineen palautetaan kahden viikon kuluessa hoidon
-          aloittamisesta. Maksu voidaan määrätä puutteellisilla tulotiedoilla
-          korkeimpaan maksuun.
+          Tuloselvitys liitteineen palautetaan kahden viikon kuluessa
+          varhaiskasvatuksen aloittamisesta. Maksu voidaan määrätä
+          puutteellisilla tulotiedoilla korkeimpaan maksuun.
         </p>
         <p>
           Asiakasmaksu peritään päätöksen mukaisesta varhaiskasvatuksen

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -6,6 +6,8 @@ import { P } from 'lib-components/typography'
 import React from 'react'
 import { Translations } from 'lib-customizations/citizen'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
+import { Gap } from 'lib-components/white-space'
+import UnorderedList from 'lib-components/atoms/UnorderedList'
 
 const sv: Translations = {
   common: {
@@ -1243,21 +1245,36 @@ const sv: Translations = {
     formTitle: 'Tulotietojen ilmoitus',
     formDescription: (
       <>
-        <p>
+        <P>
           Tuloselvitys liitteineen palautetaan kahden viikon kuluessa
           varhaiskasvatuksen aloittamisesta. Maksu voidaan määrätä
           puutteellisilla tulotiedoilla korkeimpaan maksuun.
-        </p>
-        <p>
+        </P>
+        <P>
           Asiakasmaksu peritään päätöksen mukaisesta varhaiskasvatuksen
           alkamispäivästä lähtien.
-        </p>
-        <p>
+        </P>
+        <P>
           Asiakkaan on viipymättä ilmoitettava tulojen ja perhekoon muutoksista
           asiakasmaksuyksikköön. Viranomainen on tarvittaessa oikeutettu
           perimään varhaiskasvatusmaksuja myös takautuvasti.
-        </p>
-        <p>* Tähdellä merkityt tiedot ovat pakollisia</p>
+        </P>
+        <P>
+          <strong>Huomioitavaa:</strong>
+        </P>
+        <Gap size="xs" />
+        <UnorderedList>
+          <li>
+            Jos tulosi ylittävät perhekoon mukaisen tulorajan, hyväksy korkein
+            varhaiskasvatusmaksu. Tällöin sinun ei tarvitse selvittää tulojasi
+            lainkaan.
+          </li>
+          <li>
+            Jos perheeseesi kuuluu toinen aikuinen, myös hänen on toimitettava
+            tuloselvitys.
+          </li>
+        </UnorderedList>
+        <P>* Tähdellä merkityt tiedot ovat pakollisia</P>
       </>
     ),
     confidential: (

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1474,8 +1474,6 @@ const sv: Translations = {
         'Lomakkeelta puuttuu joitakin tarvittavia tietoja tai tiedot ovat virheellisiä. Ole hyvä ja tarkista täyttämäsi tiedot.',
       choose: 'Valitse vaihtoehto',
       chooseAtLeastOne: 'Valitse vähintään yksi vaihtoehto',
-      consentRequired:
-        'Jos suostumusta tulotietojen tarkistamiseen joko kelasta tai tulorekisteristä ei anneta, määrätään maksu puuttuvilla tuloilla korkeimpaan maksuluokkaan',
       deleteFailed: 'Tuloselvitystä ei voitu poistaa'
     },
     table: {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1260,6 +1260,13 @@ const sv: Translations = {
         <p>* Tähdellä merkityt tiedot ovat pakollisia</p>
       </>
     ),
+    confidential: (
+      <P>
+        <strong>Salassapidettävä</strong>
+        <br />
+        (JulkL 24.1 §:n 23 kohta.
+      </P>
+    ),
     addNew: 'Uusi tuloselvitys',
     incomeInfo: 'Tulotiedot',
     incomesRegisterConsent:

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1281,13 +1281,13 @@ const sv: Translations = {
       <P>
         <strong>Salassapidettävä</strong>
         <br />
-        (JulkL 24.1 §:n 23 kohta.
+        (JulkL 24.1 §:n 23 kohta)
       </P>
     ),
     addNew: 'Uusi tuloselvitys',
     incomeInfo: 'Tulotiedot',
     incomesRegisterConsent:
-      'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan Kelasta sekä tulorekisteristä.',
+      'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan tulorekisteristä, sekä Kelasta tarvittaessa',
     incomeType: {
       description: (
         <>
@@ -1308,10 +1308,10 @@ const sv: Translations = {
     grossIncome: {
       title: 'Bruttotulotietojen täyttäminen',
       description:
-        'Valitse alta haluatko toimittaat tulotietosi liitteinä, vai katsooko viranomainen tietosi suoraan Kelasta ja tulorekisteristä.',
+        'Valitse alta haluatko toimittaat tulotietosi liitteinä, vai katsooko viranomainen tietosi suoraan tulorekisteristä sekä Kelasta tarvittaessa.',
       incomeSource: 'Tulotietojen toimitus',
       provideAttachments:
-        'Toimitan tiedot liitteinä ja tietoni saa tarkastaa Kelasta',
+        'Toimitan tiedot liitteinä, ja tietoni saa tarkastaa Kelasta tarvittaessa',
       estimate: 'Arvio bruttotuloistani',
       otherIncome: 'Muut tulot',
       otherIncomeInfo:
@@ -1369,7 +1369,7 @@ const sv: Translations = {
         'Yritykseni on saanut starttirahaa. Toimitan starttirahapäätöksen liitteenä.',
       checkupLabel: 'Tietojen tarkastus',
       checkupConsent:
-        'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan Kelasta sekä tulorekisteristä tarvittaessa.',
+        'Hyväksyn, että tuloihini liittyviä tietoja tarkastellaan tarvittaessa tulorekisteristä sekä Kelasta.',
       companyInfo: 'Yrityksen tiedot',
       companyForm: 'Yrityksen toimintamuoto',
       selfEmployed: 'Toiminimi',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizenIntegrationTest.kt
@@ -77,6 +77,7 @@ class IncomeStatementControllerCitizenIntegrationTest : FullApplicationTest() {
                     startOfEntrepreneurship = LocalDate.of(1998, 1, 1),
                     spouseWorksInCompany = false,
                     startupGrant = true,
+                    checkupConsent = true,
                     selfEmployed = SelfEmployed(
                         attachments = true,
                         estimatedIncome = EstimatedIncome(
@@ -123,6 +124,7 @@ class IncomeStatementControllerCitizenIntegrationTest : FullApplicationTest() {
                         startOfEntrepreneurship = LocalDate.of(1998, 1, 1),
                         spouseWorksInCompany = false,
                         startupGrant = true,
+                        checkupConsent = true,
                         selfEmployed = SelfEmployed(
                             attachments = true,
                             estimatedIncome = EstimatedIncome(
@@ -199,6 +201,7 @@ class IncomeStatementControllerCitizenIntegrationTest : FullApplicationTest() {
                     startOfEntrepreneurship = LocalDate.of(2000, 1, 1),
                     spouseWorksInCompany = true,
                     startupGrant = true,
+                    checkupConsent = true,
                     selfEmployed = null,
                     limitedCompany = null,
                     partnership = false,
@@ -227,6 +230,7 @@ class IncomeStatementControllerCitizenIntegrationTest : FullApplicationTest() {
                     startOfEntrepreneurship = LocalDate.of(2000, 1, 1),
                     spouseWorksInCompany = true,
                     startupGrant = true,
+                    checkupConsent = true,
                     selfEmployed = null,
                     limitedCompany = null,
                     partnership = true,
@@ -251,6 +255,7 @@ class IncomeStatementControllerCitizenIntegrationTest : FullApplicationTest() {
                     startOfEntrepreneurship = LocalDate.of(2000, 1, 1),
                     spouseWorksInCompany = true,
                     startupGrant = true,
+                    checkupConsent = true,
                     selfEmployed = null,
                     limitedCompany = null,
                     partnership = true,
@@ -390,6 +395,7 @@ class IncomeStatementControllerCitizenIntegrationTest : FullApplicationTest() {
                     startOfEntrepreneurship = LocalDate.of(1998, 1, 1),
                     spouseWorksInCompany = false,
                     startupGrant = true,
+                    checkupConsent = true,
                     selfEmployed = SelfEmployed(
                         attachments = true,
                         estimatedIncome = EstimatedIncome(
@@ -430,6 +436,7 @@ class IncomeStatementControllerCitizenIntegrationTest : FullApplicationTest() {
                     startOfEntrepreneurship = LocalDate.of(2019, 1, 1),
                     spouseWorksInCompany = true,
                     startupGrant = false,
+                    checkupConsent = false,
                     selfEmployed = null,
                     limitedCompany = null,
                     partnership = true,
@@ -462,6 +469,7 @@ class IncomeStatementControllerCitizenIntegrationTest : FullApplicationTest() {
                     startOfEntrepreneurship = LocalDate.of(2019, 1, 1),
                     spouseWorksInCompany = true,
                     startupGrant = false,
+                    checkupConsent = false,
                     selfEmployed = null,
                     limitedCompany = null,
                     partnership = true,

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatement.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatement.kt
@@ -72,6 +72,7 @@ data class Entrepreneur(
     val startOfEntrepreneurship: LocalDate,
     val spouseWorksInCompany: Boolean,
     val startupGrant: Boolean,
+    val checkupConsent: Boolean,
     val selfEmployed: SelfEmployed?,
     val limitedCompany: LimitedCompany?,
     val partnership: Boolean,

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementQueries.kt
@@ -34,6 +34,7 @@ SELECT
     entrepreneur_full_time,
     start_of_entrepreneurship,
     spouse_works_in_company,
+    checkup_consent,
     self_employed_attachments,
     self_employed_estimated_monthly_income,
     self_employed_income_start_date,
@@ -131,6 +132,7 @@ private fun mapIncomeStatement(row: RowView): IncomeStatement {
                 startOfEntrepreneurship = row.mapColumn("start_of_entrepreneurship"),
                 spouseWorksInCompany = row.mapColumn("spouse_works_in_company"),
                 startupGrant = row.mapColumn("startup_grant"),
+                checkupConsent = row.mapColumn("checkup_consent"),
                 selfEmployed = selfEmployed,
                 limitedCompany = limitedCompany,
                 partnership = row.mapColumn("partnership"),
@@ -186,6 +188,7 @@ private fun <This : SqlStatement<This>> SqlStatement<This>.bindIncomeStatementBo
         .bindNullable("startOfEntrepreneurship", null as LocalDate?)
         .bindNullable("spouseWorksInCompany", null as Boolean?)
         .bindNullable("startupGrant", null as Boolean?)
+        .bindNullable("checkupConsent", null as Boolean?)
         .bindNullable("selfEmployedAttachments", null as Boolean?)
         .bindNullable("selfEmployedEstimatedMonthlyIncome", null as Int?)
         .bindNullable("selfEmployedIncomeStartDate", null as LocalDate?)
@@ -232,6 +235,7 @@ private fun <This : SqlStatement<This>> SqlStatement<This>.bindEntrepreneur(entr
         .bind("startOfEntrepreneurship", entrepreneur.startOfEntrepreneurship)
         .bind("spouseWorksInCompany", entrepreneur.spouseWorksInCompany)
         .bind("startupGrant", entrepreneur.startupGrant)
+        .bind("checkupConsent", entrepreneur.checkupConsent)
         .bind("partnership", entrepreneur.partnership)
         .bind("lightEntrepreneur", entrepreneur.lightEntrepreneur)
         .run { if (entrepreneur.accountant != null) bindAccountant(entrepreneur.accountant) else this }
@@ -274,6 +278,7 @@ INSERT INTO income_statement (
     start_of_entrepreneurship,
     spouse_works_in_company,
     startup_grant,
+    checkup_consent,
     self_employed_attachments,
     self_employed_estimated_monthly_income,
     self_employed_income_start_date, 
@@ -302,6 +307,7 @@ INSERT INTO income_statement (
     :startOfEntrepreneurship,
     :spouseWorksInCompany,
     :startupGrant,
+    :checkupConsent,
     :selfEmployedAttachments,
     :selfEmployedEstimatedMonthlyIncome,
     :selfEmployedIncomeStartDate,
@@ -346,6 +352,7 @@ UPDATE income_statement SET
     start_of_entrepreneurship = :startOfEntrepreneurship,
     spouse_works_in_company = :spouseWorksInCompany,
     startup_grant = :startupGrant,
+    checkup_consent = :checkupConsent,
     self_employed_attachments = :selfEmployedAttachments,
     self_employed_estimated_monthly_income = :selfEmployedEstimatedMonthlyIncome,
     self_employed_income_start_date = :selfEmployedIncomeStartDate,

--- a/service/src/main/resources/db/migration/V138__income_statement_checkup_consent.sql
+++ b/service/src/main/resources/db/migration/V138__income_statement_checkup_consent.sql
@@ -1,0 +1,4 @@
+ALTER TABLE income_statement ADD COLUMN checkup_consent boolean;
+
+-- This selection used to be mandatory, so set it to true for existing rows that have entrepreneur selected.
+UPDATE income_statement SET checkup_consent = true WHERE entrepreneur_full_time IS NOT NULL;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -135,3 +135,4 @@ V134__income_statement.sql
 V135__remove_varda_service_need_option.sql
 V136__income_statement_handler.sql
 V137__service_need_confirmed_by_nullable.sql
+V138__income_statement_checkup_consent.sql


### PR DESCRIPTION
#### Summary

- Make incomes register / kela consent optional in entrepreneur info
- Change Kela wording: A Kela checkup is not done for everyone
- Add a recommendation to accept the highest fee
- Add a note about the partner's responsibility to fill the income statement form, too
- Add a legal disclaimer about confidentiality