### PR TITLE
EVAKA-4190: Refactor messaging, UI improvements and bugfixes

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { useTranslation } from 'citizen-frontend/localization'
 import {
   getReceivers,
   sendMessage,
@@ -51,11 +52,12 @@ export default React.memo(function MessagesPage() {
   const [receivers, setReceivers] = useState<Result<MessageAccount[]>>(
     Loading.of()
   )
+  const t = useTranslation()
   const loadReceivers = useRestApi(getReceivers, setReceivers)
 
   useEffect(() => {
-    loadReceivers()
-  }, [loadReceivers])
+    loadReceivers(t.messages.staffAnnotation)
+  }, [loadReceivers, t.messages.staffAnnotation])
 
   return (
     <FullHeightContainer>

--- a/frontend/src/citizen-frontend/messages/ThreadList.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadList.tsx
@@ -21,7 +21,7 @@ import { MessageContext } from './state'
 import ThreadListItem from './ThreadListItem'
 
 const hasUnreadMessages = (thread: MessageThread, accountId: UUID) =>
-  thread.messages.some((m) => !m.readAt && m.senderId !== accountId)
+  thread.messages.some((m) => !m.readAt && m.sender.id !== accountId)
 
 interface Props {
   accountId: UUID

--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -28,7 +28,7 @@ export default React.memo(function ThreadListItem({
 }: Props) {
   const i18n = useTranslation()
   const lastMessage = thread.messages[thread.messages.length - 1]
-  const participants = [...new Set(thread.messages.map((t) => t.senderName))]
+  const participants = [...new Set(thread.messages.map((t) => t.sender.name))]
   return (
     <Container
       isRead={!hasUnreadMessages}

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -6,7 +6,13 @@ import { UUID } from 'lib-common/types'
 import { H2 } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
-import React, { useCallback, useContext, useMemo, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
 import styled from 'styled-components'
 import { Message, MessageThread } from 'lib-common/api-types/messaging/message'
 import { MessageReplyEditor } from 'lib-components/molecules/MessageReplyEditor'
@@ -65,7 +71,7 @@ function Message({
         </TitleRow>
       )}
       <TitleRow>
-        <SenderName>{message.senderName}</SenderName>
+        <SenderName>{message.sender.name}</SenderName>
         <SentDate>{formatDate(message.sentAt)}</SentDate>
       </TitleRow>
       <span>{message.recipients.map((r) => r.name).join(', ')}</span>
@@ -101,6 +107,8 @@ export default React.memo(function ThreadView({
   const { onToggleRecipient, recipients } = useRecipients(messages, accountId)
   const [replyEditorVisible, setReplyEditorVisible] = useState<boolean>(false)
 
+  useEffect(() => setReplyEditorVisible(false), [threadId])
+
   const onUpdateContent = useCallback(
     (content) => setReplyContent(threadId, content),
     [setReplyContent, threadId]
@@ -111,7 +119,10 @@ export default React.memo(function ThreadView({
     sendReply({
       content: replyContent,
       messageId: messages.slice(-1)[0].id,
-      recipientAccountIds: recipients.filter((r) => r.selected).map((r) => r.id)
+      recipientAccountIds: recipients
+        .filter((r) => r.selected)
+        .map((r) => r.id),
+      staffAnnotation: i18n.messages.staffAnnotation
     })
 
   const editorLabels = useMemo(

--- a/frontend/src/e2e-playwright/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-playwright/specs/7_messaging/messaging.spec.ts
@@ -187,7 +187,7 @@ describe('Sending and receiving messages', () => {
   test('Citizen sends message to the unit supervisor and the group', async () => {
     const title = 'Otsikko'
     const content = 'Testiviestin sisältö'
-    const receivers = ['Esimies Essi', 'Kosmiset vakiot']
+    const receivers = ['Esimies Essi', 'Kosmiset vakiot (Henkilökunta)']
     await citizenPage.goto(config.enduserMessagesUrl)
     const citizenMessagesPage = new CitizenMessagesPage(citizenPage)
     await citizenMessagesPage.sendNewMessage(title, content, receivers)

--- a/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
+++ b/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
@@ -3,14 +3,15 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode, useContext, useState } from 'react'
 import styled from 'styled-components'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faChevronDown, faChevronUp } from 'lib-icons'
 import MessageBox, { MessageBoxRow } from './MessageBox'
-import { GroupMessageAccount } from './types'
+import { NestedGroupMessageAccount, NestedMessageAccount } from './types'
 import { AccountView, messageBoxes } from './types-view'
+import { MessageContext } from 'employee-frontend/components/messages/MessageContext'
 
 const AccountContainer = styled.div`
   margin: 12px 0;
@@ -64,23 +65,32 @@ export default function GroupMessageAccountList({
   activeView,
   setView
 }: {
-  accounts: GroupMessageAccount[]
+  accounts: NestedGroupMessageAccount[]
   activeView: AccountView | undefined
   setView: (view: AccountView) => void
 }) {
+  const { unreadCountsByAccount } = useContext(MessageContext)
+  const startCollapsed = (nestedAccount: NestedMessageAccount, i: number) =>
+    i > 0 &&
+    ((unreadCountsByAccount.isSuccess &&
+      !unreadCountsByAccount.value.find(
+        (x) => x.accountId === nestedAccount.account.id
+      )?.unreadCount) ||
+      !unreadCountsByAccount.isSuccess)
+
   return (
     <CollapsibleMessageBoxesContainer>
-      {accounts.map((acc, i) => (
+      {accounts.map((nestedAcc, i) => (
         <CollapsibleRow
-          key={acc.id}
-          startCollapsed={i > 0 && !acc.unreadCount}
-          title={acc.daycareGroup.name}
+          key={nestedAcc.account.id}
+          startCollapsed={startCollapsed(nestedAcc, i)}
+          title={nestedAcc.daycareGroup.name}
         >
           {messageBoxes.map((view) => (
             <MessageBox
               key={view}
               view={view}
-              account={acc}
+              account={nestedAcc.account}
               activeView={activeView}
               setView={setView}
             />

--- a/frontend/src/employee-frontend/components/messages/MessageBox.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageBox.tsx
@@ -2,13 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { useContext } from 'react'
 import styled from 'styled-components'
 import { espooBrandColors } from 'lib-customizations/common'
 import { defaultMargins } from 'lib-components/white-space'
 import { useTranslation } from '../../state/i18n'
-import { MessageAccount } from './types'
 import { AccountView, View } from './types-view'
+import { MessageContext } from 'employee-frontend/components/messages/MessageContext'
+import { MessageAccount } from 'lib-common/api-types/messaging/message'
 
 export const MessageBoxRow = styled.div<{ active: boolean }>`
   cursor: pointer;
@@ -39,16 +40,23 @@ export default function MessageBox({
   view
 }: MessageBoxProps) {
   const { i18n } = useTranslation()
+  const { unreadCountsByAccount } = useContext(MessageContext)
   const active = view == activeView?.view && account.id == activeView.account.id
+  const unreadCount =
+    (unreadCountsByAccount.isSuccess
+      ? unreadCountsByAccount.value.find(
+          ({ accountId }) => accountId === account.id
+        )?.unreadCount
+      : null) || 0
   return (
     <MessageBoxRow
-      onClick={() => setView({ account, view })}
+      onClick={() => setView({ account: account, view: view })}
       active={active}
       data-qa={`message-box-row-${view}`}
     >
       {i18n.messages.messageBoxes.names[view]}{' '}
-      {view === 'RECEIVED' && account.unreadCount > 0 && (
-        <UnreadCount>{account.unreadCount}</UnreadCount>
+      {view === 'RECEIVED' && unreadCount > 0 && (
+        <UnreadCount>{unreadCount}</UnreadCount>
       )}
     </MessageBoxRow>
   )

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -27,22 +27,28 @@ import React, {
 import { UUID } from '../../types'
 import {
   getMessageDrafts,
-  getMessagingAccounts,
+  getMessagingAccounts as getNestedMessagingAccounts,
   getReceivedMessages,
   getSentMessages,
+  getUnreadCounts,
   markThreadRead,
   replyToThread,
   ReplyToThreadParams
 } from './api'
-import { DraftContent, MessageAccount, SentMessage } from './types'
+import {
+  DraftContent,
+  NestedMessageAccount,
+  SentMessage,
+  UnreadCountByAccount
+} from './types'
 import { AccountView } from './types-view'
 
 const PAGE_SIZE = 20
 type RepliesByThread = Record<UUID, string>
 
 export interface MessagesState {
-  accounts: Result<MessageAccount[]>
-  loadAccounts: () => void
+  nestedAccounts: Result<NestedMessageAccount[]>
+  loadNestedAccounts: () => void
   selectedDraft: DraftContent | undefined
   setSelectedDraft: (draft: DraftContent | undefined) => void
   selectedAccount: AccountView | undefined
@@ -63,11 +69,12 @@ export interface MessagesState {
   setReplyContent: (threadId: UUID, content: string) => void
   getReplyContent: (threadId: UUID) => string
   refreshMessages: (account?: UUID) => void
+  unreadCountsByAccount: Result<UnreadCountByAccount[]>
 }
 
 const defaultState: MessagesState = {
-  accounts: Loading.of(),
-  loadAccounts: () => undefined,
+  nestedAccounts: Loading.of(),
+  loadNestedAccounts: () => undefined,
   selectedDraft: undefined,
   setSelectedDraft: () => undefined,
   selectedAccount: undefined,
@@ -87,7 +94,8 @@ const defaultState: MessagesState = {
   replyState: undefined,
   getReplyContent: () => '',
   setReplyContent: () => undefined,
-  refreshMessages: () => undefined
+  refreshMessages: () => undefined,
+  unreadCountsByAccount: Loading.of()
 }
 
 export const MessageContext = createContext<MessagesState>(defaultState)
@@ -112,16 +120,32 @@ export const MessageContextProvider = React.memo(
     const [selectedUnit, setSelectedUnit] = useState<SelectOption | undefined>()
     const { loggedIn } = useContext(UserContext)
 
-    const [accounts, setAccounts] = useState<Result<MessageAccount[]>>(
-      Loading.of()
+    const [nestedAccounts, setNestedMessagingAccounts] = useState<
+      Result<NestedMessageAccount[]>
+    >(Loading.of())
+
+    const [unreadCountsByAccount, setUnreadCountsByAccount] = useState<
+      Result<UnreadCountByAccount[]>
+    >(Loading.of())
+
+    const getNestedAccounts = useRestApi(
+      getNestedMessagingAccounts,
+      setNestedMessagingAccounts
+    )
+    const loadNestedAccounts = useDebouncedCallback(getNestedAccounts, 100)
+
+    const loadUnreadCounts = useRestApi(
+      getUnreadCounts,
+      setUnreadCountsByAccount
     )
 
-    const getAccounts = useRestApi(getMessagingAccounts, setAccounts)
-    const loadAccounts = useDebouncedCallback(getAccounts, 100)
+    useEffect(() => {
+      loggedIn ? loadNestedAccounts() : null
+    }, [loadNestedAccounts, loggedIn])
 
     useEffect(() => {
-      loggedIn ? loadAccounts() : null
-    }, [loadAccounts, loggedIn])
+      loggedIn ? loadUnreadCounts() : null
+    }, [loadUnreadCounts, loggedIn])
 
     const [selectedAccount, setSelectedAccount] = useState<AccountView>()
     const [selectedDraft, setSelectedDraft] = useState(
@@ -231,7 +255,6 @@ export const MessageContextProvider = React.memo(
       },
       [loadMessages, selectedAccount]
     )
-
     const selectThread = useCallback(
       (thread: MessageThread | undefined) => {
         setSelectedThread(thread)
@@ -239,32 +262,36 @@ export const MessageContextProvider = React.memo(
         if (!selectedAccount) throw new Error('Should never happen')
 
         const { id: accountId } = selectedAccount.account
-        const unreadCount = thread.messages.reduce(
-          (sum, m) => (!m.readAt && m.senderId !== accountId ? sum + 1 : sum),
+        const threadUnreadCount = thread.messages.reduce(
+          (sum, m) => (!m.readAt && m.sender.id !== accountId ? sum + 1 : sum),
           0
         )
-        if (unreadCount > 0) {
-          setAccounts((state) =>
-            state.map((accounts) =>
-              accounts.map((acc) =>
-                acc.id === accountId
-                  ? { ...acc, unreadCount: acc.unreadCount - unreadCount }
-                  : acc
+        if (threadUnreadCount > 0) {
+          setUnreadCountsByAccount((request) =>
+            request.map((result) =>
+              result.map(({ accountId: acc, unreadCount }) =>
+                acc === accountId
+                  ? {
+                      accountId: acc,
+                      unreadCount: unreadCount - threadUnreadCount
+                    }
+                  : { accountId: acc, unreadCount }
               )
             )
           )
-          void markThreadRead(accountId, thread.id).then(() =>
-            refreshMessages(accountId)
-          )
         }
+
+        void markThreadRead(accountId, thread.id).then(() =>
+          refreshMessages(accountId)
+        )
       },
-      [refreshMessages, selectedAccount]
+      [refreshMessages, selectedAccount, setUnreadCountsByAccount]
     )
 
     const value = useMemo(
       () => ({
-        accounts,
-        loadAccounts,
+        nestedAccounts,
+        loadNestedAccounts,
         selectedDraft,
         setSelectedDraft,
         selectedAccount,
@@ -284,11 +311,12 @@ export const MessageContextProvider = React.memo(
         sendReply,
         getReplyContent,
         setReplyContent,
-        refreshMessages
+        refreshMessages,
+        unreadCountsByAccount
       }),
       [
-        accounts,
-        loadAccounts,
+        nestedAccounts,
+        loadNestedAccounts,
         selectedDraft,
         selectedAccount,
         selectedUnit,
@@ -304,7 +332,8 @@ export const MessageContextProvider = React.memo(
         sendReply,
         getReplyContent,
         setReplyContent,
-        refreshMessages
+        refreshMessages,
+        unreadCountsByAccount
       ]
     )
 

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -34,8 +34,8 @@ const PanelContainer = styled.div`
 
 export default function MessagesPage() {
   const {
-    accounts,
-    loadAccounts,
+    nestedAccounts,
+    loadNestedAccounts,
     selectedDraft,
     setSelectedDraft,
     selectedAccount,
@@ -44,25 +44,30 @@ export default function MessagesPage() {
     refreshMessages
   } = useContext(MessageContext)
 
-  useEffect(() => loadAccounts(), [loadAccounts])
+  useEffect(() => loadNestedAccounts(), [loadNestedAccounts])
   useEffect(() => refreshMessages(), [refreshMessages])
 
   // pre-select first account on page load and on unit change
   useEffect(() => {
-    if (!accounts.isSuccess) {
+    if (!nestedAccounts.isSuccess) {
       return
     }
-    const { value: data } = accounts
+    const { value: data } = nestedAccounts
     const unitSelectionChange =
       selectedAccount &&
-      !data.find((account) => account.id === selectedAccount.account.id)
+      !data.find(
+        (nestedAccount) =>
+          nestedAccount.account.id === selectedAccount.account.id
+      )
     if ((!selectedAccount || unitSelectionChange) && data.length > 0) {
       setSelectedAccount({
         view: 'RECEIVED',
-        account: data.find((a) => a.type === 'PERSONAL') || data[0]
+        account:
+          data.find((a) => a.account.type === 'PERSONAL')?.account ||
+          data[0].account
       })
     }
-  }, [accounts, setSelectedAccount, selectedAccount])
+  }, [nestedAccounts, setSelectedAccount, selectedAccount])
 
   const [showEditor, setShowEditor] = useState<boolean>(false)
 
@@ -134,7 +139,7 @@ export default function MessagesPage() {
           />
         )}
         {showEditor &&
-          accounts.isSuccess &&
+          nestedAccounts.isSuccess &&
           selectedReceivers &&
           selectedAccount &&
           selectedUnit && (
@@ -143,7 +148,7 @@ export default function MessagesPage() {
                 value: selectedAccount.account.id,
                 label: selectedAccount.account.name
               }}
-              accounts={accounts.value}
+              accounts={nestedAccounts.value}
               selectedUnit={selectedUnit}
               availableReceivers={selectedReceivers}
               onSend={onSend}

--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -75,7 +75,7 @@ function Message({
         </TitleRow>
       )}
       <TitleRow>
-        <SenderName>{message.senderName}</SenderName>
+        <SenderName>{message.sender.name}</SenderName>
         <SentDate>{formatDate(message.sentAt, DATE_FORMAT_DATE_TIME)}</SentDate>
       </TitleRow>
       <span>{message.recipients.map((r) => r.name).join(', ')}</span>
@@ -129,7 +129,7 @@ export function SingleThreadView({
       accountId
     })
 
-  const canReply = type === 'MESSAGE' || messages[0].senderId === accountId
+  const canReply = type === 'MESSAGE' || messages[0].sender.id === accountId
   const editorLabels = useMemo(
     () => ({
       add: i18n.common.add,

--- a/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
@@ -26,7 +26,7 @@ const getUniqueParticipants: (t: MessageThread) => string[] = (
 ) =>
   Object.values(
     t.messages.reduce((acc, msg) => {
-      acc[msg.senderId] = msg.senderName
+      acc[msg.sender.id] = msg.sender.name
       msg.recipients.forEach((rec) => (acc[rec.id] = rec.name))
       return acc
     }, {})
@@ -97,7 +97,7 @@ export default React.memo(function ThreadListContainer({
     title: thread.title,
     content: thread.messages[thread.messages.length - 1].content,
     participants: getUniqueParticipants(thread),
-    unread: thread.messages.some((m) => !m.readAt && m.senderId != account.id),
+    unread: thread.messages.some((m) => !m.readAt && m.sender.id != account.id),
     onClick: () => selectThread(thread),
     type: thread.type,
     timestamp: thread.messages[thread.messages.length - 1].sentAt,
@@ -114,10 +114,9 @@ export default React.memo(function ThreadListContainer({
       messages: [
         {
           id: message.contentId,
-          senderId: account.id,
+          sender: { ...account },
           sentAt: message.sentAt,
-          senderName: account.name,
-          recipients: message.recipients,
+          recipients: message.recipients.map((r) => ({ ...r.account })),
           readAt: new Date(),
           content: message.content
         }

--- a/frontend/src/employee-frontend/components/messages/api.ts
+++ b/frontend/src/employee-frontend/components/messages/api.ts
@@ -17,10 +17,11 @@ import {
   deserializeReceiverChild,
   deserializeSentMessage,
   DraftContent,
-  MessageAccount,
+  NestedMessageAccount,
   MessageBody,
   ReceiverGroup,
   SentMessage,
+  UnreadCountByAccount,
   UpsertableDraftContent
 } from './types'
 
@@ -43,10 +44,19 @@ export async function getReceivers(
 }
 
 export async function getMessagingAccounts(): Promise<
-  Result<MessageAccount[]>
+  Result<NestedMessageAccount[]>
 > {
   return client
-    .get<JsonOf<MessageAccount[]>>('/messages/my-accounts')
+    .get<JsonOf<NestedMessageAccount[]>>('/messages/my-accounts')
+    .then(({ data }) => Success.of(data))
+    .catch((e) => Failure.fromError(e))
+}
+
+export async function getUnreadCounts(): Promise<
+  Result<UnreadCountByAccount[]>
+> {
+  return client
+    .get<JsonOf<UnreadCountByAccount[]>>('/messages/unread')
     .then(({ data }) => Success.of(data))
     .catch((e) => Failure.fromError(e))
 }
@@ -63,7 +73,7 @@ export async function getReceivedMessages(
     .then(({ data }) =>
       Success.of({
         ...data,
-        data: data.data.map(deserializeMessageThread)
+        data: data.data.map((d) => deserializeMessageThread(d))
       })
     )
     .catch((e) => Failure.fromError(e))

--- a/frontend/src/employee-frontend/components/messages/types-view.ts
+++ b/frontend/src/employee-frontend/components/messages/types-view.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { MessageAccount } from './types'
+import { MessageAccount } from 'lib-common/api-types/messaging/message'
 
 export type View = 'RECEIVED' | 'SENT' | 'RECEIVERS' | 'DRAFTS'
 

--- a/frontend/src/employee-frontend/components/messages/types.ts
+++ b/frontend/src/employee-frontend/components/messages/types.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { MessageAccount as BaseMessageAccount } from 'lib-common/api-types/messaging/message'
+import { MessageAccount } from 'lib-common/api-types/messaging/message'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from '../../types'
@@ -15,6 +15,11 @@ export interface Recipient {
   guardian: boolean
   headOfChild: boolean
   blocklisted: boolean
+}
+
+export type UnreadCountByAccount = {
+  accountId: UUID
+  unreadCount: number
 }
 
 export interface ReceiverChild {
@@ -42,14 +47,10 @@ export const deserializeReceiverChild = (
   childDateOfBirth: LocalDate.parseIso(json.childDateOfBirth)
 })
 
-interface AccountWithUnreadCount extends BaseMessageAccount {
-  unreadCount: number
+export interface NestedMessageAccount {
+  account: MessageAccount
 }
-export interface PersonalMessageAccount extends AccountWithUnreadCount {
-  type: 'PERSONAL'
-}
-export interface GroupMessageAccount extends AccountWithUnreadCount {
-  type: 'GROUP'
+export interface NestedGroupMessageAccount extends NestedMessageAccount {
   daycareGroup: {
     id: UUID
     name: string
@@ -57,15 +58,6 @@ export interface GroupMessageAccount extends AccountWithUnreadCount {
     unitName: string
   }
 }
-export type MessageAccount = PersonalMessageAccount | GroupMessageAccount
-
-export const isGroupMessageAccount = (
-  acc: MessageAccount
-): acc is GroupMessageAccount => acc.type === 'GROUP'
-
-export const isPersonalMessageAccount = (
-  acc: MessageAccount
-): acc is PersonalMessageAccount => acc.type === 'PERSONAL'
 
 export interface MessageBody {
   title: string
@@ -99,7 +91,7 @@ export interface SentMessage {
   type: MessageType
   threadTitle: string
   content: string
-  recipients: MessageAccount[]
+  recipients: NestedMessageAccount[]
   recipientNames: string[]
   sentAt: Date
 }

--- a/frontend/src/lib-common/api-types/messaging/message.ts
+++ b/frontend/src/lib-common/api-types/messaging/message.ts
@@ -6,24 +6,45 @@ import { JsonOf } from '../../json'
 import { UUID } from '../../types'
 import { MessageType } from 'lib-common/generated/enums'
 
+type AccountType = 'PERSONAL' | 'GROUP' | 'CITIZEN'
+
 export interface MessageAccount {
   id: UUID
   name: string
+  type: AccountType
 }
 
 export interface Message {
   id: UUID
-  senderId: UUID
-  senderName: string
+  sender: MessageAccount
   recipients: MessageAccount[]
   sentAt: Date
   readAt: Date | null
   content: string
 }
-export const deserializeMessage = (m: JsonOf<Message>): Message => ({
-  ...m,
-  sentAt: new Date(m.sentAt),
-  readAt: m.readAt ? new Date(m.readAt) : null
+
+export const deserializeMessageAccount = (
+  account: JsonOf<MessageAccount>,
+  staffAnnotation?: string
+): MessageAccount => ({
+  ...account,
+  name:
+    account.type === 'GROUP' && staffAnnotation
+      ? `${account.name} (${staffAnnotation})`
+      : account.name
+})
+
+export const deserializeMessage = (
+  message: JsonOf<Message>,
+  staffAnnotation?: string
+): Message => ({
+  ...message,
+  sender: deserializeMessageAccount(message.sender, staffAnnotation),
+  recipients: message.recipients.map((a) =>
+    deserializeMessageAccount(a, staffAnnotation)
+  ),
+  sentAt: new Date(message.sentAt),
+  readAt: message.readAt ? new Date(message.readAt) : null
 })
 
 export interface MessageThread {
@@ -33,20 +54,21 @@ export interface MessageThread {
   messages: Message[]
 }
 export const deserializeMessageThread = (
-  json: JsonOf<MessageThread>
+  json: JsonOf<MessageThread>,
+  staffAnnotation?: string
 ): MessageThread => ({
   ...json,
-  messages: json.messages.map(deserializeMessage)
+  messages: json.messages.map((m) => deserializeMessage(m, staffAnnotation))
 })
 
 export interface ReplyResponse {
   threadId: UUID
   message: Message
 }
-export const deserializeReplyResponse = ({
-  message,
-  threadId
-}: JsonOf<ReplyResponse>) => ({
-  threadId,
-  message: deserializeMessage(message)
+export const deserializeReplyResponse = (
+  responseData: JsonOf<ReplyResponse>,
+  staffAnnotation?: string
+) => ({
+  threadId: responseData.threadId,
+  message: deserializeMessage(responseData.message, staffAnnotation)
 })

--- a/frontend/src/lib-components/utils/useReplyRecipients.ts
+++ b/frontend/src/lib-components/utils/useReplyRecipients.ts
@@ -15,11 +15,11 @@ function getInitialRecipients(
   const lastMessage = messages.slice(-1)[0]
   const lastRecipients = lastMessage.recipients.map(({ id }) => id)
   return [
-    ...(firstMessage.senderId !== accountId
+    ...(firstMessage.sender.id !== accountId
       ? [
           {
-            id: firstMessage.senderId,
-            name: firstMessage.senderName,
+            id: firstMessage.sender.id,
+            name: firstMessage.sender.name,
             toggleable: false,
             selected: true
           }
@@ -31,7 +31,7 @@ function getInitialRecipients(
         ...acc,
         toggleable: true,
         selected:
-          lastMessage.senderId === acc.id || lastRecipients.includes(acc.id)
+          lastMessage.sender.id === acc.id || lastRecipients.includes(acc.id)
       }))
   ]
 }

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -183,6 +183,7 @@ const en: Translations = {
       BULLETIN: 'Bulletin'
     },
     replyToThread: 'Reply',
+    staffAnnotation: 'Staff',
     messageEditor: {
       newMessage: 'New message',
       receivers: 'Receivers',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -182,6 +182,7 @@ export default {
       BULLETIN: 'Tiedote'
     },
     replyToThread: 'Vastaa viestiin',
+    staffAnnotation: 'Henkilökunta',
     messageEditor: {
       newMessage: 'Uusi viesti',
       receivers: 'Vastaanottajat',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -182,6 +182,7 @@ const sv: Translations = {
       MESSAGE: 'Meddelande',
       BULLETIN: 'Bulletin'
     },
+    staffAnnotation: 'Personal',
     replyToThread: 'Svar',
     messageEditor: {
       newMessage: 'Nytt Meddelande',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -14,7 +14,7 @@ import fi.espoo.evaka.messaging.message.MessageController
 import fi.espoo.evaka.messaging.message.MessageType
 import fi.espoo.evaka.messaging.message.createPersonMessageAccount
 import fi.espoo.evaka.messaging.message.getCitizenMessageAccount
-import fi.espoo.evaka.messaging.message.getEmployeeMessageAccounts
+import fi.espoo.evaka.messaging.message.getEmployeeMessageAccountIds
 import fi.espoo.evaka.messaging.message.upsertEmployeeMessageAccount
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.resetDatabase
@@ -107,7 +107,7 @@ class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `notifications are sent to citizens`() {
-        val employeeAccount = db.read { it.getEmployeeMessageAccounts(employeeId).first() }
+        val employeeAccount = db.read { it.getEmployeeMessageAccountIds(employeeId).first() }
         val personAccounts = db.read { tx ->
             testPersons.map {
                 tx.getCitizenMessageAccount(it.id)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/Message.kt
@@ -15,8 +15,7 @@ import java.util.UUID
 
 data class Message(
     val id: UUID,
-    val senderId: UUID,
-    val senderName: String,
+    val sender: MessageAccount,
     val recipients: Set<MessageAccount>,
     val sentAt: HelsinkiDateTime,
     val content: String,
@@ -39,7 +38,7 @@ data class SentMessage(
     val type: MessageType,
     @Json
     val recipients: Set<MessageAccount>,
-    val recipientNames: List<String>,
+    val recipientNames: List<String>
 )
 
 enum class MessageType {
@@ -61,9 +60,16 @@ data class MessageReceiver(
     val receiverPersons: List<MessageReceiverPerson>
 )
 
+enum class AccountType {
+    PERSONAL,
+    GROUP,
+    CITIZEN
+}
+
 data class MessageAccount(
     val id: UUID,
     val name: String,
+    val type: AccountType
 )
 
 data class Group(
@@ -74,18 +80,11 @@ data class Group(
     val unitName: String,
 )
 
-enum class AccountType {
-    PERSONAL,
-    GROUP
-}
-
-data class DetailedMessageAccount(
-    val id: UUID,
-    val name: String,
+data class NestedMessageAccount(
+    @Nested("account_")
+    val account: MessageAccount,
     @Nested("group_")
-    val daycareGroup: Group?,
-    val type: AccountType,
-    val unreadCount: Int
+    val daycareGroup: Group?
 )
 
 data class MessageReceiverPerson(

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/message/MessageAccountQueries.kt
@@ -31,9 +31,14 @@ WHERE acc.person_id = :personId AND acc.active = true
         .one()
 }
 
-fun Database.Read.getEmployeeMessageAccounts(employeeId: UUID): Set<UUID> {
+fun Database.Read.getEmployeeMessageAccountIds(employeeId: UUID): Set<UUID> {
     val sql = """
-SELECT acc.id
+SELECT acc.id,
+CASE
+    WHEN acc.employee_id IS NOT NULL THEN 'PERSONAL'
+    WHEN acc.daycare_group_id IS NOT NULL THEN 'GROUP'
+    ELSE 'CITIZEN'
+END AS type
 FROM message_account acc
 LEFT JOIN daycare_group dg ON acc.daycare_group_id = dg.id
     LEFT JOIN daycare dc ON dc.id = dg.daycare_id
@@ -48,24 +53,22 @@ WHERE (acc.employee_id = :employeeId OR acl.employee_id = :employeeId OR gacl.em
         .toSet()
 }
 
-fun Database.Read.getEmployeeDetailedMessageAccounts(employeeId: UUID): Set<DetailedMessageAccount> {
-    val accountIds = getEmployeeMessageAccounts(employeeId)
+fun Database.Read.getEmployeeNestedMessageAccounts(employeeId: UUID): Set<NestedMessageAccount> {
+    val accountIds = getEmployeeMessageAccountIds(employeeId)
 
     val sql = """
-SELECT acc.id,
-       name_view.account_name AS name,
+SELECT acc.id AS account_id,
+       name_view.account_name AS account_name,
        CASE
            WHEN dg.id IS NOT NULL THEN 'group'
            ELSE 'personal'
-       END                    AS type,
+       END                    AS account_type,
        dg.id                  AS group_id,
        dg.name                AS group_name,
        dc.id                  AS group_unitId,
-       dc.name                AS group_unitName,
-       COUNT(rec.id)          AS unreadCount
+       dc.name                AS group_unitName
 FROM message_account acc
     JOIN message_account_name_view name_view ON name_view.id = acc.id
-    LEFT JOIN message_recipients rec ON acc.id = rec.recipient_id AND rec.read_at IS NULL
     LEFT JOIN daycare_group dg ON acc.daycare_group_id = dg.id
     LEFT JOIN daycare dc ON dc.id = dg.daycare_id
     LEFT JOIN daycare_acl acl ON acc.employee_id = acl.employee_id AND acl.role = 'UNIT_SUPERVISOR'
@@ -75,11 +78,10 @@ AND (
     'MESSAGING' = ANY(dc.enabled_pilot_features)
     OR 'MESSAGING' = ANY(supervisor_dc.enabled_pilot_features)
 )
-GROUP BY acc.id, account_name, 3, group_id, group_name, group_unitId, group_unitName
 """
     return this.createQuery(sql)
         .bind("accountIds", accountIds.toTypedArray())
-        .mapTo<DetailedMessageAccount>()
+        .mapTo<NestedMessageAccount>()
         .toSet()
 }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

* `MessageAccount` always includes `type` that can be used in altering the way different accounts are rendered.
* Annotate group accounts in the citizen frontend to emphasize the receivers are staff: E.g. Pikkukalat => Pikkukalat (Staff)
* Get unread message counts by account in a separate query. Previously these were fetched with the account data.
* Only notify supervisors about personal messages.