### PR TITLE
Add suomi.fi contact person

### DIFF
--- a/message-service/src/main/kotlin/fi/espoo/evaka/msg/properties/SfiSoapProperties.kt
+++ b/message-service/src/main/kotlin/fi/espoo/evaka/msg/properties/SfiSoapProperties.kt
@@ -32,7 +32,10 @@ data class SfiPrintingProperties(
     var forcePrintForElectronicUser: Boolean = false,
     var printingProvider: String? = "Edita",
     var billingId: String? = null,
-    var billingPassword: String? = null
+    var billingPassword: String? = null,
+    var contactPersonName: String? = "",
+    var contactPersonPhone: String? = "",
+    var contactPersonEmail: String? = ""
 
 )
 

--- a/message-service/src/main/kotlin/fi/espoo/evaka/msg/service/sfi/SfiAccountDetailsService.kt
+++ b/message-service/src/main/kotlin/fi/espoo/evaka/msg/service/sfi/SfiAccountDetailsService.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.msg.properties.SfiPrintingProperties
 import fi.espoo.evaka.msg.sficlient.soap.KyselyWS2A
 import fi.espoo.evaka.msg.sficlient.soap.KyselyWS2A.Laskutus
 import fi.espoo.evaka.msg.sficlient.soap.Viranomainen
+import fi.espoo.evaka.msg.sficlient.soap.Yhteyshenkilo
 import org.springframework.stereotype.Service
 
 @Service
@@ -24,6 +25,7 @@ class SfiAccountDetailsService(
         viranomaisTunnus = messageProperties.authorityIdentifier
         palveluTunnus = messageProperties.serviceIdentifier
         sanomaVersio = messageProperties.messageApiVersion
+        yhteyshenkilo = createContactPerson()
     }
 
     fun createQueryWithPrintingDetails(): KyselyWS2A = KyselyWS2A().apply {
@@ -39,5 +41,11 @@ class SfiAccountDetailsService(
             printingProperties.billingPassword.isNullOrEmpty() -> null
             else -> printingProperties.billingPassword
         }
+    }
+
+    private fun createContactPerson() = Yhteyshenkilo().apply {
+        nimi = printingProperties.contactPersonName
+        matkapuhelin = printingProperties.contactPersonPhone
+        sahkoposti = printingProperties.contactPersonEmail
     }
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

After a change in the printing provider, sfi messages require a field called "contact person" that is currently not sent to DVV. Here we add that to the outbound messages.