### PR TITLE
Fix async job runner logging

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -129,7 +129,7 @@ class AsyncJobRunner<T : AsyncJobPayload>(private val jdbi: Jdbi) : AutoCloseabl
     private fun runPendingJob(db: Database.Connection, job: ClaimedJobRef<out T>) {
         val logMeta = mapOf(
             "jobId" to job.jobId,
-            "jobType" to job.jobType,
+            "jobType" to job.jobType.name,
             "remainingAttempts" to job.remainingAttempts
         )
         try {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

logback silently drops log messages if log meta contains anything that
can't be encoded to JSON using its internal default Jackson instance.

In this case, it attempted to encode AsyncJobType as an object and
failed to encode this field: `val payloadClass: KClass<T>`

Let's pass the type as string instead