### PR TITLE
Require protocol in unit url

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
@@ -323,6 +323,9 @@ function validateForm(
   if (form.invoicedByMunicipality && !costCenter) {
     errors.push(i18n.unitEditor.error.costCenter)
   }
+  if (url && !(url.startsWith('https://') || url.startsWith('http://'))) {
+    errors.push(i18n.unitEditor.error.url)
+  }
   if (!visitingAddress.streetAddress) {
     errors.push(i18n.unitEditor.error.visitingAddress.streetAddress)
   }

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2653,6 +2653,7 @@ export const fi = {
       daycareType: 'Varhaiskasvatuksen tyyppi puuttuu',
       capacity: 'Kapasiteetti on virheellinen',
       costCenter: 'Kustannuspaikka puuttuu',
+      url: 'URL-osoitteessa pitää olla https://- tai http://-etuliite',
       visitingAddress: {
         streetAddress: 'Käyntiosoitteen katuosoite puuttuu',
         postalCode: 'Käyntiosoitteen postinumero puuttuu',


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
This seems like the easiest and simplest solution to the problem of urls without protocol being interpreted as relative urls.

I'm not sure if we even want to allow plain http :smile: