### PR TITLE
EVAKA-HOTFIX fix attendance arrival and departure time nanos

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
@@ -62,7 +62,7 @@ data class HelsinkiDateTime private constructor(private val instant: Instant) : 
     fun isBefore(other: HelsinkiDateTime): Boolean = this.instant.isBefore(other.instant)
 
     fun withTime(time: LocalTime): HelsinkiDateTime = update {
-        it.withHour(time.hour).withMinute(time.minute).withSecond(time.second)
+        it.withHour(time.hour).withMinute(time.minute).withSecond(time.second).withNano(time.nano)
     }
 
     /**


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Fix setting child's departure time sometimes failing at the database level by fixing `HelsinkiDateTime`'s `withTime` method to update nano seconds as well.

