### PR TITLE
EVAKA-AI: remove api-gw proxy

### DIFF
--- a/apigw/src/internal/app.ts
+++ b/apigw/src/internal/app.ts
@@ -14,7 +14,7 @@ import createAdSamlStrategy, {
 import createEvakaSamlStrategy, {
   createSamlConfig as createEvakaSamlconfig
 } from '../shared/auth/keycloak-saml'
-import { cookieSecret, enableDevApi, evakaAIUrl } from '../shared/config'
+import { cookieSecret, enableDevApi } from '../shared/config'
 import setupLoggingMiddleware from '../shared/logging'
 import { csrf, csrfCookie } from '../shared/middleware/csrf'
 import { errorHandler } from '../shared/middleware/error-handler'
@@ -107,9 +107,6 @@ function internalApiRouter() {
     authStatus
   )
   router.all('/public/*', createProxy())
-  if (evakaAIUrl) {
-    router.all('/ai/*', createProxy({ url: evakaAIUrl }))
-  }
   router.use(requireAuthentication)
   router.use(csrf)
   router.post(


### PR DESCRIPTION
#### Summary
Make evaka-ai internal by removing proxy so that authorization can be removed and deployment bucket won't be needed. UI won't be used for now.