### PR TITLE
Turn off Postgres JIT in local/ci

### DIFF
--- a/compose/db/postgresql.conf
+++ b/compose/db/postgresql.conf
@@ -670,3 +670,6 @@ log_temp_files = 0
 log_autovacuum_min_duration = 0
 log_min_duration_statement = 750ms
 log_error_verbosity = default
+
+# Turn off JIT because it actually slows down queries when there's not much data
+jit = off


### PR DESCRIPTION
#### Summary

The JIT actually makes some queries _slower_ in local and ci environments. The time to make just in time compilation dominates the query time when we don't have much data.