### PR TITLE
Employee mobile frontend: Make group selector scrollable

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/common/GroupSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/GroupSelector.tsx
@@ -96,4 +96,6 @@ const Info = styled.span`
 
 const Wrapper = styled.div`
   margin: 12px 16px 8px 16px;
+  max-height: 60vh;
+  overflow: scroll;
 `


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
There was a complaint that when the number of groups is large, it's not possible to select the desired group. As a solution, make the group selector scrollable. Height is limited for better readability.
