### PR TITLE
EVAKA-HOTFIX transfer application clean up

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -210,10 +210,10 @@ class ScheduledJobsTest : FullApplicationTest() {
     }
 
     @Test
-    fun `a daycare transfer application for a child with a past daycare placement that ended yesterday is cancelled`() {
+    fun `a daycare transfer application for a child with a past daycare placement that ended day before yesterday is cancelled`() {
         val preferredStartDate = LocalDate.now().minusMonths(2)
         val applicationId = createTransferApplication(ApplicationType.DAYCARE, preferredStartDate)
-        val dateRange = FiniteDateRange(preferredStartDate.minusMonths(1), LocalDate.now().minusDays(1))
+        val dateRange = FiniteDateRange(preferredStartDate.minusMonths(1), LocalDate.now().minusDays(2))
         createPlacement(PlacementType.DAYCARE, dateRange)
 
         scheduledJobs.cancelOutdatedTransferApplications(db)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -145,6 +145,19 @@ class ScheduledJobsTest : FullApplicationTest() {
     }
 
     @Test
+    fun `a daycare transfer application for a child with a 5yo daycare placement is not cancelled`() {
+        val preferredStartDate = LocalDate.now().plusMonths(1)
+        val applicationId = createTransferApplication(ApplicationType.DAYCARE, preferredStartDate)
+        val dateRange = FiniteDateRange(preferredStartDate, preferredStartDate.plusMonths(1))
+        createPlacement(PlacementType.DAYCARE_FIVE_YEAR_OLDS, dateRange)
+
+        scheduledJobs.cancelOutdatedTransferApplications(db)
+
+        val applicationStatus = getApplicationStatus(applicationId)
+        assertEquals(ApplicationStatus.SENT, applicationStatus)
+    }
+
+    @Test
     fun `a daycare transfer application for a child with a future daycare placement is not cancelled`() {
         val preferredStartDate = LocalDate.now().plusMonths(1)
         val applicationId = createTransferApplication(ApplicationType.DAYCARE, preferredStartDate)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -898,6 +898,8 @@ fun Database.Transaction.removeOldDrafts(deleteAttachment: (db: Database.Transac
 
 fun Database.Transaction.cancelOutdatedTransferApplications(): List<ApplicationId> = createUpdate(
     // only include applications that don't have decisions
+    // placement type checks are doing in inverse so that the addition and accidental omission of new placement types
+    // does not cause the cancellation of applications that shouldn't be cancelled
     """
 UPDATE application SET status = :cancelled
 WHERE transferapplication
@@ -910,10 +912,10 @@ AND NOT EXISTS (
         AND f.application_id = application.id
         AND f.latest
         AND (CASE
-            WHEN f.document->>'type' = 'DAYCARE' THEN p.type = ANY('{DAYCARE, DAYCARE_PART_TIME}')
-            WHEN f.document->>'type' = 'PRESCHOOL' AND NOT (f.document->>'connectedDaycare')::boolean THEN p.type = ANY('{PRESCHOOL, PRESCHOOL_DAYCARE, PREPARATORY, PREPARATORY_DAYCARE}')
-            WHEN f.document->>'type' = 'PRESCHOOL' AND (f.document->>'connectedDaycare')::boolean THEN p.type = ANY('{PRESCHOOL_DAYCARE, PREPARATORY_DAYCARE}')
-            WHEN f.document->>'type' = 'CLUB' THEN p.type = ANY('{CLUB}')
+            WHEN f.document->>'type' = 'DAYCARE' THEN NOT p.type = ANY(:notDaycarePlacements::placement_type[])
+            WHEN f.document->>'type' = 'PRESCHOOL' AND NOT (f.document->>'connectedDaycare')::boolean THEN NOT p.type = ANY(:notPreschoolPlacements::placement_type[])
+            WHEN f.document->>'type' = 'PRESCHOOL' AND (f.document->>'connectedDaycare')::boolean THEN NOT p.type = ANY(:notPreschoolDaycarePlacements::placement_type[])
+            WHEN f.document->>'type' = 'CLUB' THEN NOT p.type = ANY(:notClubPlacements::placement_type[])
         END)
         AND daterange((f.document->>'preferredStartDate')::date, null, '[]') && daterange(p.start_date, p.end_date, '[]')
         AND p.end_date >= :now
@@ -923,6 +925,63 @@ RETURNING id
 )
     .bind("cancelled", ApplicationStatus.CANCELLED)
     .bind("now", LocalDate.now())
+    .bind(
+        "notDaycarePlacements",
+        arrayOf(
+            PlacementType.CLUB,
+            PlacementType.PRESCHOOL,
+            PlacementType.PRESCHOOL_DAYCARE,
+            PlacementType.PREPARATORY,
+            PlacementType.PREPARATORY_DAYCARE,
+            PlacementType.TEMPORARY_DAYCARE,
+            PlacementType.TEMPORARY_DAYCARE_PART_DAY,
+            PlacementType.SCHOOL_SHIFT_CARE
+        )
+    )
+    .bind(
+        "notPreschoolPlacements",
+        arrayOf(
+            PlacementType.CLUB,
+            PlacementType.DAYCARE,
+            PlacementType.DAYCARE_PART_TIME,
+            PlacementType.DAYCARE_FIVE_YEAR_OLDS,
+            PlacementType.DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
+            PlacementType.TEMPORARY_DAYCARE,
+            PlacementType.TEMPORARY_DAYCARE_PART_DAY,
+            PlacementType.SCHOOL_SHIFT_CARE
+        )
+    )
+    .bind(
+        "notPreschoolDaycarePlacements",
+        arrayOf(
+            PlacementType.CLUB,
+            PlacementType.DAYCARE,
+            PlacementType.DAYCARE_PART_TIME,
+            PlacementType.DAYCARE_FIVE_YEAR_OLDS,
+            PlacementType.DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
+            PlacementType.PRESCHOOL,
+            PlacementType.PREPARATORY,
+            PlacementType.TEMPORARY_DAYCARE,
+            PlacementType.TEMPORARY_DAYCARE_PART_DAY,
+            PlacementType.SCHOOL_SHIFT_CARE
+        )
+    )
+    .bind(
+        "notClubPlacements",
+        arrayOf(
+            PlacementType.DAYCARE,
+            PlacementType.DAYCARE_PART_TIME,
+            PlacementType.DAYCARE_FIVE_YEAR_OLDS,
+            PlacementType.DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
+            PlacementType.PRESCHOOL,
+            PlacementType.PRESCHOOL_DAYCARE,
+            PlacementType.PREPARATORY,
+            PlacementType.PREPARATORY_DAYCARE,
+            PlacementType.TEMPORARY_DAYCARE,
+            PlacementType.TEMPORARY_DAYCARE_PART_DAY,
+            PlacementType.SCHOOL_SHIFT_CARE
+        )
+    )
     .executeAndReturnGeneratedKeys()
     .mapTo<ApplicationId>()
     .toList()

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -31,6 +31,7 @@ import fi.espoo.evaka.shared.db.getUUID
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.db.mapJsonColumn
 import fi.espoo.evaka.shared.mapToPaged
+import fi.espoo.evaka.shared.utils.dateNow
 import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.result.RowView
@@ -918,13 +919,13 @@ AND NOT EXISTS (
             WHEN f.document->>'type' = 'CLUB' THEN NOT p.type = ANY(:notClubPlacements::placement_type[])
         END)
         AND daterange((f.document->>'preferredStartDate')::date, null, '[]') && daterange(p.start_date, p.end_date, '[]')
-        AND p.end_date >= :now
+        AND p.end_date >= :yesterday
 )
 RETURNING id
 """
 )
     .bind("cancelled", ApplicationStatus.CANCELLED)
-    .bind("now", LocalDate.now())
+    .bind("yesterday", dateNow().minusDays(1))
     .bind(
         "notDaycarePlacements",
         arrayOf(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Fix transfer application clean up to take 5yo daycare into account when checking daycare transfer applications. Also, make the clean up a bit more conservative so that new placement types do not cause the clean up to be overeager and cancel applications which should not be cancelled.

