### PR TITLE
EVAKA-4240 permanent attendance reservation migration

### DIFF
--- a/service/src/main/resources/db/migration/R__dev_temp.sql
+++ b/service/src/main/resources/db/migration/R__dev_temp.sql
@@ -73,25 +73,3 @@ CREATE TABLE vasu_document_event(
 );
 
 CREATE INDEX idx$vasu_document_event_document_id ON vasu_document_event(vasu_document_id);
-
--- attendance reservation
-
-DROP TABLE IF EXISTS attendance_reservation;
-
-CREATE TABLE attendance_reservation (
-    id uuid PRIMARY KEY DEFAULT ext.uuid_generate_v1mc(),
-    created timestamp with time zone DEFAULT now() NOT NULL,
-    updated timestamp with time zone DEFAULT now() NOT NULL,
-    child_id uuid NOT NULL REFERENCES person(id),
-    start_time timestamp with time zone NOT NULL,
-    end_time timestamp with time zone NOT NULL,
-    start_date date GENERATED ALWAYS AS ((start_time AT TIME ZONE 'Europe/Helsinki')::date) STORED,
-    created_by_guardian_id uuid REFERENCES person(id),
-    created_by_employee_id uuid REFERENCES employee(id),
-    CONSTRAINT attendance_reservation_start_before_end CHECK (start_time < end_time),
-    CONSTRAINT attendance_reservation_max_24_hours CHECK (end_time - interval '1 day' <= start_time),
-    CONSTRAINT attendance_reservation_no_overlap EXCLUDE USING gist (child_id WITH =, tstzrange(start_time, end_time) WITH &&),
-    CONSTRAINT attendance_reservation_created_by_someone CHECK ((created_by_guardian_id IS NULL) != (created_by_employee_id IS NULL))
-);
-
-CREATE TRIGGER set_timestamp BEFORE UPDATE ON attendance_reservation FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();

--- a/service/src/main/resources/db/migration/V141__attendance_reservation.sql
+++ b/service/src/main/resources/db/migration/V141__attendance_reservation.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS attendance_reservation;
+
+CREATE TABLE attendance_reservation (
+    id uuid PRIMARY KEY DEFAULT ext.uuid_generate_v1mc(),
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    updated timestamp with time zone DEFAULT now() NOT NULL,
+    child_id uuid NOT NULL REFERENCES person(id),
+    start_time timestamp with time zone NOT NULL,
+    end_time timestamp with time zone NOT NULL,
+    start_date date GENERATED ALWAYS AS ((start_time AT TIME ZONE 'Europe/Helsinki')::date) STORED,
+    created_by_guardian_id uuid REFERENCES person(id),
+    created_by_employee_id uuid REFERENCES employee(id),
+    CONSTRAINT attendance_reservation_start_before_end CHECK (start_time < end_time),
+    CONSTRAINT attendance_reservation_max_24_hours CHECK (end_time - interval '1 day' <= start_time),
+    CONSTRAINT attendance_reservation_no_overlap EXCLUDE USING gist (child_id WITH =, tstzrange(start_time, end_time) WITH &&),
+    CONSTRAINT attendance_reservation_created_by_someone CHECK ((created_by_guardian_id IS NULL) != (created_by_employee_id IS NULL))
+);
+
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON attendance_reservation FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -138,3 +138,4 @@ V137__service_need_confirmed_by_nullable.sql
 V138__income_statement_checkup_consent.sql
 V139__absence_modified_by_citizen.sql
 V140__message_account_type.sql
+V141__attendance_reservation.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Move `attendance_reservation` creation to a permanent migration.

