### PR TITLE
EVAKA-4288 family initialization improvements

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/contact-info/ChildSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/ChildSubSection.tsx
@@ -22,7 +22,8 @@ export default React.memo(function ChildSubSection({
   formData,
   updateFormData,
   errors,
-  verificationRequested
+  verificationRequested,
+  fullFamily
 }: ContactInfoSectionProps) {
   const t = useTranslation()
   const [lang] = useLang()
@@ -30,6 +31,7 @@ export default React.memo(function ChildSubSection({
   return (
     <>
       <Gap size={'m'} />
+      {fullFamily ? t.applications.editor.contactInfo.familyInfo : null}
       {t.applications.editor.contactInfo.info()}
       <H3>{t.applications.editor.contactInfo.childInfoTitle}</H3>
       <Gap size={'xs'} />

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -73,7 +73,9 @@ describe('Citizen daycare applications', () => {
     await editorPage.verifyAndSend()
 
     const application = await getApplication(applicationId)
-    minimalDaycareForm.validateResult(application)
+    minimalDaycareForm.validateResult(application, [
+      fixtures.enduserChildFixtureKaarina
+    ])
   })
 
   test('Full valid daycare application can be sent', async () => {
@@ -89,7 +91,9 @@ describe('Citizen daycare applications', () => {
     await editorPage.verifyAndSend()
 
     const application = await getApplication(applicationId)
-    fullDaycareForm.validateResult(application)
+    fullDaycareForm.validateResult(application, [
+      fixtures.enduserChildFixtureKaarina
+    ])
   })
 
   test('Notification on duplicate application is visible', async () => {

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-preschool-application.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-preschool-application.spec.ts
@@ -75,6 +75,8 @@ describe('Citizen preschool applications', () => {
     await editorPage.verifyAndSend()
 
     const application = await getApplication(applicationId)
-    fullPreschoolForm.validateResult(application)
+    fullPreschoolForm.validateResult(application, [
+      fixtures.enduserChildFixtureKaarina
+    ])
   })
 })

--- a/frontend/src/e2e-playwright/utils/application-forms.ts
+++ b/frontend/src/e2e-playwright/utils/application-forms.ts
@@ -5,6 +5,7 @@
 import { ApplicationDetails } from 'lib-common/api-types/application/ApplicationDetails'
 import { ApplicationFormData } from 'lib-common/api-types/application/ApplicationFormData'
 import { clubFixture, daycareFixture } from 'e2e-test-common/dev-api/fixtures'
+import { PersonDetail } from 'e2e-test-common/dev-api/types'
 import { format } from 'date-fns'
 
 const currentPreferredStartDate = format(
@@ -56,7 +57,10 @@ export type FormInput = Partial<
 
 export const minimalDaycareForm: {
   form: FormInput
-  validateResult: (result: ApplicationDetails) => void
+  validateResult: (
+    result: ApplicationDetails,
+    vtjSiblingsLivingInSameAddress: PersonDetail[]
+  ) => void
 } = {
   form: {
     serviceNeed: {
@@ -77,7 +81,7 @@ export const minimalDaycareForm: {
       noGuardianEmail: true
     }
   },
-  validateResult: (res) => {
+  validateResult: (res, vtjSiblingsLivingInSameAddress) => {
     assertEquals('SENT', res.status)
 
     assertNull(res.form.child.futureAddress)
@@ -94,7 +98,16 @@ export const minimalDaycareForm: {
 
     assertNull(res.form.otherPartner)
 
-    assertEmpty(res.form.otherChildren)
+    assertEquals(
+      vtjSiblingsLivingInSameAddress.length,
+      res.form.otherChildren.length
+    )
+    for (let i = 0; i < vtjSiblingsLivingInSameAddress.length; i++) {
+      const { firstName, lastName, ssn } = vtjSiblingsLivingInSameAddress[i]
+      assertEquals(firstName, res.form.otherChildren[i].firstName)
+      assertEquals(lastName, res.form.otherChildren[i].lastName)
+      assertEquals(ssn, res.form.otherChildren[i].socialSecurityNumber)
+    }
 
     assertEquals(1, res.form.preferences.preferredUnits.length)
     assertEquals(daycareFixture.id, res.form.preferences.preferredUnits[0].id)
@@ -120,7 +133,10 @@ export const minimalDaycareForm: {
 
 export const fullDaycareForm: {
   form: FormInput
-  validateResult: (result: ApplicationDetails) => void
+  validateResult: (
+    result: ApplicationDetails,
+    vtjSiblingsLivingInSameAddress: PersonDetail[]
+  ) => void
 } = {
   form: {
     serviceNeed: {
@@ -182,7 +198,7 @@ export const fullDaycareForm: {
       allergies: 'Pähkinät, chili'
     }
   },
-  validateResult: (res) => {
+  validateResult: (res, vtjSiblingsLivingInSameAddress) => {
     assertEquals('SENT', res.status)
 
     assertEquals(
@@ -214,13 +230,30 @@ export const fullDaycareForm: {
     assertEquals('Heppuli', res.form.otherPartner?.lastName)
     assertEquals('210188-389L', res.form.otherPartner?.socialSecurityNumber)
 
-    assertEquals(2, res.form.otherChildren.length)
-    assertEquals('Tupu', res.form.otherChildren[0].firstName)
-    assertEquals('Ankka', res.form.otherChildren[0].lastName)
-    assertEquals('250718A809H', res.form.otherChildren[0].socialSecurityNumber)
-    assertEquals('Tauno', res.form.otherChildren[1].firstName)
-    assertEquals('Hanhi', res.form.otherChildren[1].lastName)
-    assertEquals('101017A479B', res.form.otherChildren[1].socialSecurityNumber)
+    assertEquals(
+      vtjSiblingsLivingInSameAddress.length + 2,
+      res.form.otherChildren.length
+    )
+    for (let i = 0; i < vtjSiblingsLivingInSameAddress.length; i++) {
+      const { firstName, lastName, ssn } = vtjSiblingsLivingInSameAddress[i]
+      assertEquals(firstName, res.form.otherChildren[i].firstName)
+      assertEquals(lastName, res.form.otherChildren[i].lastName)
+      assertEquals(ssn, res.form.otherChildren[i].socialSecurityNumber)
+    }
+    const tupuIndex = vtjSiblingsLivingInSameAddress.length + 0
+    assertEquals('Tupu', res.form.otherChildren[tupuIndex].firstName)
+    assertEquals('Ankka', res.form.otherChildren[tupuIndex].lastName)
+    assertEquals(
+      '250718A809H',
+      res.form.otherChildren[tupuIndex].socialSecurityNumber
+    )
+    const taunoIndex = vtjSiblingsLivingInSameAddress.length + 1
+    assertEquals('Tauno', res.form.otherChildren[taunoIndex].firstName)
+    assertEquals('Hanhi', res.form.otherChildren[taunoIndex].lastName)
+    assertEquals(
+      '101017A479B',
+      res.form.otherChildren[taunoIndex].socialSecurityNumber
+    )
 
     assertEquals(1, res.form.preferences.preferredUnits.length)
     assertEquals(daycareFixture.id, res.form.preferences.preferredUnits[0].id)
@@ -461,7 +494,10 @@ export const minimalPreschoolForm: {
 
 export const fullPreschoolForm: {
   form: FormInput
-  validateResult: (result: ApplicationDetails) => void
+  validateResult: (
+    result: ApplicationDetails,
+    vtjSiblingsLivingInSameAddress: PersonDetail[]
+  ) => void
 } = {
   form: {
     serviceNeed: {
@@ -521,7 +557,7 @@ export const fullPreschoolForm: {
       allergies: 'Pähkinät, chili'
     }
   },
-  validateResult: (res) => {
+  validateResult: (res, vtjSiblingsLivingInSameAddress) => {
     assertEquals('SENT', res.status)
 
     assertEquals(
@@ -555,10 +591,23 @@ export const fullPreschoolForm: {
     assertEquals('Heppuli', res.form.otherPartner?.lastName)
     assertEquals('210188-389L', res.form.otherPartner?.socialSecurityNumber)
 
-    assertEquals(1, res.form.otherChildren.length)
-    assertEquals('Tupu', res.form.otherChildren[0].firstName)
-    assertEquals('Ankka', res.form.otherChildren[0].lastName)
-    assertEquals('250718A809H', res.form.otherChildren[0].socialSecurityNumber)
+    assertEquals(
+      vtjSiblingsLivingInSameAddress.length + 1,
+      res.form.otherChildren.length
+    )
+    for (let i = 0; i < vtjSiblingsLivingInSameAddress.length; i++) {
+      const { firstName, lastName, ssn } = vtjSiblingsLivingInSameAddress[i]
+      assertEquals(firstName, res.form.otherChildren[i].firstName)
+      assertEquals(lastName, res.form.otherChildren[i].lastName)
+      assertEquals(ssn, res.form.otherChildren[i].socialSecurityNumber)
+    }
+    const tupuIndex = vtjSiblingsLivingInSameAddress.length + 0
+    assertEquals('Tupu', res.form.otherChildren[tupuIndex].firstName)
+    assertEquals('Ankka', res.form.otherChildren[tupuIndex].lastName)
+    assertEquals(
+      '250718A809H',
+      res.form.otherChildren[tupuIndex].socialSecurityNumber
+    )
 
     assertEquals(1, res.form.preferences.preferredUnits.length)
     assertEquals(daycareFixture.id, res.form.preferences.preferredUnits[0].id)

--- a/frontend/src/employee-frontend/components/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/PersonProfile.tsx
@@ -101,6 +101,7 @@ const layouts: Layouts<typeof components> = {
     { component: 'decisions', open: false }
   ],
   ['UNIT_SUPERVISOR']: [
+    { component: 'family-overview', open: true },
     { component: 'partners', open: false },
     { component: 'fridge-children', open: false },
     { component: 'dependants', open: false },

--- a/frontend/src/employee-frontend/types/family-overview.ts
+++ b/frontend/src/employee-frontend/types/family-overview.ts
@@ -15,17 +15,14 @@ export interface FamilyOverviewPerson {
   postalCode: string
   postOffice: string
   headOfChild: string
-  incomeTotal: number
-  incomeId: string
-  incomeEffect?: IncomeEffect
+  income?: FamilyOverviewIncome
 }
 
 export interface FamilyOverview {
   headOfFamily: FamilyOverviewPerson
   partner?: FamilyOverviewPerson
   children: FamilyOverviewPerson[]
-  totalIncomeEffect: IncomeEffect
-  totalIncome?: number
+  totalIncome?: FamilyOverviewIncome
 }
 
 export type FamilyOverviewPersonRole = 'HEAD' | 'PARTNER' | 'CHILD'
@@ -35,10 +32,14 @@ export interface FamilyOverviewRow {
   name: string
   role: FamilyOverviewPersonRole
   age: number
-  incomeTotal?: number
-  incomeEffect?: IncomeEffect
   restrictedDetailsEnabled: boolean
   address: string
+  income?: FamilyOverviewIncome
+}
+
+interface FamilyOverviewIncome {
+  effect?: IncomeEffect
+  total?: number
 }
 
 export type FamilyContactRole =

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1028,6 +1028,11 @@ const en: Translations = {
       },
       contactInfo: {
         title: 'Personal information',
+        familyInfo: (
+          <P>
+            Please report all adults and children living in the same household.
+          </P>
+        ),
         info: function ContactInfoInfoText() {
           return (
             <P>

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1322,6 +1322,12 @@ export default {
       },
       contactInfo: {
         title: 'Henkilötiedot',
+        familyInfo: (
+          <P>
+            Ilmoita hakemuksella kaikki samassa taloudessa asuvat aikuiset ja
+            lapset.
+          </P>
+        ),
         info: function ContactInfoInfoText() {
           return (
             <P>

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -982,6 +982,12 @@ const sv: Translations = {
       },
       contactInfo: {
         title: 'Personuppgifter',
+        familyInfo: (
+          <P>
+            Meddela på ansökningen alla de vuxna och barn som bor i samma
+            hushåll.
+          </P>
+        ),
         info: function ContactInfoInfoText() {
           return (
             <P>

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
@@ -6,7 +6,6 @@ package fi.espoo.evaka.application
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.application.utils.currentDateInFinland
-import fi.espoo.evaka.daycare.getNextPreschoolTerm
 import fi.espoo.evaka.decision.Decision
 import fi.espoo.evaka.decision.DecisionService
 import fi.espoo.evaka.decision.DecisionStatus
@@ -128,26 +127,7 @@ class ApplicationControllerCitizen(
                 childId = body.childId,
                 origin = ApplicationOrigin.ELECTRONIC
             )
-            val form = ApplicationForm.initForm(
-                type = body.type,
-                guardian = guardian,
-                child = child
-            ).let {
-                if (body.type == ApplicationType.PRESCHOOL) {
-                    it.copy(
-                        preferences = it.preferences.copy(
-                            preferredStartDate = tx.getNextPreschoolTerm()?.finnishPreschool?.start
-                        )
-                    )
-                } else it
-            }
-            tx.updateForm(
-                applicationId,
-                form,
-                body.type,
-                child.restrictedDetailsEnabled,
-                guardian.restrictedDetailsEnabled
-            )
+            applicationStateService.initializeApplicationForm(tx, user, applicationId, body.type, guardian, child)
 
             ResponseEntity.ok(applicationId)
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -155,12 +155,7 @@ class ApplicationControllerV2(
                 hideFromGuardian = body.hideFromGuardian,
                 sentDate = body.sentDate
             )
-            val form = ApplicationForm.initForm(
-                type = body.type,
-                guardian = guardian,
-                child = child
-            )
-            tx.updateForm(id, form, body.type, child.restrictedDetailsEnabled, guardian.restrictedDetailsEnabled)
+            applicationStateService.initializeApplicationForm(tx, user, id, body.type, guardian, child)
             id
         }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/PreschoolTerms.kt
@@ -6,7 +6,6 @@ package fi.espoo.evaka.daycare
 
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
-import fi.espoo.evaka.shared.utils.europeHelsinki
 import org.jdbi.v3.core.kotlin.mapTo
 import java.time.LocalDate
 
@@ -34,12 +33,4 @@ fun Database.Read.getPreschoolTerms(): List<PreschoolTerm> {
 
 fun Database.Read.getActivePreschoolTermAt(date: LocalDate): PreschoolTerm? {
     return getPreschoolTerms().firstOrNull { it.extendedTerm.includes(date) }
-}
-
-fun Database.Read.getCurrentPreschoolTerm(): PreschoolTerm? {
-    return getActivePreschoolTermAt(LocalDate.now(europeHelsinki))
-}
-
-fun Database.Read.getNextPreschoolTerm(): PreschoolTerm? {
-    return getPreschoolTerms().firstOrNull { it.extendedTerm.start.isAfter(LocalDate.now(europeHelsinki)) }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -110,7 +110,9 @@ class FamilyInitializerService(
     ): FridgeFamilyMembers {
         val headOfFamilyId = application.guardianId
 
-        val otherGuardianId = application.otherGuardianId
+        val otherGuardianId = personService.getGuardians(tx, user, application.childId)
+            .firstOrNull { it.id != application.guardianId }?.id
+
         val fridgePartnerSSN = if (
             otherGuardianId != null &&
             personService.personsLiveInTheSameAddress(tx, headOfFamilyId, otherGuardianId)

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
@@ -53,6 +53,10 @@ class PersonService(
         val person1 = db.getPersonById(person1Id)
         val person2 = db.getPersonById(person2Id)
 
+        return personsLiveInTheSameAddress(person1, person2)
+    }
+
+    fun personsLiveInTheSameAddress(person1: PersonDTO?, person2: PersonDTO?): Boolean {
         return personsHaveSameResidenceCode(person1, person2) || personsHaveSameAddress(person1, person2)
     }
 
@@ -416,7 +420,28 @@ data class PersonWithChildrenDTO(
     val nationalities: Set<Nationality>,
     val nativeLanguage: NativeLanguage?,
     val restrictedDetails: RestrictedDetails
-)
+) {
+    fun toPersonDTO() = PersonDTO(
+        id = id,
+        identity = when (socialSecurityNumber) {
+            is String -> ExternalIdentifier.SSN.getInstance(socialSecurityNumber)
+            else -> ExternalIdentifier.NoID()
+        },
+        dateOfBirth = dateOfBirth,
+        dateOfDeath = dateOfDeath,
+        firstName = firstName,
+        lastName = lastName,
+        residenceCode = residenceCode,
+        streetAddress = addresses.firstOrNull()?.streetAddress,
+        postalCode = addresses.firstOrNull()?.postalCode,
+        postOffice = addresses.firstOrNull()?.city,
+        restrictedDetailsEnabled = restrictedDetails.enabled,
+        restrictedDetailsEndDate = restrictedDetails.endDate,
+        language = nativeLanguage?.code,
+        email = null,
+        phone = null
+    )
+}
 
 data class PersonAddressDTO(
     val origin: Origin,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -221,6 +221,8 @@ sealed interface Action {
     }
     enum class Person(private val roles: EnumSet<UserRole>) : ScopedAction<PersonId> {
         READ(SERVICE_WORKER, FINANCE_ADMIN, UNIT_SUPERVISOR, STAFF, SPECIAL_EDUCATION_TEACHER),
+        READ_FAMILY_OVERVIEW(FINANCE_ADMIN, UNIT_SUPERVISOR),
+        READ_INCOME(FINANCE_ADMIN),
         READ_INCOME_STATEMENTS(FINANCE_ADMIN);
 
         constructor(vararg roles: UserRole) : this(roles.toEnumSet())


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
* Add instructions about adding family memebers to applications
* Add dependants living in the same address as the applicant to application's "other children" list by default
* Fix family initialization not adding child's other guardian to the family
* Show family overview without income to unit supervisors

This PR does not fix cases where family initialization fails when the applicants partner is already the head of the family.

