### PR TITLE
EVAKA-4000 fix oid sending and error parsing

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceIntegrationTest.kt
@@ -784,6 +784,28 @@ class VardaUpdateServiceIntegrationTest : FullApplicationTest() {
         assertVardaServiceNeedIds(snId, 1, 1)
     }
 
+    @Test
+    fun `parseVardaErrorBody works`() {
+        val errors = mockEndpoint.getMockErrorResponses()
+
+        vardaClient.parseVardaErrorBody(errors["DY004"]!!).let { (codes, descriptions) ->
+            assertEquals("DY004", codes.first())
+            assertEquals("Ensure this value is greater than or equal to 1.", descriptions.first())
+        }
+        vardaClient.parseVardaErrorBody(errors["VS009"]!!).let { (codes, descriptions) ->
+            assertEquals("VS009", codes.first())
+            assertEquals("Varhaiskasvatussuhde alkamis_pvm cannot be after Toimipaikka paattymis_pvm.", descriptions.first())
+        }
+        vardaClient.parseVardaErrorBody(errors["MA003"]!!).let { (codes, descriptions) ->
+            assertEquals("MA003", codes.first())
+            assertEquals("No matching huoltaja found.", descriptions.first())
+        }
+        vardaClient.parseVardaErrorBody(errors["HE012"]!!).let { (codes, descriptions) ->
+            assertEquals("HE012", codes.first())
+            assertEquals("Name has disallowed characters.", descriptions.first())
+        }
+    }
+
     // TODO: find a way to run update process through async job mechanism in tests (ie. use correct varda client)
     private fun updateChildData(db: Database.Connection, vardaClient: VardaClient, feeDecisionMinDate: LocalDate) {
         getChildrenToUpdate(db, feeDecisionMinDate).entries.forEach {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceIntegrationTest.kt
@@ -872,11 +872,11 @@ class VardaUpdateServiceIntegrationTest : FullApplicationTest() {
         expectedChildId: Long,
         expectedHoursPerWeek: Double
     ) {
-        assertEquals(true, vardaDecision.childUrl.endsWith("$expectedChildId/"), "Expected ${vardaDecision.childUrl} to end with $expectedChildId")
-        assertEquals(expectedStartDate, vardaDecision.startDate)
-        assertEquals(expectedEndDate, vardaDecision.endDate)
-        assertEquals(expectedApplicationDate, vardaDecision.applicationDate)
-        assertEquals(expectedHoursPerWeek, vardaDecision.hoursPerWeek)
+        assertEquals(true, vardaDecision.lapsi.endsWith("$expectedChildId/"), "Expected ${vardaDecision.lapsi} to end with $expectedChildId")
+        assertEquals(expectedStartDate, vardaDecision.alkamis_pvm)
+        assertEquals(expectedEndDate, vardaDecision.paattymis_pvm)
+        assertEquals(expectedApplicationDate, vardaDecision.hakemus_pvm)
+        assertEquals(expectedHoursPerWeek, vardaDecision.tuntimaara_viikossa)
     }
 
     private fun assertVardaFeeData(expectedVardaFeeData: VardaFeeData, vardaFeeData: VardaFeeData) {

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/Varda.kt
@@ -12,31 +12,19 @@ import java.time.LocalDate
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class VardaDecision(
-    @JsonProperty("lapsi")
-    val childUrl: String,
-    @JsonProperty("hakemus_pvm")
-    val applicationDate: LocalDate,
-    @JsonProperty("alkamis_pvm")
-    val startDate: LocalDate,
-    @JsonProperty("paattymis_pvm")
-    val endDate: LocalDate,
-    @JsonProperty("pikakasittely_kytkin")
-    val urgent: Boolean,
-    @JsonProperty("tuntimaara_viikossa")
-    val hoursPerWeek: Double,
-    @JsonProperty("tilapainen_vaka_kytkin")
-    val temporary: Boolean,
-    @JsonProperty("paivittainen_vaka_kytkin")
-    val daily: Boolean,
-    @JsonProperty("vuorohoito_kytkin")
-    val shiftCare: Boolean,
-    @JsonProperty("jarjestamismuoto_koodi")
-    val providerTypeCode: String,
-    @JsonProperty("lahdejarjestelma")
-    val sourceSystem: String
+    val lapsi: String,
+    val hakemus_pvm: LocalDate,
+    val alkamis_pvm: LocalDate,
+    val paattymis_pvm: LocalDate,
+    val pikakasittely_kytkin: Boolean,
+    val tuntimaara_viikossa: Double,
+    val tilapainen_vaka_kytkin: Boolean,
+    val paivittainen_vaka_kytkin: Boolean,
+    val vuorohoito_kytkin: Boolean,
+    val jarjestamismuoto_koodi: String,
+    val lahdejarjestelma: String
 ) {
-    @JsonProperty("kokopaivainen_vaka_kytkin")
-    val fullDay: Boolean = hoursPerWeek >= 25
+    val kokopaivainen_vaka_kytkin: Boolean = tuntimaara_viikossa >= 25
 }
 
 data class VardaDecisionResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/Varda.kt
@@ -33,16 +33,11 @@ data class VardaDecisionResponse(
 )
 
 data class VardaPlacement(
-    @JsonProperty("varhaiskasvatuspaatos")
-    val decisionUrl: String,
-    @JsonProperty("toimipaikka_oid")
-    val unitOid: String,
-    @JsonProperty("alkamis_pvm")
-    val startDate: LocalDate,
-    @JsonProperty("paattymis_pvm")
-    val endDate: LocalDate?,
-    @JsonProperty("lahdejarjestelma")
-    val sourceSystem: String
+    val varhaiskasvatuspaatos: String,
+    val toimipaikka_oid: String,
+    val alkamis_pvm: LocalDate,
+    val paattymis_pvm: LocalDate?,
+    val lahdejarjestelma: String
 )
 
 data class VardaPlacementResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -853,17 +853,17 @@ data class EvakaServiceNeedInfoForVarda(
     val asPeriod = DateRange(startDate, endDate)
 
     fun toVardaDecisionForChild(vardaChildUrl: String, sourceSystem: String): VardaDecision = VardaDecision(
-        childUrl = vardaChildUrl,
-        applicationDate = this.applicationDate,
-        startDate = this.startDate,
-        endDate = this.endDate,
-        urgent = this.urgent,
-        hoursPerWeek = this.hoursPerWeek,
-        temporary = this.temporary,
-        daily = this.daily,
-        shiftCare = this.shiftCare,
-        providerTypeCode = this.providerTypeCode,
-        sourceSystem = sourceSystem
+        lapsi = vardaChildUrl,
+        hakemus_pvm = this.applicationDate,
+        alkamis_pvm = this.startDate,
+        paattymis_pvm = this.endDate,
+        pikakasittely_kytkin = this.urgent,
+        tuntimaara_viikossa = this.hoursPerWeek,
+        tilapainen_vaka_kytkin = this.temporary,
+        paivittainen_vaka_kytkin = this.daily,
+        vuorohoito_kytkin = this.shiftCare,
+        jarjestamismuoto_koodi = this.providerTypeCode,
+        lahdejarjestelma = sourceSystem
     )
 
     fun toVardaPlacement(vardaDecisionUrl: String, sourceSystem: String): VardaPlacement = VardaPlacement(

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -867,11 +867,11 @@ data class EvakaServiceNeedInfoForVarda(
     )
 
     fun toVardaPlacement(vardaDecisionUrl: String, sourceSystem: String): VardaPlacement = VardaPlacement(
-        decisionUrl = vardaDecisionUrl,
-        unitOid = this.ophUnitOid ?: error("VardaUpdate: varda placement cannot be created for service need ${this.id}: unitOid cannot be null"),
-        startDate = this.startDate,
-        endDate = this.endDate,
-        sourceSystem = sourceSystem
+        varhaiskasvatuspaatos = vardaDecisionUrl,
+        toimipaikka_oid = this.ophUnitOid ?: error("VardaUpdate: varda placement cannot be created for service need ${this.id}: unitOid cannot be null"),
+        alkamis_pvm = this.startDate,
+        paattymis_pvm = this.endDate,
+        lahdejarjestelma = sourceSystem
     )
 
     fun toVardaServiceNeed(): VardaServiceNeed =

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/MockVardaIntegrationEndpoint.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/MockVardaIntegrationEndpoint.kt
@@ -277,7 +277,7 @@ class MockVardaIntegrationEndpoint {
         lock.withLock {
             logger.info { "Mock varda integration endpoint GET /lapset/$childId/varhaiskasvatuspaatokset received id: $childId" }
             val childDecisions = decisions.entries.filter { (_, decision) ->
-                decision.childUrl.contains("/lapset/$childId/")
+                decision.lapsi.contains("/lapset/$childId/")
             }
             ResponseEntity.ok(
                 VardaClient.PaginatedResponse(
@@ -285,7 +285,7 @@ class MockVardaIntegrationEndpoint {
                     next = null,
                     previous = null,
                     results = childDecisions.map { (vardaId, decision) ->
-                        DecisionPeriod(vardaId, decision.startDate, decision.endDate)
+                        DecisionPeriod(vardaId, decision.alkamis_pvm, decision.paattymis_pvm)
                     }
                 )
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/MockVardaIntegrationEndpoint.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/MockVardaIntegrationEndpoint.kt
@@ -437,6 +437,93 @@ class MockVardaIntegrationEndpoint {
         }
         """
 
+    fun getMockErrorResponses() = mapOf(
+        "DY004" to """
+        {
+            "tuntimaara_viikossa":[
+            {
+                "error_code":"DY004",
+                "description":"Ensure this value is greater than or equal to 1.",
+                "translations":[
+                {
+                    "language":"SV",
+                    "description":"Värdet ska vara större eller lika stort som {{}}."
+                },
+                {
+                    "language":"FI",
+                    "description":"Arvon pitää olla suurempi tai yhtäsuuri kuin {{}}."
+                }
+                ]
+            }
+            ]
+        }
+        """.trimIndent(),
+        "VS009" to """
+            {
+               "errors":[
+                  {
+                     "error_code":"VS009",
+                     "description":"Varhaiskasvatussuhde alkamis_pvm cannot be after Toimipaikka paattymis_pvm.",
+                     "translations":[
+                        {
+                           "language":"FI",
+                           "description":"Varhaiskasvatussuhteen alkamispäivämäärä ei voi olla toimipaikan päättymispäivämäärän jälkeen."
+                        },
+                        {
+                           "language":"SV",
+                           "description":"Begynnelsedatumet för deltagande i småbarnspedagogik kan inte vara senare än verksamhetsställets slutdatum."
+                        }
+                     ]
+                  }
+               ]
+            }
+        """.trimIndent(),
+        "MA003" to """
+            {
+               "huoltajat":[
+                  {
+                     "error_code":"MA003",
+                     "description":"No matching huoltaja found.",
+                     "translations":[
+                        {
+                           "language":"FI",
+                           "description":"Väestötietojärjestelmästä ei löydy lapsen ilmoitettua huoltajaa."
+                        },
+                        {
+                           "language":"SV",
+                           "description":"Det gick inte att hitta vårdnadshavaren till barnet i Befolkningsdatasystemet."
+                        }
+                     ]
+                  }
+               ]
+            }
+        """.trimIndent(),
+        "HE012" to """
+            {
+               "huoltajat":{
+                  "1":{
+                     "etunimet":[
+                        {
+                           "error_code":"HE012",
+                           "description":"Name has disallowed characters.",
+                           "translations":[
+                              {
+                                 "language":"SV",
+                                 "description":"Namnet innehåller förbjudna tecken. "
+                              },
+                              {
+                                 "language":"FI",
+                                 "description":"Nimessä on merkkejä, jotka eivät ole sallittuja."
+                              }
+                           ]
+                        }
+                     ]
+                  }
+               }
+            }
+        """.trimIndent()
+    )
+
     private fun getMockDecisionResponse(id: Long): String {
         return """
 {

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
@@ -121,9 +121,9 @@ class VardaClient(
 
     data class VardaPersonSearchRequest(
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        val henkilotunnus: String?,
+        val henkilotunnus: String? = null,
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        val henkilo_oid: String?
+        val henkilo_oid: String? = null
     ) {
         init {
             check(henkilotunnus != null || henkilo_oid != null) {

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
@@ -57,25 +57,13 @@ class VardaClient(
     val getPlacementUrl = { placementId: Long -> "$placementUrl$placementId/" }
     val sourceSystem: String = env.sourceSystem
 
-    private data class VardaErrors(
-        val errors: List<VardaError>,
-        val tuntimaara_viikossa: List<VardaError> = listOf(),
-        val huoltajat: List<VardaError> = listOf()
-    ) {
-        fun getAll() = errors + tuntimaara_viikossa + huoltajat
-    }
-
-    private data class VardaError(
-        val error_code: String,
-        val description: String
-    )
-
     data class VardaRequestError(
         val method: String,
         val url: String,
         val body: String,
         val errorMessage: String,
         val errorCode: String?,
+        val errorDescription: String?,
         val statusCode: String
     ) {
         fun asMap() = mapOf(
@@ -84,19 +72,28 @@ class VardaClient(
             "body" to body,
             "errorMessage" to errorMessage,
             "errorCode" to errorCode,
+            "errorDescription" to errorDescription,
             "statusCode" to statusCode
         )
     }
 
+    fun parseVardaErrorBody(errorString: String): Pair<List<String>, List<String>> {
+        val codes = Regex("\"error_code\":\"(.+)\"").findAll(errorString).map { it.groupValues[1] }.toList()
+        val descriptions = Regex("\"description\":\"(.+)\"").findAll(errorString).map { it.groupValues[1] }.toList()
+        return Pair(codes, descriptions)
+    }
+
     private fun parseVardaError(request: Request, error: FuelError): VardaRequestError {
         return try {
-            val errors = objectMapper.readValue<VardaErrors>(error.errorData.decodeToString()).getAll()
+            val errorString = error.errorData.decodeToString()
+            val (errorCodes, descriptions) = parseVardaErrorBody(errorString)
             VardaRequestError(
                 method = request.method.toString(),
                 url = request.url.toString(),
                 body = request.body.asString("application/json"),
-                errorMessage = errors.joinToString(", ") { it.description },
-                errorCode = errors.joinToString(", ") { it.error_code },
+                errorMessage = errorString,
+                errorCode = errorCodes.first(),
+                errorDescription = descriptions.first(),
                 statusCode = error.response.statusCode.toString()
             )
         } catch (e: Exception) {
@@ -106,6 +103,7 @@ class VardaClient(
                 body = request.body.asString("application/json"),
                 errorMessage = error.errorData.decodeToString(),
                 errorCode = null,
+                errorDescription = null,
                 statusCode = error.response.statusCode.toString()
             )
         }
@@ -114,7 +112,7 @@ class VardaClient(
     private fun vardaError(request: Request, error: FuelError, message: (meta: VardaRequestError) -> String): Nothing {
         val meta = parseVardaError(request, error)
         logger.error(request, meta.asMap()) {
-            "VardaUpdate: request failed to ${meta.url}, status ${meta.statusCode}, reason ${meta.errorCode}: ${meta.errorMessage}"
+            "VardaUpdate: request failed to ${meta.url}, status ${meta.statusCode}, reason ${meta.errorCode}: ${meta.errorDescription}"
         }
         error(message(meta))
     }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
- send ssn or oid, not both
- parse varda errors with regex (structure varies too much to use data classes)
- replace UUID with ChildId where practical
- clean up old data classes (prefer translated keys over json properties)