### PR TITLE
EVAKA-4273 finalize preparatory decisions

### DIFF
--- a/service/src/main/resources/WEB-INF/templates/club/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/club/decision.properties
@@ -6,7 +6,7 @@ header.2=
 
 decision.title=PÄÄTÖS KERHOPAIKASTA
 
-decision.details.child=<strong>Lapsellenne</strong> {0} {1} {2}
+decision.details.child=<strong>Lapsellenne</strong> {0} {1} (s. {2})
 decision.details.date=<strong>on varattu kerhopaikka ajalle</strong>
 
 decision.placement.unit=Kerhopaikka

--- a/service/src/main/resources/WEB-INF/templates/daycare/transfer/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/daycare/transfer/decision.properties
@@ -8,7 +8,7 @@ header.2=uudesta varhaiskasvatuspaikasta
 
 decision.title=PÄÄTÖS UUDESTA VARHAISKASVATUSPAIKASTA
 
-decision.details.child=<strong>Lapsellanne</strong> {0} {1} {2} on voimassa oleva päätös varhaiskasvatuspaikasta Espoon kaupungin varhaiskasvatukseen. 
+decision.details.child=<strong>Lapsellanne</strong> {0} {1} (s. {2}) on voimassa oleva päätös varhaiskasvatuspaikasta Espoon kaupungin varhaiskasvatukseen.
 decision.details.date=<strong>Uusi päätös on ajalle</strong>
 
 decision.placement.unit=Lapsellenne on varattu uusi varhaiskasvatuspaikka:

--- a/service/src/main/resources/WEB-INF/templates/daycare/transfer/decision_sv.properties
+++ b/service/src/main/resources/WEB-INF/templates/daycare/transfer/decision_sv.properties
@@ -7,7 +7,7 @@ header.2=inom småbarnspedagogisk verksamhet
 
 decision.title=BESLUT OM EN NY PLATS INOM SMÅBARNSPEDAGOGISK VERKSAMHET
 
-decision.details.child=<strong>Ert barn</strong> {0} {1} {2} har  i kraft ett beslut om plats inom småbarnspedagogisk verksamhet i Esbo stad.
+decision.details.child=<strong>Ert barn</strong> {0} {1} (f. {2}) har  i kraft ett beslut om plats inom småbarnspedagogisk verksamhet i Esbo stad.
 decision.details.date=<strong>Det nya beslutet är för tiden</strong>
 
 decision.placement.unit=Barnet har reserverats en ny plats inom småbarnspedagogisk  verksamhet  i / hos

--- a/service/src/main/resources/WEB-INF/templates/daycare/voucher/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/daycare/voucher/decision.properties
@@ -10,7 +10,7 @@ header.decisionNumber=Päätöksen numero
 decision.title=PÄÄTÖS VARHAISKASVATUKSEN PALVELUSETELISTÄ
 decision.placement.unit=Varhaiskasvatusyksikkö varhaiskasvatuksen alkaessa
 
-decision.details.child=<strong>Lapsellenne</strong> {0} {1} {2} 
+decision.details.child=<strong>Lapsellenne</strong> {0} {1} (s. {2})
 decision.details.date=<strong>on myönnetty varhaiskasvatuksen palveluseteli ajalle</strong>
 
 decision.unitsupervisor=Varhaiskasvatusyksikön johtaja

--- a/service/src/main/resources/WEB-INF/templates/daycare/voucher/decision_sv.properties
+++ b/service/src/main/resources/WEB-INF/templates/daycare/voucher/decision_sv.properties
@@ -10,7 +10,7 @@ header.decisionNumber=Beslutets nummer
 decision.title=BESLUT OM SERVICESEDEL INOM SMÅBARNSPEDAGOGIKEN 
 decision.placement.unit=Enhet för småbarnspedagogik när småbarnspedagogiken inleds
 
-decision.details.child=<strong>Ditt barn</strong> {0} {1} {2} 
+decision.details.child=<strong>Ditt barn</strong> {0} {1} (f. {2})
 decision.details.date=<strong>har beviljats servicesedel inom småbarnspedagogiken för tiden</strong>
 
 decision.unitsupervisor=Ledare inom småbarnspedagogik

--- a/service/src/main/resources/WEB-INF/templates/fee-decision/voucher-value-decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/fee-decision/voucher-value-decision.properties
@@ -12,7 +12,7 @@ decisionNumber=Päätöksen nro
 
 text.title=PÄÄTÖS VARHAISKASVATUKSEN PALVELUSETELIN ARVOSTA
 
-decision.details.child=Lapsellenne {0} {1} {2} on myönnetty oikeus palveluseteliin alkaen {3}, jonka mukaan lapsenne varhaiskasvatuspaikka varhaiskasvatuksen alkaessa on
+decision.details.child=Lapsellenne {0} {1} (s. {2}) on myönnetty oikeus palveluseteliin alkaen {3}, jonka mukaan lapsenne varhaiskasvatuspaikka varhaiskasvatuksen alkaessa on
 
 decision.details.customerFeeInfo=Asiakasmaksun muodostuminen<br/>Palvelusetelin omavastuuosuus vastaa laskennallista kunnallista asiakasmaksua, jonka lisäksi palveluntuottaja voi periä yksikkökohtaista lisähintaa enintään 50 euroa / lapsi.
 decision.details.incomeChanges=Tulojen muutokset<br/>Jos perheen tuloissa tapahtuu olennaisia (+/-10 %) muutoksia, on uusi tuloselvitys tehtävä välittömästi. Maksu tarkistetaan seuraavan kuukauden alusta alkaen. 

--- a/service/src/main/resources/WEB-INF/templates/preparatory/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/preparatory/decision.properties
@@ -7,8 +7,8 @@ header.2=
 decision.title=LAPSEN OTTAMINEN ESIOPETUKSEEN JA PERUSOPETUKSEEN VALMISTAVAAN OPETUKSEEN
 
 decision.details.child=<strong>Lapsellenne</strong> {0} {1} (s. {2})
-decision.details.date=<strong>on tehty päätös Espoon kaupungin esiopetukseen ja perusopetukseen valmistavaan opetukseen ajalle</strong>
-decision.placement.unit=Esiopetuksen ja valmistavan opetuksen yksikkö
+decision.details.date=<strong>on tehty päätös Espoon kaupungin esiopetukseen ja perusopetukseen valmistavaan opetukseen ottamisesta ajalle</strong>
+decision.placement.unit=Opetuksen yksikkö
 decision.placement.unitsupervisor=Yksikön johtaja
 
 
@@ -16,9 +16,9 @@ decision.acceptance.title=ILMOITUS ESIOPETUKSEN JA PERUSOPETUKSEEN VALMISTAVAN O
 
 decision.acceptance.child.name=Lapsen nimi
 
-decision.instructions=<p>Sovelletut oikeusohjeet:<br/> Suomenkielisen varhaiskasvatus- ja opetuslautakunnan päätös 17.11.2011 § 155 esiopetuksen oppilaaksi otossa noudatettavista kriteereistä<br/> Opetus- ja varhaiskasvatuslautakunnan päätös 25.1. 2017 § 5 esiopetusikäisten perusopetukseen valmistavan opetuksen järjestämisestä ja 12.02.2020 § 19 päätös tarkennuksista esiopetusta järjestäviin yksiköihin lukuvuonna 2020-2021.</p> <p>Päätöksessä ilmoitetun paikan vastaanottamis- tai kieltäytymisilmoitus on toimitettava <strong>välittömästi, viimeistään kahden viikon kuluessa</strong> tämän ilmoituksen saamisesta. Paikan voi käydä hyväksymässä/hylkäämässä sähköisesti osoitteessa <a href="https://espoonvarhaiskasvatus.fi" rel="noreferrer">espoonvarhaiskasvatus.fi</a> (vaatii tunnistautumisen) tai postitse.</p><p>Tämä päätös poistaa lapsen perusopetukseen valmistavan opetuksen hakemuksen.</p><p>Toimivalta: Opetus- ja varhaiskasvatuslautakunnan suomenkielisen varhaiskasvatuksen tulosyksikköä koskeva delegointipäätös 7 §:n 4 kohta.</p>
+decision.instructions=<p>Sovelletut oikeusohjeet:<br/>Perusopetuslaki 4, 5 ja 6 §<br/>Suomenkielisen varhaiskasvatus- ja opetuslautakunnan päätös 17.11.2011 § 155 esiopetuksen oppilaaksi otossa noudatettavista kriteereistä<br/>Opetus- ja varhaiskasvatuslautakunnan päätös 25.1. 2017 § 5 esiopetusikäisten perusopetukseen valmistavan opetuksen järjestämisestä<br/>Opetus- ja varhaiskasvatuslautakunnan päätös 12.02.2020 § 19 tarkennuksista esiopetusta järjestäviin yksiköihin lukuvuonna 2020-2021.</p><p>Päätöksessä ilmoitetun paikan vastaanottamis- tai kieltäytymisilmoitus on toimitettava <strong>välittömästi, viimeistään kahden viikon kuluessa</strong> tämän ilmoituksen saamisesta. Paikan voi käydä hyväksymässä/hylkäämässä sähköisesti osoitteessa <a href="https://espoonvarhaiskasvatus.fi" rel="noreferrer">espoonvarhaiskasvatus.fi</a> (vaatii tunnistautumisen) tai postitse.</p><p>Tämä päätös poistaa lapsen perusopetukseen valmistavan opetuksen hakemuksen.</p><p>Toimivalta: Opetus- ja varhaiskasvatuslautakunnan suomenkielisen varhaiskasvatuksen tulosyksikköä koskeva delegointipäätös 7 §:n 4 kohta.</p>
 
-decision.acceptance.unit.name=Yksikkö
+decision.acceptance.unit.name=Opetuksen yksikkö
 decision.timeframe=Päätös lapsen ottamisesta esiopetukseen ja perusopetukseen valmistavaan opetukseen ajalle
 decision.acceptance.instructions=<p>Päätöksessä ilmoitetun paikan <strong>vastaanottamis- tai kieltäytymisilmoitus on toimitettava välittömästi, viimeistään kahden viikon kuluessa</strong> tämän ilmoituksen saamisesta. Paikan voi käydä hyväksymässä/hylkäämässä sähköisesti osoitteessa <a href="https://espoonvarhaiskasvatus.fi" rel="noreferrer">espoonvarhaiskasvatus.fi</a> (vaatii kirjautumisen) tai toimittaa tämän sivun täytettynä alla ilmoitettuun osoitteeseen.</p>
 

--- a/service/src/main/resources/WEB-INF/templates/preparatory/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/preparatory/decision.properties
@@ -6,7 +6,7 @@ header.2=
 
 decision.title=LAPSEN OTTAMINEN ESIOPETUKSEEN JA PERUSOPETUKSEEN VALMISTAVAAN OPETUKSEEN
 
-decision.details.child=<strong>Lapsellenne</strong> {0} {1} {2}
+decision.details.child=<strong>Lapsellenne</strong> {0} {1} (s. {2})
 decision.details.date=<strong>on tehty päätös Espoon kaupungin esiopetukseen ja perusopetukseen valmistavaan opetukseen ajalle</strong>
 decision.placement.unit=Esiopetuksen ja valmistavan opetuksen yksikkö
 decision.placement.unitsupervisor=Yksikön johtaja

--- a/service/src/main/resources/WEB-INF/templates/preparatory/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/preparatory/decision.properties
@@ -34,12 +34,7 @@ section.main.4.list.3=perusteet, joilla muutoksia vaaditaan,
 section.main.4.list.4=oikaisuvaatimuksen tekijän nimi, kotikunta sekä postiosoite ja puhelinnumero, johon asiaa koskevat ilmoitukset voidaan toimittaa
 
 section.main.5=Oikaisuvaatimus on oikaisuvaatimuksen tekijän, tämän laillisen edustajan tai asiamiehen allekirjoitettava. Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen laillinen edustajansa tai asiamiehensä tai jos oikaisuvaatimuksen laatijana on joku muu henkilö, oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja kotikunta.
-section.main.6=Oikaisuvaatimukseen on liitettävä:
-
-section.main.6.list.1=päätös, johon haetaan oikaisua,
-section.main.6.list.2=todistus tiedoksisaantipäivästä,
-section.main.6.list.3=asiakirjat, joihin oikaisuvaatimuksen tekijä vetoaa, jollei niitä ole jo aikaisemmin toimitettu viranomaiselle,
-section.main.6.list.4=mahdollisen asiamiehen valtakirja, jollei hän ole asianajaja tai yleinen oikeusavustaja
+section.main.6=
 
 section.main.7=Oikaisuvaatimus on toimitettava virka-aikana muutoksenhakuajan kuluessa Etelä-Suomen aluehallintovirastolle. Postiin oikaisuvaatimus on jätettävä niin ajoissa, että se ehtii perille ennen muutoksenhakuajan päättymistä. Oikaisuvaatimuksen voi toimittaa ennen muutoksenhakuajan päättymistä myös faksilla tai sähköpostilla lähettäjän omalla vastuulla.
 

--- a/service/src/main/resources/WEB-INF/templates/preparatory/decision_sv.properties
+++ b/service/src/main/resources/WEB-INF/templates/preparatory/decision_sv.properties
@@ -7,8 +7,8 @@ header.2=
 decision.title=LAPSEN OTTAMINEN ESIOPETUKSEEN JA PERUSOPETUKSEEN VALMISTAVAAN OPETUKSEEN
 
 decision.details.child=<strong>Lapsellenne</strong> {0} {1} (s. {2})
-decision.details.date=<strong>on tehty päätös Espoon kaupungin esiopetukseen ja perusopetukseen valmistavaan opetukseen ajalle</strong>
-decision.placement.unit=Esiopetuksen ja valmistavan opetuksen yksikkö
+decision.details.date=<strong>on tehty päätös Espoon kaupungin esiopetukseen ja perusopetukseen valmistavaan opetukseen ottamisesta ajalle</strong>
+decision.placement.unit=Opetuksen yksikkö
 decision.placement.unitsupervisor=Yksikön johtaja
 
 
@@ -16,9 +16,9 @@ decision.acceptance.title=ILMOITUS ESIOPETUKSEN JA PERUSOPETUKSEEN VALMISTAVAN O
 
 decision.acceptance.child.name=Lapsen nimi
 
-decision.instructions=<p>Sovelletut oikeusohjeet:<br/> Suomenkielisen varhaiskasvatus- ja opetuslautakunnan päätös 17.11.2011 § 155 esiopetuksen oppilaaksi otossa noudatettavista kriteereistä<br/> Opetus- ja varhaiskasvatuslautakunnan päätös 25.1. 2017 § 5 esiopetusikäisten perusopetukseen valmistavan opetuksen järjestämisestä ja 12.02.2020 § 19 päätös tarkennuksista esiopetusta järjestäviin yksiköihin lukuvuonna 2020-2021.</p> <p>Päätöksessä ilmoitetun paikan vastaanottamis- tai kieltäytymisilmoitus on toimitettava <strong>välittömästi, viimeistään kahden viikon kuluessa</strong> tämän ilmoituksen saamisesta. Paikan voi käydä hyväksymässä/hylkäämässä sähköisesti osoitteessa <a href="https://espoonvarhaiskasvatus.fi" rel="noreferrer">espoonvarhaiskasvatus.fi</a> (vaatii tunnistautumisen) tai postitse.</p><p>Tämä päätös poistaa lapsen perusopetukseen valmistavan opetuksen hakemuksen.</p><p>Toimivalta: Opetus- ja varhaiskasvatuslautakunnan suomenkielisen varhaiskasvatuksen tulosyksikköä koskeva delegointipäätös 7 §:n 4 kohta.</p>
+decision.instructions=<p>Sovelletut oikeusohjeet:<br/>Perusopetuslaki 4, 5 ja 6 §<br/>Suomenkielisen varhaiskasvatus- ja opetuslautakunnan päätös 17.11.2011 § 155 esiopetuksen oppilaaksi otossa noudatettavista kriteereistä<br/>Opetus- ja varhaiskasvatuslautakunnan päätös 25.1. 2017 § 5 esiopetusikäisten perusopetukseen valmistavan opetuksen järjestämisestä<br/>Opetus- ja varhaiskasvatuslautakunnan päätös 12.02.2020 § 19 tarkennuksista esiopetusta järjestäviin yksiköihin lukuvuonna 2020-2021.</p><p>Päätöksessä ilmoitetun paikan vastaanottamis- tai kieltäytymisilmoitus on toimitettava <strong>välittömästi, viimeistään kahden viikon kuluessa</strong> tämän ilmoituksen saamisesta. Paikan voi käydä hyväksymässä/hylkäämässä sähköisesti osoitteessa <a href="https://espoonvarhaiskasvatus.fi" rel="noreferrer">espoonvarhaiskasvatus.fi</a> (vaatii tunnistautumisen) tai postitse.</p><p>Tämä päätös poistaa lapsen perusopetukseen valmistavan opetuksen hakemuksen.</p><p>Toimivalta: Opetus- ja varhaiskasvatuslautakunnan suomenkielisen varhaiskasvatuksen tulosyksikköä koskeva delegointipäätös 7 §:n 4 kohta.</p>
 
-decision.acceptance.unit.name=Yksikkö
+decision.acceptance.unit.name=Opetuksen yksikkö
 decision.timeframe=Päätös lapsen ottamisesta esiopetukseen ja perusopetukseen valmistavaan opetukseen ajalle
 decision.acceptance.instructions=<p>Päätöksessä ilmoitetun paikan <strong>vastaanottamis- tai kieltäytymisilmoitus on toimitettava välittömästi, viimeistään kahden viikon kuluessa</strong> tämän ilmoituksen saamisesta. Paikan voi käydä hyväksymässä/hylkäämässä sähköisesti osoitteessa <a href="https://espoonvarhaiskasvatus.fi" rel="noreferrer">espoonvarhaiskasvatus.fi</a> (vaatii kirjautumisen) tai toimittaa tämän sivun täytettynä alla ilmoitettuun osoitteeseen.</p>
 

--- a/service/src/main/resources/WEB-INF/templates/preparatory/decision_sv.properties
+++ b/service/src/main/resources/WEB-INF/templates/preparatory/decision_sv.properties
@@ -6,7 +6,7 @@ header.2=
 
 decision.title=LAPSEN OTTAMINEN ESIOPETUKSEEN JA PERUSOPETUKSEEN VALMISTAVAAN OPETUKSEEN
 
-decision.details.child=<strong>Lapsellenne</strong> {0} {1} {2}
+decision.details.child=<strong>Lapsellenne</strong> {0} {1} (s. {2})
 decision.details.date=<strong>on tehty päätös Espoon kaupungin esiopetukseen ja perusopetukseen valmistavaan opetukseen ajalle</strong>
 decision.placement.unit=Esiopetuksen ja valmistavan opetuksen yksikkö
 decision.placement.unitsupervisor=Yksikön johtaja

--- a/service/src/main/resources/WEB-INF/templates/preparatory/decision_sv.properties
+++ b/service/src/main/resources/WEB-INF/templates/preparatory/decision_sv.properties
@@ -34,12 +34,7 @@ section.main.4.list.3=perusteet, joilla muutoksia vaaditaan,
 section.main.4.list.4=oikaisuvaatimuksen tekijän nimi, kotikunta sekä postiosoite ja puhelinnumero, johon asiaa koskevat ilmoitukset voidaan toimittaa
 
 section.main.5=Oikaisuvaatimus on oikaisuvaatimuksen tekijän, tämän laillisen edustajan tai asiamiehen allekirjoitettava. Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen laillinen edustajansa tai asiamiehensä tai jos oikaisuvaatimuksen laatijana on joku muu henkilö, oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja kotikunta.
-section.main.6=Oikaisuvaatimukseen on liitettävä:
-
-section.main.6.list.1=päätös, johon haetaan oikaisua,
-section.main.6.list.2=todistus tiedoksisaantipäivästä,
-section.main.6.list.3=asiakirjat, joihin oikaisuvaatimuksen tekijä vetoaa, jollei niitä ole jo aikaisemmin toimitettu viranomaiselle,
-section.main.6.list.4=mahdollisen asiamiehen valtakirja, jollei hän ole asianajaja tai yleinen oikeusavustaja
+section.main.6=
 
 section.main.7=Oikaisuvaatimus on toimitettava virka-aikana muutoksenhakuajan kuluessa Etelä-Suomen aluehallintovirastolle. Postiin oikaisuvaatimus on jätettävä niin ajoissa, että se ehtii perille ennen muutoksenhakuajan päättymistä. Oikaisuvaatimuksen voi toimittaa ennen muutoksenhakuajan päättymistä myös faksilla tai sähköpostilla lähettäjän omalla vastuulla.
 

--- a/service/src/main/resources/WEB-INF/templates/preschool/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/preschool/decision.properties
@@ -38,12 +38,7 @@ section.main.4.list.3=perusteet, joilla muutoksia vaaditaan,
 section.main.4.list.4=oikaisuvaatimuksen tekijän nimi, kotikunta sekä postiosoite ja puhelinnumero, johon asiaa koskevat ilmoitukset voidaan toimittaa
 
 section.main.5=Oikaisuvaatimus on oikaisuvaatimuksen tekijän, tämän laillisen edustajan tai asiamiehen allekirjoitettava. Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen laillinen edustajansa tai asiamiehensä tai jos oikaisuvaatimuksen laatijana on joku muu henkilö, oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja kotikunta.
-section.main.6=Oikaisuvaatimukseen on liitettävä:
-
-section.main.6.list.1=päätös, johon haetaan oikaisua,
-section.main.6.list.2=todistus tiedoksisaantipäivästä,
-section.main.6.list.3=asiakirjat, joihin oikaisuvaatimuksen tekijä vetoaa, jollei niitä ole jo aikaisemmin toimitettu viranomaiselle,
-section.main.6.list.4=mahdollisen asiamiehen valtakirja, jollei hän ole asianajaja tai yleinen oikeusavustaja
+section.main.6=
 
 section.main.7=Oikaisuvaatimus on toimitettava virka-aikana muutoksenhakuajan kuluessa Etelä-Suomen aluehallintovirastolle. Postiin oikaisuvaatimus on jätettävä niin ajoissa, että se ehtii perille ennen muutoksenhakuajan päättymistä. Oikaisuvaatimuksen voi toimittaa ennen muutoksenhakuajan päättymistä myös faksilla tai sähköpostilla lähettäjän omalla vastuulla.
 

--- a/service/src/main/resources/WEB-INF/templates/preschool/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/preschool/decision.properties
@@ -5,7 +5,7 @@ header.1=PÄÄTÖS esiopetuspaikasta
 header.2=
 
 decision.title=PÄÄTÖS ESIOPETUSPAIKASTA
-decision.details.child=<strong>Lapsellenne</strong> {0} {1} {2}
+decision.details.child=<strong>Lapsellenne</strong> {0} {1} (s. {2})
 decision.details.date=<strong>on varattu esiopetuspaikka ajalle</strong>
 decision.placement.unit=Esiopetusyksikkö
 decision.placement.unitsupervisor=Esiopetusyksikön johtaja

--- a/service/src/main/resources/WEB-INF/templates/preschool/decision_sv.properties
+++ b/service/src/main/resources/WEB-INF/templates/preschool/decision_sv.properties
@@ -40,12 +40,7 @@ section.main.4.list.3=de grunder på vilka ändring yrkas.
 section.main.4.list.4=ändringssökandens eller uppsättarens kontaktuppgifter (namn, hemkommun, postadress och telefonnummer) under vilka meddelanden i saken kan tillställas
 
 section.main.5=Handlingarna ska undertecknas av den som begär om omprövning, hans eller hennes lagliga företrädare eller ombud eller om någon annan person har uppgjort dem, ska i begäran om omprövning även uppges namn och hemkommun för denna person.
-section.main.6=Till begäran om omprövning ska fogas:
-
-section.main.6.list.1=det beslut i vilket ändring söks genom besvär,
-section.main.6.list.2=intyg över vilken dag beslutet har delgivits eller annan utredning över när besvärstiden har börjat,
-section.main.6.list.3=de handlingar som ändringssökanden åberopar till stöd för sina yrkanden, om dessa inte redan tidigare har tillställts myndigheten, samt
-section.main.6.list.4=fullmakt åt eventuellt ombud, om ombudet inte är en advokat eller ett allmänt rättsbiträde.
+section.main.6=
 
 section.main.7=Begäran om omprövning ska sändas eller lämnas in till Regionförvaltningsverket i Södra Finland. Begäran om omprövning ska lämnas till posten i så god tid att den hinner fram innan omprövningstiden går ut. Handlingarna kan också på eget ansvar sändas per fax eller per e-post innan omprövningstiden gått ut.
 

--- a/service/src/main/resources/WEB-INF/templates/preschool/decision_sv.properties
+++ b/service/src/main/resources/WEB-INF/templates/preschool/decision_sv.properties
@@ -6,7 +6,7 @@ header.1=BESLUT om förskoleplats
 header.2=
 
 decision.title=BESLUT OM FÖRSKOLEPLATS
-decision.details.child=<strong>För ert barn</strong> {0} {1} {2}
+decision.details.child=<strong>För ert barn</strong> {0} {1} (f. {2})
 decision.details.date=<strong>har reserverats en förskoleplats för tiden</strong>
 decision.placement.unit=Förskoleplats
 decision.placement.unitsupervisor=Ledare för förskolan

--- a/service/src/main/resources/WEB-INF/templates/shared/common.html
+++ b/service/src/main/resources/WEB-INF/templates/shared/common.html
@@ -213,6 +213,19 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
         }
 
+        .col-row {
+            margin-bottom: 2px;
+        }
+
+        .left {
+            display: inline-block;
+            width:100px;
+        }
+
+        .right {
+            display: inline-block;
+            width:300px;
+        }
     </style>
 </head>
 <body>

--- a/service/src/main/resources/WEB-INF/templates/shared/common.properties
+++ b/service/src/main/resources/WEB-INF/templates/shared/common.properties
@@ -6,7 +6,7 @@ header.pageNumber=Sivu
 header.decisionNumber=Päätöksen numero
 text.decision.sentDate=Päätöspvm {0}
 
-decision.details.child=<strong>Lapsellenne</strong> {0} {1} {2}
+decision.details.child=<strong>Lapsellenne</strong> {0} {1} (s. {2})
 decision.details.date=<strong>on tehty päätös Espoon kaupungin varhaiskasvatukseen ajalle</strong>
 
 decision.placement.unit=Varhaiskasvatusyksikkö varhaiskasvatuksen alkaessa

--- a/service/src/main/resources/WEB-INF/templates/shared/common_sv.properties
+++ b/service/src/main/resources/WEB-INF/templates/shared/common_sv.properties
@@ -7,7 +7,7 @@ header.decisionNumber=Beslutets nummer
 text.decision.sentDate=Beslutsdatum {0}
 
 
-decision.details.child=<strong>Till ert barn</strong> {0} {1} {2}
+decision.details.child=<strong>Till ert barn</strong> {0} {1} (f. {2})
 decision.details.date=<strong>har enligt beslut beviljats plats inom Esbo stads småbarnspedagogiska verksamhet för tiden</strong>
 
 decision.placement.unit=Barnet har reserverats en plats att inleda småbarnspedagogisk verksamhet i/hos

--- a/service/src/main/resources/WEB-INF/templates/shared/daycare-correction.html
+++ b/service/src/main/resources/WEB-INF/templates/shared/daycare-correction.html
@@ -46,23 +46,31 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <div class="col-row" th:text="#{address.title}"></div>
     <br />
     <div class="row">
-        <div class="column left">
-            <div class="col-row" th:text="#{address.street.caption}"></div>
-            <div class="col-row" th:text="#{address.opening.caption}"></div>
-            <div class="col-row" th:text="#{address.postal.caption}"></div>
-            <div class="col-row" th:text="#{address.email.caption}"></div>
-            <div class="col-row" th:text="#{address.fax.caption}"></div>
-            <div class="col-row" th:text="#{address.phone.caption}"></div>
+        <div class="col-row">
+            <div class="left" th:text="#{address.street.caption}"></div>
+            <div class="right" th:text="#{address.street.value}"></div>
         </div>
-        <div class="column right">
-            <div class="col-row" th:text="#{address.street.value}"></div>
-            <div class="col-row" th:text="#{address.opening.value}"></div>
-            <div class="col-row" th:text="#{address.postal.value}"></div>
-            <div class="col-row">
+        <div class="col-row">
+            <div class="left" th:text="#{address.opening.caption}"></div>
+            <div class="right" th:text="#{address.opening.value}"></div>
+        </div>
+        <div class="col-row">
+            <div class="left" th:text="#{address.postal.caption}"></div>
+            <div class="right" th:text="#{address.postal.value}"></div>
+        </div>
+        <div class="col-row">
+            <div class="left" th:text="#{address.email.caption}"></div>
+            <div class="right">
                 <a th:href="'mailto:' + #{address.email.value}" th:text="#{address.email.value}"></a>
             </div>
-            <div class="col-row" th:text="#{address.fax.value}"></div>
-            <div class="col-row" th:text="#{address.phone.value}"></div>
+        </div>
+        <div class="col-row">
+            <div class="left" th:text="#{address.fax.caption}"></div>
+            <div class="right" th:text="#{address.fax.value}"></div>
+        </div>
+        <div class="col-row">
+            <div class="left" th:text="#{address.phone.caption}"></div>
+            <div class="right" th:text="#{address.phone.value}"></div>
         </div>
     </div>
 </th:block>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
* Remove (broken) part that details the required attachments for correction requests on preschool and preparatory decisions
* Fix the layout of address info on decision corrections part
* Clarify that the date following child name on decisions is the child's date of birth
* Update preparatory decision texts

