### PR TITLE
EVAKA-4000 schedule varda reset

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -25,7 +25,11 @@ data class ScheduledJobSettings(val enabled: Boolean, val schedule: Schedule) {
         fun default(job: ScheduledJob) = when (job) {
             ScheduledJob.VardaUpdate -> ScheduledJobSettings(
                 enabled = false,
-                schedule = JobSchedule.daily(LocalTime.of(23, 0))
+                schedule = JobSchedule.daily(LocalTime.of(23, 30))
+            )
+            ScheduledJob.VardaReset -> ScheduledJobSettings(
+                enabled = true,
+                schedule = JobSchedule.daily(LocalTime.of(20, 0))
             )
             ScheduledJob.EndOfDayAttendanceUpkeep -> ScheduledJobSettings(
                 enabled = true,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -43,6 +43,7 @@ enum class ScheduledJob(val fn: (ScheduledJobs, Database.Connection) -> Unit) {
     RemoveOldDraftApplications(ScheduledJobs::removeOldDraftApplications),
     SendPendingDecisionReminderEmails(ScheduledJobs::sendPendingDecisionReminderEmails),
     VardaUpdate(ScheduledJobs::vardaUpdate),
+    VardaReset(ScheduledJobs::vardaReset),
     InactivePeopleCleanup(ScheduledJobs::inactivePeopleCleanup),
     InactiveEmployeesRoleReset(ScheduledJobs::inactiveEmployeesRoleReset)
 }
@@ -91,6 +92,10 @@ class ScheduledJobs(
 
     fun vardaUpdate(db: Database.Connection) {
         vardaUpdateService.startVardaUpdate(db)
+    }
+
+    fun vardaReset(db: Database.Connection) {
+        vardaUpdateService.planVardaReset(db, addNewChildren = true)
     }
 
     fun removeOldDraftApplications(db: Database.Connection) {

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDevController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDevController.kt
@@ -28,7 +28,8 @@ class VardaDevController(
     fun resetChildren(
         db: Database.Connection,
         @RequestParam(defaultValue = "true") addNewChildren: Boolean,
+        @RequestParam(defaultValue = "1000") limit: Int,
     ) {
-        vardaUpdateService.planVardaReset(db, addNewChildren)
+        vardaUpdateService.planVardaReset(db, addNewChildren = addNewChildren, maxChildren = limit)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -89,11 +89,10 @@ class VardaUpdateService(
         }
     }
 
-    fun planVardaReset(db: Database.Connection, addNewChildren: Boolean) {
-        val RESET_LIMIT = 1000
+    fun planVardaReset(db: Database.Connection, addNewChildren: Boolean, maxChildren: Int = 1000) {
         logger.info("VardaUpdate: starting reset process")
-        val resetChildIds = db.transaction { it.getVardaChildrenToReset(limit = RESET_LIMIT, addNewChildren = addNewChildren) }
-        logger.info("VardaUpdate: will reset ${resetChildIds.size} children (max was $RESET_LIMIT)")
+        val resetChildIds = db.transaction { it.getVardaChildrenToReset(limit = maxChildren, addNewChildren = addNewChildren) }
+        logger.info("VardaUpdate: will reset ${resetChildIds.size} children (max was $maxChildren)")
 
         db.transaction { tx ->
             asyncJobRunner.plan(tx, resetChildIds.map { VardaAsyncJob.ResetVardaChild(it) })


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
- enable scheduled varda reset by default
- add param for max new children to process
