### PR TITLE
CI: don't push builds from branches to S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1317,6 +1317,9 @@ workflows:
             - proxy_build_and_push_image
             - service_build_and_push_image
             - message_service_build_and_push_image
+          filters:
+            branches:
+              only: master
           matrix:
             parameters:
               target_env: [dev, test, staging, prod]


### PR DESCRIPTION
#### Summary
- No reason to push branch builds to all S3 buckets, just incurs unnecessary costs

