### PR TITLE
Short circuit fuel retry on 429 to avoid blocking calls

### DIFF
--- a/service/src/test/kotlin/fi/espoo/evaka/shared/utils/FuelExtensionsTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/utils/FuelExtensionsTest.kt
@@ -53,7 +53,7 @@ class FuelExtensionsTest {
         FuelManager.instance.client = client
 
         val (_, response, result) = Fuel.get("https://example.com")
-            .responseStringWithRetries(1)
+            .responseStringWithRetries(1, false)
 
         assertEquals(200, response.statusCode)
         assertEquals("final", result.get())
@@ -70,7 +70,7 @@ class FuelExtensionsTest {
         FuelManager.instance.client = client
 
         val (_, response, result) = Fuel.get("https://example.com")
-            .responseStringWithRetries(2) // Would have to be 3 to succeed
+            .responseStringWithRetries(2, false) // Would have to be 3 to succeed
         assertEquals(429, response.statusCode) // Status code of last response
         assertTrue(result is Result.Failure)
     }
@@ -82,7 +82,7 @@ class FuelExtensionsTest {
         FuelManager.instance.client = client
 
         assertThrows<NumberFormatException> {
-            Fuel.get("https://example.com").responseStringWithRetries(1) // Would have to be 2 to succeed
+            Fuel.get("https://example.com").responseStringWithRetries(1, false) // Would have to be 2 to succeed
         }
     }
 


### PR DESCRIPTION
#### Summary
- Varda rate limiter causes thousands of varda requests to block on 429 RETRY_AFTER causing the async jobs to congest. Fail on 429 by default to avoid this

