### PR TITLE
[EVAKA-4293] Prevent parallel invoice generation

### DIFF
--- a/frontend/src/employee-frontend/components/invoices/Invoices.tsx
+++ b/frontend/src/employee-frontend/components/invoices/Invoices.tsx
@@ -25,7 +25,7 @@ import { useTranslation } from '../../state/i18n'
 import NameWithSsn from '../common/NameWithSsn'
 import ChildrenCell from '../common/ChildrenCell'
 import { InvoiceSummary } from '../../types/invoicing'
-import { Result } from 'lib-common/api'
+import { Failure, Loading, Result, Success } from 'lib-common/api'
 import { formatCents } from 'lib-common/money'
 import Tooltip from '../../components/common/Tooltip'
 import { StatusIconContainer } from '../common/StatusIconContainer'
@@ -67,19 +67,24 @@ export default React.memo(function Invoices({
   allInvoicesToggleDisabled
 }: Props) {
   const { i18n } = useTranslation()
-  const [refreshError, setRefreshError] = useState(false)
+  const [refreshResult, setRefreshResult] = useState<Result<void>>(
+    Success.of(undefined)
+  )
 
   return (
     <div className="invoices">
       <RefreshInvoices>
-        {refreshError ? (
+        {refreshResult.isFailure ? (
           <RefreshError>{i18n.common.error.unknown}</RefreshError>
         ) : null}
         <InlineButton
           icon={faSync}
+          disabled={refreshResult.isLoading}
           onClick={() => {
-            setRefreshError(false)
-            refreshInvoices().catch(() => setRefreshError(true))
+            setRefreshResult(Loading.of())
+            refreshInvoices()
+              .then(() => setRefreshResult(Success.of()))
+              .catch((err) => setRefreshResult(Failure.of(err)))
           }}
           text={i18n.invoices.buttons.createInvoices}
           data-qa="create-invoices"

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
@@ -380,17 +380,16 @@ fun Database.Transaction.updateInvoiceDates(invoiceIds: List<UUID>, invoiceDate:
         .execute()
 }
 
-fun Database.Transaction.deleteDraftInvoicesByPeriod(period: DateRange) {
+fun Database.Transaction.deleteDraftInvoicesByDateRange(range: DateRange) {
     val sql =
         """
             DELETE FROM invoice
             WHERE status = :status::invoice_status
-            AND daterange(:periodStart, :periodEnd, '[]') && daterange(period_start, period_end, '[]')
+            AND daterange(period_start, period_end, '[]') && :range
         """
 
     createUpdate(sql)
-        .bind("periodStart", period.start)
-        .bind("periodEnd", period.end)
+        .bind("range", range)
         .bind("status", InvoiceStatus.DRAFT.toString())
         .execute()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -49,6 +49,8 @@ import java.time.temporal.TemporalAdjusters
 import java.util.UUID
 
 fun Database.Transaction.createAllDraftInvoices(range: DateRange = getPreviousMonthRange()) {
+    createUpdate("LOCK TABLE invoice IN EXCLUSIVE MODE").execute()
+
     val effectiveDecisions = getInvoiceableFeeDecisions(range).groupBy { it.headOfFamily.id }
     val placements = getInvoiceablePlacements(range).groupBy { it.headOfFamily.id }
     val invoicedHeadsOfFamily = getInvoicedHeadsOfFamily(range)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Time.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Time.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.shared.domain
 
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.getUUID
+import fi.espoo.evaka.shared.db.mapColumn
 import org.jdbi.v3.core.kotlin.mapTo
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -221,8 +221,7 @@ fun Database.Read.operationalDays(year: Int, month: Month): OperationalDays {
 
     // Only includes units that don't have regular monday to friday operational days
     val specialUnitOperationalDays = createQuery("SELECT id, operation_days FROM daycare WHERE NOT (operation_days @> '{1,2,3,4,5}' AND operation_days <@ '{1,2,3,4,5}')")
-        .map { rs, _ -> DaycareId(rs.getUUID("id")) to rs.getArray("operation_days").array as Array<*> }
-        .map { (id, days) -> id to days.map { it as Int }.map { DayOfWeek.of(it) } }
+        .map { row -> row.mapColumn<DaycareId>("id") to row.mapColumn<Array<Int>>("operation_days").map { DayOfWeek.of(it) } }
         .toList()
 
     val holidays = createQuery("SELECT date FROM holiday WHERE between_start_and_end(:range, date)")


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Prevent parallel invoice generation, refactor code:

- database lock blocks parallel operations. Explicit locking always adds a risk of deadlocks, but I think this is worth a try
- disable UI button during the operation to avoid multiple clicks
- simplify some JDBI mapping cases
- rename period to range in some places

*Note: depends on https://github.com/espoon-voltti/evaka/pull/1410*, so those commits are included but are not really meant to be a part of this pull request