### PR TITLE
Write frontend install and deploy metadata 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,6 +558,19 @@ commands:
           target_env: << parameters.target_env >>
           from: frontend/src/maintenance-page-frontend
           to: "frontend/maintenance-page/${CIRCLE_SHA1}"
+      - run:
+          name: Create latest install metadata.yaml
+          command: |
+            cat <<EOF>>metadata.yaml
+            install:
+              hash: $CIRCLE_SHA1
+              date: $(date)
+              branch: $CIRCLE_BRANCH
+            EOF
+
+            aws s3 sync metadata.yaml s3://evaka-static-<< parameters.target_env >>/frontend/metadata.yaml \
+              --exact-timestamps \
+              --profile voltti-<< parameters.target_env >>
 
   copy_to_s3:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,6 +532,18 @@ commands:
           target_env: << parameters.target_env >>
           from: "frontend/maintenance-page/${CIRCLE_SHA1}"
           to: maintenance-page
+      - run:
+          name: Create deploy.metadata.yaml
+          command: |
+            cat \<<EOF>> deploy.metadata.yaml
+            version: '1'
+            updated: '$(date --iso-8601=seconds)'
+            sha1: $CIRCLE_SHA1
+            branch: $CIRCLE_BRANCH
+            EOF
+
+            aws s3 cp deploy.metadata.yaml s3://evaka-static-<< parameters.target_env >>/frontend/deploy.metadata.yaml \
+              --profile voltti-<< parameters.target_env >>
 
   install_frontend:
     parameters:
@@ -559,17 +571,16 @@ commands:
           from: frontend/src/maintenance-page-frontend
           to: "frontend/maintenance-page/${CIRCLE_SHA1}"
       - run:
-          name: Create latest install metadata.yaml
+          name: Create metadata.yaml
           command: |
-            cat \<<EOF>>metadata.yaml
-            install:
-              hash: $CIRCLE_SHA1
-              date: $(date)
-              branch: $CIRCLE_BRANCH
+            cat \<<EOF>> metadata.yaml
+            version: '1'
+            updated: '$(date --iso-8601=seconds)'
+            sha1: $CIRCLE_SHA1
+            branch: $CIRCLE_BRANCH
             EOF
 
-            aws s3 sync metadata.yaml s3://evaka-static-<< parameters.target_env >>/frontend/metadata.yaml \
-              --exact-timestamps \
+            aws s3 cp metadata.yaml "s3://evaka-static-<< parameters.target_env >>/frontend/metadata/${CIRCLE_SHA1}.yaml" \
               --profile voltti-<< parameters.target_env >>
 
   copy_to_s3:
@@ -593,7 +604,6 @@ commands:
             fi
 
             aws s3 sync . s3://evaka-static-<< parameters.target_env >>/<< parameters.to >> \
-              --acl public-read \
               --exact-timestamps \
               "${EXTRA_ARGS[@]}" \
               --profile voltti-<< parameters.target_env >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -561,7 +561,7 @@ commands:
       - run:
           name: Create latest install metadata.yaml
           command: |
-            cat <<EOF>>metadata.yaml
+            cat \<<EOF>>metadata.yaml
             install:
               hash: $CIRCLE_SHA1
               date: $(date)


### PR DESCRIPTION
#### Summary

We need to keep information about installs and deployments here in bucket.

This will write metadata files during install (for cleanup) and deployment (to see what version is installed)
