### PR TITLE
Identify SSN-less children with oid in Koski integration

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/MockKoskiServer.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/MockKoskiServer.kt
@@ -64,8 +64,13 @@ class MockKoskiServer(private val objectMapper: ObjectMapper, port: Int) : AutoC
         }
 
         val response = lock.withLock {
-            val ssn = oppija.henkilö.hetu
-            val personOid = persons.getOrPut(ssn) { "1.2.246.562.24.${personOid++}" }
+            val personOid = when (oppija.henkilö) {
+                is OidHenkilö -> (oppija.henkilö as OidHenkilö).oid
+                is UusiHenkilö -> {
+                    val ssn = (oppija.henkilö as UusiHenkilö).hetu
+                    persons.getOrPut(ssn) { "1.2.246.562.24.${personOid++}" }
+                }
+            }
             // Raw Jackson databind API is used to generate the response, because we want to add some fields
             // that are missing in our data class -based representation to simulate a real response more accurately
             objectMapper.createObjectNode().apply {

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -27,11 +27,16 @@ enum class KoskiOperation {
 }
 
 data class KoskiChildRaw(
-    val ssn: String,
+    val ssn: String?,
+    val personOid: String?,
     val firstName: String,
     val lastName: String
 ) {
-    fun toHenkilö() = UusiHenkilö(ssn, firstName, lastName)
+    fun toHenkilö(): Henkilö = when {
+        ssn != null && ssn.isNotBlank() -> UusiHenkilö(ssn, firstName, lastName)
+        personOid != null && personOid.isNotBlank() -> OidHenkilö(personOid)
+        else -> throw IllegalStateException("not enough information available to create Koski Henkilö")
+    }
 }
 
 data class KoskiUnitRaw(

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
@@ -81,7 +81,8 @@ RETURNING id, void_date IS NOT NULL AS voided
                 ksr.study_right_oid,
                 d.language AS daycare_language,
                 d.provider_type AS daycare_provider_type,
-                pr.social_security_number ssn,
+                nullif(pr.social_security_number, '') ssn,
+                nullif(pr.oph_person_oid, '') person_oid,
                 pr.first_name,
                 pr.last_name
             FROM koski_study_right ksr
@@ -104,7 +105,8 @@ RETURNING id, void_date IS NOT NULL AS voided
                 d.language AS daycare_language,
                 d.provider_type AS daycare_provider_type,
                 um.name AS approver_name,
-                pr.social_security_number ssn,
+                nullif(pr.social_security_number, '') ssn,
+                nullif(pr.oph_person_oid, '') person_oid,
                 pr.first_name,
                 pr.last_name,
                 holidays

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/Oppija.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/Oppija.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.koski
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
 import java.util.UUID
@@ -105,16 +106,22 @@ enum class SuorituksenTyyppiKoodi {
 
 // https://github.com/Opetushallitus/koski/blob/d7abc79acca44d2d1265c14be4a631bd8ee91297/src/main/scala/fi/oph/koski/schema/Oppija.scala#L6
 data class Oppija(
-    val henkilö: UusiHenkilö, // actual API supports more than one type
+    val henkilö: Henkilö,
     val opiskeluoikeudet: List<Opiskeluoikeus>
 )
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+sealed class Henkilö
 
 // https://github.com/Opetushallitus/koski/blob/1f1d05bb80cbac46cd873419975ed421370b5035/src/main/scala/fi/oph/koski/schema/Henkilo.scala#L56
 data class UusiHenkilö(
     val hetu: String,
     val etunimet: String,
     val sukunimi: String
-)
+) : Henkilö()
+
+// https://github.com/Opetushallitus/koski/blob/1f1d05bb80cbac46cd873419975ed421370b5035/src/main/scala/fi/oph/koski/schema/Henkilo.scala#L65
+data class OidHenkilö(val oid: String) : Henkilö()
 
 data class Opiskeluoikeus(
     val tila: OpiskeluoikeudenTila,
@@ -314,9 +321,6 @@ enum class PerusteenDiaarinumero {
 
 // https://github.com/Opetushallitus/koski/blob/d7abc79acca44d2d1265c14be4a631bd8ee91297/src/main/scala/fi/oph/koski/oppija/KoskiOppijaFacade.scala#L278
 data class HenkilönOpiskeluoikeusVersiot(val henkilö: OidHenkilö, val opiskeluoikeudet: List<OpiskeluoikeusVersio>)
-
-// https://github.com/Opetushallitus/koski/blob/025940091c6a13d0217422bfc75208c45120a810/src/main/scala/fi/oph/koski/schema/Henkilo.scala#L65
-data class OidHenkilö(val oid: String)
 
 // https://github.com/Opetushallitus/koski/blob/d7abc79acca44d2d1265c14be4a631bd8ee91297/src/main/scala/fi/oph/koski/oppija/KoskiOppijaFacade.scala#L279
 data class OpiskeluoikeusVersio(val oid: String, val versionumero: Int, val lähdejärjestelmänId: LähdejärjestelmäId)

--- a/service/src/main/resources/db/migration/R__koski_views.sql
+++ b/service/src/main/resources/db/migration/R__koski_views.sql
@@ -117,7 +117,7 @@ TABLE (
         ) matching_assistance_action
     ) aa ON true
     WHERE d.upload_to_koski IS TRUE
-    AND pr.social_security_number IS NOT NULL
+    AND (nullif(pr.social_security_number, '') IS NOT NULL OR nullif(pr.oph_person_oid, '') IS NOT NULL)
     AND nullif(d.oph_unit_oid, '') IS NOT NULL
     AND nullif(d.oph_organization_oid, '') IS NOT NULL
     AND nullif(d.oph_organizer_oid, '') IS NOT NULL;
@@ -145,7 +145,7 @@ TABLE (
         FROM koski_active_study_right(today) kav
         WHERE (kav.child_id, kav.unit_id, kav.type) = (ksr.child_id, ksr.unit_id, ksr.type)
     )
-    AND pr.social_security_number IS NOT NULL
+    AND (nullif(pr.social_security_number, '') IS NOT NULL OR nullif(pr.oph_person_oid, '') IS NOT NULL)
     AND d.upload_to_koski IS TRUE
     AND nullif(d.oph_unit_oid, '') IS NOT NULL
     AND nullif(d.oph_organization_oid, '') IS NOT NULL


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Add support for sending study rights belonging to SSN-less children *if* they have a person OID set in the database.
If both are set, SSN has priority, so OID is only used as a fallback.