### PR TITLE
Revert Koski incorrect off-by-one fix + fix original problem in a different way

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -171,7 +171,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         assertEquals(
             listOf(
                 Opiskeluoikeusjakso.läsnä(LocalDate.of(2018, 8, 1)),
-                Opiskeluoikeusjakso.eronnut(LocalDate.of(2019, 5, 1))
+                Opiskeluoikeusjakso.eronnut(LocalDate.of(2019, 4, 30))
             ),
             koskiServer.getStudyRights().values.single().opiskeluoikeus.tila.opiskeluoikeusjaksot
         )
@@ -246,7 +246,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         assertEquals(
             listOf(
                 Opiskeluoikeusjakso.läsnä(preschoolTerm2019.start),
-                Opiskeluoikeusjakso.eronnut(preschoolTerm2019.start.plusMonths(4).plusDays(1))
+                Opiskeluoikeusjakso.eronnut(preschoolTerm2019.start.plusMonths(4))
             ),
             studyRights.first.opiskeluoikeus.tila.opiskeluoikeusjaksot
         )
@@ -288,7 +288,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         assertEquals(
             listOf(
                 Opiskeluoikeusjakso.läsnä(start),
-                Opiskeluoikeusjakso.eronnut(firstPlacementEnd.plusDays(1))
+                Opiskeluoikeusjakso.eronnut(firstPlacementEnd)
             ),
             studyRights[0].opiskeluoikeus.tila.opiskeluoikeusjaksot
         )
@@ -456,7 +456,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
                 Opiskeluoikeusjakso.läsnä(preschoolTerm2019.start.plusDays(10)),
                 Opiskeluoikeusjakso.väliaikaisestiKeskeytynyt(preschoolTerm2019.start.plusDays(13)),
                 Opiskeluoikeusjakso.läsnä(preschoolTerm2019.start.plusDays(15)),
-                Opiskeluoikeusjakso.eronnut(preschoolTerm2019.start.plusDays(17))
+                Opiskeluoikeusjakso.eronnut(preschoolTerm2019.start.plusDays(16))
             ),
             koskiServer.getStudyRights().values.single().opiskeluoikeus.tila.opiskeluoikeusjaksot
         )
@@ -490,7 +490,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
         assertStudyRight(
             listOf(
                 Opiskeluoikeusjakso.läsnä(preschoolTerm2019.start),
-                Opiskeluoikeusjakso.eronnut(preschoolTerm2019.start.plusDays(3))
+                Opiskeluoikeusjakso.eronnut(preschoolTerm2019.start.plusDays(2))
             ),
             qualified = false
         )
@@ -721,7 +721,7 @@ class KoskiIntegrationTest : FullApplicationTest() {
                 Opiskeluoikeusjakso.läsnä(absences[0].end.plusDays(1)),
                 Opiskeluoikeusjakso.väliaikaisestiKeskeytynyt(absences[1].start),
                 Opiskeluoikeusjakso.läsnä(absences[1].end.plusDays(1)),
-                Opiskeluoikeusjakso.eronnut(preschoolTerm2020.end.plusDays(1))
+                Opiskeluoikeusjakso.eronnut(preschoolTerm2020.end)
             ),
             opiskeluoikeus.tila.opiskeluoikeusjaksot
         )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
@@ -203,7 +203,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
                                         }
                                     },
                                     {
-                                        "alku": "2019-01-01",
+                                        "alku": "2018-12-31",
                                         "tila": {
                                             "koodiarvo": "eronnut",
                                             "koodistoUri": "koskiopiskeluoikeudentila"
@@ -469,7 +469,7 @@ class KoskiPayloadIntegrationTest : FullApplicationTest() {
                                         }
                                     },
                                     {
-                                        "alku": "2019-01-01",
+                                        "alku": "2018-12-31",
                                         "tila": {
                                             "koodiarvo": "eronnut",
                                             "koodistoUri": "koskiopiskeluoikeudentila"

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiData.kt
@@ -192,13 +192,13 @@ data class KoskiActiveDataRaw(
         result.addAll((present + gaps + holidays + absent))
 
         when {
-            today.isAfter(placementSpan.end) -> result.add(
-                if (qualifiedDate != null) Opiskeluoikeusjakso.valmistunut(qualifiedDate)
-                else Opiskeluoikeusjakso.eronnut(placementSpan.end.plusDays(1))
-            )
-            else -> {
-                // placements still ongoing
+            placementSpan.end.isAfter(today) -> {
+                // still ongoing
             }
+            else -> result.add(
+                if (qualifiedDate != null) Opiskeluoikeusjakso.valmistunut(qualifiedDate)
+                else Opiskeluoikeusjakso.eronnut(placementSpan.end)
+            )
         }
         result.sortBy { it.alku }
         return result


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Wrong: resignation date = first date when the child *is not present*
Correct: resignation date = last date when the child *is present*

There can't be two states on the same date, so fix some edge cases by prioritizing study right termination state over anything else (e.g. "present" state).
