### PR TITLE
Refactor `renderResult()`

### DIFF
--- a/frontend/src/citizen-frontend/async-rendering.tsx
+++ b/frontend/src/citizen-frontend/async-rendering.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Result } from 'lib-common/api'
+import {
+  genericUnwrapResult,
+  UnwrapResultProps
+} from 'lib-components/async-rendering'
+import { useTranslation } from './localization'
+
+export function UnwrapResult<T>(props: UnwrapResultProps<T>) {
+  const t = useTranslation()
+  return genericUnwrapResult({
+    ...props,
+    failureMessage: t.common.errors.genericGetError
+  })
+}
+
+export function renderResult<T>(
+  result: Result<T>,
+  renderer: (value: T) => React.ReactElement | null
+) {
+  return <UnwrapResult result={result}>{renderer}</UnwrapResult>
+}

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -12,7 +12,6 @@ import { getReservations, ReservationsResponse } from './api'
 import LocalDate from 'lib-common/local-date'
 import { Loading, Result } from 'lib-common/api'
 import { useRestApi } from 'lib-common/utils/useRestApi'
-import Loader from 'lib-components/atoms/Loader'
 import { useTranslation } from '../localization'
 import { useUser } from '../auth'
 import ReservationModal from './ReservationModal'
@@ -24,6 +23,7 @@ import { desktopMin } from 'lib-components/breakpoints'
 import { Gap } from 'lib-components/white-space'
 import _ from 'lodash'
 import ActionPickerModal from './ActionPickerModal'
+import { UnwrapResult } from 'citizen-frontend/async-rendering'
 
 export default React.memo(function CalendarPage() {
   const history = useHistory()
@@ -74,67 +74,60 @@ export default React.memo(function CalendarPage() {
           openAbsenceModal={() => setOpenModal('absences')}
         />
       ) : null}
-      {data.mapAll({
-        loading() {
-          return <Loader />
-        },
-        failure() {
-          return <div>{i18n.common.errors.genericGetError}</div>
-        },
-        success(response) {
-          return (
-            <>
-              <MobileOnly>
-                <ContentArea
-                  opaque
-                  paddingVertical="zero"
-                  paddingHorizontal="zero"
-                >
-                  <CalendarListView
-                    dailyData={response.dailyData}
-                    onHoverButtonClick={() => setOpenModal('pickAction')}
-                    selectDate={selectDate}
-                  />
-                </ContentArea>
-              </MobileOnly>
-              <DesktopOnly>
-                <Gap size="s" />
-                <CalendarGridView
+      <UnwrapResult
+        result={data}
+        failure={() => <div>{i18n.common.errors.genericGetError}</div>}
+      >
+        {(response) => (
+          <>
+            <MobileOnly>
+              <ContentArea
+                opaque
+                paddingVertical="zero"
+                paddingHorizontal="zero"
+              >
+                <CalendarListView
                   dailyData={response.dailyData}
-                  onCreateReservationClicked={() =>
-                    setOpenModal('reservations')
-                  }
-                  onCreateAbsencesClicked={() => setOpenModal('absences')}
-                  selectedDate={selectedDate}
+                  onHoverButtonClick={() => setOpenModal('pickAction')}
                   selectDate={selectDate}
                 />
-              </DesktopOnly>
-              {openModal === 'pickAction' && (
-                <ActionPickerModal
-                  close={() => setOpenModal(undefined)}
-                  openReservations={() => setOpenModal('reservations')}
-                  openAbsences={() => setOpenModal('absences')}
-                />
-              )}
-              {openModal === 'reservations' && (
-                <ReservationModal
-                  onClose={() => setOpenModal(undefined)}
-                  availableChildren={response.children}
-                  onReload={loadDefaultRange}
-                  reservableDays={response.reservableDays}
-                />
-              )}
-              {openModal === 'absences' && (
-                <AbsenceModal
-                  close={() => setOpenModal(undefined)}
-                  reload={loadDefaultRange}
-                  availableChildren={response.children}
-                />
-              )}
-            </>
-          )
-        }
-      })}
+              </ContentArea>
+            </MobileOnly>
+            <DesktopOnly>
+              <Gap size="s" />
+              <CalendarGridView
+                dailyData={response.dailyData}
+                onCreateReservationClicked={() => setOpenModal('reservations')}
+                onCreateAbsencesClicked={() => setOpenModal('absences')}
+                selectedDate={selectedDate}
+                selectDate={selectDate}
+              />
+            </DesktopOnly>
+            {openModal === 'pickAction' && (
+              <ActionPickerModal
+                close={() => setOpenModal(undefined)}
+                openReservations={() => setOpenModal('reservations')}
+                openAbsences={() => setOpenModal('absences')}
+              />
+            )}
+            {openModal === 'reservations' && (
+              <ReservationModal
+                onClose={() => setOpenModal(undefined)}
+                availableChildren={response.children}
+                onReload={loadDefaultRange}
+                reservableDays={response.reservableDays}
+              />
+            )}
+            {openModal === 'absences' && (
+              <AbsenceModal
+                close={() => setOpenModal(undefined)}
+                reload={loadDefaultRange}
+                availableChildren={response.children}
+              />
+            )}
+          </>
+        )}
+      </UnwrapResult>
       <Footer />
     </>
   )

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
@@ -18,7 +18,7 @@ import { UUID } from 'lib-common/types'
 import LocalDate from 'lib-common/local-date'
 import { IncomeStatement } from 'lib-common/api-types/incomeStatement'
 import { initialFormData } from './types/form'
-import { renderResult } from 'lib-components/async-rendering'
+import { renderResult } from '../async-rendering'
 import { RouteComponentProps } from 'react-router'
 
 interface EditorState {

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
@@ -5,7 +5,7 @@
 import React, { useContext } from 'react'
 import { RouteComponentProps } from 'react-router'
 import { UUID } from 'lib-common/types'
-import { renderResult } from 'lib-components/async-rendering'
+import { renderResult } from '../async-rendering'
 import ListGrid from 'lib-components/layout/ListGrid'
 import { Translations, useTranslation } from '../localization'
 import {

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
@@ -6,8 +6,6 @@ import { Loading, Result } from 'lib-common/api'
 import { IncomeStatement } from 'lib-common/api-types/incomeStatement'
 import { UUID } from 'lib-common/types'
 import { useRestApi } from 'lib-common/utils/useRestApi'
-import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
-import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
@@ -23,6 +21,7 @@ import { OverlayContext } from '../overlay/state'
 import { deleteIncomeStatement, getIncomeStatements } from './api'
 import ResponsiveInlineButton from 'lib-components/atoms/buttons/ResponsiveInlineButton'
 import ResponsiveAddButton from 'lib-components/atoms/buttons/ResponsiveAddButton'
+import { renderResult } from 'citizen-frontend/async-rendering'
 
 const HeadingContainer = styled.div`
   display: flex;
@@ -157,29 +156,19 @@ export default function IncomeStatements() {
               data-qa="new-income-statement-btn"
             />
           </HeadingContainer>
-          {incomeStatements.mapAll({
-            loading() {
-              return <SpinnerSegment />
-            },
-            failure() {
-              return <ErrorSegment />
-            },
-            success(items) {
-              return (
-                items.length > 0 && (
-                  <IncomeStatementsTable
-                    items={items}
-                    onRemoveIncomeStatement={(id) =>
-                      setDeletionState({
-                        status: 'confirming',
-                        rowToDelete: id
-                      })
-                    }
-                  />
-                )
-              )
-            }
-          })}
+          {renderResult(incomeStatements, (items) =>
+            items.length > 0 ? (
+              <IncomeStatementsTable
+                items={items}
+                onRemoveIncomeStatement={(id) =>
+                  setDeletionState({
+                    status: 'confirming',
+                    rowToDelete: id
+                  })
+                }
+              />
+            ) : null
+          )}
 
           {deletionState.status !== 'row-not-selected' && (
             <InfoModal

--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -9,8 +9,6 @@ import EmptyThreadView from './EmptyThreadView'
 import MessageEditor from './MessageEditor'
 import { Loading, Result } from 'lib-common/api'
 import { useRestApi } from 'lib-common/utils/useRestApi'
-import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
-import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
 import { tabletMin } from 'lib-components/breakpoints'
 import AdaptiveFlex from 'lib-components/layout/AdaptiveFlex'
 import Container from 'lib-components/layout/Container'
@@ -21,6 +19,7 @@ import { headerHeightDesktop } from '../header/const'
 import { MessageContext } from './state'
 import ThreadList from './ThreadList'
 import ThreadView from './ThreadView'
+import { renderResult } from 'citizen-frontend/async-rendering'
 
 const FullHeightContainer = styled(Container)`
   height: calc(100vh - ${headerHeightDesktop}px);
@@ -58,32 +57,20 @@ export default React.memo(function MessagesPage() {
   return (
     <FullHeightContainer>
       <StyledFlex breakpoint={tabletMin} horizontalSpacing="L">
-        {accountId.mapAll({
-          failure() {
-            return <ErrorSegment />
-          },
-          loading() {
-            return <SpinnerSegment />
-          },
-          success(id) {
-            return (
-              <>
-                <ThreadList
-                  accountId={id}
-                  setEditorVisible={setEditorVisible}
-                  newMessageButtonEnabled={
-                    receivers.isSuccess && !editorVisible
-                  }
-                />
-                {selectedThread ? (
-                  <ThreadView accountId={id} thread={selectedThread} />
-                ) : (
-                  <EmptyThreadView inboxEmpty={threads.length == 0} />
-                )}
-              </>
-            )
-          }
-        })}
+        {renderResult(accountId, (id) => (
+          <>
+            <ThreadList
+              accountId={id}
+              setEditorVisible={setEditorVisible}
+              newMessageButtonEnabled={receivers.isSuccess && !editorVisible}
+            />
+            {selectedThread ? (
+              <ThreadView accountId={id} thread={selectedThread} />
+            ) : (
+              <EmptyThreadView inboxEmpty={threads.length == 0} />
+            )}
+          </>
+        ))}
       </StyledFlex>
       {editorVisible && receivers.isSuccess && (
         <MessageEditor

--- a/frontend/src/citizen-frontend/messages/ThreadList.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadList.tsx
@@ -6,8 +6,6 @@ import { UUID } from 'lib-common/types'
 import useIntersectionObserver from 'lib-common/utils/useIntersectionObserver'
 import Button from 'lib-components/atoms/buttons/Button'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
-import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
-import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
 import { tabletMin } from 'lib-components/breakpoints'
 import { H1 } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -20,6 +18,7 @@ import { useTranslation } from '../localization'
 import { OverlayContext } from '../overlay/state'
 import { MessageContext } from './state'
 import ThreadListItem from './ThreadListItem'
+import { renderResult } from 'citizen-frontend/async-rendering'
 
 const hasUnreadMessages = (thread: MessageThread, accountId: UUID) =>
   thread.messages.some((m) => !m.readAt && m.sender.id !== accountId)
@@ -107,17 +106,9 @@ export default React.memo(function ThreadList({
             onAttachmentUnavailable={onAttachmentUnavailable}
           />
         ))}
-        {threadLoadingResult.mapAll({
-          failure() {
-            return <ErrorSegment title={t.common.errors.genericGetError} />
-          },
-          loading() {
-            return <SpinnerSegment />
-          },
-          success() {
-            return <OnEnterView onEnter={loadMoreThreads} />
-          }
-        })}
+        {renderResult(threadLoadingResult, () => (
+          <OnEnterView onEnter={loadMoreThreads} />
+        ))}
       </Container>
     </>
   )

--- a/frontend/src/employee-frontend/components/ApplicationPage.tsx
+++ b/frontend/src/employee-frontend/components/ApplicationPage.tsx
@@ -37,7 +37,7 @@ import { useRestApi } from 'lib-common/utils/useRestApi'
 import { getServiceNeedOptionPublicInfos } from '../api/child/service-needs'
 import Loader from 'lib-components/atoms/Loader'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
-import { renderResult } from 'lib-components/async-rendering'
+import { renderResult } from './async-rendering'
 
 const ApplicationArea = styled(ContentArea)`
   width: 77%;

--- a/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
+++ b/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
@@ -25,8 +25,6 @@ import {
   IncomeStatement
 } from 'lib-common/api-types/incomeStatement'
 import { combine, Loading, Result } from 'lib-common/api'
-import Loader from 'lib-components/atoms/Loader'
-import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import { Attachment } from 'lib-common/api-types/attachment'
 import { PersonContext } from '../state/person'
@@ -39,6 +37,7 @@ import {
   saveIncomeStatementAttachment
 } from '../api/attachments'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { renderResult } from './async-rendering'
 
 export default React.memo(function IncomeStatementPage({
   match
@@ -89,53 +88,46 @@ export default React.memo(function IncomeStatementPage({
     loadIncomeStatement(personId, incomeStatementId)
   }, [loadPerson, loadIncomeStatement, personId, incomeStatementId])
 
-  return combine(person, incomeStatement).mapAll({
-    loading() {
-      return <Loader />
-    },
-    failure() {
-      return <ErrorSegment />
-    },
-    success([person, incomeStatement]) {
-      return (
-        <Container>
-          <Gap size="s" />
-          <ContentArea opaque>
-            <H1>{i18n.incomeStatement.title}</H1>
-            <H2>
-              {person.firstName} {person.lastName}
-            </H2>
-            <Row
-              label={i18n.incomeStatement.startDate}
-              value={incomeStatement.startDate.format()}
-            />
-            <Row
-              label={i18n.incomeStatement.feeBasis}
-              value={i18n.incomeStatement.statementTypes[incomeStatement.type]}
-            />
-            {incomeStatement.type === 'INCOME' && (
-              <IncomeInfo incomeStatement={incomeStatement} />
-            )}
-          </ContentArea>
+  return renderResult(
+    combine(person, incomeStatement),
+    ([person, incomeStatement]) => (
+      <Container>
+        <Gap size="s" />
+        <ContentArea opaque>
+          <H1>{i18n.incomeStatement.title}</H1>
+          <H2>
+            {person.firstName} {person.lastName}
+          </H2>
+          <Row
+            label={i18n.incomeStatement.startDate}
+            value={incomeStatement.startDate.format()}
+          />
+          <Row
+            label={i18n.incomeStatement.feeBasis}
+            value={i18n.incomeStatement.statementTypes[incomeStatement.type]}
+          />
           {incomeStatement.type === 'INCOME' && (
-            <>
-              <Gap size="L" />
-              <ContentArea opaque>
-                <EmployeeAttachments
-                  incomeStatementId={incomeStatement.id}
-                  attachments={incomeStatement.attachments.filter(
-                    (attachment) => attachment.uploadedByEmployee
-                  )}
-                  onUploaded={handleAttachmentUploaded}
-                  onDeleted={handleAttachmentDeleted}
-                />
-              </ContentArea>
-            </>
+            <IncomeInfo incomeStatement={incomeStatement} />
           )}
-        </Container>
-      )
-    }
-  })
+        </ContentArea>
+        {incomeStatement.type === 'INCOME' && (
+          <>
+            <Gap size="L" />
+            <ContentArea opaque>
+              <EmployeeAttachments
+                incomeStatementId={incomeStatement.id}
+                attachments={incomeStatement.attachments.filter(
+                  (attachment) => attachment.uploadedByEmployee
+                )}
+                onUploaded={handleAttachmentUploaded}
+                onDeleted={handleAttachmentDeleted}
+              />
+            </ContentArea>
+          </>
+        )}
+      </Container>
+    )
+  )
 })
 
 function IncomeInfo({ incomeStatement }: { incomeStatement: Income }) {

--- a/frontend/src/employee-frontend/components/UnitFeaturesPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitFeaturesPage.tsx
@@ -19,7 +19,7 @@ import Checkbox from 'lib-components/atoms/form/Checkbox'
 import { client } from '../api/client'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
-import { renderResult } from 'lib-components/async-rendering'
+import { renderResult } from './async-rendering'
 
 async function getUnitFeatures(): Promise<Result<UnitFeatures[]>> {
   return client

--- a/frontend/src/employee-frontend/components/application-page/VTJGuardian.tsx
+++ b/frontend/src/employee-frontend/components/application-page/VTJGuardian.tsx
@@ -12,7 +12,7 @@ import ListGrid from 'lib-components/layout/ListGrid'
 import { Link } from 'react-router-dom'
 import { formatName } from '../../utils'
 import { useTranslation } from '../../state/i18n'
-import { renderResult } from 'lib-components/async-rendering'
+import { renderResult } from '../async-rendering'
 
 interface VTJGuardianProps {
   guardianId: UUID | undefined | null

--- a/frontend/src/employee-frontend/components/async-rendering.tsx
+++ b/frontend/src/employee-frontend/components/async-rendering.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Result } from 'lib-common/api'
+import {
+  genericUnwrapResult,
+  UnwrapResultProps
+} from 'lib-components/async-rendering'
+import { useTranslation } from '../state/i18n'
+
+export function UnwrapResult<T>(props: UnwrapResultProps<T>) {
+  const { i18n } = useTranslation()
+  return genericUnwrapResult({
+    ...props,
+    failureMessage: i18n.common.loadingFailed
+  })
+}
+
+export function renderResult<T>(
+  result: Result<T>,
+  renderer: (value: T) => React.ReactElement | null
+) {
+  return <UnwrapResult result={result}>{renderer}</UnwrapResult>
+}

--- a/frontend/src/employee-frontend/components/child-information/ChildDetails.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildDetails.tsx
@@ -11,7 +11,7 @@ import { ChildContext, ChildState } from '../../state/child'
 import PersonDetails from '../../components/person-shared/PersonDetails'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { H2 } from 'lib-components/typography'
-import { renderResult } from 'lib-components/async-rendering'
+import { renderResult } from '../async-rendering'
 
 interface Props {
   id: UUID

--- a/frontend/src/employee-frontend/components/child-information/FridgeParents.tsx
+++ b/frontend/src/employee-frontend/components/child-information/FridgeParents.tsx
@@ -8,12 +8,12 @@ import * as _ from 'lodash'
 import { useTranslation } from '../../state/i18n'
 import { ChildContext, ChildState } from '../../state/child'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
-import Loader from 'lib-components/atoms/Loader'
 import { Parentship } from '../../types/fridge'
 import { Link } from 'react-router-dom'
 import { getStatusLabelByDateRange } from '../../utils/date'
 import StatusLabel from '../../components/common/StatusLabel'
 import { H3 } from 'lib-components/typography'
+import { renderResult } from '../async-rendering'
 
 const FridgeParents = React.memo(function FridgeParents() {
   const { i18n } = useTranslation()
@@ -22,55 +22,45 @@ const FridgeParents = React.memo(function FridgeParents() {
   return (
     <div className="fridge-parents-section">
       <H3 noMargin>{i18n.childInformation.fridgeParents.title}</H3>
-      {parentships.mapAll({
-        loading() {
-          return <Loader />
-        },
-        failure() {
-          return <div>{i18n.common.loadingFailed}</div>
-        },
-        success(data) {
-          return (
-            <Table>
-              <Thead>
-                <Tr>
-                  <Th>{i18n.childInformation.fridgeParents.name}</Th>
-                  <Th>{i18n.childInformation.fridgeParents.ssn}</Th>
-                  <Th>{i18n.childInformation.fridgeParents.startDate}</Th>
-                  <Th>{i18n.childInformation.fridgeParents.endDate}</Th>
-                  <Th>{i18n.childInformation.fridgeParents.status}</Th>
+      {renderResult(parentships, (data) => (
+        <Table>
+          <Thead>
+            <Tr>
+              <Th>{i18n.childInformation.fridgeParents.name}</Th>
+              <Th>{i18n.childInformation.fridgeParents.ssn}</Th>
+              <Th>{i18n.childInformation.fridgeParents.startDate}</Th>
+              <Th>{i18n.childInformation.fridgeParents.endDate}</Th>
+              <Th>{i18n.childInformation.fridgeParents.status}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {_.orderBy(data, ['startDate'], ['desc']).map(
+              (parentship: Parentship) => (
+                <Tr key={parentship.id}>
+                  <Td>
+                    <Link to={`/profile/${parentship.headOfChildId}`}>
+                      {parentship.headOfChild.lastName}{' '}
+                      {parentship.headOfChild.firstName}
+                    </Link>
+                  </Td>
+                  <Td>{parentship.headOfChild.socialSecurityNumber}</Td>
+                  <Td>{parentship.startDate.format()}</Td>
+                  <Td>{parentship.endDate?.format()}</Td>
+                  <Td>
+                    <StatusLabel
+                      status={
+                        parentship.conflict
+                          ? 'conflict'
+                          : getStatusLabelByDateRange(parentship)
+                      }
+                    />
+                  </Td>
                 </Tr>
-              </Thead>
-              <Tbody>
-                {_.orderBy(data, ['startDate'], ['desc']).map(
-                  (parentship: Parentship) => (
-                    <Tr key={parentship.id}>
-                      <Td>
-                        <Link to={`/profile/${parentship.headOfChildId}`}>
-                          {parentship.headOfChild.lastName}{' '}
-                          {parentship.headOfChild.firstName}
-                        </Link>
-                      </Td>
-                      <Td>{parentship.headOfChild.socialSecurityNumber}</Td>
-                      <Td>{parentship.startDate.format()}</Td>
-                      <Td>{parentship.endDate?.format()}</Td>
-                      <Td>
-                        <StatusLabel
-                          status={
-                            parentship.conflict
-                              ? 'conflict'
-                              : getStatusLabelByDateRange(parentship)
-                          }
-                        />
-                      </Td>
-                    </Tr>
-                  )
-                )}
-              </Tbody>
-            </Table>
-          )
-        }
-      })}
+              )
+            )}
+          </Tbody>
+        </Table>
+      ))}
     </div>
   )
 })

--- a/frontend/src/employee-frontend/components/child-information/VasuAndLeops.tsx
+++ b/frontend/src/employee-frontend/components/child-information/VasuAndLeops.tsx
@@ -36,6 +36,7 @@ import {
   VasuTemplateSummary
 } from '../vasu/templates/api'
 import { RequireRole } from '../../utils/roles'
+import { UnwrapResult } from '../async-rendering'
 
 const StateCell = styled(Td)`
   display: flex;
@@ -143,30 +144,32 @@ function VasuInitialization({
         }
         text={i18n.childInformation.vasu.createNew}
       />
-      {templates?.mapAll({
-        failure() {
-          return <ErrorSegment title={i18n.childInformation.vasu.init.error} />
-        },
-        loading() {
-          return <FullScreenDimmedSpinner />
-        },
-        success(value) {
-          if (value.length === 0) {
-            return <div>{i18n.childInformation.vasu.init.noTemplates}</div>
-          }
-          if (value.length === 1) {
-            return null // the template is selected automatically
-          }
-          return (
-            <TemplateSelectionModal
-              loading={initializing}
-              onClose={() => setTemplates(undefined)}
-              onSelect={(id) => createVasu(childId, id)}
-              templates={value}
-            />
-          )
-        }
-      })}
+      {templates && (
+        <UnwrapResult
+          result={templates}
+          loading={() => <FullScreenDimmedSpinner />}
+          failure={() => (
+            <ErrorSegment title={i18n.childInformation.vasu.init.error} />
+          )}
+        >
+          {(value) => {
+            if (value.length === 0) {
+              return <div>{i18n.childInformation.vasu.init.noTemplates}</div>
+            }
+            if (value.length === 1) {
+              return null // the template is selected automatically
+            }
+            return (
+              <TemplateSelectionModal
+                loading={initializing}
+                onClose={() => setTemplates(undefined)}
+                onSelect={(id) => createVasu(childId, id)}
+                templates={value}
+              />
+            )
+          }}
+        </UnwrapResult>
+      )}
     </InitializationContainer>
   )
 }

--- a/frontend/src/employee-frontend/components/child-information/person-details/AdditionalInformation.tsx
+++ b/frontend/src/employee-frontend/components/child-information/person-details/AdditionalInformation.tsx
@@ -13,7 +13,6 @@ import { ChildContext } from '../../../state'
 import TextArea from 'lib-components/atoms/form/TextArea'
 import Button from 'lib-components/atoms/buttons/Button'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
-import Loader from 'lib-components/atoms/Loader'
 import { UUID } from '../../../types'
 import LabelValueList from '../../../components/common/LabelValueList'
 import styled from 'styled-components'
@@ -26,6 +25,7 @@ import { RequireRole } from '../../../utils/roles'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { H4 } from 'lib-components/typography'
 import { FlexRow } from '../../common/styled/containers'
+import { UnwrapResult } from '../../async-rendering'
 
 const TextAreaInput = styled(TextArea)`
   width: 100%;
@@ -114,151 +114,143 @@ const AdditionalInformation = React.memo(function AdditionalInformation({
           />
         </RequireRole>
       </FlexRow>
-      {additionalInformation.mapAll({
-        loading() {
-          return <Loader />
-        },
-        failure() {
-          return <div>{i18n.common.loadingFailed}</div>
-        },
-        success(data) {
-          return (
-            <>
-              <LabelValueList
-                spacing="small"
-                contents={[
-                  {
-                    label:
-                      i18n.childInformation.additionalInformation.preferredName,
-                    value: editing ? (
-                      <TextAreaInput
-                        value={form.preferredName || ''}
-                        onChange={(
-                          event: React.ChangeEvent<HTMLTextAreaElement>
-                        ) =>
-                          setForm({
-                            ...form,
-                            preferredName: event.target.value
-                          })
-                        }
-                        rows={textAreaRows(form.preferredName || '')}
-                      />
-                    ) : (
-                      formatParagraphs(data.preferredName || '')
-                    ),
-                    valueWidth: '400px'
-                  },
-                  {
-                    label:
-                      i18n.childInformation.additionalInformation
-                        .additionalInfo,
-                    value: editing ? (
-                      <TextAreaInput
-                        value={form.additionalInfo}
-                        onChange={(
-                          event: React.ChangeEvent<HTMLTextAreaElement>
-                        ) =>
-                          setForm({
-                            ...form,
-                            additionalInfo: event.target.value
-                          })
-                        }
-                        rows={textAreaRows(form.additionalInfo)}
-                      />
-                    ) : (
-                      formatParagraphs(data.additionalInfo)
-                    ),
-                    valueWidth: '400px'
-                  },
-                  {
-                    label:
-                      i18n.childInformation.additionalInformation.allergies,
-                    value: editing ? (
-                      <TextAreaInput
-                        value={form.allergies}
-                        onChange={(
-                          event: React.ChangeEvent<HTMLTextAreaElement>
-                        ) =>
-                          setForm({
-                            ...form,
-                            allergies: event.target.value
-                          })
-                        }
-                        rows={textAreaRows(form.allergies)}
-                        maxLength={40}
-                      />
-                    ) : (
-                      formatParagraphs(data.allergies)
-                    ),
-                    valueWidth: '400px'
-                  },
-                  {
-                    label: i18n.childInformation.additionalInformation.diet,
-                    value: editing ? (
-                      <TextAreaInput
-                        value={form.diet}
-                        onChange={(
-                          event: React.ChangeEvent<HTMLTextAreaElement>
-                        ) =>
-                          setForm({
-                            ...form,
-                            diet: event.target.value
-                          })
-                        }
-                        rows={textAreaRows(form.diet)}
-                      />
-                    ) : (
-                      formatParagraphs(data.diet)
-                    ),
-                    valueWidth: '400px'
-                  },
-                  {
-                    label:
-                      i18n.childInformation.additionalInformation.medication,
-                    value: editing ? (
-                      <TextAreaInput
-                        value={form.medication}
-                        onChange={(
-                          event: React.ChangeEvent<HTMLTextAreaElement>
-                        ) =>
-                          setForm({
-                            ...form,
-                            medication: event.target.value
-                          })
-                        }
-                        rows={textAreaRows(form.medication)}
-                        data-qa="medication-input"
-                      />
-                    ) : (
-                      <span data-qa="medication">
-                        {formatParagraphs(data.medication)}
-                      </span>
-                    ),
-                    valueWidth: '400px'
-                  }
-                ]}
-              />
-              {editing && (
-                <RightAlignedRow>
-                  <FixedSpaceRow>
-                    <Button
-                      onClick={() => clearUiMode()}
-                      text={i18n.common.cancel}
+      <UnwrapResult
+        result={additionalInformation}
+        failure={() => <div>{i18n.common.loadingFailed}</div>}
+      >
+        {(data) => (
+          <>
+            <LabelValueList
+              spacing="small"
+              contents={[
+                {
+                  label:
+                    i18n.childInformation.additionalInformation.preferredName,
+                  value: editing ? (
+                    <TextAreaInput
+                      value={form.preferredName || ''}
+                      onChange={(
+                        event: React.ChangeEvent<HTMLTextAreaElement>
+                      ) =>
+                        setForm({
+                          ...form,
+                          preferredName: event.target.value
+                        })
+                      }
+                      rows={textAreaRows(form.preferredName || '')}
                     />
-                    <Button
-                      primary
-                      disabled={false}
-                      onClick={() => onSubmit()}
-                      data-qa="confirm-edited-child-button"
-                      text={i18n.common.confirm}
+                  ) : (
+                    formatParagraphs(data.preferredName || '')
+                  ),
+                  valueWidth: '400px'
+                },
+                {
+                  label:
+                    i18n.childInformation.additionalInformation.additionalInfo,
+                  value: editing ? (
+                    <TextAreaInput
+                      value={form.additionalInfo}
+                      onChange={(
+                        event: React.ChangeEvent<HTMLTextAreaElement>
+                      ) =>
+                        setForm({
+                          ...form,
+                          additionalInfo: event.target.value
+                        })
+                      }
+                      rows={textAreaRows(form.additionalInfo)}
                     />
-                  </FixedSpaceRow>
-                </RightAlignedRow>
-              )}
-            </>
-          )
-        }
-      })}
+                  ) : (
+                    formatParagraphs(data.additionalInfo)
+                  ),
+                  valueWidth: '400px'
+                },
+                {
+                  label: i18n.childInformation.additionalInformation.allergies,
+                  value: editing ? (
+                    <TextAreaInput
+                      value={form.allergies}
+                      onChange={(
+                        event: React.ChangeEvent<HTMLTextAreaElement>
+                      ) =>
+                        setForm({
+                          ...form,
+                          allergies: event.target.value
+                        })
+                      }
+                      rows={textAreaRows(form.allergies)}
+                      maxLength={40}
+                    />
+                  ) : (
+                    formatParagraphs(data.allergies)
+                  ),
+                  valueWidth: '400px'
+                },
+                {
+                  label: i18n.childInformation.additionalInformation.diet,
+                  value: editing ? (
+                    <TextAreaInput
+                      value={form.diet}
+                      onChange={(
+                        event: React.ChangeEvent<HTMLTextAreaElement>
+                      ) =>
+                        setForm({
+                          ...form,
+                          diet: event.target.value
+                        })
+                      }
+                      rows={textAreaRows(form.diet)}
+                    />
+                  ) : (
+                    formatParagraphs(data.diet)
+                  ),
+                  valueWidth: '400px'
+                },
+                {
+                  label: i18n.childInformation.additionalInformation.medication,
+                  value: editing ? (
+                    <TextAreaInput
+                      value={form.medication}
+                      onChange={(
+                        event: React.ChangeEvent<HTMLTextAreaElement>
+                      ) =>
+                        setForm({
+                          ...form,
+                          medication: event.target.value
+                        })
+                      }
+                      rows={textAreaRows(form.medication)}
+                      data-qa="medication-input"
+                    />
+                  ) : (
+                    <span data-qa="medication">
+                      {formatParagraphs(data.medication)}
+                    </span>
+                  ),
+                  valueWidth: '400px'
+                }
+              ]}
+            />
+            {editing && (
+              <RightAlignedRow>
+                <FixedSpaceRow>
+                  <Button
+                    onClick={() => clearUiMode()}
+                    text={i18n.common.cancel}
+                  />
+                  <Button
+                    primary
+                    disabled={false}
+                    onClick={() => onSubmit()}
+                    data-qa="confirm-edited-child-button"
+                    text={i18n.common.confirm}
+                  />
+                </FixedSpaceRow>
+              </RightAlignedRow>
+            )}
+          </>
+        )}
+      </UnwrapResult>
     </div>
   )
 })

--- a/frontend/src/employee-frontend/components/finance-basics/FeesSection.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeesSection.tsx
@@ -40,6 +40,7 @@ import { Translations, useTranslation } from '../../state/i18n'
 import { formatCents } from 'lib-common/money'
 import StatusLabel from '../common/StatusLabel'
 import FeeThresholdsEditor from './FeeThresholdsEditor'
+import { UnwrapResult } from '../async-rendering'
 
 export default React.memo(function FeesSection() {
   const { i18n } = useTranslation()
@@ -144,46 +145,42 @@ export default React.memo(function FeesSection() {
           existingThresholds={data}
         />
       ) : null}
-      {data.mapAll({
-        loading() {
-          return <Spinner data-qa="fees-section-spinner" />
-        },
-        failure() {
-          return <ErrorSegment title={i18n.common.error.unknown} />
-        },
-        success(feeThresholdsList) {
-          return (
-            <>
-              {feeThresholdsList.map((feeThresholds, index) =>
-                editorState.editing === feeThresholds.id ? (
-                  <FeeThresholdsEditor
-                    key={feeThresholds.id}
-                    i18n={i18n}
-                    id={feeThresholds.id}
-                    initialState={editorState.form}
-                    close={closeEditor}
-                    reloadData={loadData}
-                    toggleSaveRetroactiveWarning={toggleSaveRetroactiveWarning}
-                    existingThresholds={data}
-                  />
-                ) : (
-                  <FeeThresholdsItem
-                    key={feeThresholds.id}
-                    i18n={i18n}
-                    id={feeThresholds.id}
-                    feeThresholds={feeThresholds.thresholds}
-                    copyThresholds={copyThresholds}
-                    editThresholds={editThresholds}
-                    editing={!!editorState.editing}
-                    toggleEditRetroactiveWarning={toggleEditRetroactiveWarning}
-                    data-qa={`fee-thresholds-item-${index}`}
-                  />
-                )
-              )}
-            </>
-          )
-        }
-      })}
+      <UnwrapResult
+        result={data}
+        loading={() => <Spinner data-qa="fees-section-spinner" />}
+        failure={() => <ErrorSegment title={i18n.common.error.unknown} />}
+      >
+        {(feeThresholdsList) => (
+          <>
+            {feeThresholdsList.map((feeThresholds, index) =>
+              editorState.editing === feeThresholds.id ? (
+                <FeeThresholdsEditor
+                  key={feeThresholds.id}
+                  i18n={i18n}
+                  id={feeThresholds.id}
+                  initialState={editorState.form}
+                  close={closeEditor}
+                  reloadData={loadData}
+                  toggleSaveRetroactiveWarning={toggleSaveRetroactiveWarning}
+                  existingThresholds={data}
+                />
+              ) : (
+                <FeeThresholdsItem
+                  key={feeThresholds.id}
+                  i18n={i18n}
+                  id={feeThresholds.id}
+                  feeThresholds={feeThresholds.thresholds}
+                  copyThresholds={copyThresholds}
+                  editThresholds={editThresholds}
+                  editing={!!editorState.editing}
+                  toggleEditRetroactiveWarning={toggleEditRetroactiveWarning}
+                  data-qa={`fee-thresholds-item-${index}`}
+                />
+              )
+            )}
+          </>
+        )}
+      </UnwrapResult>
       {modal ? (
         <InfoModal
           icon={faQuestion}

--- a/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
+++ b/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
@@ -18,7 +18,7 @@ import { AreaFilter } from '../common/Filters'
 import { CareArea } from '../../types/unit'
 import { getAreas } from '../../api/daycare'
 import Pagination from 'lib-components/Pagination'
-import { renderResult } from 'lib-components/async-rendering'
+import { renderResult } from '../async-rendering'
 
 function IncomeStatementsList({
   data

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -10,8 +10,6 @@ import { getReceivers } from './api'
 import { SelectorNode, unitAsSelectorNode } from './SelectorNode'
 import { Result } from 'lib-common/api'
 import Button from 'lib-components/atoms/buttons/Button'
-import Loader from 'lib-components/atoms/Loader'
-import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import { sortBy, uniqBy } from 'lodash'
 import React, { useContext, useEffect, useMemo } from 'react'
@@ -25,12 +23,14 @@ import { MessageContext } from './MessageContext'
 import { isNestedGroupMessageAccount } from './types'
 import { messageBoxes } from './types-view'
 import { fontWeights, H1 } from 'lib-components/typography'
+import { renderResult } from '../async-rendering'
 
 const Container = styled.div`
   flex: 0 1 260px;
   display: flex;
   flex-direction: column;
   margin-right: ${defaultMargins.m};
+
   & > div {
     background-color: ${colors.greyscale.white};
   }
@@ -227,22 +227,12 @@ export default React.memo(function Sidebar({
             data-qa="new-message-btn"
           />
         </HeaderContainer>
-        {nestedAccounts.mapAll({
-          loading() {
-            return <Loader />
-          },
-          failure() {
-            return <ErrorSegment />
-          },
-          success(nestedAccounts) {
-            return (
-              <Accounts
-                nestedAccounts={nestedAccounts}
-                setSelectedReceivers={setSelectedReceivers}
-              />
-            )
-          }
-        })}
+        {renderResult(nestedAccounts, (nestedAccounts) => (
+          <Accounts
+            nestedAccounts={nestedAccounts}
+            setSelectedReceivers={setSelectedReceivers}
+          />
+        ))}
         <Receivers
           active={selectedAccount?.view === 'RECEIVERS'}
           onClick={() =>

--- a/frontend/src/employee-frontend/components/messages/ThreadList.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadList.tsx
@@ -4,10 +4,9 @@
 
 import { Result } from 'lib-common/api'
 import { MessageType } from 'lib-common/generated/enums'
-import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
-import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
 import React from 'react'
 import { UUID } from '../../types'
+import { renderResult } from '../async-rendering'
 import {
   Hyphen,
   MessageRow,
@@ -38,53 +37,36 @@ interface Props {
 }
 
 export function ThreadList({ items: messages }: Props) {
-  return messages.mapAll({
-    failure() {
-      return <ErrorSegment />
-    },
-    loading() {
-      return <SpinnerSegment />
-    },
-    success(threads) {
-      return (
-        <>
-          {threads.map((item) => {
-            return (
-              <MessageRow
-                key={item.id}
-                unread={item.unread}
-                onClick={item.onClick}
-                data-qa={item.dataQa}
-              >
-                <ParticipantsAndPreview>
-                  <Participants unread={item.unread}>
-                    {item.participants.length > 0
-                      ? item.participants.join(', ')
-                      : '-'}{' '}
-                    {item.messageCount}
-                  </Participants>
-                  <Truncated>
-                    <Title
-                      unread={item.unread}
-                      data-qa="thread-list-item-title"
-                    >
-                      {item.title}
-                    </Title>
-                    <Hyphen>{' ― '}</Hyphen>
-                    <span data-qa="thread-list-item-content">
-                      {item.content}
-                    </span>
-                  </Truncated>
-                </ParticipantsAndPreview>
-                <TypeAndDate>
-                  <MessageTypeChip type={item.type} />
-                  {item.timestamp && <Timestamp date={item.timestamp} />}
-                </TypeAndDate>
-              </MessageRow>
-            )
-          })}
-        </>
-      )
-    }
-  })
+  return renderResult(messages, (threads) => (
+    <>
+      {threads.map((item) => (
+        <MessageRow
+          key={item.id}
+          unread={item.unread}
+          onClick={item.onClick}
+          data-qa={item.dataQa}
+        >
+          <ParticipantsAndPreview>
+            <Participants unread={item.unread}>
+              {item.participants.length > 0
+                ? item.participants.join(', ')
+                : '-'}{' '}
+              {item.messageCount}
+            </Participants>
+            <Truncated>
+              <Title unread={item.unread} data-qa="thread-list-item-title">
+                {item.title}
+              </Title>
+              <Hyphen>{' ― '}</Hyphen>
+              <span data-qa="thread-list-item-content">{item.content}</span>
+            </Truncated>
+          </ParticipantsAndPreview>
+          <TypeAndDate>
+            <MessageTypeChip type={item.type} />
+            {item.timestamp && <Timestamp date={item.timestamp} />}
+          </TypeAndDate>
+        </MessageRow>
+      ))}
+    </>
+  ))
 }

--- a/frontend/src/employee-frontend/components/person-profile/PersonFridgeHead.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFridgeHead.tsx
@@ -15,7 +15,7 @@ import { PersonDetails as PersonDetailsType } from '../../types/person'
 import PersonDetails from '../../components/person-shared/PersonDetails'
 import { faUser } from 'lib-icons'
 import { TitleContext, TitleState } from '../../state/title'
-import { renderResult } from 'lib-components/async-rendering'
+import { renderResult } from '../async-rendering'
 
 interface Props {
   id: UUID

--- a/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
@@ -5,7 +5,6 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { faEuroSign, faFileAlt } from 'lib-icons'
 import { Gap } from 'lib-components/white-space'
-import Loader from 'lib-components/atoms/Loader'
 import CollapsibleSection from 'lib-components/molecules/CollapsibleSection'
 import IncomeList from './income/IncomeList'
 import { useTranslation } from '../../state/i18n'
@@ -34,6 +33,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { formatDate } from 'lib-common/date'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import { featureFlags } from 'lib-customizations/employee'
+import { UnwrapResult } from '../async-rendering'
 
 interface Props {
   id: UUID
@@ -100,34 +100,29 @@ const PersonIncome = React.memo(function PersonIncome({ id, open }: Props) {
       data-qa="person-income-collapsible"
       startCollapsed={!open}
     >
-      {incomes.mapAll({
-        loading() {
-          return <Loader />
-        },
-        failure() {
-          return <div>{i18n.personProfile.income.error}</div>
-        },
-        success([incomes, incomeStatements]) {
-          return (
-            <>
-              {featureFlags.experimental?.incomeStatements ? (
-                <IncomeStatements
-                  personId={id}
-                  incomeStatements={incomeStatements}
-                  onSuccessfulUpdate={loadData}
-                />
-              ) : null}
-              <Incomes
+      <UnwrapResult
+        result={incomes}
+        failure={() => <div>{i18n.personProfile.income.error}</div>}
+      >
+        {([incomes, incomeStatements]) => (
+          <>
+            {featureFlags.experimental?.incomeStatements ? (
+              <IncomeStatements
                 personId={id}
-                incomes={incomes}
-                isIncomeRowOpen={isIncomeRowOpen}
-                toggleIncomeRow={toggleIncomeRow}
-                onSuccessfulUpdate={reload}
+                incomeStatements={incomeStatements}
+                onSuccessfulUpdate={loadData}
               />
-            </>
-          )
-        }
-      })}
+            ) : null}
+            <Incomes
+              personId={id}
+              incomes={incomes}
+              isIncomeRowOpen={isIncomeRowOpen}
+              toggleIncomeRow={toggleIncomeRow}
+              onSuccessfulUpdate={reload}
+            />
+          </>
+        )}
+      </UnwrapResult>
     </CollapsibleSection>
   )
 })

--- a/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
@@ -9,13 +9,13 @@ import { faChild } from 'lib-icons'
 import { Loading, Result } from 'lib-common/api'
 import { formatDate } from 'lib-common/date'
 import { useRestApi } from 'lib-common/utils/useRestApi'
-import Loader from 'lib-components/atoms/Loader'
 import CollapsibleSection from 'lib-components/molecules/CollapsibleSection'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { useTranslation } from '../../state/i18n'
 import { VoucherValueDecisionSummary } from '../../types/invoicing'
 import { getPersonVoucherValueDecisions } from '../../api/invoicing'
 import { formatCents } from 'lib-common/money'
+import { UnwrapResult } from '../async-rendering'
 
 interface Props {
   id: string
@@ -45,57 +45,50 @@ export default React.memo(function PersonVoucherValueDecisions({
       data-qa="person-voucher-value-decisions-collapsible"
       startCollapsed={!open}
     >
-      {voucherValueDecisions.mapAll({
-        loading() {
-          return <Loader />
-        },
-        failure() {
-          return <div>{i18n.common.loadingFailed}</div>
-        },
-        success(data) {
-          return (
-            <Table data-qa="table-of-voucher-value-decisions">
-              <Thead>
-                <Tr>
-                  <Th>{i18n.valueDecisions.table.validity}</Th>
-                  <Th>{i18n.valueDecisions.table.number}</Th>
-                  <Th>{i18n.valueDecisions.table.totalValue}</Th>
-                  <Th>{i18n.valueDecisions.table.totalCoPayment}</Th>
-                  <Th>{i18n.valueDecisions.table.createdAt}</Th>
-                  <Th>{i18n.valueDecisions.table.sentAt}</Th>
-                  <Th>{i18n.valueDecisions.table.status}</Th>
+      <UnwrapResult
+        result={voucherValueDecisions}
+        failure={() => <div>{i18n.common.loadingFailed}</div>}
+      >
+        {(data) => (
+          <Table data-qa="table-of-voucher-value-decisions">
+            <Thead>
+              <Tr>
+                <Th>{i18n.valueDecisions.table.validity}</Th>
+                <Th>{i18n.valueDecisions.table.number}</Th>
+                <Th>{i18n.valueDecisions.table.totalValue}</Th>
+                <Th>{i18n.valueDecisions.table.totalCoPayment}</Th>
+                <Th>{i18n.valueDecisions.table.createdAt}</Th>
+                <Th>{i18n.valueDecisions.table.sentAt}</Th>
+                <Th>{i18n.valueDecisions.table.status}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {orderBy(data, ['createdAt'], ['desc']).map((decision) => (
+                <Tr
+                  key={`${decision.id}`}
+                  data-qa="table-voucher-value-decision-row"
+                >
+                  <Td>
+                    {decision.child.firstName} {decision.child.lastName}
+                    <br />
+                    <Link to={`/finance/value-decisions/${decision.id}`}>
+                      {`${decision.validFrom.format()} - ${
+                        decision.validTo?.format() ?? ''
+                      }`}
+                    </Link>
+                  </Td>
+                  <Td>{decision.decisionNumber}</Td>
+                  <Td>{formatCents(decision.voucherValue)}</Td>
+                  <Td>{formatCents(decision.finalCoPayment)}</Td>
+                  <Td>{formatDate(decision.created)}</Td>
+                  <Td>{formatDate(decision.sentAt)}</Td>
+                  <Td>{i18n.valueDecision.status[decision.status]}</Td>
                 </Tr>
-              </Thead>
-              <Tbody>
-                {orderBy(data, ['createdAt'], ['desc']).map((decision) => {
-                  return (
-                    <Tr
-                      key={`${decision.id}`}
-                      data-qa="table-voucher-value-decision-row"
-                    >
-                      <Td>
-                        {decision.child.firstName} {decision.child.lastName}
-                        <br />
-                        <Link to={`/finance/value-decisions/${decision.id}`}>
-                          {`${decision.validFrom.format()} - ${
-                            decision.validTo?.format() ?? ''
-                          }`}
-                        </Link>
-                      </Td>
-                      <Td>{decision.decisionNumber}</Td>
-                      <Td>{formatCents(decision.voucherValue)}</Td>
-                      <Td>{formatCents(decision.finalCoPayment)}</Td>
-                      <Td>{formatDate(decision.created)}</Td>
-                      <Td>{formatDate(decision.sentAt)}</Td>
-                      <Td>{i18n.valueDecision.status[decision.status]}</Td>
-                    </Tr>
-                  )
-                })}
-              </Tbody>
-            </Table>
-          )
-        }
-      })}
+              ))}
+            </Tbody>
+          </Table>
+        )}
+      </UnwrapResult>
     </CollapsibleSection>
   )
 })

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -9,7 +9,6 @@ import { Loading, Result } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import LocalDate from 'lib-common/local-date'
 import { useRestApi } from 'lib-common/utils/useRestApi'
-import Loader from 'lib-components/atoms/Loader'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { H3 } from 'lib-components/typography'
@@ -20,10 +19,10 @@ import {
   getUnitAttendanceReservations,
   UnitAttendanceReservations
 } from '../../../api/unit'
-import { useTranslation } from '../../../state/i18n'
 import ReservationsTable from './ReservationsTable'
 import ReservationModalSingleChild from './ReservationModalSingleChild'
 import { UUID } from 'lib-common/types'
+import { renderResult } from 'employee-frontend/components/async-rendering'
 
 interface Props {
   unitId: UUID
@@ -38,8 +37,6 @@ export default React.memo(function UnitAttendanceReservationsView({
   selectedDate,
   setSelectedDate
 }: Props) {
-  const { i18n } = useTranslation()
-
   const dateRange = useMemo(
     () => getWeekDateRange(selectedDate),
     [selectedDate]
@@ -64,63 +61,55 @@ export default React.memo(function UnitAttendanceReservationsView({
 
   return (
     <>
-      {reservations.mapAll({
-        loading() {
-          return <Loader />
-        },
-        failure() {
-          return <div>{i18n.common.error.unknown}</div>
-        },
-        success(data) {
-          const selectedGroup = data.groups.find((g) => g.group.id === groupId)
+      {renderResult(reservations, (data) => {
+        const selectedGroup = data.groups.find((g) => g.group.id === groupId)
 
-          return (
-            <>
-              {creatingReservationChild && (
-                <ReservationModalSingleChild
-                  child={creatingReservationChild}
-                  onReload={reload}
-                  onClose={() => setCreatingReservationChild(null)}
+        return (
+          <>
+            {creatingReservationChild && (
+              <ReservationModalSingleChild
+                child={creatingReservationChild}
+                onReload={reload}
+                onClose={() => setCreatingReservationChild(null)}
+              />
+            )}
+
+            <WeekPicker>
+              <WeekPickerButton
+                icon={faChevronLeft}
+                onClick={() => setSelectedDate(selectedDate.addDays(-7))}
+                size="s"
+              />
+              <H3 noMargin>
+                {`${dateRange.start.format(
+                  'dd.MM.'
+                )} - ${dateRange.end.format()}`}
+              </H3>
+              <WeekPickerButton
+                icon={faChevronRight}
+                onClick={() => setSelectedDate(selectedDate.addDays(7))}
+                size="s"
+              />
+            </WeekPicker>
+            <Gap size="s" />
+            <FixedSpaceColumn spacing="L">
+              {selectedGroup && (
+                <ReservationsTable
+                  operationalDays={data.operationalDays}
+                  reservations={selectedGroup.children}
+                  onMakeReservationForChild={setCreatingReservationChild}
                 />
               )}
-
-              <WeekPicker>
-                <WeekPickerButton
-                  icon={faChevronLeft}
-                  onClick={() => setSelectedDate(selectedDate.addDays(-7))}
-                  size="s"
+              {groupId === 'no-group' && (
+                <ReservationsTable
+                  operationalDays={data.operationalDays}
+                  reservations={data.ungrouped}
+                  onMakeReservationForChild={setCreatingReservationChild}
                 />
-                <H3 noMargin>
-                  {`${dateRange.start.format(
-                    'dd.MM.'
-                  )} - ${dateRange.end.format()}`}
-                </H3>
-                <WeekPickerButton
-                  icon={faChevronRight}
-                  onClick={() => setSelectedDate(selectedDate.addDays(7))}
-                  size="s"
-                />
-              </WeekPicker>
-              <Gap size="s" />
-              <FixedSpaceColumn spacing="L">
-                {selectedGroup && (
-                  <ReservationsTable
-                    operationalDays={data.operationalDays}
-                    reservations={selectedGroup.children}
-                    onMakeReservationForChild={setCreatingReservationChild}
-                  />
-                )}
-                {groupId === 'no-group' && (
-                  <ReservationsTable
-                    operationalDays={data.operationalDays}
-                    reservations={data.ungrouped}
-                    onMakeReservationForChild={setCreatingReservationChild}
-                  />
-                )}
-              </FixedSpaceColumn>
-            </>
-          )
-        }
+              )}
+            </FixedSpaceColumn>
+          </>
+        )
       })}
       <Gap size="L" />
     </>

--- a/frontend/src/employee-mobile-frontend/components/async-rendering.tsx
+++ b/frontend/src/employee-mobile-frontend/components/async-rendering.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Result } from 'lib-common/api'
+import {
+  genericUnwrapResult,
+  UnwrapResultProps
+} from 'lib-components/async-rendering'
+import { useTranslation } from '../state/i18n'
+
+export function UnwrapResult<T>(props: UnwrapResultProps<T>) {
+  const { i18n } = useTranslation()
+  return genericUnwrapResult({
+    ...props,
+    failureMessage: i18n.common.loadingFailed
+  })
+}
+
+export function renderResult<T>(
+  result: Result<T>,
+  renderer: (value: T) => React.ReactElement | null
+) {
+  return <UnwrapResult result={result}>{renderer}</UnwrapResult>
+}

--- a/frontend/src/lib-components/async-rendering.tsx
+++ b/frontend/src/lib-components/async-rendering.tsx
@@ -1,15 +1,31 @@
 import { Result } from 'lib-common/api'
 import React from 'react'
-import { SpinnerSegment } from './atoms/state/Spinner'
-import ErrorSegment from './atoms/state/ErrorSegment'
+import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
+import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 
-export function renderResult<T>(
-  result: Result<T>,
-  renderer: (data: T) => React.ReactElement | null
-) {
-  if (result.isLoading) return <SpinnerSegment />
+export interface UnwrapResultProps<T> {
+  result: Result<T>
+  loading?: () => React.ReactElement | null
+  failure?: () => React.ReactElement | null
+  children?: (value: T) => React.ReactElement | null
+}
 
-  if (result.isFailure) return <ErrorSegment />
+interface GenericUnwrapResultOpts<T> extends UnwrapResultProps<T> {
+  failureMessage: string
+}
 
-  return renderer(result.value)
+export function genericUnwrapResult<T>({
+  result,
+  loading,
+  failure,
+  children,
+  failureMessage
+}: GenericUnwrapResultOpts<T>) {
+  if (result.isLoading) {
+    return loading?.() ?? <SpinnerSegment />
+  }
+  if (result.isFailure) {
+    return failure?.() ?? <ErrorSegment title={failureMessage} />
+  }
+  return children ? children(result.value) : null
 }


### PR DESCRIPTION
#### Summary

- Use translations for the active language in `renderResult()`
- Re-introduce `<UnwrapResult>`. `renderResult()` now uses it to be able to use the translations from the context. Hooks can only be called from components.
- `<UnwrapResult>` can be used directly for the cases where the loading or failure state rendering needs to be customized. `renderResult()` is more readable and should be used for the simple case.