### PR TITLE
Reduce flakiness caused by repeated isVisible checks

### DIFF
--- a/frontend/src/e2e-playwright/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-playwright/pages/citizen/citizen-applications.ts
@@ -5,7 +5,6 @@
 import { Page } from 'playwright'
 import {
   waitUntilEqual,
-  waitUntilFalse,
   waitUntilDefined,
   waitUntilTrue
 } from 'e2e-playwright/utils'
@@ -135,7 +134,7 @@ export default class CitizenApplicationsPage {
   }
 
   async assertApplicationDoesNotExist(id: string) {
-    await waitUntilFalse(() => this.#applicationType(id).visible)
+    await this.#applicationType(id).waitUntilHidden()
   }
 }
 
@@ -323,7 +322,7 @@ class CitizenApplicationEditor {
 
   async assertPreferredStartDateInfo(infoText: string | undefined) {
     if (infoText === undefined) {
-      await waitUntilFalse(() => this.#preferredStartDateInfo.visible)
+      await this.#preferredStartDateInfo.waitUntilHidden()
       return
     }
     await waitUntilEqual(() => this.#preferredStartDateInfo.innerText, infoText)

--- a/frontend/src/e2e-playwright/pages/citizen/citizen-decisions.ts
+++ b/frontend/src/e2e-playwright/pages/citizen/citizen-decisions.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual, waitUntilFalse } from 'e2e-playwright/utils'
+import { waitUntilEqual } from 'e2e-playwright/utils'
 import { RawElement } from 'e2e-playwright/utils/element'
 import { Page } from 'playwright'
 
@@ -149,7 +149,7 @@ async function assertUnresolvedDecisionsCount(page: Page, count: number) {
   )
 
   if (count === 0) {
-    return await waitUntilFalse(() => element.visible)
+    return element.waitUntilHidden()
   }
 
   if (count === 1) {

--- a/frontend/src/e2e-playwright/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-playwright/pages/employee/finance/finance-page.ts
@@ -12,11 +12,7 @@ import {
   RawElement,
   RawTextInput
 } from 'e2e-playwright/utils/element'
-import {
-  waitUntilEqual,
-  waitUntilFalse,
-  waitUntilTrue
-} from 'e2e-playwright/utils'
+import { waitUntilEqual, waitUntilTrue } from 'e2e-playwright/utils'
 
 export class FinancePage {
   constructor(private readonly page: Page) {}
@@ -83,12 +79,12 @@ export class FeeDecisionsPage {
 
   async openFirstFeeDecision() {
     await this.#feeDecisionRow.click()
-    await waitUntilTrue(() => this.#feeDecisionDetailsPage.visible)
+    await this.#feeDecisionDetailsPage.waitUntilVisible()
   }
 
   async navigateBackFromDetails() {
     await this.#navigateBackButton.click()
-    await waitUntilTrue(() => this.#feeDecisionListPage.visible)
+    await this.#feeDecisionListPage.waitUntilVisible()
   }
 
   async toggleAllFeeDecisions(toggledOn: boolean) {
@@ -164,17 +160,17 @@ export class ValueDecisionsPage {
 
   async sendValueDecision() {
     await this.#sendDecisionButton.click()
-    await waitUntilFalse(() => this.#sendDecisionButton.visible)
+    await this.#sendDecisionButton.waitUntilHidden()
   }
 
   async openFirstValueDecision() {
     await this.#valueDecisionRow.click()
-    await waitUntilTrue(() => this.#valueDecisionDetailsPage.visible)
+    await this.#valueDecisionDetailsPage.waitUntilVisible()
   }
 
   async navigateBackFromDetails() {
     await this.#navigateBackButton.click()
-    await waitUntilTrue(() => this.#valueDecisionListPage.visible)
+    await this.#valueDecisionListPage.waitUntilVisible()
   }
 
   async getValueDecisionCount() {
@@ -284,12 +280,12 @@ export class InvoicesPage {
 
   async invoicesPageIsLoaded() {
     await this.#invoicesPage.waitUntilVisible()
-    await waitUntilFalse(() => this.#spinner.visible)
+    await this.#spinner.waitUntilHidden()
   }
 
   async createInvoiceDrafts() {
     await this.#createInvoicesButton.click()
-    await waitUntilFalse(() => this.#spinner.visible)
+    await this.#spinner.waitUntilHidden()
   }
 
   async assertInvoiceCount(count: number) {

--- a/frontend/src/e2e-playwright/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-playwright/pages/employee/messages/messages-page.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual, waitUntilFalse } from 'e2e-playwright/utils'
-import { waitUntilTrue } from 'e2e-playwright/utils'
+import { waitUntilEqual, waitUntilTrue } from 'e2e-playwright/utils'
 import { RawElement, RawTextInput } from 'e2e-playwright/utils/element'
 import { Page } from 'playwright'
 
@@ -161,6 +160,6 @@ export default class MessagesPage {
 
   async assertNoDrafts() {
     await this.#draftMessagesBoxRow.click()
-    await waitUntilFalse(() => this.#draftMessage.visible)
+    await this.#draftMessage.waitUntilHidden()
   }
 }

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-map.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-map.spec.ts
@@ -19,7 +19,7 @@ import { newBrowserContext } from '../../browser'
 import config from 'e2e-test-common/config'
 import { Page } from 'playwright'
 import CitizenMapPage from '../../pages/citizen/citizen-map'
-import { waitUntilEqual, waitUntilFalse, waitUntilTrue } from '../../utils'
+import { waitUntilEqual } from '../../utils'
 
 const swedishDaycare: Daycare = {
   ...daycare2Fixture,
@@ -79,40 +79,40 @@ afterEach(async () => {
 
 describe('Citizen map page', () => {
   test('Unit type filter affects the unit list', async () => {
-    await waitUntilTrue(() => mapPage.daycareFilter.visible)
+    await mapPage.daycareFilter.waitUntilVisible()
     expect(await mapPage.daycareFilter.checked).toBe(true)
-    await waitUntilTrue(() => mapPage.listItemFor(daycare2Fixture).visible)
-    await waitUntilFalse(() => mapPage.listItemFor(clubFixture).visible)
-    await waitUntilTrue(() => mapPage.listItemFor(preschoolFixture).visible)
+    await mapPage.listItemFor(daycare2Fixture).waitUntilVisible()
+    await mapPage.listItemFor(clubFixture).waitUntilHidden()
+    await mapPage.listItemFor(preschoolFixture).waitUntilVisible()
 
     await mapPage.clubFilter.click()
-    await waitUntilTrue(() => mapPage.listItemFor(clubFixture).visible)
-    await waitUntilFalse(() => mapPage.listItemFor(daycare2Fixture).visible)
-    await waitUntilFalse(() => mapPage.listItemFor(preschoolFixture).visible)
+    await mapPage.listItemFor(clubFixture).waitUntilVisible()
+    await mapPage.listItemFor(daycare2Fixture).waitUntilHidden()
+    await mapPage.listItemFor(preschoolFixture).waitUntilHidden()
 
     await mapPage.preschoolFilter.click()
-    await waitUntilFalse(() => mapPage.listItemFor(clubFixture).visible)
-    await waitUntilTrue(() => mapPage.listItemFor(preschoolFixture).visible)
-    await waitUntilFalse(() => mapPage.listItemFor(daycare2Fixture).visible)
+    await mapPage.listItemFor(clubFixture).waitUntilHidden()
+    await mapPage.listItemFor(preschoolFixture).waitUntilVisible()
+    await mapPage.listItemFor(daycare2Fixture).waitUntilHidden()
   })
   test('Unit language filter affects the unit list', async () => {
-    await waitUntilTrue(() => mapPage.daycareFilter.visible)
+    await mapPage.daycareFilter.waitUntilVisible()
     expect(await mapPage.daycareFilter.checked).toBe(true)
-    await waitUntilTrue(() => mapPage.listItemFor(daycare2Fixture).visible)
-    await waitUntilTrue(() => mapPage.listItemFor(swedishDaycare).visible)
+    await mapPage.listItemFor(daycare2Fixture).waitUntilVisible()
+    await mapPage.listItemFor(swedishDaycare).waitUntilVisible()
 
     await mapPage.setLanguageFilter('fi', true)
-    await waitUntilFalse(() => mapPage.listItemFor(swedishDaycare).visible)
-    await waitUntilTrue(() => mapPage.listItemFor(daycare2Fixture).visible)
+    await mapPage.listItemFor(swedishDaycare).waitUntilHidden()
+    await mapPage.listItemFor(daycare2Fixture).waitUntilVisible()
 
     await mapPage.setLanguageFilter('sv', true)
     await mapPage.setLanguageFilter('fi', false)
-    await waitUntilTrue(() => mapPage.listItemFor(swedishDaycare).visible)
-    await waitUntilFalse(() => mapPage.listItemFor(daycare2Fixture).visible)
+    await mapPage.listItemFor(swedishDaycare).waitUntilVisible()
+    await mapPage.listItemFor(daycare2Fixture).waitUntilHidden()
   })
   test('Unit details can be viewed by clicking a list item', async () => {
     await mapPage.listItemFor(daycare2Fixture).click()
-    await waitUntilTrue(() => mapPage.unitDetailsPanel.visible)
+    await mapPage.unitDetailsPanel.waitUntilVisible()
     await waitUntilEqual(
       () => mapPage.unitDetailsPanel.name,
       daycare2Fixture.name
@@ -121,7 +121,7 @@ describe('Citizen map page', () => {
     await mapPage.unitDetailsPanel.backButton.click()
     await mapPage.listItemFor(swedishDaycare).click()
 
-    await waitUntilTrue(() => mapPage.unitDetailsPanel.visible)
+    await mapPage.unitDetailsPanel.waitUntilVisible()
     await waitUntilEqual(
       () => mapPage.unitDetailsPanel.name,
       swedishDaycare.name
@@ -130,7 +130,7 @@ describe('Citizen map page', () => {
   test('Units can be searched', async () => {
     await mapPage.searchInput.type('Svart')
     await mapPage.searchInput.clickUnitResult(swedishDaycare)
-    await waitUntilTrue(() => mapPage.unitDetailsPanel.visible)
+    await mapPage.unitDetailsPanel.waitUntilVisible()
     await waitUntilEqual(
       () => mapPage.unitDetailsPanel.name,
       swedishDaycare.name
@@ -142,7 +142,7 @@ describe('Citizen map page', () => {
     })
     await mapPage.searchInput.type('Testikatu')
     await mapPage.searchInput.clickAddressResult(testStreet.properties.name)
-    await waitUntilTrue(() => mapPage.map.addressMarker.visible)
+    await mapPage.map.addressMarker.waitUntilVisible()
   })
   test('Unit markers can be clicked to open a popup', async () => {
     await mapPage.testMapPopup(daycare2Fixture)

--- a/frontend/src/e2e-playwright/specs/5_employee/employee-pin.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/employee-pin.spec.ts
@@ -39,7 +39,7 @@ describe('Employees PIN', () => {
     )
 
     await pinPage.pinInput.fill('9128')
-    await waitUntilEqual(() => pinPage.inputInfo.visible, false)
+    await pinPage.inputInfo.waitUntilHidden()
   })
 
   test('shows a warning if PIN is locked, and warning disappears when new PIN is set', async () => {
@@ -53,9 +53,9 @@ describe('Employees PIN', () => {
       .save()
 
     await page.reload()
-    await waitUntilEqual(() => pinPage.pinLockedAlertBox.visible, true)
+    await pinPage.pinLockedAlertBox.waitUntilVisible()
     await pinPage.pinInput.type('2580')
     await pinPage.pinSendButton.click()
-    await waitUntilEqual(() => pinPage.pinLockedAlertBox.visible, false)
+    await pinPage.pinLockedAlertBox.waitUntilHidden()
   })
 })

--- a/frontend/src/e2e-playwright/utils/element.ts
+++ b/frontend/src/e2e-playwright/utils/element.ts
@@ -50,6 +50,10 @@ export class RawElement {
     await this.page.waitForSelector(this.selector, { state: 'visible' })
   }
 
+  async waitUntilHidden(): Promise<void> {
+    await this.page.waitForSelector(this.selector, { state: 'hidden' })
+  }
+
   async getAttribute(name: string): Promise<string | null> {
     return this.page.getAttribute(this.selector, name)
   }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Playwright's `isVisible` is still not perfectly atomic and may throw exceptions randomly

-> use `waitForSelector` under the hood whenever possible instead of polling `isVisible`. In the future we might be able to use locator `waitFor` API once that gets released in Playwright 1.16