### PR TITLE
CI: REUSE compliance checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ aliases:
   - &remote_docker_version "20.10.7"
   - &yarn_version '1.22.\*'
   - &shellcheck_image_version v0.7.2
-  - &reuse_image fsfe/reuse:0.13.0
+  - &reuse_image fsfe/reuse:0.13.0 # NOTE: Update bin/add-license-headers.sh to match
   - &nodejs_image << pipeline.parameters.nodejs_image >>
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202107-02
@@ -823,7 +823,16 @@ jobs:
     executor: reuse_tool
     steps:
       - restore_repo
-      - run: reuse lint
+      - run:
+          name: reuse lint
+          command: |
+            reuse lint || {
+              echo '';
+              echo '=========================================';
+              echo 'Please run: ./bin/add-license-headers.sh';
+              echo '=========================================';
+              exit 1
+            }
       - run:
           when: on_fail
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@4.4.2
-  owasp: entur/owasp@0.0.15
+  slack: circleci/slack@4.4.4
+  owasp: entur/owasp@0.0.16
 
 parameters:
   workspace_root:
@@ -17,7 +17,7 @@ parameters:
     default: /home/circleci/repo
   builder_aws_version:
     type: string
-    default: bullseye-slim-e2518f5ece6862d780ff4224aad606e13cfe8293
+    default: bullseye-slim-a5a07c25c46622d35ac60836c5d5b0117f00b026
   nodejs_image:
     type: string
     default: cimg/node:14.15
@@ -41,15 +41,15 @@ aliases:
   - &ci_evaka_fingerprint 86:d0:b3:3d:aa:fc:d5:b9:6b:69:1e:c7:f5:56:66:aa
 
   # Version of remote Docker engine used with setup_remote_docker (not including machine executors)
-  - &remote_docker_version "20.10.6"
+  - &remote_docker_version "20.10.7"
   - &yarn_version '1.22.\*'
   - &shellcheck_image_version v0.7.2
   - &nodejs_image << pipeline.parameters.nodejs_image >>
   - &openjdk_image cimg/openjdk:11.0
-  - &ubuntu_machine_image ubuntu-2004:202104-01
-  - &builder_aws_core_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:core-<< pipeline.parameters.builder_aws_version >>
-  - &builder_aws_docker_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:docker-<< pipeline.parameters.builder_aws_version >>
-  - &builder_aws_terraform_image 307238562370.dkr.ecr.eu-west-1.amazonaws.com/voltti/builder-aws:terraform-<< pipeline.parameters.builder_aws_version >>
+  - &ubuntu_machine_image ubuntu-2004:202107-02
+  - &builder_aws_core_image << pipeline.parameters.ecr >>/voltti/builder-aws:core-<< pipeline.parameters.builder_aws_version >>
+  - &builder_aws_docker_image << pipeline.parameters.ecr >>/voltti/builder-aws:docker-<< pipeline.parameters.builder_aws_version >>
+  - &builder_aws_terraform_image << pipeline.parameters.ecr >>/voltti/builder-aws:terraform-<< pipeline.parameters.builder_aws_version >>
 
   - &default_contexts
     context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ aliases:
   - &remote_docker_version "20.10.7"
   - &yarn_version '1.22.\*'
   - &shellcheck_image_version v0.7.2
-  - &reuse_image cimg/base:stable-20.04
+  - &reuse_image fsfe/reuse:0.13.0
   - &nodejs_image << pipeline.parameters.nodejs_image >>
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202107-02
@@ -817,11 +817,11 @@ jobs:
     executor: reuse_tool
     steps:
       - restore_repo
-      - setup_authenticated_remote_docker
+      - run: reuse lint
       - run:
-          name: Check REUSE licensing status
-          command: |
-            ./bin/add-license-headers.sh --lint-only
+          when: on_fail
+          name: Install dependencies
+          command: apk add curl jq
       - notify_slack
 
   # BUILD JOBS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,14 +87,17 @@ executors:
     <<: *default_config
     docker:
       - image: *builder_aws_core_image
+    resource_class: small
   aws_docker_executor:
     <<: *default_config
     docker:
       - image: *builder_aws_docker_image
+    resource_class: medium
   aws_terraform_executor:
     <<: *default_config
     docker:
       - image: *builder_aws_terraform_image
+    resource_class: small
   apigw_executor:
     <<: *node_config
     docker:
@@ -102,6 +105,7 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
+    resource_class: medium
   frontend_executor:
     <<: *node_config
     docker:
@@ -109,11 +113,12 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
+    resource_class: medium
   e2e_executor:
     <<: *node_config
     machine:
       image: *ubuntu_machine_image
-      resource_class: large
+    resource_class: large
   service_executor:
     <<: *jvm_config
     docker:
@@ -125,7 +130,7 @@ executors:
     <<: *jvm_config
     machine:
       image: *ubuntu_machine_image
-      resource_class: large
+    resource_class: large
     environment:
       # YAML anchors don't merge nested keys, so re-referencing is required
       <<: *jvm_env
@@ -761,6 +766,7 @@ jobs:
 
   checkout_repo:
     executor: apigw_executor
+    resource_class: small
     steps:
       - checkout
       - store_repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ aliases:
   - &remote_docker_version "20.10.7"
   - &yarn_version '1.22.\*'
   - &shellcheck_image_version v0.7.2
+  - &reuse_image cimg/base:stable-20.04
   - &nodejs_image << pipeline.parameters.nodejs_image >>
   - &openjdk_image cimg/openjdk:11.0
   - &ubuntu_machine_image ubuntu-2004:202107-02
@@ -142,6 +143,15 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
+    resource_class: small
+    working_directory: << pipeline.parameters.workspace_root >>
+  reuse_tool:
+    docker:
+      - image: *reuse_image
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    resource_class: small
     working_directory: << pipeline.parameters.workspace_root >>
 
 commands:
@@ -803,6 +813,17 @@ jobs:
             ./bin/run-shellcheck.sh
       - notify_slack
 
+  check_licenses:
+    executor: reuse_tool
+    steps:
+      - restore_repo
+      - setup_authenticated_remote_docker
+      - run:
+          name: Check REUSE licensing status
+          command: |
+            ./bin/add-license-headers.sh --lint-only
+      - notify_slack
+
   # BUILD JOBS
 
   build_base_image:
@@ -1214,6 +1235,10 @@ workflows:
           <<: *aws_contexts
           requires:
             - checkout_repo
+      - check_licenses:
+          <<: *default_contexts
+          requires:
+            - checkout_repo
       - lint_scripts:
           <<: *default_contexts
           requires:
@@ -1334,6 +1359,7 @@ workflows:
           <<: *aws_contexts
           name: frontend_install_<< matrix.target_env >>
           requires:
+            - check_licenses
             - lint_scripts
             - frontend_build_misc_and_test
             - e2e-test-testcafe

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 # eVaka – ERP for early childhood education
 
+[![REUSE status](https://api.reuse.software/badge/github.com/espoon-voltti/evaka)](https://api.reuse.software/info/github.com/espoon-voltti/evaka)
+
+<!-- This project is registered with the REUSE API: https://api.reuse.software/ -->
+
 This is eVaka – an ERP system developed for early childhood education in
 Finland. It is a web application developed using modern technologies and
 designed to be deployed in cloud environment.

--- a/README.md
+++ b/README.md
@@ -114,9 +114,13 @@ anything but binary-like files (e.g. certificates) with
 ### Check licensing compliance
 
 This repository targets [REUSE](https://reuse.software/) compliance by utilizing
-the [reuse CLI tool](https://git.fsfe.org/reuse/tool).
+the [reuse CLI tool](https://git.fsfe.org/reuse/tool) and the
+[REUSE API](https://api.reuse.software/).
 
-To check that the repository is compliant (e.g. before submitting a pull
+The REUSE API constantly checks this repository's compliance and the status
+can be seen from the badge at the top of this README.
+
+To manually check that the repository is compliant (e.g. before submitting a pull
 request), run:
 
 ```sh

--- a/bin/add-license-headers.sh
+++ b/bin/add-license-headers.sh
@@ -8,8 +8,10 @@ set -euo pipefail
 
 # Configuration
 DEBUG=${DEBUG:-false}
-REUSE_VERSION=0.13.0
+REUSE_VERSION=0.13.0 # NOTE: Update .circleci/config.yml to match
 REUSE_YEARS=${REUSE_YEARS:-"2017-$(date +"%Y")"}
+
+REUSE_IMAGE="fsfe/reuse:${REUSE_VERSION}"
 
 if [ "$DEBUG" = "true" ]; then
     set -x
@@ -27,10 +29,10 @@ REPO_PREFIX=${PWD#"${REPO_ROOT}"}
 
 if [ "${1:-X}" = '--help' ]; then
   echo 'Usage: ./bin/add-license-headers.sh [OPTIONS]'
-  echo -e
+  echo ''
   echo 'Helper script to attempt automatically adding missing license headers to all source code files.'
   echo 'Any missing license files are downloaded automatically to LICENSES/.'
-  echo -e
+  echo ''
   echo 'Options:'
   echo "    --lint-only     Only lint for missing headers, don't attempt to add anything"
   echo '    --help          Print this help'
@@ -39,7 +41,7 @@ fi
 
 function run_reuse() {
     run_args=("$@")
-    docker run --rm --volume "${REPO_ROOT}:/data" --workdir "/data${REPO_PREFIX}" "fsfe/reuse:${REUSE_VERSION}" "${run_args[@]}"
+    docker run --rm --volume "${REPO_ROOT}:/data" --workdir "/data${REPO_PREFIX}" "$REUSE_IMAGE" "${run_args[@]}"
 }
 
 function addheader() {
@@ -48,6 +50,8 @@ function addheader() {
     local cmd_args=("$@")
     run_reuse addheader --license "LGPL-2.1-or-later" --copyright "City of Espoo" --year "$REUSE_YEARS" "${cmd_args[@]}" "$file"
 }
+
+# MAIN SCRIPT
 
 set +e
 REUSE_OUTPUT=$(run_reuse lint)


### PR DESCRIPTION
#### Summary
- CI: implement REUSE license compliance checking in CI
    - Use the official reuse-tool image as the executor
        - Using our own wrapper should no longer really be necessary as there aren't any custom exceptions -> no need for custom logic
    - Now that all files have licensing data available, this can finally be added to CI so that license headers will never be forgotten again
    - Downside here is that now CI will nag on every commit until the headers have been added but the best solution honestly will be to just either configure the `add-license-headers.sh` script to pre-commit hooks or in IDEs -- a small pain now but saves a big pain later
- CI: update all images
    - Nothing breaking, just keeping up-to-date
- CI: use smaller executors where possible
    - And be explicit with `resource_class`
    - Also, fix machine executors' `resource_class` configs; they worked due to backwards compatibility but were still in the wrong place
- Project has now been registed with the REUSE API for active compliance checking (and a neat badge for our README!): https://api.reuse.software/info/github.com/espoon-voltti/evaka

