### PR TITLE
Remove redundant navigation in Playwright tests

### DIFF
--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-applications-list.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-applications-list.spec.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Page } from 'playwright'
-import config from 'e2e-test-common/config'
 import {
   execSimpleApplicationActions,
   insertApplications,
@@ -31,7 +30,6 @@ beforeEach(async () => {
   fixtures = await initializeAreaAndPersonData()
 
   page = await (await newBrowserContext()).newPage()
-  await page.goto(config.enduserUrl)
   await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-club-application.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-club-application.spec.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Page } from 'playwright'
-import config from 'e2e-test-common/config'
 import { getApplication, resetDatabase } from 'e2e-test-common/dev-api'
 import {
   AreaAndPersonFixtures,
@@ -28,7 +27,6 @@ beforeEach(async () => {
   fixtures = await initializeAreaAndPersonData()
 
   page = await (await newBrowserContext()).newPage()
-  await page.goto(config.enduserUrl)
   await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Page } from 'playwright'
-import config from 'e2e-test-common/config'
 import {
   execSimpleApplicationActions,
   getApplication,
@@ -40,7 +39,6 @@ beforeEach(async () => {
   fixtures = await initializeAreaAndPersonData()
 
   page = await (await newBrowserContext()).newPage()
-  await page.goto(config.enduserUrl)
   await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-header.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-header.spec.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Page } from 'playwright'
-import config from 'e2e-test-common/config'
 import { resetDatabase } from 'e2e-test-common/dev-api'
 import { initializeAreaAndPersonData } from 'e2e-test-common/dev-api/data-init'
 import { enduserLogin } from 'e2e-playwright/utils/user'
@@ -19,7 +18,6 @@ beforeEach(async () => {
   await initializeAreaAndPersonData()
 
   page = await (await newBrowserContext()).newPage()
-  await page.goto(config.enduserUrl)
   await enduserLogin(page)
   header = new CitizenHeader(page)
 })

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-income-statement.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-income-statement.spec.ts
@@ -4,7 +4,6 @@
 
 import LocalDate from 'lib-common/local-date'
 import { Page } from 'playwright'
-import config from '../../../e2e-test-common/config'
 import { resetDatabase } from '../../../e2e-test-common/dev-api'
 import { newBrowserContext } from '../../browser'
 import CitizenHeader from '../../pages/citizen/citizen-header'
@@ -20,7 +19,6 @@ beforeEach(async () => {
   await resetDatabase()
 
   page = await (await newBrowserContext()).newPage()
-  await page.goto(config.enduserUrl)
   await enduserLogin(page)
   header = new CitizenHeader(page)
   incomeStatementsPage = new IncomeStatementsPage(page)

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-preschool-application.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-preschool-application.spec.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Page } from 'playwright'
-import config from 'e2e-test-common/config'
 import { getApplication, resetDatabase } from 'e2e-test-common/dev-api'
 import {
   AreaAndPersonFixtures,
@@ -28,7 +27,6 @@ beforeEach(async () => {
   fixtures = await initializeAreaAndPersonData()
 
   page = await (await newBrowserContext()).newPage()
-  await page.goto(config.enduserUrl)
   await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)


### PR DESCRIPTION
#### Summary

This seems to avoid some flakiness in e2e tests.
