### PR TITLE
Fix a re-export warning from webpack

### DIFF
--- a/frontend/src/employee-frontend/types/finance-basics.ts
+++ b/frontend/src/employee-frontend/types/finance-basics.ts
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { FeeThresholds } from 'lib-common/api-types/finance'
+import type { FeeThresholds } from 'lib-common/api-types/finance'
 
-export { FeeThresholds } from 'lib-common/api-types/finance'
+export type { FeeThresholds }
 
 export const familySizes = ['2', '3', '4', '5', '6'] as const
 export type FamilySize = typeof familySizes[number]


### PR DESCRIPTION
#### Summary

<img width="1143" alt="Näyttökuva 2021-10-4 kello 8 51 41" src="https://user-images.githubusercontent.com/70927/135800678-6c2e10eb-be40-40de-8ed5-b9ffcb9950c4.png">

It seems that webpack doesn't handle type-only imports from type-only modules very well, so tell it that we're importing and exporting a type here.
