### PR TITLE
Instead of aborting on any 429 response, use a treshold value

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
@@ -429,7 +429,7 @@ class VardaClient(
             this
                 .authentication().token(token)
                 .header(Headers.ACCEPT, "application/json")
-                .responseStringWithRetries(maxTries) { r, remainingTries ->
+                .responseStringWithRetries(maxTries, 10L) { r, remainingTries ->
                     when (r.second.statusCode) {
                         403 -> when {
                             objectMapper.readTree(r.third.error.errorData).get("errors")
@@ -441,7 +441,7 @@ class VardaClient(
                                 // any subsequent errors fall through.
                                 this
                                     .authentication().token(newToken)
-                                    .responseStringWithRetries(remainingTries)
+                                    .responseStringWithRetries(remainingTries, 10L)
                             }
                             else -> r
                         }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaTokenProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaTokenProvider.kt
@@ -61,7 +61,7 @@ class VardaTempTokenProvider(
         .header(Headers.AUTHORIZATION, basicAuth)
         .header(Headers.ACCEPT, "application/json")
         .header(Headers.CONTENT_TYPE, "application/json")
-        .responseStringWithRetries(3)
+        .responseStringWithRetries(3, 10L)
         .third
         .fold(
             { d -> VardaApiToken.from(objectMapper.readTree(d).get("token").asText()) },

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/utils/FuelExtensionsTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/utils/FuelExtensionsTest.kt
@@ -53,7 +53,7 @@ class FuelExtensionsTest {
         FuelManager.instance.client = client
 
         val (_, response, result) = Fuel.get("https://example.com")
-            .responseStringWithRetries(1, false)
+            .responseStringWithRetries(1, 1L)
 
         assertEquals(200, response.statusCode)
         assertEquals("final", result.get())
@@ -70,7 +70,7 @@ class FuelExtensionsTest {
         FuelManager.instance.client = client
 
         val (_, response, result) = Fuel.get("https://example.com")
-            .responseStringWithRetries(2, false) // Would have to be 3 to succeed
+            .responseStringWithRetries(2, 1L) // Would have to be 3 to succeed
         assertEquals(429, response.statusCode) // Status code of last response
         assertTrue(result is Result.Failure)
     }
@@ -82,7 +82,7 @@ class FuelExtensionsTest {
         FuelManager.instance.client = client
 
         assertThrows<NumberFormatException> {
-            Fuel.get("https://example.com").responseStringWithRetries(1, false) // Would have to be 2 to succeed
+            Fuel.get("https://example.com").responseStringWithRetries(1, 1L) // Would have to be 2 to succeed
         }
     }
 


### PR DESCRIPTION
#### Summary
Varda uses 429 RETRY_WAIT to control both the maximum number of requests per day as well as the frequency of the requests (too many req/s). In the latter case it is better to wait than fail, so use a threshold value for abort instead of always aborting

