### PR TITLE
EVAKA-HOTFIX date picker on small screens

### DIFF
--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
@@ -106,29 +106,33 @@ function DatePicker({
   }
 
   useLayoutEffect(() => {
-    const realignPicker = () => {
-      if (wrapperRef.current) {
-        const distanceFromLeftEdge = wrapperRef.current.offsetLeft
-        const distanceFromRightEdge =
-          window.innerWidth - wrapperRef.current.offsetLeft - inputWidth
+    if (show) {
+      const realignPicker = () => {
+        if (wrapperRef.current) {
+          const distanceFromLeftEdge = wrapperRef.current.offsetLeft
+          const distanceFromRightEdge =
+            window.innerWidth - wrapperRef.current.offsetLeft - inputWidth
 
-        const leftOffset =
-          overflow - Math.min(overflow, distanceFromLeftEdge - minMargin)
-        const rightOffset =
-          overflow - Math.min(overflow, distanceFromRightEdge - minMargin)
+          const leftOffset =
+            overflow - Math.min(overflow, distanceFromLeftEdge - minMargin)
+          const rightOffset =
+            overflow - Math.min(overflow, distanceFromRightEdge - minMargin)
 
-        if (pickerRef.current && (leftOffset !== 0 || rightOffset !== 0)) {
-          const left = -overflow + leftOffset - rightOffset
-          pickerRef.current.style['left'] = `${left}px`
-          const right = -overflow - leftOffset + rightOffset
-          pickerRef.current.style['right'] = `${right}px`
+          if (pickerRef.current && (leftOffset !== 0 || rightOffset !== 0)) {
+            const left = -overflow + leftOffset - rightOffset
+            pickerRef.current.style['left'] = `${left}px`
+            const right = -overflow - leftOffset + rightOffset
+            pickerRef.current.style['right'] = `${right}px`
+          }
         }
       }
+      realignPicker()
+      addEventListener('resize', realignPicker, { passive: true })
+      return () => removeEventListener('resize', realignPicker)
     }
-    realignPicker()
-    addEventListener('resize', realignPicker, { passive: true })
-    return () => removeEventListener('resize', realignPicker)
-  }, [])
+
+    return
+  }, [show])
 
   useEffect(() => {
     function handleEvent(event: { target: EventTarget | null }) {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Fix DatePicker's realignment by running it when the picker is rendered. This was broken when DatePicker was changed to unmount when it's not shown instead of just hiding it with css.

