### PR TITLE
Login error modal for employee frontend

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -12,12 +12,12 @@ import ApplicationCreation from './applications/ApplicationCreation'
 import ApplicationEditor from './applications/editor/ApplicationEditor'
 import ApplicationReadView from './applications/read-view/ApplicationReadView'
 import { Authentication } from './auth'
-import { LoginErrorModal } from './auth/LoginErrorModal'
+import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
 import requireAuth from './auth/requireAuth'
 import DecisionResponseList from './decisions/decision-response-page/DecisionResponseList'
 import Decisions from './decisions/decisions-page/Decisions'
 import Header from './header/Header'
-import { Localization } from './localization'
+import { Localization, useTranslation } from './localization'
 import MessagesPage from './messages/MessagesPage'
 import CalendarPage from './calendar/CalendarPage'
 import { MessageContextProvider } from './messages/state'
@@ -33,6 +33,8 @@ import PedagogicalDocuments from './pedagogical-documents/PedagogicalDocuments'
 import { PedagogicalDocumentsContextProvider } from './pedagogical-documents/state'
 
 export default function App() {
+  const translations = useTranslation()
+
   return (
     <BrowserRouter basename="/">
       <ThemeProvider theme={theme}>
@@ -125,7 +127,9 @@ export default function App() {
                   </Main>
                   <GlobalInfoDialog />
                   <GlobalErrorDialog />
-                  <LoginErrorModal />
+                  <LoginErrorModal
+                    translations={translations.login.failedModal}
+                  />
                 </PedagogicalDocumentsContextProvider>
               </MessageContextProvider>
             </OverlayContextProvider>

--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -31,6 +31,7 @@ import GroupCaretakers from './components/GroupCaretakers'
 import Header from './components/Header'
 import IncomeStatementPage from './components/IncomeStatementPage'
 import InvoicePage from './components/invoice/InvoicePage'
+import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
 import LoginPage from './components/LoginPage'
 import MessagesPage from './components/messages/MessagesPage'
 import PersonProfile from './components/PersonProfile'
@@ -450,6 +451,7 @@ export default function App() {
             <Route exact path="/" component={RedirectToMainPage} />
           </Switch>
           <ErrorMessage />
+          <LoginErrorModal translations={i18n.login.failedModal} />
         </Router>
       </StateProvider>
     </UserContextProvider>

--- a/frontend/src/lib-components/molecules/modals/LoginErrorModal.tsx
+++ b/frontend/src/lib-components/molecules/modals/LoginErrorModal.tsx
@@ -3,10 +3,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useState } from 'react'
-import InfoModal from 'lib-components/molecules/modals/InfoModal'
+import InfoModal from './InfoModal'
 import { faTimes } from 'lib-icons'
-import { useHistory } from 'react-router-dom'
-import { useTranslation } from '../localization'
+import { useHistory, useLocation } from 'react-router-dom'
 import { P } from 'lib-components/typography'
 import styled from 'styled-components'
 
@@ -14,18 +13,29 @@ const ReturnContainer = styled.div`
   margin-top: 30px;
 `
 
-export const LoginErrorModal = React.memo(function LoginErrorModal() {
-  const t = useTranslation()
+interface LoginErrorModalProps {
+  translations: {
+    header: string
+    message: string
+    returnMessage: string
+  }
+}
 
-  const queryParams = new URLSearchParams(location.search)
-  const [errorModalVisible, setErrorModalVisible] = useState<boolean>(
-    queryParams.get('loginError') === 'true'
-  )
+export const LoginErrorModal = React.memo(function LoginErrorModal(
+  props: LoginErrorModalProps
+) {
   const history = useHistory()
+  const location = useLocation()
+  const queryParamName = 'loginError'
+  const queryParams = new URLSearchParams(location.search)
 
-  function closeErrorModal(event?: React.UIEvent<unknown>) {
+  const [errorModalVisible, setErrorModalVisible] = useState<boolean>(
+    queryParams.get(queryParamName) === 'true'
+  )
+
+  function onClose(event?: React.UIEvent<unknown>) {
     setErrorModalVisible(false)
-    queryParams.delete('loginError')
+    queryParams.delete(queryParamName)
     history.replace({
       search: queryParams.toString()
     })
@@ -36,16 +46,16 @@ export const LoginErrorModal = React.memo(function LoginErrorModal() {
 
   return errorModalVisible ? (
     <InfoModal
-      title={t.login.failedModal.header}
-      close={closeErrorModal}
+      title={props.translations.header}
+      close={onClose}
       iconColour="red"
       icon={faTimes}
     >
-      <P centered>{t.login.failedModal.message}</P>
+      <P centered>{props.translations.message}</P>
       <ReturnContainer>
         <P centered>
-          <a href="#" onClick={closeErrorModal}>
-            {t.login.failedModal.returnMessage}
+          <a href="#" onClick={onClose}>
+            {props.translations.returnMessage}
           </a>
         </P>
       </ReturnContainer>

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -207,6 +207,12 @@ export const fi = {
     error: {
       noRole: 'Sinulla ei ole tarvittavaa roolia',
       default: 'Jokin meni vikaan'
+    },
+    failedModal: {
+      header: 'Kirjautuminen epäonnistui',
+      message:
+        'Palveluun tunnistautuminen epäonnistui tai se keskeytettiin. Kirjautuaksesi sisään palaa takaisin ja yritä uudelleen.',
+      returnMessage: 'Palaa takaisin'
     }
   },
   applications: {


### PR DESCRIPTION
#### Summary

Show error modal if employee login fails.

To test, start service locally and navigate to <http://localhost:9099/employee/login?loginError=true> and error should be visible.