### PR TITLE
EVAKA-4000 reset children by error report p4

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -73,6 +73,12 @@ sealed interface VardaAsyncJob : AsyncJobPayload {
     ) : VardaAsyncJob {
         override val user: AuthenticatedUser? = null
     }
+
+    data class DeleteVardaChild(
+        val vardaChildId: Long
+    ) : VardaAsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
 }
 
 @JsonIgnoreProperties("asyncJobType") // only present in old jobs in db

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDevController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDevController.kt
@@ -40,6 +40,6 @@ class VardaDevController(
         @PathVariable organizerId: Long,
         @RequestParam(defaultValue = "1000") limit: Int,
     ) {
-        vardaUpdateService.resetByVardaChildrenErrorReport(db, organizerId = organizerId, limit = limit)
+        vardaUpdateService.planResetByVardaChildrenErrorReport(db, organizerId = organizerId, limit = limit)
     }
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Use async job when deleting by report to enjoy retry functionality and avoid crashing the process for some annoying api errors like status -1