### PR TITLE
Configurable scheduled job retries

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
@@ -4,7 +4,6 @@
 
 package fi.espoo.evaka.shared.job
 
-import com.github.kagkarlsson.scheduler.task.schedule.Schedule
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.application.utils.helsinkiZone
 import fi.espoo.evaka.resetDatabase
@@ -24,9 +23,13 @@ class ScheduledJobRunnerTest : PureJdbiTest() {
     private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
     private val testTime = LocalTime.of(1, 0)
     private val testSchedule = object : JobSchedule {
-        override fun getScheduleForJob(job: ScheduledJob): Schedule? = if (job == ScheduledJob.EndOfDayAttendanceUpkeep) {
-            JobSchedule.daily(testTime)
-        } else null
+        override fun getSettingsForJob(job: ScheduledJob): ScheduledJobSettings? =
+            if (job == ScheduledJob.EndOfDayAttendanceUpkeep) {
+                ScheduledJobSettings(
+                    enabled = true,
+                    schedule = JobSchedule.daily(testTime)
+                )
+            } else null
     }
 
     @BeforeEach

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -353,7 +353,8 @@ data class ScheduledJobsEnv(val jobs: Map<ScheduledJob, ScheduledJobSettings>) {
                 val settings = ScheduledJobSettings(
                     enabled = env.lookup("$envPrefix.enabled") ?: default.enabled,
                     schedule = env.lookup<String?>("$envPrefix.cron")?.let(JobSchedule::cron)
-                        ?: default.schedule
+                        ?: default.schedule,
+                    retryCount = env.lookup("$envPrefix.retry_count") ?: default.retryCount
                 )
                 (job to settings)
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -12,7 +12,7 @@ import fi.espoo.evaka.application.utils.helsinkiZone
 import java.time.LocalTime
 
 interface JobSchedule {
-    fun getScheduleForJob(job: ScheduledJob): Schedule?
+    fun getSettingsForJob(job: ScheduledJob): ScheduledJobSettings?
 
     companion object {
         fun daily(at: LocalTime): Schedule = Daily(helsinkiZone, at)
@@ -20,16 +20,22 @@ interface JobSchedule {
     }
 }
 
-data class ScheduledJobSettings(val enabled: Boolean, val schedule: Schedule) {
+data class ScheduledJobSettings(
+    val enabled: Boolean,
+    val schedule: Schedule,
+    val retryCount: Int? = null
+) {
     companion object {
         fun default(job: ScheduledJob) = when (job) {
             ScheduledJob.VardaUpdate -> ScheduledJobSettings(
                 enabled = false,
-                schedule = JobSchedule.daily(LocalTime.of(23, 30))
+                schedule = JobSchedule.daily(LocalTime.of(23, 30)),
+                retryCount = 1
             )
             ScheduledJob.VardaReset -> ScheduledJobSettings(
                 enabled = true,
-                schedule = JobSchedule.daily(LocalTime.of(20, 0))
+                schedule = JobSchedule.daily(LocalTime.of(20, 0)),
+                retryCount = 1
             )
             ScheduledJob.EndOfDayAttendanceUpkeep -> ScheduledJobSettings(
                 enabled = true,
@@ -41,7 +47,8 @@ data class ScheduledJobSettings(val enabled: Boolean, val schedule: Schedule) {
             )
             ScheduledJob.KoskiUpdate -> ScheduledJobSettings(
                 enabled = false,
-                schedule = JobSchedule.daily(LocalTime.of(0, 0))
+                schedule = JobSchedule.daily(LocalTime.of(0, 0)),
+                retryCount = 1
             )
             ScheduledJob.RemoveOldDraftApplications -> ScheduledJobSettings(
                 enabled = false,
@@ -77,7 +84,8 @@ data class ScheduledJobSettings(val enabled: Boolean, val schedule: Schedule) {
             )
             ScheduledJob.InactivePeopleCleanup -> ScheduledJobSettings(
                 enabled = false,
-                schedule = JobSchedule.daily(LocalTime.of(3, 30))
+                schedule = JobSchedule.daily(LocalTime.of(3, 30)),
+                retryCount = 1
             )
             ScheduledJob.InactiveEmployeesRoleReset -> ScheduledJobSettings(
                 enabled = true,
@@ -88,8 +96,5 @@ data class ScheduledJobSettings(val enabled: Boolean, val schedule: Schedule) {
 }
 
 class DefaultJobSchedule(val env: ScheduledJobsEnv) : JobSchedule {
-    override fun getScheduleForJob(job: ScheduledJob): Schedule? = env.jobs[job]?.let {
-        val enabled = it.enabled
-        it.schedule.takeIf { enabled }
-    }
+    override fun getSettingsForJob(job: ScheduledJob): ScheduledJobSettings? = env.jobs[job]
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Make scheduled jobs' retry counts configurable to prevent long running non-critical failing jobs from eating up too many resources.

