### PR TITLE
Use PinInput on child sensitive information view

### DIFF
--- a/frontend/src/e2e-playwright/pages/mobile/child-page.ts
+++ b/frontend/src/e2e-playwright/pages/mobile/child-page.ts
@@ -3,12 +3,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { waitUntilEqual, waitUntilVisible } from 'e2e-playwright/utils'
-import {
-  Combobox,
-  RawElement,
-  RawTextInput
-} from 'e2e-playwright/utils/element'
+import { Combobox, RawElement } from 'e2e-playwright/utils/element'
 import { Child } from 'e2e-test-common/dev-api/types'
+import { range } from 'lodash'
 import { Page } from 'playwright'
 
 export default class MobileChildPage {
@@ -31,8 +28,8 @@ export default class MobileChildPage {
 
   #goBack = new RawElement(this.page, '[data-qa="go-back"]')
   #staffCombobox = new Combobox(this.page, '[data-qa="select-staff"]')
-  #pinInput = new RawTextInput(this.page, '[data-qa="set-pin"]')
-  #pinInfo = new RawElement(this.page, '[data-qa="set-pin-info"]')
+  #pinInput = this.page.locator('[data-qa="pin-input"]')
+  #pinInfo = new RawElement(this.page, '[data-qa="pin-input-info"]')
   #submitPin = new RawElement(this.page, '[data-qa="submit-pin"]')
   #sensitiveInfo = {
     name: new RawElement(this.page, '[data-qa="child-info-name"]'),
@@ -72,8 +69,9 @@ export default class MobileChildPage {
     await this.#sensitiveInfoLink.click()
     await this.#staffCombobox.fill(employeeName)
     await this.#staffCombobox.findItem(employeeName).click()
-    await this.#pinInput.click()
-    await this.#pinInput.type(employeePin)
+    for (const i of range(0, employeePin.length)) {
+      await this.#pinInput.locator('input').nth(i).type(employeePin[i])
+    }
     await this.#submitPin.click()
   }
 

--- a/frontend/src/e2e-test/pages/employee/mobile/mobile-groups.ts
+++ b/frontend/src/e2e-test/pages/employee/mobile/mobile-groups.ts
@@ -32,7 +32,6 @@ export default class MobileGroupsPage {
   readonly pinLoginStaffSelector = Selector('[data-qa="select-staff"]')
   readonly pinInput = Selector('[data-qa="set-pin"]')
   readonly submitPin = Selector('[data-qa="submit-pin"]')
-  readonly pinInputInfo = Selector('[data-qa="set-pin-info"]')
   readonly logoutButton = Selector('[data-qa="button-logout"]')
   readonly cancelLogoutButton = Selector('[data-qa="button-cancel-logout"]')
   readonly acceptLogoutButton = Selector('[data-qa="button-accept-logout"]')

--- a/frontend/src/employee-mobile-frontend/components/attendances/child-info/PinLogin.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/child-info/PinLogin.tsx
@@ -19,16 +19,16 @@ import {
 } from 'lib-components/layout/flex-helpers'
 import { ContentArea } from 'lib-components/layout/Container'
 import { Result } from 'lib-common/api'
-import Loader from 'lib-components/atoms/Loader'
-import InputField, { InputInfo } from 'lib-components/atoms/form/InputField'
+import { InputInfo } from 'lib-components/atoms/form/InputField'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
-import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import Title from 'lib-components/atoms/Title'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import Combobox from 'lib-components/atoms/form/Combobox'
 import { faArrowLeft, faArrowRight, faUserUnlock } from 'lib-icons'
 import { fontWeights } from 'lib-components/typography'
-import { ChildResult } from 'lib-common/generated/api-types/attendance'
+import { ChildResult, Staff } from 'lib-common/generated/api-types/attendance'
+import { EMPTY_PIN, PinInput } from 'lib-components/molecules/PinInput'
+import { renderResult } from '../../async-rendering'
 import { TallContentArea } from '../../mobile/components'
 import { getChildSensitiveInformation } from '../../../api/attendances'
 import { useTranslation } from '../../../state/i18n'
@@ -57,11 +57,16 @@ export default React.memo(function PinLogin() {
     name: string
     id: string
   }>()
-  const [selectedPin, setSelectedPin] = useState<string>('')
+  const [selectedPin, setSelectedPin] = useState(EMPTY_PIN)
   const [childResult, setChildResult] = useState<Result<ChildResult>>()
   const [loggingOut, setLoggingOut] = useState<boolean>(false)
 
   const pinInputRef = useRef<HTMLInputElement>(null)
+  useLayoutEffect(() => {
+    if (selectedStaff) {
+      pinInputRef?.current?.focus()
+    }
+  }, [selectedStaff])
 
   const { childId, groupId } = useParams<{
     groupId: string
@@ -73,102 +78,77 @@ export default React.memo(function PinLogin() {
       void getChildSensitiveInformation(
         childId,
         selectedStaff.id,
-        selectedPin
+        selectedPin.join('')
       ).then(setChildResult)
     }
   }
 
-  useLayoutEffect(() => {
-    if (selectedStaff && pinInputRef && pinInputRef.current) {
-      pinInputRef.current.focus()
-    }
-  }, [selectedStaff])
+  const formatName = ({ firstName, lastName }: Staff) =>
+    `${lastName} ${firstName}`
 
-  function formatName(firstName: string, lastName: string) {
-    return `${lastName} ${firstName}`
-  }
-
-  const staffOptions = useMemo(() => {
-    if (unitInfoResponse.isSuccess) {
-      return sortBy(
-        unitInfoResponse.value.staff.filter(({ pinSet }) => pinSet),
+  const staffOptions = useMemo(
+    () =>
+      sortBy(
+        unitInfoResponse
+          .map(({ staff }) => staff.filter(({ pinSet }) => pinSet))
+          .getOrElse([]),
         ({ groups }) => (groups.includes(groupId) ? 0 : 1),
         ({ lastName }) => lastName,
         ({ firstName }) => firstName
       ).map((staff) => ({
-        name: formatName(staff.firstName, staff.lastName),
+        name: formatName(staff),
         id: staff.id
+      })),
+    [groupId, unitInfoResponse]
+  )
+
+  const loggedInStaffName = (): string =>
+    unitInfoResponse
+      .map(({ staff }) => staff.find((s) => s.id === selectedStaff?.id))
+      .map((staff) => (staff ? formatName(staff) : ''))
+      .getOrElse('')
+
+  const getInputInfo = () =>
+    childResult
+      ?.map<InputInfo>((value) => ({
+        text: i18n.attendances.pin.status[value.status],
+        status: 'warning'
       }))
-    } else {
-      return []
-    }
-  }, [groupId, unitInfoResponse])
-
-  const childBasicInfo =
-    attendanceResponse.isSuccess &&
-    attendanceResponse.value.children.find((ac) => ac.id === childId)
-
-  const loggedInStaffName = (): string => {
-    const loggedInStaff = unitInfoResponse.isSuccess
-      ? unitInfoResponse.value.staff.find(
-          (staff) => staff.id === selectedStaff?.id
-        )
-      : null
-    return loggedInStaff
-      ? formatName(loggedInStaff.firstName, loggedInStaff.lastName)
-      : ''
-  }
-
-  const getInputInfo = (): InputInfo | undefined => {
-    return !childResult || !childResult.isSuccess
-      ? undefined
-      : {
-          text: i18n.attendances.pin.status[childResult.value.status],
-          status: 'warning'
-        }
-  }
+      .getOrElse(undefined)
 
   const logout = () => {
-    setSelectedPin('')
+    setSelectedPin(EMPTY_PIN)
     history.goBack()
   }
 
-  const cancelLogout = () => {
-    setLoggingOut(false)
-  }
+  const cancelLogout = () => setLoggingOut(false)
 
   useInactivityTimeout(120 * 1000, logout)
 
-  return (
-    <>
-      {attendanceResponse.isLoading && <Loader />}
-      {attendanceResponse.isFailure && <ErrorSegment />}
-      {attendanceResponse.isSuccess && (
+  return renderResult(attendanceResponse, (attendance) => {
+    const child = attendance.children.find((ac) => ac.id === childId)
+    const childName = child ? `${child.firstName} ${child.lastName}` : null
+    return (
+      <>
         <TallContentAreaNoOverflow
           opaque={false}
-          paddingHorizontal={'zero'}
-          paddingVertical={'zero'}
+          paddingHorizontal="zero"
+          paddingVertical="zero"
         >
           <TopBarContainer>
             <TopRow>
               <BackButtonInline
                 onClick={() => history.goBack()}
                 icon={faArrowLeft}
-                text={
-                  childBasicInfo
-                    ? `${childBasicInfo.firstName} ${childBasicInfo.lastName}`
-                    : i18n.common.back
-                }
+                text={childName ?? i18n.common.back}
                 data-qa="go-back"
               />
               {childResult && (
                 <IconButton
-                  size={'L'}
+                  size="L"
                   icon={faUserUnlock}
-                  data-qa={'button-logout'}
-                  onClick={() => {
-                    setLoggingOut(true)
-                  }}
+                  data-qa="button-logout"
+                  onClick={() => setLoggingOut(true)}
                 />
               )}
             </TopRow>
@@ -189,18 +169,18 @@ export default React.memo(function PinLogin() {
           ) : (
             <ContentArea
               shadow
-              opaque={true}
-              paddingHorizontal={'s'}
-              paddingVertical={'m'}
+              opaque
+              paddingHorizontal="s"
+              paddingVertical="m"
             >
-              <FixedSpaceColumn alignItems={'center'} spacing={'m'}>
+              <FixedSpaceColumn alignItems="center" spacing="m">
                 <Title>{i18n.attendances.pin.header}</Title>
                 <span>{i18n.attendances.pin.info}</span>
               </FixedSpaceColumn>
               <Gap />
-              <FixedSpaceColumn spacing={'m'}>
+              <FixedSpaceColumn spacing="m">
                 <Key>{i18n.attendances.pin.staff}</Key>
-                <div data-qa={'select-staff'}>
+                <div data-qa="select-staff">
                   <Combobox
                     items={staffOptions}
                     selectedItem={selectedStaff ?? null}
@@ -213,22 +193,18 @@ export default React.memo(function PinLogin() {
                 {selectedStaff && (
                   <>
                     <Key>{i18n.attendances.pin.pinCode}</Key>
-                    <FixedSpaceRow spacing={'m'} alignItems={'center'}>
-                      <InputField
-                        placeholder={i18n.attendances.pin.pinCode}
-                        onChange={setSelectedPin}
-                        value={selectedPin || ''}
+                    <FixedSpaceRow spacing="m" alignItems="center">
+                      <PinInput
+                        onPinChange={setSelectedPin}
+                        pin={selectedPin}
                         info={getInputInfo()}
-                        width="s"
-                        type="password"
                         inputRef={pinInputRef}
-                        data-qa="set-pin"
                       />
-                      {selectedPin && selectedPin.length >= 4 && (
+                      {selectedPin.join('').length === 4 && (
                         <IconButton
                           icon={faArrowRight}
                           onClick={loadChildSensitiveInfo}
-                          data-qa={'submit-pin'}
+                          data-qa="submit-pin"
                         />
                       )}
                     </FixedSpaceRow>
@@ -238,9 +214,9 @@ export default React.memo(function PinLogin() {
             </ContentArea>
           )}
         </TallContentAreaNoOverflow>
-      )}
-    </>
-  )
+      </>
+    )
+  })
 })
 
 const TopBarContainer = styled.div`

--- a/frontend/src/lib-components/molecules/PinInput.tsx
+++ b/frontend/src/lib-components/molecules/PinInput.tsx
@@ -2,10 +2,16 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import classNames from 'classnames'
 import { range } from 'lodash'
-import React, { useMemo, useRef } from 'react'
+import React, { RefObject, useMemo, useRef } from 'react'
 import styled from 'styled-components'
-import { StyledInput } from '../atoms/form/InputField'
+import {
+  InputFieldUnderRow,
+  InputInfo,
+  StyledInput
+} from '../atoms/form/InputField'
+import UnderRowStatusIcon from '../atoms/StatusIcon'
 import { fontWeights } from '../typography'
 import { defaultMargins } from '../white-space'
 
@@ -21,9 +27,16 @@ const SingleNumberInput = styled(StyledInput)<{ invalid?: boolean }>`
   color: ${(p) => p.theme.colors.main.dark};
 `
 
+const Centered = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`
+
 const PinContainer = styled.div`
   display: flex;
   justify-content: center;
+  align-items: center;
 
   ${SingleNumberInput} + ${SingleNumberInput} {
     margin-left: ${defaultMargins.s};
@@ -39,14 +52,25 @@ interface Props {
   pin: string[]
   onPinChange: (code: string[]) => void
   invalid?: boolean
+  info?: InputInfo | undefined
+  inputRef?: RefObject<HTMLInputElement>
 }
 
-export function PinInput({ pin, onPinChange, invalid = false }: Props) {
+export function PinInput({
+  pin,
+  onPinChange,
+  info,
+  inputRef,
+  invalid = false
+}: Props) {
   const input1 = useRef<HTMLInputElement>(null)
   const input2 = useRef<HTMLInputElement>(null)
   const input3 = useRef<HTMLInputElement>(null)
   const input4 = useRef<HTMLInputElement>(null)
-  const refs = useMemo(() => [input1, input2, input3, input4], [])
+  const refs = useMemo(
+    () => [inputRef ?? input1, input2, input3, input4],
+    [inputRef]
+  )
 
   if (pin.length !== 4) throw new Error('Invalid PIN length')
 
@@ -71,23 +95,31 @@ export function PinInput({ pin, onPinChange, invalid = false }: Props) {
   }
 
   return (
-    <PinContainer data-qa="pin-input">
-      {range(0, 4).map((i) => (
-        <SingleNumberInput
-          key={i}
-          type="password"
-          width="xs"
-          inputMode="numeric"
-          maxLength={1}
-          invalid={invalid}
-          clearable={false}
-          autoFocus={i === 0}
-          value={pin[i]}
-          ref={refs[i]}
-          onChange={(e) => onChange(i, e.target.value)}
-          onKeyUp={(e) => moveFocusLeftOnBackspace(i, e.key)}
-        />
-      ))}
-    </PinContainer>
+    <Centered>
+      <PinContainer data-qa="pin-input">
+        {range(0, 4).map((i) => (
+          <SingleNumberInput
+            key={i}
+            type="password"
+            width="xs"
+            inputMode="numeric"
+            maxLength={1}
+            invalid={invalid}
+            clearable={false}
+            autoFocus={i === 0}
+            value={pin[i]}
+            ref={refs[i]}
+            onChange={(e) => onChange(i, e.target.value)}
+            onKeyUp={(e) => moveFocusLeftOnBackspace(i, e.key)}
+          />
+        ))}
+      </PinContainer>
+      {info && (
+        <InputFieldUnderRow className={classNames(info.status)}>
+          <span data-qa="pin-input-info">{info.text}</span>
+          <UnderRowStatusIcon status={info?.status} />
+        </InputFieldUnderRow>
+      )}
+    </Centered>
   )
 }


### PR DESCRIPTION

#### Summary

- Support passing pin input ref as a prop to PinInput
- Support InfoText in PinInput
- Refactor "PinLogin" page
  - the page is quite a mess and does a lot more than just a pin login

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

