### PR TITLE
EVAKA-HOTFIX employee mobile backwards compatible reservations

### DIFF
--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -78,6 +78,7 @@ export interface Child {
   lastName: string
   placementType: PlacementType
   preferredName: string | null
+  reservation: AttendanceReservation | null
   reservations: AttendanceReservation[]
   status: AttendanceStatus
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
@@ -69,7 +69,10 @@ data class Child(
     val dailyNote: DaycareDailyNote?,
     val imageUrl: String?,
     val reservations: List<AttendanceReservation>
-)
+) {
+    // Added for backwards compatibility. Remove when employee mobile clients are guaranteed to be recent enough.
+    val reservation = reservations.firstOrNull()
+}
 
 enum class AttendanceStatus {
     COMING, PRESENT, DEPARTED, ABSENT


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add old `reservation` property back to child attendance payloads to prevent employee-mobile blowing up (it breaks because there is a `reservation !== null` check, which fails for `undefined` values).
