### PR TITLE
Increase frontend core build resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -946,6 +946,7 @@ jobs:
 
   frontend_build_core:
     executor: frontend_executor
+    resource_class: medium+
     steps:
       - prepare_frontend_build
       - build_frontend


### PR DESCRIPTION
#### Summary

Use resource_class medium+ instead medium for frontend core build.
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

