### PR TITLE
Fix useRestApi mounting bug

### DIFF
--- a/frontend/src/lib-common/utils/useRestApi.ts
+++ b/frontend/src/lib-common/utils/useRestApi.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   ApiFunction,
   ApiResultOf,
@@ -18,6 +18,13 @@ export function useRestApi<F extends ApiFunction>(
 ): (...args: Parameters<F>) => void {
   const [api] = useState(() => withStaleCancellation(f))
   const mountedRef = useRef(true)
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false
+    },
+    []
+  )
 
   return useCallback(
     (...args: Parameters<F>) => {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Sometimes a component is unmounted before a rest api call completes. This results in a callback on an unmounted component. Fix this.
