### PR TITLE
EVAKA-FIX citizen opens message attachments in browser

### DIFF
--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -74,6 +74,7 @@ export default React.memo(function ThreadListItem({
                 onFileUnavailable={onAttachmentUnavailable}
                 icon
                 data-qa="thread-list-attachment"
+                openInBrowser={true}
               />
             ))}
           </FixedSpaceColumn>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Open attachment in browser instead of download
