### PR TITLE
Add evaka_user table and change most someaction_by columns to point to it

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.config.defaultObjectMapper
 import fi.espoo.evaka.shared.config.getTestDataSource
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.varda.integration.VardaClient
 import fi.espoo.evaka.varda.integration.VardaTempTokenProvider
 import fi.espoo.evaka.varda.integration.VardaTokenProvider

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/PureJdbiTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/PureJdbiTest.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka
 import fi.espoo.evaka.shared.config.getTestDataSource
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
+import fi.espoo.evaka.shared.dev.resetDatabase
 import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -30,6 +30,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevCareArea
@@ -49,6 +50,7 @@ import fi.espoo.evaka.shared.dev.insertTestVoucherValue
 import fi.espoo.evaka.shared.dev.updateDaycareAcl
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.security.PilotFeature
+import fi.espoo.evaka.shared.security.upsertCitizenUser
 import org.jdbi.v3.core.kotlin.bindKotlin
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -523,6 +525,7 @@ fun Database.Transaction.insertGeneralTestFixtures() {
                 restrictedDetailsEnabled = it.restrictedDetailsEnabled
             )
         )
+        upsertCitizenUser(PersonId(it.id))
     }
 
     allChildren.forEach {
@@ -583,8 +586,6 @@ fun Database.Transaction.insertGeneralTestFixtures() {
     insertAssistanceActionOptions()
     insertAssistanceBasisOptions()
 }
-
-fun Database.Transaction.resetDatabase() = execute("SELECT reset_database()")
 
 fun Database.Transaction.insertPreschoolTerms() {
     //language=SQL

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
@@ -15,7 +15,6 @@ import fi.espoo.evaka.emailclient.MockEmailClient
 import fi.espoo.evaka.insertApplication
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -25,6 +24,7 @@ import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.dev.insertTestClubApplicationForm
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.test.validClubApplication
 import fi.espoo.evaka.test.validDaycareApplication
 import fi.espoo.evaka.testAdult_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -31,7 +31,6 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getPlacementPlan
 import fi.espoo.evaka.placement.getPlacementsForChild
 import fi.espoo.evaka.preschoolTerm2020
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.FeatureFlags
@@ -44,6 +43,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.Forbidden

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
@@ -9,12 +9,12 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.attachment.AttachmentType
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.test.getValidDaycareApplication
 import fi.espoo.evaka.testAdult_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/DuplicateApplicationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/DuplicateApplicationIntegrationTest.kt
@@ -7,9 +7,9 @@ package fi.espoo.evaka.application
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.test.validDaycareApplication
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.application.utils.currentDateInFinland
 import fi.espoo.evaka.attachment.AttachmentType
 import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -23,6 +22,7 @@ import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.dev.updateDaycareAcl
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.job.ScheduledJobs

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
@@ -10,13 +10,13 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.test.validDaycareApplication
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.emailclient.MockEmail
 import fi.espoo.evaka.emailclient.MockEmailClient
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -19,6 +18,7 @@ import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.dev.insertTestDecision
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.job.ScheduledJobs
 import fi.espoo.evaka.test.validDaycareApplication
 import fi.espoo.evaka.testAdult_6

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
@@ -8,13 +8,13 @@ import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AssistanceActionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevAssistanceAction
 import fi.espoo.evaka.shared.dev.insertTestAssistanceAction
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
 import fi.espoo.evaka.testDecisionMaker_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedIntegrationTest.kt
@@ -8,13 +8,13 @@ import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevAssistanceNeed
 import fi.espoo.evaka.shared.dev.insertTestAssistanceNeed
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
 import fi.espoo.evaka.testDecisionMaker_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsControllerIntegrationTest.kt
@@ -13,11 +13,11 @@ import fi.espoo.evaka.incomestatement.IncomeStatementBody
 import fi.espoo.evaka.incomestatement.createIncomeStatement
 import fi.espoo.evaka.insertApplication
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.IncomeStatementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_5
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.daycare.service.AbsenceCareType
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -23,6 +22,7 @@ import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
@@ -6,8 +6,8 @@ package fi.espoo.evaka.attendance
 
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.dev.insertTestChildAttendance
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.job.ScheduledJobs
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.daycare.service.AbsenceCareType
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -26,6 +25,7 @@ import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceQueriesTest.kt
@@ -7,11 +7,11 @@ package fi.espoo.evaka.attendance
 import fi.espoo.evaka.FixtureBuilder
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/backupcare/BackupCareIntegrationTest.kt
@@ -10,7 +10,6 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.BackupCareId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
@@ -22,6 +21,7 @@ import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.snDefaultDaycare
 import fi.espoo.evaka.test.getBackupCareRowById

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/childimages/ChildImageTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/childimages/ChildImageTest.kt
@@ -8,11 +8,11 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.s3.DocumentWrapper
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDecisionMaker_1
 import org.jdbi.v3.core.kotlin.mapTo

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/AbstractIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/AbstractIntegrationTest.kt
@@ -4,9 +4,9 @@
 
 package fi.espoo.evaka.daycare
 
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.config.SharedIntegrationTestConfig
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.dev.resetDatabase
 import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.daycare.controllers.DaycareController
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -20,6 +19,7 @@ import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.insertTestCareArea
 import fi.espoo.evaka.shared.dev.insertTestDaycare
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.testAreaCode

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.daycare.controllers
 import com.github.kittinunf.fuel.core.isSuccessful
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -21,6 +20,7 @@ import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.insertTestCareArea
 import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestEmployee
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAreaCode
 import fi.espoo.evaka.testAreaId
 import fi.espoo.evaka.testDaycare

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/PlacementQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/dao/PlacementQueriesIntegrationTest.kt
@@ -7,8 +7,8 @@ package fi.espoo.evaka.daycare.dao
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getDaycarePlacements
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.dev.resetDatabase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.daycare.service
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.dev.DevBackupCare
 import fi.espoo.evaka.shared.dev.DevChild
@@ -22,6 +21,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.AfterEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/CaretakerServiceIntegrationTest.kt
@@ -6,10 +6,10 @@ package fi.espoo.evaka.daycare.service
 
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/StaffAttendanceServiceIntegrationTest.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka.daycare.service
 
 import fi.espoo.evaka.daycare.AbstractIntegrationTest
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
@@ -15,6 +14,7 @@ import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestCareArea
 import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.jdbi.v3.core.kotlin.mapTo

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -21,7 +21,6 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -30,6 +29,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.test.DecisionTableRow
 import fi.espoo.evaka.test.getApplicationStatus

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
@@ -17,7 +17,6 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -28,6 +27,7 @@ import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.dev.insertTestDecision
 import fi.espoo.evaka.shared.dev.insertTestPlacementPlan
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.test.getApplicationStatus
 import fi.espoo.evaka.test.getDecisionRowById

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/DvvModificationsServiceIntegrationTest.kt
@@ -8,9 +8,9 @@ import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.pis.getPersonBySSN
 import fi.espoo.evaka.pis.service.getChildGuardians
 import fi.espoo.evaka.pis.service.getGuardianChildIds
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.vtjclient.dto.NativeLanguage
 import fi.espoo.evaka.vtjclient.dto.RestrictedDetails
 import fi.espoo.evaka.vtjclient.dto.VtjPerson

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizenIntegrationTest.kt
@@ -9,7 +9,6 @@ import com.github.kittinunf.fuel.jackson.objectBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AttachmentId
 import fi.espoo.evaka.shared.IncomeStatementId
 import fi.espoo.evaka.shared.Paged
@@ -18,6 +17,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.insertTestEmployee
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import org.junit.jupiter.api.BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerIntegrationTest.kt
@@ -10,7 +10,6 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AttachmentId
 import fi.espoo.evaka.shared.IncomeStatementId
 import fi.espoo.evaka.shared.Paged
@@ -22,6 +21,7 @@ import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeAlterationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeAlterationIntegrationTest.kt
@@ -11,10 +11,10 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.controller.Wrapper
 import fi.espoo.evaka.invoicing.data.upsertFeeAlteration
 import fi.espoo.evaka.invoicing.domain.FeeAlteration
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDecisionMaker_1
 import org.junit.jupiter.api.AfterEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -20,7 +20,6 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionSummary
 import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.async.AsyncJob
@@ -28,6 +27,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.snDaycareFullDay35
 import fi.espoo.evaka.testAdult_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/IncomeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/IncomeIntegrationTest.kt
@@ -18,14 +18,13 @@ import fi.espoo.evaka.invoicing.domain.IncomeCoefficient
 import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.invoicing.service.IncomeTypesProvider
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testDecisionMaker_1
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -55,14 +54,8 @@ class IncomeIntegrationTest : FullApplicationTest() {
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            tx.insertGeneralTestFixtures()
-        }
-    }
-
-    @AfterEach
-    fun afterEach() {
-        db.transaction { tx ->
             tx.resetDatabase()
+            tx.insertGeneralTestFixtures()
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -30,7 +30,6 @@ import fi.espoo.evaka.invoicing.integration.fallbackPostOffice
 import fi.espoo.evaka.invoicing.integration.fallbackPostalCode
 import fi.espoo.evaka.invoicing.integration.fallbackStreetAddress
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -38,6 +37,7 @@ import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.snDaycareFullDay35
 import fi.espoo.evaka.testAdult_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -20,7 +20,6 @@ import fi.espoo.evaka.placement.Placement
 import fi.espoo.evaka.placement.PlacementCreateRequestBody
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.PlacementUpdateRequestBody
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.PlacementId
@@ -31,6 +30,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPartnership
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeAlterationQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeAlterationQueriesTest.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.invoicing.data
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.FeeAlteration
-import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDecisionMaker_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
@@ -13,9 +13,9 @@ import fi.espoo.evaka.invoicing.createFeeDecisionFixture
 import fi.espoo.evaka.invoicing.domain.FeeDecisionStatus
 import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.config.defaultObjectMapper
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.snDaycareFullDay35
 import fi.espoo.evaka.testAdult_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueriesTest.kt
@@ -11,9 +11,9 @@ import fi.espoo.evaka.invoicing.domain.IncomeCoefficient
 import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.invoicing.service.EspooIncomeTypesProvider
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.config.defaultObjectMapper
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.testAdult_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueriesTest.kt
@@ -10,7 +10,7 @@ import fi.espoo.evaka.invoicing.createInvoiceFixture
 import fi.espoo.evaka.invoicing.createInvoiceRowFixture
 import fi.espoo.evaka.invoicing.domain.InvoiceStatus
 import fi.espoo.evaka.invoicing.service.getInvoicedHeadsOfFamily
-import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -30,7 +30,6 @@ import fi.espoo.evaka.placement.PlacementType.PREPARATORY
 import fi.espoo.evaka.placement.PlacementType.PREPARATORY_DAYCARE
 import fi.espoo.evaka.placement.PlacementType.PRESCHOOL
 import fi.espoo.evaka.placement.PlacementType.PRESCHOOL_DAYCARE
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.PlacementId
@@ -43,6 +42,7 @@ import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.snDaycareFullDay25to35

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
@@ -15,11 +15,11 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.invoicing.domain.merge
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.PlacementType.DAYCARE
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -25,7 +25,6 @@ import fi.espoo.evaka.invoicing.domain.Invoice
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.Product
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -33,6 +32,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.snDaycareFullDay35
 import fi.espoo.evaka.testAdult_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
@@ -20,6 +19,7 @@ import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.snDaycareFiveYearOldsFullDayPartWeek25

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -15,7 +15,6 @@ import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.preschoolTerm2019
 import fi.espoo.evaka.preschoolTerm2020
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.db.Database
@@ -28,6 +27,7 @@ import fi.espoo.evaka.shared.dev.insertTestAssistanceAction
 import fi.espoo.evaka.shared.dev.insertTestAssistanceNeed
 import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.toFiniteDateRange
 import fi.espoo.evaka.testAreaId

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiPayloadIntegrationTest.kt
@@ -10,9 +10,9 @@ import fi.espoo.evaka.defaultMunicipalOrganizerOid
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.preschoolTerm2019
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
 import fi.espoo.evaka.testDaycare

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/DraftQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/DraftQueriesTest.kt
@@ -5,11 +5,11 @@
 package fi.espoo.evaka.messaging
 
 import fi.espoo.evaka.PureJdbiTest
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.MessageAccountId
 import fi.espoo.evaka.shared.MessageDraftId
 import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.insertTestEmployee
+import fi.espoo.evaka.shared.dev.resetDatabase
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka.messaging
 
 import fi.espoo.evaka.PureJdbiTest
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
@@ -20,6 +19,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.security.PilotFeature
 import org.jdbi.v3.core.kotlin.mapTo
 import org.junit.jupiter.api.AfterEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -10,7 +10,6 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.pis.service.insertGuardian
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AttachmentId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.MessageAccountId
@@ -38,6 +37,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testAdult_3

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.emailclient.MockEmail
 import fi.espoo.evaka.emailclient.MockEmailClient
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.service.insertGuardian
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.MessageAccountId
 import fi.espoo.evaka.shared.async.AsyncJob
@@ -29,6 +28,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.MessageAccountId
@@ -32,6 +31,7 @@ import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.testAreaCode

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageReceiversIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageReceiversIntegrationTest.kt
@@ -11,7 +11,6 @@ import fi.espoo.evaka.emailclient.MockEmailClient
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.createParentship
 import fi.espoo.evaka.pis.service.insertGuardian
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.MessageAccountId
@@ -28,6 +27,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testAdult_3
 import fi.espoo.evaka.testAdult_4

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyTest.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.daycare.CareType
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.insertServiceNeedOptions
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
@@ -26,6 +25,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestStaffAttendance
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.snDefaultPartDayDaycare
 import org.junit.jupiter.api.BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancyTest.kt
@@ -12,13 +12,13 @@ import fi.espoo.evaka.attendance.ExternalStaffDeparture
 import fi.espoo.evaka.attendance.markExternalStaffArrival
 import fi.espoo.evaka.attendance.markExternalStaffDeparture
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -8,13 +8,13 @@ import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.PairingId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.dev.updateDaycareAclWithEmployee
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.testDaycare

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentIntegrationTest.kt
@@ -11,7 +11,6 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.service.insertGuardian
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AttachmentId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.GroupId
@@ -26,6 +25,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.dev.updateDaycareAclWithEmployee
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationServiceIntegrationTest.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.messaging.upsertEmployeeMessageAccount
 import fi.espoo.evaka.pis.createParentship
 import fi.espoo.evaka.pis.service.insertGuardian
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -31,6 +30,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/AbstractIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/AbstractIntegrationTest.kt
@@ -4,9 +4,9 @@
 
 package fi.espoo.evaka.pis
 
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.config.SharedIntegrationTestConfig
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.vtjclient.VtjIntegrationTestConfig
 import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.AfterAll

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka.pis
 
 import fi.espoo.evaka.PureJdbiTest
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
 import fi.espoo.evaka.shared.dev.DevCareArea
@@ -14,6 +13,7 @@ import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.insertTestCareArea
 import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestEmployee
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.pis
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.pis.service.insertGuardian
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevChild
@@ -20,6 +19,7 @@ import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testAreaId

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/PersonIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/PersonIntegrationTest.kt
@@ -86,7 +86,7 @@ class PersonIntegrationTest : PureJdbiTest() {
     @Test
     fun `getTransferablePersonReferences returns references to person and child tables`() {
         val references = db.read { it.getTransferablePersonReferences() }
-        assertEquals(41, references.size)
+        assertEquals(42, references.size)
         assertEquals(
             listOf(
                 PersonReference("absence", "child_id"),
@@ -106,6 +106,7 @@ class PersonIntegrationTest : PureJdbiTest() {
                 PersonReference("child_images", "child_id"),
                 PersonReference("child_sticky_note", "child_id"),
                 PersonReference("daily_service_time", "child_id"),
+                PersonReference("evaka_user", "citizen_id"),
                 PersonReference("family_contact", "child_id"),
                 PersonReference("family_contact", "contact_person_id"),
                 PersonReference("fee_alteration", "person_id"),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/PersonIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/PersonIntegrationTest.kt
@@ -86,19 +86,16 @@ class PersonIntegrationTest : PureJdbiTest() {
     @Test
     fun `getTransferablePersonReferences returns references to person and child tables`() {
         val references = db.read { it.getTransferablePersonReferences() }
-        assertEquals(42, references.size)
+        assertEquals(39, references.size)
         assertEquals(
             listOf(
                 PersonReference("absence", "child_id"),
-                PersonReference("absence", "modified_by_guardian_id"),
                 PersonReference("application", "child_id"),
                 PersonReference("application", "guardian_id"),
                 PersonReference("application", "other_guardian_id"),
                 PersonReference("assistance_action", "child_id"),
                 PersonReference("assistance_need", "child_id"),
-                PersonReference("attachment", "uploaded_by_person"),
                 PersonReference("attendance_reservation", "child_id"),
-                PersonReference("attendance_reservation", "created_by_guardian_id"),
                 PersonReference("backup_care", "child_id"),
                 PersonReference("backup_pickup", "child_id"),
                 PersonReference("child_attendance", "child_id"),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemControllerTest.kt
@@ -8,7 +8,6 @@ import com.github.kittinunf.fuel.core.isSuccessful
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.pairing.MobileDeviceIdentity
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.MobileDeviceId
@@ -23,6 +22,7 @@ import fi.espoo.evaka.shared.dev.insertTestCareArea
 import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestMobileDevice
+import fi.espoo.evaka.shared.dev.resetDatabase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.UUID

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.pis.AbstractIntegrationTest
 import fi.espoo.evaka.pis.Employee
 import fi.espoo.evaka.pis.NewEmployee
 import fi.espoo.evaka.pis.controllers.EmployeeController
+import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import org.junit.jupiter.api.Test
@@ -93,7 +94,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
         externalId = ExternalId.of(namespace = "espoo-ad", value = UUID.randomUUID().toString()),
         created = Instant.now(),
         updated = Instant.now(),
-        id = UUID.randomUUID()
+        id = EmployeeId(UUID.randomUUID())
     )
 
     val employee2 = Employee(
@@ -103,6 +104,6 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
         externalId = ExternalId.of(namespace = "espoo-ad", value = UUID.randomUUID().toString()),
         created = Instant.now(),
         updated = Instant.now(),
-        id = UUID.randomUUID()
+        id = EmployeeId(UUID.randomUUID())
     )
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.pis.createParentship
 import fi.espoo.evaka.pis.createPartnership
 import fi.espoo.evaka.pis.service.FamilyOverview
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -22,6 +21,7 @@ import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestIncome
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.dev.updateDaycareAcl
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PersonQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PersonQueriesIntegrationTest.kt
@@ -15,10 +15,10 @@ import fi.espoo.evaka.pis.service.ContactInfo
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.updatePersonContactInfo
 import fi.espoo.evaka.pis.updatePersonFromVtj
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.dev.resetDatabase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/GuardianQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/GuardianQueriesIntegrationTest.kt
@@ -6,8 +6,8 @@ package fi.espoo.evaka.pis.service
 
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -19,7 +19,6 @@ import fi.espoo.evaka.messaging.createPersonMessageAccount
 import fi.espoo.evaka.messaging.getMessagesReceivedByAccount
 import fi.espoo.evaka.messaging.getMessagesSentByAccount
 import fi.espoo.evaka.messaging.upsertEmployeeMessageAccount
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.MessageAccountId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -34,6 +33,7 @@ import fi.espoo.evaka.shared.dev.insertTestIncome
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.testDaycare

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -12,10 +12,10 @@ import com.nhaarman.mockitokotlin2.whenever
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/FiveYearOldDaycarePlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/FiveYearOldDaycarePlacementsIntegrationTest.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.placement
 
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
@@ -9,7 +9,6 @@ import com.github.kittinunf.fuel.jackson.objectBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PlacementId
@@ -19,6 +18,7 @@ import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.dev.updateDaycareAclWithEmployee
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
@@ -17,13 +17,13 @@ import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
 import fi.espoo.evaka.invoicing.domain.UnitData
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.test.getApplicationStatus
 import fi.espoo.evaka.test.getPlacementPlanRowByApplication

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.placement
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PlacementId
@@ -16,6 +15,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.snDefaultDaycare

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReportTest.kt
@@ -6,12 +6,12 @@ package fi.espoo.evaka.reports
 
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.dev.resetDatabase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
@@ -11,10 +11,10 @@ import fi.espoo.evaka.invoicing.createInvoiceFixture
 import fi.espoo.evaka.invoicing.createInvoiceRowFixture
 import fi.espoo.evaka.invoicing.data.upsertInvoices
 import fi.espoo.evaka.invoicing.domain.InvoiceStatus
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testArea2Code

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
@@ -7,10 +7,10 @@ package fi.espoo.evaka.reports
 import com.github.kittinunf.fuel.core.Request
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAreaId
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.AfterAll

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
@@ -15,7 +15,6 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionServiceNeed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJob
@@ -23,6 +22,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.snDefaultDaycare
 import fi.espoo.evaka.testAdult_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -17,13 +17,13 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.reports.VoucherReportRowType.CORRECTION
 import fi.espoo.evaka.reports.VoucherReportRowType.ORIGINAL
 import fi.espoo.evaka.reports.VoucherReportRowType.REFUND
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.utils.europeHelsinki
 import fi.espoo.evaka.snDefaultDaycare
 import fi.espoo.evaka.testAdult_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
@@ -8,11 +8,11 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.domain.PersonData
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.AfterEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
@@ -9,10 +9,10 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.service.insertGuardian
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenQueriesTest.kt
@@ -9,10 +9,10 @@ import fi.espoo.evaka.daycare.service.AbsenceCareType
 import fi.espoo.evaka.daycare.service.getAbsencesByChildByRange
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.service.insertGuardian
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.dev.insertTestAbsence
 import fi.espoo.evaka.shared.dev.insertTestHoliday
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedIntegrationTest.kt
@@ -9,7 +9,6 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.placement.DaycarePlacementWithDetails
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
@@ -18,6 +17,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.snDaycareFullDay25to35
 import fi.espoo.evaka.snDaycareFullDay35

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/setting/SettingQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/setting/SettingQueriesTest.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.setting
 
 import fi.espoo.evaka.PureJdbiTest
-import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.dev.resetDatabase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DatabaseTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DatabaseTest.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.shared.db
 
 import fi.espoo.evaka.PureJdbiTest
-import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.dev.resetDatabase
 import org.jdbi.v3.core.kotlin.mapTo
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException
 import org.junit.jupiter.api.BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/domain/TimeIntegrationTest.kt
@@ -6,10 +6,10 @@ package fi.espoo.evaka.shared.domain
 
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.insertTestDaycare
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAreaId
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDaycare2

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
@@ -6,10 +6,10 @@ package fi.espoo.evaka.shared.job
 
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.application.utils.helsinkiZone
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.config.getTestDataSource
+import fi.espoo.evaka.shared.dev.resetDatabase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Duration

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -22,7 +22,6 @@ import fi.espoo.evaka.note.child.sticky.createChildStickyNote
 import fi.espoo.evaka.note.child.sticky.getChildStickyNotesForChild
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.insertPlacement
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -33,6 +32,7 @@ import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.dev.insertTestBackupCare
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.test.validDaycareApplication
 import fi.espoo.evaka.testAdult_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaOrganizerChildrenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaOrganizerChildrenIntegrationTest.kt
@@ -7,8 +7,8 @@ package fi.espoo.evaka.varda
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.defaultMunicipalOrganizerOid
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.varda.integration.MockVardaIntegrationEndpoint
 import org.jdbi.v3.core.kotlin.mapTo

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaOrganizerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaOrganizerIntegrationTest.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.varda
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.service.PersonService
-import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.varda.integration.MockVardaIntegrationEndpoint
 import org.jdbi.v3.core.kotlin.mapTo
 import org.junit.jupiter.api.BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
@@ -7,13 +7,13 @@ package fi.espoo.evaka.varda
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.insertTestVardaOrganizer
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.insertTestCareArea
 import fi.espoo.evaka.shared.dev.insertTestDaycare
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAreaCode
 import fi.espoo.evaka.testAreaId
 import fi.espoo.evaka.testDaycare

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUpdateServiceIntegrationTest.kt
@@ -21,7 +21,6 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionServiceNeed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
 import fi.espoo.evaka.serviceneed.deleteServiceNeed
 import fi.espoo.evaka.shared.ChildId
@@ -33,6 +32,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertVardaServiceNeed
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.snDefaultClub

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuIntegrationTest.kt
@@ -8,12 +8,12 @@ import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.VasuDocumentId
 import fi.espoo.evaka.shared.VasuTemplateId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDecisionMaker_1

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuTemplateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuTemplateIntegrationTest.kt
@@ -8,11 +8,11 @@ import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.resetDatabase
 import fi.espoo.evaka.shared.VasuTemplateId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuTemplateQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuTemplateQueriesTest.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.vasu
 
 import fi.espoo.evaka.PureJdbiTest
-import fi.espoo.evaka.resetDatabase
+import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/VtjClientServiceTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vtjclient/VtjClientServiceTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.identity.ExternalIdentifier.SSN
 import fi.espoo.evaka.lookup
 import fi.espoo.evaka.pis.AbstractIntegrationTest
 import fi.espoo.evaka.pis.Employee
+import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.vtjclient.dto.NativeLanguage
 import fi.espoo.evaka.vtjclient.dto.PersonAddress
 import fi.espoo.evaka.vtjclient.dto.RestrictedDetails
@@ -83,7 +84,7 @@ class VtjClientServiceTest : AbstractIntegrationTest() {
             ?.andExpect(vtjRequestType(PERUSSANOMA3))
             ?.andRespond(withSoapEnvelope(perussanoma3Response))
 
-        val query = VTJQuery(requestingUserId = requestingUser.id, type = PERUSSANOMA3, ssn = "020501A999T")
+        val query = VTJQuery(requestingUserId = requestingUser.id.raw, type = PERUSSANOMA3, ssn = "020501A999T")
         val response = vtjClientService.query(query)
 
         val result = mapper.mapToVtjPerson(response!!)
@@ -110,7 +111,7 @@ class VtjClientServiceTest : AbstractIntegrationTest() {
             ?.andExpect(vtjRequestType(HUOLTAJA_HUOLLETTAVA))
             ?.andRespond(withSoapEnvelope(huoltajaHuollettavatResponse))
 
-        val query = VTJQuery(requestingUserId = requestingUser.id, type = HUOLTAJA_HUOLLETTAVA, ssn = "020190-9521")
+        val query = VTJQuery(requestingUserId = requestingUser.id.raw, type = HUOLTAJA_HUOLLETTAVA, ssn = "020190-9521")
         val response = vtjClientService.query(query)
 
         val result = mapper.mapToVtjPerson(response!!)
@@ -129,7 +130,7 @@ class VtjClientServiceTest : AbstractIntegrationTest() {
         mockServer?.expect(validPayload(schemaResource))
             ?.andExpect(vtjRequestType(HUOLLETTAVA_HUOLTAJAT))
             ?.andRespond(withSoapEnvelope(huollettavaHuoltajaResponse))
-        val query = VTJQuery(requestingUserId = requestingUser.id, type = HUOLLETTAVA_HUOLTAJAT, ssn = "311211A9527")
+        val query = VTJQuery(requestingUserId = requestingUser.id.raw, type = HUOLLETTAVA_HUOLTAJAT, ssn = "311211A9527")
         val response = vtjClientService.query(query)
 
         val result = mapper.mapToVtjPerson(response!!)
@@ -152,7 +153,7 @@ class VtjClientServiceTest : AbstractIntegrationTest() {
         val expectedSSN = "020501A999T"
         val expectedUnderageSSNs = listOf("090702A9996")
 
-        val query = VTJQuery(requestingUserId = requestingUser.id, type = ASUKASMAARA, ssn = expectedSSN)
+        val query = VTJQuery(requestingUserId = requestingUser.id.raw, type = ASUKASMAARA, ssn = expectedSSN)
         val response = vtjClientService.query(query)
 
         val result = ResidentCountExample.residentCountFromHenkilo(response!!)
@@ -167,7 +168,7 @@ class VtjClientServiceTest : AbstractIntegrationTest() {
     }
 
     private val requestingUser = Employee(
-        id = NIL_ID,
+        id = EmployeeId(NIL_ID),
         firstName = "Integration",
         lastName = "Test",
         email = "integration-test@example.org",

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -543,7 +543,7 @@ private val toPersonApplicationSummary: (ResultSet, StatementContext) -> PersonA
 }
 
 fun Database.Read.fetchApplicationDetails(applicationId: ApplicationId, includeCitizenAttachmentsOnly: Boolean = false): ApplicationDetails? {
-    val attachmentWhereClause = if (includeCitizenAttachmentsOnly) "WHERE uploaded_by_person IS NOT NULL" else ""
+    val attachmentWhereClause = if (includeCitizenAttachmentsOnly) "WHERE eu.type = 'CITIZEN'" else ""
     //language=sql
     val sql =
         """
@@ -575,8 +575,19 @@ fun Database.Read.fetchApplicationDetails(applicationId: ApplicationId, includeC
         LEFT JOIN person c ON c.id = a.child_id
         LEFT JOIN person g1 ON g1.id = a.guardian_id
         LEFT JOIN (
-            SELECT application_id, jsonb_agg(jsonb_build_object('id', id, 'name', name, 'contentType', content_type, 'updated', updated, 'receivedAt', received_at, 'type', type, 'uploadedByEmployee', uploaded_by_employee, 'uploadedByPerson', uploaded_by_person)) json
-            FROM attachment $attachmentWhereClause
+            SELECT application_id, jsonb_agg(jsonb_build_object(
+                'id', attachment.id,
+                'name', attachment.name,
+                'contentType', content_type,
+                'updated', updated,
+                'receivedAt', received_at,
+                'type', attachment.type,
+                'uploadedByEmployee', (CASE eu.type WHEN 'EMPLOYEE' THEN eu.id END),
+                'uploadedByPerson', (CASE eu.type WHEN 'CITIZEN' THEN eu.id END)
+            )) json
+            FROM attachment
+            JOIN evaka_user eu ON attachment.uploaded_by = eu.id
+            $attachmentWhereClause
             GROUP BY application_id
         ) att ON a.id = att.application_id
         WHERE a.id = :id
@@ -991,7 +1002,17 @@ RETURNING id
     .toList()
 
 fun Database.Read.getApplicationAttachments(applicationId: ApplicationId): List<ApplicationAttachment> =
-    createQuery("SELECT id, name, content_type, updated, received_at, type, uploaded_by_employee, uploaded_by_person FROM attachment WHERE application_id = :applicationId")
+    createQuery(
+        """
+SELECT
+    attachment.id, attachment.name, content_type, updated, received_at, attachment.type,
+    (CASE evaka_user.type WHEN 'EMPLOYEE' THEN evaka_user.id END) AS uploaded_by_employee,
+    (CASE evaka_user.type WHEN 'CITIZEN' THEN evaka_user.id END) AS uploaded_by_person
+FROM attachment
+JOIN evaka_user ON attachment.uploaded_by = evaka_user.id
+WHERE application_id = :applicationId
+"""
+    )
         .bind("applicationId", applicationId)
         .mapTo<ApplicationAttachment>()
         .toList()
@@ -999,8 +1020,12 @@ fun Database.Read.getApplicationAttachments(applicationId: ApplicationId): List<
 fun Database.Read.getApplicationAttachmentsForUnitSupervisor(applicationId: ApplicationId): List<ApplicationAttachment> =
     createQuery(
         """
-SELECT attachment.id, attachment.name, attachment.content_type, attachment.updated, attachment.received_at, attachment.type, attachment.uploaded_by_employee, attachment.uploaded_by_person
+SELECT
+    attachment.id, attachment.name, attachment.content_type, attachment.updated, attachment.received_at, attachment.type,
+    (CASE evaka_user.type WHEN 'EMPLOYEE' THEN evaka_user.id END) AS uploaded_by_employee,
+    (CASE evaka_user.type WHEN 'CITIZEN' THEN evaka_user.id END) AS uploaded_by_person
 FROM attachment
+JOIN evaka_user ON attachment.uploaded_by = evaka_user.id
 JOIN application ON application.id = attachment.application_id
 JOIN placement_plan ON placement_plan.application_id = application.id
 JOIN daycare ON daycare.id = placement_plan.unit_id

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/ApplicationNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/ApplicationNoteQueries.kt
@@ -28,11 +28,9 @@ fun Database.Read.getApplicationNotes(applicationId: ApplicationId): List<Applic
         """
 SELECT 
     n.id, n.application_id, n.content, 
-    n.created, n.created_by, e.first_name || ' ' || e.last_name AS created_by_name,
-    n.updated, n.updated_by, e2.first_name || ' ' || e2.last_name AS updated_by_name
+    n.created, n.created_by, (SELECT name FROM evaka_user WHERE id = n.created_by) AS created_by_name,
+    n.updated, n.updated_by, (SELECT name FROM evaka_user WHERE id = n.updated_by) AS updated_by_name
 FROM application_note n
-LEFT JOIN employee e ON n.created_by = e.id
-LEFT JOIN employee e2 ON n.updated_by = e2.id
 WHERE application_id = :applicationId
 ORDER BY n.created
         """.trimIndent()
@@ -57,12 +55,12 @@ SELECT
     n.content,
     n.created_by,
     n.updated_by,
-    e.first_name || ' ' || e.last_name AS created_by_name,
-    e.first_name || ' ' || e.last_name AS updated_by_name,
+    eu.name AS created_by_name,
+    eu.name AS updated_by_name,
     n.created,
     n.updated
 FROM new_note n
-LEFT JOIN employee e ON n.created_by = e.id
+LEFT JOIN evaka_user eu ON n.created_by = eu.id
         """.trimIndent()
 
     return createQuery(sql)
@@ -83,11 +81,9 @@ WITH updated_note AS (
 )
 SELECT 
     n.id, n.application_id, n.content, 
-    n.created, n.created_by, e.first_name || ' ' || e.last_name AS created_by_name,
-    n.updated, n.updated_by, e2.first_name || ' ' || e2.last_name AS updated_by_name
+    n.created, n.created_by, (SELECT name FROM evaka_user WHERE id = n.created_by) AS created_by_name,
+    n.updated, n.updated_by, (SELECT name FROM evaka_user WHERE id = n.updated_by) AS updated_by_name
 FROM updated_note n
-LEFT JOIN employee e ON n.created_by = e.id
-LEFT JOIN employee e2 ON n.updated_by = e2.id
         """
 
     return createQuery(sql)

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -181,12 +181,11 @@ class AttachmentsController(
         val id = AttachmentId(UUID.randomUUID())
         db.transaction { tx ->
             tx.insertAttachment(
+                user,
                 id,
                 name,
                 contentType,
                 attachTo,
-                uploadedByPerson = user.id.takeIf { user.isEndUser },
-                uploadedByEmployee = user.id.takeUnless { user.isEndUser },
                 type = type
             )
             documentClient.upload(

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.placement.PlacementType.PREPARATORY_DAYCARE
 import fi.espoo.evaka.placement.PlacementType.PRESCHOOL
 import fi.espoo.evaka.placement.PlacementType.PRESCHOOL_DAYCARE
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -79,7 +80,7 @@ class ChildAttendanceController(
 
     data class GetChildSensitiveInfoRequest(
         val pin: String,
-        val staffId: UUID
+        val staffId: EmployeeId
     )
 
     @PostMapping("/child/{childId}")

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -60,7 +60,7 @@ fun Database.Transaction.insertAbsence(
     // language=sql
     val sql =
         """
-        INSERT INTO absence (child_id, date, care_type, absence_type, modified_by_employee_id)
+        INSERT INTO absence (child_id, date, care_type, absence_type, modified_by)
         VALUES (:childId, :date, :careType, :absenceType, :userId)
         RETURNING *
         """.trimIndent()

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -237,10 +237,10 @@ private fun Database.Transaction.upsertAbsences(absences: List<Absence>, modifie
     //language=SQL
     val sql =
         """
-        INSERT INTO absence (child_id, date, care_type, absence_type, modified_by_employee_id)
+        INSERT INTO absence (child_id, date, care_type, absence_type, modified_by)
         VALUES (:childId, :date, :careType, :absenceType, :modifiedBy)
         ON CONFLICT (child_id, date, care_type)
-            DO UPDATE SET absence_type = :absenceType, modified_by_employee_id = :modifiedBy, modified_at = now()
+            DO UPDATE SET absence_type = :absenceType, modified_by = :modifiedBy, modified_at = now()
         """.trimIndent()
 
     val batch = prepareBatch(sql)

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionQueries.kt
@@ -32,19 +32,18 @@ private val decisionSelector =
             u.phone,
             m.name AS manager,
             ap.child_id, ap.guardian_id,
-            p.first_name, p.last_name,
+            (SELECT name FROM evaka_user WHERE id = d.created_by) AS created_by,
             c.first_name AS child_first_name, c.last_name AS child_last_name
         FROM decision d
         INNER JOIN daycare u on d.unit_id = u.id
         INNER JOIN application ap on d.application_id = ap.id 
-        INNER JOIN employee p on d.created_by = p.id
         INNER JOIN person c on ap.child_id = c.id
         LEFT JOIN unit_manager m on u.unit_manager_id = m.id
     """.trimIndent()
 
 private fun decisionFromResultSet(rs: ResultSet): Decision = Decision(
     id = DecisionId(rs.getUUID("id")),
-    createdBy = "${rs.getString("first_name")} ${rs.getString("last_name")}",
+    createdBy = rs.getString("created_by"),
     type = DecisionType.valueOf(rs.getString("type")),
     startDate = rs.getDate("start_date").toLocalDate(),
     endDate = rs.getDate("end_date").toLocalDate(),

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementQueries.kt
@@ -68,10 +68,11 @@ SELECT
         'contentType', content_type,
         'uploadedByEmployee', uploaded_by_employee
       )), '[]'::jsonb) FROM (
-        SELECT id, name, content_type, uploaded_by_employee IS NOT NULL AS uploaded_by_employee
+        SELECT a.id, a.name, content_type, eu.type = 'EMPLOYEE' AS uploaded_by_employee
         FROM attachment a
+        JOIN evaka_user eu ON a.uploaded_by = eu.id
         WHERE a.income_statement_id = ist.id 
-        ${if (excludeEmployeeAttachments) "AND uploaded_by_employee IS NULL" else ""}
+        ${if (excludeEmployeeAttachments) "AND eu.type != 'EMPLOYEE'" else ""}
         ORDER BY a.created
     ) s) AS attachments,
    COUNT(*) OVER () AS count

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
@@ -92,9 +92,9 @@ fun Database.Transaction.upsertIncome(mapper: ObjectMapper, income: Income, upda
 fun Database.Read.getIncome(mapper: ObjectMapper, incomeTypesProvider: IncomeTypesProvider, id: IncomeId): Income? {
     return createQuery(
         """
-        SELECT income.*, employee.first_name || ' ' || employee.last_name AS updated_by_employee
+        SELECT income.*, evaka_user.name AS updated_by_name
         FROM income
-        LEFT JOIN employee ON income.updated_by = employee.id
+        LEFT JOIN evaka_user ON income.updated_by = evaka_user.id
         WHERE income.id = :id
         """.trimIndent()
     )
@@ -111,9 +111,9 @@ fun Database.Read.getIncomesForPerson(
 ): List<Income> {
     val sql =
         """
-        SELECT income.*, employee.first_name || ' ' || employee.last_name AS updated_by_employee
+        SELECT income.*, evaka_user.name AS updated_by_name
         FROM income
-        LEFT JOIN employee ON income.updated_by = employee.id
+        LEFT JOIN evaka_user ON income.updated_by = evaka_user.id
         WHERE person_id = :personId
         AND (:validAt::timestamp IS NULL OR tsrange(valid_from, valid_to) @> :validAt::timestamp)
         ORDER BY valid_from DESC
@@ -134,9 +134,9 @@ fun Database.Read.getIncomesFrom(
 ): List<Income> {
     val sql =
         """
-        SELECT income.*, employee.first_name || ' ' || employee.last_name AS updated_by_employee
+        SELECT income.*, evaka_user.name AS updated_by_name
         FROM income
-        LEFT JOIN employee ON income.updated_by = employee.id
+        LEFT JOIN evaka_user ON income.updated_by = evaka_user.id
         WHERE
             person_id = ANY(:personIds)
             AND (valid_to IS NULL OR valid_to >= :from)
@@ -187,7 +187,7 @@ fun toIncome(objectMapper: ObjectMapper, incomeTypes: Map<String, IncomeType>) =
         validTo = rs.getDate("valid_to")?.toLocalDate(),
         notes = rs.getString("notes"),
         updatedAt = rs.getTimestamp("updated_at").toInstant(),
-        updatedBy = (rs.getString("updated_by_employee")),
+        updatedBy = rs.getString("updated_by_name"),
         applicationId = rs.getNullableUUID("application_id")?.let(::ApplicationId),
     )
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.pis.markEmployeeLastLogin
 import fi.espoo.evaka.pis.resetEmployeePinFailureCount
 import fi.espoo.evaka.pis.updateEmployeePinFailureCountAndCheckIfLocked
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -24,7 +25,6 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 class MobileDevicesController(
@@ -117,7 +117,7 @@ enum class PinLoginStatus {
 
 data class PinLoginRequest(
     val pin: String,
-    val employeeId: UUID
+    val employeeId: EmployeeId
 )
 
 data class PinLoginResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/Employee.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/Employee.kt
@@ -5,11 +5,11 @@
 package fi.espoo.evaka.pis
 
 import fi.espoo.evaka.identity.ExternalId
+import fi.espoo.evaka.shared.EmployeeId
 import java.time.Instant
-import java.util.UUID
 
 data class Employee(
-    val id: UUID,
+    val id: EmployeeId,
     val firstName: String,
     val lastName: String,
     val email: String?,

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.pis.getFinanceDecisionHandlers
 import fi.espoo.evaka.pis.isPinLocked
 import fi.espoo.evaka.pis.updateEmployee
 import fi.espoo.evaka.pis.upsertPinCode
+import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -53,9 +54,9 @@ class EmployeeController {
     }
 
     @GetMapping("/{id}")
-    fun getEmployee(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Employee> {
+    fun getEmployee(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: EmployeeId): ResponseEntity<Employee> {
         Audit.EmployeeRead.log(targetId = id)
-        if (user.id != id) {
+        if (user.id != id.raw) {
             user.requireOneOfRoles(
                 UserRole.ADMIN,
                 UserRole.SERVICE_WORKER,
@@ -114,7 +115,7 @@ class EmployeeController {
     }
 
     @DeleteMapping("/{id}")
-    fun deleteEmployee(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: UUID): ResponseEntity<Unit> {
+    fun deleteEmployee(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: EmployeeId): ResponseEntity<Unit> {
         Audit.EmployeeDelete.log(targetId = id)
         user.requireOneOfRoles(UserRole.ADMIN)
         db.transaction { it.deleteEmployee(id) }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -269,8 +269,8 @@ fun createReservationsAsEmployee(tx: Database.Transaction, userId: UUID, reserva
 private fun Database.Transaction.insertValidReservations(userId: UUID, requests: List<DailyReservationRequest>) {
     val batch = prepareBatch(
         """
-        INSERT INTO attendance_reservation (child_id, start_time, end_time, created_by_guardian_id, created_by_employee_id)
-        SELECT :childId, :start, :end, NULL, :userId
+        INSERT INTO attendance_reservation (child_id, start_time, end_time, created_by)
+        SELECT :childId, :start, :end, :userId
         FROM placement pl
         LEFT JOIN backup_care bc ON daterange(bc.start_date, bc.end_date, '[]') @> :date AND bc.child_id = :childId
         JOIN daycare d ON d.id = coalesce(bc.unit_id, pl.unit_id)

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -264,8 +264,8 @@ fun createReservationsAsCitizen(tx: Database.Transaction, userId: UUID, reservat
 private fun Database.Transaction.insertValidReservations(userId: UUID, requests: List<DailyReservationRequest>) {
     val batch = prepareBatch(
         """
-        INSERT INTO attendance_reservation (child_id, start_time, end_time, created_by_guardian_id, created_by_employee_id)
-        SELECT :childId, :start, :end, :userId, NULL
+        INSERT INTO attendance_reservation (child_id, start_time, end_time, created_by)
+        SELECT :childId, :start, :end, :userId
         FROM placement pl
         LEFT JOIN backup_care bc ON daterange(bc.start_date, bc.end_date, '[]') @> :date AND bc.child_id = :childId
         JOIN daycare d ON d.id = coalesce(bc.unit_id, pl.unit_id) AND 'RESERVATIONS' = ANY(d.enabled_pilot_features)
@@ -306,7 +306,7 @@ private fun Database.Transaction.insertValidReservations(userId: UUID, requests:
 private fun Database.Transaction.insertAbsences(userId: UUID, request: AbsenceRequest) {
     val batch = prepareBatch(
         """
-        INSERT INTO absence (child_id, date, care_type, absence_type, modified_by_guardian_id)
+        INSERT INTO absence (child_id, date, care_type, absence_type, modified_by)
         SELECT
             :childId,
             :date,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
@@ -46,7 +46,7 @@ sealed class AuthenticatedUser : RoleContainer {
 
     data class Employee private constructor(override val id: UUID, val globalRoles: Set<UserRole>, val allScopedRoles: Set<UserRole>) : AuthenticatedUser() {
         constructor(id: UUID, roles: Set<UserRole>) : this(id, roles - UserRole.SCOPED_ROLES, roles.intersect(UserRole.SCOPED_ROLES))
-        constructor(employeeUser: EmployeeUser) : this(employeeUser.id, employeeUser.globalRoles, employeeUser.allScopedRoles)
+        constructor(employeeUser: EmployeeUser) : this(employeeUser.id.raw, employeeUser.globalRoles, employeeUser.allScopedRoles)
         override val roles: Set<UserRole> = globalRoles + allScopedRoles
         override val isAdmin = roles.contains(UserRole.ADMIN)
         override val type = AuthenticatedUserType.employee

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
@@ -728,10 +728,10 @@ WHERE employee_id = :userId
     ) {
         val errorCode = Database(jdbi).connect {
             it.transaction { tx ->
-                if (tx.employeePinIsCorrect(employeeId.raw, pinCode)) {
+                if (tx.employeePinIsCorrect(employeeId, pinCode)) {
                     null
                 } else {
-                    val locked = tx.updateEmployeePinFailureCountAndCheckIfLocked(employeeId.raw)
+                    val locked = tx.updateEmployeePinFailureCountAndCheckIfLocked(employeeId)
                     if (locked) PinError.PIN_LOCKED else PinError.WRONG_PIN
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AuditQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AuditQueries.kt
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.security
+
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.MobileDeviceId
+import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.db.Database
+
+fun Database.Transaction.upsertCitizenUser(id: PersonId) = createUpdate(
+    """
+INSERT INTO evaka_user (id, type, citizen_id, name)
+SELECT id, 'CITIZEN', id, first_name || ' ' || last_name
+FROM person
+WHERE id = :id
+ON CONFLICT (id) DO UPDATE SET name = excluded.name
+"""
+)
+    .bind("id", id)
+    .execute()
+
+fun Database.Transaction.upsertEmployeeUser(id: EmployeeId) = createUpdate(
+    """
+INSERT INTO evaka_user (id, type, employee_id, name)
+SELECT id, 'EMPLOYEE', id, first_name || ' ' || last_name
+FROM employee
+WHERE id = :id
+ON CONFLICT (id) DO UPDATE SET name = excluded.name
+"""
+)
+    .bind("id", id)
+    .execute()
+
+fun Database.Transaction.upsertMobileDeviceUser(id: MobileDeviceId) = createUpdate(
+    """
+INSERT INTO evaka_user (id, type, employee_id, name)
+SELECT id, 'MOBILE_DEVICE', id, name
+FROM mobile_device
+WHERE id = :id
+ON CONFLICT (id) DO UPDATE SET name = excluded.name
+"""
+)
+    .bind("id", id)
+    .execute()

--- a/service/src/main/resources/db/migration/V164__evaka_user.sql
+++ b/service/src/main/resources/db/migration/V164__evaka_user.sql
@@ -1,0 +1,87 @@
+CREATE TYPE evaka_user_type AS ENUM (
+  'SYSTEM', 'CITIZEN', 'EMPLOYEE', 'MOBILE_DEVICE', 'UNKNOWN'
+);
+
+CREATE TABLE evaka_user(
+  id uuid PRIMARY KEY,
+  type evaka_user_type NOT NULL,
+  citizen_id uuid CONSTRAINT fk$citizen REFERENCES person (id) ON DELETE SET NULL,
+  employee_id uuid CONSTRAINT fk$employee REFERENCES employee (id) ON DELETE SET NULL,
+  mobile_device_id uuid CONSTRAINT fk$mobile_device REFERENCES mobile_device (id) ON DELETE SET NULL,
+  name text NOT NULL,
+
+  CONSTRAINT fk_count CHECK (num_nonnulls(citizen_id, employee_id, mobile_device_id) <= 1),
+  CONSTRAINT type_id_match CHECK (
+    CASE type
+      WHEN 'SYSTEM' THEN id = '00000000-0000-0000-0000-000000000000' AND num_nonnulls(citizen_id, employee_id, mobile_device_id) = 0
+      WHEN 'CITIZEN' THEN id = citizen_id OR citizen_id IS NULL
+      WHEN 'EMPLOYEE' THEN id = employee_id OR employee_id IS NULL
+      WHEN 'MOBILE_DEVICE' THEN id = mobile_device_id OR mobile_device_id IS NULL
+      WHEN 'UNKNOWN' THEN num_nonnulls(citizen_id, employee_id, mobile_device_id) = 0
+    END
+  )
+);
+
+INSERT INTO evaka_user (id, type, name) VALUES ('00000000-0000-0000-0000-000000000000', 'SYSTEM', 'eVaka');
+
+INSERT INTO evaka_user (id, type, citizen_id, name)
+SELECT id, 'CITIZEN', id, first_name || ' ' || last_name
+FROM person
+WHERE id IN (
+  SELECT modified_by_guardian_id FROM absence
+  UNION ALL
+  SELECT uploaded_by_person FROM attachment
+  UNION ALL
+  SELECT created_by_guardian_id FROM attendance_reservation
+);
+
+INSERT INTO evaka_user (id, type, employee_id, name)
+SELECT id, 'EMPLOYEE', id, first_name || ' ' || last_name
+FROM employee
+WHERE id IN (
+  SELECT modified_by_employee_id FROM absence
+  UNION ALL
+  SELECT uploaded_by_employee FROM attachment
+  UNION ALL
+  SELECT created_by_employee_id FROM attendance_reservation
+  UNION ALL
+  SELECT created_by FROM decision
+  UNION ALL
+  SELECT updated_by FROM old_service_need
+  UNION ALL
+  SELECT created_by FROM application_note
+  UNION ALL
+  SELECT updated_by FROM application_note
+  UNION ALL
+  SELECT updated_by FROM assistance_action
+  UNION ALL
+  SELECT confirmed_by FROM service_need
+  UNION ALL
+  SELECT created_by FROM pedagogical_document
+  UNION ALL
+  SELECT updated_by FROM pedagogical_document
+  UNION ALL
+  SELECT sent_by FROM invoice
+  UNION ALL
+  SELECT updated_by FROM assistance_need
+  UNION ALL
+  SELECT updated_by FROM fee_alteration
+)
+AND NOT EXISTS (SELECT 1 FROM mobile_device WHERE mobile_device.id = employee.id);
+
+INSERT INTO evaka_user (id, type, mobile_device_id, name)
+SELECT id, 'MOBILE_DEVICE', id, name
+FROM mobile_device;
+
+INSERT INTO evaka_user (id, type, name)
+SELECT DISTINCT ON (modified_by_deprecated) ext.uuid_generate_v1mc(), 'UNKNOWN', modified_by_deprecated
+FROM absence
+WHERE modified_by_deprecated IS NOT NULL
+AND modified_by_guardian_id IS NULL
+AND modified_by_employee_id IS NULL;
+
+CREATE UNIQUE INDEX uniq$evaka_user_citizen ON evaka_user (citizen_id) WHERE citizen_id IS NOT NULL;
+CREATE UNIQUE INDEX uniq$evaka_user_employee ON evaka_user (employee_id) WHERE employee_id IS NOT NULL;
+CREATE UNIQUE INDEX uniq$evaka_user_mobile_device ON evaka_user (mobile_device_id) WHERE mobile_device_id IS NOT NULL;
+
+CREATE INDEX idx$evaka_user_unknown ON evaka_user (name) WHERE type = 'UNKNOWN';

--- a/service/src/main/resources/db/migration/V165__evaka_user_data.sql
+++ b/service/src/main/resources/db/migration/V165__evaka_user_data.sql
@@ -1,0 +1,58 @@
+ALTER TABLE decision DROP CONSTRAINT created_by;
+ALTER TABLE decision ADD CONSTRAINT fk$created_by FOREIGN KEY (created_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE old_service_need DROP CONSTRAINT created_by; -- yes, this is the actual name
+ALTER TABLE old_service_need ADD CONSTRAINT fk$updated_by FOREIGN KEY (updated_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE application_note DROP CONSTRAINT fk$created_by;
+ALTER TABLE application_note ADD CONSTRAINT fk$created_by FOREIGN KEY (created_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE application_note DROP CONSTRAINT fk$updated_by;
+ALTER TABLE application_note ADD CONSTRAINT fk$updated_by FOREIGN KEY (updated_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE assistance_action DROP CONSTRAINT fk$updated_by;
+ALTER TABLE assistance_action ADD CONSTRAINT fk$updated_by FOREIGN KEY (updated_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE service_need DROP CONSTRAINT new_service_need_confirmed_by_fkey;
+ALTER TABLE service_need ADD CONSTRAINT fk$confirmed_by FOREIGN KEY (confirmed_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE pedagogical_document DROP CONSTRAINT pedagogical_document_created_by_fkey;
+ALTER TABLE pedagogical_document ADD CONSTRAINT fk$created_by FOREIGN KEY (created_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE pedagogical_document DROP CONSTRAINT pedagogical_document_updated_by_fkey;
+ALTER TABLE pedagogical_document ADD CONSTRAINT fk$updated_by FOREIGN KEY (updated_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE invoice DROP CONSTRAINT sent_by;
+ALTER TABLE invoice ADD CONSTRAINT fk$sent_by FOREIGN KEY (sent_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE assistance_need DROP CONSTRAINT updated_by;
+ALTER TABLE assistance_need ADD CONSTRAINT fk$updated_by FOREIGN KEY (updated_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE fee_alteration DROP CONSTRAINT updated_by;
+ALTER TABLE fee_alteration ADD CONSTRAINT fk$updated_by FOREIGN KEY (updated_by) REFERENCES evaka_user (id);
+
+
+ALTER TABLE attachment ADD COLUMN uploaded_by uuid CONSTRAINT fk$uploaded_by REFERENCES evaka_user (id);
+UPDATE attachment SET uploaded_by = coalesce(uploaded_by_employee, uploaded_by_person, '00000000-0000-0000-0000-000000000000');
+ALTER TABLE attachment
+    DROP COLUMN uploaded_by_employee,
+    DROP COLUMN uploaded_by_person,
+    ALTER COLUMN uploaded_by SET NOT NULL;
+
+
+ALTER TABLE attendance_reservation ADD COLUMN created_by uuid CONSTRAINT fk$created_by REFERENCES evaka_user (id);
+UPDATE attendance_reservation SET created_by = coalesce(created_by_employee_id, created_by_guardian_id, '00000000-0000-0000-0000-000000000000');
+ALTER TABLE attendance_reservation
+    DROP COLUMN created_by_employee_id,
+    DROP COLUMN created_by_guardian_id,
+    ALTER COLUMN created_by SET NOT NULL;

--- a/service/src/main/resources/db/migration/V166__evaka_user_absence.sql
+++ b/service/src/main/resources/db/migration/V166__evaka_user_absence.sql
@@ -1,0 +1,14 @@
+ALTER TABLE absence ADD COLUMN modified_by uuid CONSTRAINT fk$modified_by REFERENCES evaka_user (id);
+
+UPDATE absence SET modified_by = CASE
+    WHEN modified_by_employee_id IS NOT NULL THEN modified_by_employee_id
+    WHEN modified_by_guardian_id IS NOT NULL THEN modified_by_guardian_id
+    WHEN modified_by_deprecated IS NOT NULL THEN (SELECT id FROM evaka_user WHERE type = 'UNKNOWN' AND name = modified_by_deprecated)
+    ELSE '00000000-0000-0000-0000-000000000000'
+END;
+
+ALTER TABLE absence
+    DROP COLUMN modified_by_employee_id,
+    DROP COLUMN modified_by_guardian_id,
+    DROP COLUMN modified_by_deprecated,
+    ALTER COLUMN modified_by SET NOT NULL;

--- a/service/src/main/resources/db/migration/V167__evaka_user_indexes.sql
+++ b/service/src/main/resources/db/migration/V167__evaka_user_indexes.sql
@@ -1,0 +1,25 @@
+CREATE INDEX CONCURRENTLY idx$absence_modified_by ON absence (modified_by);
+
+CREATE INDEX CONCURRENTLY idx$application_note_created_by ON application_note (created_by);
+
+CREATE INDEX CONCURRENTLY idx$application_note_updated_by ON application_note (updated_by);
+
+CREATE INDEX CONCURRENTLY idx$assistance_action_updated_by ON assistance_action (updated_by);
+
+CREATE INDEX CONCURRENTLY idx$assistance_need_updated_by ON assistance_need (updated_by);
+
+CREATE INDEX CONCURRENTLY idx$attachment_uploaded_by ON attachment (uploaded_by);
+
+CREATE INDEX CONCURRENTLY idx$attendance_reservation_created_by ON attendance_reservation (created_by);
+
+CREATE INDEX CONCURRENTLY idx$decision_created_by ON decision (created_by);
+
+CREATE INDEX CONCURRENTLY idx$fee_alteration_updated_by ON fee_alteration (updated_by);
+
+CREATE INDEX CONCURRENTLY idx$invoice_sent_by ON invoice (sent_by);
+
+CREATE INDEX CONCURRENTLY idx$pedagogical_document_created_by ON pedagogical_document (created_by);
+
+CREATE INDEX CONCURRENTLY idx$pedagogical_document_updated_by ON pedagogical_document (updated_by);
+
+CREATE INDEX CONCURRENTLY idx$service_need_confirmed_by ON service_need (confirmed_by);

--- a/service/src/main/resources/dev-data/employees.sql
+++ b/service/src/main/resources/dev-data/employees.sql
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: LGPL-2.1-or-later
 
-INSERT INTO employee (id, first_name, last_name, email, external_id, roles) VALUES 
+INSERT INTO employee (id, first_name, last_name, email, external_id, roles) VALUES
     ('00000000-0000-0000-0000-000000000001', 'Päivi', 'Pääkäyttäjä', 'paivi.paakayttaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0000-000000000001', '{ADMIN, SERVICE_WORKER, FINANCE_ADMIN}'::user_role[]),
     ('00000000-0000-0000-0001-000000000000', 'Paula', 'Palveluohjaaja', 'paula.palveluohjaaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0001-000000000000', '{SERVICE_WORKER}'::user_role[]),
     ('00000000-0000-0000-0002-000000000000', 'Lasse', 'Laskuttaja', 'lasse.laskuttaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0002-000000000000', '{FINANCE_ADMIN}'::user_role[]),
@@ -27,6 +27,10 @@ INSERT INTO daycare_acl (daycare_id, employee_id, role) VALUES
     ('d5c7c7f8-2abe-11e9-8d80-2b926c773065', '00000000-0000-0000-0005-000000000001', 'STAFF'),
     ('2dd6e5f6-788e-11e9-bd72-9f1cfe2d8405', '00000000-0000-0000-0006-000000000000', 'SPECIAL_EDUCATION_TEACHER'),
     ('2dda790a-788e-11e9-bdab-27ae0339236a', '00000000-0000-0000-0006-000000000000', 'SPECIAL_EDUCATION_TEACHER');
+
+INSERT INTO evaka_user (id, type, employee_id, name)
+SELECT id, 'EMPLOYEE', id, first_name || ' ' || last_name
+FROM employee;
 
 INSERT INTO message_account (employee_id)
 SELECT id

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -161,3 +161,4 @@ V160__person_disable_ssn.sql
 V161__pedagogical_documents_email_notification.sql
 V162__settings.sql
 V163__service_worker_note.sql
+V164__evaka_user.sql

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -162,3 +162,6 @@ V161__pedagogical_documents_email_notification.sql
 V162__settings.sql
 V163__service_worker_note.sql
 V164__evaka_user.sql
+V165__evaka_user_data.sql
+V166__evaka_user_absence.sql
+V167__evaka_user_indexes.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

* evaka_user rows are normally created during login (citizen/employee/mobile device)
* cache a textual name in the table, so we don't need complicated joins in most use cases
* `fee_decision` / `voucher_value_decision` table `approved_by`, and `service_need` table `confirmed_by` were not changed, because multiple places assume separate `first_name` and `last_name` fields, and changing this is complicated
* add foreign key indexes to tables. Not strictly necessary, but it's a good default, and if we ever delete from `evaka_user`, this avoids full table scans in all related tables
* deduplicated `resetDatabase()` function in Kotlin code. There's no need to have two, and now we can easily add the system user after database resets
* add new `evaka_user` rows for all `employee` / `person` table rows referenced from any column we're changing here
* add `UNKNOWN` rows for legacy `absence` table rows which only have a textual name and no "real" foreign key reference