### PR TITLE
Income statement paging

### DIFF
--- a/frontend/src/employee-frontend/api/income-statement.ts
+++ b/frontend/src/employee-frontend/api/income-statement.ts
@@ -15,11 +15,21 @@ import { UUID } from '../types'
 import { client } from './client'
 
 export async function getIncomeStatements(
-  personId: UUID
-): Promise<Result<IncomeStatement[]>> {
+  personId: UUID,
+  page: number,
+  pageSize = 10
+): Promise<Result<Paged<IncomeStatement>>> {
   return client
-    .get<JsonOf<IncomeStatement[]>>(`/income-statements/person/${personId}`)
-    .then((res) => res.data.map(deserializeIncomeStatement))
+    .get<JsonOf<Paged<IncomeStatement>>>(
+      `/income-statements/person/${personId}`,
+      {
+        params: { page, pageSize }
+      }
+    )
+    .then(({ data: { data, ...rest } }) => ({
+      ...rest,
+      data: data.map(deserializeIncomeStatement)
+    }))
     .then((v) => Success.of(v))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -25,6 +25,7 @@ const en: Translations = {
     yes: 'Yes',
     no: 'No',
     select: 'Select',
+    page: 'Page',
     unit: {
       providerTypes: {
         MUNICIPAL: 'Municipal',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -24,6 +24,7 @@ export default {
     yes: 'Kyllä',
     no: 'Ei',
     select: 'Valitse',
+    page: 'Sivu',
     unit: {
       providerTypes: {
         MUNICIPAL: 'Kunnallinen',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -25,6 +25,7 @@ const sv: Translations = {
     yes: 'Ja',
     no: 'Nej',
     select: 'Utvalda',
+    page: 'Sida',
     unit: {
       providerTypes: {
         MUNICIPAL: 'Kommunal',

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -1186,7 +1186,6 @@ export const fi = {
     },
     income: {
       title: 'Tulotiedot',
-      error: 'Tulotietojen lataus epäonnistui',
       itemHeader: 'Tulotiedot ajalle',
       itemHeaderNew: 'Uusi tulotieto',
       details: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerIntegrationTest.kt
@@ -39,7 +39,6 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest() {
     private val employeeId = UUID.randomUUID()
     private val citizenId = testAdult_1.id
     private val employee = AuthenticatedUser.Employee(employeeId, setOf(UserRole.FINANCE_ADMIN))
-    private val citizen = AuthenticatedUser.Citizen(citizenId)
 
     @BeforeEach
     fun beforeEach() {
@@ -106,6 +105,8 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest() {
             ),
             incomeStatement3
         )
+
+        assertEquals(listOf(false), getIncomeStatements(citizenId).data.map { it.handled })
     }
 
     @Test
@@ -323,6 +324,12 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest() {
         http.get("/income-statements/person/$citizenId/$id")
             .asUser(employee)
             .responseObject<IncomeStatement>(objectMapper)
+            .let { (_, _, body) -> body.get() }
+
+    private fun getIncomeStatements(personId: UUID): Paged<IncomeStatement> =
+        http.get("/income-statements/person/$personId?page=1&pageSize=10")
+            .asUser(employee)
+            .responseObject<Paged<IncomeStatement>>(objectMapper)
             .let { (_, _, body) -> body.get() }
 
     private fun setIncomeStatementHandled(id: IncomeStatementId, body: IncomeStatementController.SetIncomeStatementHandledBody) {

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -132,6 +132,7 @@ enum class Audit(
     IncomeStatementUpdateHandled("evaka.income-statement.handled.update"),
     IncomeStatementsAwaitingHandler("evaka.income-statements.awaiting-handler.read"),
     IncomeStatementsOfPerson("evaka.income-statements.person.read"),
+    IncomeStatementStartDates("evaka.income-statement.start-dates.read"),
     InvoicesCreate("evaka.invoices.create"),
     InvoicesDeleteDrafts("evaka.invoices.delete-drafts"),
     InvoicesMarkSent("evaka.invoices.mark-sent"),

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatement.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatement.kt
@@ -153,7 +153,9 @@ data class Attachment(
 )
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-sealed class IncomeStatement {
+sealed class IncomeStatement(
+    val type: IncomeStatementType
+) {
     abstract val id: IncomeStatementId
     abstract val startDate: LocalDate
     abstract val endDate: LocalDate?
@@ -171,7 +173,7 @@ sealed class IncomeStatement {
         override val updated: HelsinkiDateTime,
         override val handled: Boolean,
         override val handlerNote: String
-    ) : IncomeStatement()
+    ) : IncomeStatement(IncomeStatementType.HIGHEST_FEE)
 
     @JsonTypeName("INCOME")
     data class Income(
@@ -188,5 +190,5 @@ sealed class IncomeStatement {
         override val handled: Boolean,
         override val handlerNote: String,
         val attachments: List<Attachment>,
-    ) : IncomeStatement()
+    ) : IncomeStatement(IncomeStatementType.INCOME)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
@@ -31,11 +31,20 @@ class IncomeStatementController(
     fun getIncomeStatements(
         db: Database.Connection,
         user: AuthenticatedUser,
-        @PathVariable personId: PersonId
-    ): List<IncomeStatement> {
+        @PathVariable personId: PersonId,
+        @RequestParam page: Int,
+        @RequestParam pageSize: Int
+    ): Paged<IncomeStatement> {
         Audit.IncomeStatementsOfPerson.log(personId)
         accessControl.requirePermissionFor(user, Action.Person.READ_INCOME_STATEMENTS, personId)
-        return db.read { it.readIncomeStatementsForPerson(personId.raw, includeEmployeeContent = true) }
+        return db.read {
+            it.readIncomeStatementsForPerson(
+                personId = personId.raw,
+                includeEmployeeContent = true,
+                page = page,
+                pageSize = pageSize
+            )
+        }
     }
 
     @GetMapping("/person/{personId}/{incomeStatementId}")


### PR DESCRIPTION
#### Summary

- Implement paging of income statements
- Refactor income statement editor to fetch the needed data only
  - fetch income statement by id and all start dates separately instead of fetching all income statements