### PR TITLE
Add breakpoint to empty thread view display css

### DIFF
--- a/frontend/src/citizen-frontend/messages/EmptyThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/EmptyThreadView.tsx
@@ -9,6 +9,7 @@ import { H3 } from 'lib-components/typography'
 import colors from 'lib-customizations/common'
 import React from 'react'
 import styled from 'styled-components'
+import { tabletMin } from 'lib-components/breakpoints'
 
 interface Props {
   inboxEmpty: boolean
@@ -37,4 +38,9 @@ const EmptyThreadViewContainer = styled.div`
   width: 100%;
   background: white;
   padding-top: 10%;
+
+  display: none;
+  @media (min-width: ${tabletMin}) {
+    display: block;
+  }
 `


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Citizen frontend thread list is a little broken on mobile, because an unnecessary div is displayed. Hide that in mobile.
