### PR TITLE
memo poc

### DIFF
--- a/frontend/src/citizen-frontend/header/CityLogo.tsx
+++ b/frontend/src/citizen-frontend/header/CityLogo.tsx
@@ -4,11 +4,12 @@
 
 import React from 'react'
 import styled from 'styled-components'
+import { memo } from 'lib-common/memo'
 import { desktopMin } from 'lib-components/breakpoints'
 import { defaultMargins } from 'lib-components/white-space'
 import { cityLogo } from 'lib-customizations/citizen'
 
-export default React.memo(function Logo() {
+export default memo(function Logo() {
   return (
     <Container>
       <Img src={cityLogo.src} alt={cityLogo.alt} data-qa="header-city-logo" />

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { memo } from 'lib-common/memo'
 import { desktopMin } from 'lib-components/breakpoints'
 import useCloseOnOutsideClick from 'lib-components/utils/useCloseOnOutsideClick'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -28,10 +29,10 @@ interface Props {
   unreadPedagogicalDocuments: number
 }
 
-export default React.memo(function DesktopNav({
+export default memo<Props>(function DesktopNav({
   unreadMessagesCount,
   unreadPedagogicalDocuments
-}: Props) {
+}) {
   const user = useUser()
   const t = useTranslation()
 
@@ -161,7 +162,7 @@ export const CircledChar = styled.div`
   border-radius: 100%;
 `
 
-const LanguageMenu = React.memo(function LanguageMenu() {
+const LanguageMenu = memo(function LanguageMenu() {
   const t = useTranslation()
   const [lang, setLang] = useLang()
   const [open, setOpen] = useState(false)
@@ -198,7 +199,7 @@ const LanguageMenu = React.memo(function LanguageMenu() {
   )
 })
 
-const UserMenu = React.memo(function UserMenu() {
+const UserMenu = memo(function UserMenu() {
   const t = useTranslation()
   const user = useUser()
   const [open, setOpen] = useState(false)

--- a/frontend/src/citizen-frontend/header/EvakaLogo.tsx
+++ b/frontend/src/citizen-frontend/header/EvakaLogo.tsx
@@ -4,9 +4,10 @@
 
 import React from 'react'
 import styled from 'styled-components'
+import { memo } from 'lib-common/memo'
 import { desktopMin, desktopSmall } from 'lib-components/breakpoints'
 
-export default React.memo(function Logo() {
+export default memo(function Logo() {
   return (
     <Container>
       <svg

--- a/frontend/src/citizen-frontend/header/Header.tsx
+++ b/frontend/src/citizen-frontend/header/Header.tsx
@@ -2,9 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect } from 'react'
 import styled from 'styled-components'
 import colors from 'lib-customizations/common'
+import { memo, useState } from 'lib-common/memo'
 import { desktopMin } from 'lib-components/breakpoints'
 import CityLogo from './CityLogo'
 import EvakaLogo from './EvakaLogo'
@@ -18,7 +19,7 @@ import {
   PedagogicalDocumentsState
 } from '../pedagogical-documents/state'
 
-export default React.memo(function Header() {
+export default memo(function Header() {
   const [showMenu, setShowMenu] = useState(false)
   const user = useUser()
 

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -2,11 +2,12 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { Dispatch, SetStateAction, useCallback } from 'react'
+import React, { Dispatch, SetStateAction } from 'react'
 import styled from 'styled-components'
 import { NavLink } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBars, faLockAlt, faSignIn, faSignOut, faTimes } from 'lib-icons'
+import { memo, useCallback } from 'lib-common/memo'
 import { desktopMin } from 'lib-components/breakpoints'
 import colors from 'lib-customizations/common'
 import useCloseOnOutsideClick from 'lib-components/utils/useCloseOnOutsideClick'
@@ -19,27 +20,24 @@ import { langs, useLang, useTranslation } from '../localization'
 import { getLoginUri, getLogoutUri } from './const'
 import { CircledChar } from './DesktopNav'
 
-type Props = {
+interface Props {
   showMenu: boolean
   setShowMenu: Dispatch<SetStateAction<boolean>>
   unreadMessagesCount: number
   unreadPedagogicalDocumentsCount: number
 }
 
-export default React.memo(function MobileNav({
+export default memo<Props>(function MobileNav({
   showMenu,
   setShowMenu,
   unreadMessagesCount,
   unreadPedagogicalDocumentsCount
-}: Props) {
+}) {
   const user = useUser()
   const t = useTranslation()
   const ref = useCloseOnOutsideClick<HTMLDivElement>(() => setShowMenu(false))
-  const toggleMenu = useCallback(
-    () => setShowMenu((show) => !show),
-    [setShowMenu]
-  )
-  const close = useCallback(() => setShowMenu(false), [setShowMenu])
+  const toggleMenu = useCallback(() => setShowMenu((show) => !show), [])
+  const close = () => setShowMenu(false)
 
   return (
     <Container ref={ref} data-qa="mobile-nav">
@@ -125,11 +123,9 @@ const MenuContainer = styled.div`
   flex-direction: column;
 `
 
-const LanguageMenu = React.memo(function LanguageMenu({
-  close
-}: {
+const LanguageMenu = memo<{
   close: () => void
-}) {
+}>(function LanguageMenu({ close }) {
   const [lang, setLang] = useLang()
 
   return (
@@ -180,14 +176,14 @@ const LangButton = styled.button<{ active: boolean }>`
     props.active ? colors.greyscale.white : 'transparent'};
 `
 
-const Navigation = React.memo(function Navigation({
-  close,
-  unreadMessagesCount,
-  unreadPedagogicalDocumentsCount
-}: {
+const Navigation = memo<{
   close: () => void
   unreadMessagesCount: number
   unreadPedagogicalDocumentsCount: number
+}>(function Navigation({
+  close,
+  unreadMessagesCount,
+  unreadPedagogicalDocumentsCount
 }) {
   const t = useTranslation()
   const user = useUser()

--- a/frontend/src/lib-common/memo.ts
+++ b/frontend/src/lib-common/memo.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+
+export enum MemoizedBrand {
+  _ = ''
+}
+
+type Memoized<T> = T extends
+  | string
+  | number
+  | boolean
+  | undefined
+  | null
+  | symbol
+  ? T
+  : T & MemoizedBrand
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type MemoizedProps<P extends object> = {
+  [K in keyof P]: Memoized<P[K]>
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function memo<T extends object>(
+  component: React.FunctionComponent<MemoizedProps<T>>
+) {
+  return React.memo(component)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useCallback<T extends (...args: any[]) => any>(
+  callback: T,
+  deps: React.DependencyList
+): Memoized<T> {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return React.useCallback(callback, deps) as Memoized<T>
+}
+
+export function useMemo<T>(
+  factory: () => T,
+  deps: React.DependencyList | undefined
+): Memoized<T> {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return React.useMemo(factory, deps) as Memoized<T>
+}
+
+export function useState<T>(
+  initialState: T | (() => T)
+): [Memoized<T>, Memoized<React.Dispatch<React.SetStateAction<T>>>] {
+  return React.useState(initialState) as [
+    Memoized<T>,
+    Memoized<React.Dispatch<React.SetStateAction<T>>>
+  ]
+}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
POC for a version of `memo` that requires the props to be "memoized" as well. Eslint should complain about missing dependencies in our custom hooks and typescript compiler should complain about "non-memoized" callbacks being passed as props.
