### PR TITLE
EVAKA-4290 Support multiple children on the Pedagogical Documents citizen view

### DIFF
--- a/frontend/src/citizen-frontend/pedagogical-documents/PedagogicalDocuments.tsx
+++ b/frontend/src/citizen-frontend/pedagogical-documents/PedagogicalDocuments.tsx
@@ -2,7 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback, useContext, useEffect, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  useMemo
+} from 'react'
+import { uniq } from 'lodash'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import { useTranslation } from '../localization'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -25,6 +32,262 @@ import {
 } from 'lib-components/layout/flex-helpers'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import { renderResult } from '../async-rendering'
+
+const Attachment = React.memo(function Attachment({
+  item,
+  onRead,
+  onAttachmentUnavailable,
+  dataQa
+}: {
+  item: PedagogicalDocumentCitizen
+  onRead: (doc: PedagogicalDocumentCitizen) => void
+  onAttachmentUnavailable: () => void
+  dataQa: string
+}) {
+  return item && item.attachment ? (
+    <FileDownloadButton
+      key={item.attachment.id}
+      file={item.attachment}
+      fileFetchFn={getAttachmentBlob}
+      afterFetch={() => onRead(item)}
+      onFileUnavailable={onAttachmentUnavailable}
+      icon
+      data-qa={dataQa}
+      openInBrowser={true}
+    />
+  ) : null
+})
+
+const AttachmentDownloadButton = React.memo(function AttachmentDownloadButton({
+  item,
+  onRead,
+  onAttachmentUnavailable,
+  dataQa
+}: {
+  item: PedagogicalDocumentCitizen
+  onRead: (doc: PedagogicalDocumentCitizen) => void
+  onAttachmentUnavailable: () => void
+  dataQa: string
+}) {
+  const t = useTranslation()
+  return item.attachment ? (
+    <FileDownloadButton
+      key={item.attachment.id}
+      file={item.attachment}
+      fileFetchFn={getAttachmentBlob}
+      afterFetch={() => onRead(item)}
+      onFileUnavailable={onAttachmentUnavailable}
+      icon={faArrowDown}
+      data-qa={dataQa}
+      text={t.fileDownload.download}
+    />
+  ) : null
+})
+
+const ItemDescription = React.memo(function ItemDescription({
+  item,
+  clampLines,
+  dataQa
+}: {
+  item: PedagogicalDocumentCitizen
+  clampLines: number
+  dataQa: string
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const t = useTranslation()
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded((prev) => !prev)
+  }, [])
+
+  // A description with more than 50 characters per line will be collapsed
+  const shouldShowExpandButton =
+    item?.description && item.description.length > 50 * clampLines
+
+  return (
+    <FixedSpaceRow spacing="xs" alignItems="end">
+      <ExpandableText
+        expanded={expanded}
+        clampLines={clampLines}
+        data-qa={dataQa}
+      >
+        {item.description}
+      </ExpandableText>
+      {shouldShowExpandButton && (
+        <IconButton
+          onClick={toggleExpanded}
+          data-qa={`${dataQa}-button`}
+          icon={expanded ? faChevronUp : faChevronDown}
+          altText={t.pedagogicalDocuments.toggleExpandText}
+        />
+      )}
+    </FixedSpaceRow>
+  )
+})
+
+const PedagogicalDocumentsDisplay = React.memo(
+  function PedagogicalDocumentsDisplay({
+    items,
+    onRead,
+    onAttachmentUnavailable
+  }: {
+    items: PedagogicalDocumentCitizen[]
+    onRead: (doc: PedagogicalDocumentCitizen) => void
+    onAttachmentUnavailable: () => void
+  }) {
+    const t = useTranslation()
+
+    const moreThanOneChild = useMemo(
+      () => uniq(items.map((doc) => doc.childId)).length > 1,
+      [items]
+    )
+
+    return (
+      <>
+        <Mobile>
+          <ContentArea opaque paddingVertical="L" paddingHorizontal="zero">
+            <PaddedDiv>
+              <H1 noMargin>{t.pedagogicalDocuments.title}</H1>
+              <p>{t.pedagogicalDocuments.description}</p>
+            </PaddedDiv>
+            {items.length > 0 && (
+              <PedagogicalDocumentsList
+                items={items}
+                showChildrenNames={moreThanOneChild}
+                onRead={onRead}
+                onAttachmentUnavailable={onAttachmentUnavailable}
+              />
+            )}
+          </ContentArea>
+        </Mobile>
+        <Desktop>
+          <ContentArea opaque paddingVertical="L">
+            <H1 noMargin>{t.pedagogicalDocuments.title}</H1>
+            <p>{t.pedagogicalDocuments.description}</p>
+            {items.length > 0 && (
+              <PedagogicalDocumentsTable
+                items={items}
+                showChildrenNames={moreThanOneChild}
+                onRead={onRead}
+                onAttachmentUnavailable={onAttachmentUnavailable}
+              />
+            )}
+          </ContentArea>
+        </Desktop>
+      </>
+    )
+  }
+)
+
+const PedagogicalDocumentsList = React.memo(function PedagogicalDocumentsList({
+  items,
+  showChildrenNames,
+  onRead,
+  onAttachmentUnavailable
+}: {
+  items: PedagogicalDocumentCitizen[]
+  showChildrenNames: boolean
+  onRead: (doc: PedagogicalDocumentCitizen) => void
+  onAttachmentUnavailable: () => void
+}) {
+  return (
+    <>
+      {items.map((item) => (
+        <ListItem key={item.id} documentIsRead={item.isRead} spacing="xs">
+          <ListItemHead>
+            <span>{LocalDate.fromSystemTzDate(item.created).format()}</span>
+            {showChildrenNames && (
+              <span>{item.childPreferredName || item.childFirstName}</span>
+            )}
+          </ListItemHead>
+          <ItemDescription
+            item={item}
+            clampLines={1}
+            dataQa={`pedagogical-document-list-description-${item.id}`}
+          />
+          <Attachment
+            item={item}
+            onRead={onRead}
+            onAttachmentUnavailable={onAttachmentUnavailable}
+            dataQa={`pedagogical-document-list-attachment-${item.id}`}
+          />
+          <AttachmentDownloadButton
+            item={item}
+            onRead={onRead}
+            onAttachmentUnavailable={onAttachmentUnavailable}
+            dataQa={`pedagogical-document-list-attachment-download-${item.id}`}
+          />
+        </ListItem>
+      ))}
+    </>
+  )
+})
+
+const PedagogicalDocumentsTable = React.memo(
+  function PedagogicalDocumentsTable({
+    items,
+    showChildrenNames,
+    onRead,
+    onAttachmentUnavailable
+  }: {
+    items: PedagogicalDocumentCitizen[]
+    showChildrenNames: boolean
+    onRead: (doc: PedagogicalDocumentCitizen) => void
+    onAttachmentUnavailable: () => void
+  }) {
+    const t = useTranslation()
+    return (
+      <Table>
+        <Thead>
+          <Tr>
+            <Th>{t.pedagogicalDocuments.table.date}</Th>
+            {showChildrenNames && <Th>{t.pedagogicalDocuments.table.child}</Th>}
+            <Th>{t.pedagogicalDocuments.table.description}</Th>
+            <Th>{t.pedagogicalDocuments.table.document}</Th>
+            <Th />
+          </Tr>
+        </Thead>
+        <Tbody>
+          {items.map((item) => (
+            <ItemTr key={item.id} documentIsRead={item.isRead}>
+              <DateTd data-qa={`pedagogical-document-date-${item.id}`}>
+                {LocalDate.fromSystemTzDate(item.created).format()}
+              </DateTd>
+              {showChildrenNames && (
+                <Td data-qa={`pedagogical-document-child-name-${item.id}`}>
+                  <div>{item.childPreferredName || item.childFirstName}</div>
+                </Td>
+              )}
+              <DescriptionTd>
+                <ItemDescription
+                  item={item}
+                  clampLines={3}
+                  dataQa={`pedagogical-document-description-${item.id}`}
+                />
+              </DescriptionTd>
+              <NameTd>
+                <Attachment
+                  item={item}
+                  onRead={onRead}
+                  onAttachmentUnavailable={onAttachmentUnavailable}
+                  dataQa={`pedagogical-document-attachment-${item.id}`}
+                />
+              </NameTd>
+              <ActionsTd>
+                <AttachmentDownloadButton
+                  item={item}
+                  onRead={onRead}
+                  onAttachmentUnavailable={onAttachmentUnavailable}
+                  dataQa={`pedagogical-document-attachment-download-${item.id}`}
+                />
+              </ActionsTd>
+            </ItemTr>
+          ))}
+        </Tbody>
+      </Table>
+    )
+  }
+)
 
 export default React.memo(function PedagogicalDocuments() {
   const t = useTranslation()
@@ -57,248 +320,16 @@ export default React.memo(function PedagogicalDocuments() {
     void markPedagogicalDocumentRead(doc.id).then(loadData)
   }
 
-  const Attachment = React.memo(function Attachment({
-    item,
-    dataQa
-  }: {
-    item: PedagogicalDocumentCitizen
-    dataQa: string
-  }) {
-    return (
-      <>
-        {item && item.attachment && (
-          <FileDownloadButton
-            key={item.attachment.id}
-            file={item.attachment}
-            fileFetchFn={getAttachmentBlob}
-            afterFetch={() => onRead(item)}
-            onFileUnavailable={onAttachmentUnavailable}
-            icon
-            data-qa={dataQa}
-            openInBrowser={true}
-          />
-        )}
-      </>
-    )
-  })
-
-  const AttachmentDownloadButton = React.memo(
-    function AttachmentDownloadButton({
-      item,
-      dataQa
-    }: {
-      item: PedagogicalDocumentCitizen
-      dataQa: string
-    }) {
-      return (
-        <>
-          {item.attachment && (
-            <FileDownloadButton
-              key={item.attachment.id}
-              file={item.attachment}
-              fileFetchFn={getAttachmentBlob}
-              afterFetch={() => onRead(item)}
-              onFileUnavailable={onAttachmentUnavailable}
-              icon={faArrowDown}
-              data-qa={dataQa}
-              text={t.fileDownload.download}
-            />
-          )}
-        </>
-      )
-    }
-  )
-
-  const ItemDescription = React.memo(function ItemDescription({
-    item,
-    clampLines,
-    dataQa
-  }: {
-    item: PedagogicalDocumentCitizen
-    clampLines: number
-    dataQa: string
-  }) {
-    const [expanded, setExpanded] = useState(false)
-
-    const toggleExpanded = () => {
-      setExpanded(!expanded)
-    }
-
-    // A description with more than 50 characters per line will be collapsed
-    const shouldShowExpandButton =
-      item?.description && item.description.length > 50 * clampLines
-
-    return (
-      <FixedSpaceRow spacing="xs" alignItems="end">
-        <ExpandableText
-          expanded={expanded}
-          clampLines={clampLines}
-          data-qa={dataQa}
-        >
-          {item.description}
-        </ExpandableText>
-        {shouldShowExpandButton && (
-          <IconButton
-            onClick={toggleExpanded}
-            data-qa={`${dataQa}-button`}
-            icon={expanded ? faChevronUp : faChevronDown}
-            altText={t.pedagogicalDocuments.toggleExpandText}
-          />
-        )}
-      </FixedSpaceRow>
-    )
-  })
-
-  const PedagogicalDocumentsDisplay = React.memo(
-    function PedagogicalDocumentsDisplay({
-      items
-    }: {
-      items: PedagogicalDocumentCitizen[]
-    }) {
-      const moreThanOneChild =
-        items.reduce(
-          (childIds, doc) =>
-            childIds.includes(doc.childId)
-              ? childIds
-              : [...childIds, doc.childId],
-          [] as string[]
-        ).length > 1
-      return (
-        <>
-          <Mobile>
-            <ContentArea opaque paddingVertical="L" paddingHorizontal="zero">
-              <PaddedDiv>
-                <H1 noMargin>{t.pedagogicalDocuments.title}</H1>
-                <p>{t.pedagogicalDocuments.description}</p>
-              </PaddedDiv>
-              {items.length > 0 && (
-                <PedagogicalDocumentsList
-                  items={items}
-                  showChildrenNames={moreThanOneChild}
-                />
-              )}
-            </ContentArea>
-          </Mobile>
-          <Desktop>
-            <ContentArea opaque paddingVertical="L">
-              <H1 noMargin>{t.pedagogicalDocuments.title}</H1>
-              <p>{t.pedagogicalDocuments.description}</p>
-              {items.length > 0 && (
-                <PedagogicalDocumentsTable
-                  items={items}
-                  showChildrenNames={moreThanOneChild}
-                />
-              )}
-            </ContentArea>
-          </Desktop>
-        </>
-      )
-    }
-  )
-
-  const PedagogicalDocumentsList = React.memo(
-    function PedagogicalDocumentsList({
-      items,
-      showChildrenNames
-    }: {
-      items: PedagogicalDocumentCitizen[]
-      showChildrenNames: boolean
-    }) {
-      return (
-        <>
-          {items.map((item) => (
-            <ListItem key={item.id} documentIsRead={item.isRead} spacing="xs">
-              <ListItemHead>
-                <span>{LocalDate.fromSystemTzDate(item.created).format()}</span>
-                {showChildrenNames && (
-                  <span>{item.childPreferredName || item.childFirstName}</span>
-                )}
-              </ListItemHead>
-              <ItemDescription
-                item={item}
-                clampLines={1}
-                dataQa={`pedagogical-document-list-description-${item.id}`}
-              />
-              <Attachment
-                item={item}
-                dataQa={`pedagogical-document-list-attachment-${item.id}`}
-              />
-              <AttachmentDownloadButton
-                item={item}
-                dataQa={`pedagogical-document-list-attachment-download-${item.id}`}
-              />
-            </ListItem>
-          ))}
-        </>
-      )
-    }
-  )
-
-  const PedagogicalDocumentsTable = React.memo(
-    function PedagogicalDocumentsTable({
-      items,
-      showChildrenNames
-    }: {
-      items: PedagogicalDocumentCitizen[]
-      showChildrenNames: boolean
-    }) {
-      return (
-        <Table>
-          <Thead>
-            <Tr>
-              <Th>{t.pedagogicalDocuments.table.date}</Th>
-              {showChildrenNames && (
-                <Th>{t.pedagogicalDocuments.table.child}</Th>
-              )}
-              <Th>{t.pedagogicalDocuments.table.description}</Th>
-              <Th>{t.pedagogicalDocuments.table.document}</Th>
-              <Th />
-            </Tr>
-          </Thead>
-          <Tbody>
-            {items.map((item) => (
-              <ItemTr key={item.id} documentIsRead={item.isRead}>
-                <DateTd data-qa={`pedagogical-document-date-${item.id}`}>
-                  {LocalDate.fromSystemTzDate(item.created).format()}
-                </DateTd>
-                {showChildrenNames && (
-                  <Td data-qa={`pedagogical-document-child-name-${item.id}`}>
-                    <div>{item.childPreferredName || item.childFirstName}</div>
-                  </Td>
-                )}
-                <DescriptionTd>
-                  <ItemDescription
-                    item={item}
-                    clampLines={3}
-                    dataQa={`pedagogical-document-description-${item.id}`}
-                  />
-                </DescriptionTd>
-                <NameTd>
-                  <Attachment
-                    item={item}
-                    dataQa={`pedagogical-document-attachment-${item.id}`}
-                  />
-                </NameTd>
-                <ActionsTd>
-                  <AttachmentDownloadButton
-                    item={item}
-                    dataQa={`pedagogical-document-attachment-download-${item.id}`}
-                  />
-                </ActionsTd>
-              </ItemTr>
-            ))}
-          </Tbody>
-        </Table>
-      )
-    }
-  )
-
   return (
     <>
       <Container>
         <Gap size="s" />
         {renderResult(pedagogicalDocuments, (items) => (
-          <PedagogicalDocumentsDisplay items={items} />
+          <PedagogicalDocumentsDisplay
+            items={items}
+            onRead={onRead}
+            onAttachmentUnavailable={onAttachmentUnavailable}
+          />
         ))}
       </Container>
     </>

--- a/frontend/src/citizen-frontend/pedagogical-documents/PedagogicalDocuments.tsx
+++ b/frontend/src/citizen-frontend/pedagogical-documents/PedagogicalDocuments.tsx
@@ -26,7 +26,7 @@ import {
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import { renderResult } from '../async-rendering'
 
-export default function PedagogicalDocuments() {
+export default React.memo(function PedagogicalDocuments() {
   const t = useTranslation()
   const [pedagogicalDocuments, loadData] = useApiState(
     getPedagogicalDocuments,
@@ -57,13 +57,13 @@ export default function PedagogicalDocuments() {
     void markPedagogicalDocumentRead(doc.id).then(loadData)
   }
 
-  const Attachment = ({
+  const Attachment = React.memo(function Attachment({
     item,
     dataQa
   }: {
     item: PedagogicalDocumentCitizen
     dataQa: string
-  }) => {
+  }) {
     return (
       <>
         {item && item.attachment && (
@@ -80,34 +80,36 @@ export default function PedagogicalDocuments() {
         )}
       </>
     )
-  }
+  })
 
-  const AttachmentDownloadButton = ({
-    item,
-    dataQa
-  }: {
-    item: PedagogicalDocumentCitizen
-    dataQa: string
-  }) => {
-    return (
-      <>
-        {item.attachment && (
-          <FileDownloadButton
-            key={item.attachment.id}
-            file={item.attachment}
-            fileFetchFn={getAttachmentBlob}
-            afterFetch={() => onRead(item)}
-            onFileUnavailable={onAttachmentUnavailable}
-            icon={faArrowDown}
-            data-qa={dataQa}
-            text={t.fileDownload.download}
-          />
-        )}
-      </>
-    )
-  }
+  const AttachmentDownloadButton = React.memo(
+    function AttachmentDownloadButton({
+      item,
+      dataQa
+    }: {
+      item: PedagogicalDocumentCitizen
+      dataQa: string
+    }) {
+      return (
+        <>
+          {item.attachment && (
+            <FileDownloadButton
+              key={item.attachment.id}
+              file={item.attachment}
+              fileFetchFn={getAttachmentBlob}
+              afterFetch={() => onRead(item)}
+              onFileUnavailable={onAttachmentUnavailable}
+              icon={faArrowDown}
+              data-qa={dataQa}
+              text={t.fileDownload.download}
+            />
+          )}
+        </>
+      )
+    }
+  )
 
-  const ItemDescription = ({
+  const ItemDescription = React.memo(function ItemDescription({
     item,
     clampLines,
     dataQa
@@ -115,7 +117,7 @@ export default function PedagogicalDocuments() {
     item: PedagogicalDocumentCitizen
     clampLines: number
     dataQa: string
-  }) => {
+  }) {
     const [expanded, setExpanded] = useState(false)
 
     const toggleExpanded = () => {
@@ -145,143 +147,151 @@ export default function PedagogicalDocuments() {
         )}
       </FixedSpaceRow>
     )
-  }
+  })
 
-  const PedagogicalDocumentsDisplay = ({
-    items
-  }: {
-    items: PedagogicalDocumentCitizen[]
-  }) => {
-    const moreThanOneChild =
-      items.reduce(
-        (childIds, doc) =>
-          childIds.includes(doc.childId)
-            ? childIds
-            : [...childIds, doc.childId],
-        [] as string[]
-      ).length > 1
-    return (
-      <>
-        <Mobile>
-          <ContentArea opaque paddingVertical="L" paddingHorizontal="zero">
-            <PaddedDiv>
+  const PedagogicalDocumentsDisplay = React.memo(
+    function PedagogicalDocumentsDisplay({
+      items
+    }: {
+      items: PedagogicalDocumentCitizen[]
+    }) {
+      const moreThanOneChild =
+        items.reduce(
+          (childIds, doc) =>
+            childIds.includes(doc.childId)
+              ? childIds
+              : [...childIds, doc.childId],
+          [] as string[]
+        ).length > 1
+      return (
+        <>
+          <Mobile>
+            <ContentArea opaque paddingVertical="L" paddingHorizontal="zero">
+              <PaddedDiv>
+                <H1 noMargin>{t.pedagogicalDocuments.title}</H1>
+                <p>{t.pedagogicalDocuments.description}</p>
+              </PaddedDiv>
+              {items.length > 0 && (
+                <PedagogicalDocumentsList
+                  items={items}
+                  showChildrenNames={moreThanOneChild}
+                />
+              )}
+            </ContentArea>
+          </Mobile>
+          <Desktop>
+            <ContentArea opaque paddingVertical="L">
               <H1 noMargin>{t.pedagogicalDocuments.title}</H1>
               <p>{t.pedagogicalDocuments.description}</p>
-            </PaddedDiv>
-            {items.length > 0 && (
-              <PedagogicalDocumentsList
-                items={items}
-                showChildrenNames={moreThanOneChild}
-              />
-            )}
-          </ContentArea>
-        </Mobile>
-        <Desktop>
-          <ContentArea opaque paddingVertical="L">
-            <H1 noMargin>{t.pedagogicalDocuments.title}</H1>
-            <p>{t.pedagogicalDocuments.description}</p>
-            {items.length > 0 && (
-              <PedagogicalDocumentsTable
-                items={items}
-                showChildrenNames={moreThanOneChild}
-              />
-            )}
-          </ContentArea>
-        </Desktop>
-      </>
-    )
-  }
-
-  const PedagogicalDocumentsList = ({
-    items,
-    showChildrenNames
-  }: {
-    items: PedagogicalDocumentCitizen[]
-    showChildrenNames: boolean
-  }) => {
-    return (
-      <>
-        {items.map((item) => (
-          <ListItem key={item.id} documentIsRead={item.isRead} spacing="xs">
-            <ListItemHead>
-              <span>{LocalDate.fromSystemTzDate(item.created).format()}</span>
-              {showChildrenNames && (
-                <span>{item.childPreferredName || item.childFirstName}</span>
+              {items.length > 0 && (
+                <PedagogicalDocumentsTable
+                  items={items}
+                  showChildrenNames={moreThanOneChild}
+                />
               )}
-            </ListItemHead>
-            <ItemDescription
-              item={item}
-              clampLines={1}
-              dataQa={`pedagogical-document-list-description-${item.id}`}
-            />
-            <Attachment
-              item={item}
-              dataQa={`pedagogical-document-list-attachment-${item.id}`}
-            />
-            <AttachmentDownloadButton
-              item={item}
-              dataQa={`pedagogical-document-list-attachment-download-${item.id}`}
-            />
-          </ListItem>
-        ))}
-      </>
-    )
-  }
+            </ContentArea>
+          </Desktop>
+        </>
+      )
+    }
+  )
 
-  const PedagogicalDocumentsTable = ({
-    items,
-    showChildrenNames
-  }: {
-    items: PedagogicalDocumentCitizen[]
-    showChildrenNames: boolean
-  }) => {
-    return (
-      <Table>
-        <Thead>
-          <Tr>
-            <Th>{t.pedagogicalDocuments.table.date}</Th>
-            {showChildrenNames && <Th>{t.pedagogicalDocuments.table.child}</Th>}
-            <Th>{t.pedagogicalDocuments.table.description}</Th>
-            <Th>{t.pedagogicalDocuments.table.document}</Th>
-            <Th />
-          </Tr>
-        </Thead>
-        <Tbody>
+  const PedagogicalDocumentsList = React.memo(
+    function PedagogicalDocumentsList({
+      items,
+      showChildrenNames
+    }: {
+      items: PedagogicalDocumentCitizen[]
+      showChildrenNames: boolean
+    }) {
+      return (
+        <>
           {items.map((item) => (
-            <ItemTr key={item.id} documentIsRead={item.isRead}>
-              <DateTd data-qa={`pedagogical-document-date-${item.id}`}>
-                {LocalDate.fromSystemTzDate(item.created).format()}
-              </DateTd>
-              {showChildrenNames && (
-                <Td data-qa={`pedagogical-document-child-name-${item.id}`}>
-                  <div>{item.childPreferredName || item.childFirstName}</div>
-                </Td>
-              )}
-              <DescriptionTd>
-                <ItemDescription
-                  item={item}
-                  clampLines={3}
-                  dataQa={`pedagogical-document-description-${item.id}`}
-                />
-              </DescriptionTd>
-              <NameTd>
-                <Attachment
-                  item={item}
-                  dataQa={`pedagogical-document-attachment-${item.id}`}
-                />
-              </NameTd>
-              <ActionsTd>
-                <AttachmentDownloadButton
-                  item={item}
-                  dataQa={`pedagogical-document-attachment-download-${item.id}`}
-                />
-              </ActionsTd>
-            </ItemTr>
+            <ListItem key={item.id} documentIsRead={item.isRead} spacing="xs">
+              <ListItemHead>
+                <span>{LocalDate.fromSystemTzDate(item.created).format()}</span>
+                {showChildrenNames && (
+                  <span>{item.childPreferredName || item.childFirstName}</span>
+                )}
+              </ListItemHead>
+              <ItemDescription
+                item={item}
+                clampLines={1}
+                dataQa={`pedagogical-document-list-description-${item.id}`}
+              />
+              <Attachment
+                item={item}
+                dataQa={`pedagogical-document-list-attachment-${item.id}`}
+              />
+              <AttachmentDownloadButton
+                item={item}
+                dataQa={`pedagogical-document-list-attachment-download-${item.id}`}
+              />
+            </ListItem>
           ))}
-        </Tbody>
-      </Table>
-    )
-  }
+        </>
+      )
+    }
+  )
+
+  const PedagogicalDocumentsTable = React.memo(
+    function PedagogicalDocumentsTable({
+      items,
+      showChildrenNames
+    }: {
+      items: PedagogicalDocumentCitizen[]
+      showChildrenNames: boolean
+    }) {
+      return (
+        <Table>
+          <Thead>
+            <Tr>
+              <Th>{t.pedagogicalDocuments.table.date}</Th>
+              {showChildrenNames && (
+                <Th>{t.pedagogicalDocuments.table.child}</Th>
+              )}
+              <Th>{t.pedagogicalDocuments.table.description}</Th>
+              <Th>{t.pedagogicalDocuments.table.document}</Th>
+              <Th />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {items.map((item) => (
+              <ItemTr key={item.id} documentIsRead={item.isRead}>
+                <DateTd data-qa={`pedagogical-document-date-${item.id}`}>
+                  {LocalDate.fromSystemTzDate(item.created).format()}
+                </DateTd>
+                {showChildrenNames && (
+                  <Td data-qa={`pedagogical-document-child-name-${item.id}`}>
+                    <div>{item.childPreferredName || item.childFirstName}</div>
+                  </Td>
+                )}
+                <DescriptionTd>
+                  <ItemDescription
+                    item={item}
+                    clampLines={3}
+                    dataQa={`pedagogical-document-description-${item.id}`}
+                  />
+                </DescriptionTd>
+                <NameTd>
+                  <Attachment
+                    item={item}
+                    dataQa={`pedagogical-document-attachment-${item.id}`}
+                  />
+                </NameTd>
+                <ActionsTd>
+                  <AttachmentDownloadButton
+                    item={item}
+                    dataQa={`pedagogical-document-attachment-download-${item.id}`}
+                  />
+                </ActionsTd>
+              </ItemTr>
+            ))}
+          </Tbody>
+        </Table>
+      )
+    }
+  )
 
   return (
     <>
@@ -293,7 +303,7 @@ export default function PedagogicalDocuments() {
       </Container>
     </>
   )
-}
+})
 
 const ItemTr = styled(Tr)`
   font-weight: ${(props: { documentIsRead: boolean }) =>

--- a/frontend/src/citizen-frontend/pedagogical-documents/PedagogicalDocuments.tsx
+++ b/frontend/src/citizen-frontend/pedagogical-documents/PedagogicalDocuments.tsx
@@ -152,6 +152,14 @@ export default function PedagogicalDocuments() {
   }: {
     items: PedagogicalDocumentCitizen[]
   }) => {
+    const moreThanOneChild =
+      items.reduce(
+        (childIds, doc) =>
+          childIds.includes(doc.childId)
+            ? childIds
+            : [...childIds, doc.childId],
+        [] as string[]
+      ).length > 1
     return (
       <>
         <Mobile>
@@ -160,14 +168,24 @@ export default function PedagogicalDocuments() {
               <H1 noMargin>{t.pedagogicalDocuments.title}</H1>
               <p>{t.pedagogicalDocuments.description}</p>
             </PaddedDiv>
-            {items.length > 0 && <PedagogicalDocumentsList items={items} />}
+            {items.length > 0 && (
+              <PedagogicalDocumentsList
+                items={items}
+                showChildrenNames={moreThanOneChild}
+              />
+            )}
           </ContentArea>
         </Mobile>
         <Desktop>
           <ContentArea opaque paddingVertical="L">
             <H1 noMargin>{t.pedagogicalDocuments.title}</H1>
             <p>{t.pedagogicalDocuments.description}</p>
-            {items.length > 0 && <PedagogicalDocumentsTable items={items} />}
+            {items.length > 0 && (
+              <PedagogicalDocumentsTable
+                items={items}
+                showChildrenNames={moreThanOneChild}
+              />
+            )}
           </ContentArea>
         </Desktop>
       </>
@@ -175,15 +193,22 @@ export default function PedagogicalDocuments() {
   }
 
   const PedagogicalDocumentsList = ({
-    items
+    items,
+    showChildrenNames
   }: {
     items: PedagogicalDocumentCitizen[]
+    showChildrenNames: boolean
   }) => {
     return (
       <>
         {items.map((item) => (
           <ListItem key={item.id} documentIsRead={item.isRead} spacing="xs">
-            <div>{LocalDate.fromSystemTzDate(item.created).format()}</div>
+            <ListItemHead>
+              <span>{LocalDate.fromSystemTzDate(item.created).format()}</span>
+              {showChildrenNames && (
+                <span>{item.childPreferredName || item.childFirstName}</span>
+              )}
+            </ListItemHead>
             <ItemDescription
               item={item}
               clampLines={1}
@@ -204,15 +229,18 @@ export default function PedagogicalDocuments() {
   }
 
   const PedagogicalDocumentsTable = ({
-    items
+    items,
+    showChildrenNames
   }: {
     items: PedagogicalDocumentCitizen[]
+    showChildrenNames: boolean
   }) => {
     return (
       <Table>
         <Thead>
           <Tr>
             <Th>{t.pedagogicalDocuments.table.date}</Th>
+            {showChildrenNames && <Th>{t.pedagogicalDocuments.table.child}</Th>}
             <Th>{t.pedagogicalDocuments.table.description}</Th>
             <Th>{t.pedagogicalDocuments.table.document}</Th>
             <Th />
@@ -224,6 +252,11 @@ export default function PedagogicalDocuments() {
               <DateTd data-qa={`pedagogical-document-date-${item.id}`}>
                 {LocalDate.fromSystemTzDate(item.created).format()}
               </DateTd>
+              {showChildrenNames && (
+                <Td data-qa={`pedagogical-document-child-name-${item.id}`}>
+                  <div>{item.childPreferredName || item.childFirstName}</div>
+                </Td>
+              )}
               <DescriptionTd>
                 <ItemDescription
                   item={item}
@@ -320,6 +353,13 @@ const ListItem = styled(FixedSpaceColumn)`
   & > div {
     font-weight: ${(props: { documentIsRead: boolean }) =>
       props.documentIsRead ? fontWeights.normal : fontWeights.semibold};
+  }
+`
+
+const ListItemHead = styled.div`
+  display: flex;
+  & > :first-child {
+    flex: 1;
   }
 `
 

--- a/frontend/src/e2e-playwright/pages/citizen/citizen-pedagogical-documents.ts
+++ b/frontend/src/e2e-playwright/pages/citizen/citizen-pedagogical-documents.ts
@@ -3,13 +3,15 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Page } from 'playwright'
-import { waitUntilEqual, waitUntilFalse } from '../../utils'
+import { waitUntilEqual, waitUntilFalse, waitUntilTrue } from '../../utils'
 
 export default class CitizenPedagogicalDocumentsPage {
   constructor(private readonly page: Page) {}
 
   readonly #date = (id: string) =>
     this.page.locator(`[data-qa="pedagogical-document-date-${id}"]`)
+  readonly #childName = (id: string) =>
+    this.page.locator(`[data-qa="pedagogical-document-child-name-${id}"]`)
   readonly #description = (id: string) =>
     this.page.locator(`[data-qa="pedagogical-document-description-${id}"]`)
   readonly #downloadAttachment = (id: string) =>
@@ -45,5 +47,17 @@ export default class CitizenPedagogicalDocumentsPage {
 
   async downloadAttachment(id: string) {
     await this.#downloadAttachment(id).click()
+  }
+
+  async assertChildNameIsNotShown(id: string) {
+    await waitUntilFalse(() => this.#childName(id).isVisible())
+  }
+
+  async assertChildNameIsShown(id: string) {
+    await waitUntilTrue(() => this.#childName(id).isVisible())
+  }
+
+  async assertChildNameIs(id: string, expectedName: string) {
+    await waitUntilEqual(() => this.#childName(id).innerText(), expectedName)
   }
 }

--- a/frontend/src/e2e-playwright/pages/citizen/citizen-pedagogical-documents.ts
+++ b/frontend/src/e2e-playwright/pages/citizen/citizen-pedagogical-documents.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Page } from 'playwright'
-import { waitUntilEqual, waitUntilFalse, waitUntilTrue } from '../../utils'
+import { waitUntilEqual } from '../../utils'
 
 export default class CitizenPedagogicalDocumentsPage {
   constructor(private readonly page: Page) {}
@@ -30,7 +30,7 @@ export default class CitizenPedagogicalDocumentsPage {
   }
 
   async assertUnreadPedagogicalDocumentIndicatorIsNotShown() {
-    await waitUntilFalse(() => this.#unreadDocumentCount.isVisible())
+    await this.#unreadDocumentCount.waitFor({ state: 'hidden' })
   }
 
   async assertPedagogicalDocumentExists(
@@ -50,11 +50,11 @@ export default class CitizenPedagogicalDocumentsPage {
   }
 
   async assertChildNameIsNotShown(id: string) {
-    await waitUntilFalse(() => this.#childName(id).isVisible())
+    await this.#childName(id).waitFor({ state: 'hidden' })
   }
 
   async assertChildNameIsShown(id: string) {
-    await waitUntilTrue(() => this.#childName(id).isVisible())
+    await this.#childName(id).waitFor({ state: 'visible' })
   }
 
   async assertChildNameIs(id: string, expectedName: string) {

--- a/frontend/src/e2e-playwright/specs/0_citizen/citizen-pedagogical-documents.spec.ts
+++ b/frontend/src/e2e-playwright/specs/0_citizen/citizen-pedagogical-documents.spec.ts
@@ -91,5 +91,68 @@ describe('Citizen pedagogical documents', () => {
         pd.data.description
       )
     })
+
+    test('Childrens names are not shown if only documents for one child exist', async () => {
+      const pd = await Fixture.pedagogicalDocument()
+        .with({
+          childId: fixtures.enduserChildFixtureJari.id,
+          description: 'e2e test description'
+        })
+        .save()
+
+      await header.selectTab('pedagogical-documents')
+
+      await pedagogicalDocumentsPage.assertChildNameIsNotShown(pd.data.id)
+    })
+
+    test('Childrens names are shown if documents for more than one child exist', async () => {
+      const pd = await Fixture.pedagogicalDocument()
+        .with({
+          childId: fixtures.enduserChildFixtureJari.id,
+          description: 'e2e test description'
+        })
+        .save()
+      const pd2 = await Fixture.pedagogicalDocument()
+        .with({
+          childId: fixtures.enduserChildFixtureKaarina.id,
+          description: 'e2e test description too'
+        })
+        .save()
+
+      await header.selectTab('pedagogical-documents')
+
+      await pedagogicalDocumentsPage.assertChildNameIsShown(pd.data.id)
+      await pedagogicalDocumentsPage.assertChildNameIsShown(pd2.data.id)
+    })
+
+    test('Childrens preferred names are shown if known', async () => {
+      const pd = await Fixture.pedagogicalDocument()
+        .with({
+          childId: fixtures.enduserChildFixtureJari.id,
+          description: 'e2e test description'
+        })
+        .save()
+      await Fixture.child(fixtures.enduserChildFixtureJari.id)
+        .with({
+          preferredName: 'Jari'
+        })
+        .save()
+      const pd2 = await Fixture.pedagogicalDocument()
+        .with({
+          childId: fixtures.enduserChildFixtureKaarina.id,
+          description: 'e2e test description too'
+        })
+        .save()
+
+      await header.selectTab('pedagogical-documents')
+
+      // Jari has a preferred name
+      await pedagogicalDocumentsPage.assertChildNameIs(pd.data.id, 'Jari')
+      // Kaarina does not have any preferred name
+      await pedagogicalDocumentsPage.assertChildNameIs(
+        pd2.data.id,
+        'Kaarina Veera Nelli'
+      )
+    })
   })
 })

--- a/frontend/src/e2e-test-common/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test-common/dev-api/fixtures.ts
@@ -30,6 +30,7 @@ import {
 } from './types'
 import {
   insertCareAreaFixtures,
+  insertChildFixtures,
   insertDaycareFixtures,
   insertDaycareGroupFixtures,
   insertDecisionFixtures,
@@ -1048,6 +1049,10 @@ export class Fixture {
       voucherValueDescriptionSv: `Test service need option ${id}`
     })
   }
+
+  static child(id: string): ChildBuilder {
+    return new ChildBuilder({ id })
+  }
 }
 
 export class DaycareBuilder {
@@ -1338,5 +1343,31 @@ export class ServiceNeedBuilder {
   // Note: shallow copy
   copy(): ServiceNeedBuilder {
     return new ServiceNeedBuilder({ ...this.data })
+  }
+}
+
+export class ChildBuilder {
+  data: Child
+
+  constructor(data: Child) {
+    this.data = data
+  }
+
+  with(value: Partial<Child>): ChildBuilder {
+    this.data = {
+      ...this.data,
+      ...value
+    }
+    return this
+  }
+
+  async save(): Promise<ChildBuilder> {
+    await insertChildFixtures([this.data])
+    return this
+  }
+
+  // Note: shallow copy
+  copy(): ChildBuilder {
+    return new ChildBuilder({ ...this.data })
   }
 }

--- a/frontend/src/e2e-test-common/dev-api/types.ts
+++ b/frontend/src/e2e-test-common/dev-api/types.ts
@@ -217,6 +217,7 @@ export interface DaycareCaretakers {
 
 export interface Child {
   id: UUID
+  preferredName?: string
   allergies?: string
   diet?: string
   medication?: string

--- a/frontend/src/lib-common/generated/api-types/pedagogicaldocument.ts
+++ b/frontend/src/lib-common/generated/api-types/pedagogicaldocument.ts
@@ -33,7 +33,9 @@ export interface PedagogicalDocument {
 */
 export interface PedagogicalDocumentCitizen {
   attachment: Attachment | null
+  childFirstName: string
   childId: UUID
+  childPreferredName: string | null
   created: Date
   description: string | null
   id: UUID

--- a/frontend/src/lib-components/layout/Table.tsx
+++ b/frontend/src/lib-components/layout/Table.tsx
@@ -18,7 +18,7 @@ export const Table = styled.table`
   background-color: ${({ theme: { colors } }) => colors.greyscale.white};
   color: ${({ theme: { colors } }) => colors.greyscale.darkest};
   width: 100%;
-  border-collapse: separate;
+  border-collapse: collapse;
 `
 
 interface ThProps {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1691,11 +1691,12 @@ const en: Translations = {
     }
   },
   pedagogicalDocuments: {
-    title: 'Kasvu ja oppiminen',
+    title: 'Growth and learning',
     description:
-      'Tälle sivulle kootaan lapsen kasvuun, oppimiseen ja päiväkotiarkeen liittyviä kuvia ja muita dokumentteja.',
+      'Documents and photos relating to the growth and learning of the child are gathered on this page.',
     table: {
       date: 'Date',
+      child: 'Child',
       document: 'Document',
       description: 'Description'
     },

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1628,6 +1628,7 @@ export default {
       'Tälle sivulle kootaan lapsen kasvuun, oppimiseen ja päiväkotiarkeen liittyviä kuvia ja muita dokumentteja.',
     table: {
       date: 'Päivämäärä',
+      child: 'Lapsi',
       document: 'Dokumentti',
       description: 'Kuvaus'
     },

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1647,11 +1647,12 @@ const sv: Translations = {
     }
   },
   pedagogicalDocuments: {
-    title: 'Kasvu ja oppiminen',
+    title: 'Tillväxt och inlärning',
     description:
-      'Tälle sivulle kootaan lapsen kasvuun, oppimiseen ja päiväkotiarkeen liittyviä kuvia ja muita dokumentteja.',
+      'Hit samlas dokument och bilder angående barnets/barnens tillväxt och inlärning.',
     table: {
       date: 'Datum',
+      child: 'Barn',
       document: 'Dokument',
       description: 'Beskrivning'
     },

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentControllerCitizen.kt
@@ -70,11 +70,15 @@ private fun Database.Read.findPedagogicalDocumentsByGuardian(guardianId: PersonI
                 a.id attachment_id,
                 a.name attachment_name,
                 a.content_type attachment_content_type,
-                pdr.read_at is not null is_read
+                pdr.read_at is not null is_read,
+                chp.first_name,
+                ch.preferred_name
             FROM pedagogical_document pd
             JOIN guardian g ON pd.child_id = g.child_id
             LEFT JOIN attachment a ON a.pedagogical_document_id = pd.id
             LEFT JOIN pedagogical_document_read pdr ON pd.id = pdr.pedagogical_document_id AND pdr.person_id = g.guardian_id
+            LEFT JOIN person chp ON chp.id = pd.child_id
+            LEFT JOIN child ch ON ch.id = pd.child_id
             WHERE g.guardian_id = :guardian_id
             AND (pd.description IS NOT NULL OR a.id IS NOT NULL)
             ORDER BY pd.created DESC
@@ -141,7 +145,9 @@ data class PedagogicalDocumentCitizen(
     val description: String?,
     val attachment: Attachment?,
     val created: HelsinkiDateTime,
-    val isRead: Boolean
+    val isRead: Boolean,
+    val childFirstName: String,
+    val childPreferredName: String?
 )
 
 fun mapPedagogicalDocumentCitizen(row: RowView): PedagogicalDocumentCitizen? {
@@ -158,6 +164,9 @@ fun mapPedagogicalDocumentCitizen(row: RowView): PedagogicalDocumentCitizen? {
             contentType = row.mapColumn("attachment_content_type"),
         ) else null,
         created = row.mapColumn("created"),
-        isRead = row.mapColumn("is_read")
+        isRead = row.mapColumn("is_read"),
+        childFirstName = row.mapColumn("first_name"),
+        childPreferredName = row.mapColumn("preferred_name")
+
     )
 }


### PR DESCRIPTION
#### Summary

Shows the preferred name or first names of the child on each document row if there are documents pertaining to more than one child.

This PR also removes the small gap between table columns and memoizes the Pedagogical Documents view on the citizen side.
