### PR TITLE
EVAKA time inputs

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -11,7 +11,7 @@ import {
 import Radio from 'lib-components/atoms/form/Radio'
 import { useTranslation } from '../../../localization'
 import { H3, Label, P } from 'lib-components/typography'
-import InputField from 'lib-components/atoms/form/InputField'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import { Gap } from 'lib-components/white-space'
 import FileUpload from 'lib-components/molecules/FileUpload'
 import { Result } from 'lib-common/api'
@@ -196,13 +196,11 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
               <Label htmlFor={'daily-time-starts'}>
                 {t.applications.editor.serviceNeed.dailyTime.starts}
               </Label>
-              <InputField
+              <TimeInput
                 id={'daily-time-starts'}
-                type={'time'}
                 value={formData.startTime}
                 data-qa={'startTime-input'}
                 onChange={(value) => updateFormData({ startTime: value })}
-                width={'s'}
                 info={errorToInputInfo(errors.startTime, t.validationErrors)}
                 hideErrorsBeforeTouched={!verificationRequested}
               />
@@ -214,13 +212,11 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
               <Label htmlFor={'daily-time-ends'}>
                 {t.applications.editor.serviceNeed.dailyTime.ends}
               </Label>
-              <InputField
+              <TimeInput
                 id={'daily-time-ends'}
-                type={'time'}
                 value={formData.endTime}
                 data-qa={'endTime-input'}
                 onChange={(value) => updateFormData({ endTime: value })}
-                width={'s'}
                 info={errorToInputInfo(errors.endTime, t.validationErrors)}
                 hideErrorsBeforeTouched={!verificationRequested}
               />

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -10,7 +10,7 @@ import {
 } from 'lib-components/layout/flex-helpers'
 import { useTranslation } from '../../../localization'
 import { H3, Label, P } from 'lib-components/typography'
-import InputField from 'lib-components/atoms/form/InputField'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import { Gap } from 'lib-components/white-space'
 import FileUpload from 'lib-components/molecules/FileUpload'
 import { Result } from 'lib-common/api'
@@ -127,13 +127,11 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
               <Label htmlFor={'daily-time-starts'}>
                 {t.applications.editor.serviceNeed.dailyTime.starts}
               </Label>
-              <InputField
+              <TimeInput
                 id={'daily-time-starts'}
-                type={'time'}
                 value={formData.startTime}
                 data-qa={'startTime-input'}
                 onChange={(value) => updateFormData({ startTime: value })}
-                width={'s'}
                 info={errorToInputInfo(errors.startTime, t.validationErrors)}
                 hideErrorsBeforeTouched={!verificationRequested}
               />
@@ -145,13 +143,11 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
               <Label htmlFor={'daily-time-ends'}>
                 {t.applications.editor.serviceNeed.dailyTime.ends}
               </Label>
-              <InputField
+              <TimeInput
                 id={'daily-time-ends'}
-                type={'time'}
                 value={formData.endTime}
                 data-qa={'endTime-input'}
                 onChange={(value) => updateFormData({ endTime: value })}
-                width={'s'}
                 info={errorToInputInfo(errors.endTime, t.validationErrors)}
                 hideErrorsBeforeTouched={!verificationRequested}
               />

--- a/frontend/src/citizen-frontend/applications/editor/validations.ts
+++ b/frontend/src/citizen-frontend/applications/editor/validations.ts
@@ -146,14 +146,14 @@ export const validateApplication = (
         (apiData.type === 'DAYCARE' &&
           featureFlags.daycareApplication.dailyTimesEnabled) ||
         (apiData.type === 'PRESCHOOL' && form.serviceNeed.connectedDaycare)
-          ? required(form.serviceNeed.startTime) ||
+          ? required(form.serviceNeed.startTime, 'timeRequired') ||
             regexp(form.serviceNeed.startTime, TIME_REGEXP, 'timeFormat')
           : undefined,
       endTime:
         (apiData.type === 'DAYCARE' &&
           featureFlags.daycareApplication.dailyTimesEnabled) ||
         (apiData.type === 'PRESCHOOL' && form.serviceNeed.connectedDaycare)
-          ? required(form.serviceNeed.endTime) ||
+          ? required(form.serviceNeed.endTime, 'timeRequired') ||
             regexp(form.serviceNeed.endTime, TIME_REGEXP, 'timeFormat')
           : undefined,
       assistanceDescription: form.serviceNeed.assistanceNeeded

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -571,13 +571,13 @@ function validateForm(
       startTime:
         time.startTime === ''
           ? time.endTime !== ''
-            ? 'required'
+            ? 'timeRequired'
             : undefined
           : regexp(time.startTime, TIME_REGEXP, 'timeFormat'),
       endTime:
         time.endTime === ''
           ? time.startTime !== ''
-            ? 'required'
+            ? 'timeRequired'
             : undefined
           : regexp(time.endTime, TIME_REGEXP, 'timeFormat')
     }))
@@ -590,13 +590,13 @@ function validateForm(
             startTime:
               time.startTime === ''
                 ? time.endTime !== ''
-                  ? 'required'
+                  ? 'timeRequired'
                   : undefined
                 : regexp(time.startTime, TIME_REGEXP, 'timeFormat'),
             endTime:
               time.endTime === ''
                 ? time.startTime !== ''
-                  ? 'required'
+                  ? 'timeRequired'
                   : undefined
                 : regexp(time.endTime, TIME_REGEXP, 'timeFormat')
           }))
@@ -613,13 +613,13 @@ function validateForm(
               startTime:
                 time.startTime === ''
                   ? time.endTime !== ''
-                    ? 'required'
+                    ? 'timeRequired'
                     : undefined
                   : regexp(time.startTime, TIME_REGEXP, 'timeFormat'),
               endTime:
                 time.endTime === ''
                   ? time.startTime !== ''
-                    ? 'required'
+                    ? 'timeRequired'
                     : undefined
                   : regexp(time.endTime, TIME_REGEXP, 'timeFormat')
             }))

--- a/frontend/src/e2e-playwright/pages/mobile/child-attendance-page.ts
+++ b/frontend/src/e2e-playwright/pages/mobile/child-attendance-page.ts
@@ -73,6 +73,7 @@ export default class ChildAttendancePage {
 
   // time format: "09:46"
   async setTime(time: string) {
+    await this.#setTimeInput.click()
     await this.#setTimeInput.type(time)
   }
 }

--- a/frontend/src/e2e-test/pages/employee/mobile/child-page.ts
+++ b/frontend/src/e2e-test/pages/employee/mobile/child-page.ts
@@ -73,7 +73,7 @@ export default class ChildPage {
       .eql(`${childFixture.firstName} ${childFixture.lastName}`)
 
     await t.click(this.markPresentLink)
-    await t.typeText(this.setTimeInput, time)
+    await t.typeText(this.setTimeInput, time, { replace: true })
     await t.click(this.markPresentBtn)
   }
 
@@ -93,7 +93,7 @@ export default class ChildPage {
       .eql(`${childFixture.firstName} ${childFixture.lastName}`)
 
     await t.click(this.markDepartedLink)
-    await t.typeText(this.setTimeInput, time)
+    await t.typeText(this.setTimeInput, time, { replace: true })
     await t.click(this.markDepartedBtn)
   }
 
@@ -153,7 +153,7 @@ export default class ChildPage {
       .eql(`${childFixture.firstName} ${childFixture.lastName}`)
 
     await t.click(this.markDepartedLink)
-    await t.typeText(this.setTimeInput, time)
+    await t.typeText(this.setTimeInput, time, { replace: true })
 
     await t.click(this.markAbsentRadio('SICKLEAVE'))
     await t.click(this.markDepartedWithAbsenceBtn)

--- a/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
@@ -36,7 +36,7 @@ import {
 import Button from 'lib-components/atoms/buttons/Button'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import Radio from 'lib-components/atoms/form/Radio'
-import InputField from 'lib-components/atoms/form/InputField'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import { UIContext } from '../../state/ui'
 import { NullableValues } from '../../types'
@@ -563,10 +563,9 @@ const TimeRangeInput = React.memo(function TimeRangeInput({
 }: TimeRangeInputProps) {
   return (
     <>
-      <InputField
+      <TimeInput
         value={value.start}
         onChange={(start) => onChange({ ...value, start })}
-        type="time"
         required
         data-qa={`${dataQaPrefix}-start`}
         info={
@@ -578,13 +577,11 @@ const TimeRangeInput = React.memo(function TimeRangeInput({
             : undefined
         }
         hideErrorsBeforeTouched
-        width="s"
       />
       <span> - </span>
-      <InputField
+      <TimeInput
         value={value.end}
         onChange={(end) => onChange({ ...value, end })}
-        type="time"
         required
         data-qa={`${dataQaPrefix}-end`}
         info={
@@ -596,7 +593,6 @@ const TimeRangeInput = React.memo(function TimeRangeInput({
             : undefined
         }
         hideErrorsBeforeTouched
-        width="s"
       />
     </>
   )

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
@@ -5,7 +5,7 @@
 import React, { Fragment, useMemo, useState } from 'react'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { fontWeights, H2, Label } from 'lib-components/typography'
-import InputField from 'lib-components/atoms/form/InputField'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import LocalDate from 'lib-common/local-date'
 import DatePicker, {
   DatePickerSpacer
@@ -366,9 +366,8 @@ const TimeInputs = React.memo(function TimeInputs(props: {
     <>
       {props.label}
       <FixedSpaceRow alignItems="center">
-        <InputField
+        <TimeInput
           value={timeRange.startTime ?? ''}
-          type="time"
           onChange={(value) => {
             const updatedRange = {
               startTime: value,
@@ -386,9 +385,8 @@ const TimeInputs = React.memo(function TimeInputs(props: {
           hideErrorsBeforeTouched={!props.showAllErrors}
         />
         <span>–</span>
-        <InputField
+        <TimeInput
           value={timeRange.endTime ?? ''}
-          type="time"
           onChange={(value) => {
             const updatedRange = {
               startTime: timeRange.startTime ?? '',
@@ -426,9 +424,8 @@ const TimeInputs = React.memo(function TimeInputs(props: {
         <>
           <div />
           <FixedSpaceRow alignItems="center">
-            <InputField
+            <TimeInput
               value={extraTimeRange.startTime ?? ''}
-              type="time"
               onChange={(value) =>
                 props.updateTimes([
                   timeRange,
@@ -445,9 +442,8 @@ const TimeInputs = React.memo(function TimeInputs(props: {
               hideErrorsBeforeTouched={!props.showAllErrors}
             />
             <span>–</span>
-            <InputField
+            <TimeInput
               value={extraTimeRange.endTime ?? ''}
-              type="time"
               onChange={(value) =>
                 props.updateTimes([
                   timeRange,
@@ -501,13 +497,13 @@ function validateForm(
       startTime:
         time.startTime === ''
           ? time.endTime !== ''
-            ? 'required'
+            ? 'timeRequired'
             : undefined
           : regexp(time.startTime, TIME_REGEXP, 'timeFormat'),
       endTime:
         time.endTime === ''
           ? time.startTime !== ''
-            ? 'required'
+            ? 'timeRequired'
             : undefined
           : regexp(time.endTime, TIME_REGEXP, 'timeFormat')
     }))
@@ -520,13 +516,13 @@ function validateForm(
             startTime:
               time.startTime === ''
                 ? time.endTime !== ''
-                  ? 'required'
+                  ? 'timeRequired'
                   : undefined
                 : regexp(time.startTime, TIME_REGEXP, 'timeFormat'),
             endTime:
               time.endTime === ''
                 ? time.startTime !== ''
-                  ? 'required'
+                  ? 'timeRequired'
                   : undefined
                 : regexp(time.endTime, TIME_REGEXP, 'timeFormat')
           }))
@@ -543,13 +539,13 @@ function validateForm(
               startTime:
                 time.startTime === ''
                   ? time.endTime !== ''
-                    ? 'required'
+                    ? 'timeRequired'
                     : undefined
                   : regexp(time.startTime, TIME_REGEXP, 'timeFormat'),
               endTime:
                 time.endTime === ''
                   ? time.startTime !== ''
-                    ? 'required'
+                    ? 'timeRequired'
                     : undefined
                   : regexp(time.endTime, TIME_REGEXP, 'timeFormat')
             }))

--- a/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkDeparted.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkDeparted.tsx
@@ -4,12 +4,11 @@
 
 import React, { useCallback, useContext, useMemo, useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
-import styled from 'styled-components'
 import { faArrowLeft, farStickyNote } from 'lib-icons'
 import colors from 'lib-customizations/common'
 import { formatTime, isValidTime } from 'lib-common/date'
 import { Gap } from 'lib-components/white-space'
-import InputField from 'lib-components/atoms/form/InputField'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
 import {
@@ -19,7 +18,6 @@ import {
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import { combine } from 'lib-common/api'
 import { ContentArea } from 'lib-components/layout/Container'
-import { fontWeights } from 'lib-components/typography'
 import { ChildAttendance } from 'lib-common/generated/api-types/attendance'
 import { TallContentArea } from '../../mobile/components'
 import { ChildAttendanceContext } from '../../../state/child-attendance'
@@ -37,7 +35,8 @@ import {
   Actions,
   BackButtonInline,
   CustomTitle,
-  DailyNotes
+  DailyNotes,
+  TimeWrapper
 } from '../components'
 import { AbsenceType } from '../../../types'
 import { useApiState } from 'lib-common/utils/useRestApi'
@@ -164,11 +163,9 @@ export default React.memo(function MarkDeparted() {
                 <CustomTitle>
                   {i18n.attendances.actions.markDeparted}
                 </CustomTitle>
-                <InputField
+                <TimeInput
                   onChange={setTime}
                   value={time}
-                  width="s"
-                  type="time"
                   data-qa="set-time"
                   info={
                     timeError
@@ -263,23 +260,3 @@ export default React.memo(function MarkDeparted() {
     </TallContentArea>
   )
 })
-
-const TimeWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  font-size: 20px;
-  color: ${colors.blues.dark};
-  font-weight: ${fontWeights.semibold};
-  margin-bottom: 26px;
-
-  input {
-    font-size: 60px;
-    width: 100%;
-    color: ${colors.blues.dark};
-    font-family: Montserrat, sans-serif;
-    font-weight: ${fontWeights.light};
-    border-bottom: none;
-    padding: 0;
-  }
-`

--- a/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkPresent.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkPresent.tsx
@@ -9,20 +9,20 @@ import { faArrowLeft, farStickyNote } from 'lib-icons'
 import colors from 'lib-customizations/common'
 import { formatTime, isValidTime } from 'lib-common/date'
 import { Gap } from 'lib-components/white-space'
-import InputField from 'lib-components/atoms/form/InputField'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import Title from 'lib-components/atoms/Title'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import { ContentArea } from 'lib-components/layout/Container'
-import { fontWeights } from 'lib-components/typography'
+
 import { TallContentArea } from '../../mobile/components'
 import { ChildAttendanceContext } from '../../../state/child-attendance'
 import { childArrivesPOST } from '../../../api/attendances'
 import { useTranslation } from '../../../state/i18n'
 import DailyNote from '../notes/DailyNote'
-import { Actions, BackButtonInline } from '../components'
+import { Actions, BackButtonInline, TimeWrapper } from '../components'
 import { renderResult } from '../../async-rendering'
 import { combine } from 'lib-common/api'
 
@@ -90,13 +90,7 @@ export default React.memo(function MarkPresent() {
           >
             <TimeWrapper>
               <CustomTitle>{i18n.attendances.actions.markPresent}</CustomTitle>
-              <InputField
-                onChange={setTime}
-                value={time}
-                width="s"
-                type="time"
-                data-qa="set-time"
-              />
+              <TimeInput onChange={setTime} value={time} data-qa="set-time" />
             </TimeWrapper>
             <Gap size={'xs'} />
             <Actions>
@@ -146,24 +140,6 @@ export default React.memo(function MarkPresent() {
     </TallContentArea>
   )
 })
-
-const TimeWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  font-size: 20px;
-  color: ${colors.blues.dark};
-  font-weight: ${fontWeights.semibold};
-
-  input {
-    font-size: 60px;
-    width: 100%;
-    color: ${colors.blues.dark};
-    font-family: Montserrat, sans-serif;
-    font-weight: ${fontWeights.light};
-    border-bottom: none;
-  }
-`
 
 const CustomTitle = styled(Title)`
   margin-top: 0;

--- a/frontend/src/employee-mobile-frontend/components/attendances/components.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/components.tsx
@@ -117,3 +117,20 @@ export const BackButtonInline = styled(InlineButton)`
   width: calc(100vw - 16px);
   display: flex;
 `
+
+export const TimeWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 20px;
+  color: ${colors.blues.dark};
+  font-weight: ${fontWeights.semibold};
+
+  input {
+    font-size: 60px;
+    color: ${colors.blues.dark};
+    font-family: Montserrat, sans-serif;
+    font-weight: ${fontWeights.light};
+    border-bottom: none;
+  }
+`

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/ExternalStaffMemberPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/ExternalStaffMemberPage.tsx
@@ -4,7 +4,7 @@
 
 import { formatTime } from 'lib-common/date'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
-import InputField from 'lib-components/atoms/form/InputField'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { Label } from 'lib-components/typography'
@@ -61,10 +61,8 @@ export default React.memo(function ExternalStaffMemberPage() {
                   <Label htmlFor="time-input">
                     {i18n.attendances.departureTime}
                   </Label>
-                  <InputField
+                  <TimeInput
                     id="time-input"
-                    type="time"
-                    width="s"
                     value={time}
                     onChange={(val) => setTime(val)}
                   />

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/MarkExternalStaffMemberArrivalPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/MarkExternalStaffMemberArrivalPage.tsx
@@ -5,6 +5,7 @@
 import { GroupInfo } from 'lib-common/generated/api-types/attendance'
 import Combobox from 'lib-components/atoms/form/Combobox'
 import InputField from 'lib-components/atoms/form/InputField'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import { ContentArea } from 'lib-components/layout/Container'
 import ListGrid from 'lib-components/layout/ListGrid'
@@ -82,11 +83,9 @@ export default function MarkExternalStaffMemberArrivalPage() {
         <HorizontalLine />
         <ListGrid>
           <Label>{i18n.attendances.arrivalTime}</Label>
-          <InputField
-            type="time"
+          <TimeInput
             value={form.arrived}
             onChange={(arrived) => setForm((old) => ({ ...old, arrived }))}
-            width="s"
             data-qa="input-arrived"
           />
 

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkArrivedPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkArrivedPage.tsx
@@ -8,7 +8,7 @@ import { formatTime, isValidTime } from 'lib-common/date'
 import { UUID } from 'lib-common/types'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
-import InputField from 'lib-components/atoms/form/InputField'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import SimpleSelect from 'lib-components/atoms/form/SimpleSelect'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import Title from 'lib-components/atoms/Title'
@@ -153,11 +153,9 @@ export default React.memo(function StaffMarkArrivedPage() {
                 <Gap />
                 <TimeWrapper>
                   <Label>{i18n.attendances.arrivalTime}</Label>
-                  <InputField
+                  <TimeInput
                     onChange={setTime}
                     value={time}
-                    width="s"
-                    type="time"
                     data-qa="set-time"
                     info={
                       timeInFuture

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkDepartedPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkDepartedPage.tsx
@@ -9,7 +9,7 @@ import { combine } from 'lib-common/api'
 import { formatTime, isValidTime } from 'lib-common/date'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
-import InputField from 'lib-components/atoms/form/InputField'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import Title from 'lib-components/atoms/Title'
 import { ContentArea } from 'lib-components/layout/Container'
@@ -144,11 +144,9 @@ export default React.memo(function StaffMarkDepartedPage() {
                 <Gap />
                 <TimeWrapper>
                   <Label>{i18n.attendances.departureTime}</Label>
-                  <InputField
+                  <TimeInput
                     onChange={setTime}
                     value={time}
-                    width="s"
-                    type="time"
                     data-qa="set-time"
                     info={
                       timeInFuture

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/components/staff-components.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/components/staff-components.tsx
@@ -3,28 +3,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import styled from 'styled-components'
-import { fontWeights } from 'lib-components/typography'
-import colors from 'lib-customizations/common'
+export { TimeWrapper } from '../../attendances/components'
 
 export const TimeInfo = styled.div`
   text-align: center;
   width: 100%;
-`
-
-export const TimeWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  font-size: 20px;
-  color: ${colors.blues.dark};
-  font-weight: ${fontWeights.semibold};
-
-  input {
-    font-size: 60px;
-    width: 100%;
-    color: ${colors.blues.dark};
-    font-family: Montserrat, sans-serif;
-    font-weight: ${fontWeights.light};
-    border-bottom: none;
-  }
 `

--- a/frontend/src/lib-common/form-validation.ts
+++ b/frontend/src/lib-common/form-validation.ts
@@ -24,6 +24,7 @@ export type ErrorKey =
   | 'dateTooEarly'
   | 'dateTooLate'
   | 'timeFormat'
+  | 'timeRequired'
   | 'unitNotSelected'
   | 'preferredStartDate'
   | 'emailsDoNotMatch'

--- a/frontend/src/lib-components/atoms/form/TimeInput.tsx
+++ b/frontend/src/lib-components/atoms/form/TimeInput.tsx
@@ -13,6 +13,7 @@ interface Props
     | 'placeholder'
     | 'hideErrorsBeforeTouched'
     | 'info'
+    | 'id'
     | 'name'
     | 'required'
     | 'inputRef'
@@ -40,7 +41,6 @@ export default React.memo(function TimeInput({
       onChange={onChangeWithAutocomplete}
       type="text"
       inputMode="numeric"
-      width="s"
       onFocus={onFocus}
     />
   )
@@ -51,5 +51,5 @@ function onFocus(event: React.FocusEvent<HTMLInputElement>) {
 }
 
 const ShorterInput = styled(InputField)`
-  width: 80px;
+  width: calc(3em + 24px);
 `

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1677,7 +1677,8 @@ const en: Translations = {
     dateTooEarly: 'Pick a later date',
     dateTooLate: 'Pick an earlier date',
     preferredStartDate: 'Invalid preferred start date',
-    timeFormat: 'Valid time format is hh:mm',
+    timeFormat: 'Check',
+    timeRequired: 'Required',
     unitNotSelected: 'Pick at least one choice',
     emailsDoNotMatch: 'The emails do not match'
   },

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1609,7 +1609,8 @@ export default {
     dateTooEarly: 'Valitse myöhäisempi päivä',
     dateTooLate: 'Valitse aikaisempi päivä',
     preferredStartDate: 'Aloituspäivä ei ole sallittu',
-    timeFormat: 'Anna muodossa hh:mm',
+    timeFormat: 'Tarkista',
+    timeRequired: 'Pakollinen',
     unitNotSelected: 'Valitse vähintään yksi hakutoive',
     emailsDoNotMatch: 'Sähköpostiosoitteet eivät täsmää'
   },

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1633,7 +1633,8 @@ const sv: Translations = {
     dateTooEarly: 'Välj ett senare datum',
     dateTooLate: 'Välj ett tidigare datum',
     preferredStartDate: 'Ogiltigt datum',
-    timeFormat: 'Ange i format hh:mm',
+    timeFormat: 'Kolla',
+    timeRequired: 'Nödvändig',
     unitNotSelected: 'Välj minst en enhet',
     emailsDoNotMatch: 'E-postadresserna är olika'
   },

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2941,7 +2941,8 @@ export const fi = {
     dateTooEarly: 'Valitse myöhäisempi päivä',
     dateTooLate: 'Valitse aikaisempi päivä',
     preferredStartDate: 'Aloituspäivä ei ole sallittu',
-    timeFormat: 'Anna muodossa hh:mm',
+    timeFormat: 'Tarkista',
+    timeRequired: 'Pakollinen',
     unitNotSelected: 'Valitse vähintään yksi hakutoive',
     emailsDoNotMatch: 'Sähköpostiosoitteet eivät täsmää'
   }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Replace native browser time inputs with our own `TimeInput`. Also shorten the time validation info texts to not break the layout.

