### PR TITLE
EVAKA-HOTFIX preschool daycare transfer applications

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -239,7 +239,7 @@ class ScheduledJobsTest : FullApplicationTest() {
     }
 
     @Test
-    fun `a preschool daycare transfer application for a child with a preschool placement is cancelled`() {
+    fun `a preschool daycare transfer application for a child with a preschool placement is not cancelled`() {
         val preferredStartDate = LocalDate.now().minusMonths(2)
         val applicationId =
             createTransferApplication(ApplicationType.PRESCHOOL, preferredStartDate, preschoolDaycare = true)
@@ -249,7 +249,7 @@ class ScheduledJobsTest : FullApplicationTest() {
         scheduledJobs.cancelOutdatedTransferApplications(db)
 
         val applicationStatus = getApplicationStatus(applicationId)
-        assertEquals(ApplicationStatus.CANCELLED, applicationStatus)
+        assertEquals(ApplicationStatus.SENT, applicationStatus)
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -914,8 +914,7 @@ AND NOT EXISTS (
         AND f.latest
         AND (CASE
             WHEN f.document->>'type' = 'DAYCARE' THEN NOT p.type = ANY(:notDaycarePlacements::placement_type[])
-            WHEN f.document->>'type' = 'PRESCHOOL' AND NOT (f.document->>'connectedDaycare')::boolean THEN NOT p.type = ANY(:notPreschoolPlacements::placement_type[])
-            WHEN f.document->>'type' = 'PRESCHOOL' AND (f.document->>'connectedDaycare')::boolean THEN NOT p.type = ANY(:notPreschoolDaycarePlacements::placement_type[])
+            WHEN f.document->>'type' = 'PRESCHOOL' THEN NOT p.type = ANY(:notPreschoolPlacements::placement_type[])
             WHEN f.document->>'type' = 'CLUB' THEN NOT p.type = ANY(:notClubPlacements::placement_type[])
         END)
         AND daterange((f.document->>'preferredStartDate')::date, null, '[]') && daterange(p.start_date, p.end_date, '[]')
@@ -947,21 +946,6 @@ RETURNING id
             PlacementType.DAYCARE_PART_TIME,
             PlacementType.DAYCARE_FIVE_YEAR_OLDS,
             PlacementType.DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
-            PlacementType.TEMPORARY_DAYCARE,
-            PlacementType.TEMPORARY_DAYCARE_PART_DAY,
-            PlacementType.SCHOOL_SHIFT_CARE
-        )
-    )
-    .bind(
-        "notPreschoolDaycarePlacements",
-        arrayOf(
-            PlacementType.CLUB,
-            PlacementType.DAYCARE,
-            PlacementType.DAYCARE_PART_TIME,
-            PlacementType.DAYCARE_FIVE_YEAR_OLDS,
-            PlacementType.DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
-            PlacementType.PRESCHOOL,
-            PlacementType.PREPARATORY,
             PlacementType.TEMPORARY_DAYCARE,
             PlacementType.TEMPORARY_DAYCARE_PART_DAY,
             PlacementType.SCHOOL_SHIFT_CARE


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
When a new preschool daycare application is created for a child with just a preschool placement do not treat it as a transfer application even when the application's preferred unit is not the same as the placement's unit. With "ghost units" the application unit won't match anyway.

Be a bit more conservative with cancelling preschool daycare transfer applications and do not cancel applications for children with just a preschool placement.

