### PR TITLE
Explicitly scope the database connection

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/childimages/ChildImageTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/childimages/ChildImageTest.kt
@@ -49,7 +49,7 @@ class ChildImageTest : FullApplicationTest() {
     fun `inserting image`() {
         val file = FileMock()
         controller.putImage(
-            db,
+            dbInstance(),
             AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.ADMIN)),
             testChild_1.id,
             file
@@ -82,7 +82,7 @@ class ChildImageTest : FullApplicationTest() {
 
         val file = FileMock()
         controller.putImage(
-            db,
+            dbInstance(),
             AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.ADMIN)),
             testChild_1.id,
             file
@@ -120,7 +120,7 @@ class ChildImageTest : FullApplicationTest() {
         }
 
         controller.deleteImage(
-            db,
+            dbInstance(),
             AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.ADMIN)),
             testChild_1.id
         )
@@ -145,7 +145,7 @@ class ChildImageTest : FullApplicationTest() {
             .thenReturn(file.inputStream)
 
         val response = controller.getImage(
-            db,
+            dbInstance(),
             AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.ADMIN)),
             oldImageId
         )


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This avoids keeping the connection open while we are streaming just bytes from s3 to the client