### PR TITLE
Fix promise rejection error when fetching auth status in mobile frontend

### DIFF
--- a/frontend/src/employee-mobile-frontend/api/auth.ts
+++ b/frontend/src/employee-mobile-frontend/api/auth.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { Failure, Result, Success } from 'lib-common/api'
 import { client } from './client'
 import { JsonOf } from 'lib-common/json'
 
@@ -29,6 +30,9 @@ export interface AuthStatus {
   roles?: AdRole[]
 }
 
-export async function getAuthStatus(): Promise<AuthStatus> {
-  return client.get<JsonOf<AuthStatus>>('/auth/status').then((res) => res.data)
+export async function getAuthStatus(): Promise<Result<AuthStatus>> {
+  return client
+    .get<JsonOf<AuthStatus>>('/auth/status')
+    .then((res) => Success.of(res.data))
+    .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-mobile-frontend/components/ensureAuthenticated.tsx
+++ b/frontend/src/employee-mobile-frontend/components/ensureAuthenticated.tsx
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { FullScreenDimmedSpinner } from 'lib-components/molecules/FullScreenDimmedSpinner'
 import React, { ComponentType, useContext } from 'react'
 import { Redirect } from 'react-router-dom'
-import { FullScreenDimmedSpinner } from 'lib-components/molecules/FullScreenDimmedSpinner'
 import { UserContext } from '../state/user'
 
 export default function ensureAuthenticated<P>(Component: ComponentType<P>) {
@@ -15,10 +15,9 @@ export default function ensureAuthenticated<P>(Component: ComponentType<P>) {
       return <Redirect to="" />
     }
 
-    const showSpinner = user.isLoading || (user.isSuccess && user.isReloading)
     return (
       <>
-        {showSpinner && <FullScreenDimmedSpinner />}
+        {user.isLoading && <FullScreenDimmedSpinner />}
         <Component {...props} />
       </>
     )

--- a/frontend/src/employee-mobile-frontend/components/ensureAuthenticated.tsx
+++ b/frontend/src/employee-mobile-frontend/components/ensureAuthenticated.tsx
@@ -4,16 +4,23 @@
 
 import React, { ComponentType, useContext } from 'react'
 import { Redirect } from 'react-router-dom'
+import { FullScreenDimmedSpinner } from 'lib-components/molecules/FullScreenDimmedSpinner'
 import { UserContext } from '../state/user'
 
 export default function ensureAuthenticated<P>(Component: ComponentType<P>) {
   return function Authenticated(props: P) {
-    const { loggedIn } = useContext(UserContext)
+    const { loggedIn, user } = useContext(UserContext)
 
     if (!loggedIn) {
       return <Redirect to="" />
     }
 
-    return <Component {...props} />
+    const showSpinner = user.isLoading || (user.isSuccess && user.isReloading)
+    return (
+      <>
+        {showSpinner && <FullScreenDimmedSpinner />}
+        <Component {...props} />
+      </>
+    )
   }
 }

--- a/frontend/src/employee-mobile-frontend/components/ensureAuthenticated.tsx
+++ b/frontend/src/employee-mobile-frontend/components/ensureAuthenticated.tsx
@@ -2,24 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { FullScreenDimmedSpinner } from 'lib-components/molecules/FullScreenDimmedSpinner'
 import React, { ComponentType, useContext } from 'react'
 import { Redirect } from 'react-router-dom'
 import { UserContext } from '../state/user'
 
 export default function ensureAuthenticated<P>(Component: ComponentType<P>) {
   return function Authenticated(props: P) {
-    const { loggedIn, user } = useContext(UserContext)
+    const { loggedIn } = useContext(UserContext)
 
-    if (!loggedIn) {
-      return <Redirect to="" />
-    }
-
-    return (
-      <>
-        {user.isLoading && <FullScreenDimmedSpinner />}
-        <Component {...props} />
-      </>
-    )
+    return loggedIn ? <Component {...props} /> : <Redirect to="" />
   }
 }

--- a/frontend/src/employee-mobile-frontend/components/mobile/MobileLander.tsx
+++ b/frontend/src/employee-mobile-frontend/components/mobile/MobileLander.tsx
@@ -2,15 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { Fragment } from 'react'
-import { useContext } from 'react'
+import { P } from 'lib-components/typography'
+import React, { useContext } from 'react'
 import { Redirect } from 'react-router-dom'
 import styled from 'styled-components'
-
-import { P } from 'lib-components/typography'
+import EvakaLogo from '../../assets/EvakaLogo.svg'
 import { useTranslation } from '../../state/i18n'
 import { UserContext } from '../../state/user'
-import EvakaLogo from '../../assets/EvakaLogo.svg'
+import { renderResult } from '../async-rendering'
 import { FullHeightContainer, WideLinkButton } from './components'
 
 const Top = styled.div``
@@ -25,16 +24,12 @@ export default React.memo(function MobileLander() {
   const { i18n } = useTranslation()
   const { user } = useContext(UserContext)
 
-  if (user?.unitId) {
-    return (
+  return renderResult(user, (u) =>
+    u?.unitId ? (
       <Redirect
-        to={`/units/${user.unitId}/groups/all/child-attendance/list/coming`}
+        to={`/units/${u.unitId}/groups/all/child-attendance/list/coming`}
       />
-    )
-  }
-
-  return (
-    <Fragment>
+    ) : (
       <FullHeightContainer spaced>
         <Top>
           <Img src={EvakaLogo} />
@@ -50,6 +45,6 @@ export default React.memo(function MobileLander() {
           </WideLinkButton>
         </Bottom>
       </FullHeightContainer>
-    </Fragment>
+    )
   )
 })

--- a/frontend/src/employee-mobile-frontend/state/user.tsx
+++ b/frontend/src/employee-mobile-frontend/state/user.tsx
@@ -2,37 +2,45 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useMemo, createContext } from 'react'
+import { Loading, Result } from 'lib-common/api'
+import { idleTracker } from 'lib-common/utils/idleTracker'
+import { useApiState } from 'lib-common/utils/useRestApi'
+import React, { createContext, useEffect, useMemo } from 'react'
+import { getAuthStatus } from '../api/auth'
+import { client } from '../api/client'
 import { User } from '../types'
 
 export interface UserState {
   loggedIn: boolean
-  user: User | undefined
-  refreshAuthStatus: () => Promise<void>
+  user: Result<User | null>
+  refreshAuthStatus: () => void
 }
 
 export const UserContext = createContext<UserState>({
   loggedIn: false,
-  user: undefined,
-  refreshAuthStatus: () => Promise.resolve()
+  user: Loading.of(),
+  refreshAuthStatus: () => null
 })
 
 export const UserContextProvider = React.memo(function UserContextProvider({
-  children,
-  user,
-  refreshAuthStatus
+  children
 }: {
-  children: JSX.Element
-  user: User | undefined
-  refreshAuthStatus: () => Promise<void>
+  children: React.ReactNode
 }) {
+  const [authStatus, refreshAuthStatus] = useApiState(getAuthStatus, [])
+
+  useEffect(
+    () => idleTracker(client, refreshAuthStatus, { thresholdInMinutes: 20 }),
+    [refreshAuthStatus]
+  )
+
   const value = useMemo(
     () => ({
-      loggedIn: user !== undefined,
-      user,
+      loggedIn: authStatus.map((a) => a.loggedIn).getOrElse(false),
+      user: authStatus.map((a) => a.user ?? null),
       refreshAuthStatus
     }),
-    [user, refreshAuthStatus]
+    [authStatus, refreshAuthStatus]
   )
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>
 })

--- a/frontend/src/lib-components/molecules/FullScreenDimmedSpinner.tsx
+++ b/frontend/src/lib-components/molecules/FullScreenDimmedSpinner.tsx
@@ -3,14 +3,28 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
+import styled from 'styled-components'
 import { modalZIndex } from '../layout/z-helpers'
 import ModalBackground from './modals/ModalBackground'
 import Spinner from '../atoms/state/Spinner'
 
+const FullScreenCentered = styled.div`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
 export function FullScreenDimmedSpinner() {
   return (
     <ModalBackground zIndex={modalZIndex}>
-      <Spinner zIndex={modalZIndex} />
+      <FullScreenCentered>
+        <Spinner />
+      </FullScreenCentered>
     </ModalBackground>
   )
 }


### PR DESCRIPTION
#### Summary

- Move auth status from App level to UserContext
- Refactor auth status to use Result in order to handle errors gracefully and display loading status
- Fix FullScreenDimmedSpinner to actually use the whole screen estate
- Simplify RedirectToMainPage

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

