### PR TITLE
Fix group note filtering, show currently selected group's notes only

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/attendances/notes/ChildNotes.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/notes/ChildNotes.tsx
@@ -120,8 +120,11 @@ export default React.memo(function ChildNotes() {
   )
 
   const groupNotes = useMemo<GroupNote[]>(
-    () => attendanceResponse.map((v) => v.groupNotes).getOrElse([]),
-    [attendanceResponse]
+    () =>
+      attendanceResponse
+        .map((v) => v.groupNotes.filter((n) => n.groupId === groupId))
+        .getOrElse([]),
+    [attendanceResponse, groupId]
   )
 
   const noteTabs = useMemo(() => {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

