### PR TITLE
Enable Java datadog profiling

### DIFF
--- a/message-service/Dockerfile
+++ b/message-service/Dockerfile
@@ -6,16 +6,21 @@ FROM evaka-base:latest
 
 USER root
 RUN set -eux \
-    && apt-get update && apt-get -y --no-install-recommends install \
+ && apt-get update && apt-get -y --no-install-recommends install \
        curl \
        openjdk-11-jre-headless \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
+
+ARG DD_JAVA_AGENT_VERSION="0.89.0"
+ARG DD_JAVA_AGENT_SHA256="432c110ddd4b8d769bce394b9df62fe5c627e9d1fb30250fb2af9c034569abb3"
+
+RUN curl -sSfo /opt/dd-java-agent.jar "https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${DD_JAVA_AGENT_VERSION}/dd-java-agent-${DD_JAVA_AGENT_VERSION}.jar" \
+ && echo "${DD_JAVA_AGENT_SHA256}  /opt/dd-java-agent.jar" | sha256sum -c -
 
 USER evaka
 WORKDIR /home/evaka
 
 COPY --chown=evaka:evaka "entrypoint.sh" "entrypoint.sh"
-RUN chmod +x "entrypoint.sh"
 COPY --chown=evaka:evaka "target/org/" "org/"
 COPY --chown=evaka:evaka "target/META-INF" "META-INF/"
 COPY --chown=evaka:evaka "target/BOOT-INF/lib" "BOOT-INF/lib/"

--- a/message-service/entrypoint.sh
+++ b/message-service/entrypoint.sh
@@ -17,5 +17,23 @@ fi
 
 # Run as exec so the application can receive any Unix signals sent to the container, e.g.,
 # Ctrl + C.
-# shellcheck disable=SC2086
-exec java -cp . -server $JAVA_OPTS org.springframework.boot.loader.JarLauncher "$@"
+if [ "${DD_PROFILING_ENABLED:-false}" = "true" ]; then
+  export DD_AGENT_HOST="${DD_AGENT_HOST:-$HOST_IP}"
+  export DD_ENV="${DD_ENV:-$VOLTTI_ENV}"
+  export DD_VERSION="${DD_VERSION:-$APP_COMMIT}"
+  export DD_SERVICE="${DD_SERVICE:-$APP_NAME}"
+
+  if [ "$DD_AGENT_HOST" = "UNAVAILABLE" ]; then
+    echo "Invalid DD_AGENT_HOST. Is it unset and not in AWS environment?"
+    exit 1
+  fi
+
+  # shellcheck disable=SC2086
+  exec java \
+    -javaagent:/opt/dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.logs.injection=true \
+    -Ddd.trace.sample.rate=1 -XX:FlightRecorderOptions=stackdepth=256 \
+    -cp . -server $JAVA_OPTS org.springframework.boot.loader.JarLauncher "$@"
+else
+  # shellcheck disable=SC2086
+  exec java -cp . -server $JAVA_OPTS org.springframework.boot.loader.JarLauncher "$@"
+fi

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -5,17 +5,22 @@
 FROM evaka-base:latest
 
 USER root
-RUN set -eux \
-    && apt-get update && apt-get -y --no-install-recommends install \
+RUN apt-get update \
+ && apt-get -y --no-install-recommends install \
        curl \
        openjdk-11-jre-headless \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
+
+ARG DD_JAVA_AGENT_VERSION="0.89.0"
+ARG DD_JAVA_AGENT_SHA256="432c110ddd4b8d769bce394b9df62fe5c627e9d1fb30250fb2af9c034569abb3"
+
+RUN curl -sSfo /opt/dd-java-agent.jar "https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${DD_JAVA_AGENT_VERSION}/dd-java-agent-${DD_JAVA_AGENT_VERSION}.jar" \
+ && echo "${DD_JAVA_AGENT_SHA256}  /opt/dd-java-agent.jar" | sha256sum -c -
 
 USER evaka
 WORKDIR /home/evaka
 
 COPY --chown=evaka:evaka "entrypoint.sh" "entrypoint.sh"
-RUN chmod +x "entrypoint.sh"
 COPY --chown=evaka:evaka "target/org/" "org/"
 COPY --chown=evaka:evaka "target/META-INF" "META-INF/"
 COPY --chown=evaka:evaka "target/BOOT-INF/lib" "BOOT-INF/lib/"

--- a/service/entrypoint.sh
+++ b/service/entrypoint.sh
@@ -17,5 +17,23 @@ fi
 
 # Run as exec so the application can receive any Unix signals sent to the container, e.g.,
 # Ctrl + C.
-# shellcheck disable=SC2086
-exec java -cp . -server $JAVA_OPTS org.springframework.boot.loader.JarLauncher "$@"
+if [ "${DD_PROFILING_ENABLED:-false}" = "true" ]; then
+  export DD_AGENT_HOST="${DD_AGENT_HOST:-$HOST_IP}"
+  export DD_ENV="${DD_ENV:-$VOLTTI_ENV}"
+  export DD_VERSION="${DD_VERSION:-$APP_COMMIT}"
+  export DD_SERVICE="${DD_SERVICE:-$APP_NAME}"
+
+  if [ "$DD_AGENT_HOST" = "UNAVAILABLE" ]; then
+    echo "Invalid DD_AGENT_HOST. Is it unset and not in AWS environment?"
+    exit 1
+  fi
+
+  # shellcheck disable=SC2086
+  exec java \
+    -javaagent:/opt/dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.logs.injection=true \
+    -Ddd.trace.sample.rate=1 -XX:FlightRecorderOptions=stackdepth=256 \
+    -cp . -server $JAVA_OPTS org.springframework.boot.loader.JarLauncher "$@"
+else
+  # shellcheck disable=SC2086
+  exec java -cp . -server $JAVA_OPTS org.springframework.boot.loader.JarLauncher "$@"
+fi


### PR DESCRIPTION
#### Summary

Enable Java Datadog profiling using environment variable `DD_PROFILING_ENABLED`. Requires Datadog agent running on AWS node.