### PR TITLE
Simplify default selected note tab in desktop

### DIFF
--- a/frontend/src/e2e-test/specs/2_employee-2/employee-dailynote.spec.ts
+++ b/frontend/src/e2e-test/specs/2_employee-2/employee-dailynote.spec.ts
@@ -197,7 +197,7 @@ test('Group daycare daily notes can be written and are shown on group notes tab'
   await t.click(
     unitPage.childDaycareDailyNoteIcon(enduserChildFixtureKaarina.id)
   )
-  // group tab should be immediately visible
+  await t.click(unitPage.notesModal.tab('group'))
   await t.expect(unitPage.stickyNote.note.textContent).eql('Ryhmälle viesti')
 
   // Delete group note

--- a/frontend/src/employee-frontend/components/unit/tab-groups/notes/NotesModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/notes/NotesModal.tsx
@@ -122,15 +122,7 @@ export const NotesModal = React.memo(function NotesModal({
   )
 
   type TabType = 'child' | 'sticky' | 'group'
-  const [tab, setTab] = useState<TabType>(
-    counts.child > 0
-      ? 'child'
-      : counts.sticky > 0
-      ? 'sticky'
-      : !childId || counts.group > 0
-      ? 'group'
-      : 'child'
-  )
+  const [tab, setTab] = useState<TabType>(childId ? 'child' : 'group')
 
   const stickyNoteLabels = useMemo(
     () =>


### PR DESCRIPTION
#### Summary
Simplify default selected tab to show either child or group note tab regardless of note counts