### PR TITLE
EVAKA-4290 Set the correct roles for who can create pedagogical documents

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/PedagogicalDocuments.tsx
+++ b/frontend/src/employee-frontend/components/child-information/PedagogicalDocuments.tsx
@@ -130,7 +130,14 @@ const PedagogicalDocuments = React.memo(function PedagogicalDocuments({
       paddingVertical="L"
       data-qa="pedagogical-documents-collapsible"
     >
-      <RequireRole oneOf={['SERVICE_WORKER', 'ADMIN']}>
+      <RequireRole
+        oneOf={[
+          'ADMIN',
+          'UNIT_SUPERVISOR',
+          'STAFF',
+          'SPECIAL_EDUCATION_TEACHER'
+        ]}
+      >
         <AddButtonRow
           text={i18n.childInformation.pedagogicalDocument.create}
           onClick={() => createNewDocument()}


### PR DESCRIPTION
#### Summary
This change makes the create pedagogical document button visible to admins, unit supervisors,
staff, and special education teachers

