### PR TITLE
Fix some visual and usability issues in notes

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
@@ -62,7 +62,7 @@ import {
   Stats,
   Unit
 } from '../../../../types/unit'
-import { capitalizeFirstLetter, formatName } from '../../../../utils'
+import { capitalizeFirstLetter, formatPersonName } from '../../../../utils'
 import { rangesOverlap } from '../../../../utils/date'
 import { isPartDayPlacement } from '../../../../utils/placements'
 import { requireRole } from '../../../../utils/roles'
@@ -128,6 +128,8 @@ function getChildMinMaxHeadcounts(
     : undefined
 }
 
+type IdAndName = { id: UUID; name: string }
+
 function Group({
   unit,
   filters,
@@ -149,7 +151,7 @@ function Group({
   const { uiMode, toggleUiMode } = useContext(UIContext)
 
   const [notesModal, setNotesModal] =
-    useState<{ childId?: UUID; groupId: UUID }>()
+    useState<{ child?: IdAndName; group: IdAndName }>()
   const [notesResponse, setNotesResponse] = useState<
     Result<NotesByGroupResponse>
   >(Loading.of())
@@ -318,7 +320,13 @@ function Group({
             color={colors.blues.primary}
             size="m"
             onClick={() =>
-              setNotesModal({ groupId: group.id, childId: placement.child.id })
+              setNotesModal({
+                group: { id: group.id, name: group.name },
+                child: {
+                  id: placement.child.id,
+                  name: formatPersonName(placement.child, i18n)
+                }
+              })
             }
           />
         </Tooltip>
@@ -548,12 +556,7 @@ function Group({
                           )}
                         <Td data-qa="child-name">
                           <Link to={`/child-information/${placement.child.id}`}>
-                            {formatName(
-                              placement.child.firstName,
-                              placement.child.lastName,
-                              i18n,
-                              true
-                            )}
+                            {formatPersonName(placement.child, i18n, true)}
                           </Link>
                         </Td>
                         <Td data-qa="child-dob">
@@ -676,13 +679,13 @@ function Group({
                           : faStickyNote
                       }
                       text={
-                        notesResponse.value.groupNotes.length > 0
-                          ? i18n.unit.groups.daycareDailyNote
-                              .groupNoteModalModifyLink
-                          : i18n.unit.groups.daycareDailyNote
-                              .groupNoteModalAddLink
+                        i18n.unit.groups.daycareDailyNote.groupNoteModalLink
                       }
-                      onClick={() => setNotesModal({ groupId: group.id })}
+                      onClick={() =>
+                        setNotesModal({
+                          group: { id: group.id, name: group.name }
+                        })
+                      }
                       data-qa="btn-create-group-note"
                     />
                   </GroupNoteLinkContainer>

--- a/frontend/src/employee-frontend/utils/index.ts
+++ b/frontend/src/employee-frontend/utils/index.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { MutableRefObject } from 'react'
 import { Translations } from 'lib-customizations/employee'
+import { MutableRefObject } from 'react'
 
 export const formatName = (
   maybeFirstName: string | null,
@@ -13,16 +13,20 @@ export const formatName = (
 ): string => {
   const firstName = maybeFirstName || i18n.common.noFirstName
   const lastName = maybeLastName || i18n.common.noLastName
-  const formattedName =
-    firstName && lastName
-      ? lastNameFirst
-        ? `${lastName} ${firstName}`
-        : `${firstName} ${lastName}`
-      : lastName
-      ? lastName
-      : firstName
-  return formattedName
+  return firstName && lastName
+    ? lastNameFirst
+      ? `${lastName} ${firstName}`
+      : `${firstName} ${lastName}`
+    : lastName
+    ? lastName
+    : firstName
 }
+
+export const formatPersonName = (
+  person: { firstName: string | null; lastName: string | null },
+  i18n: Translations,
+  lastNameFirst = false
+): string => formatName(person.firstName, person.lastName, i18n, lastNameFirst)
 
 export const capitalizeFirstLetter = (str: string | null): string => {
   if (!str || str.length === 0) return ''

--- a/frontend/src/employee-mobile-frontend/components/attendances/AbsenceSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/AbsenceSelector.tsx
@@ -6,9 +6,8 @@ import React, { Fragment } from 'react'
 
 import { useTranslation } from '../../state/i18n'
 import { AbsenceType, AbsenceTypes } from '../../types'
-import { ChoiceChip } from 'lib-components/atoms/Chip'
+import { ChipWrapper, ChoiceChip } from 'lib-components/atoms/Chip'
 import { Gap } from 'lib-components/white-space'
-import { ChipWrapper } from '../mobile/components'
 
 interface Props {
   selectedAbsenceType: AbsenceType | undefined

--- a/frontend/src/employee-mobile-frontend/components/attendances/notes/ChildStickyNotesTab.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/notes/ChildStickyNotesTab.tsx
@@ -73,6 +73,7 @@ export const ChildStickyNotesTab = React.memo(function ChildStickyNotesTab({
       onSave={onSave}
       onRemove={onRemove}
       labels={labels}
+      smallerHeading
     />
   )
 })

--- a/frontend/src/employee-mobile-frontend/components/attendances/notes/DailyNotesTab.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/notes/DailyNotesTab.tsx
@@ -13,7 +13,7 @@ import { UUID } from 'lib-common/types'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
 import ResponsiveInlineButton from 'lib-components/atoms/buttons/ResponsiveInlineButton'
-import { ChoiceChip } from 'lib-components/atoms/Chip'
+import { ChipWrapper, ChoiceChip } from 'lib-components/atoms/Chip'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import InputField from 'lib-components/atoms/form/InputField'
 import TextArea from 'lib-components/atoms/form/TextArea'
@@ -36,7 +36,6 @@ import {
 } from '../../../api/notes'
 import { ChildAttendanceContext } from '../../../state/child-attendance'
 import { useTranslation } from '../../../state/i18n'
-import { ChipWrapper } from '../../mobile/components'
 import { ChildDailyNoteFormData } from './daily-note'
 
 const Time = styled.div`
@@ -245,7 +244,7 @@ export const DailyNotesTab = React.memo(function DailyNotesTab({
 
           <FixedSpaceColumn spacing="s">
             <Label>{i18n.attendances.notes.labels.feedingNote}</Label>
-            <ChipWrapper $noMargin>
+            <ChipWrapper noMargin>
               {childDailyNoteLevelValues.map((level) => (
                 <Fragment key={level}>
                   <ChoiceChip
@@ -266,7 +265,7 @@ export const DailyNotesTab = React.memo(function DailyNotesTab({
           </FixedSpaceColumn>
           <FixedSpaceColumn spacing="s">
             <Label>{i18n.attendances.notes.labels.sleepingNote}</Label>
-            <ChipWrapper $noMargin>
+            <ChipWrapper noMargin>
               {childDailyNoteLevelValues.map((level) => (
                 <Fragment key={level}>
                   <ChoiceChip

--- a/frontend/src/employee-mobile-frontend/components/attendances/notes/GroupNotesTab.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/notes/GroupNotesTab.tsx
@@ -72,6 +72,7 @@ export const GroupNotesTab = React.memo(function GroupNotesTab({
       onSave={onSave}
       onRemove={onRemove}
       labels={labels}
+      smallerHeading
     />
   )
 })

--- a/frontend/src/employee-mobile-frontend/components/common/GroupSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/GroupSelector.tsx
@@ -4,12 +4,11 @@
 
 import React, { Fragment, useContext } from 'react'
 import styled from 'styled-components'
-import { ChoiceChip } from 'lib-components/atoms/Chip'
+import { ChipWrapper, ChoiceChip } from 'lib-components/atoms/Chip'
 import { Gap } from 'lib-components/white-space'
 import { fontWeights } from 'lib-components/typography'
 import { useTranslation } from '../../state/i18n'
 import colors from 'lib-customizations/common'
-import { ChipWrapper } from '../mobile/components'
 import { UnitContext } from '../../state/unit'
 import { UUID } from 'lib-common/types'
 import { GroupInfo } from 'lib-common/generated/api-types/attendance'

--- a/frontend/src/employee-mobile-frontend/components/mobile/components.tsx
+++ b/frontend/src/employee-mobile-frontend/components/mobile/components.tsx
@@ -2,14 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import IconButton from 'lib-components/atoms/buttons/IconButton'
+import { Container, ContentArea } from 'lib-components/layout/Container'
+import { fontWeights } from 'lib-components/typography'
+import { defaultMargins } from 'lib-components/white-space'
+import colors from 'lib-customizations/common'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
-
-import IconButton from 'lib-components/atoms/buttons/IconButton'
-import colors from 'lib-customizations/common'
-import { Container, ContentArea } from 'lib-components/layout/Container'
-import { defaultMargins } from 'lib-components/white-space'
-import { fontWeights } from 'lib-components/typography'
 
 export const FullHeightContainer = styled(Container)<{ spaced?: boolean }>`
   height: 100%;
@@ -51,14 +50,4 @@ export const TallContentArea = styled(ContentArea)<{ spaced?: boolean }>`
   flex-direction: column;
   flex: 1;
   ${(p) => (p.spaced ? 'justify-content: space-between;' : '')}
-`
-
-export const ChipWrapper = styled.div<{ $noMargin?: boolean }>`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-
-  > div {
-    margin-bottom: ${(p) => (p.$noMargin ? `0` : `16px`)};
-  }
 `

--- a/frontend/src/lib-components/atoms/Chip.tsx
+++ b/frontend/src/lib-components/atoms/Chip.tsx
@@ -2,17 +2,17 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback } from 'react'
-import styled from 'styled-components'
-import { readableColor } from 'polished'
-import classNames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import classNames from 'classnames'
+import { useUniqueId } from 'lib-common/utils/useUniqueId'
 
 import { faCheck } from 'lib-icons'
+import { readableColor } from 'polished'
+import React, { useCallback } from 'react'
+import styled from 'styled-components'
+import { tabletMin } from '../breakpoints'
 import { fontWeights } from '../typography'
 import { defaultMargins } from '../white-space'
-import { tabletMin } from '../breakpoints'
-import { useUniqueId } from 'lib-common/utils/useUniqueId'
 
 export const StaticChip = styled.div<{ color: string; textColor?: string }>`
   font-family: 'Open Sans', sans-serif;
@@ -182,4 +182,17 @@ const IconWrapper = styled.div`
 
   font-size: 24px;
   color: ${({ theme: { colors } }) => colors.greyscale.white};
+`
+
+export const ChipWrapper = styled.div<{ noMargin?: boolean }>`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+
+  ${(p) =>
+    p.noMargin
+      ? ''
+      : `> div {
+    margin-bottom: ${defaultMargins.s};
+  }`};
 `

--- a/frontend/src/lib-components/employee/notes/StickyNoteTab.tsx
+++ b/frontend/src/lib-components/employee/notes/StickyNoteTab.tsx
@@ -8,12 +8,18 @@ import { UUID } from 'lib-common/types'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import { ContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
-import { H2 } from 'lib-components/typography'
+import { H1, H2, H3 } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import React, { useCallback, useState } from 'react'
 import { EditedNote, Note } from './notes'
 import { StaticLabels, StaticStickyNote } from './StaticStickyNote'
 import { EditorLabels, StickyNoteEditor } from './StickyNoteEditor'
+
+const newNote = () => ({
+  id: '',
+  expires: LocalDate.today().addDays(7),
+  note: ''
+})
 
 export interface StickyNoteTabLabels {
   title: string
@@ -27,19 +33,17 @@ interface StickyNoteTabProps {
   notes: Note[]
   onSave: (note: EditedNote) => Promise<Result<unknown>>
   onRemove: (id: UUID) => Promise<Result<unknown>>
+  smallerHeading?: boolean
+  subHeading?: string
 }
-
-const newNote = () => ({
-  id: '',
-  expires: LocalDate.today().addDays(7),
-  note: ''
-})
 
 export const StickyNoteTab = React.memo(function StickyNoteTab({
   labels,
   notes,
   onSave,
-  onRemove
+  onRemove,
+  smallerHeading = false,
+  subHeading
 }: StickyNoteTabProps) {
   const [editing, setEditing] = useState<UUID | 'new' | null>(
     notes.length === 0 ? 'new' : null
@@ -47,14 +51,26 @@ export const StickyNoteTab = React.memo(function StickyNoteTab({
   const onCancelEdit = useCallback(() => setEditing(null), [])
   const setNoteToEdit = useCallback((id: UUID) => () => setEditing(id), [])
 
+  const headingProps = {
+    noMargin: true,
+    primary: true,
+    children: labels.title
+  }
   return (
     <>
       <ContentArea opaque paddingHorizontal="s">
-        <H2 primary noMargin>
-          {labels.title}
-        </H2>
+        {smallerHeading ? <H2 {...headingProps} /> : <H1 {...headingProps} />}
 
-        <Gap size="xs" />
+        {subHeading && (
+          <>
+            <Gap size="xs" />
+            <H3 primary noMargin>
+              {subHeading}
+            </H3>
+          </>
+        )}
+
+        <Gap size="s" />
 
         <FixedSpaceRow justifyContent="flex-end">
           <InlineButton

--- a/frontend/src/lib-components/molecules/modals/BaseModal.tsx
+++ b/frontend/src/lib-components/molecules/modals/BaseModal.tsx
@@ -179,7 +179,7 @@ const ModalTitle = styled.div`
 
 const StaticallyPositionedModal = styled(ModalWrapper)`
   justify-content: flex-start;
-  padding-top: ${defaultMargins.X4L};
+  padding-top: ${defaultMargins.XL};
 `
 
 type PlainModalProps = Pick<

--- a/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
@@ -169,7 +169,7 @@ export const fi = {
         feedingNote: 'Lapsi söi tänään',
         sleepingNote: 'Lapsi nukkui tänään',
         reminderNote: 'Muistettavia asioita',
-        groupNotesHeader: 'Muistiinpano koko ryhmälle'
+        groupNotesHeader: 'Koko ryhmän muistiinpano'
       },
       sleepingValues: {
         GOOD: 'Hyvin',
@@ -187,7 +187,7 @@ export const fi = {
         LAUNDRY: 'Repussa pyykkiä'
       },
       placeholders: {
-        note: 'Leikkejä, onnistumisia, ilonaiheita ja opittuja asioita tänään. (Ei terveystietoja tai salassapidettäviä tietoja).',
+        note: 'Leikkejä, onnistumisia, ilonaiheita ja opittuja asioita tänään (ei terveystietoja tai salassapidettäviä tietoja).',
         childStickyNote:
           'Muistiinpano henkilökunnalle (ei terveystietoja tai salassapidettäviä tietoja).',
         groupNote: 'Koko ryhmää koskeva muistiinpano',

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -1606,10 +1606,10 @@ export const fi = {
       daycareDailyNote: {
         dailyNote: 'Päivän muistiinpanot',
         header: 'Tänään koettua ja opittua',
-        groupNotesHeader: 'Muistiinpano koko ryhmälle',
+        groupNotesHeader: 'Ryhmän muistiinpanot',
         stickyNotesHeader: 'Huomioitavaa lähipäivinä',
         notesHint:
-          'Leikkejä, onnistumisia, ilonaiheita ja opittuja asioita tänään. (Ei terveystietoja tai salassapidettäviä tietoja).',
+          'Leikkejä, onnistumisia, ilonaiheita ja opittuja asioita tänään (ei terveystietoja tai salassapidettäviä tietoja).',
         childStickyNoteHint:
           'Muistiinpano henkilökunnalle (ei terveystietoja tai salassapidettäviä tietoja).',
         otherThings: 'Muut asiat',
@@ -1621,10 +1621,8 @@ export const fi = {
         sleepingMinutes: 'min',
         reminderHeader: 'Muistettavia asioita',
         otherThingsToRememberHeader: 'Muuta muistettavaa (esim aurinkovoide)',
-        groupNoteModalAddLink: 'Päivän muistiinpano koko ryhmälle',
+        groupNoteModalLink: 'Ryhmän muistiinpano',
         groupNoteHint: 'Koko ryhmää koskeva muistiinpano',
-        groupNoteModalModifyLink:
-          'Muokkaa tai poista muistiinpano koko ryhmälle',
         edit: 'Lisää päivän muistiinpano',
         level: {
           GOOD: 'Hyvin',


### PR DESCRIPTION
#### Summary

- Add child/group name subheadings to desktop
- Use chips instead of radios in desktop
- DRY the desktop daily note form altogether
- Do not close the daily note on desktop after deleting the note
- Unify headings, labels and placeholders between mobile and desktop
- Unify margins between form components
