### PR TITLE
Use full URL in redirects

### DIFF
--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -97,6 +97,10 @@ export const jwtPrivateKey = required(
 )
 export const jwtKid = process.env.JWT_KID ?? `evaka-${gatewayRole || 'dev'}-gw`
 
+export const evakaBaseUrl = required(
+  process.env.EVAKA_BASE_URL ?? ifNodeEnv(['local', 'test'], 'local')
+)
+
 export const evakaServiceUrl = required(
   process.env.EVAKA_SERVICE_URL ??
     ifNodeEnv(['local', 'test'], 'http://localhost:8888')


### PR DESCRIPTION
#### Summary

Use full URL in redirects. Requires `EVAKA_BASE_URL` environment variable in non-local environments.
