### PR TITLE
EVAKA-4290 Fix download attachment experience on iOS

### DIFF
--- a/frontend/src/lib-common/utils/file.ts
+++ b/frontend/src/lib-common/utils/file.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { isIOS } from './helpers'
+
 function openLink(link: HTMLAnchorElement, url: string) {
   document.body.appendChild(link)
   link.click()
@@ -44,12 +46,12 @@ export const downloadBlobAsFile = (fileName: string, blobPart: BlobPart) => {
 }
 
 export const openBlobInBrowser = (
-  fileName: string,
+  _fileName: string,
   fileType: string,
   blobPart: BlobPart
 ) => {
   const url = URL.createObjectURL(new Blob([blobPart], { type: fileType }))
   const link = createLink(url)
-  link.target = '_blank'
+  link.target = isIOS() ? '_self' : '_blank'
   openLink(link, url)
 }

--- a/frontend/src/lib-common/utils/helpers.ts
+++ b/frontend/src/lib-common/utils/helpers.ts
@@ -31,3 +31,9 @@ export const isProduction = (): boolean => {
 
 export const isAutomatedTest =
   typeof window !== 'undefined' && 'evakaAutomatedTest' in window
+
+export const isIOS = () =>
+  ['iPad', 'iPhone', 'iPad Simulator', 'iPhone Simulator'].includes(
+    navigator.platform
+  ) ||
+  (navigator.userAgent.includes('Mac') && 'ontouchend' in document)

--- a/frontend/src/lib-components/molecules/FileDownloadButton.tsx
+++ b/frontend/src/lib-components/molecules/FileDownloadButton.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 
 import { Result } from 'lib-common/api'
 import { downloadBlobAsFile, openBlobInBrowser } from 'lib-common/utils/file'
+import { isIOS } from 'lib-common/utils/helpers'
 import { Attachment } from 'lib-common/api-types/attachment'
 import { UUID } from 'lib-common/types'
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
@@ -63,9 +64,19 @@ export default React.memo(function FileDownloadButton({
       throw new Error(result.message)
     }
 
-    if (openInBrowser)
+    if (openInBrowser || isIOS()) {
+      // iOS handles downloading files poorly from an UX point of view,
+      // so always open in browser
       openBlobInBrowser(file.name, file.contentType, result.value)
-    else downloadBlobAsFile(file.name, result.value)
+    } else {
+      downloadBlobAsFile(file.name, result.value)
+    }
+
+    if (isIOS()) {
+      // on iOS we need this timeout or else any requests done in the
+      // `afterFetch` function will fail.
+      return new Promise((resolve, _reject) => setTimeout(resolve, 100))
+    }
   }
 
   return (


### PR DESCRIPTION
#### Summary
On iOS, popups are blocked by default in Safari and confusing to use in
Chrome (suddenly a new tab and I can't go back to where I came from). So
instead of opening in a new tab (`_blank`) we now open attachments in
the same window. This way the user can now go back to the eVaka UI by
the browser's back button (or swiping).

The HTML5 download functionality has quite poor UX on iOS, as it
- on Safari it asks whether to download, but gives no indication of where the file went
- on Chrome it just looks like nothing happened

Due to this, we now open the attachments in the same window as the app
in this case as well.
