### PR TITLE
EVAKA-4000 add timestamps to varda_reset_child

### DIFF
--- a/service/src/main/resources/db/migration/V168__varda_reset_child_timestamps.sql
+++ b/service/src/main/resources/db/migration/V168__varda_reset_child_timestamps.sql
@@ -1,0 +1,5 @@
+ALTER TABLE varda_reset_child
+    ADD COLUMN created timestamp with time zone DEFAULT now() NOT NULL,
+    ADD COLUMN updated timestamp with time zone DEFAULT now() NOT NULL;
+
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON varda_reset_child FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -165,3 +165,4 @@ V164__evaka_user.sql
 V165__evaka_user_data.sql
 V166__evaka_user_absence.sql
 V167__evaka_user_indexes.sql
+V168__varda_reset_child_timestamps.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add migration for timestamp fields
