### PR TITLE
Fix `evaka_user` upsert for mobile devices

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AuditQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AuditQueries.kt
@@ -35,7 +35,7 @@ ON CONFLICT (id) DO UPDATE SET name = excluded.name
 
 fun Database.Transaction.upsertMobileDeviceUser(id: MobileDeviceId) = createUpdate(
     """
-INSERT INTO evaka_user (id, type, employee_id, name)
+INSERT INTO evaka_user (id, type, mobile_device_id, name)
 SELECT id, 'MOBILE_DEVICE', id, name
 FROM mobile_device
 WHERE id = :id

--- a/service/src/main/resources/db/migration/V169__ensure_mobile_devices.sql
+++ b/service/src/main/resources/db/migration/V169__ensure_mobile_devices.sql
@@ -1,0 +1,4 @@
+INSERT INTO evaka_user (id, type, mobile_device_id, name)
+SELECT id, 'MOBILE_DEVICE', id, name
+FROM mobile_device
+ON CONFLICT (id) DO NOTHING;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -166,3 +166,4 @@ V165__evaka_user_data.sql
 V166__evaka_user_absence.sql
 V167__evaka_user_indexes.sql
 V168__varda_reset_child_timestamps.sql
+V169__ensure_mobile_devices.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- upsert immediately after pairing (vs only after refreshing mobile device session)
- use correct id column in mobile device upsert
- create missing evaka_user rows if any mobile devices are missing

