### PR TITLE
Evaka 4000 varda error report add created

### DIFF
--- a/frontend/src/employee-frontend/api/reports.ts
+++ b/frontend/src/employee-frontend/api/reports.ts
@@ -468,7 +468,8 @@ export async function getVardaErrorsReport(
       Success.of(
         res.data.map((row) => ({
           ...row,
-          updated: new Date(row.updated)
+          updated: new Date(row.updated),
+          created: new Date(row.created)
         }))
       )
     )

--- a/frontend/src/employee-frontend/components/reports/VardaErrors.tsx
+++ b/frontend/src/employee-frontend/components/reports/VardaErrors.tsx
@@ -61,6 +61,7 @@ function VardaErrors() {
             <TableScrollable>
               <Thead>
                 <Tr>
+                  <Th>{i18n.reports.vardaErrors.created}</Th>
                   <Th>{i18n.reports.vardaErrors.child}</Th>
                   <Th>{i18n.reports.vardaErrors.error}</Th>
                   <Th>{i18n.reports.vardaErrors.serviceNeed}</Th>
@@ -70,6 +71,10 @@ function VardaErrors() {
               <Tbody>
                 {rows.value.map((row: VardaErrorReportRow) => (
                   <Tr key={`${row.serviceNeedId}`}>
+                    <Td>
+                      {LocalDate.fromSystemTzDate(row.created).format()}{' '}
+                      {row.created.toLocaleTimeString()}
+                    </Td>
                     <Td>
                       <Link to={`/child-information/${row.childId}`}>
                         {row.childId}

--- a/frontend/src/employee-frontend/components/reports/VardaErrors.tsx
+++ b/frontend/src/employee-frontend/components/reports/VardaErrors.tsx
@@ -37,6 +37,11 @@ function VardaErrors() {
     void getVardaErrorsReport(filters).then(setRows)
   }, [filters])
 
+  const ageInDays = (timestamp: Date): number => {
+    const diff = new Date().getTime() - timestamp.getTime()
+    return Math.round(diff / (1000 * 3600 * 24))
+  }
+
   return (
     <Container>
       <ReturnButton label={i18n.common.goBack} />
@@ -61,7 +66,7 @@ function VardaErrors() {
             <TableScrollable>
               <Thead>
                 <Tr>
-                  <Th>{i18n.reports.vardaErrors.created}</Th>
+                  <Th>{i18n.reports.vardaErrors.age}</Th>
                   <Th>{i18n.reports.vardaErrors.child}</Th>
                   <Th>{i18n.reports.vardaErrors.error}</Th>
                   <Th>{i18n.reports.vardaErrors.serviceNeed}</Th>
@@ -71,10 +76,7 @@ function VardaErrors() {
               <Tbody>
                 {rows.value.map((row: VardaErrorReportRow) => (
                   <Tr key={`${row.serviceNeedId}`}>
-                    <Td>
-                      {LocalDate.fromSystemTzDate(row.created).format()}{' '}
-                      {row.created.toLocaleTimeString()}
-                    </Td>
+                    <Td>{ageInDays(row.created)}</Td>
                     <Td>
                       <Link to={`/child-information/${row.childId}`}>
                         {row.childId}

--- a/frontend/src/employee-frontend/types/reports.ts
+++ b/frontend/src/employee-frontend/types/reports.ts
@@ -362,5 +362,6 @@ export interface VardaErrorReportRow {
   serviceNeedOptionName: string
   childId: UUID
   updated: Date
+  created: Date
   errors: string[]
 }

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -460,6 +460,7 @@ export type UnitType =
 */
 export interface VardaErrorReportRow {
   childId: UUID
+  created: Date
   errors: string[]
   serviceNeedEndDate: string
   serviceNeedId: UUID

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2567,6 +2567,7 @@ export const fi = {
       description:
         'Varda-päivityksissä tapahtuneet virheet annetusta ajanhetkestä eteenpäin',
       updated: 'Muokattu',
+      created: 'Luotu',
       child: 'Lapsi',
       serviceNeed: 'Palveluntarve',
       error: 'Virhe'

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2567,7 +2567,7 @@ export const fi = {
       description:
         'Varda-päivityksissä tapahtuneet virheet annetusta ajanhetkestä eteenpäin',
       updated: 'Muokattu',
-      created: 'Luotu',
+      age: 'Ikä (päivää)',
       child: 'Lapsi',
       serviceNeed: 'Palveluntarve',
       error: 'Virhe'

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
@@ -41,11 +41,12 @@ SELECT
     sno.name_fi as service_need_option_name,
     vsn.evaka_child_id AS child_id,
     vsn.updated,
-    vsn.created,
+    CASE WHEN vrc.reset_timestamp IS NULL THEN vrc.created ELSE vsn.created END AS created,
     vsn.errors
 FROM varda_service_need vsn
 JOIN service_need sn on vsn.evaka_service_need_id = sn.id
 JOIN service_need_option sno ON sn.option_id = sno.id
+LEFT JOIN varda_reset_child vrc ON vrc.evaka_child_id = vsn.evaka_child_id
 WHERE vsn.updated > :errorsSince AND vsn.update_failed = true
     """.trimIndent()
 ).bind("errorsSince", errorsSince)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
@@ -41,6 +41,7 @@ SELECT
     sno.name_fi as service_need_option_name,
     vsn.evaka_child_id AS child_id,
     vsn.updated,
+    vsn.created,
     vsn.errors
 FROM varda_service_need vsn
 JOIN service_need sn on vsn.evaka_service_need_id = sn.id
@@ -58,5 +59,6 @@ data class VardaErrorReportRow(
     val serviceNeedOptionName: String,
     val childId: UUID,
     val updated: HelsinkiDateTime,
+    val created: HelsinkiDateTime,
     val errors: List<String>
 )


### PR DESCRIPTION
#### Summary
- Show varda error age in varda errors report.
- Age is calculated from either  
-- varda_reset_child.created if reset_timestamp is null (e.g. reset failed)
-- varda_service_need.created otherwise

