### PR TITLE
Enable FreezeVoucherValueReports by default

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -79,7 +79,7 @@ data class ScheduledJobSettings(
                 schedule = JobSchedule.daily(LocalTime.of(7, 0))
             )
             ScheduledJob.FreezeVoucherValueReports -> ScheduledJobSettings(
-                enabled = false,
+                enabled = true,
                 schedule = JobSchedule.cron("0 0 0 25 * ?") // Monthly on 25th
             )
             ScheduledJob.InactivePeopleCleanup -> ScheduledJobSettings(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Espoo already has this enabled in prod/staging, so this will mostly affect other Espoo environments and Tampere
