### PR TITLE
Fix broken charts

### DIFF
--- a/frontend/src/employee-frontend/components/ai/AIPage.tsx
+++ b/frontend/src/employee-frontend/components/ai/AIPage.tsx
@@ -14,7 +14,7 @@ import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
 import Button from 'lib-components/atoms/buttons/Button'
 import { Line } from 'react-chartjs-2'
 import colors from 'lib-customizations/common'
-import { ChartOptions } from 'chart.js'
+import { ChartDataset, ChartOptions, ScatterDataPoint } from 'chart.js'
 
 export default React.memo(function AIPage() {
   const [status, setStatus] = useState<Result<Status>>(Loading.of())
@@ -37,7 +37,7 @@ export default React.memo(function AIPage() {
     return () => clearInterval(interval)
   }, [setStatus])
 
-  const datasets = [
+  const datasets: ChartDataset<'line', ScatterDataPoint[]>[] = [
     {
       label: 'childrenInFirstPreferencePercentage',
       data: status.isSuccess
@@ -46,7 +46,7 @@ export default React.memo(function AIPage() {
             y: g.value.childrenInFirstPreferencePercentage / 100
           }))
         : [],
-      steppedLine: false,
+      stepped: false,
       fill: false,
       pointBackgroundColor: colors.accents.red,
       borderColor: colors.accents.red
@@ -59,7 +59,7 @@ export default React.memo(function AIPage() {
             y: g.value.childrenInOneOfPreferencesPercentage / 100
           }))
         : [],
-      steppedLine: false,
+      stepped: false,
       fill: false,
       pointBackgroundColor: colors.accents.orange,
       borderColor: colors.accents.orange
@@ -72,7 +72,7 @@ export default React.memo(function AIPage() {
             y: g.value.maxCapacityPercentage / 100
           }))
         : [],
-      steppedLine: false,
+      stepped: false,
       fill: false,
       pointBackgroundColor: colors.brandEspoo.espooBlue,
       borderColor: colors.brandEspoo.espooBlue
@@ -145,12 +145,12 @@ interface Generation {
 function getGraphOptions(): ChartOptions<'line'> {
   return {
     scales: {
-      xAxis: {
+      x: {
         type: 'linear',
         min: 1,
         suggestedMax: 200
       },
-      yAxis: {
+      y: {
         min: 0,
         max: 1.3,
         ticks: {

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
@@ -4,7 +4,6 @@
 
 import React, { useState } from 'react'
 import styled from 'styled-components'
-import 'chartjs-adapter-date-fns'
 import { UnitOccupancies } from '../../../api/unit'
 import OccupancyCard from '../../../components/unit/tab-unit-information/occupancy/OccupancyCard'
 import OccupancyGraph from '../../../components/unit/tab-unit-information/occupancy/OccupancyGraph'

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -10,7 +10,7 @@ import colors from 'lib-customizations/common'
 import { formatTime } from 'lib-common/date'
 import { ceil } from 'lodash'
 import { useTranslation } from '../../../../state/i18n'
-import { ChartOptions } from 'chart.js'
+import { ChartData, ChartOptions } from 'chart.js'
 
 type DatePoint = { x: Date; y: number | null }
 
@@ -28,7 +28,7 @@ export default React.memo(function OccupancyDayGraph({ occupancy }: Props) {
 
   const graphOptions: ChartOptions<'line'> = {
     scales: {
-      xAxis: {
+      x: {
         type: 'time',
         time: {
           displayFormats: {
@@ -42,7 +42,7 @@ export default React.memo(function OccupancyDayGraph({ occupancy }: Props) {
           }
         }
       },
-      yAxis: {
+      y: {
         min: 0,
         ticks: {
           maxTicksLimit: 5,
@@ -71,25 +71,23 @@ export default React.memo(function OccupancyDayGraph({ occupancy }: Props) {
     }
   }
 
+  const data: ChartData<'line', DatePoint[]> = {
+    datasets: [
+      {
+        label: i18n.unit.occupancy.subtitles.realized,
+        data: graphData,
+        spanGaps: true,
+        stepped: 'after',
+        fill: false,
+        pointBackgroundColor: colors.accents.green,
+        borderColor: colors.accents.green
+      }
+    ]
+  }
+
   return (
     <div>
-      <Line
-        data={{
-          datasets: [
-            {
-              label: i18n.unit.occupancy.subtitles.realized,
-              data: graphData,
-              spanGaps: true,
-              stepped: 'after',
-              fill: false,
-              pointBackgroundColor: colors.accents.green,
-              borderColor: colors.accents.green
-            }
-          ]
-        }}
-        options={graphOptions}
-        height={100}
-      />
+      <Line data={data} options={graphOptions} height={100} />
     </div>
   )
 })

--- a/frontend/src/employee-frontend/index.tsx
+++ b/frontend/src/employee-frontend/index.tsx
@@ -12,6 +12,7 @@ import App from './App'
 import './index.css'
 import { getEnvironment } from 'lib-common/utils/helpers'
 import { appConfig } from 'lib-customizations/employee'
+import 'chartjs-adapter-date-fns'
 
 // Load Sentry before React to make Sentry's integrations work automatically
 Sentry.init({


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- typings say min/max should be numbers, even for type=time scales. In
  reality type=time requires Date objects
- merge defaults.font instead of replacing it
- move datefn adapter side-effect to entry point
- `steppedLine` doesn't exist anymore and should be `stepped`. No idea
  why type checks didn't catch this
- rename scale names. "xAxis"/"yAxis" seem to work based on some magic chartjs name mangling, but it's IMHO better to se "x"/"y" directly for clarity
- add explicit types to data/datasets props