### PR TITLE
Whitelist and validate attachment file extensions

### DIFF
--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1262,6 +1262,9 @@ const en: Translations = {
     loading: 'Loading',
     loaded: 'Loaded',
     error: {
+      EXTENSION_MISSING: 'Missing file extension',
+      EXTENSION_INVALID: 'Invalid file extension',
+      INVALID_CONTENT_TYPE: 'Invalid content type',
       FILE_TOO_LARGE: 'File is too big (max. 10MB)',
       SERVER_ERROR: 'Upload failed'
     },

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1200,6 +1200,9 @@ export default {
     loading: 'Ladataan...',
     loaded: 'Ladattu',
     error: {
+      EXTENSION_MISSING: 'Tiedostopääte puuttuu',
+      EXTENSION_INVALID: 'Virheellinen tiedostopääte',
+      INVALID_CONTENT_TYPE: 'Virheellinen tiedostomuoto',
       FILE_TOO_LARGE: 'Liian suuri tiedosto (max. 10MB)',
       SERVER_ERROR: 'Lataus ei onnistunut'
     },

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1213,6 +1213,9 @@ const sv: Translations = {
     loading: 'Uppladdas...',
     loaded: 'Uppladdad',
     error: {
+      EXTENSION_MISSING: 'Filtillägget saknas',
+      EXTENSION_INVALID: 'Ogiltigt filtillägg',
+      INVALID_CONTENT_TYPE: 'Ogiltig filtyp',
       FILE_TOO_LARGE: 'För stor fil (max. 10MB)',
       SERVER_ERROR: 'Uppladdningen misslyckades'
     },

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2706,6 +2706,9 @@ export const fi = {
       loading: 'Ladataan...',
       loaded: 'Ladattu',
       error: {
+        EXTENSION_MISSING: 'Tiedostopääte puuttuu',
+        EXTENSION_INVALID: 'Virheellinen tiedostopääte',
+        INVALID_CONTENT_TYPE: 'Virheellinen tiedostomuoto',
         FILE_TOO_LARGE: 'Liian suuri tiedosto (max. 10MB)',
         SERVER_ERROR: 'Lataus ei onnistunut'
       },

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsIntegrationTest.kt
@@ -4,30 +4,72 @@
 
 package fi.espoo.evaka.attachments
 
+import fi.espoo.evaka.s3.ContentType
+import fi.espoo.evaka.s3.checkFileExtension
 import fi.espoo.evaka.s3.getAndCheckFileContentType
 import fi.espoo.evaka.shared.domain.BadRequest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
 
 class AttachmentsIntegrationTest {
     private val pngFile = this::class.java.getResource("/attachments-fixtures/evaka-logo.png")
     private val jpgFile = this::class.java.getResource("/attachments-fixtures/evaka-logo.jpg")
+    private val licenseFile = this::class.java.getResource("/attachments-fixtures/evaka-logo.jpg.license")
 
     @Test
     fun `file content type check works for png file`() {
-        val file = pngFile.openStream()
-        getAndCheckFileContentType(file, listOf("image/png"))
+        pngFile.openStream().use { file ->
+            assertEquals("image/png", getAndCheckFileContentType(file, setOf(ContentType.PNG)))
+        }
     }
 
     @Test
     fun `file content type check works for jpg file`() {
-        val file = jpgFile.openStream()
-        getAndCheckFileContentType(file, listOf("image/jpeg"))
+        jpgFile.openStream().use { file ->
+            assertEquals("image/jpeg", getAndCheckFileContentType(file, setOf(ContentType.JPEG)))
+        }
     }
 
     @Test
-    fun `file content type check throws with magic numbers and content type mismatch`() {
-        val file = pngFile.openStream()
-        assertThrows<BadRequest> { getAndCheckFileContentType(file, listOf("application/pdf")) }
+    fun `file content type check throws on disallowed content type`() {
+        pngFile.openStream().use { file ->
+            assertThrows<BadRequest> { getAndCheckFileContentType(file, setOf(ContentType.PDF)) }
+        }
+    }
+
+    @Test
+    fun `file content type check throws on invalid contentType`() {
+        licenseFile.openStream().use { file ->
+            val exception = assertThrows<BadRequest> {
+                getAndCheckFileContentType(file, ContentType.values().toSet())
+            }
+            assertEquals("Invalid content type text/plain", exception.message)
+        }
+    }
+
+    @Test
+    fun `checkFileExtension does not throw on valid cases`() {
+        val cases = listOf(
+            "jpeg" to "image/jpeg",
+            "png" to "image/png",
+            "doc" to "application/msword"
+        )
+        cases.forEach { (extension, contentType) ->
+            assertDoesNotThrow { checkFileExtension(extension, contentType) }
+        }
+    }
+
+    @Test
+    fun `checkFileExtension throws on invalid cases`() {
+        val cases = listOf(
+            "foo" to "bar",
+            "png" to "image/jpeg",
+            "pdf" to "application/msword"
+        )
+        cases.forEach { (extension, contentType) ->
+            assertThrows<BadRequest> { checkFileExtension(extension, contentType) }
+        }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/childimages/ChildImage.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/childimages/ChildImage.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.childimages
 
+import fi.espoo.evaka.s3.ContentType
 import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.s3.DocumentWrapper
 import fi.espoo.evaka.s3.getAndCheckFileContentType
@@ -18,7 +19,7 @@ data class ChildImage(
 
 const val childImagesBucketPrefix = "child-images/"
 
-val allowedContentTypes = listOf("image/jpeg", "image/png")
+val allowedContentTypes = setOf(ContentType.JPEG, ContentType.PNG)
 
 fun replaceImage(
     db: Database.Connection,

--- a/service/src/main/kotlin/fi/espoo/evaka/s3/ContentTypeUtils.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/s3/ContentTypeUtils.kt
@@ -9,22 +9,55 @@ import java.io.InputStream
 
 val tika: org.apache.tika.Tika = org.apache.tika.Tika()
 
-fun getAndCheckFileContentType(file: InputStream, allowedContentTypes: List<String>): String {
+enum class ContentType(val value: String) {
+    JPEG("image/jpeg"),
+    PNG("image/png"),
+    PDF("application/pdf"),
+    MSWORD("application/msword"),
+    MSWORD_DOCX("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+    OPEN_DOCUMENT_TEXT("application/vnd.oasis.opendocument.text"),
+    TIKA_MSOFFICE("application/x-tika-msoffice"),
+    TIKA_OOXML("application/x-tika-ooxml"),
+    VIDEO_ANY("video/*"),
+    AUDIO_ANY("audio/*"),
+}
+
+fun getAllowedFileExtensionsByContentType(contentType: ContentType): Set<String> = when (contentType) {
+    ContentType.JPEG -> setOf("jpg", "jpeg")
+    ContentType.PNG -> setOf("png")
+    ContentType.PDF -> setOf("pdf")
+    ContentType.MSWORD -> setOf("doc")
+    ContentType.MSWORD_DOCX -> setOf("docx")
+    ContentType.OPEN_DOCUMENT_TEXT -> setOf("odt")
+    ContentType.TIKA_MSOFFICE -> setOf("doc", "docx")
+    ContentType.TIKA_OOXML -> setOf("doc", "docx")
+    ContentType.VIDEO_ANY -> setOf("avi", "mp4", "mpeg", "ogv", "webm", "3gp")
+    ContentType.AUDIO_ANY -> setOf("aac", "mid", "midi", "mp3", "oga", "wav", "weba", "3gp")
+}
+
+fun getAndCheckFileContentType(file: InputStream, allowedContentTypes: Set<ContentType>): String {
     val contentType = tika.detect(file)
-    if (!isAllowedContentType(contentType, allowedContentTypes)) throw BadRequest("Invalid content type $contentType")
+    if (!isAllowedContentType(contentType, allowedContentTypes)) throw BadRequest("Invalid content type $contentType", "INVALID_CONTENT_TYPE")
     return contentType
 }
 
 // Matches given content type with list of allowed contents types which must be either be "type/subtype" or
 // "type/*" to allow all subtypes of the type, like "image/png" or "video/*
-fun isAllowedContentType(contentType: String, allowedContentTypes: List<String>): Boolean {
+fun isAllowedContentType(contentType: String, allowedContentTypes: Set<ContentType>): Boolean {
     val contentTypeParts = contentType.split("/", ";")
     return contentTypeParts.size >= 2 && allowedContentTypes.any { allowedContentType ->
-        val allowedContentTypeParts = allowedContentType.split("/")
+        val allowedContentTypeParts = allowedContentType.value.split("/")
         (allowedContentTypeParts.size == 1 && contentTypeParts.get(0) == allowedContentTypeParts.get(0)) ||
             (
                 allowedContentTypeParts.size == 2 && contentTypeParts.get(0) == allowedContentTypeParts.get(0) &&
                     (allowedContentTypeParts.get(1) == "*" || contentTypeParts.get(1) == allowedContentTypeParts.get(1))
                 )
     }
+}
+
+fun checkFileExtension(fileExtension: String, contentType: String) {
+    ContentType.values().find { it.value == contentType }
+        ?.let { getAllowedFileExtensionsByContentType(it).contains(fileExtension.lowercase()) }
+        ?: false ||
+        throw BadRequest("Invalid file extension $fileExtension", "EXTENSION_INVALID")
 }


### PR DESCRIPTION
#### Summary

- Model allowed/known contentTypes as an enum class
- File extension must match the content type
- Render contentType/extension related error messages in the file upload component

<img width="263" alt="kuva" src="https://user-images.githubusercontent.com/1176169/141103558-414680f1-af2f-4be6-94e0-2ca5a86727c5.png">
