### PR TITLE
Fix decisions routing in citizen frontend

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -4,7 +4,7 @@
 
 import { ErrorBoundary } from '@sentry/react'
 import ErrorPage from 'lib-components/molecules/ErrorPage'
-import { AuthContext, AuthContextProvider } from './auth/state'
+import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
 import { theme } from 'lib-customizations/common'
 import React, { ReactNode, useCallback, useContext } from 'react'
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom'
@@ -12,26 +12,25 @@ import { ThemeProvider } from 'styled-components'
 import ApplicationCreation from './applications/ApplicationCreation'
 import ApplicationEditor from './applications/editor/ApplicationEditor'
 import ApplicationReadView from './applications/read-view/ApplicationReadView'
-import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
+import ApplyingRouter from './applying/ApplyingRouter'
+import { UnwrapResult } from './async-rendering'
 import requireAuth from './auth/requireAuth'
+import { AuthContext, AuthContextProvider } from './auth/state'
+import CalendarPage from './calendar/CalendarPage'
+import CitizenReloadNotification from './CitizenReloadNotification'
 import DecisionResponseList from './decisions/decision-response-page/DecisionResponseList'
-import Decisions from './decisions/decisions-page/Decisions'
 import Header from './header/Header'
+import IncomeStatementEditor from './income-statements/IncomeStatementEditor'
+import IncomeStatements from './income-statements/IncomeStatements'
+import IncomeStatementView from './income-statements/IncomeStatementView'
 import { Localization, useTranslation } from './localization'
 import MessagesPage from './messages/MessagesPage'
-import CalendarPage from './calendar/CalendarPage'
 import { MessageContextProvider } from './messages/state'
 import GlobalErrorDialog from './overlay/Error'
 import GlobalInfoDialog from './overlay/Info'
 import { OverlayContextProvider } from './overlay/state'
-import IncomeStatements from './income-statements/IncomeStatements'
-import IncomeStatementEditor from './income-statements/IncomeStatementEditor'
-import IncomeStatementView from './income-statements/IncomeStatementView'
-import Applying from './applying/Applying'
 import PedagogicalDocuments from './pedagogical-documents/PedagogicalDocuments'
 import { PedagogicalDocumentsContextProvider } from './pedagogical-documents/state'
-import { UnwrapResult } from './async-rendering'
-import CitizenReloadNotification from './CitizenReloadNotification'
 
 export default function App() {
   const i18n = useTranslation()
@@ -50,21 +49,7 @@ export default function App() {
                     <Header />
                     <Main>
                       <Switch>
-                        <Route
-                          exact
-                          path="/applying/map"
-                          component={Applying}
-                        />
-                        <Route
-                          exact
-                          path="/applying/applications"
-                          component={requireAuth(Applying)}
-                        />
-                        <Route
-                          exact
-                          path="/applying/decisions"
-                          component={requireAuth(Applying)}
-                        />
+                        <Route path="/applying" component={ApplyingRouter} />
                         <Route
                           exact
                           path="/applications/new/:childId"
@@ -94,11 +79,6 @@ export default function App() {
                           exact
                           path="/applications/:applicationId/edit"
                           component={requireAuth(ApplicationEditor)}
-                        />
-                        <Route
-                          exact
-                          path="/decisions"
-                          component={requireAuth(Decisions)}
                         />
                         <Route
                           exact

--- a/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
+++ b/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import Applications from '../applications/Applications'
+import requireAuth from '../auth/requireAuth'
 import { useUser } from '../auth/state'
 import Decisions from '../decisions/decisions-page/Decisions'
 import { useTranslation } from '../localization'
@@ -10,11 +11,11 @@ import MapView from '../map/MapView'
 import Tabs from 'lib-components/molecules/Tabs'
 import { Gap } from 'lib-components/white-space'
 import React from 'react'
-import { Route, Switch } from 'react-router-dom'
+import { Redirect, Route, Switch } from 'react-router-dom'
 
-export default React.memo(function Applying() {
+export default React.memo(function ApplyingRouter() {
   const t = useTranslation()
-  const loggedIn = !!useUser()
+  const user = useUser()
 
   const tabs = [
     {
@@ -36,7 +37,7 @@ export default React.memo(function Applying() {
 
   return (
     <>
-      {loggedIn && (
+      {user && (
         <>
           <Gap size="s" />
           <Tabs tabs={tabs} dataQa="applying-subnavigation" />
@@ -44,8 +45,17 @@ export default React.memo(function Applying() {
       )}
       <Switch>
         <Route exact path="/applying/map" component={MapView} />
-        <Route exact path="/applying/applications" component={Applications} />
-        <Route exact path="/applying/decisions" component={Decisions} />
+        <Route
+          exact
+          path="/applying/applications"
+          component={requireAuth(Applications)}
+        />
+        <Route
+          exact
+          path="/applying/decisions"
+          component={requireAuth(Decisions)}
+        />
+        <Redirect to="/applying/map" />
       </Switch>
     </>
   )

--- a/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponseList.tsx
+++ b/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponseList.tsx
@@ -52,7 +52,7 @@ export default React.memo(function DecisionResponseList() {
     if (warnAboutMissingResponse) {
       setDisplayDecisionWithNoResponseWarning(true)
     } else {
-      router.push('/decisions')
+      router.push('/applying/decisions')
     }
   }
 
@@ -120,7 +120,7 @@ export default React.memo(function DecisionResponseList() {
                 t.decisions.applicationDecisions.warnings
                   .decisionWithNoResponseWarning.resolveLabel,
               action: () => {
-                router.push('/decisions')
+                router.push('/applying/decisions')
               }
             }}
             reject={{


### PR DESCRIPTION
#### Summary

- Remove `/decisions` route from root level, always route to `/applying/decisions`
- Remove duplicate routes from root router, handle everything in `ApplyingRouter`

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

