### PR TITLE
EVAKA-HOTFIX better props typing for Select

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupTransferModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupTransferModal.tsx
@@ -139,6 +139,7 @@ export default React.memo(function GroupTransferModal({
             }
             selectedItem={form.group}
             getItemLabel={(group) => group.name}
+            getItemValue={(group) => group.id}
           />
         </section>
         <section>

--- a/frontend/src/lib-components/atoms/dropdowns/Select.tsx
+++ b/frontend/src/lib-components/atoms/dropdowns/Select.tsx
@@ -9,9 +9,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faChevronDown } from 'lib-icons'
 import { borderStyles, DropdownProps, Root } from './shared'
 
-interface SelectProps<T> extends DropdownProps<T, HTMLSelectElement> {
-  getItemValue?: T extends string | number ? never : (item: T) => string
-}
+type SelectProps<T> = DropdownProps<T, HTMLSelectElement> &
+  (T extends string | number
+    ? { getItemValue?: never }
+    : { getItemValue: (item: T) => string })
 
 function Select<T>(props: SelectProps<T>) {
   const {
@@ -21,13 +22,17 @@ function Select<T>(props: SelectProps<T>) {
     onChange,
     disabled,
     getItemLabel = defaultGetItemLabel,
-    getItemValue = defaultGetItemLabel,
     getItemDataQa,
     name,
     onFocus,
     fullWidth,
     'data-qa': dataQa
   } = props
+
+  const getItemValue =
+    'getItemValue' in props && props.getItemValue
+      ? props.getItemValue
+      : defaultGetItemLabel
 
   const onSelectedItemChange = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Fix `<Select/>` to require passing `getItemValue` prop when the type parameter is not a subtype of the type `string | number`.

