### PR TITLE
Add missing foreign key index to income.updated_by

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueriesTest.kt
@@ -48,7 +48,7 @@ class IncomeQueriesTest : PureJdbiTest() {
     }
 
     private val personId = testAdult_1.id
-    private val userId = UUID.randomUUID()
+    private val userId = UUID.fromString("00000000-0000-0000-0000-000000000000")
     private val testIncome = Income(
         id = IncomeId(UUID.randomUUID()),
         personId = personId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -1971,7 +1971,8 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest() {
                 validFrom = period.start,
                 validTo = period.end,
                 effect = IncomeEffect.INCOME,
-                data = mapOf("MAIN_INCOME" to IncomeValue(amount, IncomeCoefficient.MONTHLY_NO_HOLIDAY_BONUS, 1))
+                data = mapOf("MAIN_INCOME" to IncomeValue(amount, IncomeCoefficient.MONTHLY_NO_HOLIDAY_BONUS, 1)),
+                updatedBy = testDecisionMaker_1.id
             )
         }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/FamilyOverviewTest.kt
@@ -206,7 +206,8 @@ class FamilyOverviewTest : FullApplicationTest() {
                 objectMapper,
                 personId,
                 effect = IncomeEffect.INCOME,
-                data = mapOf("MAIN_INCOME" to IncomeValue(incomeTotal, IncomeCoefficient.MONTHLY_NO_HOLIDAY_BONUS, 1))
+                data = mapOf("MAIN_INCOME" to IncomeValue(incomeTotal, IncomeCoefficient.MONTHLY_NO_HOLIDAY_BONUS, 1)),
+                updatedBy = testDecisionMaker_1.id
             )
         }
         return incomeTotal

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -37,6 +37,7 @@ import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.testDecisionMaker_1
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -119,7 +120,7 @@ class MergeServiceIntegrationTest : PureJdbiTest() {
                 startDate = LocalDate.of(2015, 1, 1),
                 endDate = LocalDate.of(2030, 1, 1)
             )
-            it.insertTestIncome(objectMapper, adultIdDuplicate, validFrom = validFrom, validTo = validTo)
+            it.insertTestIncome(objectMapper, adultIdDuplicate, validFrom = validFrom, validTo = validTo, updatedBy = testDecisionMaker_1.id)
         }
 
         val countBefore = db.read {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
@@ -94,7 +94,7 @@ fun Database.Read.getIncome(mapper: ObjectMapper, incomeTypesProvider: IncomeTyp
         """
         SELECT income.*, evaka_user.name AS updated_by_name
         FROM income
-        LEFT JOIN evaka_user ON income.updated_by = evaka_user.id
+        JOIN evaka_user ON income.updated_by = evaka_user.id
         WHERE income.id = :id
         """.trimIndent()
     )
@@ -113,7 +113,7 @@ fun Database.Read.getIncomesForPerson(
         """
         SELECT income.*, evaka_user.name AS updated_by_name
         FROM income
-        LEFT JOIN evaka_user ON income.updated_by = evaka_user.id
+        JOIN evaka_user ON income.updated_by = evaka_user.id
         WHERE person_id = :personId
         AND (:validAt::timestamp IS NULL OR tsrange(valid_from, valid_to) @> :validAt::timestamp)
         ORDER BY valid_from DESC
@@ -136,7 +136,7 @@ fun Database.Read.getIncomesFrom(
         """
         SELECT income.*, evaka_user.name AS updated_by_name
         FROM income
-        LEFT JOIN evaka_user ON income.updated_by = evaka_user.id
+        JOIN evaka_user ON income.updated_by = evaka_user.id
         WHERE
             person_id = ANY(:personIds)
             AND (valid_to IS NULL OR valid_to >= :from)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -506,7 +506,7 @@ fun Database.Transaction.insertTestIncome(
     data: Map<String, IncomeValue> = mapOf(),
     effect: IncomeEffect = IncomeEffect.MAX_FEE_ACCEPTED,
     updatedAt: Instant = Instant.now(),
-    updatedBy: UUID = UUID.randomUUID()
+    updatedBy: UUID
 ): UUID {
     createUpdate(
         """

--- a/service/src/main/resources/db/migration/V176__evaka_user_income_updated_by.sql
+++ b/service/src/main/resources/db/migration/V176__evaka_user_income_updated_by.sql
@@ -1,0 +1,38 @@
+INSERT INTO evaka_user (id, type, employee_id, name)
+SELECT id, 'EMPLOYEE', id, first_name || ' ' || last_name
+FROM employee
+WHERE id IN (
+    SELECT updated_by FROM income
+)
+  AND NOT EXISTS (SELECT 1 FROM mobile_device WHERE mobile_device.id = employee.id)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO evaka_user (id, type, citizen_id, name)
+SELECT id, 'CITIZEN', id, first_name || ' ' || last_name
+FROM person
+WHERE id IN (
+    SELECT updated_by FROM income
+)
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE income
+    ADD COLUMN updated_by_new uuid;
+
+UPDATE income
+SET updated_by_new = COALESCE(
+    (
+        SELECT id
+        FROM evaka_user
+        WHERE evaka_user.id = income.updated_by
+    ),
+    '00000000-0000-0000-0000-000000000000');
+
+ALTER TABLE income
+    DROP COLUMN updated_by;
+ALTER TABLE income
+    RENAME COLUMN updated_by_new TO updated_by;
+ALTER TABLE income
+    ALTER COLUMN updated_by SET NOT NULL,
+    ADD CONSTRAINT fk$updated_by FOREIGN KEY (updated_by) REFERENCES evaka_user (id);
+
+CREATE INDEX idx$income_updated_by ON income (updated_by);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -173,3 +173,4 @@ V172__remove_daycare_organization_oid.sql
 V173__create_rejected_not_confirmed_state_for_placement_plans.sql
 V174__non_nullable_person_data.sql
 V175__person_preferred_name.sql
+V176__evaka_user_income_updated_by.sql


### PR DESCRIPTION
#### Summary

- Add `evaka_user` rows for all `income.updated_by` references
- Add missing foreign key index to `income.updated_by`
  - create new column first to verify that there are no broken references
- Add missing fk index
- Use inner joins on `income.updated_by`

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

