### PR TITLE
Don't try to void study rights that were never sent

### DIFF
--- a/service/src/main/resources/db/migration/R__koski_views.sql
+++ b/service/src/main/resources/db/migration/R__koski_views.sql
@@ -145,6 +145,7 @@ TABLE (
         FROM koski_placement(today) kp
         WHERE (kp.child_id, kp.unit_id, kp.type) = (ksr.child_id, ksr.unit_id, ksr.type)
     )
+    AND ksr.study_right_oid IS NOT NULL
     AND (nullif(pr.social_security_number, '') IS NOT NULL OR nullif(pr.oph_person_oid, '') IS NOT NULL)
     AND d.upload_to_koski IS TRUE
     AND nullif(d.oph_unit_oid, '') IS NOT NULL


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

There's never any reason to try to void a study right if we don't have an OID. I'm still not sure if this scenario is possible with the current code, but it's reasonable to do this anyway.

Based on production data investigation, this seems to be a problem with only legacy data where a row was inserted to `koski_study_right` without a valid OID. This should not be possible anymore, because we run the `INSERT` without OID and `UPDATE` with OID in the same transaction.