### PR TITLE
Refresh employee's unread message counts periodically

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -37,7 +37,6 @@ const PanelContainer = styled.div`
 export default function MessagesPage() {
   const {
     nestedAccounts,
-    loadNestedAccounts,
     selectedDraft,
     setSelectedDraft,
     selectedAccount,
@@ -49,7 +48,6 @@ export default function MessagesPage() {
   const { setErrorMessage } = useContext(UIContext)
   const { i18n } = useTranslation()
 
-  useEffect(() => loadNestedAccounts(), [loadNestedAccounts])
   useEffect(() => refreshMessages(), [refreshMessages])
   const [sending, setSending] = useState(false)
 

--- a/frontend/src/lib-common/utils/useAxiosResponseInterceptor.ts
+++ b/frontend/src/lib-common/utils/useAxiosResponseInterceptor.ts
@@ -2,23 +2,23 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import axios, { AxiosInstance } from 'axios'
-import { useEffect, useState } from 'react'
+import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios'
+import { useEffect } from 'react'
 
-export function useAxiosResponseInterceptor(client: AxiosInstance): {
-  lastResponse: number
-} {
-  const [lastResponse, setLastResponse] = useState(Date.now())
-
+export function useAxiosResponseInterceptor(
+  client: AxiosInstance,
+  onSuccess: (res: AxiosResponse) => void,
+  onError?: (res: AxiosError) => void
+) {
   useEffect(() => {
     const id = client.interceptors.response.use(
       (res) => {
-        setLastResponse(Date.now())
+        onSuccess(res)
         return res
       },
       (err: unknown) => {
-        if (axios.isAxiosError(err) && err.response) {
-          setLastResponse(Date.now())
+        if (onError && axios.isAxiosError(err)) {
+          onError(err)
         }
         return Promise.reject(err)
       }
@@ -26,7 +26,5 @@ export function useAxiosResponseInterceptor(client: AxiosInstance): {
     return () => {
       client.interceptors.response.eject(id)
     }
-  }, [client.interceptors.response])
-
-  return { lastResponse }
+  }, [client.interceptors.response, onError, onSuccess])
 }

--- a/frontend/src/lib-common/utils/useAxiosResponseInterceptor.ts
+++ b/frontend/src/lib-common/utils/useAxiosResponseInterceptor.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import axios, { AxiosInstance } from 'axios'
+import { useEffect, useState } from 'react'
+
+export function useAxiosResponseInterceptor(client: AxiosInstance): {
+  lastResponse: number
+} {
+  const [lastResponse, setLastResponse] = useState(Date.now())
+
+  useEffect(() => {
+    const id = client.interceptors.response.use(
+      (res) => {
+        setLastResponse(Date.now())
+        return res
+      },
+      (err: unknown) => {
+        if (axios.isAxiosError(err) && err.response) {
+          setLastResponse(Date.now())
+        }
+        return Promise.reject(err)
+      }
+    )
+    return () => {
+      client.interceptors.response.eject(id)
+    }
+  }, [client.interceptors.response])
+
+  return { lastResponse }
+}

--- a/frontend/src/lib-common/utils/useInterval.ts
+++ b/frontend/src/lib-common/utils/useInterval.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { useEffect, useRef } from 'react'
+
+type Callback = () => void
+
+export function useInterval(cb: Callback, delayMs: number) {
+  const callbackRef = useRef<Callback>()
+
+  useEffect(() => {
+    callbackRef.current = cb
+  }, [cb])
+
+  useEffect(() => {
+    function functionToBeExecutedLater() {
+      callbackRef?.current?.()
+    }
+
+    const id = setInterval(functionToBeExecutedLater, delayMs)
+    return () => clearInterval(id)
+  }, [delayMs])
+}

--- a/frontend/src/lib-common/utils/usePeriodicRefresh.ts
+++ b/frontend/src/lib-common/utils/usePeriodicRefresh.ts
@@ -23,7 +23,9 @@ export function usePeriodicRefresh(
   callback: () => void,
   { thresholdInMinutes }: PeriodicRefreshOptions
 ) {
-  const { lastResponse } = useAxiosResponseInterceptor(client)
+  const [lastResponse, setLastResponse] = useState(Date.now())
+  const updateLastResponse = useCallback(() => setLastResponse(Date.now()), [])
+  useAxiosResponseInterceptor(client, updateLastResponse)
 
   const [nextThreshold, setNextThreshold] = useState(
     calculateNextThreshold(thresholdInMinutes)

--- a/frontend/src/lib-common/utils/usePeriodicRefresh.ts
+++ b/frontend/src/lib-common/utils/usePeriodicRefresh.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { AxiosInstance } from 'axios'
+import { useCallback, useState } from 'react'
+import { useAxiosResponseInterceptor } from './useAxiosResponseInterceptor'
+import { useInterval } from './useInterval'
+
+const TEN_SECONDS_MILLIS = 10 * 1000
+
+const calculateNextThreshold = (minutes: number) =>
+  Date.now() + minutes * 60 * 1000
+
+export interface PeriodicRefreshOptions {
+  thresholdInMinutes: number
+}
+
+// triggers after the given threshold in minutes
+// if there has also been axios activity after the threshold
+export function usePeriodicRefresh(
+  client: AxiosInstance,
+  callback: () => void,
+  { thresholdInMinutes }: PeriodicRefreshOptions
+) {
+  const { lastResponse } = useAxiosResponseInterceptor(client)
+
+  const [nextThreshold, setNextThreshold] = useState(
+    calculateNextThreshold(thresholdInMinutes)
+  )
+
+  const executeOnExceededThreshold = useCallback(() => {
+    if (Date.now() >= nextThreshold && lastResponse >= nextThreshold) {
+      setNextThreshold(calculateNextThreshold(thresholdInMinutes))
+      callback()
+    }
+  }, [callback, lastResponse, nextThreshold, thresholdInMinutes])
+
+  useInterval(executeOnExceededThreshold, TEN_SECONDS_MILLIS)
+}


### PR DESCRIPTION
#### Summary

- Add `useInterval` hook for fetching unread message counts every minute
- Instead of manually tracking the unread count after opening the thread, just mark the thread read and refresh unread counts
- Simplify `unreadCount` logic in `Header`
- Also load message accounts only in the message context, do not expose refresh callback
  - They are always needed in the header
  - There is no use fetching them again after message page is mounted

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

