### PR TITLE
Display count of income statements awaiting handler

### DIFF
--- a/frontend/src/employee-frontend/api/income-statement.ts
+++ b/frontend/src/employee-frontend/api/income-statement.ts
@@ -34,11 +34,19 @@ export async function getIncomeStatements(
     .catch((e) => Failure.fromError(e))
 }
 
-export async function getIncomeStatementsAwaitingHandler(
-  areas: string[] = [],
-  page = 1,
-  pageSize = 50
-): Promise<Result<Paged<IncomeStatementAwaitingHandler>>> {
+export interface IncomeStatementsAwaitingHandlerParams {
+  areas: string[]
+  page: number
+  pageSize: number
+}
+
+export async function getIncomeStatementsAwaitingHandler({
+  areas,
+  page,
+  pageSize
+}: IncomeStatementsAwaitingHandlerParams): Promise<
+  Result<Paged<IncomeStatementAwaitingHandler>>
+> {
   return client
     .get<JsonOf<Paged<IncomeStatementAwaitingHandler>>>(
       '/income-statements/awaiting-handler',


### PR DESCRIPTION
#### Summary

- Display count of income statements awaiting handler
- Also hide pagination when there's nothing to paginate
- Refactor to useApiState and search params as object

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

