### PR TITLE
Refactor child context

### DIFF
--- a/frontend/src/employee-frontend/components/ChildInformation.tsx
+++ b/frontend/src/employee-frontend/components/ChildInformation.tsx
@@ -209,11 +209,11 @@ function getCurrentHeadOfChildId(fridgeRelations: Parentship[]) {
 }
 
 const ChildInformation = React.memo(function ChildInformation({
-  match
-}: RouteComponentProps<{ id: UUID }>) {
+  id
+}: {
+  id: UUID
+}) {
   const { i18n } = useTranslation()
-  const { id } = match.params
-
   const { roles } = useContext(UserContext)
   const { person, parentships } = useContext<ChildState>(ChildContext)
 
@@ -304,7 +304,7 @@ export default React.memo(function ChildInformationWrapper(
   const { id } = props.match.params
   return (
     <ChildContextProvider id={id}>
-      <ChildInformation {...props} />
+      <ChildInformation id={id} />
     </ChildContextProvider>
   )
 })

--- a/frontend/src/employee-frontend/components/ChildInformation.tsx
+++ b/frontend/src/employee-frontend/components/ChildInformation.tsx
@@ -334,8 +334,9 @@ const ChildInformation = React.memo(function ChildInformation({
 export default React.memo(function ChildInformationWrapper(
   props: RouteComponentProps<{ id: UUID }>
 ) {
+  const { id } = props.match.params
   return (
-    <ChildContextProvider>
+    <ChildContextProvider id={id}>
       <ChildInformation {...props} />
     </ChildContextProvider>
   )

--- a/frontend/src/employee-frontend/components/ChildInformation.tsx
+++ b/frontend/src/employee-frontend/components/ChildInformation.tsx
@@ -6,7 +6,6 @@ import { faCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { fontWeights } from 'lib-components/typography'
 import MessageBlocklist from './child-information/MessageBlocklist'
-import { Loading } from 'lib-common/api'
 import LocalDate from 'lib-common/local-date'
 import Title from 'lib-components/atoms/Title'
 import { Container, ContentArea } from 'lib-components/layout/Container'
@@ -16,8 +15,6 @@ import { faUsers } from 'lib-icons'
 import React, { useContext, useEffect, useMemo } from 'react'
 import { Link, RouteComponentProps } from 'react-router-dom'
 import styled from 'styled-components'
-import { getParentshipsByChild } from '../api/parentships'
-import { getChildDetails } from '../api/person'
 import Assistance from './child-information/Assistance'
 import BackupCare from './child-information/BackupCare'
 import ChildApplications from './child-information/ChildApplications'
@@ -32,7 +29,6 @@ import { useTranslation } from '../state/i18n'
 import { TitleContext, TitleState } from '../state/title'
 import { UserContext } from '../state/user'
 import { Parentship } from 'lib-common/generated/api-types/pis'
-import { requireRole } from '../utils/roles'
 import DailyServiceTimesSection from './child-information/DailyServiceTimesSection'
 import VasuAndLeops from './child-information/VasuAndLeops'
 import { getLayout, Layouts } from './layouts'
@@ -219,38 +215,9 @@ const ChildInformation = React.memo(function ChildInformation({
   const { id } = match.params
 
   const { roles } = useContext(UserContext)
-  const {
-    person,
-    setPerson,
-    parentships,
-    setParentships,
-    setPermittedActions
-  } = useContext<ChildState>(ChildContext)
+  const { person, parentships } = useContext<ChildState>(ChildContext)
 
   const { setTitle, formatTitleName } = useContext<TitleState>(TitleContext)
-
-  useEffect(() => {
-    setPerson(Loading.of())
-    setParentships(Loading.of())
-    setPermittedActions(new Set())
-    void getChildDetails(id).then((result) => {
-      setPerson(result.map((details) => details.person))
-      if (result.isSuccess) {
-        setPermittedActions(
-          new Set([
-            ...result.value.permittedActions,
-            ...result.value.permittedPersonActions
-          ])
-        )
-      }
-    })
-
-    if (
-      requireRole(roles, 'SERVICE_WORKER', 'UNIT_SUPERVISOR', 'FINANCE_ADMIN')
-    ) {
-      void getParentshipsByChild(id).then(setParentships)
-    }
-  }, [id, roles, setParentships, setPermittedActions, setPerson])
 
   useEffect(() => {
     if (person.isSuccess) {

--- a/frontend/src/employee-frontend/components/async-rendering.tsx
+++ b/frontend/src/employee-frontend/components/async-rendering.tsx
@@ -8,21 +8,12 @@ import {
   UnwrapResultProps
 } from 'lib-components/async-rendering'
 import { useTranslation } from '../state/i18n'
-import { Result } from 'lib-common/api'
-import React from 'react'
 
 function useFailureMessage() {
   const { i18n } = useTranslation()
   return i18n.common.loadingFailed
 }
 
-const { UnwrapResult } = makeHelpers(useFailureMessage)
+const { UnwrapResult, renderResult } = makeHelpers(useFailureMessage)
 export type { UnwrapResultProps, RenderResultFn }
-export { UnwrapResult }
-
-export function renderResult<T>(
-  result: Result<T>,
-  renderer: RenderResultFn<T>
-) {
-  return <UnwrapResult result={result}>{renderer}</UnwrapResult>
-}
+export { UnwrapResult, renderResult }

--- a/frontend/src/employee-frontend/components/child-information/Assistance.tsx
+++ b/frontend/src/employee-frontend/components/child-information/Assistance.tsx
@@ -16,7 +16,7 @@ export interface Props {
   startOpen: boolean
 }
 
-function Assistance({ id, startOpen }: Props) {
+export default React.memo(function Assistance({ id, startOpen }: Props) {
   const { i18n } = useTranslation()
   const { permittedActions } = useContext<ChildState>(ChildContext)
 
@@ -42,6 +42,4 @@ function Assistance({ id, startOpen }: Props) {
       </CollapsibleContentArea>
     </div>
   )
-}
-
-export default Assistance
+})

--- a/frontend/src/employee-frontend/components/child-information/AssistanceNeed.tsx
+++ b/frontend/src/employee-frontend/components/child-information/AssistanceNeed.tsx
@@ -2,11 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import React, { useContext, useMemo, useRef } from 'react'
 import { useTranslation } from '../../state/i18n'
-import { Loading, Result, Success } from 'lib-common/api'
-import { ChildContext } from '../../state'
-import Loader from 'lib-components/atoms/Loader'
+import { combine } from 'lib-common/api'
 import Title from 'lib-components/atoms/Title'
 import AssistanceNeedRow from './assistance-need/AssistanceNeedRow'
 import AssistanceNeedForm from '../../components/child-information/assistance-need/AssistanceNeedForm'
@@ -18,9 +16,9 @@ import {
   getAssistanceBasisOptions,
   getAssistanceNeeds
 } from '../../api/child/assistance-needs'
-import { AssistanceBasisOption } from '../../types/child'
-import { useRestApi } from 'lib-common/utils/useRestApi'
+import { useApiState } from 'lib-common/utils/useRestApi'
 import { UUID } from 'lib-common/types'
+import { renderResult } from '../async-rendering'
 
 const TitleRow = styled.div`
   display: flex;
@@ -39,98 +37,78 @@ export interface Props {
 
 function AssistanceNeed({ id }: Props) {
   const { i18n } = useTranslation()
-  const { assistanceNeeds, setAssistanceNeeds } = useContext(ChildContext)
+  const [assistanceNeeds, loadData] = useApiState(
+    () => getAssistanceNeeds(id),
+    [id]
+  )
+  const [assistanceBasisOptions] = useApiState(getAssistanceBasisOptions, [])
   const { uiMode, toggleUiMode } = useContext(UIContext)
   const refSectionTop = useRef(null)
 
-  const loadData = () => {
-    setAssistanceNeeds(Loading.of())
-    void getAssistanceNeeds(id).then(setAssistanceNeeds)
-  }
-
-  useEffect(loadData, [id]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const [assistanceBasisOptions, setAssistanceBasisOptions] = useState<
-    Result<AssistanceBasisOption[]>
-  >(Success.of([]))
-  const loadAssistanceBasisOptions = useRestApi(
-    getAssistanceBasisOptions,
-    setAssistanceBasisOptions
+  const duplicate = useMemo(
+    () =>
+      !!uiMode && uiMode.startsWith('duplicate-assistance-need')
+        ? assistanceNeeds
+            .map((needs) =>
+              needs.find((an) => an.id == uiMode.split('_').pop())
+            )
+            .getOrElse(undefined)
+        : undefined,
+    [assistanceNeeds, uiMode]
   )
-  useEffect(() => {
-    loadAssistanceBasisOptions()
-  }, [loadAssistanceBasisOptions])
 
-  function renderAssistanceNeeds() {
-    if (assistanceNeeds.isLoading || assistanceBasisOptions.isLoading) {
-      return <Loader />
-    } else if (assistanceNeeds.isFailure || assistanceBasisOptions.isFailure) {
-      return <div>{i18n.common.loadingFailed}</div>
-    } else {
-      return assistanceNeeds.value.map((assistanceNeed) => (
-        <AssistanceNeedRow
-          key={assistanceNeed.id}
-          assistanceNeed={assistanceNeed}
-          onReload={loadData}
-          assistanceBasisOptions={assistanceBasisOptions.value}
-          refSectionTop={refSectionTop}
-        />
-      ))
-    }
-  }
-
-  const duplicate =
-    !!uiMode &&
-    uiMode.startsWith('duplicate-assistance-need') &&
-    assistanceNeeds
-      .map((needs) => needs.find((an) => an.id == uiMode.split('_').pop()))
-      .getOrElse(undefined)
-
-  if (assistanceBasisOptions.isLoading) {
-    return <Loader />
-  }
-  if (assistanceBasisOptions.isFailure) {
-    return <div>{i18n.common.loadingFailed}</div>
-  }
-
-  return (
-    <div ref={refSectionTop}>
-      <TitleRow>
-        <Title size={4}>{i18n.childInformation.assistanceNeed.title}</Title>
-        <AddButton
-          flipped
-          text={i18n.childInformation.assistanceNeed.create}
-          onClick={() => {
-            toggleUiMode('create-new-assistance-need')
-            scrollToRef(refSectionTop)
-          }}
-          disabled={uiMode === 'create-new-assistance-need'}
-          data-qa="assistance-need-create-btn"
-        />
-      </TitleRow>
-      {uiMode === 'create-new-assistance-need' && (
-        <>
-          <AssistanceNeedForm
-            childId={id}
-            onReload={loadData}
-            assistanceBasisOptions={assistanceBasisOptions.value}
+  return renderResult(
+    combine(assistanceNeeds, assistanceBasisOptions),
+    ([assistanceNeeds, assistanceBasisOptions]) => (
+      <div ref={refSectionTop}>
+        <TitleRow>
+          <Title size={4}>{i18n.childInformation.assistanceNeed.title}</Title>
+          <AddButton
+            flipped
+            text={i18n.childInformation.assistanceNeed.create}
+            onClick={() => {
+              toggleUiMode('create-new-assistance-need')
+              scrollToRef(refSectionTop)
+            }}
+            disabled={uiMode === 'create-new-assistance-need'}
+            data-qa="assistance-need-create-btn"
           />
-          <div className="separator" />
-        </>
-      )}
-      {duplicate && (
-        <>
-          <AssistanceNeedForm
-            childId={id}
-            assistanceNeed={duplicate}
+        </TitleRow>
+        {uiMode === 'create-new-assistance-need' && (
+          <>
+            <AssistanceNeedForm
+              childId={id}
+              onReload={loadData}
+              assistanceNeeds={assistanceNeeds}
+              assistanceBasisOptions={assistanceBasisOptions}
+            />
+            <div className="separator" />
+          </>
+        )}
+        {duplicate && (
+          <>
+            <AssistanceNeedForm
+              childId={id}
+              assistanceNeed={duplicate}
+              onReload={loadData}
+              assistanceNeeds={assistanceNeeds}
+              assistanceBasisOptions={assistanceBasisOptions}
+            />
+            <div className="separator" />
+          </>
+        )}
+        {assistanceNeeds.map((assistanceNeed) => (
+          <AssistanceNeedRow
+            key={assistanceNeed.id}
+            assistanceNeed={assistanceNeed}
             onReload={loadData}
-            assistanceBasisOptions={assistanceBasisOptions.value}
+            assistanceNeeds={assistanceNeeds}
+            assistanceBasisOptions={assistanceBasisOptions}
+            refSectionTop={refSectionTop}
           />
-          <div className="separator" />
-        </>
-      )}
-      {renderAssistanceNeeds()}
-    </div>
+        ))}
+      </div>
+    )
   )
 }
 

--- a/frontend/src/employee-frontend/components/child-information/ChildApplications.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildApplications.tsx
@@ -2,14 +2,12 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useState, useContext, useEffect } from 'react'
+import React, { useContext, useState } from 'react'
 import * as _ from 'lodash'
 import { Link } from 'react-router-dom'
 import { faFileAlt } from 'lib-icons'
 import { useTranslation } from '../../state/i18n'
-import { Loading } from 'lib-common/api'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
-import Loader from 'lib-components/atoms/Loader'
 import { getChildApplicationSummaries } from '../../api/person'
 import { DateTd, NameTd, StatusTd } from '../PersonProfile'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
@@ -23,86 +21,23 @@ import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { H2 } from 'lib-components/typography'
 import { UUID } from 'lib-common/types'
 import { PersonApplicationSummary } from 'lib-common/generated/api-types/application'
+import { useApiState } from 'lib-common/utils/useRestApi'
+import { renderResult } from '../async-rendering'
 
 interface Props {
   id: UUID
   startOpen: boolean
 }
 
-const ChildApplications = React.memo(function ChildApplications({
-  id,
-  startOpen
-}: Props) {
+export default React.memo(function ChildApplications({ id, startOpen }: Props) {
   const { i18n } = useTranslation()
-  const { applications, setApplications, person, guardians } =
-    useContext(ChildContext)
+  const { person, guardians } = useContext(ChildContext)
   const { uiMode, toggleUiMode } = useContext(UIContext)
-
+  const [applications] = useApiState(
+    () => getChildApplicationSummaries(id),
+    [id]
+  )
   const [open, setOpen] = useState(startOpen)
-
-  const loadData = () => {
-    setApplications(Loading.of())
-    void getChildApplicationSummaries(id).then(setApplications)
-  }
-
-  useEffect(loadData, [id, setApplications])
-
-  function renderApplications() {
-    if (applications.isLoading) {
-      return <Loader />
-    } else if (applications.isFailure) {
-      return <div>{i18n.common.loadingFailed}</div>
-    } else
-      return _.orderBy(
-        applications.value,
-        ['preferredStartDate', 'preferredUnitName'],
-        ['desc', 'desc']
-      ).map((application: PersonApplicationSummary) => {
-        return (
-          <Tr
-            key={`${application.applicationId}`}
-            data-qa="table-application-row"
-          >
-            <NameTd data-qa="application-guardian-name">
-              <Link to={`/profile/${application.guardianId}`}>
-                {application.guardianName}
-              </Link>
-            </NameTd>
-            <Td data-qa="application-preferred-unit-id">
-              <Link to={`/units/${application.preferredUnitId ?? ''}`}>
-                {application.preferredUnitName}
-              </Link>
-            </Td>
-            <DateTd data-qa="application-start-date">
-              {application.preferredStartDate?.format()}
-            </DateTd>
-            <DateTd data-qa="application-sent-date">
-              {application.sentDate?.format()}
-            </DateTd>
-            <Td data-qa="application-type">
-              {
-                i18n.personProfile.application.types[
-                  inferApplicationType(application)
-                ]
-              }
-            </Td>
-            <StatusTd>
-              {i18n.personProfile.application.statuses[application.status] ??
-                application.status}
-            </StatusTd>
-            <Td>
-              <Link to={`/applications/${application.applicationId}`}>
-                <IconButton
-                  onClick={() => undefined}
-                  icon={faFileAlt}
-                  altText={i18n.personProfile.application.open}
-                />
-              </Link>
-            </Td>
-          </Tr>
-        )
-      })
-  }
 
   return (
     <CollapsibleContentArea
@@ -121,9 +56,7 @@ const ChildApplications = React.memo(function ChildApplications({
         />
       </RequireRole>
 
-      {applications.isLoading && <Loader />}
-      {applications.isFailure && <div>{i18n.common.loadingFailed}</div>}
-      {applications.isSuccess && (
+      {renderResult(applications, (applications) => (
         <Table data-qa="table-of-applications">
           <Thead>
             <Tr>
@@ -136,9 +69,58 @@ const ChildApplications = React.memo(function ChildApplications({
               <Th>{i18n.childInformation.application.open}</Th>
             </Tr>
           </Thead>
-          <Tbody>{renderApplications()}</Tbody>
+          <Tbody>
+            {_.orderBy(
+              applications,
+              ['preferredStartDate', 'preferredUnitName'],
+              ['desc', 'desc']
+            ).map((application: PersonApplicationSummary) => (
+              <Tr
+                key={`${application.applicationId}`}
+                data-qa="table-application-row"
+              >
+                <NameTd data-qa="application-guardian-name">
+                  <Link to={`/profile/${application.guardianId}`}>
+                    {application.guardianName}
+                  </Link>
+                </NameTd>
+                <Td data-qa="application-preferred-unit-id">
+                  <Link to={`/units/${application.preferredUnitId ?? ''}`}>
+                    {application.preferredUnitName}
+                  </Link>
+                </Td>
+                <DateTd data-qa="application-start-date">
+                  {application.preferredStartDate?.format()}
+                </DateTd>
+                <DateTd data-qa="application-sent-date">
+                  {application.sentDate?.format()}
+                </DateTd>
+                <Td data-qa="application-type">
+                  {
+                    i18n.personProfile.application.types[
+                      inferApplicationType(application)
+                    ]
+                  }
+                </Td>
+                <StatusTd>
+                  {i18n.personProfile.application.statuses[
+                    application.status
+                  ] ?? application.status}
+                </StatusTd>
+                <Td>
+                  <Link to={`/applications/${application.applicationId}`}>
+                    <IconButton
+                      onClick={() => undefined}
+                      icon={faFileAlt}
+                      altText={i18n.personProfile.application.open}
+                    />
+                  </Link>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
         </Table>
-      )}
+      ))}
 
       {uiMode === 'create-new-application' &&
         person.isSuccess &&
@@ -151,5 +133,3 @@ const ChildApplications = React.memo(function ChildApplications({
     </CollapsibleContentArea>
   )
 })
-
-export default ChildApplications

--- a/frontend/src/employee-frontend/components/child-information/ChildDetails.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildDetails.tsx
@@ -4,7 +4,6 @@
 
 import React, { useContext, useState } from 'react'
 import { useTranslation } from '../../state/i18n'
-import { Success } from 'lib-common/api'
 import AdditionalInformation from '../../components/child-information/person-details/AdditionalInformation'
 import { ChildContext, ChildState } from '../../state/child'
 import PersonDetails from '../../components/person-shared/PersonDetails'
@@ -17,7 +16,7 @@ interface Props {
   id: UUID
 }
 
-const ChildDetails = React.memo(function ChildDetails({ id }: Props) {
+export default React.memo(function ChildDetails({ id }: Props) {
   const { i18n } = useTranslation()
   const { person, setPerson, permittedActions } =
     useContext<ChildState>(ChildContext)
@@ -37,7 +36,7 @@ const ChildDetails = React.memo(function ChildDetails({ id }: Props) {
           <PersonDetails
             person={person}
             isChild={true}
-            onUpdateComplete={(p) => setPerson(Success.of(p))}
+            onUpdateComplete={setPerson}
             permittedActions={permittedActions}
           />
         ))}
@@ -50,5 +49,3 @@ const ChildDetails = React.memo(function ChildDetails({ id }: Props) {
     </div>
   )
 })
-
-export default ChildDetails

--- a/frontend/src/employee-frontend/components/child-information/GuardiansAndParents.tsx
+++ b/frontend/src/employee-frontend/components/child-information/GuardiansAndParents.tsx
@@ -2,47 +2,31 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import { useTranslation } from '../../state/i18n'
-import { useEffect } from 'react'
-import { Loading } from 'lib-common/api'
-import { useContext } from 'react'
-import Loader from 'lib-components/atoms/Loader'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import _ from 'lodash'
 import { Link } from 'react-router-dom'
 import { PersonJSON } from 'lib-common/generated/api-types/pis'
 import { formatName } from '../../utils'
 import { NameTd } from '../PersonProfile'
-import { ChildContext } from '../../state'
-import { getPersonGuardians } from '../../api/person'
 import { getAge } from 'lib-common/utils/local-date'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { H2, H3 } from 'lib-components/typography'
 import FridgeParents from './FridgeParents'
 import { Gap } from 'lib-components/white-space'
-import { UUID } from 'lib-common/types'
+import { UnwrapResult } from '../async-rendering'
+import { ChildContext } from '../../state'
 
 interface Props {
-  id: UUID
   startOpen: boolean
 }
 
-const GuardiansAndParents = React.memo(function Guardians({
-  id,
-  startOpen
-}: Props) {
+export default React.memo(function Guardians({ startOpen }: Props) {
   const { i18n } = useTranslation()
-  const { guardians, setGuardians } = useContext(ChildContext)
+  const { guardians } = useContext(ChildContext)
 
   const [open, setOpen] = useState(startOpen)
-
-  useEffect(() => {
-    setGuardians(Loading.of())
-    void getPersonGuardians(id).then((response) => {
-      setGuardians(response)
-    })
-  }, [id, setGuardians])
 
   const printableAddresses = (guardian: PersonJSON) =>
     [
@@ -50,30 +34,6 @@ const GuardiansAndParents = React.memo(function Guardians({
       guardian.postalCode || '',
       guardian.postOffice || ''
     ].join(', ')
-
-  const renderGuardians = () =>
-    guardians
-      .map((gs) =>
-        _.orderBy(gs, ['lastName', 'firstName'], ['asc']).map(
-          (guardian: PersonJSON) => {
-            return (
-              <Tr key={`${guardian.id}`} data-qa="table-guardian-row">
-                <NameTd data-qa="guardian-name">
-                  <Link to={`/profile/${guardian.id}`}>
-                    {formatName(guardian.firstName, guardian.lastName, i18n)}
-                  </Link>
-                </NameTd>
-                <Td data-qa="guardian-ssn">{guardian.socialSecurityNumber}</Td>
-                <Td data-qa="guardian-age">{getAge(guardian.dateOfBirth)}</Td>
-                <Td data-qa="guardian-street-address">
-                  {printableAddresses(guardian)}
-                </Td>
-              </Tr>
-            )
-          }
-        )
-      )
-      .getOrElse(null)
 
   return (
     <div>
@@ -96,15 +56,42 @@ const GuardiansAndParents = React.memo(function Guardians({
               <Th>{i18n.personProfile.streetAddress}</Th>
             </Tr>
           </Thead>
-          <Tbody>{renderGuardians()}</Tbody>
+          <Tbody>
+            <UnwrapResult result={guardians}>
+              {(guardians) => (
+                <>
+                  {_.orderBy(guardians, ['lastName', 'firstName'], ['asc']).map(
+                    (guardian: PersonJSON) => (
+                      <Tr key={`${guardian.id}`} data-qa="table-guardian-row">
+                        <NameTd data-qa="guardian-name">
+                          <Link to={`/profile/${guardian.id}`}>
+                            {formatName(
+                              guardian.firstName,
+                              guardian.lastName,
+                              i18n
+                            )}
+                          </Link>
+                        </NameTd>
+                        <Td data-qa="guardian-ssn">
+                          {guardian.socialSecurityNumber}
+                        </Td>
+                        <Td data-qa="guardian-age">
+                          {getAge(guardian.dateOfBirth)}
+                        </Td>
+                        <Td data-qa="guardian-street-address">
+                          {printableAddresses(guardian)}
+                        </Td>
+                      </Tr>
+                    )
+                  )}
+                </>
+              )}
+            </UnwrapResult>
+          </Tbody>
         </Table>
-        {guardians.isLoading && <Loader />}
-        {guardians.isFailure && <div>{i18n.common.loadingFailed}</div>}
         <Gap size="XL" />
         <FridgeParents />
       </CollapsibleContentArea>
     </div>
   )
 })
-
-export default GuardiansAndParents

--- a/frontend/src/employee-frontend/components/child-information/GuardiansAndParents.tsx
+++ b/frontend/src/employee-frontend/components/child-information/GuardiansAndParents.tsx
@@ -15,7 +15,7 @@ import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { H2, H3 } from 'lib-components/typography'
 import FridgeParents from './FridgeParents'
 import { Gap } from 'lib-components/white-space'
-import { UnwrapResult } from '../async-rendering'
+import { renderResult } from '../async-rendering'
 import { ChildContext } from '../../state'
 
 interface Props {
@@ -47,48 +47,44 @@ export default React.memo(function Guardians({ startOpen }: Props) {
       >
         <Gap size="m" />
         <H3 noMargin>{i18n.personProfile.guardians}</H3>
-        <Table data-qa="table-of-guardians">
-          <Thead>
-            <Tr>
-              <Th>{i18n.personProfile.name}</Th>
-              <Th>{i18n.personProfile.ssn}</Th>
-              <Th>{i18n.personProfile.age}</Th>
-              <Th>{i18n.personProfile.streetAddress}</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            <UnwrapResult result={guardians}>
-              {(guardians) => (
-                <>
-                  {_.orderBy(guardians, ['lastName', 'firstName'], ['asc']).map(
-                    (guardian: PersonJSON) => (
-                      <Tr key={`${guardian.id}`} data-qa="table-guardian-row">
-                        <NameTd data-qa="guardian-name">
-                          <Link to={`/profile/${guardian.id}`}>
-                            {formatName(
-                              guardian.firstName,
-                              guardian.lastName,
-                              i18n
-                            )}
-                          </Link>
-                        </NameTd>
-                        <Td data-qa="guardian-ssn">
-                          {guardian.socialSecurityNumber}
-                        </Td>
-                        <Td data-qa="guardian-age">
-                          {getAge(guardian.dateOfBirth)}
-                        </Td>
-                        <Td data-qa="guardian-street-address">
-                          {printableAddresses(guardian)}
-                        </Td>
-                      </Tr>
-                    )
-                  )}
-                </>
+        {renderResult(guardians, (guardians) => (
+          <Table data-qa="table-of-guardians">
+            <Thead>
+              <Tr>
+                <Th>{i18n.personProfile.name}</Th>
+                <Th>{i18n.personProfile.ssn}</Th>
+                <Th>{i18n.personProfile.age}</Th>
+                <Th>{i18n.personProfile.streetAddress}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {_.orderBy(guardians, ['lastName', 'firstName'], ['asc']).map(
+                (guardian: PersonJSON) => (
+                  <Tr key={`${guardian.id}`} data-qa="table-guardian-row">
+                    <NameTd data-qa="guardian-name">
+                      <Link to={`/profile/${guardian.id}`}>
+                        {formatName(
+                          guardian.firstName,
+                          guardian.lastName,
+                          i18n
+                        )}
+                      </Link>
+                    </NameTd>
+                    <Td data-qa="guardian-ssn">
+                      {guardian.socialSecurityNumber}
+                    </Td>
+                    <Td data-qa="guardian-age">
+                      {getAge(guardian.dateOfBirth)}
+                    </Td>
+                    <Td data-qa="guardian-street-address">
+                      {printableAddresses(guardian)}
+                    </Td>
+                  </Tr>
+                )
               )}
-            </UnwrapResult>
-          </Tbody>
-        </Table>
+            </Tbody>
+          </Table>
+        ))}
         <Gap size="XL" />
         <FridgeParents />
       </CollapsibleContentArea>

--- a/frontend/src/employee-frontend/components/child-information/MessageBlocklist.tsx
+++ b/frontend/src/employee-frontend/components/child-information/MessageBlocklist.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from '../../state/i18n'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import { UIContext } from '../../state/ui'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
-import { UnwrapResult } from '../async-rendering'
+import { renderResult } from '../async-rendering'
 
 interface Props {
   id: UUID
@@ -66,51 +66,42 @@ export default React.memo(function ChildDetails({ id, startOpen }: Props) {
         data-qa="child-message-blocklist-collapsible"
       >
         <P>{i18n.childInformation.messaging.info}</P>
-        <Table>
-          <Thead>
-            <Tr>
-              <Th>{i18n.childInformation.messaging.name}</Th>
-              <Th>{i18n.childInformation.messaging.role}</Th>
-              <Th>{i18n.childInformation.messaging.notBlocklisted}</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            <UnwrapResult result={recipients}>
-              {(recipients) => (
-                <>
-                  {recipients.map((recipient) => (
-                    <Tr
-                      key={recipient.personId}
-                      data-qa={`recipient-${recipient.personId}`}
-                    >
-                      <Td>{`${recipient.lastName} ${recipient.firstName}`}</Td>
-                      <Td>
-                        {getRoleString(
-                          recipient.headOfChild,
-                          recipient.guardian
-                        )}
-                      </Td>
-                      <Td>
-                        <Checkbox
-                          label={`${recipient.firstName} ${recipient.lastName}`}
-                          hiddenLabel
-                          checked={!recipient.blocklisted}
-                          data-qa={'blocklist-checkbox'}
-                          disabled={
-                            !permittedActions.has('UPDATE_CHILD_RECIPIENT')
-                          }
-                          onChange={(checked) =>
-                            onChange(recipient.personId, checked)
-                          }
-                        />
-                      </Td>
-                    </Tr>
-                  ))}
-                </>
-              )}
-            </UnwrapResult>
-          </Tbody>
-        </Table>
+        {renderResult(recipients, (recipients) => (
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>{i18n.childInformation.messaging.name}</Th>
+                <Th>{i18n.childInformation.messaging.role}</Th>
+                <Th>{i18n.childInformation.messaging.notBlocklisted}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {recipients.map((recipient) => (
+                <Tr
+                  key={recipient.personId}
+                  data-qa={`recipient-${recipient.personId}`}
+                >
+                  <Td>{`${recipient.lastName} ${recipient.firstName}`}</Td>
+                  <Td>
+                    {getRoleString(recipient.headOfChild, recipient.guardian)}
+                  </Td>
+                  <Td>
+                    <Checkbox
+                      label={`${recipient.firstName} ${recipient.lastName}`}
+                      hiddenLabel
+                      checked={!recipient.blocklisted}
+                      data-qa={'blocklist-checkbox'}
+                      disabled={!permittedActions.has('UPDATE_CHILD_RECIPIENT')}
+                      onChange={(checked) =>
+                        onChange(recipient.personId, checked)
+                      }
+                    />
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        ))}
       </CollapsibleContentArea>
     </div>
   )

--- a/frontend/src/employee-frontend/components/child-information/Placements.tsx
+++ b/frontend/src/employee-frontend/components/child-information/Placements.tsx
@@ -2,12 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useContext, useEffect, useState, Fragment } from 'react'
+import React, { Fragment, useContext, useEffect, useState } from 'react'
 import { useTranslation } from '../../state/i18n'
-import { ChildContext } from '../../state'
-import { ChildState } from '../../state/child'
+import { ChildContext, ChildState } from '../../state/child'
 import { Gap } from 'lib-components/white-space'
-import Loader from 'lib-components/atoms/Loader'
 import PlacementRow from '../../components/child-information/placements/PlacementRow'
 import { UIContext } from '../../state/ui'
 import CreatePlacementModal from '../../components/child-information/placements/CreatePlacementModal'
@@ -16,35 +14,31 @@ import { getPlacements } from '../../api/child/placements'
 import { RequireRole } from '../../utils/roles'
 import { DateRange, rangesOverlap } from '../../utils/date'
 import { getServiceNeedOptions } from '../../api/child/service-needs'
-import { useRestApi } from 'lib-common/utils/useRestApi'
+import { useApiState, useRestApi } from 'lib-common/utils/useRestApi'
 import _ from 'lodash'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { H2, H3 } from 'lib-components/typography'
 import { FlexRow } from '../common/styled/containers'
 import { UUID } from 'lib-common/types'
 import { DaycarePlacementWithDetails } from 'lib-common/generated/api-types/placement'
+import { renderResult } from '../async-rendering'
+import { combine } from 'lib-common/api'
 
 interface Props {
   id: UUID
   startOpen: boolean
 }
 
-const Placements = React.memo(function Placements({ id, startOpen }: Props) {
+export default React.memo(function Placements({ id, startOpen }: Props) {
   const { i18n } = useTranslation()
-  const { placements, setPlacements, setServiceNeedOptions } =
-    useContext<ChildState>(ChildContext)
+  const { placements, setPlacements } = useContext<ChildState>(ChildContext)
+  const [serviceNeedOptions] = useApiState(getServiceNeedOptions, [])
   const { uiMode, toggleUiMode } = useContext(UIContext)
 
   const [open, setOpen] = useState(startOpen)
 
   const loadPlacements = useRestApi(getPlacements, setPlacements)
   useEffect(() => loadPlacements(id), [id, loadPlacements])
-
-  const loadServiceNeedOptions = useRestApi(
-    getServiceNeedOptions,
-    setServiceNeedOptions
-  )
-  useEffect(loadServiceNeedOptions, [loadServiceNeedOptions])
 
   const checkOverlaps = (
     range: DateRange,
@@ -58,30 +52,6 @@ const Placements = React.memo(function Placements({ id, startOpen }: Props) {
             .filter((p) => rangesOverlap(range, p)).length > 0
       )
       .getOrElse(false)
-
-  function renderContents() {
-    if (placements.isLoading) {
-      return <Loader />
-    } else if (placements.isFailure) {
-      return <div>{i18n.common.loadingFailed}</div>
-    }
-    return (
-      <div>
-        {_.orderBy(placements.value, ['startDate'], ['desc']).map((p, i) => (
-          <Fragment key={p.id}>
-            <PlacementRow
-              placement={p}
-              onRefreshNeeded={() => loadPlacements(id)}
-              checkOverlaps={checkOverlaps}
-            />
-            {i < placements.value.length - 1 && (
-              <div className="separator large" />
-            )}
-          </Fragment>
-        ))}
-      </div>
-    )
-  }
 
   return (
     <div>
@@ -111,7 +81,26 @@ const Placements = React.memo(function Placements({ id, startOpen }: Props) {
             />
           </RequireRole>
         </FlexRow>
-        {renderContents()}
+        {renderResult(
+          combine(serviceNeedOptions, placements),
+          ([serviceNeedOptions, placements]) => (
+            <div>
+              {_.orderBy(placements, ['startDate'], ['desc']).map((p, i) => (
+                <Fragment key={p.id}>
+                  <PlacementRow
+                    placement={p}
+                    onRefreshNeeded={() => loadPlacements(id)}
+                    checkOverlaps={checkOverlaps}
+                    serviceNeedOptions={serviceNeedOptions}
+                  />
+                  {i < placements.length - 1 && (
+                    <div className="separator large" />
+                  )}
+                </Fragment>
+              ))}
+            </div>
+          )
+        )}
       </CollapsibleContentArea>
       {uiMode === 'create-new-placement' && (
         <CreatePlacementModal childId={id} reload={() => loadPlacements(id)} />
@@ -119,5 +108,3 @@ const Placements = React.memo(function Placements({ id, startOpen }: Props) {
     </div>
   )
 })
-
-export default Placements

--- a/frontend/src/employee-frontend/components/child-information/Placements.tsx
+++ b/frontend/src/employee-frontend/components/child-information/Placements.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { Fragment, useContext, useEffect, useState } from 'react'
+import React, { Fragment, useContext, useState } from 'react'
 import { useTranslation } from '../../state/i18n'
 import { ChildContext, ChildState } from '../../state/child'
 import { Gap } from 'lib-components/white-space'
@@ -10,11 +10,10 @@ import PlacementRow from '../../components/child-information/placements/Placemen
 import { UIContext } from '../../state/ui'
 import CreatePlacementModal from '../../components/child-information/placements/CreatePlacementModal'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
-import { getPlacements } from '../../api/child/placements'
 import { RequireRole } from '../../utils/roles'
 import { DateRange, rangesOverlap } from '../../utils/date'
 import { getServiceNeedOptions } from '../../api/child/service-needs'
-import { useApiState, useRestApi } from 'lib-common/utils/useRestApi'
+import { useApiState } from 'lib-common/utils/useRestApi'
 import _ from 'lodash'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { H2, H3 } from 'lib-components/typography'
@@ -31,14 +30,11 @@ interface Props {
 
 export default React.memo(function Placements({ id, startOpen }: Props) {
   const { i18n } = useTranslation()
-  const { placements, setPlacements } = useContext<ChildState>(ChildContext)
+  const { placements, loadPlacements } = useContext<ChildState>(ChildContext)
   const [serviceNeedOptions] = useApiState(getServiceNeedOptions, [])
   const { uiMode, toggleUiMode } = useContext(UIContext)
 
   const [open, setOpen] = useState(startOpen)
-
-  const loadPlacements = useRestApi(getPlacements, setPlacements)
-  useEffect(() => loadPlacements(id), [id, loadPlacements])
 
   const checkOverlaps = (
     range: DateRange,
@@ -89,7 +85,7 @@ export default React.memo(function Placements({ id, startOpen }: Props) {
                 <Fragment key={p.id}>
                   <PlacementRow
                     placement={p}
-                    onRefreshNeeded={() => loadPlacements(id)}
+                    onRefreshNeeded={loadPlacements}
                     checkOverlaps={checkOverlaps}
                     serviceNeedOptions={serviceNeedOptions}
                   />
@@ -103,7 +99,7 @@ export default React.memo(function Placements({ id, startOpen }: Props) {
         )}
       </CollapsibleContentArea>
       {uiMode === 'create-new-placement' && (
-        <CreatePlacementModal childId={id} reload={() => loadPlacements(id)} />
+        <CreatePlacementModal childId={id} reload={loadPlacements} />
       )}
     </div>
   )

--- a/frontend/src/employee-frontend/components/child-information/VasuAndLeops.tsx
+++ b/frontend/src/employee-frontend/components/child-information/VasuAndLeops.tsx
@@ -40,7 +40,7 @@ import {
   VasuTemplateSummary
 } from '../vasu/templates/api'
 import { RequireRole } from '../../utils/roles'
-import { UnwrapResult } from '../async-rendering'
+import { renderResult, UnwrapResult } from '../async-rendering'
 import { UUID } from 'lib-common/types'
 
 const StateCell = styled(Td)`
@@ -249,58 +249,52 @@ export default React.memo(function VasuAndLeops({
         paddingVertical="L"
       >
         <VasuInitialization childId={childId} allowCreation={allowCreation} />
-        <Table>
-          <Tbody>
-            <UnwrapResult result={vasus}>
-              {(vasus) => (
-                <>
-                  {vasus.map((vasu) => (
-                    <Tr key={vasu.id}>
-                      <Td>
+        {renderResult(vasus, (vasus) => (
+          <Table>
+            <Tbody>
+              {vasus.map((vasu) => (
+                <Tr key={vasu.id}>
+                  <Td>
+                    <InlineButton
+                      onClick={() => history.push(`/vasu/${vasu.id}`)}
+                      text={vasu.name}
+                    />
+                  </Td>
+                  <Td>{getDates(vasu)}</Td>
+                  <StateCell>
+                    <VasuStateChip
+                      state={vasu.documentState}
+                      labels={i18n.vasu.states}
+                    />
+                  </StateCell>
+                  <Td>
+                    {vasu.documentState === 'CLOSED' ? (
+                      <RequireRole oneOf={['ADMIN']}>
                         <InlineButton
-                          onClick={() => history.push(`/vasu/${vasu.id}`)}
-                          text={vasu.name}
+                          onClick={() =>
+                            void updateDocumentState({
+                              documentId: vasu.id,
+                              eventType: 'RETURNED_TO_REVIEWED'
+                            }).finally(() => loadVasus())
+                          }
+                          text={
+                            i18n.vasu.transitions.RETURNED_TO_REVIEWED
+                              .buttonText
+                          }
                         />
-                      </Td>
-                      <Td>{getDates(vasu)}</Td>
-                      <StateCell>
-                        <VasuStateChip
-                          state={vasu.documentState}
-                          labels={i18n.vasu.states}
-                        />
-                      </StateCell>
-                      <Td>
-                        {vasu.documentState === 'CLOSED' ? (
-                          <RequireRole oneOf={['ADMIN']}>
-                            <InlineButton
-                              onClick={() =>
-                                void updateDocumentState({
-                                  documentId: vasu.id,
-                                  eventType: 'RETURNED_TO_REVIEWED'
-                                }).finally(() => loadVasus())
-                              }
-                              text={
-                                i18n.vasu.transitions.RETURNED_TO_REVIEWED
-                                  .buttonText
-                              }
-                            />
-                          </RequireRole>
-                        ) : (
-                          <InlineButton
-                            onClick={() =>
-                              history.push(`/vasu/${vasu.id}/edit`)
-                            }
-                            text={i18n.common.edit}
-                          />
-                        )}
-                      </Td>
-                    </Tr>
-                  ))}
-                </>
-              )}
-            </UnwrapResult>
-          </Tbody>
-        </Table>
+                      </RequireRole>
+                    ) : (
+                      <InlineButton
+                        onClick={() => history.push(`/vasu/${vasu.id}/edit`)}
+                        text={i18n.common.edit}
+                      />
+                    )}
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        ))}
       </CollapsibleContentArea>
     </div>
   )

--- a/frontend/src/employee-frontend/components/child-information/VasuAndLeops.tsx
+++ b/frontend/src/employee-frontend/components/child-information/VasuAndLeops.tsx
@@ -2,13 +2,18 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import Loader from 'lib-components/atoms/Loader'
-import React, { useCallback, useContext, useEffect, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
 import { useHistory } from 'react-router'
 import styled from 'styled-components'
 import { Result } from 'lib-common/api'
 import { formatDate } from 'lib-common/date'
-import { useRestApi } from 'lib-common/utils/useRestApi'
+import { useApiState, useRestApi } from 'lib-common/utils/useRestApi'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import Radio from 'lib-components/atoms/form/Radio'
@@ -179,19 +184,19 @@ interface Props {
   startOpen: boolean
 }
 
-const VasuAndLeops = React.memo(function VasuAndLeops({
+export default React.memo(function VasuAndLeops({
   id: childId,
   startOpen
 }: Props) {
   const { i18n } = useTranslation()
-  const { permittedActions, placements, vasus, setVasus } =
-    useContext(ChildContext)
+  const { permittedActions, placements } = useContext(ChildContext)
+  const [vasus, loadVasus] = useApiState(
+    () => getVasuDocumentSummaries(childId),
+    [childId]
+  )
   const history = useHistory()
 
   const [open, setOpen] = useState(startOpen)
-
-  const loadVasus = useRestApi(getVasuDocumentSummaries, setVasus)
-  useEffect(() => loadVasus(childId), [childId, loadVasus])
 
   const getDates = ({ modifiedAt, events }: VasuDocumentSummary): string => {
     const publishedAt = getLastPublished(events)
@@ -207,64 +212,30 @@ const VasuAndLeops = React.memo(function VasuAndLeops({
     ].join(', ')
   }
 
-  const renderSummaries = () =>
-    vasus
-      .map((value) =>
-        value.map((vasu) => (
-          <Tr key={vasu.id}>
-            <Td>
-              <InlineButton
-                onClick={() => history.push(`/vasu/${vasu.id}`)}
-                text={vasu.name}
-              />
-            </Td>
-            <Td>{getDates(vasu)}</Td>
-            <StateCell>
-              <VasuStateChip
-                state={vasu.documentState}
-                labels={i18n.vasu.states}
-              />
-            </StateCell>
-            <Td>
-              {vasu.documentState === 'CLOSED' ? (
-                <RequireRole oneOf={['ADMIN']}>
-                  <InlineButton
-                    onClick={() =>
-                      void updateDocumentState({
-                        documentId: vasu.id,
-                        eventType: 'RETURNED_TO_REVIEWED'
-                      }).finally(() => loadVasus(childId))
-                    }
-                    text={i18n.vasu.transitions.RETURNED_TO_REVIEWED.buttonText}
-                  />
-                </RequireRole>
-              ) : (
-                <InlineButton
-                  onClick={() => history.push(`/vasu/${vasu.id}/edit`)}
-                  text={i18n.common.edit}
-                />
-              )}
-            </Td>
-          </Tr>
-        ))
-      )
-      .getOrElse(null)
+  const allowCreation = useMemo(
+    () =>
+      vasus
+        .map((docs) => docs.every((doc) => doc.documentState === 'CLOSED'))
+        .getOrElse(false),
+    [vasus]
+  )
 
-  const allowCreation = vasus
-    .map((docs) => docs.every((doc) => doc.documentState === 'CLOSED'))
-    .getOrElse(false)
-
-  if (
-    !permittedActions.has('READ_VASU_DOCUMENT') ||
-    placements
-      .map(
-        (ps) =>
-          !ps.some((placement) =>
-            placement.daycare.enabledPilotFeatures.includes('VASU_AND_PEDADOC')
-          )
-      )
-      .getOrElse(true)
-  ) {
+  const noPermission = useMemo(
+    () =>
+      !permittedActions.has('READ_VASU_DOCUMENT') ||
+      placements
+        .map(
+          (ps) =>
+            !ps.some((placement) =>
+              placement.daycare.enabledPilotFeatures.includes(
+                'VASU_AND_PEDADOC'
+              )
+            )
+        )
+        .getOrElse(true),
+    [permittedActions, placements]
+  )
+  if (noPermission) {
     return null
   }
 
@@ -279,13 +250,58 @@ const VasuAndLeops = React.memo(function VasuAndLeops({
       >
         <VasuInitialization childId={childId} allowCreation={allowCreation} />
         <Table>
-          <Tbody>{renderSummaries()}</Tbody>
+          <Tbody>
+            <UnwrapResult result={vasus}>
+              {(vasus) => (
+                <>
+                  {vasus.map((vasu) => (
+                    <Tr key={vasu.id}>
+                      <Td>
+                        <InlineButton
+                          onClick={() => history.push(`/vasu/${vasu.id}`)}
+                          text={vasu.name}
+                        />
+                      </Td>
+                      <Td>{getDates(vasu)}</Td>
+                      <StateCell>
+                        <VasuStateChip
+                          state={vasu.documentState}
+                          labels={i18n.vasu.states}
+                        />
+                      </StateCell>
+                      <Td>
+                        {vasu.documentState === 'CLOSED' ? (
+                          <RequireRole oneOf={['ADMIN']}>
+                            <InlineButton
+                              onClick={() =>
+                                void updateDocumentState({
+                                  documentId: vasu.id,
+                                  eventType: 'RETURNED_TO_REVIEWED'
+                                }).finally(() => loadVasus())
+                              }
+                              text={
+                                i18n.vasu.transitions.RETURNED_TO_REVIEWED
+                                  .buttonText
+                              }
+                            />
+                          </RequireRole>
+                        ) : (
+                          <InlineButton
+                            onClick={() =>
+                              history.push(`/vasu/${vasu.id}/edit`)
+                            }
+                            text={i18n.common.edit}
+                          />
+                        )}
+                      </Td>
+                    </Tr>
+                  ))}
+                </>
+              )}
+            </UnwrapResult>
+          </Tbody>
         </Table>
-        {vasus.isLoading && <Loader />}
-        {vasus.isFailure && <div>{i18n.common.loadingFailed}</div>}
       </CollapsibleContentArea>
     </div>
   )
 })
-
-export default VasuAndLeops

--- a/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionRow.tsx
@@ -21,13 +21,15 @@ import { assistanceMeasures, featureFlags } from 'lib-customizations/employee'
 export interface Props {
   assistanceAction: AssistanceAction
   onReload: () => undefined | void
+  assistanceActions: AssistanceAction[]
   assistanceActionOptions: AssistanceActionOption[]
   refSectionTop: MutableRefObject<HTMLElement | null>
 }
 
-function AssistanceActionRow({
+export default React.memo(function AssistanceActionRow({
   assistanceAction,
   onReload,
+  assistanceActions,
   assistanceActionOptions,
   refSectionTop
 }: Props) {
@@ -95,6 +97,7 @@ function AssistanceActionRow({
             <AssistanceActionForm
               assistanceAction={assistanceAction}
               onReload={onReload}
+              assistanceActions={assistanceActions}
               assistanceActionOptions={assistanceActionOptions}
             />
           </div>
@@ -153,6 +156,4 @@ function AssistanceActionRow({
       </ToolbarAccordion>
     </div>
   )
-}
-
-export default AssistanceActionRow
+})

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
@@ -24,6 +24,7 @@ import { featureFlags } from 'lib-customizations/employee'
 export interface Props {
   assistanceNeed: AssistanceNeed
   onReload: () => undefined | void
+  assistanceNeeds: AssistanceNeed[]
   assistanceBasisOptions: AssistanceBasisOption[]
   refSectionTop: MutableRefObject<HTMLElement | null>
 }
@@ -31,6 +32,7 @@ export interface Props {
 function AssistanceNeedRow({
   assistanceNeed,
   onReload,
+  assistanceNeeds,
   assistanceBasisOptions,
   refSectionTop
 }: Props) {
@@ -98,6 +100,7 @@ function AssistanceNeedRow({
             <AssistanceNeedForm
               assistanceNeed={assistanceNeed}
               onReload={onReload}
+              assistanceNeeds={assistanceNeeds}
               assistanceBasisOptions={assistanceBasisOptions}
             />
           </div>

--- a/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
@@ -34,6 +34,7 @@ import {
 import { InputWarning } from '../../common/InputWarning'
 import ServiceNeeds from './ServiceNeeds'
 import { DaycarePlacementWithDetails } from 'lib-common/generated/api-types/placement'
+import { ServiceNeedOption } from 'lib-common/generated/api-types/serviceneed'
 
 interface Props {
   placement: DaycarePlacementWithDetails
@@ -42,6 +43,7 @@ interface Props {
     range: DateRange,
     placement: DaycarePlacementWithDetails
   ) => boolean | undefined
+  serviceNeedOptions: ServiceNeedOption[]
 }
 
 const DataRow = styled.div`
@@ -80,7 +82,12 @@ const CompactDatePicker = styled(DatePickerDeprecated)`
   }
 `
 
-function PlacementRow({ placement, onRefreshNeeded, checkOverlaps }: Props) {
+export default React.memo(function PlacementRow({
+  placement,
+  onRefreshNeeded,
+  checkOverlaps,
+  serviceNeedOptions
+}: Props) {
   const { i18n } = useTranslation()
   const { setErrorMessage } = useContext<UiState>(UIContext)
 
@@ -324,7 +331,11 @@ function PlacementRow({ placement, onRefreshNeeded, checkOverlaps }: Props) {
 
         <Gap size="s" />
 
-        <ServiceNeeds placement={placement} reload={onRefreshNeeded} />
+        <ServiceNeeds
+          placement={placement}
+          reload={onRefreshNeeded}
+          serviceNeedOptions={serviceNeedOptions}
+        />
       </ToolbarAccordion>
       {confirmingDelete && (
         <InfoModal
@@ -343,9 +354,7 @@ function PlacementRow({ placement, onRefreshNeeded, checkOverlaps }: Props) {
       )}
     </>
   )
-}
-
-export default PlacementRow
+})
 
 const DatepickerContainer = styled.div`
   display: flex;

--- a/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
@@ -38,7 +38,7 @@ import { ServiceNeedOption } from 'lib-common/generated/api-types/serviceneed'
 
 interface Props {
   placement: DaycarePlacementWithDetails
-  onRefreshNeeded: () => void | undefined
+  onRefreshNeeded: () => void
   checkOverlaps: (
     range: DateRange,
     placement: DaycarePlacementWithDetails

--- a/frontend/src/employee-frontend/components/child-information/placements/ServiceNeeds.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/ServiceNeeds.tsx
@@ -4,7 +4,10 @@
 
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { DaycarePlacementWithDetails } from 'lib-common/generated/api-types/placement'
-import { ServiceNeed } from 'lib-common/generated/api-types/serviceneed'
+import {
+  ServiceNeed,
+  ServiceNeedOption
+} from 'lib-common/generated/api-types/serviceneed'
 import LocalDate from 'lib-common/local-date'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import { Table, Tbody, Th, Thead, Tr } from 'lib-components/layout/Table'
@@ -12,10 +15,9 @@ import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { H4 } from 'lib-components/typography'
 import { faPlus, faQuestion } from 'lib-icons'
 import _ from 'lodash'
-import React, { useContext, useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { deleteServiceNeed } from '../../../api/child/service-needs'
-import { ChildContext } from '../../../state'
 import { useTranslation } from '../../../state/i18n'
 import { DateRange } from '../../../utils/date'
 import { RequireRole } from '../../../utils/roles'
@@ -26,9 +28,14 @@ import ServiceNeedReadRow from './service-needs/ServiceNeedReadRow'
 interface Props {
   placement: DaycarePlacementWithDetails
   reload: () => void
+  serviceNeedOptions: ServiceNeedOption[]
 }
 
-function ServiceNeeds({ placement, reload }: Props) {
+export default React.memo(function ServiceNeeds({
+  placement,
+  reload,
+  serviceNeedOptions
+}: Props) {
   const { serviceNeeds, type: placementType } = placement
 
   const { i18n } = useTranslation()
@@ -37,8 +44,6 @@ function ServiceNeeds({ placement, reload }: Props) {
   const [creatingNew, setCreatingNew] = useState<boolean | LocalDate>(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
-
-  const { serviceNeedOptions } = useContext(ChildContext)
 
   const gaps: DateRange[] = useMemo(
     () =>
@@ -54,20 +59,14 @@ function ServiceNeeds({ placement, reload }: Props) {
 
   const rows: ServiceNeedOrGap[] = [...placement.serviceNeeds, ...gaps]
 
-  const options = serviceNeedOptions
-    .map((options) =>
-      options.filter(
-        (option) =>
-          option.validPlacementType === placementType && !option.defaultOption
-      )
-    )
-    .getOrElse([])
+  const options = serviceNeedOptions.filter(
+    (option) =>
+      option.validPlacementType === placementType && !option.defaultOption
+  )
 
-  const placementHasNonDefaultServiceNeedOptions =
-    serviceNeedOptions.isSuccess &&
-    serviceNeedOptions.value.some(
-      (opt) => opt.validPlacementType === placementType && !opt.defaultOption
-    )
+  const placementHasNonDefaultServiceNeedOptions = serviceNeedOptions.some(
+    (opt) => opt.validPlacementType === placementType && !opt.defaultOption
+  )
 
   // if only default option exists service needs are not relevant and do not need to be rendered
   return placementHasNonDefaultServiceNeedOptions ? (
@@ -192,7 +191,7 @@ function ServiceNeeds({ placement, reload }: Props) {
       )}
     </div>
   ) : null
-}
+})
 
 type ServiceNeedOrGap = ServiceNeed | DateRange
 
@@ -201,5 +200,3 @@ const HeaderRow = styled.div`
   justify-content: space-between;
   align-items: center;
 `
-
-export default ServiceNeeds

--- a/frontend/src/employee-frontend/components/person-shared/PersonDetails.tsx
+++ b/frontend/src/employee-frontend/components/person-shared/PersonDetails.tsx
@@ -75,7 +75,7 @@ const RightAlignedRow = styled.div`
   justify-content: flex-end;
 `
 
-const PersonDetails = React.memo(function PersonDetails({
+export default React.memo(function PersonDetails({
   person,
   isChild,
   onUpdateComplete,
@@ -531,5 +531,3 @@ const PersonDetails = React.memo(function PersonDetails({
     </>
   )
 })
-
-export default PersonDetails

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -22,7 +22,7 @@ import { DaycarePlacementWithDetails } from 'lib-common/generated/api-types/plac
 import { getPlacements } from '../api/child/placements'
 import { useApiState, useRestApi } from 'lib-common/utils/useRestApi'
 import { UUID } from 'lib-common/types'
-import { getChildDetails } from '../api/person'
+import { getChildDetails, getPersonGuardians } from '../api/person'
 import { requireRole } from '../utils/roles'
 import { getParentshipsByChild } from '../api/parentships'
 import { UserContext } from './user'
@@ -38,7 +38,6 @@ export interface ChildState {
   backupCares: Result<ChildBackupCare[]>
   setBackupCares: (request: Result<ChildBackupCare[]>) => void
   guardians: Result<PersonJSON[]>
-  setGuardians: (request: Result<PersonJSON[]>) => void
   applications: Result<PersonApplicationSummary[]>
   setApplications: (r: Result<PersonApplicationSummary[]>) => void
   recipients: Result<Recipient[]>
@@ -61,7 +60,6 @@ const defaultState: ChildState = {
   backupCares: Loading.of(),
   setBackupCares: () => undefined,
   guardians: Loading.of(),
-  setGuardians: () => undefined,
   applications: Loading.of(),
   setApplications: () => undefined,
   recipients: Loading.of(),
@@ -136,9 +134,7 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
   const [backupCares, setBackupCares] = useState<Result<ChildBackupCare[]>>(
     defaultState.backupCares
   )
-  const [guardians, setGuardians] = useState<Result<PersonJSON[]>>(
-    defaultState.guardians
-  )
+  const [guardians] = useApiState(() => getPersonGuardians(id), [id])
   const [applications, setApplications] = useState<
     Result<PersonApplicationSummary[]>
   >(defaultState.applications)
@@ -165,7 +161,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       backupCares,
       setBackupCares,
       guardians,
-      setGuardians,
       vasus,
       setVasus,
       applications,

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -13,10 +13,6 @@ import { Action } from 'lib-common/generated/action'
 import { PedagogicalDocument } from 'lib-common/generated/api-types/pedagogicaldocument'
 import { PersonApplicationSummary } from 'lib-common/generated/api-types/application'
 import { DaycarePlacementWithDetails } from 'lib-common/generated/api-types/placement'
-import {
-  ServiceNeed,
-  ServiceNeedOption
-} from 'lib-common/generated/api-types/serviceneed'
 import { AdditionalInformation } from 'lib-common/generated/api-types/daycare'
 
 export interface ChildState {
@@ -24,10 +20,6 @@ export interface ChildState {
   setPerson: (request: Result<PersonJSON>) => void
   permittedActions: Set<Action.Child | Action.Person>
   setPermittedActions: (r: Set<Action.Child | Action.Person>) => void
-  serviceNeeds: Result<ServiceNeed[]>
-  setServiceNeeds: (request: Result<ServiceNeed[]>) => void
-  serviceNeedOptions: Result<ServiceNeedOption[]>
-  setServiceNeedOptions: (request: Result<ServiceNeedOption[]>) => void
   additionalInformation: Result<AdditionalInformation>
   setAdditionalInformation: (request: Result<AdditionalInformation>) => void
   feeAlterations: Result<FeeAlteration[]>
@@ -55,10 +47,6 @@ const defaultState: ChildState = {
   setPerson: () => undefined,
   permittedActions: new Set(),
   setPermittedActions: () => undefined,
-  serviceNeeds: Loading.of(),
-  setServiceNeeds: () => undefined,
-  serviceNeedOptions: Loading.of(),
-  setServiceNeedOptions: () => undefined,
   additionalInformation: Loading.of(),
   setAdditionalInformation: () => undefined,
   feeAlterations: Loading.of(),
@@ -92,12 +80,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
   const [permittedActions, setPermittedActions] = useState(
     defaultState.permittedActions
   )
-  const [serviceNeeds, setServiceNeeds] = useState<Result<ServiceNeed[]>>(
-    defaultState.serviceNeeds
-  )
-  const [serviceNeedOptions, setServiceNeedOptions] = useState<
-    Result<ServiceNeedOption[]>
-  >(defaultState.serviceNeedOptions)
   const [additionalInformation, setAdditionalInformation] = useState<
     Result<AdditionalInformation>
   >(defaultState.additionalInformation)
@@ -137,10 +119,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       setPerson,
       permittedActions,
       setPermittedActions,
-      serviceNeeds,
-      setServiceNeeds,
-      serviceNeedOptions,
-      setServiceNeedOptions,
       additionalInformation,
       setAdditionalInformation,
       feeAlterations,
@@ -165,8 +143,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
     [
       person,
       permittedActions,
-      serviceNeeds,
-      serviceNeedOptions,
       feeAlterations,
       placements,
       parentships,

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -14,7 +14,6 @@ import { ChildBackupCare } from '../types/child'
 import { Loading, Result } from 'lib-common/api'
 import { Parentship, PersonJSON } from 'lib-common/generated/api-types/pis'
 import { Action } from 'lib-common/generated/action'
-import { PedagogicalDocument } from 'lib-common/generated/api-types/pedagogicaldocument'
 import { PersonApplicationSummary } from 'lib-common/generated/api-types/application'
 import { DaycarePlacementWithDetails } from 'lib-common/generated/api-types/placement'
 import { getPlacements } from '../api/child/placements'
@@ -38,8 +37,6 @@ export interface ChildState {
   guardians: Result<PersonJSON[]>
   applications: Result<PersonApplicationSummary[]>
   setApplications: (r: Result<PersonApplicationSummary[]>) => void
-  pedagogicalDocuments: Result<PedagogicalDocument[]>
-  setPedagogicalDocuments: (r: Result<PedagogicalDocument[]>) => void
 }
 
 const emptyPermittedActions = new Set<Action.Child | Action.Person>()
@@ -55,9 +52,7 @@ const defaultState: ChildState = {
   setBackupCares: () => undefined,
   guardians: Loading.of(),
   applications: Loading.of(),
-  setApplications: () => undefined,
-  pedagogicalDocuments: Loading.of(),
-  setPedagogicalDocuments: () => undefined
+  setApplications: () => undefined
 }
 
 export const ChildContext = createContext<ChildState>(defaultState)
@@ -129,10 +124,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
     Result<PersonApplicationSummary[]>
   >(defaultState.applications)
 
-  const [pedagogicalDocuments, setPedagogicalDocuments] = useState<
-    Result<PedagogicalDocument[]>
-  >(defaultState.pedagogicalDocuments)
-
   const value = useMemo(
     (): ChildState => ({
       person,
@@ -145,9 +136,7 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       setBackupCares,
       guardians,
       applications,
-      setApplications,
-      pedagogicalDocuments,
-      setPedagogicalDocuments
+      setApplications
     }),
     [
       person,
@@ -158,8 +147,7 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       parentships,
       backupCares,
       guardians,
-      applications,
-      pedagogicalDocuments
+      applications
     ]
   )
 

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -10,7 +10,6 @@ import React, {
   useMemo,
   useState
 } from 'react'
-import { Recipient } from 'lib-common/generated/api-types/messaging'
 import { ChildBackupCare } from '../types/child'
 import { Loading, Result } from 'lib-common/api'
 import { Parentship, PersonJSON } from 'lib-common/generated/api-types/pis'
@@ -40,8 +39,6 @@ export interface ChildState {
   guardians: Result<PersonJSON[]>
   applications: Result<PersonApplicationSummary[]>
   setApplications: (r: Result<PersonApplicationSummary[]>) => void
-  recipients: Result<Recipient[]>
-  setRecipients: (r: Result<Recipient[]>) => void
   vasus: Result<VasuDocumentSummary[]>
   setVasus: (r: Result<VasuDocumentSummary[]>) => void
   pedagogicalDocuments: Result<PedagogicalDocument[]>
@@ -62,8 +59,6 @@ const defaultState: ChildState = {
   guardians: Loading.of(),
   applications: Loading.of(),
   setApplications: () => undefined,
-  recipients: Loading.of(),
-  setRecipients: () => undefined,
   vasus: Loading.of(),
   setVasus: () => undefined,
   pedagogicalDocuments: Loading.of(),
@@ -142,10 +137,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
     defaultState.vasus
   )
 
-  const [recipients, setRecipients] = useState<Result<Recipient[]>>(
-    defaultState.recipients
-  )
-
   const [pedagogicalDocuments, setPedagogicalDocuments] = useState<
     Result<PedagogicalDocument[]>
   >(defaultState.pedagogicalDocuments)
@@ -165,8 +156,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       setVasus,
       applications,
       setApplications,
-      recipients,
-      setRecipients,
       pedagogicalDocuments,
       setPedagogicalDocuments
     }),
@@ -181,7 +170,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       guardians,
       vasus,
       applications,
-      recipients,
       pedagogicalDocuments
     ]
   )

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -2,14 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useMemo, useState, createContext } from 'react'
+import React, { createContext, useMemo, useState } from 'react'
 import { Recipient } from 'lib-common/generated/api-types/messaging'
 import { FeeAlteration } from '../types/fee-alteration'
-import {
-  AssistanceAction,
-  AssistanceNeed,
-  ChildBackupCare
-} from '../types/child'
+import { AssistanceNeed, ChildBackupCare } from '../types/child'
 import { Loading, Result } from 'lib-common/api'
 import { Parentship, PersonJSON } from 'lib-common/generated/api-types/pis'
 import { VasuDocumentSummary } from '../components/vasu/api'
@@ -34,8 +30,6 @@ export interface ChildState {
   setServiceNeedOptions: (request: Result<ServiceNeedOption[]>) => void
   assistanceNeeds: Result<AssistanceNeed[]>
   setAssistanceNeeds: (request: Result<AssistanceNeed[]>) => void
-  assistanceActions: Result<AssistanceAction[]>
-  setAssistanceActions: (request: Result<AssistanceAction[]>) => void
   additionalInformation: Result<AdditionalInformation>
   setAdditionalInformation: (request: Result<AdditionalInformation>) => void
   feeAlterations: Result<FeeAlteration[]>
@@ -69,8 +63,6 @@ const defaultState: ChildState = {
   setServiceNeedOptions: () => undefined,
   assistanceNeeds: Loading.of(),
   setAssistanceNeeds: () => undefined,
-  assistanceActions: Loading.of(),
-  setAssistanceActions: () => undefined,
   additionalInformation: Loading.of(),
   setAdditionalInformation: () => undefined,
   feeAlterations: Loading.of(),
@@ -113,9 +105,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
   const [assistanceNeeds, setAssistanceNeeds] = useState<
     Result<AssistanceNeed[]>
   >(defaultState.assistanceNeeds)
-  const [assistanceActions, setAssistanceActions] = useState<
-    Result<AssistanceAction[]>
-  >(defaultState.assistanceActions)
   const [additionalInformation, setAdditionalInformation] = useState<
     Result<AdditionalInformation>
   >(defaultState.additionalInformation)
@@ -161,8 +150,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       setServiceNeedOptions,
       assistanceNeeds,
       setAssistanceNeeds,
-      assistanceActions,
-      setAssistanceActions,
       additionalInformation,
       setAdditionalInformation,
       feeAlterations,
@@ -186,36 +173,20 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
     }),
     [
       person,
-      setPerson,
       permittedActions,
-      setPermittedActions,
       serviceNeeds,
-      setServiceNeeds,
       serviceNeedOptions,
-      setServiceNeedOptions,
       assistanceNeeds,
-      setAssistanceNeeds,
-      assistanceActions,
-      setAssistanceActions,
       additionalInformation,
-      setAdditionalInformation,
       feeAlterations,
-      setFeeAlterations,
       placements,
-      setPlacements,
       parentships,
-      setParentships,
       backupCares,
-      setBackupCares,
       guardians,
-      setGuardians,
       vasus,
       applications,
-      setApplications,
       recipients,
-      setRecipients,
-      pedagogicalDocuments,
-      setPedagogicalDocuments
+      pedagogicalDocuments
     ]
   )
 

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -14,7 +14,6 @@ import { ChildBackupCare } from '../types/child'
 import { Loading, Result } from 'lib-common/api'
 import { Parentship, PersonJSON } from 'lib-common/generated/api-types/pis'
 import { Action } from 'lib-common/generated/action'
-import { PersonApplicationSummary } from 'lib-common/generated/api-types/application'
 import { DaycarePlacementWithDetails } from 'lib-common/generated/api-types/placement'
 import { getPlacements } from '../api/child/placements'
 import { useApiState, useRestApi } from 'lib-common/utils/useRestApi'
@@ -35,8 +34,6 @@ export interface ChildState {
   backupCares: Result<ChildBackupCare[]>
   setBackupCares: (request: Result<ChildBackupCare[]>) => void
   guardians: Result<PersonJSON[]>
-  applications: Result<PersonApplicationSummary[]>
-  setApplications: (r: Result<PersonApplicationSummary[]>) => void
 }
 
 const emptyPermittedActions = new Set<Action.Child | Action.Person>()
@@ -50,9 +47,7 @@ const defaultState: ChildState = {
   parentships: Loading.of(),
   backupCares: Loading.of(),
   setBackupCares: () => undefined,
-  guardians: Loading.of(),
-  applications: Loading.of(),
-  setApplications: () => undefined
+  guardians: Loading.of()
 }
 
 export const ChildContext = createContext<ChildState>(defaultState)
@@ -120,9 +115,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
     defaultState.backupCares
   )
   const [guardians] = useApiState(() => getPersonGuardians(id), [id])
-  const [applications, setApplications] = useState<
-    Result<PersonApplicationSummary[]>
-  >(defaultState.applications)
 
   const value = useMemo(
     (): ChildState => ({
@@ -134,9 +126,7 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       parentships,
       backupCares,
       setBackupCares,
-      guardians,
-      applications,
-      setApplications
+      guardians
     }),
     [
       person,
@@ -146,8 +136,7 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       loadPlacements,
       parentships,
       backupCares,
-      guardians,
-      applications
+      guardians
     ]
   )
 

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -5,7 +5,7 @@
 import React, { createContext, useMemo, useState } from 'react'
 import { Recipient } from 'lib-common/generated/api-types/messaging'
 import { FeeAlteration } from '../types/fee-alteration'
-import { AssistanceNeed, ChildBackupCare } from '../types/child'
+import { ChildBackupCare } from '../types/child'
 import { Loading, Result } from 'lib-common/api'
 import { Parentship, PersonJSON } from 'lib-common/generated/api-types/pis'
 import { VasuDocumentSummary } from '../components/vasu/api'
@@ -28,8 +28,6 @@ export interface ChildState {
   setServiceNeeds: (request: Result<ServiceNeed[]>) => void
   serviceNeedOptions: Result<ServiceNeedOption[]>
   setServiceNeedOptions: (request: Result<ServiceNeedOption[]>) => void
-  assistanceNeeds: Result<AssistanceNeed[]>
-  setAssistanceNeeds: (request: Result<AssistanceNeed[]>) => void
   additionalInformation: Result<AdditionalInformation>
   setAdditionalInformation: (request: Result<AdditionalInformation>) => void
   feeAlterations: Result<FeeAlteration[]>
@@ -61,8 +59,6 @@ const defaultState: ChildState = {
   setServiceNeeds: () => undefined,
   serviceNeedOptions: Loading.of(),
   setServiceNeedOptions: () => undefined,
-  assistanceNeeds: Loading.of(),
-  setAssistanceNeeds: () => undefined,
   additionalInformation: Loading.of(),
   setAdditionalInformation: () => undefined,
   feeAlterations: Loading.of(),
@@ -102,9 +98,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
   const [serviceNeedOptions, setServiceNeedOptions] = useState<
     Result<ServiceNeedOption[]>
   >(defaultState.serviceNeedOptions)
-  const [assistanceNeeds, setAssistanceNeeds] = useState<
-    Result<AssistanceNeed[]>
-  >(defaultState.assistanceNeeds)
   const [additionalInformation, setAdditionalInformation] = useState<
     Result<AdditionalInformation>
   >(defaultState.additionalInformation)
@@ -148,8 +141,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       setServiceNeeds,
       serviceNeedOptions,
       setServiceNeedOptions,
-      assistanceNeeds,
-      setAssistanceNeeds,
       additionalInformation,
       setAdditionalInformation,
       feeAlterations,
@@ -176,8 +167,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       permittedActions,
       serviceNeeds,
       serviceNeedOptions,
-      assistanceNeeds,
-      additionalInformation,
       feeAlterations,
       placements,
       parentships,

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -14,6 +14,9 @@ import { PedagogicalDocument } from 'lib-common/generated/api-types/pedagogicald
 import { PersonApplicationSummary } from 'lib-common/generated/api-types/application'
 import { DaycarePlacementWithDetails } from 'lib-common/generated/api-types/placement'
 import { AdditionalInformation } from 'lib-common/generated/api-types/daycare'
+import { getPlacements } from '../api/child/placements'
+import { useApiState } from 'lib-common/utils/useRestApi'
+import { UUID } from 'lib-common/types'
 
 export interface ChildState {
   person: Result<PersonJSON>
@@ -25,7 +28,7 @@ export interface ChildState {
   feeAlterations: Result<FeeAlteration[]>
   setFeeAlterations: (result: Result<FeeAlteration[]>) => void
   placements: Result<DaycarePlacementWithDetails[]>
-  setPlacements: (request: Result<DaycarePlacementWithDetails[]>) => void
+  loadPlacements: () => void
   parentships: Result<Parentship[]>
   setParentships: (request: Result<Parentship[]>) => void
   backupCares: Result<ChildBackupCare[]>
@@ -52,7 +55,7 @@ const defaultState: ChildState = {
   feeAlterations: Loading.of(),
   setFeeAlterations: () => undefined,
   placements: Loading.of(),
-  setPlacements: () => undefined,
+  loadPlacements: () => undefined,
   parentships: Loading.of(),
   setParentships: () => undefined,
   backupCares: Loading.of(),
@@ -72,8 +75,10 @@ const defaultState: ChildState = {
 export const ChildContext = createContext<ChildState>(defaultState)
 
 export const ChildContextProvider = React.memo(function ChildContextProvider({
+  id,
   children
 }: {
+  id: UUID
   children: JSX.Element
 }) {
   const [person, setPerson] = useState<Result<PersonJSON>>(defaultState.person)
@@ -86,9 +91,10 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
   const [feeAlterations, setFeeAlterations] = useState<Result<FeeAlteration[]>>(
     defaultState.feeAlterations
   )
-  const [placements, setPlacements] = useState<
-    Result<DaycarePlacementWithDetails[]>
-  >(defaultState.placements)
+  const [placements, loadPlacements] = useApiState(
+    () => getPlacements(id),
+    [id]
+  )
   const [parentships, setParentships] = useState<Result<Parentship[]>>(
     defaultState.parentships
   )
@@ -124,7 +130,7 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       feeAlterations,
       setFeeAlterations,
       placements,
-      setPlacements,
+      loadPlacements,
       parentships,
       setParentships,
       backupCares,

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -20,7 +20,6 @@ import { Action } from 'lib-common/generated/action'
 import { PedagogicalDocument } from 'lib-common/generated/api-types/pedagogicaldocument'
 import { PersonApplicationSummary } from 'lib-common/generated/api-types/application'
 import { DaycarePlacementWithDetails } from 'lib-common/generated/api-types/placement'
-import { AdditionalInformation } from 'lib-common/generated/api-types/daycare'
 import { getPlacements } from '../api/child/placements'
 import { useApiState, useRestApi } from 'lib-common/utils/useRestApi'
 import { UUID } from 'lib-common/types'
@@ -34,8 +33,6 @@ export interface ChildState {
   person: Result<PersonJSON>
   setPerson: (value: PersonJSON) => void
   permittedActions: Set<Action.Child | Action.Person>
-  additionalInformation: Result<AdditionalInformation>
-  setAdditionalInformation: (request: Result<AdditionalInformation>) => void
   feeAlterations: Result<FeeAlteration[]>
   setFeeAlterations: (result: Result<FeeAlteration[]>) => void
   placements: Result<DaycarePlacementWithDetails[]>
@@ -61,8 +58,6 @@ const defaultState: ChildState = {
   person: Loading.of(),
   setPerson: () => undefined,
   permittedActions: emptyPermittedActions,
-  additionalInformation: Loading.of(),
-  setAdditionalInformation: () => undefined,
   feeAlterations: Loading.of(),
   setFeeAlterations: () => undefined,
   placements: Loading.of(),
@@ -132,9 +127,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
     []
   )
 
-  const [additionalInformation, setAdditionalInformation] = useState<
-    Result<AdditionalInformation>
-  >(defaultState.additionalInformation)
   const [feeAlterations, setFeeAlterations] = useState<Result<FeeAlteration[]>>(
     defaultState.feeAlterations
   )
@@ -175,8 +167,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       person,
       setPerson,
       permittedActions,
-      additionalInformation,
-      setAdditionalInformation,
       feeAlterations,
       setFeeAlterations,
       placements,
@@ -199,7 +189,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       person,
       setPerson,
       permittedActions,
-      additionalInformation,
       feeAlterations,
       placements,
       loadPlacements,

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -13,7 +13,6 @@ import React, {
 import { ChildBackupCare } from '../types/child'
 import { Loading, Result } from 'lib-common/api'
 import { Parentship, PersonJSON } from 'lib-common/generated/api-types/pis'
-import { VasuDocumentSummary } from '../components/vasu/api'
 import { Action } from 'lib-common/generated/action'
 import { PedagogicalDocument } from 'lib-common/generated/api-types/pedagogicaldocument'
 import { PersonApplicationSummary } from 'lib-common/generated/api-types/application'
@@ -39,8 +38,6 @@ export interface ChildState {
   guardians: Result<PersonJSON[]>
   applications: Result<PersonApplicationSummary[]>
   setApplications: (r: Result<PersonApplicationSummary[]>) => void
-  vasus: Result<VasuDocumentSummary[]>
-  setVasus: (r: Result<VasuDocumentSummary[]>) => void
   pedagogicalDocuments: Result<PedagogicalDocument[]>
   setPedagogicalDocuments: (r: Result<PedagogicalDocument[]>) => void
 }
@@ -59,8 +56,6 @@ const defaultState: ChildState = {
   guardians: Loading.of(),
   applications: Loading.of(),
   setApplications: () => undefined,
-  vasus: Loading.of(),
-  setVasus: () => undefined,
   pedagogicalDocuments: Loading.of(),
   setPedagogicalDocuments: () => undefined
 }
@@ -133,9 +128,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
   const [applications, setApplications] = useState<
     Result<PersonApplicationSummary[]>
   >(defaultState.applications)
-  const [vasus, setVasus] = useState<Result<VasuDocumentSummary[]>>(
-    defaultState.vasus
-  )
 
   const [pedagogicalDocuments, setPedagogicalDocuments] = useState<
     Result<PedagogicalDocument[]>
@@ -152,8 +144,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       backupCares,
       setBackupCares,
       guardians,
-      vasus,
-      setVasus,
       applications,
       setApplications,
       pedagogicalDocuments,
@@ -168,7 +158,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       parentships,
       backupCares,
       guardians,
-      vasus,
       applications,
       pedagogicalDocuments
     ]

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -11,7 +11,6 @@ import React, {
   useState
 } from 'react'
 import { Recipient } from 'lib-common/generated/api-types/messaging'
-import { FeeAlteration } from '../types/fee-alteration'
 import { ChildBackupCare } from '../types/child'
 import { Loading, Result } from 'lib-common/api'
 import { Parentship, PersonJSON } from 'lib-common/generated/api-types/pis'
@@ -33,8 +32,6 @@ export interface ChildState {
   person: Result<PersonJSON>
   setPerson: (value: PersonJSON) => void
   permittedActions: Set<Action.Child | Action.Person>
-  feeAlterations: Result<FeeAlteration[]>
-  setFeeAlterations: (result: Result<FeeAlteration[]>) => void
   placements: Result<DaycarePlacementWithDetails[]>
   loadPlacements: () => void
   parentships: Result<Parentship[]>
@@ -58,8 +55,6 @@ const defaultState: ChildState = {
   person: Loading.of(),
   setPerson: () => undefined,
   permittedActions: emptyPermittedActions,
-  feeAlterations: Loading.of(),
-  setFeeAlterations: () => undefined,
   placements: Loading.of(),
   loadPlacements: () => undefined,
   parentships: Loading.of(),
@@ -127,9 +122,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
     []
   )
 
-  const [feeAlterations, setFeeAlterations] = useState<Result<FeeAlteration[]>>(
-    defaultState.feeAlterations
-  )
   const [placements, loadPlacements] = useApiState(
     () => getPlacements(id),
     [id]
@@ -167,8 +159,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       person,
       setPerson,
       permittedActions,
-      feeAlterations,
-      setFeeAlterations,
       placements,
       loadPlacements,
       parentships,
@@ -189,7 +179,6 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
       person,
       setPerson,
       permittedActions,
-      feeAlterations,
       placements,
       loadPlacements,
       parentships,

--- a/frontend/src/lib-components/layout/Container.tsx
+++ b/frontend/src/lib-components/layout/Container.tsx
@@ -122,7 +122,7 @@ export const CollapsibleContentArea = React.memo(
             data-qa="collapsible-trigger"
           />
         </TitleContainer>
-        {open ? children : null}
+        <Collapsible open={open}>{children}</Collapsible>
       </ContentArea>
     )
   }
@@ -176,6 +176,10 @@ const TitleIcon = styled(FontAwesomeIcon)`
   color: ${({ theme: { colors } }) => colors.main.primary};
   height: 24px !important;
   width: 24px !important;
+`
+
+const Collapsible = styled.div<{ open: boolean }>`
+  display: ${(props) => (props.open ? 'block' : 'none')};
 `
 
 export default Container


### PR DESCRIPTION
#### Summary

- Move most data out of `ChildContext` to be managed by the components that use the data
- Data that's used commonly by many components were left, but is now fetched by `ChildContextProvider`
- Add `React.memo`, `renderResult`, etc. usages to affected components