### PR TITLE
Add missing hander is null index to income_statement

### DIFF
--- a/service/src/main/resources/db/migration/V177__income_statement_awaiting_handler_index.sql
+++ b/service/src/main/resources/db/migration/V177__income_statement_awaiting_handler_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY idx$income_statement_handler_id_null ON income_statement(id) WHERE (handler_id IS NULL);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -174,3 +174,4 @@ V173__create_rejected_not_confirmed_state_for_placement_plans.sql
 V174__non_nullable_person_data.sql
 V175__person_preferred_name.sql
 V176__evaka_user_income_updated_by.sql
+V177__income_statement_awaiting_handler_index.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Supposedly fixes bad query performance as full table scan should not be needed anymore.
