### PR TITLE
EVAKA-HOTFIX realtime occupancy graph and calendar fixes

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -295,7 +295,7 @@ function useEditState(
   }[]
 ) {
   const editable =
-    data.reservableDays.includes(date) &&
+    (data.reservableDays?.includes(date) ?? false) &&
     childrenWithReservations.some(
       ({ editableReservation }) => editableReservation
     )

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -37,7 +37,7 @@ interface Props {
   onClose: () => void
   onReload: () => void
   availableChildren: ReservationChild[]
-  reservableDays: FiniteDateRange
+  reservableDays: FiniteDateRange | null
 }
 
 type Repetition = 'DAILY' | 'WEEKLY' | 'IRREGULAR'
@@ -85,7 +85,7 @@ export default React.memo(function ReservationModal({
 
   const [formData, setFormData] = useState<ReservationFormData>({
     selectedChildren: availableChildren.map((child) => child.id),
-    startDate: reservableDays.start.format(),
+    startDate: reservableDays?.start.format() ?? '',
     endDate: '',
     repetition: 'DAILY',
     dailyTimes: [
@@ -224,7 +224,7 @@ export default React.memo(function ReservationModal({
           date={formData.startDate}
           onChange={(date) => updateForm({ startDate: date })}
           locale={lang}
-          isValidDate={(date) => reservableDays.includes(date)}
+          isValidDate={(date) => reservableDays?.includes(date) ?? false}
           info={errorToInputInfo(
             validationResult.errors?.startDate,
             i18n.validationErrors
@@ -237,14 +237,14 @@ export default React.memo(function ReservationModal({
           date={formData.endDate}
           onChange={(date) => updateForm({ endDate: date })}
           locale={lang}
-          isValidDate={(date) => reservableDays.includes(date)}
+          isValidDate={(date) => reservableDays?.includes(date) ?? false}
           info={errorToInputInfo(
             validationResult.errors?.endDate,
             i18n.validationErrors
           )}
           hideErrorsBeforeTouched={!showAllErrors}
           initialMonth={
-            LocalDate.parseFiOrNull(formData.startDate) ?? reservableDays.start
+            LocalDate.parseFiOrNull(formData.startDate) ?? reservableDays?.start
           }
           data-qa="end-date"
         />
@@ -540,7 +540,7 @@ type ValidationResult =
   | { errors: undefined; requestPayload: DailyReservationRequest[] }
 
 function validateForm(
-  reservableDays: FiniteDateRange,
+  reservableDays: FiniteDateRange | null,
   formData: ReservationFormData
 ): ValidationResult {
   const errors: ReservationErrors = {}
@@ -550,14 +550,14 @@ function validateForm(
   }
 
   const startDate = LocalDate.parseFiOrNull(formData.startDate)
-  if (startDate === null) {
+  if (startDate === null || reservableDays === null) {
     errors['startDate'] = 'validDate'
   } else if (startDate.isBefore(reservableDays.start)) {
     errors['startDate'] = 'dateTooEarly'
   }
 
   const endDate = LocalDate.parseFiOrNull(formData.endDate)
-  if (endDate === null) {
+  if (endDate === null || reservableDays === null) {
     errors['endDate'] = 'validDate'
   } else if (startDate && endDate.isBefore(startDate)) {
     errors['endDate'] = 'dateTooEarly'

--- a/frontend/src/citizen-frontend/calendar/api.ts
+++ b/frontend/src/citizen-frontend/calendar/api.ts
@@ -33,7 +33,9 @@ export async function getReservations(
           placementMinStart: LocalDate.parseIso(child.placementMinStart),
           placementMaxEnd: LocalDate.parseIso(child.placementMaxEnd)
         })),
-        reservableDays: FiniteDateRange.parseJson(res.data.reservableDays)
+        reservableDays: res.data.reservableDays
+          ? FiniteDateRange.parseJson(res.data.reservableDays)
+          : null
       })
     )
     .catch((e) => Failure.fromError(e))

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -77,7 +77,7 @@ export default React.memo(function OccupancyDayGraph({ occupancy }: Props) {
         label: i18n.unit.occupancy.subtitles.realized,
         data: graphData,
         spanGaps: true,
-        stepped: 'after',
+        stepped: 'before',
         fill: false,
         pointBackgroundColor: colors.accents.green,
         borderColor: colors.accents.green

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -74,7 +74,7 @@ export interface ReservationsResponse {
   children: ReservationChild[]
   dailyData: DailyReservationData[]
   includesWeekends: boolean
-  reservableDays: FiniteDateRange
+  reservableDays: FiniteDateRange | null
 }
 
 /**

--- a/frontend/src/lib-components/atoms/form/TimeInput.tsx
+++ b/frontend/src/lib-components/atoms/form/TimeInput.tsx
@@ -51,5 +51,5 @@ function onFocus(event: React.FocusEvent<HTMLInputElement>) {
 }
 
 const ShorterInput = styled(InputField)`
-  width: calc(3em + 24px);
+  width: calc(3.4em + 24px);
 `


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
* Fix realtime occupancy graphic to be more intuitive.
* Make `<TimeInput>` slightly wider to fit the `Päättyy` placeholder.
* Also, I noticed that citizen calendar breaks if the child's placements end before the first reservable day, so that is also fixed.

