### PR TITLE
EVAKA-FIX avoid error on empty relayState

### DIFF
--- a/apigw/src/shared/routes/auth/saml/index.ts
+++ b/apigw/src/shared/routes/auth/saml/index.ts
@@ -52,7 +52,7 @@ function getRedirectUrl(req: express.Request): string {
     }
   }
 
-  logError('Invalid RelayState for redirect', req)
+  if (relayState) logError('Invalid RelayState for redirect', req)
 
   return getDefaultPageUrl(req)
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Skip error logging if logout relayState is falsy