### PR TITLE
Fix Finnish only translation on calendar day view

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -132,7 +132,7 @@ export default React.memo(function DayView({
         </DayPicker>
         <Gap size="m" />
         <ReservationTitle>
-          <H2 noMargin>Varaukset ja toteuma</H2>
+          <H2 noMargin>{i18n.calendar.reservationsAndRealized}</H2>
           {editable ? (
             editing ? (
               <InlineButton

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -194,6 +194,7 @@ const en: Translations = {
     noReservation: 'No reservations',
     reservation: 'Reservation',
     realized: 'Realized',
+    reservationsAndRealized: 'Reservations and realized',
     reservationModal: {
       title: 'Make a reservation',
       selectChildren: 'Children the reservation is made for',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -193,6 +193,7 @@ export default {
     noReservation: 'Ei varausta',
     reservation: 'Varaus',
     realized: 'Toteuma',
+    reservationsAndRealized: 'Varaukset ja toteuma',
     reservationModal: {
       title: 'Tee varaus',
       selectChildren: 'Lapset, joille varaus tehdään',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -193,7 +193,8 @@ const sv: Translations = {
     newReservationBtn: 'Reservera',
     noReservation: 'Ingen reservation',
     reservation: 'Reservation',
-    realized: 'Insikt',
+    realized: 'Förverkligad',
+    reservationsAndRealized: 'Reservationer och förverkligade',
     reservationModal: {
       title: 'Reservera',
       selectChildren: 'Barn som reserveras för',


### PR DESCRIPTION
#### Summary
Adds sv and en translations for the 'reservations and realized' header
on the calendar day view.

Also fixes the Swedish translation of 'Realized'.
