### PR TITLE
Temporarily suppress CVE-2021-43466 regarding Thymeleaf

### DIFF
--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -71,4 +71,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         ]]></notes>
         <cve>CVE-2021-32626</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Temporarily suppress while waiting for patched Thymeleaf version, upgrade reminders are in place
+        ]]></notes>
+        <cve>CVE-2021-43466</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Summary

Temporarily suppress CVE-2021-43466 regarding Thymeleaf, upgrade reminders are in place