### PR TITLE
EVAKA-HOTFIX fix application start date validation

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormClub.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormClub.tsx
@@ -28,6 +28,11 @@ export default React.memo(function ApplicationFormClub({
     [formData.serviceNeed.preferredStartDate]
   )
 
+  const originalPreferredStartDate =
+    apiData.status !== 'CREATED'
+      ? apiData.form.preferences.preferredStartDate
+      : null
+
   return (
     <FixedSpaceColumn spacing="s">
       <Heading
@@ -40,7 +45,7 @@ export default React.memo(function ApplicationFormClub({
 
       <ServiceNeedSection
         status={apiData.status}
-        originalPreferredStartDate={apiData.form.preferences.preferredStartDate}
+        originalPreferredStartDate={originalPreferredStartDate}
         type={applicationType}
         formData={formData.serviceNeed}
         updateFormData={(data) =>

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormDaycare.tsx
@@ -61,6 +61,11 @@ export default React.memo(function ApplicationFormDaycare({
     [formData.serviceNeed.preferredStartDate]
   )
 
+  const originalPreferredStartDate =
+    apiData.status !== 'CREATED'
+      ? apiData.form.preferences.preferredStartDate
+      : null
+
   return (
     <>
       {serviceNeedOptions.isLoading && <Loader />}
@@ -79,9 +84,7 @@ export default React.memo(function ApplicationFormDaycare({
 
           <ServiceNeedSection
             status={apiData.status}
-            originalPreferredStartDate={
-              apiData.form.preferences.preferredStartDate
-            }
+            originalPreferredStartDate={originalPreferredStartDate}
             type={applicationType}
             formData={formData.serviceNeed}
             updateFormData={(data) =>

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormPreschool.tsx
@@ -29,6 +29,11 @@ export default React.memo(function ApplicationFormPreschool({
     [formData.serviceNeed.preferredStartDate]
   )
 
+  const originalPreferredStartDate =
+    apiData.status !== 'CREATED'
+      ? apiData.form.preferences.preferredStartDate
+      : null
+
   return (
     <FixedSpaceColumn spacing="s">
       <Heading
@@ -41,7 +46,7 @@ export default React.memo(function ApplicationFormPreschool({
 
       <ServiceNeedSection
         status={apiData.status}
-        originalPreferredStartDate={apiData.form.preferences.preferredStartDate}
+        originalPreferredStartDate={originalPreferredStartDate}
         type={applicationType}
         formData={formData.serviceNeed}
         updateFormData={(data) =>

--- a/frontend/src/citizen-frontend/applications/editor/validations.ts
+++ b/frontend/src/citizen-frontend/applications/editor/validations.ts
@@ -137,7 +137,9 @@ export const validateApplication = (
         required,
         validDate,
         preferredStartDateValidator(
-          apiData.form.preferences.preferredStartDate,
+          apiData.status !== 'CREATED'
+            ? apiData.form.preferences.preferredStartDate
+            : null,
           apiData.type,
           terms
         )


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
When next year's club and preschool terms are added any start dates before the term's start are incorrectly interpreted as invalid.
Club and preschool applications get a sensible default start date, which the application validation function incorrectly interprets as an already filled start date.

Does not yet affect production since we haven't configured next year's terms yet.


