### PR TITLE
Update assistance need/action/measure data, fix and extend report

### DIFF
--- a/frontend/src/employee-frontend/api/reports.ts
+++ b/frontend/src/employee-frontend/api/reports.ts
@@ -22,10 +22,10 @@ import {
   RawReportRow,
   FamilyContactsReportRow,
   PlacementSketchingRow,
-  AssistanceNeedsAndActionsReportRow,
   InvalidServiceNeedReportRow,
   DecisionsReportRow,
-  VardaErrorReportRow
+  VardaErrorReportRow,
+  AssistanceNeedsAndActionsReport
 } from '../types/reports'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
@@ -250,9 +250,9 @@ export interface AssistanceNeedsAndActionsReportFilters {
 
 export async function getAssistanceNeedsAndActionsReport(
   filters: AssistanceNeedsAndActionsReportFilters
-): Promise<Result<AssistanceNeedsAndActionsReportRow[]>> {
+): Promise<Result<AssistanceNeedsAndActionsReport>> {
   return client
-    .get<JsonOf<AssistanceNeedsAndActionsReportRow[]>>(
+    .get<JsonOf<AssistanceNeedsAndActionsReport>>(
       '/reports/assistance-needs-and-actions',
       {
         params: {

--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedsAndActions.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedsAndActions.tsx
@@ -27,6 +27,7 @@ import {
   AssistanceNeedsAndActionsReport,
   AssistanceNeedsAndActionsReportRow
 } from '../../types/reports'
+import { AssistanceMeasure } from 'lib-common/generated/api-types/assistanceaction'
 
 interface DisplayFilters {
   careArea: string
@@ -39,6 +40,15 @@ const emptyDisplayFilters: DisplayFilters = {
 const Wrapper = styled.div`
   width: 100%;
 `
+
+const measures: AssistanceMeasure[] = [
+  'SPECIAL_ASSISTANCE_DECISION',
+  'INTENSIFIED_ASSISTANCE',
+  'EXTENDED_COMPULSORY_EDUCATION',
+  'CHILD_SERVICE',
+  'CHILD_ACCULTURATION_SUPPORT',
+  'TRANSPORT_BENEFIT'
+]
 
 function AssistanceNeedsAndActions() {
   const { i18n } = useTranslation()
@@ -147,6 +157,12 @@ function AssistanceNeedsAndActions() {
                     `ACTION-${value}`,
                     count ?? 0
                   ])
+                ),
+                ...Object.fromEntries(
+                  Object.entries(row.measureCounts).map(([value, count]) => [
+                    `MEASURE-${value}`,
+                    count ?? 0
+                  ])
                 )
               }))}
               headers={[
@@ -197,7 +213,14 @@ function AssistanceNeedsAndActions() {
                 {
                   label: i18n.reports.assistanceNeedsAndActions.actionMissing,
                   key: 'noActionCount'
-                }
+                },
+                ...measures.map((measure) => ({
+                  label:
+                    i18n.childInformation.assistanceAction.fields.measureTypes[
+                      measure
+                    ],
+                  key: `MEASURE-${measure}`
+                }))
               ]}
               filename={`Lapsien tuentarpeet ja tukitoimet yksiköissä ${filters.date.formatIso()}.csv`}
             />
@@ -231,6 +254,14 @@ function AssistanceNeedsAndActions() {
                   <Th>
                     {i18n.reports.assistanceNeedsAndActions.actionMissing}
                   </Th>
+                  {measures.map((measure) => (
+                    <Th key={measure}>
+                      {
+                        i18n.childInformation.assistanceAction.fields
+                          .measureTypes[measure]
+                      }
+                    </Th>
+                  ))}
                 </Tr>
               </Thead>
               <Tbody>
@@ -267,6 +298,9 @@ function AssistanceNeedsAndActions() {
                     ))}
                     <Td>{row.otherActionCount}</Td>
                     <Td>{row.noActionCount}</Td>
+                    {measures.map((measure) => (
+                      <Td key={measure}>{row.measureCounts[measure] ?? 0}</Td>
+                    ))}
                   </Tr>
                 ))}
               </Tbody>
@@ -305,6 +339,14 @@ function AssistanceNeedsAndActions() {
                   <Td>
                     {reducePropertySum(filteredRows, (r) => r.noActionCount)}
                   </Td>
+                  {measures.map((measure) => (
+                    <Td key={measure}>
+                      {reducePropertySum(
+                        filteredRows,
+                        (r) => r.measureCounts[measure] ?? 0
+                      )}
+                    </Td>
+                  ))}
                 </Tr>
               </TableFooter>
             </TableScrollable>

--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedsAndActions.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedsAndActions.tsx
@@ -12,7 +12,6 @@ import Title from 'lib-components/atoms/Title'
 import { Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { useTranslation } from '../../state/i18n'
 import { Loading, Result } from 'lib-common/api'
-import { AssistanceNeedsAndActionsReportRow } from '../../types/reports'
 import {
   AssistanceNeedsAndActionsReportFilters,
   getAssistanceNeedsAndActionsReport
@@ -24,6 +23,10 @@ import { FilterLabel, FilterRow, TableFooter, TableScrollable } from './common'
 import { distinct, reducePropertySum } from '../../utils'
 import LocalDate from 'lib-common/local-date'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
+import {
+  AssistanceNeedsAndActionsReport,
+  AssistanceNeedsAndActionsReportRow
+} from '../../types/reports'
 
 interface DisplayFilters {
   careArea: string
@@ -39,9 +42,9 @@ const Wrapper = styled.div`
 
 function AssistanceNeedsAndActions() {
   const { i18n } = useTranslation()
-  const [rows, setRows] = useState<
-    Result<AssistanceNeedsAndActionsReportRow[]>
-  >(Loading.of())
+  const [report, setReport] = useState<Result<AssistanceNeedsAndActionsReport>>(
+    Loading.of()
+  )
   const [filters, setFilters] =
     useState<AssistanceNeedsAndActionsReportFilters>({
       date: LocalDate.today()
@@ -56,17 +59,14 @@ function AssistanceNeedsAndActions() {
   }
 
   useEffect(() => {
-    setRows(Loading.of())
+    setReport(Loading.of())
     setDisplayFilters(emptyDisplayFilters)
-    void getAssistanceNeedsAndActionsReport(filters).then(setRows)
+    void getAssistanceNeedsAndActionsReport(filters).then(setReport)
   }, [filters])
 
-  const basisTypes = i18n.childInformation.assistanceNeed.fields.basisTypes
-  const actionTypes = i18n.childInformation.assistanceAction.fields.actionTypes
-
   const filteredRows: AssistanceNeedsAndActionsReportRow[] = useMemo(
-    () => rows.map((rs) => rs.filter(displayFilter)).getOrElse([]),
-    [rows, displayFilters] // eslint-disable-line react-hooks/exhaustive-deps
+    () => report.map((rs) => rs.rows.filter(displayFilter)).getOrElse([]),
+    [report, displayFilters] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   return (
@@ -88,12 +88,14 @@ function AssistanceNeedsAndActions() {
             <Combobox
               items={[
                 { value: '', label: i18n.common.all },
-                ...rows
+                ...report
                   .map((rs) =>
-                    distinct(rs.map((row) => row.careAreaName)).map((s) => ({
-                      value: s,
-                      label: s
-                    }))
+                    distinct(rs.rows.map((row) => row.careAreaName)).map(
+                      (s) => ({
+                        value: s,
+                        label: s
+                      })
+                    )
                   )
                   .getOrElse([])
               ]}
@@ -122,18 +124,30 @@ function AssistanceNeedsAndActions() {
           </Wrapper>
         </FilterRow>
 
-        {rows.isLoading && <Loader />}
-        {rows.isFailure && <span>{i18n.common.loadingFailed}</span>}
-        {rows.isSuccess && (
+        {report.isLoading && <Loader />}
+        {report.isFailure && <span>{i18n.common.loadingFailed}</span>}
+        {report.isSuccess && (
           <>
-            <ReportDownload
+            <ReportDownload<Record<string, unknown>>
               data={filteredRows.map((row) => ({
                 ...row,
                 unitType: row.unitType
                   ? i18n.reports.common.unitTypes[row.unitType]
                   : '',
                 unitProviderType:
-                  i18n.reports.common.unitProviderTypes[row.unitProviderType]
+                  i18n.reports.common.unitProviderTypes[row.unitProviderType],
+                ...Object.fromEntries(
+                  Object.entries(row.basisCounts).map(([value, count]) => [
+                    `BASIS-${value}`,
+                    count ?? 0
+                  ])
+                ),
+                ...Object.fromEntries(
+                  Object.entries(row.actionCounts).map(([value, count]) => [
+                    `ACTION-${value}`,
+                    count ?? 0
+                  ])
+                )
               }))}
               headers={[
                 {
@@ -156,85 +170,33 @@ function AssistanceNeedsAndActions() {
                   label: i18n.reports.common.unitProviderType,
                   key: 'unitProviderType'
                 },
+                ...report.value.bases.map((basis) => ({
+                  label: basis.nameFi,
+                  key: `BASIS-${basis.value}`
+                })),
                 {
-                  label: basisTypes.AUTISM,
-                  key: 'autism'
-                },
-                {
-                  label: basisTypes.DEVELOPMENTAL_DISABILITY_1,
-                  key: 'developmentalDisability1'
-                },
-                {
-                  label: basisTypes.DEVELOPMENTAL_DISABILITY_2,
-                  key: 'developmentalDisability2'
-                },
-                {
-                  label: basisTypes.FOCUS_CHALLENGE,
-                  key: 'focusChallenge'
-                },
-                {
-                  label: basisTypes.LINGUISTIC_CHALLENGE,
-                  key: 'linguisticChallenge'
-                },
-                {
-                  label: basisTypes.DEVELOPMENT_MONITORING,
-                  key: 'developmentMonitoring'
-                },
-                {
-                  label: basisTypes.DEVELOPMENT_MONITORING_PENDING,
-                  key: 'developmentMonitoringPending'
-                },
-                {
-                  label: basisTypes.MULTI_DISABILITY,
-                  key: 'multiDisability'
-                },
-                {
-                  label: basisTypes.LONG_TERM_CONDITION,
-                  key: 'longTermCondition'
-                },
-                {
-                  label: basisTypes.REGULATION_SKILL_CHALLENGE,
-                  key: 'regulationSkillChallenge'
-                },
-                {
-                  label: basisTypes.DISABILITY,
-                  key: 'disability'
-                },
-                {
-                  label: basisTypes.OTHER,
-                  key: 'otherAssistanceNeed'
+                  label:
+                    i18n.childInformation.assistanceNeed.fields.basisTypes
+                      .OTHER,
+                  key: 'otherBasisCount'
                 },
                 {
                   label: i18n.reports.assistanceNeedsAndActions.basisMissing,
-                  key: 'noAssistanceNeeds'
+                  key: 'noBasisCount'
                 },
+                ...report.value.actions.map((action) => ({
+                  label: action.nameFi,
+                  key: `ACTION-${action.value}`
+                })),
                 {
-                  label: actionTypes.ASSISTANCE_SERVICE_CHILD,
-                  key: 'assistanceServiceChild'
-                },
-                {
-                  label: actionTypes.ASSISTANCE_SERVICE_UNIT,
-                  key: 'assistanceServiceUnit'
-                },
-                { label: actionTypes.SMALLER_GROUP, key: 'smallerGroup' },
-                { label: actionTypes.SPECIAL_GROUP, key: 'specialGroup' },
-                {
-                  label: actionTypes.PERVASIVE_VEO_SUPPORT,
-                  key: 'pervasiveVeoSupport'
-                },
-                { label: actionTypes.RESOURCE_PERSON, key: 'resourcePerson' },
-                { label: actionTypes.RATIO_DECREASE, key: 'ratioDecrease' },
-                {
-                  label: actionTypes.PERIODICAL_VEO_SUPPORT,
-                  key: 'periodicalVeoSupport'
-                },
-                {
-                  label: actionTypes.OTHER,
-                  key: 'otherAssistanceAction'
+                  label:
+                    i18n.childInformation.assistanceAction.fields.actionTypes
+                      .OTHER,
+                  key: 'otherActionCount'
                 },
                 {
                   label: i18n.reports.assistanceNeedsAndActions.actionMissing,
-                  key: 'noAssistanceActions'
+                  key: 'noActionCount'
                 }
               ]}
               filename={`Lapsien tuentarpeet ja tukitoimet yksiköissä ${filters.date.formatIso()}.csv`}
@@ -247,28 +209,25 @@ function AssistanceNeedsAndActions() {
                   <Th>{i18n.reports.common.groupName}</Th>
                   <Th>{i18n.reports.common.unitType}</Th>
                   <Th>{i18n.reports.common.unitProviderType}</Th>
-                  <Th>{basisTypes.AUTISM}</Th>
-                  <Th>{basisTypes.DEVELOPMENTAL_DISABILITY_1}</Th>
-                  <Th>{basisTypes.DEVELOPMENTAL_DISABILITY_2}</Th>
-                  <Th>{basisTypes.FOCUS_CHALLENGE}</Th>
-                  <Th>{basisTypes.LINGUISTIC_CHALLENGE}</Th>
-                  <Th>{basisTypes.DEVELOPMENT_MONITORING}</Th>
-                  <Th>{basisTypes.DEVELOPMENT_MONITORING_PENDING}</Th>
-                  <Th>{basisTypes.MULTI_DISABILITY}</Th>
-                  <Th>{basisTypes.LONG_TERM_CONDITION}</Th>
-                  <Th>{basisTypes.REGULATION_SKILL_CHALLENGE}</Th>
-                  <Th>{basisTypes.DISABILITY}</Th>
-                  <Th>{basisTypes.OTHER}</Th>
+                  {report.value.bases.map((basis) => (
+                    <Th key={basis.value}>{basis.nameFi}</Th>
+                  ))}
+                  <Th>
+                    {
+                      i18n.childInformation.assistanceNeed.fields.basisTypes
+                        .OTHER
+                    }
+                  </Th>
                   <Th>{i18n.reports.assistanceNeedsAndActions.basisMissing}</Th>
-                  <Th>{actionTypes.ASSISTANCE_SERVICE_CHILD}</Th>
-                  <Th>{actionTypes.ASSISTANCE_SERVICE_UNIT}</Th>
-                  <Th>{actionTypes.SMALLER_GROUP}</Th>
-                  <Th>{actionTypes.SPECIAL_GROUP}</Th>
-                  <Th>{actionTypes.PERVASIVE_VEO_SUPPORT}</Th>
-                  <Th>{actionTypes.RESOURCE_PERSON}</Th>
-                  <Th>{actionTypes.RATIO_DECREASE}</Th>
-                  <Th>{actionTypes.PERIODICAL_VEO_SUPPORT}</Th>
-                  <Th>{actionTypes.OTHER}</Th>
+                  {report.value.actions.map((action) => (
+                    <Th key={action.value}>{action.nameFi}</Th>
+                  ))}
+                  <Th>
+                    {
+                      i18n.childInformation.assistanceAction.fields.actionTypes
+                        .OTHER
+                    }
+                  </Th>
                   <Th>
                     {i18n.reports.assistanceNeedsAndActions.actionMissing}
                   </Th>
@@ -294,29 +253,20 @@ function AssistanceNeedsAndActions() {
                         ]
                       }
                     </Td>
-                    <Td>{row.autism}</Td>
-                    <Td>{row.developmentalDisability1}</Td>
-                    <Td>{row.developmentalDisability2}</Td>
-                    <Td>{row.focusChallenge}</Td>
-                    <Td>{row.linguisticChallenge}</Td>
-                    <Td>{row.developmentMonitoring}</Td>
-                    <Td>{row.developmentMonitoringPending}</Td>
-                    <Td>{row.multiDisability}</Td>
-                    <Td>{row.longTermCondition}</Td>
-                    <Td>{row.regulationSkillChallenge}</Td>
-                    <Td>{row.disability}</Td>
-                    <Td>{row.otherAssistanceNeed}</Td>
-                    <Td>{row.noAssistanceNeeds}</Td>
-                    <Td>{row.assistanceServiceChild}</Td>
-                    <Td>{row.assistanceServiceUnit}</Td>
-                    <Td>{row.smallerGroup}</Td>
-                    <Td>{row.specialGroup}</Td>
-                    <Td>{row.pervasiveVeoSupport}</Td>
-                    <Td>{row.resourcePerson}</Td>
-                    <Td>{row.ratioDecrease}</Td>
-                    <Td>{row.periodicalVeoSupport}</Td>
-                    <Td>{row.otherAssistanceAction}</Td>
-                    <Td>{row.noAssistanceActions}</Td>
+                    {report.value.bases.map((basis) => (
+                      <Td key={basis.value}>
+                        {row.basisCounts[basis.value] ?? 0}
+                      </Td>
+                    ))}
+                    <Td>{row.otherBasisCount}</Td>
+                    <Td>{row.noBasisCount}</Td>
+                    {report.value.actions.map((action) => (
+                      <Td key={action.value}>
+                        {row.actionCounts[action.value] ?? 0}
+                      </Td>
+                    ))}
+                    <Td>{row.otherActionCount}</Td>
+                    <Td>{row.noActionCount}</Td>
                   </Tr>
                 ))}
               </Tbody>
@@ -327,117 +277,33 @@ function AssistanceNeedsAndActions() {
                   <Td />
                   <Td />
                   <Td />
-                  <Td>{reducePropertySum(filteredRows, (r) => r.autism)}</Td>
+                  {report.value.bases.map((basis) => (
+                    <Td key={basis.value}>
+                      {reducePropertySum(
+                        filteredRows,
+                        (r) => r.basisCounts[basis.value] ?? 0
+                      )}
+                    </Td>
+                  ))}
                   <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.developmentalDisability1
-                    )}
+                    {reducePropertySum(filteredRows, (r) => r.otherBasisCount)}
                   </Td>
                   <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.developmentalDisability2
-                    )}
+                    {reducePropertySum(filteredRows, (r) => r.noBasisCount)}
+                  </Td>
+                  {report.value.actions.map((action) => (
+                    <Td key={action.value}>
+                      {reducePropertySum(
+                        filteredRows,
+                        (r) => r.actionCounts[action.value] ?? 0
+                      )}
+                    </Td>
+                  ))}
+                  <Td>
+                    {reducePropertySum(filteredRows, (r) => r.otherActionCount)}
                   </Td>
                   <Td>
-                    {reducePropertySum(filteredRows, (r) => r.focusChallenge)}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.linguisticChallenge
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.developmentMonitoring
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.developmentMonitoringPending
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(filteredRows, (r) => r.multiDisability)}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.longTermCondition
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.regulationSkillChallenge
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(filteredRows, (r) => r.disability)}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.otherAssistanceNeed
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.noAssistanceNeeds
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.assistanceServiceChild
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.assistanceServiceUnit
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(filteredRows, (r) => r.smallerGroup)}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(filteredRows, (r) => r.specialGroup)}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.pervasiveVeoSupport
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(filteredRows, (r) => r.resourcePerson)}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(filteredRows, (r) => r.ratioDecrease)}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.periodicalVeoSupport
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.otherAssistanceAction
-                    )}
-                  </Td>
-                  <Td>
-                    {reducePropertySum(
-                      filteredRows,
-                      (r) => r.noAssistanceActions
-                    )}
+                    {reducePropertySum(filteredRows, (r) => r.noActionCount)}
                   </Td>
                 </Tr>
               </TableFooter>

--- a/frontend/src/employee-frontend/types/reports.ts
+++ b/frontend/src/employee-frontend/types/reports.ts
@@ -6,7 +6,10 @@ import LocalDate from 'lib-common/local-date'
 import { UnitProviderType } from 'lib-customizations/types'
 import { AbsenceType } from 'lib-common/generated/enums'
 import { UUID } from 'lib-common/types'
-import { AssistanceActionOption } from 'lib-common/generated/api-types/assistanceaction'
+import {
+  AssistanceActionOption,
+  AssistanceMeasure
+} from 'lib-common/generated/api-types/assistanceaction'
 import { AssistanceBasisOption } from 'lib-common/generated/api-types/assistanceneed'
 import { ProviderType } from 'lib-common/generated/api-types/daycare'
 import { UnitType } from 'lib-common/generated/api-types/reports'
@@ -264,6 +267,7 @@ export interface AssistanceNeedsAndActionsReport {
 export interface AssistanceNeedsAndActionsReportRow {
   actionCounts: Record<string, number>
   basisCounts: Record<string, number>
+  measureCounts: Record<AssistanceMeasure, number>
   careAreaName: string
   groupId: UUID
   groupName: string

--- a/frontend/src/employee-frontend/types/reports.ts
+++ b/frontend/src/employee-frontend/types/reports.ts
@@ -6,6 +6,10 @@ import LocalDate from 'lib-common/local-date'
 import { UnitProviderType } from 'lib-customizations/types'
 import { AbsenceType } from 'lib-common/generated/enums'
 import { UUID } from 'lib-common/types'
+import { AssistanceActionOption } from 'lib-common/generated/api-types/assistanceaction'
+import { AssistanceBasisOption } from 'lib-common/generated/api-types/assistanceneed'
+import { ProviderType } from 'lib-common/generated/api-types/daycare'
+import { UnitType } from 'lib-common/generated/api-types/reports'
 
 export interface InvoiceReportRow {
   areaCode: number
@@ -251,32 +255,26 @@ export interface ChildAgeLanguageReportRow extends UnitBasicsAbstractReportRow {
   other_7y: number
 }
 
-export interface AssistanceNeedsAndActionsReportRow
-  extends GroupBasicsAbstractReportRow {
-  autism: number
-  developmentalDisability1: number
-  developmentalDisability2: number
-  focusChallenge: number
-  linguisticChallenge: number
-  developmentMonitoring: number
-  developmentMonitoringPending: number
-  multiDisability: number
-  longTermCondition: number
-  regulationSkillChallenge: number
-  disability: number
-  otherAssistanceNeed: number
-  noAssistanceNeeds: number
+export interface AssistanceNeedsAndActionsReport {
+  actions: AssistanceActionOption[]
+  bases: AssistanceBasisOption[]
+  rows: AssistanceNeedsAndActionsReportRow[]
+}
 
-  assistanceServiceChild: number
-  assistanceServiceUnit: number
-  smallerGroup: number
-  specialGroup: number
-  pervasiveVeoSupport: number
-  resourcePerson: number
-  ratioDecrease: number
-  periodicalVeoSupport: number
-  otherAssistanceAction: number
-  noAssistanceActions: number
+export interface AssistanceNeedsAndActionsReportRow {
+  actionCounts: Record<string, number>
+  basisCounts: Record<string, number>
+  careAreaName: string
+  groupId: UUID
+  groupName: string
+  noActionCount: number
+  noBasisCount: number
+  otherActionCount: number
+  otherBasisCount: number
+  unitId: UUID
+  unitName: string
+  unitProviderType: ProviderType
+  unitType: UnitType
 }
 
 export interface OccupancyReportRow {

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -8,7 +8,10 @@
 import FiniteDateRange from '../../finite-date-range'
 import LocalDate from '../../local-date'
 import { AbsenceType } from './daycare'
+import { AssistanceActionOption } from './assistanceaction'
+import { AssistanceBasisOption } from './assistanceneed'
 import { PlacementType } from './placement'
+import { ProviderType } from './daycare'
 import { UUID } from '../../types'
 
 /**
@@ -27,39 +30,31 @@ export interface ApplicationsReportRow {
 }
 
 /**
-* Generated from fi.espoo.evaka.reports.AssistanceNeedsAndActionsReportRow
+* Generated from fi.espoo.evaka.reports.AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReport
+*/
+export interface AssistanceNeedsAndActionsReport {
+  actions: AssistanceActionOption[]
+  bases: AssistanceBasisOption[]
+  rows: AssistanceNeedsAndActionsReportRow[]
+}
+
+/**
+* Generated from fi.espoo.evaka.reports.AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow
 */
 export interface AssistanceNeedsAndActionsReportRow {
-  assistanceServiceChild: number
-  assistanceServiceUnit: number
-  autism: number
+  actionCounts: string[]
+  basisCounts: string[]
   careAreaName: string
-  developmentMonitoring: number
-  developmentMonitoringPending: number
-  developmentalDisability1: number
-  developmentalDisability2: number
-  disability: number
-  focusChallenge: number
   groupId: UUID
   groupName: string
-  linguisticChallenge: number
-  longTermCondition: number
-  multiDisability: number
-  noAssistanceActions: number
-  noAssistanceNeeds: number
-  otherAssistanceAction: number
-  otherAssistanceNeed: number
-  periodicalVeoSupport: number
-  pervasiveVeoSupport: number
-  ratioDecrease: number
-  regulationSkillChallenge: number
-  resourcePerson: number
-  smallerGroup: number
-  specialGroup: number
+  noActionCount: number
+  noBasisCount: number
+  otherActionCount: number
+  otherBasisCount: number
   unitId: UUID
   unitName: string
-  unitProviderType: string
-  unitType: UnitType | null
+  unitProviderType: ProviderType
+  unitType: UnitType
 }
 
 /**

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -10,6 +10,7 @@ import LocalDate from '../../local-date'
 import { AbsenceType } from './daycare'
 import { AssistanceActionOption } from './assistanceaction'
 import { AssistanceBasisOption } from './assistanceneed'
+import { AssistanceMeasure } from './assistanceaction'
 import { PlacementType } from './placement'
 import { ProviderType } from './daycare'
 import { UUID } from '../../types'
@@ -47,6 +48,7 @@ export interface AssistanceNeedsAndActionsReportRow {
   careAreaName: string
   groupId: UUID
   groupName: string
+  measureCounts: AssistanceMeasure[]
   noActionCount: number
   noBasisCount: number
   otherActionCount: number

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -610,22 +610,6 @@ export const fi = {
           'Voit kirjoittaa tähän lisätietoa tuen tarpeesta.',
         bases: 'Perusteet',
         basisTypes: {
-          AUTISM: 'Autismin kirjo',
-          DEVELOPMENTAL_DISABILITY_1: 'Kehitysvamma 1',
-          DEVELOPMENTAL_DISABILITY_2: 'Kehitysvamma 2',
-          DEVELOPMENTAL_DISABILITY_2_INFO:
-            'Käytetään silloin, kun esiopetuksessa oleva lapsi on vaikeasti kehitysvammainen.',
-          FOCUS_CHALLENGE: 'Keskittymisen / tarkkaavaisuuden vaikeus',
-          LINGUISTIC_CHALLENGE: 'Kielellinen vaikeus',
-          DEVELOPMENT_MONITORING: 'Lapsen kehityksen seuranta',
-          DEVELOPMENT_MONITORING_PENDING:
-            'Lapsen kehityksen seuranta, tutkimukset kesken',
-          DEVELOPMENT_MONITORING_PENDING_INFO:
-            'Lapsi on terveydenhuollon tutkimuksissa, diagnoosi ei ole vielä varmistunut.',
-          MULTI_DISABILITY: 'Monivammaisuus',
-          LONG_TERM_CONDITION: 'Pitkäaikaissairaus',
-          REGULATION_SKILL_CHALLENGE: 'Säätelytaitojen vaikeus',
-          DISABILITY: 'Vamma (näkö, kuulo, liikunta, muu)',
           OTHER: 'Muu peruste'
         },
         otherBasisPlaceholder: 'Kirjoita muu peruste.'
@@ -647,22 +631,14 @@ export const fi = {
         dateRange: 'Tukitoimien voimassaoloaika',
         actions: 'Tukitoimet',
         actionTypes: {
-          ASSISTANCE_SERVICE_CHILD: 'Avustamispalvelut yhdelle lapselle',
-          ASSISTANCE_SERVICE_UNIT: 'Avustamispalvelut yksikköön',
-          SMALLER_GROUP: 'Pienennetty ryhmä',
-          SPECIAL_GROUP: 'Erityisryhmä',
-          PERVASIVE_VEO_SUPPORT: 'Laaja-alaisen veon tuki',
-          RESOURCE_PERSON: 'Resurssihenkilö',
-          RATIO_DECREASE: 'Suhdeluvun väljennys',
-          PERIODICAL_VEO_SUPPORT: 'Jaksottainen veon tuki (2–6 kk)',
           OTHER: 'Muu tukitoimi'
         },
         measures: 'Toimenpiteet',
         measureTypes: {
-          SPECIAL_ASSISTANCE_DECISION: 'Erityisen tuen päätös, esiopetus\n',
+          SPECIAL_ASSISTANCE_DECISION: 'Erityisen tuen päätös\n',
           SPECIAL_ASSISTANCE_DECISION_INFO:
             'Lapsella on pidennetty oppivelvollisuus.',
-          INTENSIFIED_ASSISTANCE: 'Tehostettu tuki, esiopetus',
+          INTENSIFIED_ASSISTANCE: 'Tehostettu tuki',
           INTENSIFIED_ASSISTANCE_INFO:
             'Lapsella on avustamispalvelu tai lapsi on pedagogisesti vahvistetussa ryhmässä. Koskee myös osaa laaja-alaisen veon tukea saavista lapsista. ',
           EXTENDED_COMPULSORY_EDUCATION: 'Pidennetty oppivelvollisuus',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -681,7 +681,7 @@ fun Database.Transaction.insertAssistanceActionOptions() {
 INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
     ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10),
     ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20),
-    ('SMALLER_GROUP', 'Pienennetty ryhmä', 30),
+    ('SMALLER_GROUP', 'Pedagogisesti vahvistettu ryhmä', 30),
     ('SPECIAL_GROUP', 'Erityisryhmä', 40),
     ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', 50),
     ('RESOURCE_PERSON', 'Resurssihenkilö', 60),
@@ -696,17 +696,8 @@ fun Database.Transaction.insertAssistanceBasisOptions() {
     // language=sql
     val sql = """
 INSERT INTO assistance_basis_option (value, name_fi, description_fi, display_order) VALUES
-    ('AUTISM', 'Autismin kirjo', NULL, 10),
     ('DEVELOPMENTAL_DISABILITY_1', 'Kehitysvamma 1', NULL, 15),
-    ('DEVELOPMENTAL_DISABILITY_2', 'Kehitysvamma 2', 'Käytetään silloin, kun esiopetuksessa oleva lapsi on vaikeasti kehitysvammainen.', 20),
-    ('FOCUS_CHALLENGE', 'Keskittymisen / tarkkaavaisuuden vaikeus', NULL, 25),
-    ('LINGUISTIC_CHALLENGE', 'Kielellinen vaikeus', NULL, 30),
-    ('DEVELOPMENT_MONITORING', 'Lapsen kehityksen seuranta', NULL, 35),
-    ('DEVELOPMENT_MONITORING_PENDING', 'Lapsen kehityksen seuranta, tutkimukset kesken', 'Lapsi on terveydenhuollon tutkimuksissa, diagnoosi ei ole vielä varmistunut.', 40),
-    ('MULTI_DISABILITY', 'Monivammaisuus', NULL, 45),
-    ('LONG_TERM_CONDITION', 'Pitkäaikaissairaus', NULL, 50),
-    ('REGULATION_SKILL_CHALLENGE', 'Säätelytaitojen vaikeus', NULL, 55),
-    ('DISABILITY', 'Vamma (näkö, kuulo, liikunta, muu)', NULL, 60);
+    ('DEVELOPMENTAL_DISABILITY_2', 'Kehitysvamma 2', 'Käytetään silloin, kun esiopetuksessa oleva lapsi on vaikeasti kehitysvammainen.', 20);
 """
 
     createUpdate(sql).execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionQueries.kt
@@ -164,7 +164,7 @@ fun Database.Transaction.deleteAssistanceActionOptionRefsByActionId(actionId: As
         .execute()
 }
 
-fun Database.Transaction.getAssistanceActionOptions(): List<AssistanceActionOption> {
+fun Database.Read.getAssistanceActionOptions(): List<AssistanceActionOption> {
     //language=sql
     val sql = "SELECT value, name_fi FROM assistance_action_option ORDER BY display_order"
     return createQuery(sql).mapTo(AssistanceActionOption::class.java).list()

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedQueries.kt
@@ -184,7 +184,7 @@ fun Database.Transaction.deleteAssistanceBasisOptionRefsByNeedId(needId: Assista
         .execute()
 }
 
-fun Database.Transaction.getAssistanceBasisOptions(): List<AssistanceBasisOption> {
+fun Database.Read.getAssistanceBasisOptions(): List<AssistanceBasisOption> {
     //language=sql
     val sql = "SELECT value, name_fi, description_fi FROM assistance_basis_option ORDER BY display_order"
     return createQuery(sql).mapTo(AssistanceBasisOption::class.java).list()

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
@@ -5,7 +5,11 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.Audit
-import fi.espoo.evaka.daycare.controllers.utils.ok
+import fi.espoo.evaka.assistanceaction.AssistanceActionOption
+import fi.espoo.evaka.assistanceaction.getAssistanceActionOptions
+import fi.espoo.evaka.assistanceneed.AssistanceBasisOption
+import fi.espoo.evaka.assistanceneed.getAssistanceBasisOptions
+import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AccessControlList
@@ -13,9 +17,9 @@ import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.db.getUUID
+import org.jdbi.v3.core.kotlin.mapTo
+import org.jdbi.v3.json.Json
 import org.springframework.format.annotation.DateTimeFormat
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -28,147 +32,128 @@ class AssistanceNeedsAndActionsReportController(private val acl: AccessControlLi
         db: Database.Connection,
         user: AuthenticatedUser,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
-    ): ResponseEntity<List<AssistanceNeedsAndActionsReportRow>> {
+    ): AssistanceNeedsAndActionsReport {
         Audit.AssistanceNeedsReportRead.log()
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.ADMIN, UserRole.DIRECTOR, UserRole.UNIT_SUPERVISOR, UserRole.SPECIAL_EDUCATION_TEACHER)
-        return db.read { it.getAssistanceNeedsAndActionsReportRows(date, acl.getAuthorizedUnits(user)).let(::ok) }
+        return db.read {
+            AssistanceNeedsAndActionsReport(
+                bases = it.getAssistanceBasisOptions(),
+                actions = it.getAssistanceActionOptions(),
+                rows = it.getReportRows(date, acl.getAuthorizedUnits(user))
+            )
+        }
     }
+
+    data class AssistanceNeedsAndActionsReport(
+        val bases: List<AssistanceBasisOption>,
+        val actions: List<AssistanceActionOption>,
+        val rows: List<AssistanceNeedsAndActionsReportRow>
+    )
+
+    data class AssistanceNeedsAndActionsReportRow(
+        val careAreaName: String,
+        val unitId: DaycareId,
+        val unitName: String,
+        val groupId: GroupId,
+        val groupName: String,
+        val unitType: UnitType,
+        val unitProviderType: ProviderType,
+        @Json
+        val basisCounts: Map<AssistanceBasisOptionValue, Int>,
+        val otherBasisCount: Int,
+        val noBasisCount: Int,
+        @Json
+        val actionCounts: Map<AssistanceActionOptionValue, Int>,
+        val otherActionCount: Int,
+        val noActionCount: Int,
+    )
 }
 
-fun Database.Read.getAssistanceNeedsAndActionsReportRows(date: LocalDate, authorizedUnits: AclAuthorization): List<AssistanceNeedsAndActionsReportRow> {
-    // language=sql
-    val sql =
-        """
-        SELECT
-            ca.name AS care_area_name,
-            u.id AS unit_id,
-            u.name as unit_name,
-            g.id as group_id,
-            initcap(g.name) as group_name,
-            u.type as unit_type,
-            u.provider_type as unit_provider_type,
-            
-            count(DISTINCT pl.child_id) FILTER (WHERE 'AUTISM' = ANY(abo.bases)) AS autism,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENTAL_DISABILITY_1' = ANY(abo.bases)) AS developmental_disability_1,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENTAL_DISABILITY_2' = ANY(abo.bases)) AS developmental_disability_2,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'FOCUS_CHALLENGE' = ANY(abo.bases)) AS focus_challenge,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'LINGUISTIC_CHALLENGE' = ANY(abo.bases)) AS linguistic_challenge,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENT_MONITORING' = ANY(abo.bases)) AS development_monitoring,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'DEVELOPMENT_MONITORING_PENDING' = ANY(abo.bases)) AS development_monitoring_pending,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'MULTI_DISABILITY' = ANY(abo.bases)) AS multi_disability,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'LONG_TERM_CONDITION' = ANY(abo.bases)) AS long_term_condition,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'REGULATION_SKILL_CHALLENGE' = ANY(abo.bases)) AS regulation_skill_challenge,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'DISABILITY' = ANY(abo.bases)) AS disability,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'OTHER' = ANY(abo.bases)) AS other_assistance_need,
-            count(DISTINCT pl.child_id) FILTER (WHERE cardinality(abo.bases) = 0) AS no_assistance_needs,
-            
-            count(DISTINCT pl.child_id) FILTER (WHERE 'ASSISTANCE_SERVICE_CHILD' = ANY(aao.actions)) AS assistance_service_child,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'ASSISTANCE_SERVICE_UNIT' = ANY(aao.actions)) AS assistance_service_unit,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'SMALLER_GROUP' = ANY(aao.actions)) AS smaller_group,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'SPECIAL_GROUP' = ANY(aao.actions)) AS special_group,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'PERVASIVE_VEO_SUPPORT' = ANY(aao.actions)) AS pervasive_veo_support,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'RESOURCE_PERSON' = ANY(aao.actions)) AS resource_person,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'RATIO_DECREASE' = ANY(aao.actions)) AS ratio_decrease,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'PERIODICAL_VEO_SUPPORT' = ANY(aao.actions)) AS periodical_veo_support,
-            count(DISTINCT pl.child_id) FILTER (WHERE 'OTHER' = ANY(aao.actions)) AS other_assistance_action,
-            count(DISTINCT pl.child_id) FILTER (WHERE cardinality(aao.actions) = 0) AS no_assistance_actions
-        FROM daycare u
-        JOIN care_area ca on u.care_area_id = ca.id
-        JOIN daycare_group g ON g.daycare_id = u.id AND daterange(g.start_date, g.end_date, '[]') @> :target_date
-        LEFT JOIN daycare_group_placement gpl ON gpl.daycare_group_id = g.id AND daterange(gpl.start_date, gpl.end_date, '[]') @> :target_date
-        LEFT JOIN placement pl ON pl.id = gpl.daycare_placement_id
-        LEFT JOIN assistance_need an on an.child_id = pl.child_id AND daterange(an.start_date, an.end_date, '[]') @> :target_date
-        LEFT JOIN (
-            SELECT r.need_id, array_remove(array_agg(o.value), null) AS bases
-            FROM assistance_basis_option_ref r
-            JOIN assistance_basis_option o ON o.id = r.option_id
-            GROUP BY r.need_id
-        ) abo ON abo.need_id = an.id
-        LEFT JOIN assistance_action aa on aa.child_id = pl.child_id AND daterange(aa.start_date, aa.end_date, '[]') @> :target_date
-        LEFT JOIN (
-            SELECT r.action_id, array_remove(array_agg(o.value), null) AS actions
-            FROM assistance_action_option_ref r
-            JOIN assistance_action_option o ON o.id = r.option_id
-            GROUP BY r.action_id
-        ) aao ON aao.action_id = aa.id
-        ${if (authorizedUnits != AclAuthorization.All) "WHERE u.id = ANY(:units)" else ""}
-        GROUP BY ca.name, u.id, u.name, g.id, g.name, u.type, u.provider_type
-        ORDER BY ca.name, u.name, g.name;
-        """.trimIndent()
+private typealias AssistanceBasisOptionValue = String
+private typealias AssistanceActionOptionValue = String
 
-    @Suppress("UNCHECKED_CAST")
-    return createQuery(sql)
+private fun Database.Read.getReportRows(date: LocalDate, authorizedUnits: AclAuthorization) =
+    createQuery(
+        """
+SELECT
+    ca.name AS care_area_name,
+    u.id AS unit_id,
+    u.name AS unit_name,
+    g.id AS group_id,
+    initcap(g.name) AS group_name,
+    u.type AS unit_type,
+    u.provider_type AS unit_provider_type,
+    (
+        SELECT jsonb_object_agg(value, count)
+        FROM (
+            SELECT
+                o.value,
+                count(an.child_id) AS count
+            FROM assistance_basis_option o
+            LEFT JOIN daycare_group_placement gpl ON daterange(gpl.start_date, gpl.end_date, '[]') @> :target_date
+            AND gpl.daycare_group_id = g.id
+            LEFT JOIN placement pl ON pl.id = gpl.daycare_placement_id
+            LEFT JOIN assistance_basis_option_ref r ON r.option_id = o.id
+            LEFT JOIN assistance_need an ON r.need_id = an.id
+            AND an.child_id = pl.child_id
+            AND daterange(an.start_date, an.end_date, '[]') @> :target_date
+            GROUP BY o.value
+        ) basis_counts
+    ) AS basis_counts,
+    coalesce(basis_stats.other_count, 0) AS other_basis_count,
+    coalesce(basis_stats.none_count, 0) AS no_basis_count,
+    (
+        SELECT jsonb_object_agg(value, count)
+        FROM (
+            SELECT
+                o.value,
+                count(aa.child_id) AS count
+            FROM assistance_action_option o
+            LEFT JOIN daycare_group_placement gpl ON daterange(gpl.start_date, gpl.end_date, '[]') @> :target_date
+            AND gpl.daycare_group_id = g.id
+            LEFT JOIN placement pl ON pl.id = gpl.daycare_placement_id
+            LEFT JOIN assistance_action_option_ref r ON r.option_id = o.id
+            LEFT JOIN assistance_action aa ON r.action_id = aa.id
+            AND aa.child_id = pl.child_id
+            AND daterange(aa.start_date, aa.end_date, '[]') @> :target_date
+            GROUP BY o.value
+        ) action_counts
+    ) AS action_counts,
+    coalesce(action_stats.other_count, 0) AS other_action_count,
+    coalesce(action_stats.none_count, 0) AS no_action_count
+FROM daycare u
+JOIN care_area ca ON u.care_area_id = ca.id
+JOIN daycare_group g ON g.daycare_id = u.id AND daterange(g.start_date, g.end_date, '[]') @> :target_date
+LEFT JOIN (
+    SELECT
+        gpl.daycare_group_id AS group_id,
+        count(1) FILTER (WHERE an.other_basis != '') AS other_count,
+        count(1) FILTER (WHERE an.other_basis = '' AND NOT EXISTS (SELECT 1 FROM assistance_basis_option_ref WHERE need_id = an.id)) AS none_count
+    FROM daycare_group_placement gpl
+    JOIN placement pl ON pl.id = gpl.daycare_placement_id
+    JOIN assistance_need an ON an.child_id = pl.child_id
+    AND daterange(an.start_date, an.end_date, '[]') @> :target_date
+    WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> :target_date
+    GROUP BY gpl.daycare_group_id
+) basis_stats ON g.id = basis_stats.group_id
+LEFT JOIN (
+    SELECT
+        gpl.daycare_group_id AS group_id,
+        count(1) FILTER (WHERE aa.other_action != '') AS other_count,
+        count(1) FILTER (WHERE aa.other_action = '' AND NOT EXISTS (SELECT 1 FROM assistance_action_option_ref WHERE action_id = aa.id)) AS none_count
+    FROM daycare_group_placement gpl
+    JOIN placement pl ON pl.id = gpl.daycare_placement_id
+    JOIN assistance_action aa ON aa.child_id = pl.child_id
+    AND daterange(aa.start_date, aa.end_date, '[]') @> :target_date
+    WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> :target_date
+    GROUP BY gpl.daycare_group_id
+) action_stats ON g.id = action_stats.group_id
+${if (authorizedUnits != AclAuthorization.All) "WHERE u.id = ANY(:units)" else ""}
+ORDER BY ca.name, u.name, g.name
+        """.trimIndent()
+    )
         .bind("target_date", date)
         .bind("units", authorizedUnits.ids?.toTypedArray())
-        .map { rs, _ ->
-            AssistanceNeedsAndActionsReportRow(
-                careAreaName = rs.getString("care_area_name"),
-                unitId = DaycareId(rs.getUUID("unit_id")),
-                unitName = rs.getString("unit_name"),
-                groupId = GroupId(rs.getUUID("group_id")),
-                groupName = rs.getString("group_name"),
-                unitType = (rs.getArray("unit_type").array as Array<out Any>).map { it.toString() }.toSet().let(::getPrimaryUnitType),
-                unitProviderType = rs.getString("unit_provider_type"),
-
-                autism = rs.getInt("autism"),
-                developmentalDisability1 = rs.getInt("developmental_disability_1"),
-                developmentalDisability2 = rs.getInt("developmental_disability_2"),
-                focusChallenge = rs.getInt("focus_challenge"),
-                linguisticChallenge = rs.getInt("linguistic_challenge"),
-                developmentMonitoring = rs.getInt("development_monitoring"),
-                developmentMonitoringPending = rs.getInt("development_monitoring_pending"),
-                multiDisability = rs.getInt("multi_disability"),
-                longTermCondition = rs.getInt("long_term_condition"),
-                regulationSkillChallenge = rs.getInt("regulation_skill_challenge"),
-                disability = rs.getInt("disability"),
-                otherAssistanceNeed = rs.getInt("other_assistance_need"),
-                noAssistanceNeeds = rs.getInt("no_assistance_needs"),
-
-                assistanceServiceChild = rs.getInt("assistance_service_child"),
-                assistanceServiceUnit = rs.getInt("assistance_service_unit"),
-                smallerGroup = rs.getInt("smaller_group"),
-                specialGroup = rs.getInt("special_group"),
-                pervasiveVeoSupport = rs.getInt("pervasive_veo_support"),
-                resourcePerson = rs.getInt("resource_person"),
-                ratioDecrease = rs.getInt("ratio_decrease"),
-                periodicalVeoSupport = rs.getInt("periodical_veo_support"),
-                otherAssistanceAction = rs.getInt("other_assistance_action"),
-                noAssistanceActions = rs.getInt("no_assistance_actions")
-            )
-        }.toList()
-}
-
-data class AssistanceNeedsAndActionsReportRow(
-    val careAreaName: String,
-    val unitId: DaycareId,
-    val unitName: String,
-    val groupId: GroupId,
-    val groupName: String,
-    val unitType: UnitType?,
-    val unitProviderType: String,
-
-    val autism: Int,
-    val developmentalDisability1: Int,
-    val developmentalDisability2: Int,
-    val focusChallenge: Int,
-    val linguisticChallenge: Int,
-    val developmentMonitoring: Int,
-    val developmentMonitoringPending: Int,
-    val multiDisability: Int,
-    val longTermCondition: Int,
-    val regulationSkillChallenge: Int,
-    val disability: Int,
-    val otherAssistanceNeed: Int,
-    val noAssistanceNeeds: Int,
-
-    val assistanceServiceChild: Int,
-    val assistanceServiceUnit: Int,
-    val smallerGroup: Int,
-    val specialGroup: Int,
-    val pervasiveVeoSupport: Int,
-    val resourcePerson: Int,
-    val ratioDecrease: Int,
-    val periodicalVeoSupport: Int,
-    val otherAssistanceAction: Int,
-    val noAssistanceActions: Int
-)
+        .registerColumnMapper(UnitType::class.java, UnitType.JDBI_COLUMN_MAPPER)
+        .mapTo<AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow>()
+        .list()

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/Common.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/Common.kt
@@ -4,6 +4,10 @@
 
 package fi.espoo.evaka.reports
 
+import org.jdbi.v3.core.mapper.ColumnMapper
+import org.jdbi.v3.core.statement.StatementContext
+import java.sql.ResultSet
+
 fun getPrimaryUnitType(careTypes: Set<String>): UnitType? {
     if (careTypes.contains("FAMILY")) return UnitType.FAMILY
     if (careTypes.contains("GROUP_FAMILY")) return UnitType.GROUP_FAMILY
@@ -16,5 +20,13 @@ enum class UnitType {
     DAYCARE,
     FAMILY,
     GROUP_FAMILY,
-    CLUB
+    CLUB;
+
+    companion object {
+        val JDBI_COLUMN_MAPPER: ColumnMapper<UnitType> = ColumnMapper<UnitType> {
+            rs: ResultSet, columnNumber: Int, _: StatementContext ->
+            @Suppress("UNCHECKED_CAST")
+            (rs.getArray(columnNumber).array as Array<out Any>).map { it.toString() }.toSet().let(::getPrimaryUnitType)
+        }
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -115,10 +115,7 @@ ORDER BY p.id, t
     return createQuery(sql)
         .bind("start_date", from)
         .bind("end_date", to)
-        .registerColumnMapper(UnitType::class.java) { rs, columnNumber, _ ->
-            @Suppress("UNCHECKED_CAST")
-            (rs.getArray(columnNumber).array as Array<out Any>).map { it.toString() }.toSet().let(::getPrimaryUnitType)
-        }
+        .registerColumnMapper(UnitType::class.java, UnitType.JDBI_COLUMN_MAPPER)
         .mapTo<RawReportRow>()
         .toList()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -17,6 +17,8 @@ sealed interface DatabaseTable {
     sealed class ApplicationNote : DatabaseTable
     sealed class Area : DatabaseTable
     sealed class AssistanceAction : DatabaseTable
+    sealed class AssistanceActionOption : DatabaseTable
+    sealed class AssistanceBasisOption : DatabaseTable
     sealed class AssistanceNeed : DatabaseTable
     sealed class Attachment : DatabaseTable
     sealed class Attendance : DatabaseTable
@@ -63,6 +65,8 @@ typealias ApplicationId = Id<DatabaseTable.Application>
 typealias ApplicationNoteId = Id<DatabaseTable.ApplicationNote>
 typealias AreaId = Id<DatabaseTable.Area>
 typealias AssistanceActionId = Id<DatabaseTable.AssistanceAction>
+typealias AssistanceActionOptionId = Id<DatabaseTable.AssistanceActionOption>
+typealias AssistanceBasisOptionId = Id<DatabaseTable.AssistanceBasisOption>
 typealias AssistanceNeedId = Id<DatabaseTable.AssistanceNeed>
 typealias AttachmentId = Id<DatabaseTable.Attachment>
 typealias AttendanceId = Id<DatabaseTable.Attendance>

--- a/service/src/main/resources/dev-data/espoo-dev-data.sql
+++ b/service/src/main/resources/dev-data/espoo-dev-data.sql
@@ -30,7 +30,7 @@ INSERT INTO message_account (daycare_group_id) SELECT id FROM daycare_group;
 INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
                                                                          ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10),
                                                                          ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20),
-                                                                         ('SMALLER_GROUP', 'Pienennetty ryhmä', 30),
+                                                                         ('SMALLER_GROUP', 'Pedagogisesti vahvistettu ryhmä', 30),
                                                                          ('SPECIAL_GROUP', 'Erityisryhmä', 40),
                                                                          ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', 50),
                                                                          ('RESOURCE_PERSON', 'Resurssihenkilö', 60),
@@ -38,16 +38,7 @@ INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
                                                                          ('PERIODICAL_VEO_SUPPORT', 'Jaksottainen veon tuki (2–6 kk)', 80);
 
 INSERT INTO assistance_basis_option (value, name_fi, description_fi, display_order) VALUES
-                                                                                        ('AUTISM', 'Autismin kirjo', NULL, 10),
                                                                                         ('DEVELOPMENTAL_DISABILITY_1', 'Kehitysvamma 1', NULL, 15),
-                                                                                        ('DEVELOPMENTAL_DISABILITY_2', 'Kehitysvamma 2', 'Käytetään silloin, kun esiopetuksessa oleva lapsi on vaikeasti kehitysvammainen.', 20),
-                                                                                        ('FOCUS_CHALLENGE', 'Keskittymisen / tarkkaavaisuuden vaikeus', NULL, 25),
-                                                                                        ('LINGUISTIC_CHALLENGE', 'Kielellinen vaikeus', NULL, 30),
-                                                                                        ('DEVELOPMENT_MONITORING', 'Lapsen kehityksen seuranta', NULL, 35),
-                                                                                        ('DEVELOPMENT_MONITORING_PENDING', 'Lapsen kehityksen seuranta, tutkimukset kesken', 'Lapsi on terveydenhuollon tutkimuksissa, diagnoosi ei ole vielä varmistunut.', 40),
-                                                                                        ('MULTI_DISABILITY', 'Monivammaisuus', NULL, 45),
-                                                                                        ('LONG_TERM_CONDITION', 'Pitkäaikaissairaus', NULL, 50),
-                                                                                        ('REGULATION_SKILL_CHALLENGE', 'Säätelytaitojen vaikeus', NULL, 55),
-                                                                                        ('DISABILITY', 'Vamma (näkö, kuulo, liikunta, muu)', NULL, 60);
+                                                                                        ('DEVELOPMENTAL_DISABILITY_2', 'Kehitysvamma 2', 'Käytetään silloin, kun esiopetuksessa oleva lapsi on vaikeasti kehitysvammainen.', 20);
 
 UPDATE daycare SET enabled_pilot_features = '{MESSAGING, MOBILE, RESERVATIONS}';


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

##### Data updates (EVAKA-4281 / EVAKA-4282)

- Remove most assistance need bases from test data
- Rename `SMALLER_GROUP` action in test data
- Remove "esiopetus" from some assistance measures

##### Make assistance needs/actions report dynamic. 

Since bases/actions are configured using database rows, the report should use this information instead of relying on a static hard-coded list.

- Generated API types are not used, because our API generation doesn't handle `Map<K, V>` columns correctly and fixing this seems complicated.

##### Fix broken assistance needs/actions report columns

These columns were always reported as 0: "other bases", "no bases", "other actions", "no actions". The "other" columns were broken because they assumed an option with `OTHER` value, but the database model uses non-empty `otherText` to model these cases. The "no" columns were broken because of incorrect handling of SQL NULL values.

##### Extend report (EVAKA-4333)

- add assistance action measures to the report