### PR TITLE
Hide old assistance need information when child goes to preschool

### DIFF
--- a/frontend/src/e2e-playwright/pages/employee/child-information-page.ts
+++ b/frontend/src/e2e-playwright/pages/employee/child-information-page.ts
@@ -109,4 +109,11 @@ export class ChildAssistanceNeed {
       expected
     )
   }
+
+  async assertAssistanceNeedCount(expectedCount: number) {
+    await waitUntilEqual(
+      () => this.#assistanceNeedDescription.count(),
+      expectedCount
+    )
+  }
 }

--- a/frontend/src/e2e-playwright/pages/employee/child-information-page.ts
+++ b/frontend/src/e2e-playwright/pages/employee/child-information-page.ts
@@ -81,38 +81,39 @@ export class ChildAssistanceNeed {
   #createAssistanceNeedButton = this.page.locator(
     '[data-qa="assistance-need-create-btn"]'
   )
-  #assistanceNeedDescriptionInput = this.page.locator(
-    '[data-qa="input-assistance-need-description"]'
+  #assistanceNeedMultiplierInput = this.page.locator(
+    '[data-qa="input-assistance-need-multiplier"]'
   )
   #confirmAssistanceNeedButton = this.page.locator(
     '[data-qa="button-assistance-need-confirm"]'
   )
-  #assistanceNeedDescription = this.page.locator(
-    '[data-qa="assistance-need-description"]'
+  #assistanceNeedMultiplier = this.page.locator(
+    '[data-qa="assistance-need-multiplier"]'
   )
 
   async createNewAssistanceNeed() {
     await this.#createAssistanceNeedButton.click()
   }
 
-  async setAssistanceNeedDescription(description: string) {
-    await this.#assistanceNeedDescriptionInput.type(description)
+  async setAssistanceNeedMultiplier(multiplier: string) {
+    await this.#assistanceNeedMultiplierInput.selectText()
+    await this.#assistanceNeedMultiplierInput.type(multiplier)
   }
 
   async confirmAssistanceNeed() {
     await this.#confirmAssistanceNeedButton.click()
   }
 
-  async assertAssistanceNeedDescription(expected: string, nth = 0) {
+  async assertAssistanceNeedMultiplier(expected: string, nth = 0) {
     await waitUntilEqual(
-      () => this.#assistanceNeedDescription.nth(nth).innerText(),
+      () => this.#assistanceNeedMultiplier.nth(nth).innerText(),
       expected
     )
   }
 
   async assertAssistanceNeedCount(expectedCount: number) {
     await waitUntilEqual(
-      () => this.#assistanceNeedDescription.count(),
+      () => this.#assistanceNeedMultiplier.count(),
       expectedCount
     )
   }

--- a/frontend/src/e2e-playwright/pages/employee/child-information-page.ts
+++ b/frontend/src/e2e-playwright/pages/employee/child-information-page.ts
@@ -74,3 +74,39 @@ export default class ChildInformationPage {
       .click()
   }
 }
+
+export class ChildAssistanceNeed {
+  constructor(private page: Page) {}
+
+  #createAssistanceNeedButton = this.page.locator(
+    '[data-qa="assistance-need-create-btn"]'
+  )
+  #assistanceNeedDescriptionInput = this.page.locator(
+    '[data-qa="input-assistance-need-description"]'
+  )
+  #confirmAssistanceNeedButton = this.page.locator(
+    '[data-qa="button-assistance-need-confirm"]'
+  )
+  #assistanceNeedDescription = this.page.locator(
+    '[data-qa="assistance-need-description"]'
+  )
+
+  async createNewAssistanceNeed() {
+    await this.#createAssistanceNeedButton.click()
+  }
+
+  async setAssistanceNeedDescription(description: string) {
+    await this.#assistanceNeedDescriptionInput.type(description)
+  }
+
+  async confirmAssistanceNeed() {
+    await this.#confirmAssistanceNeedButton.click()
+  }
+
+  async assertAssistanceNeedDescription(expected: string, nth = 0) {
+    await waitUntilEqual(
+      () => this.#assistanceNeedDescription.nth(nth).innerText(),
+      expected
+    )
+  }
+}

--- a/frontend/src/e2e-playwright/specs/5_employee/child-information-assistance-needs.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/child-information-assistance-needs.spec.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Page } from 'playwright'
+import config from 'e2e-test-common/config'
+import {
+  insertDaycareGroupFixtures,
+  insertDaycarePlacementFixtures,
+  resetDatabase
+} from 'e2e-test-common/dev-api'
+import { initializeAreaAndPersonData } from 'e2e-test-common/dev-api/data-init'
+import {
+  createDaycarePlacementFixture,
+  daycareGroupFixture,
+  uuidv4
+} from 'e2e-test-common/dev-api/fixtures'
+import { newBrowserContext } from 'e2e-playwright/browser'
+import { employeeLogin } from 'e2e-playwright/utils/user'
+import { UUID } from 'lib-common/types'
+import ChildInformationPage, {
+  ChildAssistanceNeed
+} from '../../pages/employee/child-information-page'
+
+let page: Page
+let childInformationPage: ChildInformationPage
+let assistanceNeeds: ChildAssistanceNeed
+let childId: UUID
+
+beforeEach(async () => {
+  await resetDatabase()
+
+  const fixtures = await initializeAreaAndPersonData()
+  await insertDaycareGroupFixtures([daycareGroupFixture])
+
+  const unitId = fixtures.daycareFixture.id
+  childId = fixtures.familyWithTwoGuardians.children[0].id
+
+  const daycarePlacementFixture = createDaycarePlacementFixture(
+    uuidv4(),
+    childId,
+    unitId
+  )
+  await insertDaycarePlacementFixtures([daycarePlacementFixture])
+
+  page = await (await newBrowserContext()).newPage()
+  await employeeLogin(page, 'ADMIN')
+  await page.goto(config.employeeUrl + '/child-information/' + childId)
+  childInformationPage = new ChildInformationPage(page)
+  await childInformationPage.assistanceCollapsible.click()
+  assistanceNeeds = new ChildAssistanceNeed(page)
+})
+
+describe('Child Information assistance need', () => {
+  test('assistance need can be added', async () => {
+    await assistanceNeeds.createNewAssistanceNeed()
+    await assistanceNeeds.setAssistanceNeedDescription('a description')
+    await assistanceNeeds.confirmAssistanceNeed()
+    await assistanceNeeds.assertAssistanceNeedDescription('a description')
+  })
+})

--- a/frontend/src/e2e-playwright/specs/5_employee/child-information-assistance-needs.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/child-information-assistance-needs.spec.ts
@@ -85,9 +85,9 @@ describe('Child Information assistance need functionality for employees', () => 
     await setupUser(config.unitSupervisorAad)
     await logUserIn('UNIT_SUPERVISOR')
     await assistanceNeeds.createNewAssistanceNeed()
-    await assistanceNeeds.setAssistanceNeedDescription('a description')
+    await assistanceNeeds.setAssistanceNeedMultiplier('1,5')
     await assistanceNeeds.confirmAssistanceNeed()
-    await assistanceNeeds.assertAssistanceNeedDescription('a description')
+    await assistanceNeeds.assertAssistanceNeedMultiplier('1,5')
   })
 
   test('assistance need before preschool for a child in preschool is not shown for unit manager', async () => {

--- a/frontend/src/e2e-test-common/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test-common/dev-api/fixtures.ts
@@ -26,9 +26,11 @@ import {
   DaycareGroupPlacement,
   EmployeePin,
   PedagogicalDocument,
-  ServiceNeedFixture
+  ServiceNeedFixture,
+  AssistanceNeed
 } from './types'
 import {
+  insertAssistanceNeedFixtures,
   insertCareAreaFixtures,
   insertChildFixtures,
   insertDaycareFixtures,
@@ -1065,6 +1067,19 @@ export class Fixture {
   static child(id: string): ChildBuilder {
     return new ChildBuilder({ id })
   }
+
+  static assistanceNeed(): AssistanceNeedBuilder {
+    return new AssistanceNeedBuilder({
+      id: uuidv4(),
+      capacityFactor: 1.0,
+      childId: 'not_set',
+      description: '',
+      startDate: new Date(),
+      endDate: new Date(),
+      otherBasis: '',
+      updatedBy: ''
+    })
+  }
 }
 
 export class DaycareBuilder {
@@ -1381,5 +1396,31 @@ export class ChildBuilder {
   // Note: shallow copy
   copy(): ChildBuilder {
     return new ChildBuilder({ ...this.data })
+  }
+}
+
+export class AssistanceNeedBuilder {
+  data: AssistanceNeed
+
+  constructor(data: AssistanceNeed) {
+    this.data = data
+  }
+
+  with(value: Partial<AssistanceNeed>): AssistanceNeedBuilder {
+    this.data = {
+      ...this.data,
+      ...value
+    }
+    return this
+  }
+
+  async save(): Promise<AssistanceNeedBuilder> {
+    await insertAssistanceNeedFixtures([this.data])
+    return this
+  }
+
+  // Note: shallow copy
+  copy(): AssistanceNeedBuilder {
+    return new AssistanceNeedBuilder({ ...this.data })
   }
 }

--- a/frontend/src/e2e-test-common/dev-api/index.ts
+++ b/frontend/src/e2e-test-common/dev-api/index.ts
@@ -36,7 +36,8 @@ import {
   PersonDetailWithDependantsAndGuardians,
   HighestFeeFixture,
   PedagogicalDocument,
-  ServiceNeedFixture
+  ServiceNeedFixture,
+  AssistanceNeed
 } from './types'
 import { JsonOf } from 'lib-common/json'
 import {
@@ -216,6 +217,16 @@ export async function insertDaycareGroupFixtures(
 export async function insertChildFixtures(fixture: Child[]): Promise<void> {
   try {
     await devClient.post(`/children`, fixture)
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}
+
+export async function insertAssistanceNeedFixtures(
+  fixture: AssistanceNeed[]
+): Promise<void> {
+  try {
+    await devClient.post(`/assistance-needs`, fixture)
   } catch (e) {
     throw new DevApiError(e)
   }

--- a/frontend/src/e2e-test-common/dev-api/types.ts
+++ b/frontend/src/e2e-test-common/dev-api/types.ts
@@ -589,3 +589,14 @@ export interface ServiceNeedFixture {
   confirmedBy: UUID
   confirmedAt: LocalDate
 }
+
+export interface AssistanceNeed {
+  id: string
+  updatedBy: string
+  childId: string
+  startDate: Date
+  endDate: Date
+  capacityFactor: number
+  description: string
+  otherBasis: string
+}

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
@@ -305,6 +305,7 @@ export default React.memo(function AssistanceNeedForm(props: Props) {
                       info={basis.descriptionFi}
                       ariaLabel={''}
                       fullWidth={true}
+                      data-qa={'input-assistance-need-description'}
                     >
                       <CheckboxRow key={basis.value}>
                         <Checkbox

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
@@ -305,7 +305,6 @@ export default React.memo(function AssistanceNeedForm(props: Props) {
                       info={basis.descriptionFi}
                       ariaLabel={''}
                       fullWidth={true}
-                      data-qa={'input-assistance-need-description'}
                     >
                       <CheckboxRow key={basis.value}>
                         <Checkbox

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
@@ -114,7 +114,9 @@ export default React.memo(function AssistanceNeedRow({
                   i18n.childInformation.assistanceNeed.fields.capacityFactor,
                 value: (
                   <span>
-                    {formatDecimal(assistanceNeed.capacityFactor)}
+                    <span data-qa={'assistance-need-multiplier'}>
+                      {formatDecimal(assistanceNeed.capacityFactor)}
+                    </span>
                     <InfoBall
                       text={
                         i18n.childInformation.assistanceNeed.fields

--- a/frontend/src/lib-common/generated/action.d.ts
+++ b/frontend/src/lib-common/generated/action.d.ts
@@ -54,6 +54,7 @@ export type AssistanceAction =
 
 export type AssistanceNeed =
   | 'DELETE'
+  | 'READ_PRE_PRESCHOOL_ASSISTANCE_NEED'
   | 'UPDATE'
 
 export type BackupCare =

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -9,9 +9,6 @@ import fi.espoo.evaka.daycare.controllers.utils.created
 import fi.espoo.evaka.daycare.controllers.utils.noContent
 import fi.espoo.evaka.daycare.controllers.utils.ok
 import fi.espoo.evaka.pis.service.PersonService
-import fi.espoo.evaka.placement.Placement
-import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.placement.getPlacementsForChild
 import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
@@ -61,12 +58,6 @@ class AssistanceNeedController(
         accessControl.requirePermissionFor(user, Action.Child.READ_ASSISTANCE_NEED, childId)
         return assistanceNeedService.getAssistanceNeedsByChildId(db, childId).filter { assistanceNeed ->
             accessControl.hasPermissionFor(user, Action.AssistanceNeed.READ_PRE_PRESCHOOL_ASSISTANCE_NEED, assistanceNeed.id)
-        }
-    }
-
-    private fun getChildPreschoolPlacements(db: Database.Connection, childId: UUID): List<Placement> {
-        return db.read { it.getPlacementsForChild(childId) }.filter {
-            (it.type == PlacementType.PRESCHOOL || it.type == PlacementType.PRESCHOOL_DAYCARE)
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -60,14 +60,7 @@ class AssistanceNeedController(
         Audit.ChildAssistanceNeedRead.log(targetId = childId)
         accessControl.requirePermissionFor(user, Action.Child.READ_ASSISTANCE_NEED, childId)
         return assistanceNeedService.getAssistanceNeedsByChildId(db, childId).filter { assistanceNeed ->
-            // If child is or has been in preschool, do not show pre preschool daycare assistance needs for non admin
-            if (!user.isAdmin) {
-                if (getChildPreschoolPlacements(db, childId).any { preschoolPlacement ->
-                    assistanceNeed.startDate.isBefore(preschoolPlacement.startDate)
-                }
-                ) false else true
-            } else
-                true
+            accessControl.hasPermissionFor(user, Action.AssistanceNeed.READ_PRE_PRESCHOOL_ASSISTANCE_NEED, assistanceNeed.id)
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -892,6 +892,16 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
         db.transaction { it.insertVoucherValues() }
         return ResponseEntity.noContent().build()
     }
+
+    @PostMapping("/assistance-needs")
+    fun createAssistanceNeeds(db: Database.Connection, @RequestBody assistanceNeeds: List<DevAssistanceNeed>): ResponseEntity<Unit> {
+        db.transaction { tx ->
+            assistanceNeeds.forEach {
+                tx.insertTestAssistanceNeed(it)
+            }
+        }
+        return ResponseEntity.noContent().build()
+    }
 }
 
 fun Database.Transaction.ensureFakeAdminExists() {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.shared.security
 import fi.espoo.evaka.ExcludeCodeGen
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.ApplicationNoteId
+import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.AttachmentId
 import fi.espoo.evaka.shared.BackupCareId
 import fi.espoo.evaka.shared.ChildDailyNoteId
@@ -125,9 +126,10 @@ sealed interface Action {
         override fun toString(): String = "${javaClass.name}.$name"
         override fun defaultRoles(): Set<UserRole> = roles
     }
-    enum class AssistanceNeed(private val roles: EnumSet<UserRole>) : Action {
+    enum class AssistanceNeed(private val roles: EnumSet<UserRole>) : ScopedAction<AssistanceNeedId> {
         UPDATE(SERVICE_WORKER, UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER),
-        DELETE(SERVICE_WORKER, UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER);
+        DELETE(SERVICE_WORKER, UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER),
+        READ_PRE_PRESCHOOL_ASSISTANCE_NEED;
 
         constructor(vararg roles: UserRole) : this(roles.toEnumSet())
         override fun toString(): String = "${javaClass.name}.$name"


### PR DESCRIPTION
#### Summary
- If child is or has been in preschool, hide pre preschool service needs from non admins
- Add E2E tests for child information page assistance needs

