### PR TITLE
Fix child absence layout in employee mobile

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/attendances/Absences.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/Absences.tsx
@@ -2,46 +2,38 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { Child } from 'lib-common/generated/api-types/attendance'
+import HorizontalLine from 'lib-components/atoms/HorizontalLine'
+import { Label } from 'lib-components/typography'
 import React from 'react'
 import styled from 'styled-components'
-
-import Title from 'lib-components/atoms/Title'
-import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
-import { Label } from 'lib-components/typography'
 import { useTranslation } from '../../state/i18n'
 import { formatCareType } from '../../types'
-import { Child } from 'lib-common/generated/api-types/attendance'
 
-const CustomLabel = styled(Label)`
-  min-width: 150px;
-  display: inline-block;
+const AbsenceLabels = styled.div`
+  text-align: center;
 `
 
-const AbsencesTitle = styled(Title)`
-  font-size: 18px;
-`
-
-interface ChildListItemProps {
+interface Props {
   child: Child
 }
 
-export default React.memo(function Absences({ child }: ChildListItemProps) {
+export default React.memo(function Absences({ child }: Props) {
   const { i18n } = useTranslation()
 
   if (child.absences.length === 0) return null
 
+  const absenceCareTypes = child.absences
+    .map(({ careType }) => formatCareType(careType, child.placementType, i18n))
+    .join(', ')
   return (
-    <FixedSpaceColumn>
-      <AbsencesTitle size={2}>{i18n.absences.title}</AbsencesTitle>
+    <>
+      <HorizontalLine slim />
 
-      {child.absences.map((absence) => (
-        <div key={absence.id} data-qa="absence">
-          <CustomLabel>
-            {formatCareType(absence.careType, child.placementType, i18n)}
-          </CustomLabel>
-          <span>{i18n.absences.absence}</span>
-        </div>
-      ))}
-    </FixedSpaceColumn>
+      <AbsenceLabels>
+        <Label>{i18n.absences.title}</Label>{' '}
+        <span data-qa="absence">{absenceCareTypes}</span>
+      </AbsenceLabels>
+    </>
   )
 })

--- a/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
@@ -84,7 +84,7 @@ export const fi = {
     title: 'Jotain meni pieleen'
   },
   absences: {
-    title: 'Poissaolomerkinnät',
+    title: 'Poissaolomerkintä',
     absenceTypes: {
       OTHER_ABSENCE: 'Muu poissaolo',
       SICKLEAVE: 'Sairaus',
@@ -104,7 +104,6 @@ export const fi = {
       DAYCARE: 'Varhaiskasvatus',
       CLUB: 'Kerho'
     },
-    absence: 'Poissaolo',
     chooseStartDate: 'Valitse tuleva päivä',
     startBeforeEnd: 'Aloitus oltava ennen päättymispäivää.',
     reason: 'Poissaolon syy',


### PR DESCRIPTION
#### Summary

Absences are now centered with an inline label and a horizontal line above them.

Before
<img width="373" alt="kuva" src="https://user-images.githubusercontent.com/1176169/142429153-d24b938e-70b3-4f65-9ab2-5c586a28caed.png">

After
<img width="374" alt="kuva" src="https://user-images.githubusercontent.com/1176169/142427685-df95fba1-674b-497d-8a6e-197f411ad821.png">

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

