### PR TITLE
Fix placement type in child sensitive info

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/attendances/child-info/ChildSensitiveInfo.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/child-info/ChildSensitiveInfo.tsx
@@ -4,7 +4,6 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ChildSensitiveInformation } from 'lib-common/generated/api-types/sensitive'
-import { PlacementType } from 'lib-common/generated/enums'
 import Title from 'lib-components/atoms/Title'
 import { ContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
@@ -66,10 +65,6 @@ interface Props {
 
 export default React.memo(function ChildSensitiveInfo({ child }: Props) {
   const { i18n } = useTranslation()
-
-  const placementTypesToText = (types: PlacementType[]): string =>
-    types.map((type) => i18n.common.placement[type]).join(', ')
-
   return (
     <FixedSpaceColumn spacing="m">
       <ContentArea shadow opaque paddingHorizontal="s" paddingVertical="xs">
@@ -112,8 +107,10 @@ export default React.memo(function ChildSensitiveInfo({ child }: Props) {
 
             {renderKeyValue(
               i18n.attendances.childInfo.type,
-              placementTypesToText(child.placementTypes) || '-',
-              'child-info-placement-types'
+              child.placementType
+                ? i18n.common.placement[child.placementType]
+                : '-',
+              'child-info-placement-type'
             )}
           </FixedSpaceColumn>
         </CollapsibleSection>

--- a/frontend/src/lib-common/generated/api-types/sensitive.ts
+++ b/frontend/src/lib-common/generated/api-types/sensitive.ts
@@ -24,6 +24,7 @@ export interface ChildSensitiveInformation {
   id: UUID
   lastName: string
   medication: string
+  placementType: PlacementType | null
   placementTypes: PlacementType[]
   preferredName: string
   ssn: string

--- a/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInformation.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInformation.kt
@@ -17,7 +17,8 @@ data class ChildSensitiveInformation(
     val dateOfBirth: LocalDate,
     val ssn: String,
     val childAddress: String,
-    val placementTypes: List<PlacementType>,
+    val placementTypes: List<PlacementType>, // TODO only for backward compatibility, safe to remove in Dec 2021
+    val placementType: PlacementType?,
     val allergies: String,
     val diet: String,
     val medication: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/sensitive/GetChildSensitiveInfoQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sensitive/GetChildSensitiveInfoQueries.kt
@@ -9,14 +9,14 @@ import fi.espoo.evaka.backuppickup.getBackupPickupsForChild
 import fi.espoo.evaka.daycare.getChild
 import fi.espoo.evaka.pis.controllers.fetchFamilyContacts
 import fi.espoo.evaka.pis.getPersonById
-import fi.espoo.evaka.placement.getPlacementsForChild
+import fi.espoo.evaka.placement.getCurrentPlacementForChild
 import fi.espoo.evaka.shared.db.Database
 import java.util.UUID
 
 fun Database.Read.getChildSensitiveInfo(childId: UUID): ChildSensitiveInformation? {
     val person = getPersonById(childId) ?: return null
 
-    val placementTypes = getPlacementsForChild(childId).map { it.type }
+    val placementType = getCurrentPlacementForChild(childId)?.let { it.type }
     val child = getChild(childId)
     val backupPickups = getBackupPickupsForChild(childId)
     val familyContacts = fetchFamilyContacts(childId)
@@ -29,7 +29,8 @@ fun Database.Read.getChildSensitiveInfo(childId: UUID): ChildSensitiveInformatio
         dateOfBirth = person.dateOfBirth,
         ssn = person.identity.toString(),
         childAddress = person.streetAddress,
-        placementTypes = placementTypes,
+        placementTypes = listOfNotNull(placementType),
+        placementType = placementType,
         allergies = child?.additionalInformation?.allergies ?: "",
         diet = child?.additionalInformation?.diet ?: "",
         medication = child?.additionalInformation?.medication ?: "",


### PR DESCRIPTION
#### Summary

Display type of current placement instead of all placements in child sensitive info

- previously the page would list all placements including placements from the past and future
- leave placementTypes temporarily for backward compatibility
- remove $placementSelector variable in PlacementQueries.kt for better autocomplete and IDE experience in general

