### PR TITLE
Remove mobile devices from employee table

### DIFF
--- a/frontend/src/e2e-playwright/specs/6_mobile/absences.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/absences.spec.ts
@@ -6,7 +6,6 @@ import {
   createDaycareGroupPlacementFixture,
   createDaycarePlacementFixture,
   daycareGroupFixture,
-  Fixture,
   uuidv4
 } from 'e2e-test-common/dev-api/fixtures'
 import { newBrowserContext } from '../../browser'
@@ -58,17 +57,12 @@ beforeEach(async () => {
   )
   await insertDaycareGroupPlacementFixtures([groupPlacementFixture])
 
-  const employee = await Fixture.employee().save()
-
   page = await (await newBrowserContext()).newPage()
   listPage = new MobileListPage(page)
   childPage = new MobileChildPage(page)
   absencesPage = new MobileAbsencesPage(page)
 
-  const mobileSignupUrl = await pairMobileDevice(
-    employee.data.id!, // eslint-disable-line
-    fixtures.daycareFixture.id
-  )
+  const mobileSignupUrl = await pairMobileDevice(fixtures.daycareFixture.id)
   await page.goto(mobileSignupUrl)
 })
 afterEach(async () => {

--- a/frontend/src/e2e-playwright/specs/6_mobile/child-attendances.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/child-attendances.spec.ts
@@ -72,10 +72,7 @@ const createPlacementAndReload = async (
   )
   await insertDaycareGroupPlacementFixtures([groupPlacementFixture])
 
-  const mobileSignupUrl = await pairMobileDevice(
-    employee.data.id!, // eslint-disable-line
-    fixtures.daycareFixture.id
-  )
+  const mobileSignupUrl = await pairMobileDevice(fixtures.daycareFixture.id)
   await page.goto(mobileSignupUrl)
 
   return daycarePlacementFixture

--- a/frontend/src/e2e-playwright/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/messages.spec.ts
@@ -114,10 +114,7 @@ beforeEach(async () => {
   messagesPage = new MobileMessagesPage(page)
   threadView = new ThreadViewPage(page)
 
-  const mobileSignupUrl = await pairMobileDevice(
-    employee.data.id!, // eslint-disable-line
-    unit.id
-  )
+  const mobileSignupUrl = await pairMobileDevice(unit.id)
   await page.goto(mobileSignupUrl)
 })
 afterEach(async () => {

--- a/frontend/src/e2e-playwright/specs/6_mobile/notes.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/notes.spec.ts
@@ -86,10 +86,7 @@ beforeEach(async () => {
 
   page = await (await newBrowserContext()).newPage()
 
-  const mobileSignupUrl = await pairMobileDevice(
-    employee.data.id!, // eslint-disable-line
-    unit.id
-  )
+  const mobileSignupUrl = await pairMobileDevice(unit.id)
   await page.goto(mobileSignupUrl)
 
   await new MobileListPage(page).selectChild(child.id)

--- a/frontend/src/e2e-playwright/specs/6_mobile/pin-login.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/pin-login.spec.ts
@@ -107,10 +107,7 @@ beforeEach(async () => {
   pinLoginPage = new PinLoginPage(page)
   topNav = new TopNav(page)
 
-  const mobileSignupUrl = await pairMobileDevice(
-    employee.data.id!, // eslint-disable-line
-    unit.id
-  )
+  const mobileSignupUrl = await pairMobileDevice(unit.id)
   await page.goto(mobileSignupUrl)
 })
 afterEach(async () => {

--- a/frontend/src/e2e-playwright/specs/6_mobile/staff.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/staff.spec.ts
@@ -6,7 +6,6 @@ import {
   createDaycareGroupPlacementFixture,
   createDaycarePlacementFixture,
   daycareGroupFixture,
-  Fixture,
   uuidv4
 } from 'e2e-test-common/dev-api/fixtures'
 import { newBrowserContext } from '../../browser'
@@ -53,16 +52,11 @@ beforeEach(async () => {
   )
   await insertDaycareGroupPlacementFixtures([groupPlacementFixture])
 
-  const employee = await Fixture.employee().save()
-
   page = await (await newBrowserContext()).newPage()
   nav = new MobileNav(page)
   staffPage = new StaffPage(page)
 
-  const mobileSignupUrl = await pairMobileDevice(
-    employee.data.id!, // eslint-disable-line
-    fixtures.daycareFixture.id
-  )
+  const mobileSignupUrl = await pairMobileDevice(fixtures.daycareFixture.id)
   await page.goto(mobileSignupUrl)
   await nav.openPage('staff')
 })

--- a/frontend/src/e2e-playwright/utils/mobile.ts
+++ b/frontend/src/e2e-playwright/utils/mobile.ts
@@ -11,13 +11,10 @@ import { UUID } from 'lib-common/types'
  *
  * @return An URL that completes the pairing in the browser
  */
-export async function pairMobileDevice(
-  employeeId: UUID,
-  unitId: UUID
-): Promise<string> {
+export async function pairMobileDevice(unitId: UUID): Promise<string> {
   const longTermToken = uuidv4()
   await postMobileDevice({
-    id: employeeId,
+    id: uuidv4(),
     unitId,
     name: 'testMobileDevice',
     deleted: false,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemControllerTest.kt
@@ -16,11 +16,9 @@ import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
-import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.DevMobileDevice
 import fi.espoo.evaka.shared.dev.insertTestCareArea
 import fi.espoo.evaka.shared.dev.insertTestDaycare
-import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestMobileDevice
 import fi.espoo.evaka.shared.dev.resetDatabase
 import org.junit.jupiter.api.BeforeEach
@@ -62,7 +60,7 @@ class SystemControllerTest : FullApplicationTest() {
     }
 
     private fun Database.Transaction.insertTestDevice(longTermToken: UUID? = null, deleted: Boolean = false): MobileDeviceId {
-        val id = MobileDeviceId(insertTestEmployee(DevEmployee()))
+        val id = MobileDeviceId(UUID.randomUUID())
         insertTestMobileDevice(
             DevMobileDevice(
                 id = id,

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDeviceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDeviceQueries.kt
@@ -56,13 +56,6 @@ fun Database.Transaction.renameDevice(id: MobileDeviceId, name: String) {
         .bind("id", id)
         .bind("name", name)
         .updateExactlyOne(notFoundMsg = "Device $id not found")
-
-    // language=sql
-    val employeeUpdate = "UPDATE employee SET first_name = :name WHERE id = :id"
-    createUpdate(employeeUpdate)
-        .bind("id", id)
-        .bind("name", name)
-        .execute()
 }
 
 fun Database.Transaction.softDeleteDevice(id: MobileDeviceId) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
@@ -63,15 +63,10 @@ fun Database.Transaction.respondPairingChallengeCreateDevice(id: PairingId, chal
                 JOIN daycare u ON u.id = p.unit_id
                 WHERE p.id = :id AND p.challenge_key = :challenge AND p.response_key = :response 
                     AND p.status = 'WAITING_RESPONSE' AND p.expires > :now AND p.attempts <= :maxAttempts
-            ), new_employee AS (
-                INSERT INTO employee (first_name, last_name, email, external_id)
-                SELECT :name, unit_name, null, null
-                FROM target_pairing
-                RETURNING employee.id
             ), new_device AS (
-                INSERT INTO mobile_device (id, unit_id, name)
-                SELECT new_employee.id, target_pairing.unit_id, :name
-                FROM new_employee, target_pairing
+                INSERT INTO mobile_device (unit_id, name)
+                SELECT target_pairing.unit_id, :name
+                FROM target_pairing
                 RETURNING mobile_device.id
             )
             UPDATE pairing SET status = 'READY', mobile_device_id = new_device.id

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
@@ -75,8 +75,7 @@ private fun Database.Read.searchEmployees(id: EmployeeId? = null) = createQuery(
     """
 SELECT e.id, first_name, last_name, email, external_id, e.created, e.updated, roles
 FROM employee e
-LEFT JOIN mobile_device md on e.id = md.id 
-WHERE (:id::uuid IS NULL OR e.id = :id) AND md.id IS NULL
+WHERE (:id::uuid IS NULL OR e.id = :id)
     """.trimIndent()
 ).bind("id", id)
     .mapTo<Employee>()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -157,9 +157,6 @@ fun Database.Transaction.createMobileDeviceToUnit(id: UUID, unitId: DaycareId, n
     // language=sql
     val sql =
         """
-        INSERT INTO employee (id, first_name, last_name, email, external_id)
-        VALUES (:id, :name, 'Yksikkö', null, null);
-
         INSERT INTO mobile_device (id, unit_id, name) VALUES (:id, :unitId, :name);
 
         INSERT INTO evaka_user (id, type, mobile_device_id, name) VALUES (:id, 'MOBILE_DEVICE', :id, :name);

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -898,7 +898,6 @@ fun Database.Transaction.ensureFakeAdminExists() {
 
 fun Database.Transaction.deleteAndCascadeEmployee(id: UUID) {
     execute("DELETE FROM message_account WHERE employee_id = ?", id)
-    execute("DELETE FROM mobile_device WHERE id = ?", id)
     execute("DELETE FROM employee_pin WHERE user_id = ?", id)
     execute("DELETE FROM employee WHERE id = ?", id)
 }

--- a/service/src/main/resources/db/migration/V178__delete_mobile_devices_from_employee.sql
+++ b/service/src/main/resources/db/migration/V178__delete_mobile_devices_from_employee.sql
@@ -1,0 +1,22 @@
+-- Fix evaka_user data where some mobile_device entries had their references in the employee_id column
+ALTER TABLE evaka_user DROP CONSTRAINT type_id_match;
+
+UPDATE evaka_user SET mobile_device_id = employee_id, employee_id = NULL
+WHERE type = 'MOBILE_DEVICE' AND employee_id IS NOT NULL AND mobile_device_id IS NULL
+AND NOT EXISTS (SELECT 1 FROM evaka_user eu2 WHERE evaka_user.employee_id = eu2.mobile_device_id);
+
+ALTER TABLE evaka_user ADD CONSTRAINT type_id_match CHECK (
+  CASE type
+    WHEN 'SYSTEM' THEN id = '00000000-0000-0000-0000-000000000000' AND num_nonnulls(citizen_id, employee_id, mobile_device_id) = 0
+    WHEN 'CITIZEN' THEN (id = citizen_id OR citizen_id IS NULL) AND employee_id IS NULL AND mobile_device_id IS NULL
+    WHEN 'EMPLOYEE' THEN (id = employee_id OR employee_id IS NULL) AND citizen_id IS NULL AND mobile_device_id IS NULL
+    WHEN 'MOBILE_DEVICE' THEN (id = mobile_device_id OR mobile_device_id IS NULL) AND citizen_id IS NULL AND employee_id IS NULL
+    WHEN 'UNKNOWN' THEN num_nonnulls(citizen_id, employee_id, mobile_device_id) = 0
+  END
+);
+
+
+-- Remove mobile devices from employee table
+ALTER TABLE mobile_device DROP CONSTRAINT mobile_device_id_fkey;
+ALTER TABLE mobile_device ALTER COLUMN id SET DEFAULT ext.uuid_generate_v1mc();
+DELETE FROM employee WHERE id IN (SELECT id FROM mobile_device);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -175,3 +175,4 @@ V174__non_nullable_person_data.sql
 V175__person_preferred_name.sql
 V176__evaka_user_income_updated_by.sql
 V177__income_statement_awaiting_handler_index.sql
+V178__delete_mobile_devices_from_employee.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Remove `mobile_device` table's link to the `employee` table, delete mobile devices from `employee` table and make `evaka_user` table's `type_id_match` constraint more constraining.
