### PR TITLE
Ensure we wait until session is saved in /auth/status and after all req.logIn calls

### DIFF
--- a/apigw/src/internal/mobile-device-session.ts
+++ b/apigw/src/internal/mobile-device-session.ts
@@ -18,6 +18,7 @@ import {
   MobileDeviceIdentity,
   validatePairing
 } from '../shared/service-client'
+import { saveSession } from '../shared/session'
 
 export const mobileLongTermCookieName = 'evaka.employee.mobile'
 const mobileLongTermCookieOptions: CookieOptions = {
@@ -48,6 +49,7 @@ async function mobileLogin(
       cb
     )
   )
+  await saveSession(req)
   // Unconditionally refresh long-term cookie on each login to refresh expiry
   // time and make it a "rolling" cookie
   res.cookie(mobileLongTermCookieName, device.longTermToken, {

--- a/apigw/src/internal/routes/auth-status.ts
+++ b/apigw/src/internal/routes/auth-status.ts
@@ -8,7 +8,7 @@ import {
   getEmployeeDetails,
   getMobileDevice
 } from '../../shared/service-client'
-import { logoutExpress } from '../../shared/session'
+import { logoutExpress, saveSession } from '../../shared/session'
 import { fromCallback } from '../../shared/promise-utils'
 import { appCommit } from '../../shared/config'
 
@@ -26,6 +26,7 @@ export default toRequestHandler(async (req, res) => {
         const allScopedRoles = user.allScopedRoles ?? ['MOBILE']
         const employeeId = user.mobileEmployeeId
         const { id, name, unitId } = device
+        await saveSession(req)
         res.status(200).json({
           loggedIn: true,
           user: { id, name, unitId, employeeId },
@@ -56,6 +57,7 @@ export default toRequestHandler(async (req, res) => {
         )
       }
 
+      await saveSession(req)
       res.status(200).json({
         loggedIn: true,
         user: { id, name, accessibleFeatures: accessibleFeatures ?? {} },

--- a/apigw/src/shared/routes/auth/saml/index.ts
+++ b/apigw/src/shared/routes/auth/saml/index.ts
@@ -13,7 +13,7 @@ import { getEmployees } from '../../../dev-api'
 import { toMiddleware, toRequestHandler } from '../../../express'
 import { logAuditEvent, logDebug, logError } from '../../../logging'
 import { fromCallback } from '../../../promise-utils'
-import { logoutExpress, saveLogoutToken } from '../../../session'
+import { logoutExpress, saveLogoutToken, saveSession } from '../../../session'
 import { parseDescriptionFromSamlError } from './error-utils'
 import { SamlEndpointConfig, SamlUser } from './types'
 
@@ -92,6 +92,7 @@ function createLoginHandler({
             await fromCallback<void>((cb) => session.regenerate(cb))
           }
           await fromCallback<void>((cb) => req.logIn(user, cb))
+          await saveSession(req)
           logAuditEvent(
             `evaka.saml.${strategyName}.sign_in`,
             req,

--- a/apigw/src/shared/session.ts
+++ b/apigw/src/shared/session.ts
@@ -152,6 +152,13 @@ export async function logoutExpress(
   res.clearCookie(sessionCookie(sessionType))
 }
 
+export async function saveSession(req: express.Request) {
+  if (req.session) {
+    const session = req.session
+    await fromCallback((cb) => session.save(cb))
+  }
+}
+
 export default (sessionType: SessionType, redisClient?: RedisClient) => {
   asyncRedisClient = redisClient && new AsyncRedisClient(redisClient)
   return session({


### PR DESCRIPTION
express-session saves the session to the backing store (= Redis) lazily and asynchronously after the HTTP response has been sent. This introduces a possible race condition if we save something important
to the session, and assume the next request will see it immediately. This assumption is not true, because the backing store has latency, or might even return an error which is probably just logged and ignored since the HTTP response has already been sent.

In practice, CSRF tokens sometimes hit this race condition...the /auth/status endpoint saves the CSRF secret to the session, and returns HTTP 200 response which includes a CSRF cookie. If a new request comes in quickly enough, it will contain the CSRF cookie but the server will not see the CSRF secret in the session, leading to a "invalid CSRF token" error.

Fix the problem by ensuring the session is fully saved *before* we even return a response. In logged out cases this is not needed. One slight downside of this approach is that we always do a save, even if the session contents have not changed. This can be improved later if necessary by adding some equality checks.