### PR TITLE
Use plain values instead of objects in `FormModal` props

### DIFF
--- a/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
@@ -56,24 +56,20 @@ export default React.memo(function AbsenceModal({
     <AsyncFormModal
       mobileFullScreen
       title={i18n.calendar.absenceModal.title}
-      resolve={{
-        action: (cancel) => {
-          if (!request) {
-            setShowAllErrors(true)
-            return cancel()
-          }
-          return postAbsences(request)
-        },
-        onSuccess: () => {
-          close()
-          reload()
-        },
-        label: i18n.common.confirm
+      resolveAction={(cancel) => {
+        if (!request) {
+          setShowAllErrors(true)
+          return cancel()
+        }
+        return postAbsences(request)
       }}
-      reject={{
-        action: close,
-        label: i18n.common.cancel
+      onSuccess={() => {
+        close()
+        reload()
       }}
+      resolveLabel={i18n.common.confirm}
+      rejectAction={close}
+      rejectLabel={i18n.common.cancel}
     >
       <Label>{i18n.calendar.absenceModal.selectedChildren}</Label>
       <Gap size="xs" />

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -155,26 +155,22 @@ export default React.memo(function ReservationModal({
     <AsyncFormModal
       mobileFullScreen
       title={i18n.calendar.reservationModal.title}
-      resolve={{
-        action: (cancel) => {
-          if (validationResult.errors) {
-            setShowAllErrors(true)
-            return cancel()
-          } else {
-            return postReservations(validationResult.requestPayload)
-          }
-        },
-        onSuccess: () => {
-          onReload()
-          onClose()
-        },
-        label: i18n.common.confirm,
-        disabled: formData.selectedChildren.length === 0
+      resolveAction={(cancel) => {
+        if (validationResult.errors) {
+          setShowAllErrors(true)
+          return cancel()
+        } else {
+          return postReservations(validationResult.requestPayload)
+        }
       }}
-      reject={{
-        action: onClose,
-        label: i18n.common.cancel
+      onSuccess={() => {
+        onReload()
+        onClose()
       }}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={formData.selectedChildren.length === 0}
+      rejectAction={onClose}
+      rejectLabel={i18n.common.cancel}
     >
       <H2>{i18n.calendar.reservationModal.selectChildren}</H2>
       <Label>{i18n.calendar.reservationModal.selectChildrenLabel}</Label>

--- a/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
+++ b/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
@@ -282,19 +282,17 @@ export default React.memo(function DecisionResponse({
           text={
             t.decisions.applicationDecisions.warnings.doubleRejectWarning.text
           }
-          resolve={{
-            label:
-              t.decisions.applicationDecisions.warnings.doubleRejectWarning
-                .resolveLabel,
-            action: onSubmit,
-            onSuccess: () => setDisplayCascadeWarning(false)
-          }}
-          reject={{
-            label:
-              t.decisions.applicationDecisions.warnings.doubleRejectWarning
-                .rejectLabel,
-            action: () => setDisplayCascadeWarning(false)
-          }}
+          resolveLabel={
+            t.decisions.applicationDecisions.warnings.doubleRejectWarning
+              .resolveLabel
+          }
+          resolveAction={onSubmit}
+          onSuccess={() => setDisplayCascadeWarning(false)}
+          rejectLabel={
+            t.decisions.applicationDecisions.warnings.doubleRejectWarning
+              .rejectLabel
+          }
+          rejectAction={() => setDisplayCascadeWarning(false)}
           data-qa={'cascade-warning-modal'}
         />
       )}

--- a/frontend/src/employee-frontend/components/absences/AbsenceModal.tsx
+++ b/frontend/src/employee-frontend/components/absences/AbsenceModal.tsx
@@ -38,15 +38,11 @@ export default React.memo(function AbsenceModal({
     <FormModal
       title=""
       className="absence-modal"
-      resolve={{
-        action: onSave,
-        label: i18n.absences.modal.saveButton,
-        disabled: saveDisabled
-      }}
-      reject={{
-        action: onCancel,
-        label: i18n.absences.modal.cancelButton
-      }}
+      resolveAction={onSave}
+      resolveLabel={i18n.absences.modal.saveButton}
+      resolveDisabled={saveDisabled}
+      rejectAction={onCancel}
+      rejectLabel={i18n.absences.modal.cancelButton}
     >
       <FixedSpaceColumn spacing={'L'}>
         <Label>

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -537,19 +537,16 @@ const ApplicationsList = React.memo(function Applications({
       {editedNote && (
         <AsyncFormModal
           title={i18n.applications.list.serviceWorkerNote}
-          resolve={{
-            action: async () =>
-              updateServiceWorkerNote(editedNote, editedNoteText),
-            label: i18n.common.save,
-            onSuccess: () => {
-              setEditedNote(null)
-              reloadApplications()
-            }
+          resolveAction={async () =>
+            updateServiceWorkerNote(editedNote, editedNoteText)
+          }
+          resolveLabel={i18n.common.save}
+          onSuccess={() => {
+            setEditedNote(null)
+            reloadApplications()
           }}
-          reject={{
-            action: () => setEditedNote(null),
-            label: i18n.common.cancel
-          }}
+          rejectAction={() => setEditedNote(null)}
+          rejectLabel={i18n.common.cancel}
         >
           <AlignRight>
             <InlineButton

--- a/frontend/src/employee-frontend/components/child-information/BackupPickup.tsx
+++ b/frontend/src/employee-frontend/components/child-information/BackupPickup.tsx
@@ -84,11 +84,14 @@ function BackupPickup({ id }: BackupPickupProps) {
         clearUiMode()
       }
     }
+
     return (
       <FormModal
         title={i18n.childInformation.backupPickups.add}
-        reject={{ action: () => clearUiMode(), label: i18n.common.cancel }}
-        resolve={{ action: () => saveBackupPickup(), label: i18n.common.save }}
+        resolveAction={saveBackupPickup}
+        resolveLabel={i18n.common.save}
+        rejectAction={clearUiMode}
+        rejectLabel={i18n.common.cancel}
       >
         <FixedSpaceColumn>
           <FixedSpaceColumn spacing={'xxs'}>
@@ -131,11 +134,14 @@ function BackupPickup({ id }: BackupPickupProps) {
         clearUiMode()
       }
     }
+
     return (
       <FormModal
         title={i18n.childInformation.backupPickups.edit}
-        reject={{ action: () => clearUiMode(), label: i18n.common.cancel }}
-        resolve={{ action: () => saveBackupPickup(), label: i18n.common.save }}
+        resolveAction={clearUiMode}
+        resolveLabel={i18n.common.cancel}
+        rejectAction={saveBackupPickup}
+        rejectLabel={i18n.common.save}
       >
         <FixedSpaceColumn>
           <FixedSpaceColumn spacing={'xxs'}>

--- a/frontend/src/employee-frontend/components/child-information/CreateApplicationModal.tsx
+++ b/frontend/src/employee-frontend/components/child-information/CreateApplicationModal.tsx
@@ -161,15 +161,11 @@ function CreateApplicationModal({
       title={i18nView.modalTitle}
       icon={faFileAlt}
       iconColour={'blue'}
-      resolve={{
-        action: submit,
-        label: i18nView.createButton,
-        disabled: !canSubmit()
-      }}
-      reject={{
-        action: clearUiMode,
-        label: i18n.common.cancel
-      }}
+      resolveAction={submit}
+      resolveLabel={i18nView.createButton}
+      resolveDisabled={!canSubmit()}
+      rejectAction={clearUiMode}
+      rejectLabel={i18n.common.cancel}
     >
       <FixedSpaceColumn spacing="L">
         <div>

--- a/frontend/src/employee-frontend/components/child-information/VasuAndLeops.tsx
+++ b/frontend/src/employee-frontend/components/child-information/VasuAndLeops.tsx
@@ -66,12 +66,11 @@ function TemplateSelectionModal({
   return (
     <FormModal
       title={i18n.childInformation.vasu.init.chooseTemplate}
-      resolve={{
-        action: () => onSelect(templateId),
-        disabled: !templateId || loading,
-        label: i18n.common.select
-      }}
-      reject={{ action: onClose, label: i18n.common.cancel }}
+      resolveAction={() => onSelect(templateId)}
+      resolveDisabled={!templateId || loading}
+      resolveLabel={i18n.common.select}
+      rejectAction={onClose}
+      rejectLabel={i18n.common.cancel}
     >
       {templates.map((t) => (
         <Radio

--- a/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
@@ -118,15 +118,11 @@ function CreatePlacementModal({ childId, reload }: Props) {
       text={i18n.childInformation.placements.createPlacement.text}
       icon={faMapMarkerAlt}
       iconColour={'blue'}
-      resolve={{
-        action: submitForm,
-        label: i18n.common.confirm,
-        disabled: errors.length > 0 || submitting
-      }}
-      reject={{
-        action: clearUiMode,
-        label: i18n.common.cancel
-      }}
+      resolveAction={submitForm}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={errors.length > 0 || submitting}
+      rejectAction={clearUiMode}
+      rejectLabel={i18n.common.cancel}
     >
       <FixedSpaceColumn>
         <section>

--- a/frontend/src/employee-frontend/components/group-caretakers/GroupCaretakersModal.tsx
+++ b/frontend/src/employee-frontend/components/group-caretakers/GroupCaretakersModal.tsx
@@ -118,15 +118,11 @@ function GroupCaretakersModal({
       title={existing ? i18n.groupCaretakers.edit : i18n.groupCaretakers.create}
       icon={existing ? faPen : faPlus}
       iconColour={'blue'}
-      resolve={{
-        action: submit,
-        label: i18n.common.confirm,
-        disabled: hasErrors || submitting
-      }}
-      reject={{
-        action: onReject,
-        label: i18n.common.cancel
-      }}
+      resolveAction={submit}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={hasErrors || submitting}
+      rejectAction={onReject}
+      rejectLabel={i18n.common.cancel}
     >
       <section>
         <div className="bold">{i18n.common.form.startDate}</div>

--- a/frontend/src/employee-frontend/components/invoices/InvoicesPage.tsx
+++ b/frontend/src/employee-frontend/components/invoices/InvoicesPage.tsx
@@ -107,15 +107,11 @@ const Modal = React.memo(function Modal({
       iconColour={'blue'}
       title={i18n.invoices.sendModal.title}
       icon={faEnvelope}
-      resolve={{
-        action: () => sendInvoices({ invoiceDate, dueDate }),
-        label: i18n.common.confirm,
-        onSuccess: onSendDone
-      }}
-      reject={{
-        action: actions.closeModal,
-        label: i18n.common.cancel
-      }}
+      resolveAction={() => sendInvoices({ invoiceDate, dueDate })}
+      resolveLabel={i18n.common.confirm}
+      onSuccess={onSendDone}
+      rejectAction={actions.closeModal}
+      rejectLabel={i18n.common.cancel}
       data-qa="send-invoices-dialog"
     >
       <ModalContent>

--- a/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
@@ -177,15 +177,11 @@ const Modal = React.memo(function Modal({
       icon={faPlus}
       iconColour={'blue'}
       title={i18n.personProfile.feeDecisions.modalTitle}
-      resolve={{
-        action: resolve,
-        label: i18n.common.create,
-        disabled: date === undefined
-      }}
-      reject={{
-        action: clear,
-        label: i18n.common.cancel
-      }}
+      resolveAction={resolve}
+      resolveLabel={i18n.common.create}
+      resolveDisabled={date === undefined}
+      rejectAction={clear}
+      rejectLabel={i18n.common.cancel}
     >
       <ModalContent>
         <InputContainer>

--- a/frontend/src/employee-frontend/components/person-profile/person-fridge-child/FridgeChildModal.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/person-fridge-child/FridgeChildModal.tsx
@@ -127,15 +127,11 @@ function FridgeChildModal({ headPersonId, onSuccess, parentship }: Props) {
           }
           icon={faChild}
           iconColour={'blue'}
-          resolve={{
-            action: childFormActions,
-            label: i18n.common.confirm,
-            disabled: !form.child || validationErrors.length > 0
-          }}
-          reject={{
-            action: clearUiMode,
-            label: i18n.common.cancel
-          }}
+          resolveAction={childFormActions}
+          resolveLabel={i18n.common.confirm}
+          resolveDisabled={!form.child || validationErrors.length > 0}
+          rejectAction={clearUiMode}
+          rejectLabel={i18n.common.cancel}
         >
           {errorStatusCode === 409 && (
             <section className="error">

--- a/frontend/src/employee-frontend/components/person-profile/person-fridge-partner/FridgePartnerModal.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/person-fridge-partner/FridgePartnerModal.tsx
@@ -140,15 +140,11 @@ function FridgePartnerModal({ partnership, onSuccess, headPersonId }: Props) {
       }
       icon={partnership ? faPen : faUser}
       iconColour={'blue'}
-      resolve={{
-        action: onSubmit,
-        label: i18n.common.confirm,
-        disabled: !form.partner || validationErrors.length > 0
-      }}
-      reject={{
-        action: clearUiMode,
-        label: i18n.common.cancel
-      }}
+      resolveAction={onSubmit}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={!form.partner || validationErrors.length > 0}
+      rejectAction={clearUiMode}
+      rejectLabel={i18n.common.cancel}
     >
       {errorStatusCode === 409 && (
         <section className="error">

--- a/frontend/src/employee-frontend/components/person-search/AddVTJPersonModal.tsx
+++ b/frontend/src/employee-frontend/components/person-search/AddVTJPersonModal.tsx
@@ -61,15 +61,11 @@ export default React.memo(function VTJModal({
       iconColour={'blue'}
       icon={faPlus}
       title={i18n.personSearch.addPersonFromVTJ.title}
-      resolve={{
-        action: onConfirm,
-        label: i18n.personSearch.addPersonFromVTJ.modalConfirmLabel,
-        disabled: !(person && person.isSuccess) || requestInFlight
-      }}
-      reject={{
-        action: closeModal,
-        label: i18n.common.cancel
-      }}
+      resolveAction={onConfirm}
+      resolveLabel={i18n.personSearch.addPersonFromVTJ.modalConfirmLabel}
+      resolveDisabled={!(person && person.isSuccess) || requestInFlight}
+      rejectAction={closeModal}
+      rejectLabel={i18n.common.cancel}
     >
       <ModalContent>
         <Label>

--- a/frontend/src/employee-frontend/components/person-search/CreatePersonModal.tsx
+++ b/frontend/src/employee-frontend/components/person-search/CreatePersonModal.tsx
@@ -72,15 +72,11 @@ export default React.memo(function CreatePersonModal({
       iconColour={'blue'}
       icon={faPlus}
       title={i18n.personSearch.createNewPerson.title}
-      resolve={{
-        action: onConfirm,
-        label: i18n.personSearch.createNewPerson.modalConfirmLabel,
-        disabled: requestInFlight || !validateForm(form)
-      }}
-      reject={{
-        action: closeModal,
-        label: i18n.common.cancel
-      }}
+      resolveAction={onConfirm}
+      resolveLabel={i18n.personSearch.createNewPerson.modalConfirmLabel}
+      resolveDisabled={requestInFlight || !validateForm(form)}
+      rejectAction={closeModal}
+      rejectLabel={i18n.common.cancel}
     >
       <ModalContent>
         <ListGrid labelWidth="min-content">

--- a/frontend/src/employee-frontend/components/person-shared/person-details/AddSsnModal.tsx
+++ b/frontend/src/employee-frontend/components/person-shared/person-details/AddSsnModal.tsx
@@ -63,15 +63,11 @@ function AddSsnModal({ personId, onUpdateComplete }: Props) {
   return (
     <FormModal
       title={i18n.personProfile.addSsn}
-      resolve={{
-        action: submit,
-        label: i18n.common.confirm,
-        disabled: submitting || !isSsnValid(ssn.toUpperCase())
-      }}
-      reject={{
-        action: clearUiMode,
-        label: i18n.common.cancel
-      }}
+      resolveAction={submit}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={submitting || !isSsnValid(ssn.toUpperCase())}
+      rejectAction={clearUiMode}
+      rejectLabel={i18n.common.cancel}
     >
       <InputField
         value={ssn}

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
@@ -82,14 +82,10 @@ export default React.memo(function GroupModal({ unitId, reload }: Props) {
   return (
     <FormModal
       title={i18n.unit.groups.createModal.title}
-      resolve={{
-        action: submit,
-        label: i18n.unit.groups.createModal.confirmButton
-      }}
-      reject={{
-        action: clearUiMode,
-        label: i18n.unit.groups.createModal.cancelButton
-      }}
+      resolveAction={submit}
+      resolveLabel={i18n.unit.groups.createModal.confirmButton}
+      rejectAction={clearUiMode}
+      rejectLabel={i18n.unit.groups.createModal.cancelButton}
     >
       <FixedSpaceColumn spacing={'m'}>
         <div>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupTransferModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupTransferModal.tsx
@@ -115,15 +115,11 @@ export default React.memo(function GroupTransferModal({
       title={i18n.unit.placements.modal.transferTitle}
       icon={faExchange}
       iconColour={'blue'}
-      resolve={{
-        action: submitForm,
-        label: i18n.common.confirm,
-        disabled: form.errors.length > 0
-      }}
-      reject={{
-        action: clearUiMode,
-        label: i18n.common.cancel
-      }}
+      resolveAction={submitForm}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={form.errors.length > 0}
+      rejectAction={clearUiMode}
+      rejectLabel={i18n.common.cancel}
     >
       <FixedSpaceColumn>
         <section>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupUpdateModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupUpdateModal.tsx
@@ -50,17 +50,13 @@ export default React.memo(function GroupUpdateModal({ group, reload }: Props) {
       title={i18n.unit.groups.updateModal.title}
       icon={faPen}
       iconColour={'blue'}
-      resolve={{
-        action: submitForm,
-        label: i18n.common.confirm,
-        disabled:
-          data.name.trim().length === 0 ||
-          data.endDate?.isBefore(data.startDate)
-      }}
-      reject={{
-        action: clearUiMode,
-        label: i18n.common.cancel
-      }}
+      resolveAction={submitForm}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={
+        data.name.trim().length === 0 || data.endDate?.isBefore(data.startDate)
+      }
+      rejectAction={clearUiMode}
+      rejectLabel={i18n.common.cancel}
     >
       <FixedSpaceColumn>
         <section>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/missing-group-placements/BackupCareGroupModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/missing-group-placements/BackupCareGroupModal.tsx
@@ -72,15 +72,11 @@ export default React.memo(function BackupCareGroupModal({
       }
       icon={isTransfer ? faExchange : faChild}
       iconColour={'blue'}
-      resolve={{
-        action: submitForm,
-        label: i18n.common.confirm,
-        disabled: !group
-      }}
-      reject={{
-        action: clearUiMode,
-        label: i18n.common.cancel
-      }}
+      resolveAction={submitForm}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={!group}
+      rejectAction={clearUiMode}
+      rejectLabel={i18n.common.cancel}
     >
       <section>
         <div className="bold">{i18n.unit.placements.modal.child}</div>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/missing-group-placements/GroupPlacementModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/missing-group-placements/GroupPlacementModal.tsx
@@ -170,15 +170,11 @@ export default React.memo(function GroupPlacementModal({
       title={i18n.unit.placements.modal.createTitle}
       icon={faChild}
       iconColour={'blue'}
-      resolve={{
-        action: submitForm,
-        label: i18n.common.confirm,
-        disabled: form.errors.length > 0
-      }}
-      reject={{
-        action: clearUiMode,
-        label: i18n.common.cancel
-      }}
+      resolveAction={submitForm}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={form.errors.length > 0}
+      rejectAction={clearUiMode}
+      rejectLabel={i18n.common.cancel}
     >
       <FixedSpaceColumn>
         <section>

--- a/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposalRow.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposalRow.tsx
@@ -76,21 +76,17 @@ export default React.memo(function PlacementProposalRow({
       {modalOpen && (
         <FormModal
           title={i18n.unit.placementProposals.rejectTitle}
-          resolve={{
-            action: () => {
-              if (reason != null) {
-                onChange('REJECTED_NOT_CONFIRMED', reason, otherReason)
-                setModalOpen(false)
-                void loadUnitData()
-              }
-            },
-            label: i18n.common.save,
-            disabled: !reason || (reason === 'OTHER' && !otherReason)
+          resolveAction={() => {
+            if (reason != null) {
+              onChange('REJECTED_NOT_CONFIRMED', reason, otherReason)
+              setModalOpen(false)
+              void loadUnitData()
+            }
           }}
-          reject={{
-            action: () => setModalOpen(false),
-            label: i18n.common.cancel
-          }}
+          resolveLabel={i18n.common.save}
+          resolveDisabled={!reason || (reason === 'OTHER' && !otherReason)}
+          rejectAction={() => setModalOpen(false)}
+          rejectLabel={i18n.common.cancel}
         >
           <FixedSpaceColumn>
             {placementPlanRejectReasons.map((option) => {

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
@@ -135,25 +135,21 @@ export default React.memo(function ReservationModalSingleChild({
     <AsyncFormModal
       mobileFullScreen
       title={i18n.unit.attendanceReservations.reservationModal.title}
-      resolve={{
-        action: (cancel) => {
-          if (validationResult.errors) {
-            setShowAllErrors(true)
-            return cancel()
-          } else {
-            return postReservations(validationResult.requestPayload)
-          }
-        },
-        onSuccess: () => {
-          onReload()
-          onClose()
-        },
-        label: i18n.common.confirm
+      resolveAction={(cancel) => {
+        if (validationResult.errors) {
+          setShowAllErrors(true)
+          return cancel()
+        } else {
+          return postReservations(validationResult.requestPayload)
+        }
       }}
-      reject={{
-        action: onClose,
-        label: i18n.common.cancel
+      onSuccess={() => {
+        onReload()
+        onClose()
       }}
+      resolveLabel={i18n.common.confirm}
+      rejectAction={onClose}
+      rejectLabel={i18n.common.cancel}
     >
       <H2>
         {i18n.unit.attendanceReservations.reservationModal.selectedChildren}

--- a/frontend/src/employee-frontend/components/vasu/templates/CopyTemplateModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/CopyTemplateModal.tsx
@@ -34,30 +34,27 @@ export default React.memo(function CopyTemplateModal({
   return (
     <FormModal
       title={t.templateModal.copyTitle}
-      resolve={{
-        action: () => {
-          setSubmitting(true)
-          void copyVasuTemplate(
-            template.id,
-            name,
-            new FiniteDateRange(startDate, endDate)
-          ).then((res) => {
-            setSubmitting(false)
-            if (res.isSuccess) {
-              onSuccess(res.value)
-            }
-          })
-        },
-        label: i18n.common.confirm,
-        disabled:
-          submitting ||
-          endDate.isEqualOrBefore(startDate) ||
-          name.trim().length === 0
+      resolveAction={() => {
+        setSubmitting(true)
+        void copyVasuTemplate(
+          template.id,
+          name,
+          new FiniteDateRange(startDate, endDate)
+        ).then((res) => {
+          setSubmitting(false)
+          if (res.isSuccess) {
+            onSuccess(res.value)
+          }
+        })
       }}
-      reject={{
-        action: onCancel,
-        label: i18n.common.cancel
-      }}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={
+        submitting ||
+        endDate.isEqualOrBefore(startDate) ||
+        name.trim().length === 0
+      }
+      rejectAction={onCancel}
+      rejectLabel={i18n.common.cancel}
     >
       <FixedSpaceColumn>
         <FixedSpaceColumn spacing="xxs">

--- a/frontend/src/employee-frontend/components/vasu/templates/CreateOrEditTemplateModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/CreateOrEditTemplateModal.tsx
@@ -63,38 +63,35 @@ export default React.memo(function CreateOrEditTemplateModal({
       title={
         templateToEdit ? t.templateModal.editTitle : t.templateModal.createTitle
       }
-      resolve={{
-        action: () => {
-          setSubmitting(true)
-          void apiCall({
-            name,
-            valid: new FiniteDateRange(startDate, endDate),
-            language
-          }).then((res) => {
-            setSubmitting(false)
-            if (res.isSuccess) {
-              onSuccess(res.value)
-            } else if (res.isFailure) {
-              setErrorMessage({
-                resolveLabel: i18n.common.ok,
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                text: (res?.errorCode && t.errorCodes[res.errorCode]) || '',
-                title: i18n.common.error.saveFailed,
-                type: 'error'
-              })
-            }
-          })
-        },
-        label: i18n.common.confirm,
-        disabled:
-          submitting ||
-          endDate.isEqualOrBefore(startDate) ||
-          name.trim().length === 0
+      resolveAction={() => {
+        setSubmitting(true)
+        void apiCall({
+          name,
+          valid: new FiniteDateRange(startDate, endDate),
+          language
+        }).then((res) => {
+          setSubmitting(false)
+          if (res.isSuccess) {
+            onSuccess(res.value)
+          } else if (res.isFailure) {
+            setErrorMessage({
+              resolveLabel: i18n.common.ok,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              text: (res?.errorCode && t.errorCodes[res.errorCode]) || '',
+              title: i18n.common.error.saveFailed,
+              type: 'error'
+            })
+          }
+        })
       }}
-      reject={{
-        action: onCancel,
-        label: i18n.common.cancel
-      }}
+      resolveLabel={i18n.common.confirm}
+      resolveDisabled={
+        submitting ||
+        endDate.isEqualOrBefore(startDate) ||
+        name.trim().length === 0
+      }
+      rejectAction={onCancel}
+      rejectLabel={i18n.common.cancel}
     >
       <FixedSpaceColumn>
         <FixedSpaceColumn spacing="xxs">

--- a/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
@@ -100,14 +100,10 @@ export default React.memo(function CreateQuestionModal({
   return (
     <FormModal
       title={t.title}
-      resolve={{
-        action: () => onSave(createQuestion()),
-        label: i18n.common.confirm
-      }}
-      reject={{
-        action: onCancel,
-        label: i18n.common.cancel
-      }}
+      resolveAction={() => onSave(createQuestion())}
+      resolveLabel={i18n.common.confirm}
+      rejectAction={onCancel}
+      rejectLabel={i18n.common.cancel}
     >
       <FixedSpaceColumn>
         <FixedSpaceColumn spacing="xxs">

--- a/frontend/src/lib-components/molecules/modals/FormModal.tsx
+++ b/frontend/src/lib-components/molecules/modals/FormModal.tsx
@@ -2,54 +2,54 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { FormEvent, useCallback } from 'react'
 import Button from '../../atoms/buttons/Button'
 import AsyncButton from '../../atoms/buttons/AsyncButton'
 import { Gap } from '../../white-space'
 import BaseModal, { ModalBaseProps, ModalButtons } from './BaseModal'
 
 type FormModalProps = ModalBaseProps & {
-  resolve: {
-    action: () => void
-    label: string
-    disabled?: boolean
-  }
-  reject: {
-    action: () => void
-    label: string
-  }
+  resolveAction: () => void
+  resolveLabel: string
+  resolveDisabled?: boolean
+  rejectAction: () => void
+  rejectLabel: string
 }
 
 export default React.memo(function FormModal({
   children,
-  resolve,
-  reject,
+  resolveAction,
+  resolveLabel,
+  resolveDisabled,
+  rejectAction,
+  rejectLabel,
   ...props
 }: FormModalProps) {
+  const onSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      if (!resolveDisabled) resolveAction()
+    },
+    [resolveAction, resolveDisabled]
+  )
+
   return (
-    <BaseModal {...props} close={reject?.action}>
-      <form
-        onSubmit={(event) => {
-          event.preventDefault()
-          if (!resolve.disabled) resolve.action()
-        }}
-      >
-        {children}
-      </form>
+    <BaseModal {...props} close={rejectAction}>
+      <form onSubmit={onSubmit}>{children}</form>
       <ModalButtons $singleButton={!('reject' in props)}>
         <Button
-          onClick={reject.action}
+          onClick={rejectAction}
           data-qa="modal-cancelBtn"
-          text={reject.label}
+          text={rejectLabel}
         />
         <Gap horizontal size={'xs'} />
         <Button
           primary
           type="submit"
           data-qa="modal-okBtn"
-          onClick={resolve.action}
-          disabled={resolve.disabled}
-          text={resolve.label}
+          onClick={resolveAction}
+          disabled={resolveDisabled}
+          text={resolveLabel}
         />
       </ModalButtons>
     </BaseModal>
@@ -57,41 +57,42 @@ export default React.memo(function FormModal({
 })
 
 type AsyncModalProps = ModalBaseProps & {
-  resolve: {
-    //eslint-disable-next-line @typescript-eslint/no-explicit-any
-    action: (cancel: () => Promise<void>) => Promise<any>
-    label: string
-    disabled?: boolean
-    onSuccess: () => void
-  }
-  reject: {
-    action: () => void
-    label: string
-  }
+  resolveAction: (
+    cancel: () => Promise<void>
+  ) => Promise<void | { isFailure: boolean }>
+  resolveLabel: string
+  resolveDisabled?: boolean
+  onSuccess: () => void
+  rejectAction: () => void
+  rejectLabel: string
 }
 
 export const AsyncFormModal = React.memo(function AsyncFormModal({
   children,
-  resolve,
-  reject,
+  resolveAction,
+  resolveLabel,
+  resolveDisabled,
+  onSuccess,
+  rejectAction,
+  rejectLabel,
   ...props
 }: AsyncModalProps) {
   return (
-    <BaseModal {...props} close={reject.action}>
+    <BaseModal {...props} close={rejectAction}>
       {children}
       <ModalButtons $singleButton={!('reject' in props)}>
         <Button
-          onClick={reject.action}
+          onClick={rejectAction}
           data-qa="modal-cancelBtn"
-          text={reject.label}
+          text={rejectLabel}
         />
         <Gap horizontal size={'xs'} />
         <AsyncButton
           primary
-          text={resolve.label}
-          disabled={resolve.disabled}
-          onClick={resolve.action}
-          onSuccess={resolve.onSuccess}
+          text={resolveLabel}
+          disabled={resolveDisabled}
+          onClick={resolveAction}
+          onSuccess={onSuccess}
           data-qa="modal-okBtn"
         />
       </ModalButtons>


### PR DESCRIPTION
#### Summary

This enables more effective `React.memo()`, because passing props as objects virtually always create a new value identity.
