### PR TITLE
Send messages to guardians only

### DIFF
--- a/frontend/src/e2e-playwright/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/messages.spec.ts
@@ -11,7 +11,7 @@ import config from 'e2e-test-common/config'
 import {
   insertDaycareGroupPlacementFixtures,
   insertDaycarePlacementFixtures,
-  insertParentshipFixtures,
+  insertGuardianFixtures,
   resetDatabase,
   setAclForDaycares,
   upsertMessageAccounts
@@ -29,12 +29,12 @@ import {
 } from 'e2e-test-common/dev-api/fixtures'
 import { DaycarePlacement, PersonDetail } from 'e2e-test-common/dev-api/types'
 import { Page } from 'playwright'
-import MobileMessageEditorPage from '../../pages/mobile/message-editor'
 import CitizenMessagesPage from '../../pages/citizen/citizen-messages'
-import { enduserLogin } from '../../utils/user'
+import MobileMessageEditorPage from '../../pages/mobile/message-editor'
 import MobileMessagesPage from '../../pages/mobile/messages'
 import ThreadViewPage from '../../pages/mobile/thread-view'
 import { waitUntilEqual } from '../../utils'
+import { enduserLogin } from '../../utils/user'
 
 let page: Page
 let fixtures: AreaAndPersonFixtures
@@ -99,12 +99,10 @@ beforeEach(async () => {
     }
   ])
   await upsertMessageAccounts()
-  await insertParentshipFixtures([
+  await insertGuardianFixtures([
     {
       childId: child.id,
-      headOfChildId: fixtures.enduserGuardianFixture.id,
-      startDate: '2021-01-01',
-      endDate: '2028-01-01'
+      guardianId: fixtures.enduserGuardianFixture.id
     }
   ])
 

--- a/frontend/src/e2e-playwright/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-playwright/specs/7_messaging/messaging.spec.ts
@@ -2,35 +2,35 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { newBrowserContext } from '../../browser'
-import { Page } from 'playwright'
-import {
-  AreaAndPersonFixtures,
-  initializeAreaAndPersonData
-} from 'e2e-test-common/dev-api/data-init'
+import CitizenMessagesPage from 'e2e-playwright/pages/citizen/citizen-messages'
+import ChildInformationPage from 'e2e-playwright/pages/employee/child-information-page'
+import MessagesPage from 'e2e-playwright/pages/employee/messages/messages-page'
+import { waitUntilEqual } from 'e2e-playwright/utils'
+import { employeeLogin, enduserLogin } from 'e2e-playwright/utils/user'
+import config from 'e2e-test-common/config'
 import {
   insertDaycareGroupFixtures,
   insertDaycareGroupPlacementFixtures,
   insertDaycarePlacementFixtures,
   insertEmployeeFixture,
-  insertParentshipFixtures,
+  insertGuardianFixtures,
   resetDatabase,
   setAclForDaycares,
   upsertMessageAccounts
 } from 'e2e-test-common/dev-api'
 import {
-  daycareGroupFixture,
+  AreaAndPersonFixtures,
+  initializeAreaAndPersonData
+} from 'e2e-test-common/dev-api/data-init'
+import {
+  createDaycareGroupPlacementFixture,
   createDaycarePlacementFixture,
-  uuidv4,
-  createDaycareGroupPlacementFixture
+  daycareGroupFixture,
+  uuidv4
 } from 'e2e-test-common/dev-api/fixtures'
 import { UUID } from 'lib-common/types'
-import { employeeLogin, enduserLogin } from 'e2e-playwright/utils/user'
-import config from 'e2e-test-common/config'
-import MessagesPage from 'e2e-playwright/pages/employee/messages/messages-page'
-import CitizenMessagesPage from 'e2e-playwright/pages/citizen/citizen-messages'
-import ChildInformationPage from 'e2e-playwright/pages/employee/child-information-page'
-import { waitUntilEqual } from 'e2e-playwright/utils'
+import { Page } from 'playwright'
+import { newBrowserContext } from '../../browser'
 
 let unitSupervisorPage: Page
 let citizenPage: Page
@@ -71,12 +71,10 @@ beforeEach(async () => {
   )
   await insertDaycareGroupPlacementFixtures([groupPlacementFixture])
   await upsertMessageAccounts()
-  await insertParentshipFixtures([
+  await insertGuardianFixtures([
     {
       childId: childId,
-      headOfChildId: fixtures.enduserGuardianFixture.id,
-      startDate: '2021-01-01',
-      endDate: '2028-01-01'
+      guardianId: fixtures.enduserGuardianFixture.id
     }
   ])
 })

--- a/frontend/src/employee-frontend/components/child-information/MessageBlocklist.tsx
+++ b/frontend/src/employee-frontend/components/child-information/MessageBlocklist.tsx
@@ -2,17 +2,18 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { getChildRecipients, updateChildRecipient } from '../../api/person'
-import { ChildContext } from '../../state'
 import { UUID } from 'lib-common/types'
+import { useApiState } from 'lib-common/utils/useRestApi'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
+import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { H2, P } from 'lib-components/typography'
 import React, { useContext, useState } from 'react'
+import { getChildRecipients, updateChildRecipient } from '../../api/person'
+import { ChildContext } from '../../state'
 import { useTranslation } from '../../state/i18n'
-import { useApiState } from 'lib-common/utils/useRestApi'
 import { UIContext } from '../../state/ui'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
+import { formatPersonName } from '../../utils'
 import { renderResult } from '../async-rendering'
 
 interface Props {
@@ -20,27 +21,13 @@ interface Props {
   startOpen: boolean
 }
 
-export default React.memo(function ChildDetails({ id, startOpen }: Props) {
+export default React.memo(function MessageBlocklist({ id, startOpen }: Props) {
   const { i18n } = useTranslation()
 
   const { setErrorMessage } = useContext(UIContext)
   const { permittedActions } = useContext(ChildContext)
   const [recipients, loadData] = useApiState(() => getChildRecipients(id), [id])
   const [open, setOpen] = useState(startOpen)
-
-  const getRoleString = (headOfChild: boolean, guardian: boolean) => {
-    if (headOfChild && guardian) {
-      return `${
-        i18n.childInformation.messaging.guardian
-      } (${i18n.childInformation.messaging.headOfChild.toLowerCase()})`
-    } else if (headOfChild && !guardian) {
-      return `${i18n.childInformation.messaging.headOfChild}`
-    } else if (!headOfChild && guardian) {
-      return `${i18n.childInformation.messaging.guardian}`
-    } else {
-      return null
-    }
-  }
 
   const onChange = async (personId: UUID, checked: boolean) => {
     const res = await updateChildRecipient(id, personId, !checked)
@@ -71,7 +58,6 @@ export default React.memo(function ChildDetails({ id, startOpen }: Props) {
             <Thead>
               <Tr>
                 <Th>{i18n.childInformation.messaging.name}</Th>
-                <Th>{i18n.childInformation.messaging.role}</Th>
                 <Th>{i18n.childInformation.messaging.notBlocklisted}</Th>
               </Tr>
             </Thead>
@@ -81,13 +67,10 @@ export default React.memo(function ChildDetails({ id, startOpen }: Props) {
                   key={recipient.personId}
                   data-qa={`recipient-${recipient.personId}`}
                 >
-                  <Td>{`${recipient.lastName} ${recipient.firstName}`}</Td>
-                  <Td>
-                    {getRoleString(recipient.headOfChild, recipient.guardian)}
-                  </Td>
+                  <Td>{formatPersonName(recipient, i18n)}</Td>
                   <Td>
                     <Checkbox
-                      label={`${recipient.firstName} ${recipient.lastName}`}
+                      label={formatPersonName(recipient, i18n)}
                       hiddenLabel
                       checked={!recipient.blocklisted}
                       data-qa={'blocklist-checkbox'}

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -153,8 +153,6 @@ export interface PostMessageBody {
 export interface Recipient {
   blocklisted: boolean
   firstName: string
-  guardian: boolean
-  headOfChild: boolean
   lastName: string
   personId: string
 }

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -820,12 +820,9 @@ export const fi = {
     },
     messaging: {
       title: 'Lapseen liittyvä viestintä (vastaanottajat)',
-      info: 'Lapseen liittyvät viestit lähetetään merkityille vastaanottajille. Esimies tai palveluohjaus voi perustelluista syistä estää viestin lähettämisen valitulle päämiehelle tai huoltajalle, poistamalla ruksin kyseisen henkilön kohdalta.',
+      info: 'Lapseen liittyvät viestit lähetetään merkityille huoltajille. Esimies tai palveluohjaus voi perustelluista syistä estää viestin lähettämisen valitulle huoltajalle, poistamalla ruksin kyseisen henkilön kohdalta. Viestejä ei lähetetä päämiehille.',
       name: 'Vastaanottajan nimi',
-      role: 'Rooli',
-      notBlocklisted: 'Saa Vastaanottaa',
-      guardian: 'Huoltaja',
-      headOfChild: 'Päämies'
+      notBlocklisted: 'Saa vastaanottaa'
     },
     backupCares: {
       title: 'Varasijoitukset',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -435,7 +435,7 @@ class MessageQueriesTest : PureJdbiTest() {
             tx.insertTestDaycareGroupPlacement(id = GroupPlacementId(UUID.randomUUID()), daycarePlacementId = PlacementId(placementId), groupId = GroupId(group1Id), startDate = startDate, endDate = endDate)
 
             // and person1 is a blocked receiver
-            addToBlocklist(tx, testChild_1.id, person1Id)
+            tx.addToBlocklist(testChild_1.id, person1Id)
         }
 
         val person1Account = db.read {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageReceiversIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageReceiversIntegrationTest.kt
@@ -123,7 +123,7 @@ class MessageReceiversIntegrationTest : FullApplicationTest() {
             insertChildToGroup(tx, testChild_3.id, testAdult_3.id, secondGroupId, secondUnitId)
             insertChildToGroup(tx, testChild_4.id, testAdult_4.id, secondGroupId, secondUnitId)
 
-            // Child 2 has a placement but is not in any group => should not
+            // Child 2 has a placement but is not in any group => should not
             // (currently) show up in receivers list
             insertChildToUnit(tx, testChild_2.id, testAdult_2.id, unitId)
 
@@ -179,8 +179,11 @@ class MessageReceiversIntegrationTest : FullApplicationTest() {
             setOf(testChild_3.id, testChild_4.id),
             groupKoekaniinit.receivers.map { it.childId }.toSet()
         )
-        val childWithTwoReceiverPersons = groupKoekaniinit.receivers.find { it.childId == testChild_3.id }!!
-        assertEquals(2, childWithTwoReceiverPersons.receiverPersons.size)
+
+        // child 3 has a guardian and a head of child, only the guardian gets the messages
+        val childWithANonGuardian = groupKoekaniinit.receivers.find { it.childId == testChild_3.id }!!
+        assertEquals(1, childWithANonGuardian.receiverPersons.size)
+        assertEquals(testAdult_3.lastName, childWithANonGuardian.receiverPersons[0].receiverLastName)
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/ChildRecipientsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/ChildRecipientsController.kt
@@ -9,16 +9,11 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
-import fi.espoo.evaka.shared.utils.europeHelsinki
-import org.jdbi.v3.core.kotlin.mapTo
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-import java.time.Instant
-import java.time.LocalDate
 import java.util.UUID
 
 @RestController
@@ -29,12 +24,11 @@ class ChildRecipientsController(private val accessControl: AccessControl) {
         db: Database.Connection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
-    ): ResponseEntity<List<Recipient>> {
+    ): List<Recipient> {
         Audit.MessagingBlocklistRead.log(childId)
         accessControl.requirePermissionFor(user, Action.Child.READ_CHILD_RECIPIENTS, childId)
 
-        return db.read { fetchRecipients(it, Instant.now(), childId) }
-            .let { ResponseEntity.ok(it) }
+        return db.read { it.fetchRecipients(childId) }
     }
 
     data class EditRecipientRequest(
@@ -47,88 +41,16 @@ class ChildRecipientsController(private val accessControl: AccessControl) {
         @PathVariable childId: UUID,
         @PathVariable personId: UUID,
         @RequestBody body: EditRecipientRequest
-    ): ResponseEntity<Unit> {
+    ) {
         Audit.MessagingBlocklistEdit.log(childId)
         accessControl.requirePermissionFor(user, Action.Child.UPDATE_CHILD_RECIPIENT, childId)
 
         db.transaction { tx ->
             if (body.blocklisted) {
-                addToBlocklist(tx, childId, personId)
+                tx.addToBlocklist(childId, personId)
             } else {
-                removeFromBlocklist(tx, childId, personId)
+                tx.removeFromBlocklist(childId, personId)
             }
         }
-
-        return ResponseEntity.noContent().build()
     }
 }
-
-fun addToBlocklist(tx: Database.Transaction, childId: UUID, recipientId: UUID) {
-    // language=sql
-    val sql = """
-        INSERT INTO messaging_blocklist (child_id, blocked_recipient)
-        VALUES (:childId, :recipient)
-        ON CONFLICT DO NOTHING;
-    """.trimIndent()
-
-    tx.createUpdate(sql)
-        .bind("childId", childId)
-        .bind("recipient", recipientId)
-        .execute()
-}
-
-fun removeFromBlocklist(tx: Database.Transaction, childId: UUID, recipientId: UUID) {
-    // language=sql
-    val sql = """
-        DELETE FROM messaging_blocklist
-        WHERE child_id = :childId AND blocked_recipient = :recipient
-    """.trimIndent()
-
-    tx.createUpdate(sql)
-        .bind("childId", childId)
-        .bind("recipient", recipientId)
-        .execute()
-}
-
-fun fetchRecipients(tx: Database.Read, now: Instant, childId: UUID): List<Recipient> {
-    // language=sql
-    val sql = """
-        WITH guardians AS (
-            SELECT g.guardian_id AS person_id
-            FROM guardian g
-            WHERE g.child_id = :childId
-        ), head_of_child AS (
-            SELECT fc.head_of_child AS person_id
-            FROM fridge_child fc 
-            WHERE fc.child_id = :childId AND daterange(fc.start_date, fc.end_date, '[]') @> :date
-        ), recipient_ids AS (
-            SELECT person_id FROM guardians
-            UNION DISTINCT 
-            SELECT person_id FROM head_of_child
-        )
-        SELECT 
-            person_id,
-            first_name,
-            last_name,
-            EXISTS(SELECT 1 FROM guardians g WHERE g.person_id = r.person_id) AS guardian,
-            EXISTS(SELECT 1 FROM head_of_child hoc WHERE hoc.person_id = r.person_id) AS head_of_child,
-            EXISTS(SELECT 1 FROM messaging_blocklist bl WHERE bl.child_id = :childId AND bl.blocked_recipient = person_id) AS blocklisted
-        FROM recipient_ids r
-        JOIN person p ON r.person_id = p.id
-    """.trimIndent()
-
-    return tx.createQuery(sql)
-        .bind("childId", childId)
-        .bind("date", LocalDate.ofInstant(now, europeHelsinki))
-        .mapTo<Recipient>()
-        .list()
-}
-
-data class Recipient(
-    val personId: String,
-    val firstName: String,
-    val lastName: String,
-    val guardian: Boolean,
-    val headOfChild: Boolean,
-    val blocklisted: Boolean
-)


### PR DESCRIPTION
#### Summary

- Remove head_of_child JOINs from message receiver queries, because only the guardians are allowed to receive messages
- Move queries from controller to queries, use extension functions

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

