### PR TITLE
EVAKA-4000 run reset every other day

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -29,12 +29,12 @@ data class ScheduledJobSettings(
         fun default(job: ScheduledJob) = when (job) {
             ScheduledJob.VardaUpdate -> ScheduledJobSettings(
                 enabled = false,
-                schedule = JobSchedule.daily(LocalTime.of(23, 30)),
+                schedule = JobSchedule.cron("0 0 23 * * 1,3,5"), // mon, wed, fri @ 23 pm
                 retryCount = 1
             )
             ScheduledJob.VardaReset -> ScheduledJobSettings(
                 enabled = true,
-                schedule = JobSchedule.daily(LocalTime.of(20, 0)),
+                schedule = JobSchedule.cron("0 0 20 * * 1,3,5"), // mon, wed, fri @ 20 pm
                 retryCount = 1
             )
             ScheduledJob.EndOfDayAttendanceUpkeep -> ScheduledJobSettings(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Run varda jobs every other day to bypass varda guardian delay
