### PR TITLE
Fix a flaky e2e test

### DIFF
--- a/frontend/src/e2e-playwright/specs/4_finance/value-decisions.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/value-decisions.spec.ts
@@ -144,7 +144,7 @@ describe('Value decisions', () => {
       decision2DateTo.subDays(1)
     )
     await waitUntilEqual(() => valueDecisionsPage.getValueDecisionCount(), 2)
-    await valueDecisionsPage.startDateWithinrange()
+    await valueDecisionsPage.startDateWithinRange()
     await waitUntilEqual(() => valueDecisionsPage.getValueDecisionCount(), 1)
   })
 
@@ -170,7 +170,6 @@ describe('Value decisions', () => {
 
     await valueDecisionsPage.toggleAllValueDecisions(true)
     await valueDecisionsPage.sendValueDecisions()
-    await runPendingAsyncJobs()
     await valueDecisionsPage.assertSentDecisionsCount(2)
   })
 

--- a/frontend/src/e2e-playwright/utils/element.ts
+++ b/frontend/src/e2e-playwright/utils/element.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from 'playwright'
+import { Locator, Page } from 'playwright'
 import {
   BoundingBox,
   toCssString,
@@ -106,9 +106,11 @@ export const WithTextInput = <T extends Constructor<RawElement>>(
   }
 
 export class Checkbox extends WithChecked(RawElement, descendantInput) {}
+
 export class Radio extends WithChecked(RawElement, descendantInput) {}
 
 export class RawTextInput extends WithTextInput(RawElement) {}
+
 export class RawRadio extends WithChecked(RawElement) {}
 
 export class SelectionChip extends WithChecked(RawElement, descendantInput) {}
@@ -139,12 +141,42 @@ export class Collapsible extends RawElement {
   }
 }
 
-export class AsyncButton extends RawElement {
+export class AsyncButton {
+  readonly #root: Locator
+
+  constructor(root: Locator) {
+    this.#root = root
+  }
+
+  async click() {
+    await this.#root.click()
+  }
+
   async status() {
-    return this.getAttribute('data-status')
+    return this.#root.getAttribute('data-status')
   }
 
   async waitUntilSuccessful() {
     await waitUntilEqual(() => this.status(), 'success')
+  }
+}
+
+export class CheckboxLocator {
+  readonly #root: Locator
+
+  constructor(root: Locator) {
+    this.#root = root
+  }
+
+  async click() {
+    await this.#root.click()
+  }
+
+  async isChecked() {
+    return this.#root.locator('input').isChecked()
+  }
+
+  async waitUntilChecked(checked = true) {
+    await waitUntilEqual(() => this.isChecked(), checked)
   }
 }

--- a/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisions.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisions.tsx
@@ -6,16 +6,15 @@ import React from 'react'
 import styled from 'styled-components'
 import { useHistory } from 'react-router-dom'
 import {
+  SortableTh,
   Table,
-  Tr,
-  Th,
-  Td,
-  Thead,
   Tbody,
-  SortableTh
+  Td,
+  Th,
+  Thead,
+  Tr
 } from 'lib-components/layout/Table'
 import { H1 } from 'lib-components/typography'
-import Loader from 'lib-components/atoms/Loader'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import NameWithSsn from '../common/NameWithSsn'
 import ChildrenCell from '../common/ChildrenCell'
@@ -27,6 +26,7 @@ import { formatDate } from 'lib-common/date'
 import { formatCents } from 'lib-common/money'
 import { SortByVoucherValueDecisions } from '../../api/invoicing'
 import Pagination from 'lib-components/Pagination'
+import { renderResult } from '../async-rendering'
 
 const TitleRowContainer = styled.div`
   display: flex;
@@ -171,7 +171,7 @@ export default React.memo(function VoucherValueDecisions({
             >
               {i18n.valueDecisions.table.status}
             </SortableTh>
-            {showCheckboxes ? (
+            {showCheckboxes && (!decisions || decisions.isSuccess) ? (
               <Td>
                 <Checkbox
                   label="all"
@@ -187,18 +187,17 @@ export default React.memo(function VoucherValueDecisions({
         </Thead>
         <Tbody>{rows}</Tbody>
       </Table>
-      {decisions?.isSuccess && (
-        <ResultsContainer>
-          <Pagination
-            pages={pages}
-            currentPage={currentPage}
-            setPage={setPage}
-            label={i18n.common.page}
-          />
-        </ResultsContainer>
-      )}
-      {decisions?.isLoading && <Loader />}
-      {decisions?.isFailure && <div>{i18n.common.error.unknown}</div>}
+      {decisions &&
+        renderResult(decisions, () => (
+          <ResultsContainer>
+            <Pagination
+              pages={pages}
+              currentPage={currentPage}
+              setPage={setPage}
+              label={i18n.common.page}
+            />
+          </ResultsContainer>
+        ))}
     </div>
   )
 })


### PR DESCRIPTION
#### Summary

Show the toggle all checkbox only after data has loaded. If the e2e happened to click it when data hadn't arrived yet, it didn't select anything.

While at it, refactor the e2e tests to use locators.