### PR TITLE
EVAKA-HOTFIX staff attendance in absence table

### DIFF
--- a/frontend/src/employee-frontend/components/absences/Absences.tsx
+++ b/frontend/src/employee-frontend/components/absences/Absences.tsx
@@ -527,6 +527,10 @@ const AbsencesPage = styled.div`
         border-width: 0 0 1px;
         background-color: transparent;
 
+        :disabled {
+          color: ${colors.greyscale.medium};
+        }
+
         @media print {
           border: none;
         }

--- a/frontend/src/employee-frontend/components/absences/StaffAttendance.tsx
+++ b/frontend/src/employee-frontend/components/absences/StaffAttendance.tsx
@@ -206,8 +206,11 @@ const StaffAttendanceCell = memo(function StaffAttendanceCell({
     const handle = setTimeout(() => {
       void save()
     }, 2000)
+
     return () => {
-      clearTimeout(handle)
+      if (mountedRef.current) {
+        clearTimeout(handle)
+      }
     }
   }, [save])
 
@@ -220,7 +223,7 @@ const StaffAttendanceCell = memo(function StaffAttendanceCell({
           onChange={(e) => {
             setValue(e.target.value)
           }}
-          onBlur={() => save()}
+          onBlur={save}
           data-qa="staff-attendance-input"
         />
       </div>

--- a/frontend/src/employee-frontend/components/absences/StaffAttendance.tsx
+++ b/frontend/src/employee-frontend/components/absences/StaffAttendance.tsx
@@ -2,7 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { memo, useCallback, useEffect, useRef, useState } from 'react'
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState
+} from 'react'
 import LocalDate from 'lib-common/local-date'
 import { Td, Tr } from 'lib-components/layout/Table'
 import { GroupStaffAttendanceForDates } from 'lib-common/api-types/codegen-excluded'
@@ -174,8 +181,12 @@ const StaffAttendanceCell = memo(function StaffAttendanceCell({
     []
   )
 
-  const initialValue: string = formatDecimal(attendance?.count) ?? ''
+  const initialValue = formatDecimal(attendance?.count) ?? ''
   const [value, setValue] = useState(initialValue)
+
+  useLayoutEffect(() => {
+    setValue(initialValue)
+  }, [initialValue])
 
   const save = useCallback(() => {
     if (value !== initialValue) {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Fix a bug in absence table that caused changing groups from the dropdown to update previous group's staff attendance values to the selected group.
Also, save staff attendance if user navigates away from the view before the debounced save callback is fired and disable the inputs when new values are being loaded.

