### PR TITLE
EVAKA-4000 add workaround for error MA003

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -229,7 +229,7 @@ private fun addServiceNeedDataToVarda(
     } catch (e: Exception) {
         val errors = listOf("VardaUpdate: error adding service need ${evakaServiceNeed.id} to Varda: ${e.message}")
         db.transaction { it.upsertVardaServiceNeed(vardaServiceNeed, errors) }
-        error(errors)
+        if (e.message?.contains("MA003") != true) error(errors) // Error code MA003 should result to successful reset
     }
 }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Error MA003 should not result to new reset. MA003 means that Varda does not yet have the child's guardian data but will fetch it in the following 24 hours. Trying to reset the child again will result to Varda deleting their guardian data and therefore ensure that the reset will fail again. Hence we must consider MA003 as successful outcome for reset mechanism and then rely on our update mechanism. It will send the missing data on the next run.
