### PR TITLE
Citizen personal details only with strong auth

### DIFF
--- a/frontend/src/citizen-frontend/auth/requireAuth.tsx
+++ b/frontend/src/citizen-frontend/auth/requireAuth.tsx
@@ -8,7 +8,7 @@ import { RouteComponentProps } from 'react-router'
 import { Redirect } from 'react-router-dom'
 import { getWeakLoginUri, getLoginUri } from '../header/const'
 
-function refreshRedirect(uri: string) {
+export function refreshRedirect(uri: string) {
   window.location.replace(uri)
   return null
 }

--- a/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
+++ b/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
@@ -26,12 +26,14 @@ import {
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 import { H1, H2, Label } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
-import { faPen, fasExclamationTriangle } from 'lib-icons'
+import { faLockAlt, faPen, fasExclamationTriangle } from 'lib-icons'
 import React, { useCallback, useContext, useMemo, useState } from 'react'
 import { Redirect } from 'react-router'
 import styled, { useTheme } from 'styled-components'
 import { renderResult } from '../async-rendering'
+import { refreshRedirect } from '../auth/requireAuth'
 import Footer from '../Footer'
+import { getLoginUri } from '../header/const'
 import { Translations, useTranslation } from '../localization'
 import { updatePersonalData } from './api'
 
@@ -55,6 +57,8 @@ export default React.memo(function PersonalDetails() {
     () => getPreferredNameOptions(user),
     [user]
   )
+
+  const navigateToLogin = useCallback(() => refreshRedirect(getLoginUri()), [])
 
   const formWrapper = (children: React.ReactNode) =>
     editing ? (
@@ -105,8 +109,11 @@ export default React.memo(function PersonalDetails() {
               postOffice,
               phone,
               backupPhone,
-              email
+              email,
+              userType
             } = personalData
+
+            const canEdit = userType === 'ENDUSER'
 
             return (
               <>
@@ -120,10 +127,10 @@ export default React.memo(function PersonalDetails() {
                 <EditButtonRow>
                   <InlineButton
                     text={t.common.edit}
-                    icon={faPen}
-                    onClick={startEditing}
+                    icon={canEdit ? faPen : faLockAlt}
+                    onClick={canEdit ? startEditing : navigateToLogin}
                     disabled={editing}
-                    data-qa="start-editing"
+                    data-qa={canEdit ? 'start-editing' : 'start-editing-login'}
                   />
                 </EditButtonRow>
                 {formWrapper(

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/citizen/personal-data")
 class PersonalDataControllerCitizen {
     @PutMapping
-    fun updatePersonalData(db: Database.Connection, user: AuthenticatedUser, @RequestBody body: PersonalDataUpdate) {
+    fun updatePersonalData(db: Database.Connection, user: AuthenticatedUser.Citizen, @RequestBody body: PersonalDataUpdate) {
         Audit.PersonalDataUpdate.log(targetId = user.id)
         user.requireOneOfRoles(UserRole.END_USER)
 


### PR DESCRIPTION
#### Summary

Require strong auth for viewing the personal details page and updating the details. Currently the page can be accessed but update request will fail with 403.

Lock icons for _weak citizen_ are coming in #1726 
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

