### PR TITLE
Allow storing of many rows of followup comments in Vasu documents

### DIFF
--- a/frontend/src/e2e-playwright/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-playwright/pages/employee/vasu/vasu.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from 'playwright'
-import { RawElement } from '../../../utils/element'
+import { Locator, Page } from 'playwright'
 
 export default class VasuPage {
   constructor(private readonly page: Page) {}
@@ -11,11 +10,10 @@ export default class VasuPage {
   readonly #followupQuestion = this.page.locator(
     '[data-qa="vasu-followup-question"]'
   )
-  readonly #finalizeButton = new RawElement(
-    this.page,
+  readonly #finalizeButton = this.page.locator(
     '[data-qa="transition-button-MOVED_TO_READY"]'
   )
-  readonly #modalOkButton = new RawElement(this.page, '[data-qa="modal-okBtn"]')
+  readonly #modalOkButton = this.page.locator('[data-qa="modal-okBtn"]')
   readonly #documentSection = this.page.locator(
     '[data-qa="vasu-document-section"]'
   )
@@ -37,11 +35,11 @@ export default class VasuPage {
       .then(() => this.#followupQuestion.count())
   }
 
-  get finalizeButton(): RawElement {
+  get finalizeButton(): Locator {
     return this.#finalizeButton
   }
 
-  get modalOkButton(): RawElement {
+  get modalOkButton(): Locator {
     return this.#modalOkButton
   }
 

--- a/frontend/src/e2e-playwright/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-playwright/pages/employee/vasu/vasu.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Page } from 'playwright'
+import { RawElement } from '../../../utils/element'
+
+export default class VasuPage {
+  constructor(private readonly page: Page) {}
+
+  readonly #followupQuestion = this.page.locator(
+    '[data-qa="vasu-followup-question"]'
+  )
+  readonly #finalizeButton = new RawElement(
+    this.page,
+    '[data-qa="transition-button-MOVED_TO_READY"]'
+  )
+  readonly #modalOkButton = new RawElement(this.page, '[data-qa="modal-okBtn"]')
+  readonly #documentSection = this.page.locator(
+    '[data-qa="vasu-document-section"]'
+  )
+
+  readonly #followupInput = this.page.locator('[data-qa="vasu-followup-input"]')
+  readonly #followupAddBtn = this.page.locator(
+    '[data-qa="vasu-followup-addBtn"]'
+  )
+  readonly #followupEntryText = this.page.locator(
+    '[data-qa="vasu-followup-entry-text"]'
+  )
+  readonly #followupEntryMetadata = this.page.locator(
+    '[data-qa="vasu-followup-entry-metadata"]'
+  )
+
+  get followupQuestionCount(): Promise<number> {
+    return this.page
+      .waitForLoadState('networkidle')
+      .then(() => this.#followupQuestion.count())
+  }
+
+  get finalizeButton(): RawElement {
+    return this.#finalizeButton
+  }
+
+  get modalOkButton(): RawElement {
+    return this.#modalOkButton
+  }
+
+  async assertDocumentVisible() {
+    await this.#documentSection.first().waitFor({ state: 'visible' })
+  }
+
+  async inputFollowupComment(comment: string) {
+    await this.#followupInput.type(comment)
+    await this.#followupAddBtn.click()
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  get followupEntryTexts(): Promise<Array<string>> {
+    return this.#followupEntryText.allInnerTexts()
+  }
+
+  get followupEntryMetadata(): Promise<Array<string>> {
+    return this.#followupEntryMetadata.allInnerTexts()
+  }
+}

--- a/frontend/src/e2e-playwright/utils/element.ts
+++ b/frontend/src/e2e-playwright/utils/element.ts
@@ -11,6 +11,9 @@ import {
   waitUntilTrue
 } from '.'
 
+/**
+ * @deprecated Use playwright locators instead
+ */
 export class RawElement {
   constructor(public page: Page, public selector: string) {}
 

--- a/frontend/src/e2e-test-common/dev-api/index.ts
+++ b/frontend/src/e2e-test-common/dev-api/index.ts
@@ -825,9 +825,25 @@ export async function insertGuardianFixtures(
   }
 }
 
-export async function insertVasuTemplateFixture(): Promise<void> {
+export async function insertVasuTemplateFixture(): Promise<UUID> {
   try {
-    await devClient.post('/vasu-template')
+    const { data } = await devClient.post<UUID>('/vasu/template')
+    return data
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}
+
+export async function insertVasuDocument(
+  childId: UUID,
+  templateId: UUID
+): Promise<UUID> {
+  try {
+    const { data } = await devClient.post<UUID>('/vasu/doc', {
+      childId,
+      templateId
+    })
+    return data
   } catch (e) {
     throw new DevApiError(e)
   }

--- a/frontend/src/employee-frontend/components/vasu/VasuPage.tsx
+++ b/frontend/src/employee-frontend/components/vasu/VasuPage.tsx
@@ -44,7 +44,7 @@ export default React.memo(function VasuPage({
   const dynamicSectionsOffset = 2
 
   return (
-    <VasuContainer gapSize={'zero'}>
+    <VasuContainer gapSize={'zero'} data-qa="vasu-preview">
       <Gap size={'L'} />
       {vasu && (
         <>

--- a/frontend/src/employee-frontend/components/vasu/VasuStateTransitionButtons.tsx
+++ b/frontend/src/employee-frontend/components/vasu/VasuStateTransitionButtons.tsx
@@ -62,6 +62,7 @@ export function VasuStateTransitionButtons({
       text={i18n.vasu.transitions[eventType].buttonText}
       onClick={() => setSelectedEventType(eventType)}
       primary={primary}
+      data-qa={`transition-button-${eventType}`}
     />
   )
 

--- a/frontend/src/employee-frontend/components/vasu/api.ts
+++ b/frontend/src/employee-frontend/components/vasu/api.ts
@@ -6,7 +6,7 @@ import { Failure, Result, Success } from 'lib-common/api'
 import { JsonOf } from 'lib-common/json'
 import { client } from '../../api/client'
 import { getDocumentState } from './vasu-events'
-import { VasuContent } from './vasu-content'
+import { mapVasuContent, VasuContent } from './vasu-content'
 import LocalDate from 'lib-common/local-date'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { UUID } from 'lib-common/types'
@@ -108,11 +108,13 @@ const mapVasuDocumentResponse = ({
   modifiedAt,
   templateRange,
   basics,
+  content,
   vasuDiscussionContent,
   evaluationDiscussionContent,
   ...rest
 }: JsonOf<VasuDocumentResponse>): VasuDocument => ({
   ...rest,
+  content: mapVasuContent(content),
   events: events.map(mapVasuDocumentEvent),
   documentState: getDocumentState(events),
   modifiedAt: new Date(modifiedAt),

--- a/frontend/src/employee-frontend/components/vasu/components/FollowupQuestion.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/FollowupQuestion.tsx
@@ -25,8 +25,8 @@ const FollowupEntryElement = React.memo(function FollowupEntryElement({
 }) {
   return (
     <Entry>
-      <EntryText>{entry.text}</EntryText>
-      <Dimmed>
+      <EntryText data-qa="vasu-followup-entry-text">{entry.text}</EntryText>
+      <Dimmed data-qa="vasu-followup-entry-metadata">
         {entry.date.format()} {entry.authorName}
       </Dimmed>
     </Entry>
@@ -64,13 +64,18 @@ const FollowupEntryEditor = React.memo(function FollowupEntryEditor({
 
   return (
     <FollowupEntryInputRow fullWidth>
-      <TextArea value={textValue} onChange={setTextValue} />
+      <TextArea
+        value={textValue}
+        onChange={setTextValue}
+        data-qa="vasu-followup-input"
+      />
       <Button
         primary
         type="submit"
         disabled={textValue === ''}
         text={i18n.common.addNew}
         onClick={onSubmit}
+        data-qa="vasu-followup-addBtn"
       />
     </FollowupEntryInputRow>
   )
@@ -100,7 +105,10 @@ export default React.memo(function FollowupQuestion({
   )
 
   return (
-    <FollowupQuestionContainer editable={!!onChange}>
+    <FollowupQuestionContainer
+      editable={!!onChange}
+      data-qa="vasu-followup-question"
+    >
       <H2>{title}</H2>
       <QuestionInfo info={info}>
         <Label>{name}</Label>

--- a/frontend/src/employee-frontend/components/vasu/sections/DynamicSections.tsx
+++ b/frontend/src/employee-frontend/components/vasu/sections/DynamicSections.tsx
@@ -58,7 +58,11 @@ export function DynamicSections({
     const isLastQuestionFollowup = last(section.questions)?.type === 'FOLLOWUP'
     return (
       <Fragment key={section.name}>
-        <SectionContent opaque padBottom={!isLastQuestionFollowup}>
+        <SectionContent
+          opaque
+          padBottom={!isLastQuestionFollowup}
+          data-qa="vasu-document-section"
+        >
           <H2>
             {sectionIndex + 1 + sectionOffset}. {section.name}
           </H2>

--- a/frontend/src/employee-frontend/components/vasu/sections/DynamicSections.tsx
+++ b/frontend/src/employee-frontend/components/vasu/sections/DynamicSections.tsx
@@ -17,6 +17,7 @@ import FollowupQuestionElem from '../components/FollowupQuestion'
 import {
   CheckboxQuestion,
   Followup,
+  FollowupEntry,
   isCheckboxQuestion,
   isFollowup,
   isMultiSelectQuestion,
@@ -175,12 +176,12 @@ export function DynamicSections({
                       translations={translations}
                       onChange={
                         setContent
-                          ? (value: string) =>
+                          ? (value: FollowupEntry) =>
                               setContent((prev) => {
                                 const clone = cloneDeep(prev)
                                 const question1 = clone.sections[sectionIndex]
                                   .questions[questionIndex] as Followup
-                                question1.value = value
+                                question1.value.push(value)
                                 return clone
                               })
                           : undefined

--- a/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
@@ -92,7 +92,7 @@ export default React.memo(function CreateQuestionModal({
           name: name,
           info: info,
           title: '',
-          value: ''
+          value: []
         }
     }
   }

--- a/frontend/src/employee-frontend/components/vasu/templates/api.ts
+++ b/frontend/src/employee-frontend/components/vasu/templates/api.ts
@@ -6,7 +6,7 @@ import { Result, Success, Failure } from 'lib-common/api'
 import { JsonOf } from 'lib-common/json'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { client } from '../../../api/client'
-import { VasuContent } from '../vasu-content'
+import { mapVasuContent, VasuContent } from '../vasu-content'
 import { UUID } from 'lib-common/types'
 
 export interface VasuTemplateSummary {
@@ -90,6 +90,7 @@ export async function getVasuTemplate(id: UUID): Promise<Result<VasuTemplate>> {
     .then((res) =>
       Success.of({
         ...res.data,
+        content: mapVasuContent(res.data.content),
         valid: FiniteDateRange.parseJson(res.data.valid)
       })
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/OphQuestion.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/OphQuestion.kt
@@ -132,7 +132,7 @@ fun getDefaultTemplateContent(lang: VasuLanguage) = VasuContent(
                         VasuLanguage.FI -> "Laadittu-tilassa olevaa varhaiskasvatussuunnitelmaa päivitetään pääasiassa lisäämällä uutta tekstiä Täydennykset ja jatkuva arviointi -osioon. Sinne voidaan mm. lisätä huomioita koskien lapsen kehitystä, arjen tapahtumia sekä huoltajien kanssa käytyjä keskusteluja."
                         VasuLanguage.SV -> ""
                     },
-                    value = ""
+                    value = emptyList()
                 )
             )
         ),

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/Vasu.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/Vasu.kt
@@ -211,7 +211,7 @@ sealed class VasuQuestion(
         override val ophKey: OphQuestionKey? = null,
         override val info: String = "",
         val title: String = "",
-        val value: String
+        val value: List<FollowupEntry>
     ) : VasuQuestion(VasuQuestionType.FOLLOWUP) {
         override fun equalsIgnoringValue(question: VasuQuestion?): Boolean {
             return question is Followup && question.copy(value = this.value) == this
@@ -257,4 +257,11 @@ data class EvaluationDiscussionContent(
     val participants: String = "",
     val guardianViewsAndCollaboration: String = "",
     val evaluation: String = ""
+)
+
+@Json
+data class FollowupEntry(
+    val date: LocalDate = LocalDate.now(),
+    val authorName: String = "",
+    val text: String = ""
 )


### PR DESCRIPTION
#### Summary
After a Vasu document has been finalized, a followup question is added to what currently is question number 5.

The followup section renders as a text area and when a comment is added, the comment is rendered as a "log row" above the text area. Each "log row" is tagged with the date when it was created as well as the name of the author.