### PR TITLE
Unify user experience in mobile when marking child absent

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkAbsent.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkAbsent.tsx
@@ -83,7 +83,7 @@ export default React.memo(function MarkAbsent() {
       {renderResult(combine(child, groupNote), ([child, groupNote]) => (
         <>
           <BackButtonInline
-            onClick={() => history.goBack()}
+            onClick={() => history.go(-2)}
             icon={faArrowLeft}
             text={
               child ? `${child.firstName} ${child.lastName}` : i18n.common.back


### PR DESCRIPTION
#### Summary

Unify user experience with mark arrived/departed when marking child absent. `history.go(-2)` takes the user back to group page.

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

