### PR TITLE
Serve child images through nginx

### DIFF
--- a/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -290,6 +290,21 @@ server {
     proxy_pass  $internalUrl/api/csp/csp-report;
   }
 
+  # Fox X-Accel-Redirect to S3
+  location ~* ^/internal_redirect/(.*) {
+    internal;
+
+    # Don't proxy sensitive headers
+    proxy_set_header Authorization '';
+    proxy_set_header Cookie '';
+
+    # Do not touch local disks when proxying content to clients
+    proxy_max_temp_file_size 0;
+
+    proxy_pass $1$is_args$args;
+  }
+
+
   <% if ENV.key?("KEYCLOAK_CONFIGURATION") && ENV["KEYCLOAK_CONFIGURATION"] != "" %>
   <%= ENV["KEYCLOAK_CONFIGURATION"] %>
   <% elsif ENV.key?("KEYCLOAK_URL") && ENV["KEYCLOAK_URL"] != "" %>

--- a/service/src/main/kotlin/fi/espoo/evaka/s3/DocumentService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/s3/DocumentService.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.s3
 
 import java.io.InputStream
+import java.net.URL
 
 interface Document {
     fun getName(): String
@@ -23,6 +24,11 @@ interface DocumentService {
      * Get attachment by attachment path. Subclasses can set add more restrictions to path value.
      */
     fun get(bucketName: String, key: String): Document
+
+    /**
+     * Create a presigned URL to get a file. Returns NULL if not supported.
+     */
+    fun presignedGetUrl(bucketName: String, key: String): URL?
 
     /**
      * Get InputStream of the file by path.

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AwsConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AwsConfig.kt
@@ -17,6 +17,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.S3Configuration
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.ses.SesClient
 
 @Configuration
@@ -46,11 +47,23 @@ class AwsConfig {
     }
 
     @Bean
+    @Profile("local")
+    fun amazonS3PresignerLocal(): S3Presigner? = null
+
+    @Bean
     @Profile("production")
     fun amazonS3Prod(env: EvakaEnv, credentialsProvider: AwsCredentialsProvider): S3Client = S3Client.builder()
         .region(env.awsRegion)
         .credentialsProvider(credentialsProvider)
         .build()
+
+    @Bean
+    @Profile("production")
+    fun amazonS3PresignerProd(env: EvakaEnv, credentialsProvider: AwsCredentialsProvider): S3Presigner? =
+        S3Presigner.builder()
+            .region(env.awsRegion)
+            .credentialsProvider(credentialsProvider)
+            .build()
 
     @Bean
     fun amazonSES(env: EvakaEnv, awsCredentialsProvider: AwsCredentialsProvider?): SesClient = SesClient.builder()


### PR DESCRIPTION
#### Summary

- Add an internal nginx endpoint that can proxy any URL
- When a child image request comes, generate a presigned S3 URL
- Use [X-Accel-Redirect](https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/) to the internal endpoint to serve the presigned URL to the client through nginx only

This way, slow clients don't consume a thread from service while downloading a child image. nginx uses async i/o and is able to handle thousands of concurrent requests, whereas service chokes already for a few hundred.