### PR TITLE
Fix message date formatting in employee mobile thread view

### DIFF
--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -2,21 +2,20 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import LocalDate from 'lib-common/local-date'
-import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
-import React from 'react'
+import { formatDateOrTime } from 'lib-common/date'
 import { MessageThread } from 'lib-common/generated/api-types/messaging'
+import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import FileDownloadButton from 'lib-components/molecules/FileDownloadButton'
-import { useTranslation } from '../localization'
-import { MessageTypeChip } from './MessageTypeChip'
-import { formatDate } from 'lib-common/date'
-import { getAttachmentBlob } from '../attachments'
 import {
   Container,
   Header,
   TitleAndDate,
   Truncated
 } from 'lib-components/molecules/ThreadListItem'
+import React from 'react'
+import { getAttachmentBlob } from '../attachments'
+import { useTranslation } from '../localization'
+import { MessageTypeChip } from './MessageTypeChip'
 
 interface Props {
   thread: MessageThread
@@ -52,16 +51,7 @@ export default React.memo(function ThreadListItem({
         </Header>
         <TitleAndDate isRead={!hasUnreadMessages}>
           <Truncated>{thread.title}</Truncated>
-          <span>
-            {formatDate(
-              lastMessage.sentAt,
-              LocalDate.fromSystemTzDate(lastMessage.sentAt).isEqual(
-                LocalDate.today()
-              )
-                ? 'HH:mm'
-                : 'd.M.'
-            )}
-          </span>
+          <span>{formatDateOrTime(lastMessage.sentAt)}</span>
         </TitleAndDate>
         <Truncated>
           {lastMessage.content.substring(0, 200).replace('\n', ' ')}

--- a/frontend/src/employee-frontend/components/messages/MessageComponents.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageComponents.tsx
@@ -2,16 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { isToday } from 'date-fns'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import React from 'react'
 import styled from 'styled-components'
-import {
-  DATE_FORMAT_NO_YEAR,
-  DATE_FORMAT_TIME_ONLY,
-  formatDate
-} from 'lib-common/date'
+import { formatDateOrTime } from 'lib-common/date'
 import { fontWeights } from 'lib-components/typography'
 
 export const MessageRow = styled.div<{ unread?: boolean }>`
@@ -56,10 +51,6 @@ export const TypeAndDate = styled.div`
   align-items: flex-end;
 `
 
-function formatTimestamp(sentAt: Date) {
-  const format = isToday(sentAt) ? DATE_FORMAT_TIME_ONLY : DATE_FORMAT_NO_YEAR
-  return formatDate(sentAt, format)
-}
 export function Timestamp({ date }: { date: Date }) {
-  return <span>{formatTimestamp(date)}</span>
+  return <span>{formatDateOrTime(date)}</span>
 }

--- a/frontend/src/employee-mobile-frontend/components/messages/MessagePreview.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessagePreview.tsx
@@ -11,8 +11,7 @@ import {
 } from 'lib-components/molecules/ThreadListItem'
 import { MessageThread } from 'lib-common/generated/api-types/messaging'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
-import { formatDate } from 'lib-common/date'
-import LocalDate from 'lib-common/local-date'
+import { formatDateOrTime } from 'lib-common/date'
 import React from 'react'
 
 export function MessagePreview({
@@ -41,16 +40,7 @@ export function MessagePreview({
         </Header>
         <TitleAndDate isRead={!hasUnreadMessages}>
           <Truncated>{thread.title}</Truncated>
-          <span>
-            {formatDate(
-              lastMessage.sentAt,
-              LocalDate.fromSystemTzDate(lastMessage.sentAt).isEqual(
-                LocalDate.today()
-              )
-                ? 'HH:mm'
-                : 'd.M.'
-            )}
-          </span>
+          <span>{formatDateOrTime(lastMessage.sentAt)}</span>
         </TitleAndDate>
         <Truncated>
           {lastMessage.content.substring(0, 200).replace('\n', ' ')}

--- a/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
@@ -12,7 +12,7 @@ import {
   MessageThread,
   NestedMessageAccount
 } from 'lib-common/generated/api-types/messaging'
-import { formatTime } from 'lib-common/date'
+import { formatDateOrTime } from 'lib-common/date'
 import React, { useCallback, useContext, useEffect, useRef } from 'react'
 import { getAccountsByUserAndUnit, MessageContext } from '../../state/messages'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -144,7 +144,7 @@ function SingleMessage({ message, ours }: { message: Message; ours: boolean }) {
         <SenderName data-qa={'single-message-sender-name'}>
           {message.sender.name}
         </SenderName>
-        <SentDate white={ours}>{formatTime(message.sentAt)}</SentDate>
+        <SentDate white={ours}>{formatDateOrTime(message.sentAt)}</SentDate>
       </TitleRow>
       <MessageContent data-qa="single-message-content">
         {message.content}

--- a/frontend/src/lib-common/date.ts
+++ b/frontend/src/lib-common/date.ts
@@ -2,11 +2,12 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { format } from 'date-fns'
+import { format, isToday } from 'date-fns'
 
 export const DATE_FORMAT_DATE = 'dd.MM.yyyy'
 export const DATE_FORMAT_DATE_TIME = 'dd.MM.yyyy HH:mm'
 export const DATE_FORMAT_NO_YEAR = 'dd.MM.'
+export const DATE_FORMAT_SHORT_NO_YEAR = 'd.M.'
 export const DATE_FORMAT_ISO = 'yyyy-MM-dd'
 export const DATE_FORMAT_TIME_ONLY = 'HH:mm'
 
@@ -26,4 +27,11 @@ const timeRegex = /^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/
 
 export function isValidTime(time: string): boolean {
   return timeRegex.test(time)
+}
+
+export function formatDateOrTime(date: Date): string {
+  return format(
+    date,
+    isToday(date) ? DATE_FORMAT_TIME_ONLY : DATE_FORMAT_SHORT_NO_YEAR
+  )
 }


### PR DESCRIPTION
#### Summary

Previously the date was always formatted as time.

Also unify formatting in all message components.

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

