### PR TITLE
Mobile child attendance query performance improvements

### DIFF
--- a/frontend/src/employee-mobile-frontend/api/attendances.ts
+++ b/frontend/src/employee-mobile-frontend/api/attendances.ts
@@ -212,7 +212,6 @@ function deserializeAttendanceResponse(
             ...attendanceChild,
             attendance: attendanceChild.attendance
               ? {
-                  ...attendanceChild.attendance,
                   arrived: new Date(attendanceChild.attendance.arrived),
                   departed: attendanceChild.attendance.departed
                     ? new Date(attendanceChild.attendance.departed)

--- a/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkDeparted.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkDeparted.tsx
@@ -18,7 +18,7 @@ import {
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import { combine } from 'lib-common/api'
 import { ContentArea } from 'lib-components/layout/Container'
-import { ChildAttendance } from 'lib-common/generated/api-types/attendance'
+import { AttendanceTimes } from 'lib-common/generated/api-types/attendance'
 import { TallContentArea } from '../../mobile/components'
 import { ChildAttendanceContext } from '../../../state/child-attendance'
 import {
@@ -45,7 +45,7 @@ import { renderResult } from '../../async-rendering'
 function validateTime(
   i18n: Translations,
   time: string,
-  attendance: ChildAttendance | null | undefined
+  attendance: AttendanceTimes | null | undefined
 ): string | undefined {
   if (!attendance) return undefined
 

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -66,11 +66,19 @@ export type AttendanceStatus =
   | 'ABSENT'
 
 /**
+* Generated from fi.espoo.evaka.attendance.AttendanceTimes
+*/
+export interface AttendanceTimes {
+  arrived: Date
+  departed: Date | null
+}
+
+/**
 * Generated from fi.espoo.evaka.attendance.Child
 */
 export interface Child {
   absences: ChildAbsence[]
-  attendance: ChildAttendance | null
+  attendance: AttendanceTimes | null
   backup: boolean
   dailyNote: ChildDailyNote | null
   dailyServiceTimes: DailyServiceTimes | null
@@ -92,19 +100,6 @@ export interface Child {
 */
 export interface ChildAbsence {
   careType: AbsenceCareType
-  childId: UUID
-  id: UUID
-}
-
-/**
-* Generated from fi.espoo.evaka.attendance.ChildAttendance
-*/
-export interface ChildAttendance {
-  arrived: Date
-  childId: UUID
-  departed: Date | null
-  id: UUID
-  unitId: UUID
 }
 
 /**

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
@@ -157,7 +157,6 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
         assertNotNull(child.attendance)
         assertEquals(arrived, child.attendance!!.arrived)
         assertNull(child.attendance!!.departed)
-        assertEquals(testDaycare.id, child.attendance!!.unitId)
         assertEquals(0, child.absences.size)
     }
 
@@ -178,7 +177,6 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
         assertNotNull(child.attendance)
         assertEquals(arrived, child.attendance!!.arrived)
         assertEquals(departed, child.attendance!!.departed)
-        assertEquals(testDaycare.id, child.attendance!!.unitId)
         assertEquals(0, child.absences.size)
     }
 
@@ -260,7 +258,6 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
         assertNotNull(child.attendance)
         assertEquals(arrived, child.attendance!!.arrived)
         assertNull(child.attendance!!.departed)
-        assertEquals(testDaycare.id, child.attendance!!.unitId)
         assertEquals(0, child.absences.size)
     }
 
@@ -281,7 +278,6 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
         assertNotNull(child.attendance)
         assertEquals(arrived, child.attendance!!.arrived)
         assertEquals(departed, child.attendance!!.departed)
-        assertEquals(testDaycare.id, child.attendance!!.unitId)
         assertEquals(0, child.absences.size)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.note.child.daily.ChildDailyNote
 import fi.espoo.evaka.note.child.sticky.ChildStickyNote
 import fi.espoo.evaka.note.group.GroupNote
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.shared.AbsenceId
 import fi.espoo.evaka.shared.AttendanceId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
@@ -41,7 +40,7 @@ data class Child(
     val groupId: GroupId,
     val backup: Boolean,
     val status: AttendanceStatus,
-    val attendance: ChildAttendance?,
+    val attendance: AttendanceTimes?,
     val absences: List<ChildAbsence>,
     val dailyServiceTimes: DailyServiceTimes?,
     val dailyNote: ChildDailyNote?,
@@ -65,9 +64,12 @@ data class ChildAttendance(
     val departed: HelsinkiDateTime?
 )
 
+data class AttendanceTimes(
+    val arrived: HelsinkiDateTime,
+    val departed: HelsinkiDateTime?
+)
+
 data class ChildAbsence(
-    val id: AbsenceId,
-    val childId: UUID,
     val careType: AbsenceCareType
 )
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The now deleted `fetchChildrenAttendances` was very inefficient because it couldn't utilize indexes properly and fetching the data inside the `fetchChildrenBasics` query has an unnoticeable performance impact (checked in prod with `EXPLAIN ANALYZE`).

