### PR TITLE
Employee mobile save selected group

### DIFF
--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -5,12 +5,13 @@
 import { ErrorBoundary } from '@sentry/react'
 import ErrorPage from 'lib-components/molecules/ErrorPage'
 import { theme } from 'lib-customizations/common'
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
   BrowserRouter as Router,
   Redirect,
   Route,
   Switch,
+  useHistory,
   useParams,
   useRouteMatch
 } from 'react-router-dom'
@@ -98,6 +99,7 @@ function UnitRouter() {
 
 function GroupRouter() {
   const { path } = useRouteMatch()
+  useGroupIdInLocalStorage()
 
   return (
     <Switch>
@@ -225,4 +227,31 @@ function MessagesRouter() {
       </Switch>
     </MessageContextProvider>
   )
+}
+
+const groupIdKey = 'evakaEmployeeMobileGroupId'
+
+function useGroupIdInLocalStorage() {
+  const history = useHistory()
+  const { unitId, groupId } = useParams<{ unitId: string; groupId: string }>()
+
+  useEffect(() => {
+    try {
+      const storedGroupId = window.localStorage?.getItem(groupIdKey)
+
+      if (groupId === 'all' && storedGroupId && groupId !== storedGroupId) {
+        history.replace(`/units/${unitId}/groups/${storedGroupId}`)
+      }
+    } catch (e) {
+      // do nothing
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    try {
+      window.localStorage?.setItem(groupIdKey, groupId)
+    } catch (e) {
+      // do nothing
+    }
+  }, [groupId])
 }

--- a/frontend/src/employee-mobile-frontend/state/user.tsx
+++ b/frontend/src/employee-mobile-frontend/state/user.tsx
@@ -9,6 +9,7 @@ import { useApiState } from 'lib-common/utils/useRestApi'
 import React, { createContext, useEffect, useMemo } from 'react'
 import { getAuthStatus } from '../api/auth'
 import { client } from '../api/client'
+import { renderResult } from '../components/async-rendering'
 
 export interface UserState {
   apiVersion: string | undefined
@@ -45,5 +46,11 @@ export const UserContextProvider = React.memo(function UserContextProvider({
     }),
     [authStatus, refreshAuthStatus]
   )
-  return <UserContext.Provider value={value}>{children}</UserContext.Provider>
+  return (
+    <UserContext.Provider value={value}>
+      {renderResult(authStatus, () => (
+        <>{children}</>
+      ))}
+    </UserContext.Provider>
+  )
 })


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
* Wait that auth status request completes before rendering components that use it. Fixes a bug where users were always redirected to employee mobile's default page no matter the initial url.
* Store employee mobile selected group in local storage.