### PR TITLE
Make citizen reservation threshold configurable

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -32,7 +32,7 @@ import fi.espoo.evaka.placement.getPlacementsForChild
 import fi.espoo.evaka.preschoolTerm2020
 import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
 import fi.espoo.evaka.shared.ApplicationId
-import fi.espoo.evaka.shared.FeatureFlags
+import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -81,7 +81,7 @@ import kotlin.test.assertTrue
 class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @MockBean
-    private lateinit var featureFlags: FeatureFlags
+    private lateinit var featureConfig: FeatureConfig
 
     @Autowired
     private lateinit var service: ApplicationStateService
@@ -118,7 +118,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `initialize daycare application form with null service need option`() {
-        whenever(featureFlags.daycareApplicationServiceNeedOptionsEnabled).thenReturn(false)
+        whenever(featureConfig.daycareApplicationServiceNeedOptionsEnabled).thenReturn(false)
         db.transaction { tx ->
             // given
             tx.insertApplication(
@@ -148,7 +148,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
     @Test
     fun `initialize daycare application form with service need option`() {
-        whenever(featureFlags.daycareApplicationServiceNeedOptionsEnabled).thenReturn(true)
+        whenever(featureConfig.daycareApplicationServiceNeedOptionsEnabled).thenReturn(true)
         db.transaction { tx ->
             // given
             tx.insertApplication(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservableDaysCalculationUnitTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservableDaysCalculationUnitTest.kt
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.reservations
+
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+class ReservableDaysCalculationUnitTest {
+    private val thresholdMondayAt1800 = 150L
+
+    private val end2021 = LocalDate.of(2021, 7, 31)
+    private val end2022 = LocalDate.of(2022, 7, 31)
+
+    @Test
+    fun `reservable days query date is Monday`() {
+        assertEquals(
+            FiniteDateRange(LocalDate.of(2021, 6, 14), end2021),
+            getReservableDays(HelsinkiDateTime.of(LocalDateTime.of(2021, 6, 7, 12, 0)), thresholdMondayAt1800)
+        )
+    }
+
+    @Test
+    fun `reservable days query date is Tuesday`() {
+        assertEquals(
+            FiniteDateRange(LocalDate.of(2021, 6, 21), end2021),
+            getReservableDays(HelsinkiDateTime.of(LocalDateTime.of(2021, 6, 8, 12, 0)), thresholdMondayAt1800)
+        )
+    }
+
+    @Test
+    fun `reservable days includes next year when start is in July`() {
+        assertEquals(
+            FiniteDateRange(LocalDate.of(2021, 7, 5), end2022),
+            getReservableDays(HelsinkiDateTime.of(LocalDateTime.of(2021, 6, 28, 12, 0)), thresholdMondayAt1800)
+        )
+    }
+
+    @Test
+    fun `reservable days query date is in September`() {
+        assertEquals(
+            FiniteDateRange(LocalDate.of(2021, 9, 13), end2022),
+            getReservableDays(HelsinkiDateTime.of(LocalDateTime.of(2021, 9, 1, 12, 0)), thresholdMondayAt1800)
+        )
+    }
+
+    private val justBeforeThreshold = HelsinkiDateTime.of(LocalDateTime.of(2021, 9, 13, 17, 59))
+    private val mondayNextWeekAfterThreshold = LocalDate.of(2021, 9, 20)
+    @Test
+    fun `reservable days query date is just before threshold`() {
+        assertEquals(
+            FiniteDateRange(mondayNextWeekAfterThreshold, end2022),
+            getReservableDays(justBeforeThreshold, thresholdMondayAt1800)
+        )
+    }
+
+    @Test
+    fun `reservable days query date is just at threshold`() {
+        val justAtThreshold = justBeforeThreshold.plusMinutes(1)
+        assertEquals(
+            FiniteDateRange(mondayNextWeekAfterThreshold.plusWeeks(1), end2022),
+            getReservableDays(justAtThreshold, thresholdMondayAt1800)
+        )
+    }
+}

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenQueriesTest.kt
@@ -295,40 +295,4 @@ class ReservationCitizenQueriesTest : PureJdbiTest() {
         assertEquals(monday.plusDays(1), reservations[1].first)
         assertEquals("09:00", reservations[1].second[0].startTime)
     }
-
-    @Test
-    fun `reservable days query date is Monday`() {
-        val result = getReservableDays(LocalDate.of(2021, 6, 7))
-        assertEquals(
-            FiniteDateRange(LocalDate.of(2021, 6, 14), LocalDate.of(2021, 7, 31)),
-            result
-        )
-    }
-
-    @Test
-    fun `reservable days query date is Tuesday`() {
-        val result = getReservableDays(LocalDate.of(2021, 6, 8))
-        assertEquals(
-            FiniteDateRange(LocalDate.of(2021, 6, 21), LocalDate.of(2021, 7, 31)),
-            result
-        )
-    }
-
-    @Test
-    fun `reservable days includes next year when start is in July`() {
-        val result = getReservableDays(LocalDate.of(2021, 6, 28))
-        assertEquals(
-            FiniteDateRange(LocalDate.of(2021, 7, 5), LocalDate.of(2022, 7, 31)),
-            result
-        )
-    }
-
-    @Test
-    fun `reservable days query date is in September`() {
-        val result = getReservableDays(LocalDate.of(2021, 9, 1))
-        assertEquals(
-            FiniteDateRange(LocalDate.of(2021, 9, 13), LocalDate.of(2022, 7, 31)),
-            result
-        )
-    }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -14,7 +14,7 @@ import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
 import fi.espoo.evaka.invoicing.service.EspooIncomeTypesProvider
 import fi.espoo.evaka.invoicing.service.IncomeTypesProvider
-import fi.espoo.evaka.shared.FeatureFlags
+import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
 import fi.espoo.evaka.shared.dev.resetDatabase
@@ -167,8 +167,9 @@ class SharedIntegrationTestConfig {
     fun incomeTypesProvider(): IncomeTypesProvider = EspooIncomeTypesProvider()
 
     @Bean
-    fun featureFlags(): FeatureFlags = FeatureFlags(
+    fun featureConfig(): FeatureConfig = FeatureConfig(
         valueDecisionCapacityFactorEnabled = true,
-        daycareApplicationServiceNeedOptionsEnabled = false
+        daycareApplicationServiceNeedOptionsEnabled = false,
+        citizenReservationThresholdHours = 150,
     )
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -10,7 +10,7 @@ import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
 import fi.espoo.evaka.invoicing.service.EspooIncomeTypesProvider
 import fi.espoo.evaka.invoicing.service.IncomeTypesProvider
-import fi.espoo.evaka.shared.FeatureFlags
+import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.db.DevDataInitializer
 import fi.espoo.evaka.shared.job.DefaultJobSchedule
 import fi.espoo.evaka.shared.job.JobSchedule
@@ -65,9 +65,10 @@ class EspooConfig {
     fun incomeTypesProvider(): IncomeTypesProvider = EspooIncomeTypesProvider()
 
     @Bean
-    fun featureFlags(): FeatureFlags = FeatureFlags(
+    fun featureConfig(): FeatureConfig = FeatureConfig(
         valueDecisionCapacityFactorEnabled = false,
-        daycareApplicationServiceNeedOptionsEnabled = false
+        daycareApplicationServiceNeedOptionsEnabled = false,
+        citizenReservationThresholdHours = 150,
     )
 
     @Bean

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -62,7 +62,7 @@ import fi.espoo.evaka.serviceneed.getServiceNeedOptionPublicInfos
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
-import fi.espoo.evaka.shared.FeatureFlags
+import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -97,7 +97,7 @@ class ApplicationStateService(
     private val mapper: ObjectMapper,
     private val documentClient: DocumentService,
     private val incomeTypesProvider: IncomeTypesProvider,
-    private val featureFlags: FeatureFlags,
+    private val featureConfig: FeatureConfig,
     env: BucketEnv
 ) {
     private val filesBucket = env.attachments
@@ -169,7 +169,7 @@ class ApplicationStateService(
         form: ApplicationForm
     ): ApplicationForm {
         var defaultServiceNeedOption: ServiceNeedOptionPublicInfo? = null
-        if (ApplicationType.DAYCARE == type && featureFlags.daycareApplicationServiceNeedOptionsEnabled) {
+        if (ApplicationType.DAYCARE == type && featureConfig.daycareApplicationServiceNeedOptionsEnabled) {
             defaultServiceNeedOption = tx.getServiceNeedOptionPublicInfos(listOf(PlacementType.DAYCARE)).firstOrNull()
         }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -18,7 +18,7 @@ import fi.espoo.evaka.pis.getPartnersForPerson
 import fi.espoo.evaka.pis.service.Parentship
 import fi.espoo.evaka.pis.service.Partner
 import fi.espoo.evaka.pis.service.getChildGuardians
-import fi.espoo.evaka.shared.FeatureFlags
+import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.asDistinctPeriods
@@ -40,10 +40,10 @@ class FinanceDecisionGenerator(
     private val objectMapper: ObjectMapper,
     private val incomeTypesProvider: IncomeTypesProvider,
     env: EvakaEnv,
-    featureFlags: FeatureFlags
+    featureConfig: FeatureConfig
 ) {
     private val feeDecisionMinDate = env.feeDecisionMinDate
-    private val valueDecisionCapacityFactorEnabled = featureFlags.valueDecisionCapacityFactorEnabled
+    private val valueDecisionCapacityFactorEnabled = featureConfig.valueDecisionCapacityFactorEnabled
 
     fun createRetroactiveFeeDecisions(tx: Database.Transaction, headOfFamily: UUID, from: LocalDate) {
         val families = tx.findFamiliesByHeadOfFamily(headOfFamily, from)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.DaycareId
-import fi.espoo.evaka.shared.FeatureFlags
+import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -35,7 +35,7 @@ import java.util.UUID
 class ServiceVoucherValueReportController(
     private val acl: AccessControlList,
     private val accessControl: AccessControl,
-    private val featureFlags: FeatureFlags
+    private val featureConfig: FeatureConfig
 ) {
 
     data class ServiceVoucherReport(
@@ -107,7 +107,7 @@ class ServiceVoucherValueReportController(
                 locked = snapshotTime,
                 rows = rows,
                 voucherTotal = rows.sumOf { it.realizedAmount },
-                assistanceNeedCapacityFactorEnabled = featureFlags.valueDecisionCapacityFactorEnabled,
+                assistanceNeedCapacityFactorEnabled = featureConfig.valueDecisionCapacityFactorEnabled,
             )
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -4,7 +4,8 @@
 
 package fi.espoo.evaka.shared
 
-data class FeatureFlags(
+data class FeatureConfig(
     val valueDecisionCapacityFactorEnabled: Boolean,
-    val daycareApplicationServiceNeedOptionsEnabled: Boolean
+    val daycareApplicationServiceNeedOptionsEnabled: Boolean,
+    val citizenReservationThresholdHours: Long
 )


### PR DESCRIPTION
#### Summary

Cities have different thresholds, so make the threshold configurable.
Set threshold to 150 hours in Espoo which translates to Monday at 18:00 week before.

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

