### PR TITLE
EVAKA-4256 remove personal accounts from mobile messaging

### DIFF
--- a/frontend/src/e2e-playwright/pages/mobile/messages.ts
+++ b/frontend/src/e2e-playwright/pages/mobile/messages.ts
@@ -11,6 +11,12 @@ export default class MobileMessagesPage {
     return (await this.page.findAll('[data-qa^="message-preview"]').count()) > 0
   }
 
+  async messagesDontExist() {
+    const els = this.page.findAll('[data-qa^="message-preview"]')
+
+    return (await els.count()) === 0
+  }
+
   async openThread() {
     await this.page.find(`[data-qa^="message-preview"]`).click()
   }

--- a/frontend/src/e2e-playwright/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/messages.spec.ts
@@ -171,7 +171,7 @@ describe('Message editor in child page', () => {
 describe('Child message thread', () => {
   beforeEach(async () => await initCitizenPage())
 
-  test('Employee can reply to thread', async () => {
+  test('Employee does not see messages to personal account', async () => {
     const title = 'Otsikko'
     const content = 'Testiviestin sisältö'
     const receivers = [`${empLastName} ${empFirstName}`]
@@ -182,15 +182,8 @@ describe('Child message thread', () => {
 
     await listPage.gotoMessages()
     await pinLoginPage.login(employeeName, pin)
-    await messagesPage.messagesExist()
-    await messagesPage.openThread()
-    await waitUntilEqual(() => threadView.countMessages(), 1)
-    await waitUntilEqual(() => threadView.getMessageContent(0), content)
 
-    const replyContent = 'Testivastauksen sisältö'
-    await threadView.replyThread(replyContent)
-    await waitUntilEqual(() => threadView.countMessages(), 2)
-    await waitUntilEqual(() => threadView.getMessageContent(1), replyContent)
+    await messagesPage.messagesDontExist()
   })
 
   test("Staff sees citizen's message for group", async () => {

--- a/frontend/src/employee-mobile-frontend/components/common/BottomNavbar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/BottomNavbar.tsx
@@ -135,7 +135,9 @@ export default function BottomNavbar({ selected }: BottomNavbarProps) {
               selected={selected === 'messages'}
               onClick={() =>
                 selected !== 'messages' &&
-                history.push(`/units/${unitId}/groups/${groupId}/messages`)
+                history.push(
+                  `/units/${unitId}/groups/${unit.groups[0].id}/messages`
+                )
               }
             >
               <CustomIcon

--- a/frontend/src/employee-mobile-frontend/components/common/GroupSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/GroupSelector.tsx
@@ -19,6 +19,7 @@ interface GroupSelectorProps {
   onChangeGroup: (group: GroupInfo | undefined) => void
   countInfo?: CountInfo
   groups?: GroupInfo[]
+  includeSelectAll: boolean
 }
 
 export interface CountInfo {
@@ -31,7 +32,8 @@ export default function GroupSelector({
   selectedGroup,
   onChangeGroup,
   countInfo,
-  groups
+  groups,
+  includeSelectAll
 }: GroupSelectorProps) {
   const { i18n } = useTranslation()
 
@@ -41,18 +43,20 @@ export default function GroupSelector({
     <Wrapper>
       <ChipWrapper>
         <>
-          <ChoiceChip
-            text={`${i18n.common.all}${
-              countInfo
-                ? `(${countInfo.getPresentCount(
-                    undefined
-                  )}/${countInfo.getTotalCount(undefined)})`
-                : ''
-            }`}
-            selected={!selectedGroup}
-            onChange={() => onChangeGroup(undefined)}
-            data-qa="group--all"
-          />
+          {includeSelectAll && (
+            <ChoiceChip
+              text={`${i18n.common.all}${
+                countInfo
+                  ? `(${countInfo.getPresentCount(
+                      undefined
+                    )}/${countInfo.getTotalCount(undefined)})`
+                  : ''
+              }`}
+              selected={!selectedGroup}
+              onChange={() => onChangeGroup(undefined)}
+              data-qa="group--all"
+            />
+          )}
           <Gap horizontal size={'xxs'} />
           {(groups || unitInfo.groups).map((group) => (
             <Fragment key={group.id}>

--- a/frontend/src/employee-mobile-frontend/components/common/GroupSelectorBar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/GroupSelectorBar.tsx
@@ -55,6 +55,7 @@ export interface Props {
   onSearch?: () => void
   countInfo?: CountInfo
   groups?: GroupInfo[]
+  includeSelectAll: boolean
 }
 
 export const GroupSelectorBar = React.memo(function GroupSelectorBar({
@@ -62,7 +63,8 @@ export const GroupSelectorBar = React.memo(function GroupSelectorBar({
   onChangeGroup,
   onSearch,
   countInfo,
-  groups
+  groups,
+  includeSelectAll
 }: Props) {
   const { i18n } = useTranslation()
   const [showGroupSelector, setShowGroupSelector] = useState<boolean>(false)
@@ -104,6 +106,7 @@ export const GroupSelectorBar = React.memo(function GroupSelectorBar({
           }}
           countInfo={countInfo}
           groups={groups}
+          includeSelectAll={includeSelectAll}
           data-qa="group-selector"
         />
       </GroupSelectorWrapper>

--- a/frontend/src/employee-mobile-frontend/components/common/GroupSelectorBar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/GroupSelectorBar.tsx
@@ -70,6 +70,7 @@ export const GroupSelectorBar = React.memo(function GroupSelectorBar({
     x: showGroupSelector ? 1 : 0,
     config: { duration: 100 }
   })
+  const hasMultipleGroups = groups && groups.length > 1
   return (
     <GroupContainer data-qa={`selected-group--${selectedGroup?.id ?? 'all'}`}>
       <GroupSelectorWrapper
@@ -83,7 +84,13 @@ export const GroupSelectorBar = React.memo(function GroupSelectorBar({
             onClick={() => {
               setShowGroupSelector(!showGroupSelector)
             }}
-            icon={showGroupSelector ? faAngleUp : faAngleDown}
+            icon={
+              hasMultipleGroups
+                ? showGroupSelector
+                  ? faAngleUp
+                  : faAngleDown
+                : undefined
+            }
             iconRight
             data-qa="group-selector-button"
           />

--- a/frontend/src/employee-mobile-frontend/components/common/TopBarWithGroupSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/TopBarWithGroupSelector.tsx
@@ -12,6 +12,7 @@ import { UnitContext } from '../../state/unit'
 import { CountInfo } from './GroupSelector'
 import { GroupSelectorBar } from './GroupSelectorBar'
 import TopBar from './TopBar'
+import { UUID } from 'lib-common/types'
 
 interface Props {
   selectedGroup: GroupInfo | undefined
@@ -19,6 +20,7 @@ interface Props {
   includeSelectAll?: boolean
   toggleSearch?: () => void
   countInfo?: CountInfo | undefined
+  allowedGroupIds?: UUID[] | undefined
 }
 
 export default React.memo(function TopBarWithGroupSelector({
@@ -26,7 +28,8 @@ export default React.memo(function TopBarWithGroupSelector({
   toggleSearch,
   selectedGroup,
   countInfo,
-  includeSelectAll = true
+  includeSelectAll = true,
+  allowedGroupIds = undefined
 }: Props) {
   const history = useHistory()
   const { user } = useContext(UserContext)
@@ -46,8 +49,16 @@ export default React.memo(function TopBarWithGroupSelector({
   }, [history, user, unitInfoResponse])
 
   const groups: GroupInfo[] = useMemo(
-    () => unitInfoResponse.map(({ groups }) => groups).getOrElse([]),
-    [unitInfoResponse]
+    () =>
+      unitInfoResponse
+        .map(({ groups }) => groups)
+        .getOrElse([])
+        .filter(
+          (g) =>
+            allowedGroupIds === undefined ||
+            allowedGroupIds.findIndex((gid) => gid === g.id) > -1
+        ),
+    [unitInfoResponse, allowedGroupIds]
   )
 
   return (

--- a/frontend/src/employee-mobile-frontend/components/common/TopBarWithGroupSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/TopBarWithGroupSelector.tsx
@@ -16,6 +16,7 @@ import TopBar from './TopBar'
 interface Props {
   selectedGroup: GroupInfo | undefined
   onChangeGroup: (group: GroupInfo | undefined) => void
+  includeSelectAll?: boolean
   toggleSearch?: () => void
   countInfo?: CountInfo | undefined
 }
@@ -24,7 +25,8 @@ export default React.memo(function TopBarWithGroupSelector({
   onChangeGroup,
   toggleSearch,
   selectedGroup,
-  countInfo
+  countInfo,
+  includeSelectAll = true
 }: Props) {
   const history = useHistory()
   const { user } = useContext(UserContext)
@@ -58,6 +60,7 @@ export default React.memo(function TopBarWithGroupSelector({
         onSearch={toggleSearch}
         countInfo={countInfo}
         groups={groups}
+        includeSelectAll={includeSelectAll}
       />
     </>
   )

--- a/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
@@ -38,20 +38,25 @@ export default function MessageEditorPage() {
     groupId: UUID
     childId: UUID
   }>()
-  const { nestedAccounts, selectedAccount, selectedUnit, loadNestedAccounts, groupAccounts, setSelectedAccount } =
-    useContext(MessageContext)
+  const {
+    nestedAccounts,
+    selectedAccount,
+    selectedUnit,
+    loadNestedAccounts,
+    groupAccounts,
+    setSelectedAccount
+  } = useContext(MessageContext)
 
   useEffect(() => loadNestedAccounts(unitId), [loadNestedAccounts, unitId])
 
   useEffect(() => {
     const maybeAccount = groupAccounts.find(
-      ({ daycareGroup }) =>
-        daycareGroup?.id === groupId
+      ({ daycareGroup }) => daycareGroup?.id === groupId
     )?.account
     if (maybeAccount) {
       setSelectedAccount(maybeAccount)
     }
-  }, [groupAccounts, setSelectedAccount])
+  }, [groupAccounts, setSelectedAccount, groupId])
 
   const [sending, setSending] = useState(false)
 

--- a/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
@@ -33,20 +33,25 @@ import { Result } from 'lib-common/api'
 
 export default function MessageEditorPage() {
   const { i18n } = useTranslation()
-  const { childId, unitId } = useParams<{
+  const { childId, groupId, unitId } = useParams<{
     unitId: UUID
-    groupId: UUID | 'all'
+    groupId: UUID
     childId: UUID
   }>()
-  const {
-    nestedAccounts,
-    selectedSender,
-    selectedUnit,
-    loadMessagesForSelectedAccount,
-    loadNestedAccounts
-  } = useContext(MessageContext)
+  const { nestedAccounts, selectedAccount, selectedUnit, loadNestedAccounts, groupAccounts, setSelectedAccount } =
+    useContext(MessageContext)
 
   useEffect(() => loadNestedAccounts(unitId), [loadNestedAccounts, unitId])
+
+  useEffect(() => {
+    const maybeAccount = groupAccounts.find(
+      ({ daycareGroup }) =>
+        daycareGroup?.id === groupId
+    )?.account
+    if (maybeAccount) {
+      setSelectedAccount(maybeAccount)
+    }
+  }, [groupAccounts, setSelectedAccount])
 
   const [sending, setSending] = useState(false)
 
@@ -73,7 +78,6 @@ export default function MessageEditorPage() {
       setSending(true)
       void postMessage(accountId, messageBody).then((res) => {
         if (res.isSuccess) {
-          loadMessagesForSelectedAccount()
           history.back()
         } else {
           // TODO handle eg. expired pin session correctly
@@ -82,33 +86,22 @@ export default function MessageEditorPage() {
         setSending(false)
       })
     },
-    [loadMessagesForSelectedAccount]
+    []
   )
 
-  const onDiscard = useCallback(
-    (accountId: UUID, draftId: UUID) => {
-      void deleteDraft(accountId, draftId)
-        .then(() => loadMessagesForSelectedAccount())
-        .then(() => history.back())
-    },
-    [loadMessagesForSelectedAccount]
-  )
+  const onDiscard = useCallback((accountId: UUID, draftId: UUID) => {
+    void deleteDraft(accountId, draftId).then(() => history.back())
+  }, [])
 
-  const onHide = useCallback(
-    (didChanges: boolean) => {
-      if (didChanges) {
-        loadMessagesForSelectedAccount()
-      }
-      history.back()
-    },
-    [loadMessagesForSelectedAccount]
-  )
+  const onHide = useCallback(() => {
+    history.back()
+  }, [])
 
   return (
     <>
       {nestedAccounts.isSuccess &&
         selectedReceivers &&
-        selectedSender &&
+        selectedAccount &&
         selectedUnit && (
           <MessageEditor
             availableReceivers={selectedReceivers}
@@ -116,8 +109,8 @@ export default function MessageEditorPage() {
               featureFlags.experimental?.messageAttachments ?? false
             }
             defaultSender={{
-              value: selectedSender.id,
-              label: selectedSender.name
+              value: selectedAccount.id,
+              label: selectedAccount.name
             }}
             deleteAttachment={deleteAttachment}
             draftContent={undefined}

--- a/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
@@ -23,7 +23,7 @@ import { defaultMargins } from 'lib-components/white-space'
 
 export default function MessagesPage() {
   const history = useHistory()
-  const { unitId, groupId: groupIdOrAll } = useParams<{
+  const { unitId, groupId } = useParams<{
     unitId: UUID
     groupId: UUID | 'all'
   }>()
@@ -31,15 +31,14 @@ export default function MessagesPage() {
   const { unitInfoResponse } = useContext(UnitContext)
 
   function changeGroup(group: GroupInfo | undefined) {
-    const groupId = group === undefined ? 'all' : group.id
-    history.push(`/units/${unitId}/groups/${groupId}/messages`)
+    if (group) history.push(`/units/${unitId}/groups/${group.id}/messages`)
   }
 
   const selectedGroup =
-    groupIdOrAll === 'all'
+    groupId === 'all'
       ? undefined
       : unitInfoResponse
-          .map((res) => res.groups.find((g) => g.id === groupIdOrAll))
+          .map((res) => res.groups.find((g) => g.id === groupId))
           .getOrElse(undefined)
 
   const {

--- a/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
@@ -43,33 +43,42 @@ export default function MessagesPage() {
 
   const {
     loadNestedAccounts,
+    setSelectedAccount,
     groupAccounts,
-    selectedSender,
-    loadMessagesWhenGroupChanges,
     receivedMessages,
-    personalAccount,
     selectedThread,
-    selectThread
+    selectThread,
+    selectedAccount
   } = useContext(MessageContext)
 
   useEffect(() => loadNestedAccounts(unitId), [loadNestedAccounts, unitId])
 
   useEffect(() => {
-    loadMessagesWhenGroupChanges(selectedGroup)
-  }, [selectedGroup, loadMessagesWhenGroupChanges])
+    const maybeAccount = groupAccounts.find(
+      ({ daycareGroup }) =>
+        daycareGroup?.id === groupId
+    )?.account
+    if (maybeAccount) {
+      setSelectedAccount(maybeAccount)
+    }
+  }, [groupAccounts, setSelectedAccount])
 
   const { i18n } = useTranslation()
 
   const onBack = useCallback(() => selectThread(undefined), [selectThread])
 
-  return selectedThread && selectedSender ? (
+  return selectedThread && selectedAccount ? (
     <ContentArea
       opaque
       fullHeight
       paddingHorizontal={'zero'}
       paddingVertical={'zero'}
     >
-      <ThreadView thread={selectedThread} onBack={onBack} />
+      <ThreadView
+        thread={selectedThread}
+        onBack={onBack}
+        senderAccountId={selectedAccount.id}
+      />
     </ContentArea>
   ) : (
     <>
@@ -89,7 +98,7 @@ export default function MessagesPage() {
                 hasUnreadMessages={thread.messages.some(
                   (item) =>
                     !item.readAt &&
-                    item.sender.id !== personalAccount?.id &&
+                    item.sender.id !== selectedAccount?.id &&
                     !groupAccounts.some(
                       (ga) => ga.account.id === item.sender.id
                     )

--- a/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
@@ -55,13 +55,12 @@ export default function MessagesPage() {
 
   useEffect(() => {
     const maybeAccount = groupAccounts.find(
-      ({ daycareGroup }) =>
-        daycareGroup?.id === groupId
+      ({ daycareGroup }) => daycareGroup?.id === groupId
     )?.account
     if (maybeAccount) {
       setSelectedAccount(maybeAccount)
     }
-  }, [groupAccounts, setSelectedAccount])
+  }, [groupAccounts, setSelectedAccount, groupId])
 
   const { i18n } = useTranslation()
 
@@ -85,6 +84,10 @@ export default function MessagesPage() {
       <TopBarWithGroupSelector
         selectedGroup={selectedGroup}
         onChangeGroup={changeGroup}
+        allowedGroupIds={groupAccounts.flatMap(
+          (ga) => ga.daycareGroup?.id || []
+        )}
+        includeSelectAll={false}
       />
       {renderResult(receivedMessages, (messages) => (
         <ContentArea opaque paddingVertical={'zero'} paddingHorizontal={'zero'}>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
In mobile messaging,
- Don't use personal accounts
- Don't show "All" in group selection
- Remove the caret from group selection if there is only one group