### PR TITLE
Fix misleading 500 internal server errors in e2e tests

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -43,6 +43,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecision
 import fi.espoo.evaka.invoicing.domain.FeeThresholds
 import fi.espoo.evaka.invoicing.domain.Invoice
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
+import fi.espoo.evaka.messaging.createPersonMessageAccount
 import fi.espoo.evaka.note.child.daily.ChildDailyNoteBody
 import fi.espoo.evaka.note.child.daily.createChildDailyNote
 import fi.espoo.evaka.note.child.sticky.ChildStickyNoteBody
@@ -393,6 +394,7 @@ class DevApi(
     fun createPerson(db: Database.Connection, @RequestBody body: DevPerson): ResponseEntity<UUID> {
         return db.transaction { tx ->
             val personId = tx.insertTestPerson(body)
+            tx.createPersonMessageAccount(personId)
             val dto = body.copy(id = personId).toPersonDTO()
             if (dto.identity is ExternalIdentifier.SSN) {
                 tx.updatePersonFromVtj(dto)


### PR DESCRIPTION
#### Summary

Many e2e tests logged a 500 internal server error to console because of a missing message account.
