### PR TITLE
Use esbuild for bundling in development

### DIFF
--- a/frontend/build.js
+++ b/frontend/build.js
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// TODO Fix before going to prod:
+// - Use browserslist to determine the esbuild target
+// - Upload a release to sentry
+//
+// Nice to have:
+// - Use babel-plugin-styled-components
+
+const fs = require('fs/promises')
+const path = require('path')
+const esbuild = require('esbuild')
+const alias = require('esbuild-plugin-alias')
+const express = require('express')
+const proxy = require('express-http-proxy')
+const yargs = require('yargs')
+const _ = require('lodash')
+
+function resolveCustomizations() {
+  const customizations = process.env.EVAKA_CUSTOMIZATIONS || 'espoo'
+  const customizationsPath = path.resolve(
+    __dirname,
+    'src/lib-customizations',
+    customizations
+  )
+  console.info(`Using customizations from ${customizationsPath}`)
+  return customizationsPath
+}
+
+function resolveIcons() {
+  switch (process.env.ICONS) {
+    case 'pro':
+      console.info('Using pro icons (forced)')
+      return 'pro'
+    case 'free':
+      console.info('Using free icons (forced)')
+      return 'free'
+    case undefined:
+      break
+    default:
+      throw new Error(`Invalid environment variable ICONS=${process.env.ICONS}`)
+  }
+  try {
+    require('@fortawesome/pro-light-svg-icons')
+    require('@fortawesome/pro-regular-svg-icons')
+    require('@fortawesome/pro-solid-svg-icons')
+    console.info('Using pro icons (auto-detected)')
+    return 'pro'
+  } catch (e) {
+    console.info('Using free icons (fallback)')
+    return 'free'
+  }
+}
+
+function resolveSrcdir(project) {
+  return `src/${project.name}`
+}
+
+function resolveOutdir(project) {
+  return `dist/esbuild/${project.name}`
+}
+
+function findOutputFile(obj, outdir, name, suffix) {
+  const re = new RegExp(`^${outdir}/(${name}-.*\\.${suffix}$)`)
+  for (const key of Object.keys(obj)) {
+    const match = key.match(re)
+    if (match) {
+      return match[1]
+    }
+  }
+  return undefined
+}
+
+function script(publicPath, fileName) {
+  return `<script defer src="${publicPath}${fileName}"></script>`
+}
+
+function stylesheet(publicPath, fileName) {
+  return `<link rel="stylesheet" type="text/css" href="${publicPath}${fileName}">`
+}
+
+function favicon(publicPath) {
+  return `<link rel="shortcut icon" href="${publicPath}favicon.ico">`
+}
+
+async function buildProject(project, config) {
+  const { dev, watch, customizationsModule, icons } = config
+
+  const srcdir = resolveSrcdir(project)
+  const outdir = resolveOutdir(project)
+
+  const buildOutput = await esbuild.build({
+    entryPoints: [`${srcdir}/index.tsx`],
+    entryNames: '[name]-[hash]',
+    bundle: true,
+    sourcemap: dev,
+    minify: !dev,
+    resolveExtensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
+    loader: {
+      '.ico': 'file',
+      '.png': 'file',
+      '.svg': 'file',
+      '.woff': 'file',
+      '.woff2': 'file'
+    },
+    publicPath: project.publicPath,
+    define: {
+      'process.env.APP_COMMIT': `'${process.env.APP_COMMIT || 'UNDEFINED'}'`
+    },
+    plugins: [
+      alias({
+        Icons: path.resolve(__dirname, `src/lib-icons/${icons}-icons.ts`),
+        '@evaka/customizations/common': `${customizationsModule}/common.tsx`,
+        '@evaka/customizations/citizen': `${customizationsModule}/citizen.tsx`,
+        '@evaka/customizations/employee': `${customizationsModule}/employee.tsx`,
+        '@evaka/customizations/employeeMobile': `${customizationsModule}/employeeMobile.tsx`
+      })
+    ],
+    metafile: true,
+    logLevel: 'info',
+    color: dev,
+    outdir,
+    watch: watch
+      ? {
+          async onRebuild(error, result) {
+            if (error) return
+            await staticFiles(project, result.metafile.outputs)
+            console.log(`${project.name}: Build done`)
+          }
+        }
+      : undefined
+  })
+
+  const outputs = buildOutput.metafile.outputs
+  await staticFiles(project, outputs)
+}
+
+async function staticFiles(project, outputs) {
+  const { publicPath } = project
+  const srcdir = resolveSrcdir(project)
+  const outdir = resolveOutdir(project)
+
+  const indexJs = findOutputFile(outputs, outdir, 'index', 'js')
+  const indexCss = findOutputFile(outputs, outdir, 'index', 'css')
+  if (!indexJs || !indexCss) {
+    throw new Error(`No output file for index.js or index.css for ${name}`)
+  }
+
+  const indexHtml = _.template(
+    await fs.readFile(`${srcdir}/index-esbuild.html`)
+  )
+  await fs.writeFile(
+    `${outdir}/index.html`,
+    indexHtml({
+      assets: [
+        favicon(publicPath),
+        stylesheet(publicPath, indexCss),
+        script(publicPath, indexJs)
+      ].join('\n')
+    })
+  )
+}
+
+async function serve(projects) {
+  const app = express()
+  app.use(
+    '/api/internal',
+    proxy(process.env.API_PROXY_URL ?? 'http://localhost:3020', {
+      proxyReqPathResolver: ({ originalUrl }) => originalUrl,
+      limit: '100mb'
+    })
+  )
+  app.use(
+    '/api/application',
+    proxy(process.env.API_PROXY_URL ?? 'http://localhost:3010', {
+      proxyReqPathResolver: ({ originalUrl }) => originalUrl
+    })
+  )
+  for (const project of projects) {
+    const pathPrefix = _.trimEnd(project.publicPath, '/')
+    const outdir = resolveOutdir(project)
+    const middleware = express.static(outdir)
+
+    app.use(pathPrefix, middleware)
+    app.get(`${pathPrefix}/*`, (req, res, next) => {
+      req.url = `${pathPrefix}/index.html`
+      next()
+    })
+    app.use(pathPrefix, middleware)
+  }
+
+  const port = 9099
+  app.listen(port, () => {
+    console.info(`Server started at http://localhost:${port}`)
+  })
+}
+
+async function main() {
+  const args = yargs
+    .option('--dev', {
+      describe: 'Make a development build',
+      type: 'boolean',
+      default: false
+    })
+    .option('--watch', {
+      describe: 'Watch for file changes and rebuild',
+      type: 'boolean',
+      default: false
+    })
+    .option('--serve', {
+      describe: 'Serve the result at localhost:9099',
+      type: 'boolean',
+      default: false
+    }).argv
+
+  const projects = [
+    { name: 'employee-mobile-frontend', publicPath: '/employee/mobile/' },
+    { name: 'employee-frontend', publicPath: '/employee/' },
+    { name: 'citizen-frontend', publicPath: '/' }
+  ]
+  const config = {
+    dev: args.dev,
+    watch: args.watch,
+    customizationsModule: resolveCustomizations(),
+    icons: resolveIcons()
+  }
+
+  console.log(`Building for ${args.dev ? 'development' : 'production'}`)
+  for (const project of projects) {
+    await buildProject(project, config)
+  }
+
+  if (args.serve) {
+    serve(projects)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,12 +6,15 @@
   "license": "LGPL-2.1-or-later",
   "scripts": {
     "clean": "rm -rf dist screenshots videos node_modules/.cache",
-    "dev": "tsc -b . && node dev-server.js",
+    "dev": "concurrently -n tsc,esbuild -c blue,green 'yarn type-check:watch' 'yarn build:serve'",
+    "dev:old": "tsc -b . && node dev-server.js",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --max-warnings 0 .",
     "lint:fix": "yarn lint --fix",
     "type-check": "tsc -b .",
+    "type-check:watch": "yarn type-check --watch --preserveWatchOutput",
     "build": "webpack --mode production",
-    "build:dev": "webpack",
+    "build:dev": "node build.js --dev",
+    "build:serve": "node build.js --dev --watch --serve",
     "test": "jest src/*-frontend src/lib-*",
     "test:watch": "jest --watchAll src/*-frontend src/lib-*",
     "dev-maintenance-page": "cd src/maintenance-page-frontend && npx http-server",
@@ -94,9 +97,12 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "babel-loader": "^8.2.3",
+    "concurrently": "^6.4.0",
     "css-loader": "^6.5.1",
     "csstype": "^3.0.9",
     "e2e-playwright": "link:src/e2e-playwright",
+    "esbuild": "^0.14.2",
+    "esbuild-plugin-alias": "^0.2.1",
     "eslint": "^7.31.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
@@ -128,7 +134,8 @@
     "webpack": "5.64.1",
     "webpack-cli": "^4.9.1",
     "webpack-dev-middleware": "^5.2.2",
-    "webpack-pwa-manifest": "^4.3.0"
+    "webpack-pwa-manifest": "^4.3.0",
+    "yargs": "^17.3.0"
   },
   "peerDependencies": {
     "@fortawesome/pro-light-svg-icons": "^6.0.0-beta2",
@@ -179,13 +186,8 @@
       "./src/employee-frontend",
       "./src/lib-common"
     ],
-    "reporters": [
-      "default",
-      "jest-junit"
-    ],
-    "modulePathIgnorePatterns": [
-      "<rootDir>/node_modules/"
-    ],
+    "reporters": ["default", "jest-junit"],
+    "modulePathIgnorePatterns": ["<rootDir>/node_modules/"],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png)$": "<rootDir>/assetsTransformer.js"
     }

--- a/frontend/src/citizen-frontend/index-esbuild.html
+++ b/frontend/src/citizen-frontend/index-esbuild.html
@@ -1,0 +1,21 @@
+<!--
+SPDX-FileCopyrightText: 2017-2020 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, minimum-scale=1"
+    />
+    <title>Varhaiskasvatus</title>
+    <%= assets %>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/frontend/src/employee-frontend/index-esbuild.html
+++ b/frontend/src/employee-frontend/index-esbuild.html
@@ -1,0 +1,17 @@
+<!--
+SPDX-FileCopyrightText: 2017-2020 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Varhaiskasvatus</title>
+    <%= assets %>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/frontend/src/employee-mobile-frontend/index-esbuild.html
+++ b/frontend/src/employee-mobile-frontend/index-esbuild.html
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: 2017-2020 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Varhaiskasvatus</title>
+    <%= assets %>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3702,13 +3702,13 @@ __metadata:
   linkType: hard
 
 "ajv-keywords@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "ajv-keywords@npm:5.0.0"
+  version: 5.1.0
+  resolution: "ajv-keywords@npm:5.1.0"
   dependencies:
     fast-deep-equal: ^3.1.3
   peerDependencies:
-    ajv: ^8.0.0
-  checksum: 239dd46383a861f9e1dda1f463542ddfa07b4aed886eccb2a4328672c886030b5fdbb7869e0e293ba5549c9b86b23b40fa0e3c0785047e081302f00e41b1e4c1
+    ajv: ^8.8.2
+  checksum: c35193940b853119242c6757787f09ecf89a2c19bcd36d03ed1a615e710d19d450cb448bfda407b939aba54b002368c8bff30529cc50a0536a8e10bcce300421
   languageName: node
   linkType: hard
 
@@ -3724,7 +3724,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.8.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.8.0":
+  version: 8.8.2
+  resolution: "ajv@npm:8.8.2"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: 90849ef03c4f4f7051d15f655120137b89e3205537d683beebd39d95f40c0ca00ea8476cd999602d2f433863e7e4bf1b81d1869d1e07f4dcf56d71b6430a605c
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.1":
   version: 8.8.1
   resolution: "ajv@npm:8.8.1"
   dependencies:
@@ -4931,6 +4943,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"concurrently@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "concurrently@npm:6.4.0"
+  dependencies:
+    chalk: ^4.1.0
+    date-fns: ^2.16.1
+    lodash: ^4.17.21
+    rxjs: ^6.6.3
+    spawn-command: ^0.0.2-1
+    supports-color: ^8.1.0
+    tree-kill: ^1.2.2
+    yargs: ^16.2.0
+  bin:
+    concurrently: bin/concurrently.js
+  checksum: 902864cc853176cac406246fa367a1b24ebfcbea9ba43c164f9cb4e2c9c1a5f9d8be05ce98fe7ef13329ffd5cc340a052007a9c870863e2068425d95b3bf89d7
+  languageName: node
+  linkType: hard
+
 "console-control-strings@npm:^1.0.0, console-control-strings@npm:~1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
@@ -5254,6 +5284,13 @@ __metadata:
   version: 2.25.0
   resolution: "date-fns@npm:2.25.0"
   checksum: 8896dc1dde0ee5ef77616942423bfa11fa2017a5ac19457293b7aaedc8822ff94f0a14eaf93da573b09b601dc0149eb430988a046cc9f79a2eb15f8c66c9c50c
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^2.16.1":
+  version: 2.27.0
+  resolution: "date-fns@npm:2.27.0"
+  checksum: db62036b3816eb0322c9532b353beac7f660a91e1a55dbd21c14893c621ebb8509f21c66ba287844dabd34dee0207edd54a9537bce6bb7cab9383dedc6b8bc90
   languageName: node
   linkType: hard
 
@@ -5804,6 +5841,194 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-android-arm64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-android-arm64@npm:0.14.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-darwin-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-darwin-64@npm:0.14.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-darwin-arm64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-darwin-arm64@npm:0.14.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-freebsd-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-freebsd-64@npm:0.14.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-freebsd-arm64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-freebsd-arm64@npm:0.14.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-32@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-32@npm:0.14.2"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-64@npm:0.14.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-arm64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-arm64@npm:0.14.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-arm@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-arm@npm:0.14.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-mips64le@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-mips64le@npm:0.14.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-ppc64le@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-ppc64le@npm:0.14.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"esbuild-netbsd-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-netbsd-64@npm:0.14.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-openbsd-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-openbsd-64@npm:0.14.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-plugin-alias@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "esbuild-plugin-alias@npm:0.2.1"
+  checksum: afe2d2c8b5f09d5321cb8d9c0825e8a9f6e03c2d50df92f953a291d4620cc29eddb3da9e33b238f6d8f77738e0277bdcb831f127399449fecf78fb84c04e5da9
+  languageName: node
+  linkType: hard
+
+"esbuild-sunos-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-sunos-64@npm:0.14.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-32@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-windows-32@npm:0.14.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-windows-64@npm:0.14.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-arm64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-windows-arm64@npm:0.14.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.14.2":
+  version: 0.14.2
+  resolution: "esbuild@npm:0.14.2"
+  dependencies:
+    esbuild-android-arm64: 0.14.2
+    esbuild-darwin-64: 0.14.2
+    esbuild-darwin-arm64: 0.14.2
+    esbuild-freebsd-64: 0.14.2
+    esbuild-freebsd-arm64: 0.14.2
+    esbuild-linux-32: 0.14.2
+    esbuild-linux-64: 0.14.2
+    esbuild-linux-arm: 0.14.2
+    esbuild-linux-arm64: 0.14.2
+    esbuild-linux-mips64le: 0.14.2
+    esbuild-linux-ppc64le: 0.14.2
+    esbuild-netbsd-64: 0.14.2
+    esbuild-openbsd-64: 0.14.2
+    esbuild-sunos-64: 0.14.2
+    esbuild-windows-32: 0.14.2
+    esbuild-windows-64: 0.14.2
+    esbuild-windows-arm64: 0.14.2
+  dependenciesMeta:
+    esbuild-android-arm64:
+      optional: true
+    esbuild-darwin-64:
+      optional: true
+    esbuild-darwin-arm64:
+      optional: true
+    esbuild-freebsd-64:
+      optional: true
+    esbuild-freebsd-arm64:
+      optional: true
+    esbuild-linux-32:
+      optional: true
+    esbuild-linux-64:
+      optional: true
+    esbuild-linux-arm:
+      optional: true
+    esbuild-linux-arm64:
+      optional: true
+    esbuild-linux-mips64le:
+      optional: true
+    esbuild-linux-ppc64le:
+      optional: true
+    esbuild-netbsd-64:
+      optional: true
+    esbuild-openbsd-64:
+      optional: true
+    esbuild-sunos-64:
+      optional: true
+    esbuild-windows-32:
+      optional: true
+    esbuild-windows-64:
+      optional: true
+    esbuild-windows-arm64:
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: d786e6330b541d9d79ed81e82c1c35944c007cb38bf30bb021e68cf6bb25023316a45c68a4e94fa8397f4b79c69bb7a3b221afd9fac7725a4a2ca4ad8b55dff8
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
@@ -6138,6 +6363,7 @@ __metadata:
     chartjs-adapter-date-fns: ^2.0.0
     classnames: ^2.3.1
     compute-scroll-into-view: ^1.0.17
+    concurrently: ^6.4.0
     core-js: ^3.19.0
     css-loader: ^6.5.1
     csstype: ^3.0.9
@@ -6145,6 +6371,8 @@ __metadata:
     downshift: ^6.1.7
     e2e-playwright: "link:src/e2e-playwright"
     e2e-test-common: "link:src/e2e-test-common"
+    esbuild: ^0.14.2
+    esbuild-plugin-alias: ^0.2.1
     eslint: ^7.31.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-prettier: ^3.4.0
@@ -6203,6 +6431,7 @@ __metadata:
     webpack-cli: ^4.9.1
     webpack-dev-middleware: ^5.2.2
     webpack-pwa-manifest: ^4.3.0
+    yargs: ^17.3.0
   peerDependencies:
     "@fortawesome/pro-light-svg-icons": ^6.0.0-beta2
     "@fortawesome/pro-regular-svg-icons": ^6.0.0-beta2
@@ -8914,12 +9143,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memfs@npm:^3.1.2, memfs@npm:^3.2.2":
+"memfs@npm:^3.1.2":
   version: 3.2.2
   resolution: "memfs@npm:3.2.2"
   dependencies:
     fs-monkey: 1.0.3
   checksum: b50f91aafda967c440a38e793bbe70cd04e4f155a38316468b90b7a2256328cebe87e0665ff81057cf72110f9017cbfd1e1a9c66df1ebce3cbf39ec3620220d9
+  languageName: node
+  linkType: hard
+
+"memfs@npm:^3.2.2":
+  version: 3.4.0
+  resolution: "memfs@npm:3.4.0"
+  dependencies:
+    fs-monkey: 1.0.3
+  checksum: 56ed70e1bdbc67d0c3758fa76c7ef25cd48c93c192f20c492e6b9811d783fdc453528d7ea91d9a79d5e6e121efa865adffd13fda30db0fa2b894ab91dfd1d653
   languageName: node
   linkType: hard
 
@@ -8984,12 +9222,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24":
+"mime-db@npm:1.51.0":
+  version: 1.51.0
+  resolution: "mime-db@npm:1.51.0"
+  checksum: 613b1ac9d6e725cc24444600b124a7f1ce6c60b1baa654f39a3e260d0995a6dffc5693190217e271af7e2a5612dae19f2a73f3e316707d797a7391165f7ef423
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24":
   version: 2.1.31
   resolution: "mime-types@npm:2.1.31"
   dependencies:
     mime-db: 1.48.0
   checksum: eb1612aa96403823c7a2ccb1a39d58ce11477e685560186e7d369d8164260fd6fc1eeb56fa23acb6a4050583f417b2a685b69c23eb2bd8ed169fb0c6e323740a
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.31":
+  version: 2.1.34
+  resolution: "mime-types@npm:2.1.34"
+  dependencies:
+    mime-db: 1.51.0
+  checksum: 67013de9e9d6799bde6d669d18785b7e18bcd212e710d3e04a4727f92f67a8ad4e74aee24be28b685adb794944814bde649119b58ee3282ffdbee58f9278d9f3
   languageName: node
   linkType: hard
 
@@ -11302,6 +11556,15 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"rxjs@npm:^6.6.3":
+  version: 6.6.7
+  resolution: "rxjs@npm:6.6.7"
+  dependencies:
+    tslib: ^1.9.0
+  checksum: bc334edef1bb8bbf56590b0b25734ba0deaf8825b703256a93714308ea36dff8a11d25533671adf8e104e5e8f256aa6fdfe39b2e248cdbd7a5f90c260acbbd1b
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
@@ -11692,6 +11955,13 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"spawn-command@npm:^0.0.2-1":
+  version: 0.0.2
+  resolution: "spawn-command@npm:0.0.2"
+  checksum: e35c5d28177b4d461d33c88cc11f6f3a5079e2b132c11e1746453bbb7a0c0b8a634f07541a2a234fa4758239d88203b758def509161b651e81958894c0b4b64b
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:~1.0.2":
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
@@ -11782,6 +12052,17 @@ resolve@^2.0.0-next.3:
     is-fullwidth-code-point: ^3.0.0
     strip-ansi: ^6.0.0
   checksum: ee2c68df9a3ce4256565d2bdc8490f5706f195f88e799d3d425889264d3eff3d7984fe8b38dfc983dac948e03d8cdc737294b1c81f1528c37c9935d86b67593d
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: ^8.0.0
+    is-fullwidth-code-point: ^3.0.0
+    strip-ansi: ^6.0.1
+  checksum: e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
   languageName: node
   linkType: hard
 
@@ -11952,7 +12233,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.0.0":
+"supports-color@npm:^8.0.0, supports-color@npm:^8.1.0":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -13353,6 +13634,13 @@ typescript@^3.3.3:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^21.0.0":
+  version: 21.0.0
+  resolution: "yargs-parser@npm:21.0.0"
+  checksum: 1e205fca1cb7a36a1585e2b94a64e641c12741b53627d338e12747f4dca3c3610cdd9bb235040621120548dd74c3ef03a8168d52a1eabfedccbe4a62462b6731
+  languageName: node
+  linkType: hard
+
 "yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
@@ -13365,6 +13653,21 @@ typescript@^3.3.3:
     y18n: ^5.0.5
     yargs-parser: ^20.2.2
   checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.3.0":
+  version: 17.3.0
+  resolution: "yargs@npm:17.3.0"
+  dependencies:
+    cliui: ^7.0.2
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.0.0
+  checksum: 2b687338684bf9645e9389ffdbe813fc5a2ddfede299d46fbe5ac80eb9a391e558b97861ba44d2256936ebe9d7f8135f6a38af1c76a5685eac4061008b2df57a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Summary

`yarn dev` now uses esbuild. A clean build takes around 1 second, whereas with webpack it took around 1 minute.

`tsc  --watch` is run concurrently for type checking. `esbuild` itself doesn't check types at all.

If something is broken and it prevents your work, use `yarn dev:old` to start the old webpack dev-server.

Missing things for using `esbuild` also for production builds:
- Use `browserslist` to determine the esbuild target
- Upload a release to Sentry

Nice to have but still missing:
- Use `babel-plugin-styled-components`
