### PR TITLE
Enable ESLint also for .js files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -916,7 +916,7 @@ jobs:
             - apigw/dist
       - run:
           working_directory: *workspace_apigw
-          command: yarn lint:strict
+          command: yarn lint
       - run:
           working_directory: *workspace_apigw
           command: yarn test-ci
@@ -962,7 +962,7 @@ jobs:
       - prepare_frontend_build
       - run:
           working_directory: *workspace_frontend
-          command: yarn lint:strict
+          command: yarn lint
       - run:
           working_directory: *workspace_frontend
           command: yarn type-check

--- a/apigw/package.json
+++ b/apigw/package.json
@@ -7,9 +7,8 @@
   "scripts": {
     "clean": "rm -rf ./build ./dist",
     "build": "yarn clean && yarn install && tsc --build src",
-    "lint": "eslint --ext .ts,.tsx src/",
-    "lint:strict": "eslint --ext .ts,.tsx --max-warnings 0 src/",
-    "lint:fix": "eslint --fix --ext .ts,.tsx src/",
+    "lint": "eslint --ext .ts,.tsx --max-warnings 0 .",
+    "lint:fix": "yarn lint --fix",
     "pretest": "tsc --build src/pino-cli",
     "test": "yarn lint:fix && NODE_ENV=test jest",
     "dev": "tsc --build src && concurrently --prefix '[{name}]' --names 'tsc,nodemon' 'tsc --build --preserveWatchOutput -w src' 'NODE_ENV=local nodemon dist/index.js'",

--- a/frontend/assetsTransformer.js
+++ b/frontend/assetsTransformer.js
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-const path = require('path');
+const path = require('path')
 
 module.exports = {
-  process(src, filename, config, options) {
-    return 'module.exports = ' + JSON.stringify(path.basename(filename)) + ';';
-  },
-};
+  process(src, filename) {
+    return 'module.exports = ' + JSON.stringify(path.basename(filename)) + ';'
+  }
+}

--- a/frontend/eslint-plugin/index.js
+++ b/frontend/eslint-plugin/index.js
@@ -6,7 +6,7 @@ module.exports = {
   rules: {
     'no-testonly': require('./rules/no-testonly'),
     'no-duplicate-testcafe-hooks': require('./rules/no-duplicate-testcafe-hooks'),
-    'no-relative-lib-imports': require('./rules/no-relative-lib-imports'),
+    'no-relative-lib-imports': require('./rules/no-relative-lib-imports')
   },
   configs: {
     recommended: {
@@ -14,7 +14,7 @@ module.exports = {
       rules: {
         '@evaka/no-testonly': 'error',
         '@evaka/no-duplicate-testcafe-hooks': 'error',
-        '@evaka/no-relative-lib-imports': 'error',
+        '@evaka/no-relative-lib-imports': 'error'
       }
     }
   }

--- a/frontend/eslint-plugin/rules/no-duplicate-testcafe-hooks.js
+++ b/frontend/eslint-plugin/rules/no-duplicate-testcafe-hooks.js
@@ -4,7 +4,9 @@
 
 function getDuplicateNodeFinder(context, name) {
   return () => {
-    const node = context.getAncestors().find(node => node.property && node.property.name === name)
+    const node = context
+      .getAncestors()
+      .find((node) => node.property && node.property.name === name)
     return context.report({
       node,
       message: `Multiple "${name}" hooks not allowed in the same fixture`
@@ -23,15 +25,11 @@ module.exports = {
     schema: []
   },
   create: (context) => {
-    return [
-      "before",
-      "beforeEach",
-      "after",
-      "afterEach"
-    ].reduce((o, hook) => {
+    return ['before', 'beforeEach', 'after', 'afterEach'].reduce((o, hook) => {
       return Object.assign(o, {
-        [`MemberExpression[property.name='${hook}'] MemberExpression[property.name='${hook}'] Identifier[name='fixture']`]: getDuplicateNodeFinder(context, hook)
+        [`MemberExpression[property.name='${hook}'] MemberExpression[property.name='${hook}'] Identifier[name='fixture']`]:
+          getDuplicateNodeFinder(context, hook)
       })
-    }, {});
+    }, {})
   }
 }

--- a/frontend/eslint-plugin/rules/no-testonly.js
+++ b/frontend/eslint-plugin/rules/no-testonly.js
@@ -15,11 +15,15 @@ function isCallOfOnly(node) {
 }
 
 function isTestOnlyCall(node) {
-  return isCallExpression(node) && isMethodOf('test', node) && isCallOfOnly(node)
+  return (
+    isCallExpression(node) && isMethodOf('test', node) && isCallOfOnly(node)
+  )
 }
 
 function isFixtureOnlyCall(node) {
-  return isCallExpression(node) && isMethodOf('fixture', node) && isCallOfOnly(node)
+  return (
+    isCallExpression(node) && isMethodOf('fixture', node) && isCallOfOnly(node)
+  )
 }
 
 module.exports = {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "clean": "rm -rf dist screenshots videos node_modules/.cache",
     "dev": "tsc -b . && node dev-server.js",
-    "lint": "eslint --ext .ts,.tsx src",
-    "lint:strict": "eslint --ext .ts,.tsx --max-warnings 0 src",
+    "lint": "eslint --ext .js,.jsx,.ts,.tsx --max-warnings 0 .",
     "lint:fix": "yarn lint --fix",
     "type-check": "tsc -b .",
     "build": "webpack --mode production",
@@ -201,52 +200,30 @@
     }
   },
   "eslintConfig": {
+    "parserOptions": {
+      "ecmaVersion": "latest",
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    },
+    "env": {
+      "browser": true,
+      "node": true
+    },
     "extends": [
       "eslint:recommended",
       "plugin:react/recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking",
       "plugin:prettier/recommended",
       "plugin:react-hooks/recommended",
       "plugin:@evaka/recommended"
     ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "project": "./tsconfig.eslint.json"
-    },
-    "plugins": [
-      "@typescript-eslint",
-      "react-hooks"
-    ],
+    "plugins": ["react-hooks"],
     "settings": {
       "react": {
         "version": "detect"
       }
     },
     "rules": {
-      "@typescript-eslint/explicit-function-return-type": "off",
-      "@typescript-eslint/explicit-module-boundary-types": "off",
-      "@typescript-eslint/member-delimiter-style": [
-        "warn",
-        {
-          "multiline": {
-            "delimiter": "none"
-          },
-          "singleline": {
-            "delimiter": "semi",
-            "requireLast": false
-          }
-        }
-      ],
-      "@typescript-eslint/no-unused-vars": [
-        "warn",
-        {
-          "argsIgnorePattern": "^_",
-          "varsIgnorePattern": "^_"
-        }
-      ],
-      "@typescript-eslint/no-floating-promises": "error",
       "react/prop-types": 0,
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": [
@@ -255,6 +232,45 @@
           "additionalHooks": "(useApiState)"
         }
       ]
-    }
+    },
+    "overrides": [
+      {
+        "files": "**/*.{ts,tsx}",
+        "extends": [
+          "plugin:@typescript-eslint/eslint-recommended",
+          "plugin:@typescript-eslint/recommended",
+          "plugin:@typescript-eslint/recommended-requiring-type-checking"
+        ],
+        "parser": "@typescript-eslint/parser",
+        "parserOptions": {
+          "project": "./tsconfig.eslint.json"
+        },
+        "plugins": ["@typescript-eslint", "react-hooks"],
+        "rules": {
+          "@typescript-eslint/explicit-function-return-type": "off",
+          "@typescript-eslint/explicit-module-boundary-types": "off",
+          "@typescript-eslint/member-delimiter-style": [
+            "warn",
+            {
+              "multiline": {
+                "delimiter": "none"
+              },
+              "singleline": {
+                "delimiter": "semi",
+                "requireLast": false
+              }
+            }
+          ],
+          "@typescript-eslint/no-unused-vars": [
+            "warn",
+            {
+              "argsIgnorePattern": "^_",
+              "varsIgnorePattern": "^_"
+            }
+          ],
+          "@typescript-eslint/no-floating-promises": "error"
+        }
+      }
+    ]
   }
 }

--- a/frontend/src/e2e-playwright/jest-environment.js
+++ b/frontend/src/e2e-playwright/jest-environment.js
@@ -12,7 +12,7 @@
 const NodeEnvironment = require('jest-environment-node')
 
 class PlaywrightEnvironment extends NodeEnvironment {
-  async handleTestEvent(event, _state) {
+  async handleTestEvent(event) {
     if (!this.global.evaka) return
     const { saveTraces, promises } = this.global.evaka
 

--- a/frontend/src/lib-common/utils/helpers.spec.ts
+++ b/frontend/src/lib-common/utils/helpers.spec.ts
@@ -10,7 +10,7 @@ import { isProduction, getEnvironment } from './helpers'
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 function defineWindowLocation(host: string) {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-extra-semi
   ;(global as any).window = Object.create(window)
   Object.defineProperty(window, 'location', { value: { host }, writable: true })
 }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -69,7 +69,7 @@ function baseConfig({ isDevelopment, isDevServer }, { name, publicPath }) {
       }
     ),
     new webpack.DefinePlugin({
-      // This matches APP_COMMIT in apigw
+      // This matches APP_COMMIT in apigw
       'process.env.APP_COMMIT': `'${process.env.APP_COMMIT || 'UNDEFINED'}'`
     })
   ]


### PR DESCRIPTION
#### Summary

The eslint config is now two part:
- The base config is used for JavaScript
- The override config is used for TypeScript files, and adds a TypeScript parser and TypeScript specific rules