### PR TITLE
Resolve symlinks correctly under lib-customizations

### DIFF
--- a/frontend/build.js
+++ b/frontend/build.js
@@ -74,15 +74,20 @@ function findOutputFile(obj, outdir, name, suffix) {
 }
 
 function script(publicPath, fileName) {
-  return `<script defer src="${publicPath}${fileName}"></script>`
+  return '<script defer src="' + publicPath + fileName + '"></script>'
 }
 
 function stylesheet(publicPath, fileName) {
-  return `<link rel="stylesheet" type="text/css" href="${publicPath}${fileName}">`
+  return (
+    '<link rel="stylesheet" type="text/css" href="' +
+    publicPath +
+    fileName +
+    '">'
+  )
 }
 
 function favicon(publicPath) {
-  return `<link rel="shortcut icon" href="${publicPath}favicon.ico">`
+  return '<link rel="shortcut icon" href="' + publicPath + 'favicon.ico">'
 }
 
 async function buildProject(project, config) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,7 +102,6 @@
     "csstype": "^3.0.9",
     "e2e-playwright": "link:src/e2e-playwright",
     "esbuild": "^0.14.2",
-    "esbuild-plugin-alias": "^0.2.1",
     "eslint": "^7.31.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
@@ -186,8 +185,13 @@
       "./src/employee-frontend",
       "./src/lib-common"
     ],
-    "reporters": ["default", "jest-junit"],
-    "modulePathIgnorePatterns": ["<rootDir>/node_modules/"],
+    "reporters": [
+      "default",
+      "jest-junit"
+    ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/node_modules/"
+    ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png)$": "<rootDir>/assetsTransformer.js"
     }
@@ -220,7 +224,9 @@
       "plugin:react-hooks/recommended",
       "plugin:@evaka/recommended"
     ],
-    "plugins": ["react-hooks"],
+    "plugins": [
+      "react-hooks"
+    ],
     "settings": {
       "react": {
         "version": "detect"
@@ -248,7 +254,10 @@
         "parserOptions": {
           "project": "./tsconfig.eslint.json"
         },
-        "plugins": ["@typescript-eslint", "react-hooks"],
+        "plugins": [
+          "@typescript-eslint",
+          "react-hooks"
+        ],
         "rules": {
           "@typescript-eslint/explicit-function-return-type": "off",
           "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5932,13 +5932,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-plugin-alias@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "esbuild-plugin-alias@npm:0.2.1"
-  checksum: afe2d2c8b5f09d5321cb8d9c0825e8a9f6e03c2d50df92f953a291d4620cc29eddb3da9e33b238f6d8f77738e0277bdcb831f127399449fecf78fb84c04e5da9
-  languageName: node
-  linkType: hard
-
 "esbuild-sunos-64@npm:0.14.2":
   version: 0.14.2
   resolution: "esbuild-sunos-64@npm:0.14.2"
@@ -6372,7 +6365,6 @@ __metadata:
     e2e-playwright: "link:src/e2e-playwright"
     e2e-test-common: "link:src/e2e-test-common"
     esbuild: ^0.14.2
-    esbuild-plugin-alias: ^0.2.1
     eslint: ^7.31.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-prettier: ^3.4.0


### PR DESCRIPTION
#### Summary

Preserve symlinks under the customizations module. This makes it possible to symlink a customizations module to `lib-customizations/<city-name>` and still use symlinks inside the customizations module.

The `preserveSymlinks` option of esbuild doesn't seem to be enough if there's a path that has multiple symlinks along it.
