### PR TITLE
EVAKA-4335: Handle overnight reservations

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -303,13 +303,13 @@ private fun Database.Transaction.insertValidReservations(userId: UUID, requests:
     )
 
     requests.forEach { request ->
-        request.reservations?.forEach { res ->
+        handleOvernightReserations(request.reservations, request.date)?.forEach { (res, date) ->
             val start = HelsinkiDateTime.of(
-                date = request.date,
+                date = date,
                 time = res.startTime
             )
             val end = HelsinkiDateTime.of(
-                date = if (res.endTime.isAfter(res.startTime)) request.date else request.date.plusDays(1),
+                date = date,
                 time = res.endTime
             )
             batch

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -291,13 +291,14 @@ private fun Database.Transaction.insertValidReservations(userId: UUID, requests:
     )
 
     requests.forEach { request ->
-        request.reservations?.forEach { res ->
+        handleOvernightReserations(request.reservations, request.date)?.forEach {
+            (res, date) ->
             val start = HelsinkiDateTime.of(
-                date = request.date,
+                date = date,
                 time = res.startTime
             )
             val end = HelsinkiDateTime.of(
-                date = if (res.endTime.isAfter(res.startTime)) request.date else request.date.plusDays(1),
+                date = date,
                 time = res.endTime
             )
             batch
@@ -305,7 +306,7 @@ private fun Database.Transaction.insertValidReservations(userId: UUID, requests:
                 .bind("childId", request.childId)
                 .bind("start", start)
                 .bind("end", end)
-                .bind("date", request.date)
+                .bind("date", date)
                 .add()
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -49,3 +49,11 @@ fun Database.Transaction.clearOldReservations(reservations: List<Pair<UUID, Loca
 
     batch.execute()
 }
+
+fun handleOvernightReserations(reservations: List<TimeRange>?, date: LocalDate) = reservations?.flatMap {
+    res ->
+    if (!res.endTime.isAfter(res.startTime)) listOf(
+        Pair(TimeRange(startTime = res.startTime, endTime = LocalTime.MIDNIGHT.minusMinutes(1)), date),
+        Pair(TimeRange(startTime = LocalTime.MIDNIGHT, endTime = res.endTime), date.plusDays(1))
+    ) else listOf(Pair(res, date))
+}


### PR DESCRIPTION
#### Summary

After trying several different solutions to this problem, my opinion is that the correct way to solve this issue is to split overnight reservations into two separate reservations on the corresponding days. I.e.
`9:00, 8:00` -> `9:00-23:59, 00:00 - 8:00`. This way everything works as expected with the current frontend that doesn't seem to take into account the possibility of an overnight stay.

This doesn't fix any broken data though. So we need to run a query in order to clean up currently existing overnight reservations.

Closes #1809.