### PR TITLE
EVAKA-4256 tweak unread message counts logic in mobile

### DIFF
--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -90,10 +90,12 @@ function UnitRouter() {
 
   return (
     <UnitContextProvider unitId={unitId}>
-      <Switch>
-        <Route path={`${path}/groups/:groupId`} component={GroupRouter} />
-        <Redirect to={`${path}/groups/all`} />
-      </Switch>
+      <MessageContextProvider>
+        <Switch>
+          <Route path={`${path}/groups/:groupId`} component={GroupRouter} />
+          <Redirect to={`${path}/groups/all`} />
+        </Switch>
+      </MessageContextProvider>
     </UnitContextProvider>
   )
 }
@@ -216,22 +218,20 @@ function MessagesRouter() {
   const { path } = useRouteMatch()
 
   return (
-    <MessageContextProvider>
-      <Switch>
-        <Route exact path={path} component={requirePinAuth(MessagesPage)} />
-        <Route
-          exact
-          path={`${path}/unread-messages`}
-          component={UnreadMessagesPage}
-        />
-        <Route
-          exact
-          path={`${path}/:childId/new-message`}
-          component={requirePinAuth(MessageEditorPage)}
-        />
-        <Redirect to={path} />
-      </Switch>
-    </MessageContextProvider>
+    <Switch>
+      <Route exact path={path} component={requirePinAuth(MessagesPage)} />
+      <Route
+        exact
+        path={`${path}/unread-messages`}
+        component={UnreadMessagesPage}
+      />
+      <Route
+        exact
+        path={`${path}/:childId/new-message`}
+        component={requirePinAuth(MessageEditorPage)}
+      />
+      <Redirect to={path} />
+    </Switch>
   )
 }
 

--- a/frontend/src/employee-mobile-frontend/api/messages.ts
+++ b/frontend/src/employee-mobile-frontend/api/messages.ts
@@ -13,7 +13,6 @@ import {
   PostMessageBody,
   ReplyToMessageBody,
   ThreadReply,
-  UnreadCountByAccount,
   UnreadCountByAccountAndGroup
 } from 'lib-common/generated/api-types/messaging'
 import {
@@ -32,15 +31,6 @@ export async function getMessagingAccounts(
     .get<JsonOf<NestedMessageAccount[]>>(
       `/messages/mobile/my-accounts/${unitId}`
     )
-    .then(({ data }) => Success.of(data))
-    .catch((e) => Failure.fromError(e))
-}
-
-export async function getUnreadCounts(): Promise<
-  Result<UnreadCountByAccount[]>
-> {
-  return client
-    .get<JsonOf<UnreadCountByAccount[]>>(`/messages/unread`)
     .then(({ data }) => Success.of(data))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-mobile-frontend/components/common/BottomNavbar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/BottomNavbar.tsx
@@ -20,6 +20,7 @@ import { renderResult } from '../async-rendering'
 import { combine } from 'lib-common/api'
 import { defaultMargins } from 'lib-components/white-space'
 import { UserContext } from '../../state/user'
+import { MessageContext } from '../../state/messages'
 
 export type NavItem = 'child' | 'staff' | 'messages'
 
@@ -96,6 +97,9 @@ export default function BottomNavbar({ selected }: BottomNavbarProps) {
 
   const { unitInfoResponse, unreadCountsResponse } = useContext(UnitContext)
   const { user } = useContext(UserContext)
+  const { groupAccounts } = useContext(MessageContext)
+
+  const groupAccountIds = groupAccounts.map(({ account }) => account.id)
 
   return renderResult(
     combine(unitInfoResponse, unreadCountsResponse, user),
@@ -152,7 +156,12 @@ export default function BottomNavbar({ selected }: BottomNavbarProps) {
                   icon={faComments}
                   selected={selected === 'messages'}
                 />
-                {unreadCounts.some(({ unreadCount }) => unreadCount > 0) && (
+                {(user?.pinLoginActive && groupAccountIds.length > 0
+                  ? unreadCounts.filter(({ accountId }) =>
+                      groupAccountIds.includes(accountId)
+                    )
+                  : unreadCounts
+                ).some(({ unreadCount }) => unreadCount > 0) && (
                   <UnreadMessagesIndicator
                     data-qa={'unread-messages-indicator'}
                   />

--- a/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
@@ -30,33 +30,17 @@ import { featureFlags } from 'lib-customizations/employee'
 import { useTranslation } from '../../state/i18n'
 import { useParams } from 'react-router-dom'
 import { Result } from 'lib-common/api'
+import { renderResult } from '../async-rendering'
 
 export default function MessageEditorPage() {
   const { i18n } = useTranslation()
-  const { childId, groupId, unitId } = useParams<{
+  const { childId, unitId } = useParams<{
     unitId: UUID
     groupId: UUID
     childId: UUID
   }>()
-  const {
-    nestedAccounts,
-    selectedAccount,
-    selectedUnit,
-    loadNestedAccounts,
-    groupAccounts,
-    setSelectedAccount
-  } = useContext(MessageContext)
-
-  useEffect(() => loadNestedAccounts(unitId), [loadNestedAccounts, unitId])
-
-  useEffect(() => {
-    const maybeAccount = groupAccounts.find(
-      ({ daycareGroup }) => daycareGroup?.id === groupId
-    )?.account
-    if (maybeAccount) {
-      setSelectedAccount(maybeAccount)
-    }
-  }, [groupAccounts, setSelectedAccount, groupId])
+  const { nestedAccounts, selectedAccount, selectedUnit } =
+    useContext(MessageContext)
 
   const [sending, setSending] = useState(false)
 
@@ -102,41 +86,36 @@ export default function MessageEditorPage() {
     history.back()
   }, [])
 
-  return (
-    <>
-      {nestedAccounts.isSuccess &&
-        selectedReceivers &&
-        selectedAccount &&
-        selectedUnit && (
-          <MessageEditor
-            availableReceivers={selectedReceivers}
-            attachmentsEnabled={
-              featureFlags.experimental?.messageAttachments ?? false
-            }
-            defaultSender={{
-              value: selectedAccount.id,
-              label: selectedAccount.name
-            }}
-            deleteAttachment={deleteAttachment}
-            draftContent={undefined}
-            getAttachmentBlob={getAttachmentBlob}
-            i18n={{
-              ...i18n.messages.messageEditor,
-              ...i18n.fileUpload,
-              ...i18n.common
-            }}
-            initDraftRaw={initDraft}
-            mobileVersion={true}
-            nestedAccounts={nestedAccounts.value}
-            onClose={onHide}
-            onDiscard={onDiscard}
-            onSend={onSend}
-            saveDraftRaw={saveDraft}
-            saveMessageAttachment={saveMessageAttachment}
-            selectedUnit={selectedUnit}
-            sending={sending}
-          />
-        )}
-    </>
+  return renderResult(nestedAccounts, (accounts) =>
+    selectedReceivers && selectedAccount && selectedUnit ? (
+      <MessageEditor
+        availableReceivers={selectedReceivers}
+        attachmentsEnabled={
+          featureFlags.experimental?.messageAttachments ?? false
+        }
+        defaultSender={{
+          value: selectedAccount.id,
+          label: selectedAccount.name
+        }}
+        deleteAttachment={deleteAttachment}
+        draftContent={undefined}
+        getAttachmentBlob={getAttachmentBlob}
+        i18n={{
+          ...i18n.messages.messageEditor,
+          ...i18n.fileUpload,
+          ...i18n.common
+        }}
+        initDraftRaw={initDraft}
+        mobileVersion={true}
+        nestedAccounts={accounts}
+        onClose={onHide}
+        onDiscard={onDiscard}
+        onSend={onSend}
+        saveDraftRaw={saveDraft}
+        saveMessageAttachment={saveMessageAttachment}
+        selectedUnit={selectedUnit}
+        sending={sending}
+      />
+    ) : null
   )
 }

--- a/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
@@ -116,7 +116,24 @@ export default function MessagesPage() {
         </ContentArea>
       ))}
     </>
-  ) : null
+  ) : (
+    <ContentArea
+      opaque
+      paddingVertical={'zero'}
+      paddingHorizontal={'zero'}
+      data-qa={`messages-page-content-area`}
+    >
+      <HeaderContainer>
+        <H1 noMargin={true}>{i18n.messages.title}</H1>
+      </HeaderContainer>
+      <EmptyMessageFolder
+        loading={receivedMessages.isLoading}
+        iconColor={colors.greyscale.medium}
+        text={i18n.messages.emptyInbox}
+      />
+      <BottomNavBar selected="messages" />
+    </ContentArea>
+  )
 }
 
 export const HeaderContainer = styled.div`

--- a/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback, useContext, useEffect } from 'react'
+import React, { useCallback, useContext } from 'react'
 import { useTranslation } from '../../state/i18n'
 import { useHistory, useParams } from 'react-router-dom'
 import { UUID } from 'lib-common/types'
@@ -32,8 +32,6 @@ export default function MessagesPage() {
   }
 
   const {
-    loadNestedAccounts,
-    setSelectedAccount,
     groupAccounts,
     receivedMessages,
     selectedThread,
@@ -41,21 +39,9 @@ export default function MessagesPage() {
     selectedAccount
   } = useContext(MessageContext)
 
-  const selectedGroup2 =
+  const selectedGroup =
     groupAccounts.find(({ daycareGroup }) => daycareGroup?.id === groupId) ??
     groupAccounts[0]
-
-  useEffect(() => loadNestedAccounts(unitId), [loadNestedAccounts, unitId])
-
-  useEffect(() => {
-    const maybeAccount = (
-      groupAccounts.find(({ daycareGroup }) => daycareGroup?.id === groupId) ??
-      groupAccounts[0]
-    )?.account
-    if (maybeAccount) {
-      setSelectedAccount(maybeAccount)
-    }
-  }, [groupAccounts, setSelectedAccount, groupId])
 
   const { i18n } = useTranslation()
   const onBack = useCallback(() => selectThread(undefined), [selectThread])
@@ -78,10 +64,10 @@ export default function MessagesPage() {
     <>
       <TopBarWithGroupSelector
         selectedGroup={
-          selectedGroup2?.daycareGroup
+          selectedGroup?.daycareGroup
             ? {
-                id: selectedGroup2.daycareGroup.id,
-                name: selectedGroup2.daycareGroup.name
+                id: selectedGroup.daycareGroup.id,
+                name: selectedGroup.daycareGroup.name
               }
             : undefined
         }

--- a/frontend/src/employee-mobile-frontend/state/messages.tsx
+++ b/frontend/src/employee-mobile-frontend/state/messages.tsx
@@ -31,6 +31,7 @@ import { UUID } from 'lib-common/types'
 import { UnitContext } from './unit'
 import { SelectOption } from 'lib-components/molecules/Select'
 import { useParams } from 'react-router-dom'
+import { UserContext } from './user'
 
 const PAGE_SIZE = 20
 
@@ -93,6 +94,7 @@ export const MessageContextProvider = React.memo(
     const [page, setPage] = useState<number>(1)
     const [pages, setPages] = useState<number>()
     const { unitInfoResponse, reloadUnreadCounts } = useContext(UnitContext)
+    const { user } = useContext(UserContext)
     const unitId = unitInfoResponse.map((res) => res.id).getOrElse(undefined)
 
     const selectedUnit = useMemo(
@@ -119,8 +121,9 @@ export const MessageContextProvider = React.memo(
     }>()
 
     useEffect(() => {
-      if (unitId) loadNestedAccounts(unitId)
-    }, [loadNestedAccounts, unitId])
+      const hasPinLogin = user.map((u) => u?.pinLoginActive).getOrElse(false)
+      if (unitId && hasPinLogin) loadNestedAccounts(unitId)
+    }, [loadNestedAccounts, unitId, user])
 
     const groupAccounts: NestedMessageAccount[] = useMemo(() => {
       return nestedAccounts


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- If user has active pin login, we should show unread messages notification only regarding the groups user has permissions for
- Fix a bug regarding selected group in messages page
- Remove some unnecessary code related to unread message counts
