### PR TITLE
Enable dependabot for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,11 @@ updates:
   directory: "/proxy"
   schedule:
     interval: weekly
+- package-ecosystem: npm
+  directory: "/frontend"
+  schedule:
+    interval: daily
+- package-ecosystem: npm
+  directory: "/apigw"
+  schedule:
+    interval: daily


### PR DESCRIPTION
#### Summary

Daily at first. Let's see how much spam we get.
