### PR TITLE
EVAKA-4349 Ensures printing of vasu documents looks OK

### DIFF
--- a/frontend/src/employee-frontend/components/vasu/components/VasuContainer.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/VasuContainer.tsx
@@ -19,4 +19,18 @@ export const VasuContainer = styled(Container)<VasuContainerProps>`
   & > section {
     padding-bottom: ${defaultMargins.L};
   }
+
+  @media print {
+    display: block;
+    * {
+      overflow: visible;
+      text-overflow: visible;
+    }
+
+    section {
+      display: block;
+      break-inside: avoid-page;
+      break-before: auto;
+    }
+  }
 `

--- a/frontend/src/employee-frontend/index.css
+++ b/frontend/src/employee-frontend/index.css
@@ -89,7 +89,6 @@ button.inline {
   color: #db0c41;
 }
 
-
 @media print {
   .section-toggle,
   .navbar-menu {
@@ -124,4 +123,9 @@ button.inline {
   a {
     color: #000000 !important;
   }
+}
+
+@page {
+  size: A4;
+  margin: 1cm;
 }


### PR DESCRIPTION
Printing `display: flex` causes issues where text may be rendered so
that the top half of a line of text is on one page and the bottom half
on the second page. This fixes that issue by using `display: block` and
`break-inside: avoid-page` to keep relevant blocks on a single page.

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

