### PR TITLE
Disable dependabot for frontend deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,3 @@ updates:
   directory: "/proxy"
   schedule:
     interval: weekly
-- package-ecosystem: npm
-  directory: "/frontend"
-  schedule:
-    interval: daily
-- package-ecosystem: npm
-  directory: "/apigw"
-  schedule:
-    interval: daily


### PR DESCRIPTION
#### Summary

Appears that dependabot doesn't support yarn v2 or newer after all:

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem

https://github.com/dependabot/dependabot-core/issues/1297#issuecomment-804491821