### PR TITLE
Deprecate automagical Spring MVC Database.Connection

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/AbstractIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/AbstractIntegrationTest.kt
@@ -45,15 +45,18 @@ abstract class AbstractIntegrationTest {
     lateinit var jdbi: Jdbi
 
     lateinit var db: Database.Connection
+    lateinit var deprecatedDb: Database.DeprecatedConnection
 
     @BeforeAll
     protected fun beforeAll() {
         db = Database(jdbi).connectWithManualLifecycle()
+        deprecatedDb = Database(jdbi).deprecatedConnection()
     }
 
     @AfterAll
     protected fun afterAll() {
         db.close()
+        deprecatedDb.close()
     }
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
@@ -68,7 +68,7 @@ class ChildrenControllerIntegrationTest : AbstractIntegrationTest() {
     }
 
     fun getAdditionalInfo(user: AuthenticatedUser) {
-        val response = childController.getAdditionalInfo(db, user, childId)
+        val response = childController.getAdditionalInfo(deprecatedDb, user, childId)
         val body = response.body!!
 
         assertEquals(HttpStatus.OK, response.statusCode)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/AbstractIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/AbstractIntegrationTest.kt
@@ -40,15 +40,18 @@ abstract class AbstractIntegrationTest {
     lateinit var jdbi: Jdbi
 
     lateinit var db: Database.Connection
+    lateinit var deprecatedDb: Database.DeprecatedConnection
 
     @BeforeAll
     protected fun beforeAll() {
         db = Database(jdbi).connectWithManualLifecycle()
+        deprecatedDb = Database(jdbi).deprecatedConnection()
     }
 
     @AfterAll
     protected fun afterAll() {
         db.close()
+        deprecatedDb.close()
     }
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
@@ -27,7 +27,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `no employees return empty list`() {
         val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
-        val response = employeeController.getEmployees(db, user)
+        val response = employeeController.getEmployees(deprecatedDb, user)
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(emptyList<Employee>(), response.body)
     }
@@ -35,7 +35,7 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `admin can add employee`() {
         val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
-        val response = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
+        val response = employeeController.createEmployee(deprecatedDb, user, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(employee1.firstName, response.body!!.firstName)
         assertEquals(employee1.lastName, response.body!!.lastName)
@@ -46,9 +46,9 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `admin gets all employees`() {
         val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
-        assertEquals(HttpStatus.OK, employeeController.createEmployee(db, user, requestFromEmployee(employee1)).statusCode)
-        assertEquals(HttpStatus.OK, employeeController.createEmployee(db, user, requestFromEmployee(employee2)).statusCode)
-        val response = employeeController.getEmployees(db, user)
+        assertEquals(HttpStatus.OK, employeeController.createEmployee(deprecatedDb, user, requestFromEmployee(employee1)).statusCode)
+        assertEquals(HttpStatus.OK, employeeController.createEmployee(deprecatedDb, user, requestFromEmployee(employee2)).statusCode)
+        val response = employeeController.getEmployees(deprecatedDb, user)
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(2, response.body?.size)
         assertEquals(employee1.email, response.body?.get(0)?.email)
@@ -58,26 +58,26 @@ class EmployeeControllerIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `admin can first create, then get employee`() {
         val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
-        assertEquals(0, employeeController.getEmployees(db, user).body?.size)
+        assertEquals(0, employeeController.getEmployees(deprecatedDb, user).body?.size)
 
-        val responseCreate = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
+        val responseCreate = employeeController.createEmployee(deprecatedDb, user, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, responseCreate.statusCode)
-        assertEquals(1, employeeController.getEmployees(db, user).body?.size)
+        assertEquals(1, employeeController.getEmployees(deprecatedDb, user).body?.size)
 
-        val responseGet = employeeController.getEmployee(db, user, responseCreate.body!!.id)
+        val responseGet = employeeController.getEmployee(deprecatedDb, user, responseCreate.body!!.id)
         assertEquals(HttpStatus.OK, responseGet.statusCode)
-        assertEquals(1, employeeController.getEmployees(db, user).body?.size)
+        assertEquals(1, employeeController.getEmployees(deprecatedDb, user).body?.size)
         assertEquals(responseCreate.body?.id, responseGet.body?.id)
     }
 
     @Test
     fun `admin can delete employee`() {
         val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
-        val createdEmployeeResponse = employeeController.createEmployee(db, user, requestFromEmployee(employee1))
+        val createdEmployeeResponse = employeeController.createEmployee(deprecatedDb, user, requestFromEmployee(employee1))
         assertEquals(HttpStatus.OK, createdEmployeeResponse.statusCode)
-        val response = employeeController.deleteEmployee(db, user, createdEmployeeResponse.body?.id!!)
+        val response = employeeController.deleteEmployee(deprecatedDb, user, createdEmployeeResponse.body?.id!!)
         assertEquals(HttpStatus.OK, response.statusCode)
-        assertEquals(0, employeeController.getEmployees(db, user).body?.size)
+        assertEquals(0, employeeController.getEmployees(deprecatedDb, user).body?.size)
     }
 
     fun requestFromEmployee(employee: Employee) = NewEmployee(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerSearchIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerSearchIntegrationTest.kt
@@ -37,7 +37,7 @@ class EmployeeControllerSearchIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `admin searches employees`() {
         val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
-        val response = controller.searchEmployees(db, user, SearchEmployeeRequest(page = 1, pageSize = 3, searchTerm = null))
+        val response = controller.searchEmployees(deprecatedDb, user, SearchEmployeeRequest(page = 1, pageSize = 3, searchTerm = null))
         assertEquals(HttpStatus.OK, response.statusCode)
         val body = response.body ?: fail("missing body")
         assertEquals(3, body.total)
@@ -58,7 +58,7 @@ class EmployeeControllerSearchIntegrationTest : AbstractIntegrationTest() {
     @Test
     fun `admin searches employees with free text`() {
         val user = AuthenticatedUser.Employee(UUID.randomUUID(), setOf(UserRole.ADMIN))
-        val response = controller.searchEmployees(db, user, SearchEmployeeRequest(page = 1, pageSize = 10, searchTerm = "super"))
+        val response = controller.searchEmployees(deprecatedDb, user, SearchEmployeeRequest(page = 1, pageSize = 10, searchTerm = "super"))
         assertEquals(HttpStatus.OK, response.statusCode)
         val body = response.body ?: fail("missing body")
         assertEquals(1, body.data.size)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
@@ -79,9 +79,9 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
         val reqBody =
             ParentshipController.ParentshipRequest(PersonId(parent.id), PersonId(child.id), startDate, endDate)
-        controller.createParentship(db, user, reqBody)
+        controller.createParentship(deprecatedDb, user, reqBody)
 
-        val getResponse = controller.getParentships(db, user, headOfChildId = PersonId(parent.id))
+        val getResponse = controller.getParentships(deprecatedDb, user, headOfChildId = PersonId(parent.id))
         with(getResponse.first()) {
             assertNotNull(this.id)
             assertEquals(parent.id, this.headOfChildId)
@@ -90,7 +90,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
             assertEquals(endDate, this.endDate)
         }
 
-        assertEquals(0, controller.getParentships(db, user, headOfChildId = PersonId(child.id)).size)
+        assertEquals(0, controller.getParentships(deprecatedDb, user, headOfChildId = PersonId(child.id)).size)
     }
 
     fun `can add a sibling parentship and fetch parentships`(user: AuthenticatedUser) {
@@ -103,9 +103,9 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
         val reqBody =
             ParentshipController.ParentshipRequest(PersonId(parent.id), PersonId(sibling.id), startDate, endDate)
-        controller.createParentship(db, user, reqBody)
+        controller.createParentship(deprecatedDb, user, reqBody)
 
-        val getResponse = controller.getParentships(db, user, headOfChildId = PersonId(parent.id))
+        val getResponse = controller.getParentships(deprecatedDb, user, headOfChildId = PersonId(parent.id))
         with(getResponse.first()) {
             assertNotNull(this.id)
             assertEquals(parentship.headOfChildId, this.headOfChildId)
@@ -121,7 +121,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
             assertEquals(endDate, this.endDate)
         }
 
-        assertEquals(0, controller.getParentships(db, user, headOfChildId = PersonId(child.id)).size)
+        assertEquals(0, controller.getParentships(deprecatedDb, user, headOfChildId = PersonId(child.id)).size)
     }
 
     @Test
@@ -147,10 +147,10 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val newStartDate = child.dateOfBirth.plusDays(100)
         val newEndDate = child.dateOfBirth.plusDays(300)
         val requestBody = ParentshipController.ParentshipUpdateRequest(newStartDate, newEndDate)
-        controller.updateParentship(db, user, parentship.id, requestBody)
+        controller.updateParentship(deprecatedDb, user, parentship.id, requestBody)
 
         // child1 should have new dates
-        val fetched1 = controller.getParentship(db, user, parentship.id)
+        val fetched1 = controller.getParentship(deprecatedDb, user, parentship.id)
         assertEquals(newStartDate, fetched1.startDate)
         assertEquals(newEndDate, fetched1.endDate)
     }
@@ -183,7 +183,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
             }
         }
 
-        controller.deleteParentship(db, user, parentship.id)
+        controller.deleteParentship(deprecatedDb, user, parentship.id)
         db.read { r ->
             assertEquals(1, r.getParentships(headOfChildId = parent.id, childId = null).size)
         }
@@ -201,7 +201,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
                 assertEquals(2, tx.getParentships(headOfChildId = parent.id, childId = null).size)
             }
         }
-        assertThrows<Forbidden> { controller.deleteParentship(db, user, parentship.id) }
+        assertThrows<Forbidden> { controller.deleteParentship(deprecatedDb, user, parentship.id) }
     }
 
     @Test
@@ -210,7 +210,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         db.transaction { tx ->
             tx.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
         }
-        assertThrows<Forbidden> { controller.getParentships(db, user, headOfChildId = PersonId(parent.id)) }
+        assertThrows<Forbidden> { controller.getParentships(deprecatedDb, user, headOfChildId = PersonId(parent.id)) }
     }
 
     @Test
@@ -222,7 +222,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val newStartDate = child.dateOfBirth.plusDays(100)
         val newEndDate = child.dateOfBirth.plusDays(300)
         val requestBody = ParentshipController.ParentshipUpdateRequest(newStartDate, newEndDate)
-        assertThrows<Forbidden> { controller.updateParentship(db, user, parentship.id, requestBody) }
+        assertThrows<Forbidden> { controller.updateParentship(deprecatedDb, user, parentship.id, requestBody) }
     }
 
     @Test
@@ -231,7 +231,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
         val parentship = db.transaction { tx ->
             tx.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
         }
-        assertThrows<Forbidden> { controller.deleteParentship(db, user, parentship.id) }
+        assertThrows<Forbidden> { controller.deleteParentship(deprecatedDb, user, parentship.id) }
     }
 
     @Test
@@ -243,7 +243,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
             child.dateOfBirth.minusDays(1),
             child.dateOfBirth.plusYears(1)
         )
-        assertThrows<BadRequest> { controller.createParentship(db, user, request) }
+        assertThrows<BadRequest> { controller.createParentship(deprecatedDb, user, request) }
     }
 
     @Test
@@ -255,6 +255,6 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
             child.dateOfBirth,
             child.dateOfBirth.plusYears(18)
         )
-        assertThrows<BadRequest> { controller.createParentship(db, user, request) }
+        assertThrows<BadRequest> { controller.createParentship(deprecatedDb, user, request) }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
@@ -102,9 +102,9 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val endDate = startDate.plusDays(200)
         val reqBody =
             PartnershipsController.PartnershipRequest(PersonId(person.id), PersonId(partner.id), startDate, endDate)
-        controller.createPartnership(db, user, reqBody)
+        controller.createPartnership(deprecatedDb, user, reqBody)
 
-        val getResponse = controller.getPartnerships(db, user, PersonId(person.id))
+        val getResponse = controller.getPartnerships(deprecatedDb, user, PersonId(person.id))
         assertEquals(1, getResponse.size)
         with(getResponse.first()) {
             assertNotNull(this.id)
@@ -142,7 +142,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
             }
         }
 
-        controller.deletePartnership(db, user, partnership1.id)
+        controller.deletePartnership(deprecatedDb, user, partnership1.id)
         db.read { r ->
             assertEquals(1, r.getPartnershipsForPerson(person.id).size)
         }
@@ -178,10 +178,10 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val newStartDate = LocalDate.now().plusDays(100)
         val newEndDate = LocalDate.now().plusDays(300)
         val requestBody = PartnershipsController.PartnershipUpdateRequest(newStartDate, newEndDate)
-        controller.updatePartnership(db, user, partnership1.id, requestBody)
+        controller.updatePartnership(deprecatedDb, user, partnership1.id, requestBody)
 
         // partnership1 should have new dates
-        val fetched1 = controller.getPartnership(db, user, partnership1.id)
+        val fetched1 = controller.getPartnership(deprecatedDb, user, partnership1.id)
         assertEquals(newStartDate, fetched1.startDate)
         assertEquals(newEndDate, fetched1.endDate)
     }
@@ -204,7 +204,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val newEndDate = LocalDate.now().plusDays(600)
         val requestBody = PartnershipsController.PartnershipUpdateRequest(newStartDate, newEndDate)
         assertThrows<Conflict> {
-            controller.updatePartnership(db, user, partnership1.id, requestBody)
+            controller.updatePartnership(deprecatedDb, user, partnership1.id, requestBody)
         }
     }
 
@@ -216,7 +216,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         }
 
         assertThrows<Forbidden> {
-            controller.getPartnerships(db, user, PersonId(person.id))
+            controller.getPartnerships(deprecatedDb, user, PersonId(person.id))
         }
     }
 
@@ -229,7 +229,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
             PartnershipsController.PartnershipRequest(PersonId(person.id), PersonId(partner.id), startDate, endDate)
 
         assertThrows<Forbidden> {
-            controller.createPartnership(db, user, reqBody)
+            controller.createPartnership(deprecatedDb, user, reqBody)
         }
     }
 
@@ -243,7 +243,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         val requestBody =
             PartnershipsController.PartnershipUpdateRequest(LocalDate.now(), LocalDate.now().plusDays(999))
         assertThrows<Forbidden> {
-            controller.updatePartnership(db, user, partnership.id, requestBody)
+            controller.updatePartnership(deprecatedDb, user, partnership.id, requestBody)
         }
     }
 
@@ -255,7 +255,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
         }
 
         assertThrows<Forbidden> {
-            controller.deletePartnership(db, user, partnership.id)
+            controller.deletePartnership(deprecatedDb, user, partnership.id)
         }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -57,7 +57,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
     fun `End user cannot end update end user's contact info`() {
         val user = AuthenticatedUser.Citizen(UUID.randomUUID())
         assertThrows<Forbidden> {
-            controller.updateContactInfo(db, user, UUID.randomUUID(), contactInfo)
+            controller.updateContactInfo(deprecatedDb, user, UUID.randomUUID(), contactInfo)
         }
     }
 
@@ -67,7 +67,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
-            db,
+            deprecatedDb,
             user,
             SearchPersonBody(
                 searchTerm = "${person.firstName} ${person.lastName}",
@@ -85,7 +85,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
-            db,
+            deprecatedDb,
             user,
             SearchPersonBody(
                 searchTerm = "${person.firstName}\t${person.lastName}",
@@ -103,7 +103,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         val person = createPerson()
 
         val response = controller.findBySearchTerms(
-            db,
+            deprecatedDb,
             user,
             SearchPersonBody(
                 searchTerm = "${person.firstName}\u00A0${person.lastName}",
@@ -123,7 +123,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
         // IDEOGRAPHIC SPACE, not supported by default in regexes
         // unless Java's Pattern.UNICODE_CHARACTER_CLASS-like functionality is enabled.
         val response = controller.findBySearchTerms(
-            db,
+            deprecatedDb,
             user,
             SearchPersonBody(
                 searchTerm = "${person.firstName}\u3000${person.lastName}",
@@ -137,7 +137,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     private fun updateContactInfo(user: AuthenticatedUser) {
         val person = createPerson()
-        val actual = controller.updateContactInfo(db, user, person.id, contactInfo)
+        val actual = controller.updateContactInfo(deprecatedDb, user, person.id, contactInfo)
 
         assertEquals(HttpStatus.OK, actual.statusCode)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/utils/SpringMvcTestController.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/utils/SpringMvcTestController.kt
@@ -14,15 +14,15 @@ import java.util.concurrent.atomic.AtomicReference
 @RestController
 @RequestMapping("/integration-test")
 class SpringMvcTestController {
-    val lastDbConnection = AtomicReference<Database.Connection?>()
+    val lastDbConnection = AtomicReference<Database.DeprecatedConnection?>()
 
     @GetMapping("/db-connection-pass")
-    fun dbConnectionPass(db: Database.Connection) {
+    fun dbConnectionPass(db: Database.DeprecatedConnection) {
         lastDbConnection.set(db)
     }
 
     @GetMapping("/db-connection-fail")
-    fun dbConnectionFail(db: Database.Connection) {
+    fun dbConnectionFail(db: Database.DeprecatedConnection) {
         lastDbConnection.set(db)
         throw RuntimeException("Failed")
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
@@ -51,7 +51,7 @@ class ApplicationControllerCitizen(
 
     @GetMapping("/applications/by-guardian")
     fun getGuardianApplications(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): ResponseEntity<List<ApplicationsOfChild>> {
         Audit.ApplicationRead.log(targetId = user.id)
@@ -79,7 +79,7 @@ class ApplicationControllerCitizen(
 
     @GetMapping("/applications/{applicationId}")
     fun getApplication(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId
     ): ResponseEntity<ApplicationDetails> {
@@ -99,7 +99,7 @@ class ApplicationControllerCitizen(
 
     @PostMapping("/applications")
     fun createApplication(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         evakaClock: EvakaClock,
         @RequestBody body: CreateApplicationBody
@@ -139,7 +139,7 @@ class ApplicationControllerCitizen(
 
     @GetMapping("/applications/duplicates/{childId}")
     fun getChildDuplicateApplications(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<Map<ApplicationType, Boolean>> {
@@ -162,7 +162,7 @@ class ApplicationControllerCitizen(
 
     @GetMapping("/applications/active-placements/{childId}")
     fun getChildPlacementStatusByApplicationType(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<Map<ApplicationType, Boolean>> {
@@ -182,7 +182,7 @@ class ApplicationControllerCitizen(
 
     @PutMapping("/applications/{applicationId}")
     fun updateApplication(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         evakaClock: EvakaClock,
         @PathVariable applicationId: ApplicationId,
@@ -206,7 +206,7 @@ class ApplicationControllerCitizen(
 
     @PutMapping("/applications/{applicationId}/draft")
     fun saveApplicationAsDraft(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         evakaClock: EvakaClock,
         @PathVariable applicationId: ApplicationId,
@@ -231,7 +231,7 @@ class ApplicationControllerCitizen(
 
     @DeleteMapping("/applications/{applicationId}")
     fun deleteUnprocessedApplication(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId
     ): ResponseEntity<Unit> {
@@ -254,7 +254,7 @@ class ApplicationControllerCitizen(
 
     @PostMapping("/applications/{applicationId}/actions/send-application")
     fun sendApplication(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         evakaClock: EvakaClock,
         @PathVariable applicationId: ApplicationId
@@ -264,7 +264,7 @@ class ApplicationControllerCitizen(
     }
 
     @GetMapping("/decisions")
-    fun getDecisions(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<ApplicationDecisions>> {
+    fun getDecisions(db: Database.DeprecatedConnection, user: AuthenticatedUser): ResponseEntity<List<ApplicationDecisions>> {
         Audit.DecisionRead.log(targetId = user.id)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.END_USER)
@@ -273,7 +273,7 @@ class ApplicationControllerCitizen(
 
     @GetMapping("/applications/{applicationId}/decisions")
     fun getApplicationDecisions(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId
     ): ResponseEntity<List<Decision>> {
@@ -292,7 +292,7 @@ class ApplicationControllerCitizen(
 
     @PostMapping("/applications/{applicationId}/actions/accept-decision")
     fun acceptDecision(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId,
         @RequestBody body: AcceptDecisionRequest
@@ -313,7 +313,7 @@ class ApplicationControllerCitizen(
 
     @PostMapping("/applications/{applicationId}/actions/reject-decision")
     fun rejectDecision(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId,
         @RequestBody body: RejectDecisionRequest
@@ -327,7 +327,7 @@ class ApplicationControllerCitizen(
 
     @GetMapping("/decisions/{id}/download", produces = [MediaType.APPLICATION_PDF_VALUE])
     fun downloadDecisionPdf(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: DecisionId
     ): ResponseEntity<ByteArray> {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -122,7 +122,7 @@ class ApplicationControllerV2(
 ) {
     @PostMapping
     fun createPaperApplication(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         evakaClock: EvakaClock,
         @RequestBody body: PaperApplicationCreateRequest
@@ -166,7 +166,7 @@ class ApplicationControllerV2(
 
     @PostMapping("/search")
     fun getApplicationSummaries(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: SearchApplicationRequest
     ): ResponseEntity<Paged<ApplicationSummary>> {
@@ -221,7 +221,7 @@ class ApplicationControllerV2(
 
     @GetMapping("/by-guardian/{guardianId}")
     fun getGuardianApplicationSummaries(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "guardianId") guardianId: UUID
     ): ResponseEntity<List<PersonApplicationSummary>> {
@@ -234,7 +234,7 @@ class ApplicationControllerV2(
 
     @GetMapping("/by-child/{childId}")
     fun getChildApplicationSummaries(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "childId") childId: UUID
     ): ResponseEntity<List<PersonApplicationSummary>> {
@@ -247,7 +247,7 @@ class ApplicationControllerV2(
 
     @GetMapping("/{applicationId}")
     fun getApplicationDetails(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "applicationId") applicationId: ApplicationId
     ): ResponseEntity<ApplicationResponse> {
@@ -293,7 +293,7 @@ class ApplicationControllerV2(
 
     @PutMapping("/{applicationId}")
     fun updateApplication(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId,
         @RequestBody application: ApplicationUpdate
@@ -316,7 +316,7 @@ class ApplicationControllerV2(
 
     @PostMapping("/{applicationId}/actions/send-application")
     fun sendApplication(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId
     ): ResponseEntity<Unit> {
@@ -326,7 +326,7 @@ class ApplicationControllerV2(
 
     @GetMapping("/{applicationId}/placement-draft")
     fun getPlacementPlanDraft(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "applicationId") applicationId: ApplicationId
     ): ResponseEntity<PlacementPlanDraft> {
@@ -338,7 +338,7 @@ class ApplicationControllerV2(
 
     @GetMapping("/{applicationId}/decision-drafts")
     fun getDecisionDrafts(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "applicationId") applicationId: ApplicationId
     ): ResponseEntity<DecisionDraftJSON> {
@@ -399,7 +399,7 @@ class ApplicationControllerV2(
 
     @PutMapping("/{applicationId}/decision-drafts")
     fun updateDecisionDrafts(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "applicationId") applicationId: ApplicationId,
         @RequestBody body: List<DecisionDraftService.DecisionDraftUpdate>
@@ -413,7 +413,7 @@ class ApplicationControllerV2(
 
     @PostMapping("/placement-proposals/{unitId}/accept")
     fun acceptPlacementProposal(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "unitId") unitId: DaycareId
     ): ResponseEntity<Unit> {
@@ -423,7 +423,7 @@ class ApplicationControllerV2(
 
     @PostMapping("/batch/actions/{action}")
     fun simpleBatchAction(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable action: String,
         @RequestBody body: SimpleBatchRequest
@@ -448,7 +448,7 @@ class ApplicationControllerV2(
 
     @PostMapping("/{applicationId}/actions/create-placement-plan")
     fun createPlacementPlan(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId,
         @RequestBody body: DaycarePlacementPlan
@@ -462,7 +462,7 @@ class ApplicationControllerV2(
 
     @PostMapping("/{applicationId}/actions/respond-to-placement-proposal")
     fun respondToPlacementProposal(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId,
         @RequestBody body: PlacementProposalConfirmationUpdate
@@ -482,7 +482,7 @@ class ApplicationControllerV2(
 
     @PostMapping("/{applicationId}/actions/accept-decision")
     fun acceptDecision(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId,
         @RequestBody body: AcceptDecisionRequest
@@ -495,7 +495,7 @@ class ApplicationControllerV2(
 
     @PostMapping("/{applicationId}/actions/reject-decision")
     fun rejectDecision(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId,
         @RequestBody body: RejectDecisionRequest
@@ -506,7 +506,7 @@ class ApplicationControllerV2(
 
     @PostMapping("/{applicationId}/actions/{action}")
     fun simpleAction(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId,
         @PathVariable action: String

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
@@ -32,7 +32,7 @@ import java.util.UUID
 class NoteController(private val accessControl: AccessControl) {
     @GetMapping("/application/{applicationId}")
     fun getNotes(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId
     ): ResponseEntity<List<NoteJSON>> {
@@ -47,7 +47,7 @@ class NoteController(private val accessControl: AccessControl) {
 
     @PostMapping("/application/{id}")
     fun createNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("id") applicationId: ApplicationId,
         @RequestBody note: NoteRequest
@@ -63,7 +63,7 @@ class NoteController(private val accessControl: AccessControl) {
 
     @PutMapping("/{noteId}")
     fun updateNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("noteId") noteId: ApplicationNoteId,
         @RequestBody note: NoteRequest
@@ -79,7 +79,7 @@ class NoteController(private val accessControl: AccessControl) {
 
     @DeleteMapping("/{noteId}")
     fun deleteNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("noteId") noteId: ApplicationNoteId
     ): ResponseEntity<Unit> {
@@ -93,7 +93,7 @@ class NoteController(private val accessControl: AccessControl) {
 
     @PutMapping("/service-worker/application/{applicationId}")
     fun updateServiceWorkerNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId,
         @RequestBody note: NoteRequest

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -31,7 +31,7 @@ class AssistanceActionController(
 ) {
     @PostMapping("/children/{childId}/assistance-actions")
     fun createAssistanceAction(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: AssistanceActionRequest
@@ -48,7 +48,7 @@ class AssistanceActionController(
 
     @GetMapping("/children/{childId}/assistance-actions")
     fun getAssistanceActions(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): List<AssistanceAction> {
@@ -61,7 +61,7 @@ class AssistanceActionController(
 
     @PutMapping("/assistance-actions/{id}")
     fun updateAssistanceAction(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("id") assistanceActionId: AssistanceActionId,
         @RequestBody body: AssistanceActionRequest
@@ -78,7 +78,7 @@ class AssistanceActionController(
 
     @DeleteMapping("/assistance-actions/{id}")
     fun deleteAssistanceAction(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("id") assistanceActionId: AssistanceActionId
     ): ResponseEntity<Unit> {
@@ -89,7 +89,7 @@ class AssistanceActionController(
     }
 
     @GetMapping("/assistance-action-options")
-    fun getAssistanceActionOptions(db: Database.Connection, user: AuthenticatedUser): List<AssistanceActionOption> {
+    fun getAssistanceActionOptions(db: Database.DeprecatedConnection, user: AuthenticatedUser): List<AssistanceActionOption> {
         accessControl.requirePermissionFor(user, Action.Global.READ_ASSISTANCE_BASIS_OPTIONS)
         return assistanceActionService.getAssistanceActionOptions(db)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -31,7 +31,7 @@ class AssistanceNeedController(
 ) {
     @PostMapping("/children/{childId}/assistance-needs")
     fun createAssistanceNeed(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: AssistanceNeedRequest
@@ -48,7 +48,7 @@ class AssistanceNeedController(
 
     @GetMapping("/children/{childId}/assistance-needs")
     fun getAssistanceNeeds(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): List<AssistanceNeed> {
@@ -61,7 +61,7 @@ class AssistanceNeedController(
 
     @PutMapping("/assistance-needs/{id}")
     fun updateAssistanceNeed(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("id") assistanceNeedId: AssistanceNeedId,
         @RequestBody body: AssistanceNeedRequest
@@ -78,7 +78,7 @@ class AssistanceNeedController(
 
     @DeleteMapping("/assistance-needs/{id}")
     fun deleteAssistanceNeed(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("id") assistanceNeedId: AssistanceNeedId
     ): ResponseEntity<Unit> {
@@ -89,7 +89,7 @@ class AssistanceNeedController(
     }
 
     @GetMapping("/assistance-basis-options")
-    fun getAssistanceBasisOptions(db: Database.Connection, user: AuthenticatedUser): List<AssistanceBasisOption> {
+    fun getAssistanceBasisOptions(db: Database.DeprecatedConnection, user: AuthenticatedUser): List<AssistanceBasisOption> {
         accessControl.requirePermissionFor(user, Action.Global.READ_ASSISTANCE_BASIS_OPTIONS)
         return assistanceNeedService.getAssistanceBasisOptions(db)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -57,7 +57,7 @@ class AttachmentsController(
 
     @PostMapping("/applications/{applicationId}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun uploadApplicationAttachmentEmployee(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         evakaClock: EvakaClock,
         user: AuthenticatedUser,
         @PathVariable applicationId: ApplicationId,
@@ -73,7 +73,7 @@ class AttachmentsController(
 
     @PostMapping("/income-statements/{incomeStatementId}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun uploadIncomeStatementAttachmentEmployee(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable incomeStatementId: IncomeStatementId,
         @RequestPart("file") file: MultipartFile
@@ -85,7 +85,7 @@ class AttachmentsController(
 
     @PostMapping("/messages/{draftId}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun uploadMessageAttachment(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable draftId: MessageDraftId,
         @RequestPart("file") file: MultipartFile
@@ -97,7 +97,7 @@ class AttachmentsController(
 
     @PostMapping("/pedagogical-documents/{documentId}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun uploadPedagogicalDocumentAttachment(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable documentId: PedagogicalDocumentId,
         @RequestPart("file") file: MultipartFile
@@ -112,7 +112,7 @@ class AttachmentsController(
 
     @PostMapping("/citizen/applications/{applicationId}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun uploadApplicationAttachmentCitizen(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         evakaClock: EvakaClock,
         @PathVariable applicationId: ApplicationId,
@@ -135,7 +135,7 @@ class AttachmentsController(
         consumes = [MediaType.MULTIPART_FORM_DATA_VALUE]
     )
     fun uploadAttachmentCitizen(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Citizen,
         @PathVariable(required = false) incomeStatementId: IncomeStatementId?,
         @RequestPart("file") file: MultipartFile
@@ -152,7 +152,7 @@ class AttachmentsController(
         return handleFileUpload(db, user, attachTo, file, defaultAllowedAttachmentContentTypes)
     }
 
-    private fun checkAttachmentCount(db: Database.Connection, attachTo: AttachmentParent, user: AuthenticatedUser) {
+    private fun checkAttachmentCount(db: Database.DeprecatedConnection, attachTo: AttachmentParent, user: AuthenticatedUser) {
         val count = db.read {
             when (attachTo) {
                 AttachmentParent.None -> it.userUnparentedAttachmentCount(user.id)
@@ -186,7 +186,7 @@ class AttachmentsController(
         .last()
 
     private fun handleFileUpload(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         attachTo: AttachmentParent,
         file: MultipartFile,
@@ -227,7 +227,7 @@ class AttachmentsController(
 
     @GetMapping("/{attachmentId}/download")
     fun getAttachment(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable attachmentId: AttachmentId
     ): ResponseEntity<ByteArray> {
@@ -261,7 +261,7 @@ class AttachmentsController(
 
     @DeleteMapping(value = ["/{attachmentId}", "/citizen/{attachmentId}"])
     fun deleteAttachmentHandler(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable attachmentId: AttachmentId
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -69,7 +69,7 @@ class ChildAttendanceController(
 
     @GetMapping("/units/{unitId}")
     fun getAttendances(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId
     ): AttendanceResponse {
@@ -86,7 +86,7 @@ class ChildAttendanceController(
 
     @PostMapping("/units/{unitId}/children/{childId}/arrival")
     fun postArrival(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID,
@@ -115,7 +115,7 @@ class ChildAttendanceController(
 
     @PostMapping("/units/{unitId}/children/{childId}/return-to-coming")
     fun returnToComing(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID
@@ -145,7 +145,7 @@ class ChildAttendanceController(
 
     @GetMapping("/units/{unitId}/children/{childId}/departure")
     fun getChildDeparture(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID
@@ -183,7 +183,7 @@ class ChildAttendanceController(
 
     @PostMapping("/units/{unitId}/children/{childId}/departure")
     fun postDeparture(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID,
@@ -240,7 +240,7 @@ class ChildAttendanceController(
 
     @PostMapping("/units/{unitId}/children/{childId}/return-to-present")
     fun returnToPresent(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID
@@ -273,7 +273,7 @@ class ChildAttendanceController(
 
     @PostMapping("/units/{unitId}/children/{childId}/full-day-absence")
     fun postFullDayAbsence(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID,
@@ -310,7 +310,7 @@ class ChildAttendanceController(
 
     @PostMapping("/units/{unitId}/children/{childId}/absence-range")
     fun postAbsenceRange(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @PathVariable childId: UUID,
@@ -338,7 +338,7 @@ class ChildAttendanceController(
 
     @DeleteMapping("/units/{unitId}/children/{childId}/absence-range")
     fun deleteAbsenceRange(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
@@ -30,7 +30,7 @@ class MobileUnitController(
 ) {
     @GetMapping("/{unitId}")
     fun getUnitInfo(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         evakaClock: EvakaClock,
         @PathVariable unitId: DaycareId
@@ -43,7 +43,7 @@ class MobileUnitController(
 
     @GetMapping("/stats")
     fun getUnitStats(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         evakaClock: EvakaClock,
         @RequestParam unitIds: List<DaycareId>,

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -36,7 +36,7 @@ class RealtimeStaffAttendanceController(
 ) {
     @GetMapping
     fun getAttendancesByUnit(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam unitId: DaycareId
     ): StaffAttendanceResponse {
@@ -64,7 +64,7 @@ class RealtimeStaffAttendanceController(
     )
     @PostMapping("/arrival")
     fun markArrival(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: StaffArrivalRequest
     ) {
@@ -95,7 +95,7 @@ class RealtimeStaffAttendanceController(
     )
     @PostMapping("/{attendanceId}/departure")
     fun markDeparture(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable attendanceId: StaffAttendanceId,
         @RequestBody body: StaffDepartureRequest
@@ -125,7 +125,7 @@ class RealtimeStaffAttendanceController(
     )
     @PostMapping("/arrival-external")
     fun markExternalArrival(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: ExternalStaffArrivalRequest
     ): StaffAttendanceExternalId {
@@ -149,7 +149,7 @@ class RealtimeStaffAttendanceController(
     )
     @PostMapping("/departure-external")
     fun markExternalDeparture(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: ExternalStaffDepartureRequest
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -31,7 +31,7 @@ import java.util.UUID
 class BackupCareController(private val accessControl: AccessControl) {
     @GetMapping("/children/{childId}/backup-cares")
     fun getForChild(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("childId") childId: UUID
     ): ResponseEntity<ChildBackupCaresResponse> {
@@ -43,7 +43,7 @@ class BackupCareController(private val accessControl: AccessControl) {
 
     @PostMapping("/children/{childId}/backup-cares")
     fun createForChild(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("childId") childId: UUID,
         @RequestBody body: NewBackupCare
@@ -60,7 +60,7 @@ class BackupCareController(private val accessControl: AccessControl) {
 
     @PostMapping("/backup-cares/{id}")
     fun update(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("id") backupCareId: BackupCareId,
         @RequestBody body: BackupCareUpdateRequest
@@ -77,7 +77,7 @@ class BackupCareController(private val accessControl: AccessControl) {
 
     @DeleteMapping("/backup-cares/{id}")
     fun delete(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("id") backupCareId: BackupCareId
     ): ResponseEntity<Unit> {
@@ -89,7 +89,7 @@ class BackupCareController(private val accessControl: AccessControl) {
 
     @GetMapping("/daycares/{daycareId}/backup-cares")
     fun getForDaycare(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("daycareId") daycareId: DaycareId,
         @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/backuppickup/BackupPickupController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backuppickup/BackupPickupController.kt
@@ -30,7 +30,7 @@ class BackupPickupController(
 ) {
     @PostMapping("/children/{childId}/backup-pickups")
     fun createForChild(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("childId") childId: UUID,
         @RequestBody body: ChildBackupPickupContent
@@ -46,7 +46,7 @@ class BackupPickupController(
 
     @GetMapping("/children/{childId}/backup-pickups")
     fun getForChild(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("childId") childId: UUID
     ): ResponseEntity<List<ChildBackupPickup>> {
@@ -60,7 +60,7 @@ class BackupPickupController(
 
     @PutMapping("/backup-pickups/{id}")
     fun update(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("id") id: BackupPickupId,
         @RequestBody body: ChildBackupPickupContent
@@ -76,7 +76,7 @@ class BackupPickupController(
 
     @DeleteMapping("/backup-pickups/{id}")
     fun delete(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("id") id: BackupPickupId
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesController.kt
@@ -29,7 +29,7 @@ class DailyServiceTimesController(
 
     @GetMapping("/children/{childId}/daily-service-times")
     fun getDailyServiceTimes(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<DailyServiceTimesResponse> {
@@ -45,7 +45,7 @@ class DailyServiceTimesController(
 
     @PutMapping("/children/{childId}/daily-service-times")
     fun putDailyServiceTimes(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: DailyServiceTimes
@@ -60,7 +60,7 @@ class DailyServiceTimesController(
 
     @DeleteMapping("/children/{childId}/daily-service-times")
     fun deleteDailyServiceTimes(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
@@ -33,7 +33,7 @@ import java.util.UUID
 class AbsenceController(private val absenceService: AbsenceService, private val acl: AccessControlList, private val accessControl: AccessControl) {
     @GetMapping("/{groupId}")
     fun getAbsencesByGroupAndMonth(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam year: Int,
         @RequestParam month: Int,
@@ -47,7 +47,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
 
     @PostMapping("/{groupId}")
     fun upsertAbsences(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody absences: Wrapper<List<Absence>>,
         @PathVariable groupId: GroupId
@@ -64,7 +64,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
 
     @PostMapping("/{groupId}/delete")
     fun deleteAbsences(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody deletions: List<AbsenceDelete>,
         @PathVariable groupId: GroupId
@@ -81,7 +81,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
 
     @GetMapping("/by-child/{childId}")
     fun getAbsencesByChild(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestParam year: Int,
@@ -95,7 +95,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
 
     @GetMapping("/by-child/{childId}/future")
     fun getFutureAbsencesByChild(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): ResponseEntity<List<Absence>> {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
@@ -33,7 +33,7 @@ import java.util.UUID
 @RestController
 class ChildController(private val accessControl: AccessControl) {
     @GetMapping("/children/{childId}")
-    fun getChild(db: Database.Connection, user: AuthenticatedUser, @PathVariable childId: UUID): ChildResponse {
+    fun getChild(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable childId: UUID): ChildResponse {
         Audit.PersonDetailsRead.log(targetId = childId)
         accessControl.requirePermissionFor(user, Action.Child.READ, childId)
         val child = db.read { it.getPersonById(childId) }
@@ -55,7 +55,7 @@ class ChildController(private val accessControl: AccessControl) {
     }
 
     @GetMapping("/children/{childId}/additional-information")
-    fun getAdditionalInfo(db: Database.Connection, user: AuthenticatedUser, @PathVariable childId: UUID): ResponseEntity<AdditionalInformation> {
+    fun getAdditionalInfo(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable childId: UUID): ResponseEntity<AdditionalInformation> {
         Audit.ChildAdditionalInformationRead.log(targetId = childId)
         accessControl.requirePermissionFor(user, Action.Child.READ_ADDITIONAL_INFO, childId)
         return db.read { it.getAdditionalInformation(childId) }.let(::ok)
@@ -63,7 +63,7 @@ class ChildController(private val accessControl: AccessControl) {
 
     @PutMapping("/children/{childId}/additional-information")
     fun updateAdditionalInfo(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody data: AdditionalInformation

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -56,7 +56,7 @@ class DaycareController(
     private val accessControl: AccessControl
 ) {
     @GetMapping
-    fun getDaycares(db: Database.Connection, user: AuthenticatedUser): List<Daycare> {
+    fun getDaycares(db: Database.DeprecatedConnection, user: AuthenticatedUser): List<Daycare> {
         Audit.UnitSearch.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_UNITS)
         return db.read { it.getDaycares(acl.getAuthorizedDaycares(user)) }
@@ -64,7 +64,7 @@ class DaycareController(
 
     @GetMapping("/features")
     fun getFeatures(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): List<UnitFeatures> {
         Audit.UnitFeaturesRead.log()
@@ -74,7 +74,7 @@ class DaycareController(
 
     @PutMapping("/{daycareId}/features")
     fun putFeatures(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @RequestBody features: Set<PilotFeature>
@@ -86,7 +86,7 @@ class DaycareController(
 
     @GetMapping("/{daycareId}")
     fun getDaycare(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId
     ): DaycareResponse {
@@ -109,7 +109,7 @@ class DaycareController(
 
     @GetMapping("/{daycareId}/groups")
     fun getGroups(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate? = null,
@@ -122,7 +122,7 @@ class DaycareController(
 
     @PostMapping("/{daycareId}/groups")
     fun createGroup(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @RequestBody body: CreateGroupRequest
@@ -140,7 +140,7 @@ class DaycareController(
     )
     @PutMapping("/{daycareId}/groups/{groupId}")
     fun updateGroup(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId,
@@ -154,7 +154,7 @@ class DaycareController(
 
     @DeleteMapping("/{daycareId}/groups/{groupId}")
     fun deleteGroup(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId
@@ -167,7 +167,7 @@ class DaycareController(
 
     @GetMapping("/{daycareId}/groups/{groupId}/caretakers")
     fun getCaretakers(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId
@@ -186,7 +186,7 @@ class DaycareController(
 
     @PostMapping("/{daycareId}/groups/{groupId}/caretakers")
     fun createCaretakers(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId,
@@ -208,7 +208,7 @@ class DaycareController(
 
     @PutMapping("/{daycareId}/groups/{groupId}/caretakers/{id}")
     fun updateCaretakers(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId,
@@ -232,7 +232,7 @@ class DaycareController(
 
     @DeleteMapping("/{daycareId}/groups/{groupId}/caretakers/{id}")
     fun removeCaretakers(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId,
@@ -252,7 +252,7 @@ class DaycareController(
 
     @GetMapping("/{daycareId}/stats")
     fun getStats(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
@@ -265,7 +265,7 @@ class DaycareController(
 
     @PutMapping("/{daycareId}")
     fun updateDaycare(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @RequestBody fields: DaycareFields
@@ -282,7 +282,7 @@ class DaycareController(
 
     @PostMapping
     fun createDaycare(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody fields: DaycareFields
     ): CreateDaycareResponse {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -34,7 +34,7 @@ import java.util.UUID
 class LocationController {
     @GetMapping("/units")
     fun getApplicationUnits(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam type: ApplicationUnitType,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
@@ -46,7 +46,7 @@ class LocationController {
 
     @GetMapping("/public/units/{applicationType}")
     fun getAllApplicableUnits(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable applicationType: ApplicationType
     ): ResponseEntity<List<PublicUnit>> {
         return db
@@ -55,7 +55,7 @@ class LocationController {
     }
 
     @GetMapping("/areas")
-    fun getAreas(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<Collection<AreaJSON>> {
+    fun getAreas(db: Database.DeprecatedConnection, user: AuthenticatedUser): ResponseEntity<Collection<AreaJSON>> {
         return db
             .read {
                 it.createQuery("SELECT id, name, short_name FROM care_area")
@@ -66,7 +66,7 @@ class LocationController {
     }
 
     @GetMapping("/filters/units")
-    fun getUnits(db: Database.Connection, @RequestParam type: UnitTypeFilter, @RequestParam area: String?): ResponseEntity<List<UnitStub>> {
+    fun getUnits(db: Database.DeprecatedConnection, @RequestParam type: UnitTypeFilter, @RequestParam area: String?): ResponseEntity<List<UnitStub>> {
         val areas = area?.split(",") ?: listOf()
         val units = db.read { it.getUnits(areas, type) }
         return ResponseEntity.ok(units)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
@@ -35,7 +35,7 @@ class StaffAttendanceController(
 ) {
     @GetMapping("/unit/{unitId}")
     fun getAttendancesByUnit(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId
     ): ResponseEntity<UnitStaffAttendance> {
@@ -48,7 +48,7 @@ class StaffAttendanceController(
 
     @GetMapping("/group/{groupId}")
     fun getAttendancesByGroup(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam year: Int,
         @RequestParam month: Int,
@@ -64,7 +64,7 @@ class StaffAttendanceController(
 
     @PostMapping("/group/{groupId}")
     fun upsertStaffAttendance(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody staffAttendance: StaffAttendanceUpdate,
         @PathVariable groupId: GroupId

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/TermsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/TermsController.kt
@@ -16,12 +16,12 @@ import org.springframework.web.bind.annotation.RestController
 class TermsController {
 
     @GetMapping("/public/club-terms")
-    fun getClubTerms(db: Database.Connection): List<ClubTerm> {
+    fun getClubTerms(db: Database.DeprecatedConnection): List<ClubTerm> {
         return db.read { it.getClubTerms() }
     }
 
     @GetMapping("/public/preschool-terms")
-    fun getPreschoolTerms(db: Database.Connection): List<PreschoolTerm> {
+    fun getPreschoolTerms(db: Database.DeprecatedConnection): List<PreschoolTerm> {
         return db.read { it.getPreschoolTerms() }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController
 class UnitAclController(private val accessControl: AccessControl) {
     @GetMapping("/daycares/{daycareId}/acl")
     fun getAcl(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId
     ): ResponseEntity<DaycareAclResponse> {
@@ -46,7 +46,7 @@ class UnitAclController(private val accessControl: AccessControl) {
 
     @PutMapping("/daycares/{daycareId}/supervisors/{employeeId}")
     fun insertUnitSupervisor(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
@@ -59,7 +59,7 @@ class UnitAclController(private val accessControl: AccessControl) {
 
     @DeleteMapping("/daycares/{daycareId}/supervisors/{employeeId}")
     fun deleteUnitSupervisor(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
@@ -72,7 +72,7 @@ class UnitAclController(private val accessControl: AccessControl) {
 
     @PutMapping("/daycares/{daycareId}/specialeducationteacher/{employeeId}")
     fun insertSpecialEducationTeacher(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
@@ -85,7 +85,7 @@ class UnitAclController(private val accessControl: AccessControl) {
 
     @DeleteMapping("/daycares/{daycareId}/specialeducationteacher/{employeeId}")
     fun deleteSpecialEducationTeacher(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
@@ -98,7 +98,7 @@ class UnitAclController(private val accessControl: AccessControl) {
 
     @PutMapping("/daycares/{daycareId}/staff/{employeeId}")
     fun insertStaff(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
@@ -111,7 +111,7 @@ class UnitAclController(private val accessControl: AccessControl) {
 
     @DeleteMapping("/daycares/{daycareId}/staff/{employeeId}")
     fun deleteStaff(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
@@ -124,7 +124,7 @@ class UnitAclController(private val accessControl: AccessControl) {
 
     @PutMapping("/daycares/{daycareId}/staff/{employeeId}/groups")
     fun updateStaffGroupAcl(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId,

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
@@ -34,7 +34,7 @@ class DecisionController(
 ) {
     @GetMapping("/by-guardian")
     fun getDecisionsByGuardian(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("id") guardianId: UUID
     ): ResponseEntity<DecisionListResponse> {
@@ -48,7 +48,7 @@ class DecisionController(
 
     @GetMapping("/by-child")
     fun getDecisionsByChild(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("id") childId: UUID
     ): ResponseEntity<DecisionListResponse> {
@@ -62,7 +62,7 @@ class DecisionController(
 
     @GetMapping("/by-application")
     fun getDecisionsByApplication(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("id") applicationId: ApplicationId
     ): ResponseEntity<DecisionListResponse> {
@@ -75,7 +75,7 @@ class DecisionController(
     }
 
     @GetMapping("/units")
-    fun getDecisionUnits(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<DecisionUnit>> {
+    fun getDecisionUnits(db: Database.DeprecatedConnection, user: AuthenticatedUser): ResponseEntity<List<DecisionUnit>> {
         Audit.UnitRead.log()
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
@@ -85,7 +85,7 @@ class DecisionController(
 
     @GetMapping("/{id}/download", produces = [MediaType.APPLICATION_PDF_VALUE])
     fun downloadDecisionPdf(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("id") decisionId: DecisionId
     ): ResponseEntity<ByteArray> {

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
@@ -29,7 +29,7 @@ class IncomeStatementController(
 ) {
     @GetMapping("/person/{personId}")
     fun getIncomeStatements(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable personId: PersonId,
         @RequestParam page: Int,
@@ -49,7 +49,7 @@ class IncomeStatementController(
 
     @GetMapping("/person/{personId}/{incomeStatementId}")
     fun getIncomeStatement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable personId: PersonId,
         @PathVariable incomeStatementId: IncomeStatementId,
@@ -69,7 +69,7 @@ class IncomeStatementController(
 
     @PostMapping("/{incomeStatementId}/handled")
     fun setHandled(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable incomeStatementId: IncomeStatementId,
         @RequestBody body: SetIncomeStatementHandledBody
@@ -87,7 +87,7 @@ class IncomeStatementController(
 
     @GetMapping("/awaiting-handler")
     fun getIncomeStatementsAwaitingHandler(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam areas: String,
         @RequestParam page: Int,

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizen.kt
@@ -31,7 +31,7 @@ import java.time.LocalDate
 class IncomeStatementControllerCitizen {
     @GetMapping
     fun getIncomeStatements(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Citizen,
         @RequestParam page: Int,
         @RequestParam pageSize: Int
@@ -46,7 +46,7 @@ class IncomeStatementControllerCitizen {
 
     @GetMapping("/start-dates")
     fun getIncomeStatementStartDates(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Citizen
     ): List<LocalDate> {
         Audit.IncomeStatementStartDates.log()
@@ -57,7 +57,7 @@ class IncomeStatementControllerCitizen {
 
     @GetMapping("/{incomeStatementId}")
     fun getIncomeStatement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Citizen,
         @PathVariable incomeStatementId: IncomeStatementId,
     ): IncomeStatement {
@@ -72,7 +72,7 @@ class IncomeStatementControllerCitizen {
 
     @PostMapping
     fun createIncomeStatement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Citizen,
         @RequestBody body: IncomeStatementBody
     ) {
@@ -97,7 +97,7 @@ class IncomeStatementControllerCitizen {
 
     @PutMapping("/{incomeStatementId}")
     fun updateIncomeStatement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Citizen,
         @PathVariable incomeStatementId: IncomeStatementId,
         @RequestBody body: IncomeStatementBody
@@ -124,7 +124,7 @@ class IncomeStatementControllerCitizen {
 
     @DeleteMapping("/{id}")
     fun removeIncomeStatement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Citizen,
         @PathVariable id: IncomeStatementId
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
@@ -35,7 +35,7 @@ import java.util.UUID
 @RequestMapping("/fee-alterations")
 class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner<AsyncJob>, private val accessControl: AccessControl) {
     @GetMapping
-    fun getFeeAlterations(db: Database.Connection, user: AuthenticatedUser, @RequestParam personId: UUID): ResponseEntity<Wrapper<List<FeeAlteration>>> {
+    fun getFeeAlterations(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestParam personId: UUID): ResponseEntity<Wrapper<List<FeeAlteration>>> {
         Audit.ChildFeeAlterationsRead.log(targetId = personId)
         accessControl.requirePermissionFor(user, Action.Child.READ_FEE_ALTERATIONS, personId)
 
@@ -44,7 +44,7 @@ class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner<AsyncJo
     }
 
     @PostMapping
-    fun createFeeAlteration(db: Database.Connection, user: AuthenticatedUser, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
+    fun createFeeAlteration(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
         Audit.ChildFeeAlterationsCreate.log(targetId = feeAlteration.personId)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -65,7 +65,7 @@ class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner<AsyncJo
     }
 
     @PutMapping("/{feeAlterationId}")
-    fun updateFeeAlteration(db: Database.Connection, user: AuthenticatedUser, @PathVariable feeAlterationId: String, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
+    fun updateFeeAlteration(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable feeAlterationId: String, @RequestBody feeAlteration: FeeAlteration): ResponseEntity<Unit> {
         Audit.ChildFeeAlterationsUpdate.log(targetId = feeAlterationId)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -85,7 +85,7 @@ class FeeAlterationController(private val asyncJobRunner: AsyncJobRunner<AsyncJo
     }
 
     @DeleteMapping("/{feeAlterationId}")
-    fun deleteFeeAlteration(db: Database.Connection, user: AuthenticatedUser, @PathVariable feeAlterationId: String): ResponseEntity<Unit> {
+    fun deleteFeeAlteration(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable feeAlterationId: String): ResponseEntity<Unit> {
         Audit.ChildFeeAlterationsDelete.log(targetId = feeAlterationId)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -69,7 +69,7 @@ class FeeDecisionController(
 ) {
     @PostMapping("/search")
     fun search(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: SearchFeeDecisionRequest
     ): ResponseEntity<Paged<FeeDecisionSummary>> {
@@ -102,7 +102,7 @@ class FeeDecisionController(
     }
 
     @PostMapping("/confirm")
-    fun confirmDrafts(db: Database.Connection, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<FeeDecisionId>): ResponseEntity<Unit> {
+    fun confirmDrafts(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<FeeDecisionId>): ResponseEntity<Unit> {
         Audit.FeeDecisionConfirm.log(targetId = feeDecisionIds)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -114,7 +114,7 @@ class FeeDecisionController(
     }
 
     @PostMapping("/mark-sent")
-    fun setSent(db: Database.Connection, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<FeeDecisionId>): ResponseEntity<Unit> {
+    fun setSent(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<FeeDecisionId>): ResponseEntity<Unit> {
         Audit.FeeDecisionMarkSent.log(targetId = feeDecisionIds)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -123,7 +123,7 @@ class FeeDecisionController(
     }
 
     @GetMapping("/pdf/{uuid}")
-    fun getDecisionPdf(db: Database.Connection, user: AuthenticatedUser, @PathVariable uuid: FeeDecisionId): ResponseEntity<ByteArray> {
+    fun getDecisionPdf(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable uuid: FeeDecisionId): ResponseEntity<ByteArray> {
         Audit.FeeDecisionPdfRead.log(targetId = uuid)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -135,7 +135,7 @@ class FeeDecisionController(
     }
 
     @GetMapping("/{uuid}")
-    fun getDecision(db: Database.Connection, user: AuthenticatedUser, @PathVariable uuid: FeeDecisionId): ResponseEntity<Wrapper<FeeDecisionDetailed>> {
+    fun getDecision(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable uuid: FeeDecisionId): ResponseEntity<Wrapper<FeeDecisionDetailed>> {
         Audit.FeeDecisionRead.log(targetId = uuid)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -146,7 +146,7 @@ class FeeDecisionController(
 
     @GetMapping("/head-of-family/{uuid}")
     fun getHeadOfFamilyFeeDecisions(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable uuid: UUID
     ): ResponseEntity<Wrapper<List<FeeDecision>>> {
@@ -165,7 +165,7 @@ class FeeDecisionController(
 
     @PostMapping("/head-of-family/{id}/create-retroactive")
     fun generateRetroactiveDecisions(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: UUID,
         @RequestBody body: CreateRetroactiveFeeDecisionsBody
@@ -179,7 +179,7 @@ class FeeDecisionController(
 
     @PostMapping("/set-type/{uuid}")
     fun setType(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable uuid: FeeDecisionId,
         @RequestBody request: FeeDecisionTypeRequest

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
@@ -30,7 +30,7 @@ data class GenerateDecisionsBody(
 @RequestMapping("/fee-decision-generator")
 class FeeDecisionGeneratorController(private val asyncJobRunner: AsyncJobRunner<AsyncJob>) {
     @PostMapping("/generate")
-    fun generateDecisions(db: Database.Connection, user: AuthenticatedUser, @RequestBody data: GenerateDecisionsBody): ResponseEntity<Unit> {
+    fun generateDecisions(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody data: GenerateDecisionsBody): ResponseEntity<Unit> {
         Audit.FeeDecisionGenerate.log(targetId = data.targetHeads)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -42,7 +42,7 @@ class FeeDecisionGeneratorController(private val asyncJobRunner: AsyncJobRunner<
         return ResponseEntity.noContent().build()
     }
 
-    private fun generateAllStartingFrom(db: Database.Connection, starting: LocalDate, targetHeads: List<UUID>) {
+    private fun generateAllStartingFrom(db: Database.DeprecatedConnection, starting: LocalDate, targetHeads: List<UUID>) {
         db.transaction { planFinanceDecisionGeneration(it, asyncJobRunner, DateRange(starting, null), targetHeads) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
@@ -39,7 +39,7 @@ class FinanceBasicsController(
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     @GetMapping("/fee-thresholds")
-    fun getFeeThresholds(db: Database.Connection, user: AuthenticatedUser): List<FeeThresholdsWithId> {
+    fun getFeeThresholds(db: Database.DeprecatedConnection, user: AuthenticatedUser): List<FeeThresholdsWithId> {
         Audit.FinanceBasicsFeeThresholdsRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_FEE_THRESHOLDS)
 
@@ -48,7 +48,7 @@ class FinanceBasicsController(
 
     @PostMapping("/fee-thresholds")
     fun createFeeThresholds(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: FeeThresholds
     ) {
@@ -77,7 +77,7 @@ class FinanceBasicsController(
 
     @PutMapping("/fee-thresholds/{id}")
     fun updateFeeThresholds(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: FeeThresholdsId,
         @RequestBody thresholds: FeeThresholds

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -49,7 +49,7 @@ class IncomeController(
     private val accessControl: AccessControl
 ) {
     @GetMapping
-    fun getIncome(db: Database.Connection, user: AuthenticatedUser, @RequestParam personId: PersonId): Wrapper<List<Income>> {
+    fun getIncome(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestParam personId: PersonId): Wrapper<List<Income>> {
         Audit.PersonIncomeRead.log(targetId = personId)
         accessControl.requirePermissionFor(user, Action.Person.READ_INCOME, personId)
 
@@ -58,7 +58,7 @@ class IncomeController(
     }
 
     @PostMapping
-    fun createIncome(db: Database.Connection, user: AuthenticatedUser, @RequestBody income: Income): ResponseEntity<IncomeId> {
+    fun createIncome(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody income: Income): ResponseEntity<IncomeId> {
         Audit.PersonIncomeCreate.log(targetId = income.personId)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -85,7 +85,7 @@ class IncomeController(
 
     @PutMapping("/{incomeId}")
     fun updateIncome(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable incomeId: IncomeId,
         @RequestBody income: Income
@@ -111,7 +111,7 @@ class IncomeController(
     }
 
     @DeleteMapping("/{incomeId}")
-    fun deleteIncome(db: Database.Connection, user: AuthenticatedUser, @PathVariable incomeId: IncomeId): ResponseEntity<Unit> {
+    fun deleteIncome(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable incomeId: IncomeId): ResponseEntity<Unit> {
         Audit.PersonIncomeDelete.log(targetId = incomeId)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
@@ -60,7 +60,7 @@ class InvoiceController(
 ) {
     @PostMapping("/search")
     fun searchInvoices(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: SearchInvoicesRequest
     ): ResponseEntity<Paged<InvoiceSummary>> {
@@ -89,7 +89,7 @@ class InvoiceController(
     }
 
     @PostMapping("/create-drafts")
-    fun createDraftInvoices(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<Unit> {
+    fun createDraftInvoices(db: Database.DeprecatedConnection, user: AuthenticatedUser): ResponseEntity<Unit> {
         Audit.InvoicesCreate.log()
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -98,7 +98,7 @@ class InvoiceController(
     }
 
     @PostMapping("/delete-drafts")
-    fun deleteDraftInvoices(db: Database.Connection, user: AuthenticatedUser, @RequestBody invoiceIds: List<UUID>): ResponseEntity<Unit> {
+    fun deleteDraftInvoices(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody invoiceIds: List<UUID>): ResponseEntity<Unit> {
         Audit.InvoicesDeleteDrafts.log(targetId = invoiceIds)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -108,7 +108,7 @@ class InvoiceController(
 
     @PostMapping("/send")
     fun sendInvoices(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         @RequestParam(required = false) invoiceDate: LocalDate?,
@@ -127,7 +127,7 @@ class InvoiceController(
 
     @PostMapping("/send/by-date")
     fun sendInvoicesByDate(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody payload: InvoicePayload
     ): ResponseEntity<Unit> {
@@ -142,7 +142,7 @@ class InvoiceController(
     }
 
     @PostMapping("/mark-sent")
-    fun markInvoicesSent(db: Database.Connection, user: AuthenticatedUser, @RequestBody invoiceIds: List<UUID>): ResponseEntity<Unit> {
+    fun markInvoicesSent(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody invoiceIds: List<UUID>): ResponseEntity<Unit> {
         Audit.InvoicesMarkSent.log(targetId = invoiceIds)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -151,7 +151,7 @@ class InvoiceController(
     }
 
     @GetMapping("/{uuid}")
-    fun getInvoice(db: Database.Connection, user: AuthenticatedUser, @PathVariable uuid: String): ResponseEntity<Wrapper<InvoiceDetailed>> {
+    fun getInvoice(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable uuid: String): ResponseEntity<Wrapper<InvoiceDetailed>> {
         Audit.InvoicesRead.log(targetId = uuid)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -163,7 +163,7 @@ class InvoiceController(
 
     @GetMapping("/head-of-family/{uuid}")
     fun getHeadOfFamilyInvoices(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable uuid: String
     ): ResponseEntity<Wrapper<List<Invoice>>> {
@@ -177,7 +177,7 @@ class InvoiceController(
 
     @PutMapping("/{uuid}")
     fun putInvoice(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable uuid: String,
         @RequestBody invoice: Invoice
@@ -191,7 +191,7 @@ class InvoiceController(
     }
 
     @GetMapping("/codes")
-    fun getInvoiceCodes(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<Wrapper<InvoiceCodes>> {
+    fun getInvoiceCodes(db: Database.DeprecatedConnection, user: AuthenticatedUser): ResponseEntity<Wrapper<InvoiceCodes>> {
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
         val codes = db.read { it.getInvoiceCodes() }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -63,7 +63,7 @@ class VoucherValueDecisionController(
 ) {
     @PostMapping("/search")
     fun search(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: SearchVoucherValueDecisionRequest
     ): ResponseEntity<Paged<VoucherValueDecisionSummary>> {
@@ -95,7 +95,7 @@ class VoucherValueDecisionController(
 
     @GetMapping("/{id}")
     fun getDecision(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: VoucherValueDecisionId
     ): ResponseEntity<Wrapper<VoucherValueDecisionDetailed>> {
@@ -109,7 +109,7 @@ class VoucherValueDecisionController(
 
     @GetMapping("/head-of-family/{headOfFamilyId}")
     fun getHeadOfFamilyDecisions(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable headOfFamilyId: UUID
     ): ResponseEntity<List<VoucherValueDecisionSummary>> {
@@ -121,7 +121,7 @@ class VoucherValueDecisionController(
     }
 
     @PostMapping("/send")
-    fun sendDrafts(db: Database.Connection, user: AuthenticatedUser, @RequestBody decisionIds: List<VoucherValueDecisionId>): ResponseEntity<Unit> {
+    fun sendDrafts(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody decisionIds: List<VoucherValueDecisionId>): ResponseEntity<Unit> {
         Audit.VoucherValueDecisionSend.log(targetId = decisionIds)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -138,7 +138,7 @@ class VoucherValueDecisionController(
     }
 
     @PostMapping("/mark-sent")
-    fun markSent(db: Database.Connection, user: AuthenticatedUser, @RequestBody ids: List<VoucherValueDecisionId>): ResponseEntity<Unit> {
+    fun markSent(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody ids: List<VoucherValueDecisionId>): ResponseEntity<Unit> {
         Audit.VoucherValueDecisionMarkSent.log(targetId = ids)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -152,7 +152,7 @@ class VoucherValueDecisionController(
     }
 
     @GetMapping("/pdf/{id}")
-    fun getDecisionPdf(db: Database.Connection, user: AuthenticatedUser, @PathVariable id: VoucherValueDecisionId): ResponseEntity<ByteArray> {
+    fun getDecisionPdf(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable id: VoucherValueDecisionId): ResponseEntity<ByteArray> {
         Audit.FeeDecisionPdfRead.log(targetId = id)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
@@ -166,7 +166,7 @@ class VoucherValueDecisionController(
 
     @PostMapping("/set-type/{uuid}")
     fun setType(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable uuid: VoucherValueDecisionId,
         @RequestBody request: VoucherValueDecisionTypeRequest
@@ -180,7 +180,7 @@ class VoucherValueDecisionController(
 
     @PostMapping("/head-of-family/{id}/create-retroactive")
     fun generateRetroactiveDecisions(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: UUID,
         @RequestBody body: CreateRetroactiveFeeDecisionsBody

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/ChildRecipientsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/ChildRecipientsController.kt
@@ -21,7 +21,7 @@ class ChildRecipientsController(private val accessControl: AccessControl) {
 
     @GetMapping("/child/{childId}/recipients")
     fun getRecipients(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): List<Recipient> {
@@ -36,7 +36,7 @@ class ChildRecipientsController(private val accessControl: AccessControl) {
     )
     @PutMapping("/child/{childId}/recipients/{personId}")
     fun editRecipient(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @PathVariable personId: UUID,

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -49,7 +49,7 @@ class MessageController(
     private val messageService = MessageService(messageNotificationEmailService)
 
     @GetMapping("/my-accounts")
-    fun getAccountsByUser(db: Database.Connection, user: AuthenticatedUser): Set<NestedMessageAccount> {
+    fun getAccountsByUser(db: Database.DeprecatedConnection, user: AuthenticatedUser): Set<NestedMessageAccount> {
         Audit.MessagingMyAccountsRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_USER_MESSAGE_ACCOUNTS)
         return db.read { it.getEmployeeNestedMessageAccounts(user.id) }
@@ -57,7 +57,7 @@ class MessageController(
 
     @GetMapping("/mobile/my-accounts/{unitId}")
     fun getAccountsByDevice(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId
     ): Set<NestedMessageAccount> {
@@ -71,7 +71,7 @@ class MessageController(
 
     @GetMapping("/{accountId}/received")
     fun getReceivedMessages(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable accountId: MessageAccountId,
         @RequestParam pageSize: Int,
@@ -84,7 +84,7 @@ class MessageController(
 
     @GetMapping("/{accountId}/sent")
     fun getSentMessages(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable accountId: MessageAccountId,
         @RequestParam pageSize: Int,
@@ -97,7 +97,7 @@ class MessageController(
 
     @GetMapping("/unread")
     fun getUnreadMessages(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
     ): Set<UnreadCountByAccount> {
         Audit.MessagingUnreadMessagesRead.log()
@@ -107,7 +107,7 @@ class MessageController(
 
     @GetMapping("/unread/{unitId}")
     fun getUnreadMessagesByUnit(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId
     ): Set<UnreadCountByAccountAndGroup> {
@@ -129,7 +129,7 @@ class MessageController(
 
     @PostMapping("/{accountId}")
     fun createMessage(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable accountId: MessageAccountId,
         @RequestBody body: PostMessageBody,
@@ -158,7 +158,7 @@ class MessageController(
 
     @GetMapping("/{accountId}/drafts")
     fun getDrafts(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable accountId: MessageAccountId,
     ): List<DraftContent> {
@@ -169,7 +169,7 @@ class MessageController(
 
     @PostMapping("/{accountId}/drafts")
     fun initDraft(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable accountId: MessageAccountId,
     ): MessageDraftId {
@@ -180,7 +180,7 @@ class MessageController(
 
     @PutMapping("/{accountId}/drafts/{draftId}")
     fun upsertDraft(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable accountId: MessageAccountId,
         @PathVariable draftId: MessageDraftId,
@@ -193,7 +193,7 @@ class MessageController(
 
     @DeleteMapping("/{accountId}/drafts/{draftId}")
     fun deleteDraft(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable accountId: MessageAccountId,
         @PathVariable draftId: MessageDraftId,
@@ -205,7 +205,7 @@ class MessageController(
 
     @PostMapping("{accountId}/{messageId}/reply")
     fun replyToThread(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable accountId: MessageAccountId,
         @PathVariable messageId: MessageId,
@@ -225,7 +225,7 @@ class MessageController(
 
     @PutMapping("/{accountId}/threads/{threadId}/read")
     fun markThreadRead(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable accountId: MessageAccountId,
         @PathVariable threadId: MessageThreadId,
@@ -237,7 +237,7 @@ class MessageController(
 
     @GetMapping("/receivers")
     fun getReceiversForNewMessage(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam unitId: DaycareId
     ): List<MessageReceiversResponse> {
@@ -264,7 +264,7 @@ class MessageController(
     }
 
     private fun requireMessageAccountAccess(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         accountId: MessageAccountId
     ) {
@@ -274,7 +274,7 @@ class MessageController(
     }
 
     private fun checkAuthorizedRecipients(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         recipientAccountIds: Set<MessageAccountId>
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -37,7 +37,7 @@ class MessageControllerCitizen(
 
     @GetMapping("/my-account")
     fun getMyAccount(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): MessageAccountId {
         Audit.MessagingMyAccountsRead.log()
@@ -45,7 +45,7 @@ class MessageControllerCitizen(
     }
     @GetMapping("/unread-count")
     fun getUnreadMessages(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): Set<UnreadCountByAccount> {
         Audit.MessagingUnreadMessagesRead.log()
@@ -55,7 +55,7 @@ class MessageControllerCitizen(
 
     @PutMapping("/threads/{threadId}/read")
     fun markThreadRead(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("threadId") threadId: MessageThreadId
     ) {
@@ -66,7 +66,7 @@ class MessageControllerCitizen(
 
     @GetMapping("/received")
     fun getReceivedMessages(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam pageSize: Int,
         @RequestParam page: Int,
@@ -78,7 +78,7 @@ class MessageControllerCitizen(
 
     @GetMapping("/sent")
     fun getSentMessages(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam pageSize: Int,
         @RequestParam page: Int,
@@ -90,7 +90,7 @@ class MessageControllerCitizen(
 
     @GetMapping("/receivers")
     fun getReceivers(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
     ): List<MessageAccount> {
         Audit.MessagingCitizenFetchReceiversForAccount.log()
@@ -100,7 +100,7 @@ class MessageControllerCitizen(
 
     @PostMapping("/{messageId}/reply")
     fun replyToThread(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable messageId: MessageId,
         @RequestBody body: ReplyToMessageBody,
@@ -119,7 +119,7 @@ class MessageControllerCitizen(
 
     @PostMapping
     fun newMessage(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: CitizenMessageBody,
     ): List<MessageThreadId> {
@@ -149,7 +149,7 @@ class MessageControllerCitizen(
     }
 
     private fun requireMessageAccountAccess(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): MessageAccountId {
         @Suppress("DEPRECATION")

--- a/service/src/main/kotlin/fi/espoo/evaka/note/NotesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/NotesController.kt
@@ -36,7 +36,7 @@ class NotesController(
     @GetMapping("/children/{childId}/notes")
     fun getNotesByChild(
         user: AuthenticatedUser,
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable childId: UUID
     ): NotesByChildResponse {
         Audit.NotesByChildRead.log(childId)
@@ -59,7 +59,7 @@ class NotesController(
     @GetMapping("/daycare-groups/{groupId}/notes")
     fun getNotesByGroup(
         user: AuthenticatedUser,
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable groupId: GroupId
     ): NotesByGroupResponse {
         Audit.NotesByGroupRead.log(groupId)

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteController.kt
@@ -29,7 +29,7 @@ class ChildDailyNoteController(
 ) {
     @PostMapping("/children/{childId}/child-daily-notes")
     fun createChildDailyNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: ChildDailyNoteBody
@@ -49,7 +49,7 @@ class ChildDailyNoteController(
 
     @PutMapping("/child-daily-notes/{noteId}")
     fun updateChildDailyNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable noteId: ChildDailyNoteId,
         @RequestBody body: ChildDailyNoteBody
@@ -62,7 +62,7 @@ class ChildDailyNoteController(
 
     @DeleteMapping("/child-daily-notes/{noteId}")
     fun deleteChildDailyNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable noteId: ChildDailyNoteId
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/sticky/ChildStickyNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/sticky/ChildStickyNoteController.kt
@@ -27,7 +27,7 @@ class ChildStickyNoteController(
 ) {
     @PostMapping("/children/{childId}/child-sticky-notes")
     fun createChildStickyNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: ChildStickyNoteBody
@@ -42,7 +42,7 @@ class ChildStickyNoteController(
 
     @PutMapping("/child-sticky-notes/{noteId}")
     fun updateChildStickyNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable noteId: ChildStickyNoteId,
         @RequestBody body: ChildStickyNoteBody
@@ -57,7 +57,7 @@ class ChildStickyNoteController(
 
     @DeleteMapping("/child-sticky-notes/{noteId}")
     fun deleteChildStickyNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable noteId: ChildStickyNoteId
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/note/group/GroupNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/group/GroupNoteController.kt
@@ -24,7 +24,7 @@ class GroupNoteController(
 ) {
     @PostMapping("/daycare-groups/{groupId}/group-notes")
     fun createGroupNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable groupId: GroupId,
         @RequestBody body: GroupNoteBody
@@ -37,7 +37,7 @@ class GroupNoteController(
 
     @PutMapping("/group-notes/{noteId}")
     fun updateGroupNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable noteId: GroupNoteId,
         @RequestBody body: GroupNoteBody
@@ -50,7 +50,7 @@ class GroupNoteController(
 
     @DeleteMapping("/group-notes/{noteId}")
     fun deleteGroupNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable noteId: GroupNoteId
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
@@ -26,7 +26,7 @@ import java.time.LocalDate
 class OccupancyController(private val acl: AccessControlList) {
     @GetMapping("/by-unit/{unitId}/realtime")
     fun getRealtimeOccupancy(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
@@ -46,7 +46,7 @@ class OccupancyController(private val acl: AccessControlList) {
 
     @GetMapping("/by-unit/{unitId}")
     fun getOccupancyPeriods(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
@@ -71,7 +71,7 @@ class OccupancyController(private val acl: AccessControlList) {
 
     @GetMapping("/by-unit/{unitId}/groups")
     fun getOccupancyPeriodsOnGroups(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
@@ -33,7 +33,7 @@ class MobileDevicesController(
 ) {
     @GetMapping("/mobile-devices")
     fun getMobileDevices(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam unitId: DaycareId
     ): ResponseEntity<List<MobileDevice>> {
@@ -47,7 +47,7 @@ class MobileDevicesController(
 
     @GetMapping("/mobile-devices/personal")
     fun getMobileDevices(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Employee,
     ): List<MobileDevice> {
         Audit.MobileDevicesList.log(targetId = user.id)
@@ -58,7 +58,7 @@ class MobileDevicesController(
 
     @GetMapping("/system/mobile-devices/{id}")
     fun getMobileDevice(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: MobileDeviceId
     ): ResponseEntity<MobileDeviceDetails> {
@@ -75,7 +75,7 @@ class MobileDevicesController(
     )
     @PutMapping("/mobile-devices/{id}/name")
     fun putMobileDeviceName(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: MobileDeviceId,
         @RequestBody body: RenameRequest
@@ -90,7 +90,7 @@ class MobileDevicesController(
 
     @DeleteMapping("/mobile-devices/{id}")
     fun deleteMobileDevice(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: MobileDeviceId
     ): ResponseEntity<Unit> {
@@ -104,7 +104,7 @@ class MobileDevicesController(
 
     @PostMapping("/mobile-devices/pin-login")
     fun pinLogin(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.MobileDevice,
         @RequestBody params: PinLoginRequest
     ): PinLoginResponse {

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -45,7 +45,7 @@ class PairingsController(
     }
     @PostMapping("/pairings")
     fun postPairing(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Employee,
         @RequestBody body: PostPairingReq
     ): ResponseEntity<Pairing> {
@@ -90,7 +90,7 @@ class PairingsController(
     )
     @PostMapping("/public/pairings/challenge")
     fun postPairingChallenge(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @RequestBody body: PostPairingChallengeReq
     ): ResponseEntity<Pairing> {
         Audit.PairingChallenge.log(targetId = body.challengeKey)
@@ -112,7 +112,7 @@ class PairingsController(
     )
     @PostMapping("/pairings/{id}/response")
     fun postPairingResponse(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: PairingId,
         @RequestBody body: PostPairingResponseReq
@@ -153,7 +153,7 @@ class PairingsController(
     )
     @PostMapping("/system/pairings/{id}/validation")
     fun postPairingValidation(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable id: PairingId,
         @RequestBody body: PostPairingValidationReq
     ): MobileDeviceIdentity {
@@ -178,7 +178,7 @@ class PairingsController(
     )
     @GetMapping("/public/pairings/{id}/status")
     fun getPairingStatus(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable id: PairingId
     ): ResponseEntity<PairingStatusRes> {
         Audit.PairingStatusRead.log(targetId = id)

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentController.kt
@@ -33,7 +33,7 @@ class PedagogicalDocumentController(
 ) {
     @PostMapping
     fun createPedagogicalDocument(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: PedagogicalDocumentPostBody
     ): PedagogicalDocument {
@@ -48,7 +48,7 @@ class PedagogicalDocumentController(
 
     @PutMapping("/{documentId}")
     fun updatePedagogicalDocument(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable documentId: PedagogicalDocumentId,
         @RequestBody body: PedagogicalDocumentPostBody
@@ -64,7 +64,7 @@ class PedagogicalDocumentController(
 
     @GetMapping("/child/{childId}")
     fun getChildPedagogicalDocuments(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: ChildId
     ): List<PedagogicalDocument> {
@@ -75,7 +75,7 @@ class PedagogicalDocumentController(
 
     @DeleteMapping("/{documentId}")
     fun deletePedagogicalDocument(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable documentId: PedagogicalDocumentId
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentControllerCitizen.kt
@@ -31,7 +31,7 @@ class PedagogicalDocumentControllerCitizen(
 ) {
     @GetMapping
     fun getPedagogicalDocumentsByGuardian(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): List<PedagogicalDocumentCitizen> {
         Audit.PedagogicalDocumentReadByGuardian.log(user.id)
@@ -40,7 +40,7 @@ class PedagogicalDocumentControllerCitizen(
 
     @PostMapping("/{documentId}/mark-read")
     fun markPedagogicalDocumentRead(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable documentId: PedagogicalDocumentId
     ) {
@@ -51,7 +51,7 @@ class PedagogicalDocumentControllerCitizen(
 
     @GetMapping("/unread-count")
     fun getUnreadPedagogicalDocumentCount(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): Number {
         Audit.PedagogicalDocumentCountUnread.log(user.id)

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
@@ -35,7 +35,7 @@ import java.util.UUID
 class SystemController(private val personService: PersonService, private val accessControl: AccessControl) {
     @PostMapping("/system/citizen-login")
     fun citizenLogin(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.SystemInternalUser,
         @RequestBody request: CitizenLoginRequest
     ): CitizenUser {
@@ -57,7 +57,7 @@ class SystemController(private val personService: PersonService, private val acc
 
     @PostMapping("/system/employee-login")
     fun employeeLogin(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.SystemInternalUser,
         @RequestBody request: EmployeeLoginRequest
     ): EmployeeUser {
@@ -80,7 +80,7 @@ class SystemController(private val personService: PersonService, private val acc
 
     @GetMapping("/system/employee/{id}")
     fun employeeUser(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.SystemInternalUser,
         @PathVariable
         id: EmployeeId
@@ -102,7 +102,7 @@ class SystemController(private val personService: PersonService, private val acc
 
     @GetMapping("/system/mobile-identity/{token}")
     fun mobileIdentity(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.SystemInternalUser,
         @PathVariable
         token: UUID

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
@@ -40,7 +40,7 @@ import java.util.UUID
 class EmployeeController {
 
     @GetMapping
-    fun getEmployees(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<Employee>> {
+    fun getEmployees(db: Database.DeprecatedConnection, user: AuthenticatedUser): ResponseEntity<List<Employee>> {
         Audit.EmployeesRead.log()
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR)
@@ -48,7 +48,7 @@ class EmployeeController {
     }
 
     @GetMapping("/finance-decision-handler")
-    fun getFinanceDecisionHandlers(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<List<Employee>> {
+    fun getFinanceDecisionHandlers(db: Database.DeprecatedConnection, user: AuthenticatedUser): ResponseEntity<List<Employee>> {
         Audit.EmployeesRead.log()
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
@@ -56,7 +56,7 @@ class EmployeeController {
     }
 
     @GetMapping("/{id}")
-    fun getEmployee(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: EmployeeId): ResponseEntity<Employee> {
+    fun getEmployee(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable(value = "id") id: EmployeeId): ResponseEntity<Employee> {
         Audit.EmployeeRead.log(targetId = id)
         if (user.id != id.raw) {
             @Suppress("DEPRECATION")
@@ -79,7 +79,7 @@ class EmployeeController {
     )
     @PutMapping("/{id}")
     fun updateEmployee(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") id: UUID,
         @RequestBody body: EmployeeUpdate
@@ -100,7 +100,7 @@ class EmployeeController {
 
     @GetMapping("/{id}/details")
     fun getEmployeeDetails(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") id: UUID
     ): ResponseEntity<EmployeeWithDaycareRoles> {
@@ -114,7 +114,7 @@ class EmployeeController {
     }
 
     @PostMapping("")
-    fun createEmployee(db: Database.Connection, user: AuthenticatedUser, @RequestBody employee: NewEmployee): ResponseEntity<Employee> {
+    fun createEmployee(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody employee: NewEmployee): ResponseEntity<Employee> {
         Audit.EmployeeCreate.log(targetId = employee.externalId)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.ADMIN)
@@ -122,7 +122,7 @@ class EmployeeController {
     }
 
     @DeleteMapping("/{id}")
-    fun deleteEmployee(db: Database.Connection, user: AuthenticatedUser, @PathVariable(value = "id") id: EmployeeId): ResponseEntity<Unit> {
+    fun deleteEmployee(db: Database.DeprecatedConnection, user: AuthenticatedUser, @PathVariable(value = "id") id: EmployeeId): ResponseEntity<Unit> {
         Audit.EmployeeDelete.log(targetId = id)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.ADMIN)
@@ -132,7 +132,7 @@ class EmployeeController {
 
     @PostMapping("/pin-code")
     fun upsertPinCode(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: PinCode
     ): ResponseEntity<Unit> {
@@ -148,7 +148,7 @@ class EmployeeController {
 
     @GetMapping("/pin-code/is-pin-locked")
     fun isPinLocked(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): Boolean {
         Audit.PinCodeLockedRead.log(targetId = user.id)
@@ -159,7 +159,7 @@ class EmployeeController {
 
     @PostMapping("/search")
     fun searchEmployees(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: SearchEmployeeRequest
     ): ResponseEntity<Paged<EmployeeWithDaycareRoles>> {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
@@ -35,7 +35,7 @@ class FamilyController(
 ) {
     @GetMapping("/by-adult/{id}")
     fun getFamilyByPerson(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") id: PersonId
     ): FamilyOverview {
@@ -56,7 +56,7 @@ class FamilyController(
 
     @GetMapping("/contacts")
     fun getFamilyContactSummary(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam(value = "childId", required = true) childId: UUID
     ): ResponseEntity<List<FamilyContact>> {
@@ -69,7 +69,7 @@ class FamilyController(
 
     @PostMapping("/contacts")
     fun updateFamilyContactPriority(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: FamilyContactUpdate
     ): ResponseEntity<Unit> {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -33,7 +33,7 @@ import java.time.LocalDate
 class ParentshipController(private val parentshipService: ParentshipService, private val accessControl: AccessControl) {
     @PostMapping
     fun createParentship(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: ParentshipRequest
     ) {
@@ -53,7 +53,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
 
     @GetMapping
     fun getParentships(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam(value = "headOfChildId", required = false) headOfChildId: PersonId? = null,
         @RequestParam(value = "childId", required = false) childId: PersonId? = null
@@ -80,7 +80,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
 
     @GetMapping("/{id}")
     fun getParentship(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") id: ParentshipId
     ): Parentship {
@@ -93,7 +93,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
 
     @PutMapping("/{id}")
     fun updateParentship(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") id: ParentshipId,
         @RequestBody body: ParentshipUpdateRequest
@@ -108,7 +108,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
 
     @PutMapping("/{id}/retry")
     fun retryPartnership(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") parentshipId: ParentshipId
     ) {
@@ -120,7 +120,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
 
     @DeleteMapping("/{id}")
     fun deleteParentship(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "id") id: ParentshipId
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
@@ -39,7 +39,7 @@ class PartnershipsController(
 ) {
     @PostMapping
     fun createPartnership(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: PartnershipRequest
     ) {
@@ -69,7 +69,7 @@ class PartnershipsController(
 
     @GetMapping
     fun getPartnerships(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam personId: PersonId
     ): List<Partnership> {
@@ -81,7 +81,7 @@ class PartnershipsController(
 
     @GetMapping("/{partnershipId}")
     fun getPartnership(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable partnershipId: PartnershipId
     ): Partnership {
@@ -94,7 +94,7 @@ class PartnershipsController(
 
     @PutMapping("/{partnershipId}")
     fun updatePartnership(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable partnershipId: PartnershipId,
         @RequestBody body: PartnershipUpdateRequest
@@ -120,7 +120,7 @@ class PartnershipsController(
 
     @PutMapping("/{partnershipId}/retry")
     fun retryPartnership(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable partnershipId: PartnershipId
     ) {
@@ -144,7 +144,7 @@ class PartnershipsController(
 
     @DeleteMapping("/{partnershipId}")
     fun deletePartnership(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable partnershipId: PartnershipId
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -53,7 +53,7 @@ class PersonController(
     private val accessControl: AccessControl
 ) {
     @PostMapping
-    fun createEmpty(db: Database.Connection, user: AuthenticatedUser): ResponseEntity<PersonIdentityResponseJSON> {
+    fun createEmpty(db: Database.DeprecatedConnection, user: AuthenticatedUser): ResponseEntity<PersonIdentityResponseJSON> {
         Audit.PersonCreate.log()
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN, UserRole.ADMIN)
@@ -63,7 +63,7 @@ class PersonController(
 
     @GetMapping("/{personId}")
     fun getPerson(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable personId: PersonId
     ): PersonResponse {
@@ -81,7 +81,7 @@ class PersonController(
 
     @GetMapping(value = ["/details/{personId}", "/identity/{personId}"])
     fun getPersonIdentity(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: UUID
     ): ResponseEntity<PersonJSON> {
@@ -102,7 +102,7 @@ class PersonController(
 
     @GetMapping("/dependants/{personId}")
     fun getPersonDependants(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: UUID
     ): ResponseEntity<List<PersonWithChildrenDTO>> {
@@ -116,7 +116,7 @@ class PersonController(
 
     @GetMapping("/guardians/{personId}")
     fun getPersonGuardians(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") childId: UUID
     ): ResponseEntity<List<PersonJSON>> {
@@ -128,7 +128,7 @@ class PersonController(
 
     @PostMapping("/search")
     fun findBySearchTerms(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: SearchPersonBody
     ): List<PersonSummary> {
@@ -146,7 +146,7 @@ class PersonController(
 
     @PutMapping(value = ["/{personId}/contact-info"])
     fun updateContactInfo(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: UUID,
         @RequestBody contactInfo: ContactInfo
@@ -163,7 +163,7 @@ class PersonController(
 
     @PatchMapping("/{personId}")
     fun updatePersonDetails(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: UUID,
         @RequestBody data: PersonPatch
@@ -194,7 +194,7 @@ class PersonController(
 
     @DeleteMapping("/{personId}")
     fun safeDeletePerson(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: UUID
     ): ResponseEntity<Unit> {
@@ -207,7 +207,7 @@ class PersonController(
 
     @PutMapping("/{personId}/ssn")
     fun addSsn(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable personId: PersonId,
         @RequestBody body: AddSsnRequest
@@ -226,7 +226,7 @@ class PersonController(
 
     @PutMapping("/{personId}/ssn/disable")
     fun disableSsn(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable personId: PersonId,
         @RequestBody body: DisableSsnRequest
@@ -239,7 +239,7 @@ class PersonController(
 
     @PostMapping("/details/ssn")
     fun getOrCreatePersonBySsn(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: GetOrCreatePersonBySsnRequest
     ): ResponseEntity<PersonJSON> {
@@ -265,7 +265,7 @@ class PersonController(
 
     @GetMapping("/get-deceased/")
     fun getDeceased(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("sinceDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) sinceDate: LocalDate
     ): ResponseEntity<List<PersonJSON>> {
@@ -281,7 +281,7 @@ class PersonController(
 
     @PostMapping("/merge")
     fun mergePeople(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: MergeRequest
     ): ResponseEntity<Unit> {
@@ -296,7 +296,7 @@ class PersonController(
 
     @PostMapping("/create")
     fun createPerson(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: CreatePersonBody
     ): ResponseEntity<UUID> {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/citizen/personal-data")
 class PersonalDataControllerCitizen {
     @PutMapping
-    fun updatePersonalData(db: Database.Connection, user: AuthenticatedUser.Citizen, @RequestBody body: PersonalDataUpdate) {
+    fun updatePersonalData(db: Database.DeprecatedConnection, user: AuthenticatedUser.Citizen, @RequestBody body: PersonalDataUpdate) {
         Audit.PersonalDataUpdate.log(targetId = user.id)
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.END_USER)

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -47,7 +47,7 @@ class PlacementController(
 
     @GetMapping("/placements")
     fun getPlacements(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam(value = "daycareId", required = false) daycareId: DaycareId? = null,
         @RequestParam(value = "childId", required = false) childId: UUID? = null,
@@ -82,7 +82,7 @@ class PlacementController(
 
     @GetMapping("/placements/plans")
     fun getPlacementPlans(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam(value = "daycareId", required = true) daycareId: DaycareId,
         @RequestParam(
@@ -99,7 +99,7 @@ class PlacementController(
 
     @PostMapping("/placements")
     fun createPlacement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: PlacementCreateRequestBody
     ) {
@@ -136,7 +136,7 @@ class PlacementController(
 
     @PutMapping("/placements/{placementId}")
     fun updatePlacementById(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("placementId") placementId: PlacementId,
         @RequestBody body: PlacementUpdateRequestBody
@@ -164,7 +164,7 @@ class PlacementController(
 
     @DeleteMapping("/placements/{placementId}")
     fun deletePlacement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("placementId") placementId: PlacementId
     ) {
@@ -182,7 +182,7 @@ class PlacementController(
 
     @PostMapping("/placements/{placementId}/group-placements")
     fun createGroupPlacement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("placementId") placementId: PlacementId,
         @RequestBody body: GroupPlacementRequestBody
@@ -202,7 +202,7 @@ class PlacementController(
 
     @DeleteMapping("/group-placements/{groupPlacementId}")
     fun deleteGroupPlacement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("groupPlacementId") groupPlacementId: GroupPlacementId
     ) {
@@ -214,7 +214,7 @@ class PlacementController(
 
     @PostMapping("/group-placements/{groupPlacementId}/transfer")
     fun transferGroupPlacement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable("groupPlacementId") groupPlacementId: GroupPlacementId,
         @RequestBody body: GroupTransferRequestBody

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
@@ -22,7 +22,7 @@ import java.time.LocalDate
 class ApplicationsReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/applications")
     fun getApplicationsReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
@@ -31,7 +31,7 @@ import java.time.LocalDate
 class AssistanceNeedsAndActionsReportController(private val acl: AccessControlList, private val accessControl: AccessControl) {
     @GetMapping("/reports/assistance-needs-and-actions")
     fun getAssistanceNeedReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): AssistanceNeedsAndActionsReport {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
@@ -23,7 +23,7 @@ import java.time.LocalDate
 class ChildAgeLanguageReportController(private val acl: AccessControlList, private val accessControl: AccessControl) {
     @GetMapping("/reports/child-age-language")
     fun getChildAgeLanguageReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): List<ChildAgeLanguageReportRow> {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
@@ -25,7 +25,7 @@ class ChildrenInDifferentAddressReportController(
 ) {
     @GetMapping("/reports/children-in-different-address")
     fun getChildrenInDifferentAddressReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): List<ChildrenInDifferentAddressReportRow> {
         Audit.ChildrenInDifferentAddressReportRead.log()

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DecisionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DecisionsReport.kt
@@ -23,7 +23,7 @@ import java.time.LocalDate
 class DecisionsReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/decisions")
     fun getDecisionsReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 @RestController
 class DuplicatePeopleReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/duplicate-people")
-    fun getDuplicatePeopleReport(db: Database.Connection, user: AuthenticatedUser): List<DuplicatePeopleReportRow> {
+    fun getDuplicatePeopleReport(db: Database.DeprecatedConnection, user: AuthenticatedUser): List<DuplicatePeopleReportRow> {
         Audit.DuplicatePeopleReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_DUPLICATE_PEOPLE_REPORT)
         return db.read { it.getDuplicatePeople() }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 class EndedPlacementsReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/ended-placements")
     fun getEndedPlacementsReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam year: Int,
         @RequestParam month: Int

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 @RestController
 class FamilyConflictReportController(private val acl: AccessControlList, private val accessControl: AccessControl) {
     @GetMapping("/reports/family-conflicts")
-    fun getFamilyConflictsReport(db: Database.Connection, user: AuthenticatedUser): List<FamilyConflictReportRow> {
+    fun getFamilyConflictsReport(db: Database.DeprecatedConnection, user: AuthenticatedUser): List<FamilyConflictReportRow> {
         Audit.FamilyConflictReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_FAMILY_CONFLICT_REPORT)
         return db.read { it.getFamilyConflicts(acl.getAuthorizedUnits(user)) }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 class FamilyContactReportController(private val acl: AccessControlList, private val accessControl: AccessControl) {
     @GetMapping("/reports/family-contacts")
     fun getFamilyContactsReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam unitId: DaycareId
     ): List<FamilyContactReportRow> {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
@@ -31,7 +31,7 @@ internal fun getMonthPeriod(date: LocalDate): DateRange {
 class InvoiceReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/invoices")
     fun getInvoiceReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): InvoiceReport {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 class MissingHeadOfFamilyReportController(private val acl: AccessControlList, private val accessControl: AccessControl) {
     @GetMapping("/reports/missing-head-of-family")
     fun getMissingHeadOfFamilyReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 class MissingServiceNeedReportController(private val acl: AccessControlList, private val accessControl: AccessControl) {
     @GetMapping("/reports/missing-service-need")
     fun getMissingServiceNeedReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -28,7 +28,7 @@ import java.time.LocalDate
 class OccupancyReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/occupancy-by-unit")
     fun getOccupancyUnitReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam type: OccupancyType,
         @RequestParam careAreaId: AreaId,
@@ -52,7 +52,7 @@ class OccupancyReportController(private val accessControl: AccessControl) {
 
     @GetMapping("/reports/occupancy-by-group")
     fun getOccupancyGroupReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam type: OccupancyType,
         @RequestParam careAreaId: AreaId,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
@@ -25,7 +25,7 @@ class PartnersInDifferentAddressReportController(
 ) {
     @GetMapping("/reports/partners-in-different-address")
     fun getPartnersInDifferentAddressReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): List<PartnersInDifferentAddressReportRow> {
         Audit.PartnersInDifferentAddressReportRead.log()

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 class PlacementSketchingReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/placement-sketching")
     fun getPlacementSketchingReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("placementStartDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) placementStartDate: LocalDate,
         @RequestParam("earliestPreferredStartDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) earliestPreferredStartDate: LocalDate?

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
@@ -24,7 +24,7 @@ const val MAX_NUMBER_OF_DAYS = 14
 class PresenceReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/presences")
     fun getPresenceReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -28,7 +28,7 @@ import java.util.UUID
 class RawReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/raw")
     fun getRawReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
@@ -21,7 +21,7 @@ import java.time.LocalDate
 class ServiceNeedReport(private val acl: AccessControlList, private val accessControl: AccessControl) {
     @GetMapping("/reports/service-need")
     fun getServiceNeedReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): List<ServiceNeedReportRow> {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -45,7 +45,7 @@ class ServiceVoucherValueReportController(
 
     @GetMapping("/units")
     fun getServiceVoucherValuesForAllUnits(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Employee,
         @RequestParam year: Int,
         @RequestParam month: Int,
@@ -87,7 +87,7 @@ class ServiceVoucherValueReportController(
 
     @GetMapping("/units/{unitId}")
     fun getServiceVoucherValuesForUnit(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser.Employee,
         @PathVariable unitId: DaycareId,
         @RequestParam year: Int,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 class StartingPlacementsReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/starting-placements")
     fun getStartingPlacementsReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam("year") year: Int,
         @RequestParam("month") month: Int

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 class VardaErrorReport(private val accessControl: AccessControl) {
     @GetMapping("/reports/varda-errors")
     fun getVardaErrors(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): List<VardaErrorReportRow> {
         Audit.VardaReportRead.log()

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -39,7 +39,7 @@ import java.util.UUID
 class AttendanceReservationController(private val ac: AccessControl) {
     @GetMapping
     fun getAttendanceReservations(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam unitId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
@@ -79,7 +79,7 @@ class AttendanceReservationController(private val ac: AccessControl) {
 
     @PostMapping
     fun postReservations(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: List<DailyReservationRequest>
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -33,7 +33,7 @@ class ReservationControllerCitizen(
 ) {
     @GetMapping("/citizen/reservations")
     fun getReservations(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
@@ -73,7 +73,7 @@ class ReservationControllerCitizen(
 
     @PostMapping("/citizen/reservations")
     fun postReservations(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: List<DailyReservationRequest>
     ) {
@@ -93,7 +93,7 @@ class ReservationControllerCitizen(
 
     @PostMapping("/citizen/absences")
     fun postAbsences(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: AbsenceRequest
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInfoController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInfoController.kt
@@ -22,7 +22,7 @@ class ChildSensitiveInfoController(
 
     @GetMapping("/children/{childId}/sensitive-info")
     fun getSensitiveInfo(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: ChildId,
     ): ChildSensitiveInformation {

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -43,7 +43,7 @@ class ServiceNeedController(
 
     @PostMapping("/service-needs")
     fun postServiceNeed(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: ServiceNeedCreateRequest
     ) {
@@ -75,7 +75,7 @@ class ServiceNeedController(
 
     @PutMapping("/service-needs/{id}")
     fun putServiceNeed(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: ServiceNeedId,
         @RequestBody body: ServiceNeedUpdateRequest
@@ -111,7 +111,7 @@ class ServiceNeedController(
 
     @DeleteMapping("/service-needs/{id}")
     fun deleteServiceNeed(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: ServiceNeedId
     ) {
@@ -127,7 +127,7 @@ class ServiceNeedController(
 
     @GetMapping("/service-needs/options")
     fun getServiceNeedOptions(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser
     ): List<ServiceNeedOption> {
         Audit.ServiceNeedOptionsRead.log()
@@ -138,7 +138,7 @@ class ServiceNeedController(
 
     @GetMapping("/public/service-needs/options")
     fun getServiceNeedOptionPublicInfos(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @RequestParam(required = true) placementTypes: List<PlacementType>
     ): List<ServiceNeedOptionPublicInfo> {
         return db.read { it.getServiceNeedOptionPublicInfos(placementTypes) }

--- a/service/src/main/kotlin/fi/espoo/evaka/setting/SettingController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/setting/SettingController.kt
@@ -20,14 +20,14 @@ import org.springframework.web.bind.annotation.RestController
 class SettingController(private val accessControl: AccessControl) {
 
     @GetMapping
-    fun getSettings(db: Database.Connection, user: AuthenticatedUser): Map<SettingType, String> {
+    fun getSettings(db: Database.DeprecatedConnection, user: AuthenticatedUser): Map<SettingType, String> {
         Audit.SettingsRead.log()
         accessControl.requirePermissionFor(user, Action.Global.UPDATE_SETTINGS)
         return db.read { tx -> tx.getSettings() }
     }
 
     @PutMapping
-    fun setSettings(db: Database.Connection, user: AuthenticatedUser, @RequestBody settings: Map<SettingType, String>) {
+    fun setSettings(db: Database.DeprecatedConnection, user: AuthenticatedUser, @RequestBody settings: Map<SettingType, String>) {
         Audit.SettingsUpdate.log()
         accessControl.requirePermissionFor(user, Action.Global.UPDATE_SETTINGS)
         return db.transaction { tx -> tx.setSettings(settings) }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/SpringMvcConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/SpringMvcConfig.kt
@@ -65,8 +65,8 @@ class SpringMvcConfig(private val jdbi: Jdbi, private val env: EvakaEnv) : WebMv
         registry.addConverter(convertFrom<String, Id<*>> { Id<DatabaseTable>(UUID.fromString(it)) })
     }
 
-    private fun WebRequest.getOrOpenConnection(): Database.Connection = getConnection()
-        ?: getDatabaseInstance().connectWithManualLifecycle().also(::setConnection)
+    private fun WebRequest.getOrOpenConnection(): Database.DeprecatedConnection = getConnection()
+        ?: getDatabaseInstance().deprecatedConnection().also(::setConnection)
 
     private fun WebRequest.getDatabaseInstance(): Database = getDatabase()
         ?: Database(jdbi).also(::setDatabase)
@@ -96,5 +96,5 @@ private fun WebRequest.setDatabase(db: Database) = setAttribute(ATTR_DB, db, SCO
 
 private const val ATTR_DB_CONNECTION = "evaka.database.connection"
 
-private fun WebRequest.getConnection() = getAttribute(ATTR_DB_CONNECTION, SCOPE_REQUEST) as Database.Connection?
-private fun WebRequest.setConnection(db: Database.Connection) = setAttribute(ATTR_DB_CONNECTION, db, SCOPE_REQUEST)
+private fun WebRequest.getConnection() = getAttribute(ATTR_DB_CONNECTION, SCOPE_REQUEST) as Database.DeprecatedConnection?
+private fun WebRequest.setConnection(db: Database.DeprecatedConnection) = setAttribute(ATTR_DB_CONNECTION, db, SCOPE_REQUEST)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledJobTriggerController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledJobTriggerController.kt
@@ -62,7 +62,7 @@ class ScheduledJobTriggerController(private val asyncJobRunner: AsyncJobRunner<A
     }
 
     @PostMapping
-    fun trigger(user: AuthenticatedUser, db: Database.Connection, @RequestBody body: TriggerBody) {
+    fun trigger(user: AuthenticatedUser, db: Database.DeprecatedConnection, @RequestBody body: TriggerBody) {
         @Suppress("DEPRECATION")
         user.requireOneOfRoles(UserRole.ADMIN)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
@@ -54,10 +54,18 @@ class Database(private val jdbi: Jdbi) {
         return Connection(threadId, connected, lazy(LazyThreadSafetyMode.NONE) { jdbi.open() })
     }
 
+    fun deprecatedConnection(): DeprecatedConnection {
+        threadId.assertCurrentThread()
+        check(!connected.get()) { "Already connected to database" }
+        return DeprecatedConnection(threadId, connected, lazy(LazyThreadSafetyMode.NONE) { jdbi.open() })
+    }
+
+    class DeprecatedConnection internal constructor(threadId: ThreadId, connected: AtomicBoolean, lazyHandle: Lazy<Handle>) : Connection(threadId, connected, lazyHandle)
+
     /**
      * A single lazily initialized database connection tied to a single thread
      */
-    class Connection internal constructor(private val threadId: ThreadId, private val connected: AtomicBoolean, private val lazyHandle: Lazy<Handle>) : AutoCloseable {
+    open class Connection internal constructor(private val threadId: ThreadId, private val connected: AtomicBoolean, private val lazyHandle: Lazy<Handle>) : AutoCloseable {
         private fun getHandle(): Handle {
             threadId.assertCurrentThread()
             return if (lazyHandle.isInitialized()) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -163,7 +163,7 @@ class DevApi(
     }
 
     @PostMapping("/reset-db")
-    fun resetDatabase(db: Database.Connection): ResponseEntity<Unit> {
+    fun resetDatabase(db: Database.DeprecatedConnection): ResponseEntity<Unit> {
         // Run async jobs before database reset to avoid database locks/deadlocks
         asyncJobRunner.runPendingJobsSync()
         asyncJobRunner.waitUntilNoRunningJobs(timeout = Duration.ofSeconds(20))
@@ -186,20 +186,20 @@ class DevApi(
     }
 
     @PostMapping("/care-areas")
-    fun createCareAreas(db: Database.Connection, @RequestBody careAreas: List<DevCareArea>): ResponseEntity<Unit> {
+    fun createCareAreas(db: Database.DeprecatedConnection, @RequestBody careAreas: List<DevCareArea>): ResponseEntity<Unit> {
         db.transaction { careAreas.forEach { careArea -> it.insertTestCareArea(careArea) } }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/daycares")
-    fun createDaycares(db: Database.Connection, @RequestBody daycares: List<DevDaycare>): ResponseEntity<Unit> {
+    fun createDaycares(db: Database.DeprecatedConnection, @RequestBody daycares: List<DevDaycare>): ResponseEntity<Unit> {
         db.transaction { daycares.forEach { daycare -> it.insertTestDaycare(daycare) } }
         return ResponseEntity.noContent().build()
     }
 
     @PutMapping("/daycares/{daycareId}/acl")
     fun addAclRoleForDaycare(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable daycareId: DaycareId,
         @RequestBody body: DaycareAclInsert
     ): ResponseEntity<Unit> {
@@ -210,12 +210,12 @@ class DevApi(
     }
 
     @PostMapping("/daycare-group-acl")
-    fun createDaycareGroupAclRows(db: Database.Connection, @RequestBody rows: List<DevDaycareGroupAcl>) {
+    fun createDaycareGroupAclRows(db: Database.DeprecatedConnection, @RequestBody rows: List<DevDaycareGroupAcl>) {
         db.transaction { tx -> rows.forEach { tx.insertTestDaycareGroupAcl(it) } }
     }
 
     @PostMapping("/daycare-groups")
-    fun createDaycareGroups(db: Database.Connection, @RequestBody groups: List<DevDaycareGroup>): ResponseEntity<Unit> {
+    fun createDaycareGroups(db: Database.DeprecatedConnection, @RequestBody groups: List<DevDaycareGroup>): ResponseEntity<Unit> {
         db.transaction {
             groups.forEach { group -> it.insertTestDaycareGroup(group) }
         }
@@ -224,7 +224,7 @@ class DevApi(
 
     @PostMapping("/daycare-group-placements")
     fun createDaycareGroupPlacement(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @RequestBody placements: List<DevDaycareGroupPlacement>
     ): ResponseEntity<Unit> {
         db.transaction { tx ->
@@ -249,7 +249,7 @@ class DevApi(
     )
 
     @PostMapping("/daycare-caretakers")
-    fun createDaycareCaretakers(db: Database.Connection, @RequestBody caretakers: List<Caretaker>): ResponseEntity<Unit> {
+    fun createDaycareCaretakers(db: Database.DeprecatedConnection, @RequestBody caretakers: List<Caretaker>): ResponseEntity<Unit> {
         db.transaction { tx ->
             caretakers.forEach { caretaker ->
                 tx.insertTestCaretakers(
@@ -264,7 +264,7 @@ class DevApi(
     }
 
     @PostMapping("/children")
-    fun createChildren(db: Database.Connection, @RequestBody children: List<DevChild>): ResponseEntity<Unit> {
+    fun createChildren(db: Database.DeprecatedConnection, @RequestBody children: List<DevChild>): ResponseEntity<Unit> {
         db.transaction { tx ->
             children.forEach {
                 tx.insertTestChild(it)
@@ -274,7 +274,7 @@ class DevApi(
     }
 
     @PostMapping("/daycare-placements")
-    fun createDaycarePlacements(db: Database.Connection, @RequestBody placements: List<DevPlacement>): ResponseEntity<Unit> {
+    fun createDaycarePlacements(db: Database.DeprecatedConnection, @RequestBody placements: List<DevPlacement>): ResponseEntity<Unit> {
         db.transaction { placements.forEach { placement -> it.insertTestPlacement(placement) } }
         return ResponseEntity.noContent().build()
     }
@@ -290,7 +290,7 @@ class DevApi(
     )
 
     @PostMapping("/decisions")
-    fun createDecisions(db: Database.Connection, @RequestBody decisions: List<DecisionRequest>): ResponseEntity<Unit> {
+    fun createDecisions(db: Database.DeprecatedConnection, @RequestBody decisions: List<DecisionRequest>): ResponseEntity<Unit> {
         db.transaction { tx ->
             decisions.forEach { decision ->
                 tx.insertDecision(
@@ -309,14 +309,14 @@ class DevApi(
     }
 
     @PostMapping("/decisions/{id}/actions/create-pdf")
-    fun createDecisionPdf(db: Database.Connection, @PathVariable id: DecisionId): ResponseEntity<Unit> {
+    fun createDecisionPdf(db: Database.DeprecatedConnection, @PathVariable id: DecisionId): ResponseEntity<Unit> {
         db.transaction { decisionService.createDecisionPdfs(it, fakeAdmin, id) }
         return ResponseEntity.noContent().build()
     }
 
     @GetMapping("/applications/{applicationId}")
     fun getApplication(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable applicationId: ApplicationId
     ): ResponseEntity<ApplicationDetails> {
         return db.read { tx ->
@@ -326,7 +326,7 @@ class DevApi(
 
     @GetMapping("/applications/{applicationId}/decisions")
     fun getApplicationDecisions(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable applicationId: ApplicationId
     ): ResponseEntity<List<Decision>> {
         return db.read { tx ->
@@ -335,7 +335,7 @@ class DevApi(
     }
 
     @PostMapping("/fee-decisions")
-    fun createFeeDecisions(db: Database.Connection, @RequestBody decisions: List<FeeDecision>): ResponseEntity<Unit> {
+    fun createFeeDecisions(db: Database.DeprecatedConnection, @RequestBody decisions: List<FeeDecision>): ResponseEntity<Unit> {
         db.transaction { tx ->
             tx.upsertFeeDecisions(decisions)
             decisions.forEach { fd ->
@@ -349,7 +349,7 @@ class DevApi(
 
     @PostMapping("/value-decisions")
     fun createVoucherValueDecisions(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @RequestBody decisions: List<VoucherValueDecision>
     ): ResponseEntity<Unit> {
         db.transaction { tx -> tx.upsertValueDecisions(decisions) }
@@ -357,13 +357,13 @@ class DevApi(
     }
 
     @PostMapping("/invoices")
-    fun createInvoices(db: Database.Connection, @RequestBody invoices: List<Invoice>): ResponseEntity<Unit> {
+    fun createInvoices(db: Database.DeprecatedConnection, @RequestBody invoices: List<Invoice>): ResponseEntity<Unit> {
         db.transaction { tx -> tx.upsertInvoices(invoices) }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/fee-thresholds")
-    fun createFeeThresholds(db: Database.Connection, @RequestBody feeThresholds: FeeThresholds): ResponseEntity<UUID> =
+    fun createFeeThresholds(db: Database.DeprecatedConnection, @RequestBody feeThresholds: FeeThresholds): ResponseEntity<UUID> =
         db.transaction {
             ResponseEntity.ok(
                 it.insertTestFeeThresholds(feeThresholds)
@@ -373,11 +373,11 @@ class DevApi(
     data class DevCreateIncomeStatements(val personId: UUID, val data: List<IncomeStatementBody>)
 
     @PostMapping("/income-statements")
-    fun createIncomeStatements(db: Database.Connection, @RequestBody body: DevCreateIncomeStatements) =
+    fun createIncomeStatements(db: Database.DeprecatedConnection, @RequestBody body: DevCreateIncomeStatements) =
         db.transaction { tx -> body.data.forEach { tx.createIncomeStatement(body.personId, it) } }
 
     @PostMapping("/person")
-    fun upsertPerson(db: Database.Connection, @RequestBody body: DevPerson): ResponseEntity<PersonDTO> {
+    fun upsertPerson(db: Database.DeprecatedConnection, @RequestBody body: DevPerson): ResponseEntity<PersonDTO> {
         if (body.ssn == null) throw BadRequest("SSN is required for using this endpoint")
         return db.transaction { tx ->
             val person = tx.getPersonBySSN(body.ssn)
@@ -392,7 +392,7 @@ class DevApi(
     }
 
     @PostMapping("/person/create")
-    fun createPerson(db: Database.Connection, @RequestBody body: DevPerson): ResponseEntity<UUID> {
+    fun createPerson(db: Database.DeprecatedConnection, @RequestBody body: DevPerson): ResponseEntity<UUID> {
         return db.transaction { tx ->
             val personId = tx.insertTestPerson(body)
             tx.createPersonMessageAccount(personId)
@@ -406,7 +406,7 @@ class DevApi(
 
     @PostMapping("/parentship")
     fun createParentships(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @RequestBody parentships: List<DevParentship>
     ): ResponseEntity<List<DevParentship>> {
         return db.transaction { tx -> parentships.map { tx.insertTestParentship(it) } }
@@ -414,24 +414,24 @@ class DevApi(
     }
 
     @GetMapping("/employee")
-    fun getEmployees(db: Database.Connection): ResponseEntity<List<Employee>> {
+    fun getEmployees(db: Database.DeprecatedConnection): ResponseEntity<List<Employee>> {
         return ResponseEntity.ok(db.read { it.getEmployees() })
     }
 
     @PostMapping("/employee")
-    fun createEmployee(db: Database.Connection, @RequestBody body: DevEmployee): ResponseEntity<UUID> {
+    fun createEmployee(db: Database.DeprecatedConnection, @RequestBody body: DevEmployee): ResponseEntity<UUID> {
         return ResponseEntity.ok(db.transaction { it.insertTestEmployee(body) })
     }
 
     @DeleteMapping("/employee/external-id/{externalId}")
-    fun deleteEmployeeByExternalId(db: Database.Connection, @PathVariable externalId: ExternalId): ResponseEntity<Unit> {
+    fun deleteEmployeeByExternalId(db: Database.DeprecatedConnection, @PathVariable externalId: ExternalId): ResponseEntity<Unit> {
         db.transaction { it.deleteAndCascadeEmployeeByExternalId(externalId) }
         return ResponseEntity.ok().build()
     }
 
     @PostMapping("/employee/external-id/{externalId}")
     fun upsertEmployeeByExternalId(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable externalId: ExternalId,
         @RequestBody employee: DevEmployee
     ): ResponseEntity<UUID> = db.transaction {
@@ -457,7 +457,7 @@ RETURNING id
     )
 
     @PostMapping("/guardian")
-    fun insertGuardians(db: Database.Connection, @RequestBody guardians: List<DevGuardian>): ResponseEntity<Unit> {
+    fun insertGuardians(db: Database.DeprecatedConnection, @RequestBody guardians: List<DevGuardian>): ResponseEntity<Unit> {
         db.transaction {
             guardians.forEach { guardian ->
                 it.insertGuardian(guardian.guardianId, guardian.childId)
@@ -467,7 +467,7 @@ RETURNING id
     }
 
     @PostMapping("/child")
-    fun insertChild(db: Database.Connection, @RequestBody body: DevPerson): ResponseEntity<UUID> = db.transaction {
+    fun insertChild(db: Database.DeprecatedConnection, @RequestBody body: DevPerson): ResponseEntity<UUID> = db.transaction {
         val id = it.insertTestPerson(
             DevPerson(
                 id = body.id,
@@ -486,7 +486,7 @@ RETURNING id
     }
 
     @PostMapping("/message-account/upsert-all")
-    fun createMessageAccounts(db: Database.Connection) {
+    fun createMessageAccounts(db: Database.DeprecatedConnection) {
         db.transaction { tx ->
             tx.execute("INSERT INTO message_account (daycare_group_id) SELECT id FROM daycare_group ON CONFLICT DO NOTHING")
             tx.execute("INSERT INTO message_account (person_id) SELECT id FROM person ON CONFLICT DO NOTHING")
@@ -495,14 +495,14 @@ RETURNING id
     }
 
     @PostMapping("/backup-cares")
-    fun createBackupCares(db: Database.Connection, @RequestBody backupCares: List<DevBackupCare>): ResponseEntity<Unit> {
+    fun createBackupCares(db: Database.DeprecatedConnection, @RequestBody backupCares: List<DevBackupCare>): ResponseEntity<Unit> {
         db.transaction { tx -> backupCares.forEach { tx.insertTestBackupCare(it) } }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/applications")
     fun createApplications(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @RequestBody applications: List<ApplicationWithForm>
     ): ResponseEntity<List<ApplicationId>> {
         val uuids =
@@ -531,7 +531,7 @@ RETURNING id
 
     @PostMapping("/placement-plan/{application-id}")
     fun createPlacementPlan(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable("application-id") applicationId: ApplicationId,
         @RequestBody placementPlan: PlacementPlan
     ): ResponseEntity<Unit> {
@@ -568,7 +568,7 @@ RETURNING id
     }
 
     @PostMapping("/vtj-persons")
-    fun upsertPerson(db: Database.Connection, @RequestBody person: VtjPerson): ResponseEntity<Unit> {
+    fun upsertPerson(db: Database.DeprecatedConnection, @RequestBody person: VtjPerson): ResponseEntity<Unit> {
         MockPersonDetailsService.upsertPerson(person)
         db.transaction { tx ->
             val uuid = tx.createQuery("SELECT id FROM person WHERE social_security_number = :ssn")
@@ -586,7 +586,7 @@ RETURNING id
     }
 
     @GetMapping("/vtj-persons/{ssn}")
-    fun getVtjPerson(db: Database.Connection, @PathVariable ssn: String): ResponseEntity<VtjPerson> {
+    fun getVtjPerson(db: Database.DeprecatedConnection, @PathVariable ssn: String): ResponseEntity<VtjPerson> {
         return MockPersonDetailsService.getPerson(ssn)?.let { person -> ResponseEntity.ok(person) }
             ?: throw NotFound("vtj person $ssn was not found")
     }
@@ -598,7 +598,7 @@ RETURNING id
 
     @PostMapping("/applications/{applicationId}/actions/{action}")
     fun simpleAction(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable applicationId: ApplicationId,
         @PathVariable action: String
     ): ResponseEntity<Unit> {
@@ -622,7 +622,7 @@ RETURNING id
 
     @PostMapping("/applications/{applicationId}/actions/create-placement-plan")
     fun createPlacementPlan(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable applicationId: ApplicationId,
         @RequestBody body: DaycarePlacementPlan
     ): ResponseEntity<Unit> {
@@ -635,7 +635,7 @@ RETURNING id
 
     @PostMapping("/applications/{applicationId}/actions/create-default-placement-plan")
     fun createDefaultPlacementPlan(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable applicationId: ApplicationId
     ): ResponseEntity<Unit> {
         db.transaction { tx ->
@@ -656,7 +656,7 @@ RETURNING id
 
     @PostMapping("/mobile/pairings/challenge")
     fun postPairingChallenge(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @RequestBody body: PairingsController.PostPairingChallengeReq
     ): ResponseEntity<Pairing> {
         return db
@@ -666,7 +666,7 @@ RETURNING id
 
     @PostMapping("/mobile/pairings/{id}/response")
     fun postPairingResponse(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable id: PairingId,
         @RequestBody body: PairingsController.PostPairingResponseReq
     ): ResponseEntity<Pairing> {
@@ -681,7 +681,7 @@ RETURNING id
 
     @PostMapping("/mobile/pairings")
     fun postPairing(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @RequestBody body: PairingsController.PostPairingReq
     ): ResponseEntity<Pairing> {
         return db.transaction {
@@ -702,7 +702,7 @@ RETURNING id
 
     @PostMapping("/mobile/devices")
     fun postMobileDevice(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @RequestBody body: MobileDeviceReq
     ): ResponseEntity<Unit> {
         return db.transaction {
@@ -719,7 +719,7 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
 
     @PostMapping("/children/{childId}/child-daily-notes")
     fun postChildDailyNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable childId: UUID,
         @RequestBody body: ChildDailyNoteBody
     ): ChildDailyNoteId {
@@ -733,7 +733,7 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
 
     @PostMapping("/children/{childId}/child-sticky-notes")
     fun postChildStickyNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable childId: UUID,
         @RequestBody body: ChildStickyNoteBody
     ): ChildStickyNoteId {
@@ -747,7 +747,7 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
 
     @PostMapping("/daycare-groups/{groupId}/group-notes")
     fun postGroupNote(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable groupId: GroupId,
         @RequestBody body: GroupNoteBody
     ): GroupNoteId {
@@ -767,31 +767,31 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
         digitransit.setAutocomplete(mockResponse)
 
     @PostMapping("/family-contact")
-    fun createFamilyContact(db: Database.Connection, @RequestBody contacts: List<DevFamilyContact>): ResponseEntity<Unit> {
+    fun createFamilyContact(db: Database.DeprecatedConnection, @RequestBody contacts: List<DevFamilyContact>): ResponseEntity<Unit> {
         db.transaction { contacts.forEach { contact -> it.insertFamilyContact(contact) } }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/backup-pickup")
-    fun createBackupPickup(db: Database.Connection, @RequestBody backupPickups: List<DevBackupPickup>): ResponseEntity<Unit> {
+    fun createBackupPickup(db: Database.DeprecatedConnection, @RequestBody backupPickups: List<DevBackupPickup>): ResponseEntity<Unit> {
         db.transaction { backupPickups.forEach { backupPickup -> it.insertBackupPickup(backupPickup) } }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/fridge-child")
-    fun createFridgeChild(db: Database.Connection, @RequestBody fridgeChildren: List<DevFridgeChild>): ResponseEntity<Unit> {
+    fun createFridgeChild(db: Database.DeprecatedConnection, @RequestBody fridgeChildren: List<DevFridgeChild>): ResponseEntity<Unit> {
         db.transaction { fridgeChildren.forEach { child -> it.insertFridgeChild(child) } }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/fridge-partner")
-    fun createFridgePartner(db: Database.Connection, @RequestBody fridgePartners: List<DevFridgePartner>): ResponseEntity<Unit> {
+    fun createFridgePartner(db: Database.DeprecatedConnection, @RequestBody fridgePartners: List<DevFridgePartner>): ResponseEntity<Unit> {
         db.transaction { fridgePartners.forEach { partner -> it.insertFridgePartner(partner) } }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/employee-pin")
-    fun createEmployeePins(db: Database.Connection, @RequestBody employeePins: List<DevEmployeePin>): ResponseEntity<Unit> {
+    fun createEmployeePins(db: Database.DeprecatedConnection, @RequestBody employeePins: List<DevEmployeePin>): ResponseEntity<Unit> {
         db.transaction {
             employeePins.forEach { employeePin ->
                 val userId =
@@ -806,7 +806,7 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
     }
 
     @PostMapping("/pedagogical-document")
-    fun createPedagogicalDocuments(db: Database.Connection, @RequestBody pedagogicalDocuments: List<DevPedagogicalDocument>): ResponseEntity<Unit> {
+    fun createPedagogicalDocuments(db: Database.DeprecatedConnection, @RequestBody pedagogicalDocuments: List<DevPedagogicalDocument>): ResponseEntity<Unit> {
         db.transaction {
             pedagogicalDocuments.forEach { pedagogicalDocument ->
                 it.insertPedagogicalDocument(pedagogicalDocument)
@@ -817,7 +817,7 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
 
     @PostMapping("/pedagogical-document-attachment/{pedagogicalDocumentId}")
     fun createPedagogicalDocumentAttachment(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable pedagogicalDocumentId: PedagogicalDocumentId,
         @RequestParam employeeId: UUID,
         @RequestPart("file") file: MultipartFile
@@ -844,7 +844,7 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
     }
 
     @PostMapping("/vasu/template")
-    fun createVasuTemplate(db: Database.Connection): VasuTemplateId {
+    fun createVasuTemplate(db: Database.DeprecatedConnection): VasuTemplateId {
         return db.transaction { tx ->
             tx.insertVasuTemplate(
                 name = "testipohja",
@@ -857,14 +857,14 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
     }
 
     @PostMapping("/vasu/doc")
-    fun createVasuDocument(db: Database.Connection, @RequestBody body: PostVasuDocBody): VasuDocumentId {
+    fun createVasuDocument(db: Database.DeprecatedConnection, @RequestBody body: PostVasuDocBody): VasuDocumentId {
         return db.transaction { tx ->
             tx.insertVasuDocument(body.childId, body.templateId)
         }
     }
 
     @PostMapping("/service-need")
-    fun createServiceNeeds(db: Database.Connection, @RequestBody serviceNeeds: List<DevServiceNeed>): ResponseEntity<Unit> {
+    fun createServiceNeeds(db: Database.DeprecatedConnection, @RequestBody serviceNeeds: List<DevServiceNeed>): ResponseEntity<Unit> {
         db.transaction {
             serviceNeeds.forEach { sn ->
                 it.insertTestServiceNeed(
@@ -881,7 +881,7 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
     }
 
     @PostMapping("/service-need-option")
-    fun createServiceNeedOption(db: Database.Connection, @RequestBody serviceNeedOptions: List<ServiceNeedOption>): ResponseEntity<Unit> {
+    fun createServiceNeedOption(db: Database.DeprecatedConnection, @RequestBody serviceNeedOptions: List<ServiceNeedOption>): ResponseEntity<Unit> {
         db.transaction {
             serviceNeedOptions.forEach { option -> it.insertServiceNeedOption(option) }
         }
@@ -889,19 +889,19 @@ VALUES(:id, :unitId, :name, :deleted, :longTermToken)
     }
 
     @PostMapping("/service-need-options")
-    fun createDefaultServiceNeedOptions(db: Database.Connection): ResponseEntity<Unit> {
+    fun createDefaultServiceNeedOptions(db: Database.DeprecatedConnection): ResponseEntity<Unit> {
         db.transaction { it.insertServiceNeedOptions() }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/voucher-values")
-    fun createVoucherValues(db: Database.Connection): ResponseEntity<Unit> {
+    fun createVoucherValues(db: Database.DeprecatedConnection): ResponseEntity<Unit> {
         db.transaction { it.insertVoucherValues() }
         return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/assistance-needs")
-    fun createAssistanceNeeds(db: Database.Connection, @RequestBody assistanceNeeds: List<DevAssistanceNeed>): ResponseEntity<Unit> {
+    fun createAssistanceNeeds(db: Database.DeprecatedConnection, @RequestBody assistanceNeeds: List<DevAssistanceNeed>): ResponseEntity<Unit> {
         db.transaction { tx ->
             assistanceNeeds.forEach {
                 tx.insertTestAssistanceNeed(it)

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -55,7 +55,7 @@ import java.time.LocalDate
 class UnitsView(private val accessControl: AccessControl) {
     @GetMapping("/{unitId}")
     fun getUnitViewData(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDevController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaDevController.kt
@@ -20,7 +20,7 @@ class VardaDevController(
 ) {
     @PostMapping("/run-update-all")
     fun runFullVardaUpdate(
-        db: Database.Connection
+        db: Database.DeprecatedConnection
     ): ResponseEntity<Unit> {
         vardaUpdateService.startVardaUpdate(db)
         return ResponseEntity.noContent().build()
@@ -28,7 +28,7 @@ class VardaDevController(
 
     @PostMapping("/reset-children")
     fun resetChildren(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @RequestParam(defaultValue = "true") addNewChildren: Boolean,
         @RequestParam(defaultValue = "1000") limit: Int,
     ) {
@@ -37,7 +37,7 @@ class VardaDevController(
 
     @PostMapping("/reset-by-report/{organizerId}")
     fun resetChildrenByReport(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         @PathVariable organizerId: Long,
         @RequestParam(defaultValue = "1000") limit: Int,
     ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
@@ -45,7 +45,7 @@ class VasuController(
 
     @PostMapping("/children/{childId}/vasu")
     fun createDocument(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID,
         @RequestBody body: CreateDocumentRequest
@@ -70,7 +70,7 @@ class VasuController(
 
     @GetMapping("/children/{childId}/vasu-summaries")
     fun getVasuSummariesByChild(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable childId: UUID
     ): List<VasuDocumentSummary> {
@@ -90,7 +90,7 @@ class VasuController(
     )
     @GetMapping("/vasu/{id}")
     fun getDocument(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: VasuDocumentId
     ): GetVasuDocumentResponse {
@@ -112,7 +112,7 @@ class VasuController(
 
     @PutMapping("/vasu/{id}")
     fun putDocument(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: VasuDocumentId,
         @RequestBody body: UpdateDocumentRequest
@@ -150,7 +150,7 @@ class VasuController(
 
     @PostMapping("/vasu/{id}/edit-followup/{entryId}")
     fun editFollowupEntry(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: VasuDocumentId,
         @PathVariable entryId: UUID,
@@ -175,7 +175,7 @@ class VasuController(
 
     @PostMapping("/vasu/{id}/update-state")
     fun updateDocumentState(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: VasuDocumentId,
         @RequestBody body: ChangeDocumentStateRequest

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuTemplateController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuTemplateController.kt
@@ -38,7 +38,7 @@ class VasuTemplateController(
 
     @PostMapping
     fun postTemplate(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestBody body: CreateTemplateRequest
     ): VasuTemplateId {
@@ -58,7 +58,7 @@ class VasuTemplateController(
 
     @PutMapping("/{id}")
     fun editTemplate(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: VasuTemplateId,
         @RequestBody body: VasuTemplateUpdate
@@ -80,7 +80,7 @@ class VasuTemplateController(
 
     @PostMapping("/{id}/copy")
     fun copyTemplate(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: VasuTemplateId,
         @RequestBody body: CopyTemplateRequest
@@ -102,7 +102,7 @@ class VasuTemplateController(
 
     @GetMapping
     fun getTemplates(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @RequestParam(required = false) validOnly: Boolean = false
     ): List<VasuTemplateSummary> {
@@ -114,7 +114,7 @@ class VasuTemplateController(
 
     @GetMapping("/{id}")
     fun getTemplate(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: VasuTemplateId
     ): VasuTemplate {
@@ -128,7 +128,7 @@ class VasuTemplateController(
 
     @DeleteMapping("/{id}")
     fun deleteTemplate(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: VasuTemplateId
     ) {
@@ -140,7 +140,7 @@ class VasuTemplateController(
 
     @PutMapping("/{id}/content")
     fun putTemplateContent(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable id: VasuTemplateId,
         @RequestBody content: VasuContent

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -29,7 +29,7 @@ import java.util.UUID
 class VtjController(private val personService: PersonService, private val accessControlCitizen: AccessControlCitizen) {
     @GetMapping("/uuid/{personId}")
     internal fun getDetails(
-        db: Database.Connection,
+        db: Database.DeprecatedConnection,
         user: AuthenticatedUser,
         @PathVariable(value = "personId") personId: UUID
     ): CitizenUserDetails {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

We decided some time ago that `db: Database` + manual connections are the right way to go.

- all existing use of Spring MVC `db: Database.Connection` injection has been changed to `db: Database.DeprecatedConnection`
- `db: Database.Connection` no longer gets injected, so new code needs to either A) use `db: Database` + manual connections (the right way), or B) use DeprecatedConection (the deprecated way, as suggested by the name)