### PR TITLE
EVAKA DOC add invoicing diagram sources

### DIFF
--- a/docs/diagrams/src/evaka-correcting-invoicing.puml
+++ b/docs/diagrams/src/evaka-correcting-invoicing.puml
@@ -1,3 +1,7 @@
+' SPDX-FileCopyrightText: 2017-2021 City of Espoo
+'
+' SPDX-License-Identifier: LGPL-2.1-or-later
+
 @startuml evaka-correcting-invoicing
 title eVakan laskutuksen korjausprosessi
 

--- a/docs/diagrams/src/evaka-correcting-invoicing.puml
+++ b/docs/diagrams/src/evaka-correcting-invoicing.puml
@@ -1,0 +1,26 @@
+@startuml evaka-correcting-invoicing
+title eVakan laskutuksen korjausprosessi
+
+:Asiakas huomaa virheen maksupäätöksessä tai laskussa;
+:Asiakas ottaa yhteyttä talouskoordinaattoriin (TK);
+:TK käsittelee korjaustarpeen asiakkaan ja 
+tarvittaessa yksikön kanssa;
+split
+  :Tulotiedot;
+  :TK korjaa tiedot;
+split again
+split
+  :Perhekoko;
+split again
+  :Perheen kokoonpano;
+split again
+  :Sijoitus tai palveluntarve;
+split again
+  :Päiväkirjatiedot;
+end split
+  :Päiväkodin johtaja korjaa tiedot;
+end split
+:Syntyy uusi maksupäätösluonnos;
+:TK luo maksupäätöksen;
+:TK korjaa laskutuksen käsin laskutusjärjestelmään;
+@enduml

--- a/docs/diagrams/src/evaka-monthly-invoicing.puml
+++ b/docs/diagrams/src/evaka-monthly-invoicing.puml
@@ -1,3 +1,7 @@
+' SPDX-FileCopyrightText: 2017-2021 City of Espoo
+'
+' SPDX-License-Identifier: LGPL-2.1-or-later
+
 @startuml evaka-monthly-invoicing
 title eVakan kuukausilaskutusprosessi
 :Asiakas hakee varhaiskasvatuspaikkaa;

--- a/docs/diagrams/src/evaka-monthly-invoicing.puml
+++ b/docs/diagrams/src/evaka-monthly-invoicing.puml
@@ -1,0 +1,38 @@
+@startuml evaka-monthly-invoicing
+title eVakan kuukausilaskutusprosessi
+:Asiakas hakee varhaiskasvatuspaikkaa;
+if(Asiakas hyväksyy korkeimman maksun?) then (kyllä)
+else (ei)
+:Asiakas täyttää tuloselvityksen;
+:Talouskoordinaattori (TK) lisää asiakkaalle tulotiedot;
+endif
+:Syntyy maksupäätösluonnos
+(palveluseteliyksikölle arvopäätösluonnos);
+:TK tarkastaa puuttuvat
+palveluntarpeet ja päämiehet-raportin;
+:TK ajaa oman alueensa maksuluonnokset
+maksupäätöksiksi kuun viimeinen arkipäivä;
+split
+    :TK tarkastaa oman alueensa,
+    että kaikki maksupäätökset on lähetetty;
+    :TK tarkistaa koko kaupungin tyhjät nollapäätökset
+    (katkaisee laskutuksen) ja lähettää ne;
+    :TK luo laskuluonnokset massana
+    kaikille asiakkaille ennen laskujen lähettämistä;
+    :TK tekee manuaalisesti hyvitys- ja lisälaskurivit eVakaan;
+    :TK siirtää oman alueensa laskut laskutusjärjestelmään;
+    :TK tarkistaa oman alueensa laskujen täsmäytyksen;
+    kill
+split again
+    if (Huoltajalla Suomi.fi-viestit käytössä?) then (kyllä)
+      :Päätös Suomi.fi-viestinä;
+    else (ei)
+      if (Hakijalla turvakielto) then (kyllä)
+        :TK selvittää turvakiellollisen osoitteen;
+      else (ei)
+      endif
+      :TK lähettää päätöksen maapostissa;
+    endif
+    kill
+end split
+@enduml


### PR DESCRIPTION
- Add process diagram of invoicing; this is cut-n-paste conversion from "Laskutus" frame in "eVaka 2.0 kaaviot" Miro board
- Add initial process diagram for corrections in invoicing
- These are published on wiki

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

