### PR TITLE
EVAKA-FIX Use i18n with AbsenceDay

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
@@ -9,12 +9,14 @@ import RoundIcon from 'lib-components/atoms/RoundIcon'
 import { faThermometer } from 'lib-icons'
 import colors from 'lib-customizations/common'
 import { AbsenceType } from 'lib-common/generated/enums'
+import { useTranslation } from '../../../state/i18n'
 
 interface Props {
   type: AbsenceType
 }
 
 export default React.memo(function AbsenceDay({ type }: Props) {
+  const { i18n } = useTranslation()
   if (type === 'SICKLEAVE')
     return (
       <AbsenceCell>
@@ -24,7 +26,7 @@ export default React.memo(function AbsenceDay({ type }: Props) {
             color={colors.accents.violet}
             size="m"
           />
-          <div>Sairaus</div>
+          <div>{i18n.absences.absenceTypes.SICKLEAVE}</div>
         </FixedSpaceRow>
       </AbsenceCell>
     )
@@ -33,7 +35,10 @@ export default React.memo(function AbsenceDay({ type }: Props) {
     <AbsenceCell>
       <FixedSpaceRow spacing="xs" alignItems="center">
         <RoundIcon content="–" color={colors.primary} size="m" />
-        <div>Muu syy</div>
+        <div>
+          {i18n.absences.absenceTypes[type] ??
+            i18n.absences.absenceTypes.OTHER_ABSENCE}
+        </div>
       </FixedSpaceRow>
     </AbsenceCell>
   )


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Use absence type translations in the reservation week view.
<img width="943" alt="Screenshot 2021-12-16 at 14 32 46" src="https://user-images.githubusercontent.com/3275771/146372746-a7a1fd06-7ec5-459b-b07e-e111f6203c12.png">

