### PR TITLE
Include sficlient in build cache

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -337,6 +337,7 @@ commands:
             - service/build
             - service/buildSrc/build
             - service/custom-ktlint-rules/build
+            - service/sficlient/build
             - service/vtjclient/build
             - service-lib/build
   restore_service_build_cache:


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This fixes a regression in CI integration test job times caused by recompilation.