### PR TITLE
TREV-433 possibility to send fee decisions in advance with configurable date

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.core.env.Environment
 import java.io.File

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
@@ -60,7 +60,7 @@ abstract class FullApplicationTest {
 
     @Autowired
     protected lateinit var env: Environment
-    @SpyBean
+    @Autowired
     protected lateinit var evakaEnv: EvakaEnv
     @Autowired
     protected lateinit var vardaEnv: VardaEnv

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.core.env.Environment
 import java.io.File
@@ -59,7 +60,7 @@ abstract class FullApplicationTest {
 
     @Autowired
     protected lateinit var env: Environment
-    @Autowired
+    @SpyBean
     protected lateinit var evakaEnv: EvakaEnv
     @Autowired
     protected lateinit var vardaEnv: VardaEnv

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -942,7 +942,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
     @Test
     fun `confirmDrafts returns bad request when some decisions being in the future`() {
         val draftWithFutureDates = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
-            .copy(validDuring = DateRange(LocalDate.now().plusDays(1), LocalDate.now().plusYears(1)))
+            .copy(validDuring = DateRange(LocalDate.now().plusDays(2), LocalDate.now().plusYears(1)))
         db.transaction { tx -> tx.upsertFeeDecisions(listOf(draftWithFutureDates)) }
 
         val (_, response, _) = http.post("/decisions/confirm")
@@ -958,7 +958,6 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `confirmDrafts when decision at last possible confirmation date exists`() {
-        doReturn(1L).whenever(evakaEnv).nrOfDaysFeeDecisionCanBeSentInAdvance
         val now = HelsinkiDateTime.now()
         val draftWithFutureDates = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
             .copy(validDuring = DateRange(now.toLocalDate().plusDays(1), now.toLocalDate().plusYears(1)))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -4,25 +4,11 @@
 
 package fi.espoo.evaka.invoicing
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.result.Result
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.snDaycareFullDay35
-import fi.espoo.evaka.testAdult_1
-import fi.espoo.evaka.testAdult_2
-import fi.espoo.evaka.testAdult_3
-import fi.espoo.evaka.testChild_1
-import fi.espoo.evaka.testChild_2
-import fi.espoo.evaka.testChild_3
-import fi.espoo.evaka.testChild_4
-import fi.espoo.evaka.testDaycare
-import fi.espoo.evaka.testDaycare2
-import fi.espoo.evaka.testDecisionMaker_1
-import fi.espoo.evaka.testDecisionMaker_2
-import fi.espoo.evaka.toFeeDecisionServiceNeed
 import fi.espoo.evaka.invoicing.controller.FeeDecisionTypeRequest
 import fi.espoo.evaka.invoicing.controller.Wrapper
 import fi.espoo.evaka.invoicing.data.upsertFeeDecisions
@@ -44,14 +30,23 @@ import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
-import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.snDaycareFullDay35
+import fi.espoo.evaka.testAdult_1
+import fi.espoo.evaka.testAdult_2
+import fi.espoo.evaka.testAdult_3
+import fi.espoo.evaka.testChild_1
+import fi.espoo.evaka.testChild_2
+import fi.espoo.evaka.testChild_3
+import fi.espoo.evaka.testChild_4
+import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.testDaycare2
+import fi.espoo.evaka.testDecisionMaker_1
+import fi.espoo.evaka.testDecisionMaker_2
+import fi.espoo.evaka.toFeeDecisionServiceNeed
 import fi.espoo.evaka.withMockedTime
-import org.json.JSONObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.Instant
 import java.time.LocalDate
@@ -970,7 +965,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
             .response()
         assertEquals(204, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2 )
+        asyncJobRunner.runPendingJobsSync(2)
 
         val (_, _, result) = http.get("/decisions/${draftWithFutureDates.id}")
             .asUser(user)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -10,6 +10,19 @@ import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.result.Result
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
+import fi.espoo.evaka.snDaycareFullDay35
+import fi.espoo.evaka.testAdult_1
+import fi.espoo.evaka.testAdult_2
+import fi.espoo.evaka.testAdult_3
+import fi.espoo.evaka.testChild_1
+import fi.espoo.evaka.testChild_2
+import fi.espoo.evaka.testChild_3
+import fi.espoo.evaka.testChild_4
+import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.testDaycare2
+import fi.espoo.evaka.testDecisionMaker_1
+import fi.espoo.evaka.testDecisionMaker_2
+import fi.espoo.evaka.toFeeDecisionServiceNeed
 import fi.espoo.evaka.invoicing.controller.FeeDecisionTypeRequest
 import fi.espoo.evaka.invoicing.controller.Wrapper
 import fi.espoo.evaka.invoicing.data.upsertFeeDecisions
@@ -30,25 +43,17 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
-import fi.espoo.evaka.snDaycareFullDay35
-import fi.espoo.evaka.testAdult_1
-import fi.espoo.evaka.testAdult_2
-import fi.espoo.evaka.testAdult_3
-import fi.espoo.evaka.testChild_1
-import fi.espoo.evaka.testChild_2
-import fi.espoo.evaka.testChild_3
-import fi.espoo.evaka.testChild_4
-import fi.espoo.evaka.testDaycare
-import fi.espoo.evaka.testDaycare2
-import fi.espoo.evaka.testDecisionMaker_1
-import fi.espoo.evaka.testDecisionMaker_2
-import fi.espoo.evaka.toFeeDecisionServiceNeed
+import org.json.JSONObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -941,9 +946,45 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
 
         val (_, response, _) = http.post("/decisions/confirm")
             .asUser(user)
-            .jsonBody(objectMapper.writeValueAsString(draftWithFutureDates.id))
+            .jsonBody(objectMapper.writeValueAsString(listOf(draftWithFutureDates.id)))
             .response()
         assertEquals(400, response.statusCode)
+        assertEquals(
+            "feeDecisions.confirmation.tooFarInFuture",
+            JSONObject(response.body().asString("text/json")).getString("errorCode")
+        )
+    }
+
+    @Test
+    fun `confirmDrafts when decision at last possible confirmation date exists`() {
+        doReturn(1).whenever(evakaEnv).nrOfDaysFeeDecisionCanBeSentInAdvance
+        val nowDate = LocalDate.now()
+        val draftWithFutureDates = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
+            .copy(validDuring = DateRange(nowDate.plusDays(1), nowDate.plusYears(1)))
+        db.transaction { tx -> tx.upsertFeeDecisions(listOf(draftWithFutureDates)) }
+
+        val (_, response, _) = http.post("/decisions/confirm")
+            .asUser(user)
+            .jsonBody(objectMapper.writeValueAsString(listOf(draftWithFutureDates.id)))
+            .response()
+        assertEquals(204, response.statusCode)
+
+        asyncJobRunner.runPendingJobsSync(2 )
+
+        val (_, _, result) = http.get("/decisions/${draftWithFutureDates.id}")
+            .asUser(user)
+            .responseString()
+
+        val expected = draftWithFutureDates.copy(
+            decisionNumber = 1,
+            status = FeeDecisionStatus.SENT,
+            approvedBy = PersonData.JustId(testDecisionMaker_1.id),
+            decisionHandler = PersonData.JustId(testDecisionMaker_1.id),
+            documentKey = "feedecision_${draftWithFutureDates.id}_fi.pdf"
+        )
+        val actual = deserializeResult(result.get()).data
+        assertEqualEnough(expected.let(::toDetailed), actual)
+        assertEquals(actual.sentAt?.truncatedTo(ChronoUnit.DAYS), nowDate.atStartOfDay().toInstant(ZoneOffset.UTC))
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.invoicing
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.result.Result

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -45,6 +45,7 @@ import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.withMockedTime
 import org.json.JSONObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -54,8 +55,6 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneOffset
-import java.time.temporal.ChronoUnit
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -961,9 +960,8 @@ class FeeDecisionIntegrationTest : FullApplicationTest() {
     fun `confirmDrafts when decision at last possible confirmation date exists`() {
         doReturn(1L).whenever(evakaEnv).nrOfDaysFeeDecisionCanBeSentInAdvance
         val now = HelsinkiDateTime.now()
-        val clock = MockEvakaClock(now)
         val draftWithFutureDates = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
-            .copy(validDuring = DateRange(clock.today().plusDays(1), clock.today().plusYears(1)))
+            .copy(validDuring = DateRange(now.toLocalDate().plusDays(1), now.toLocalDate().plusYears(1)))
         db.transaction { tx -> tx.upsertFeeDecisions(listOf(draftWithFutureDates)) }
 
         val (_, response, _) = http.post("/decisions/confirm")

--- a/service/src/integrationTest/resources/application-integration-test.yaml
+++ b/service/src/integrationTest/resources/application-integration-test.yaml
@@ -25,6 +25,7 @@ evaka:
     disable_runner: true
   fee_decision:
     min_date: "2015-01-01"
+    days_in_advance: 1
   oph:
     organizer_oid: "1.2.246.562.10.888888888888"
     municipality_code: "049"

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -32,7 +32,7 @@ data class EvakaEnv(
     val httpClientCertificateCheck: Boolean,
     val fiveYearsOldDaycareEnabled: Boolean,
     val mockClock: Boolean,
-    val nrOfDaysFeeDecisionCanBeSentInAdvance: Int
+    val nrOfDaysFeeDecisionCanBeSentInAdvance: Long
 ) {
     companion object {
         fun fromEnvironment(env: Environment): EvakaEnv {

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -32,6 +32,7 @@ data class EvakaEnv(
     val httpClientCertificateCheck: Boolean,
     val fiveYearsOldDaycareEnabled: Boolean,
     val mockClock: Boolean,
+    val nrOfDaysFeeDecisionCanBeSentInAdvance: Int
 ) {
     companion object {
         fun fromEnvironment(env: Environment): EvakaEnv {
@@ -57,6 +58,7 @@ data class EvakaEnv(
                     "fi.espoo.evaka.five_years_old_daycare.enabled"
                 ) ?: true,
                 mockClock = env.lookup("evaka.clock.mock") ?: false,
+                nrOfDaysFeeDecisionCanBeSentInAdvance = env.lookup("evaka.fee_decision.days_in_advance") ?: 0
             )
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
@@ -40,6 +40,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.message.IMessageProvider
 import fi.espoo.evaka.shared.message.MessageLanguage


### PR DESCRIPTION
Made this with env variable for the less amount of hassle in case all cities will take this later on as default way of working.

Also, fixed related test, that had feeDecision id as string instead of a string array.
