### PR TITLE
EVAKA-4265 fix misplaced messages context

### DIFF
--- a/frontend/src/e2e-playwright/pages/mobile/messages.ts
+++ b/frontend/src/e2e-playwright/pages/mobile/messages.ts
@@ -9,17 +9,22 @@ export default class MobileMessagesPage {
 
   messagesContainer = this.page.find(`[data-qa="messages-page-content-area"]`)
 
+  async getThreadTitle(index: number) {
+    const titles = this.page.findAll('[data-qa="message-preview-title"]')
+    return titles.nth(index).innerText
+  }
+
   async messagesExist() {
-    return (await this.page.findAll('[data-qa^="message-preview"]').count()) > 0
+    return (await this.page.findAll('[data-qa="message-preview"]').count()) > 0
   }
 
   async messagesDontExist() {
-    const els = this.page.findAll('[data-qa^="message-preview"]')
+    const els = this.page.findAll('[data-qa="message-preview"]')
 
     return (await els.count()) === 0
   }
 
   async openFirstThread() {
-    await this.page.find(`[data-qa^="message-preview"]`).click()
+    await this.page.find(`[data-qa="message-preview"]`).click()
   }
 }

--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -90,12 +90,10 @@ function UnitRouter() {
 
   return (
     <UnitContextProvider unitId={unitId}>
-      <MessageContextProvider>
-        <Switch>
-          <Route path={`${path}/groups/:groupId`} component={GroupRouter} />
-          <Redirect to={`${path}/groups/all`} />
-        </Switch>
-      </MessageContextProvider>
+      <Switch>
+        <Route path={`${path}/groups/:groupId`} component={GroupRouter} />
+        <Redirect to={`${path}/groups/all`} />
+      </Switch>
     </UnitContextProvider>
   )
 }
@@ -105,19 +103,21 @@ function GroupRouter() {
   useGroupIdInLocalStorage()
 
   return (
-    <Switch>
-      <Route
-        path={`${path}/child-attendance`}
-        component={ChildAttendanceRouter}
-      />
-      <Route path={`${path}/staff`} component={StaffRouter} />
-      <Route
-        path={`${path}/staff-attendance`}
-        component={StaffAttendanceRouter}
-      />
-      <Route path={`${path}/messages`} component={MessagesRouter} />
-      <Redirect to={`${path}/child-attendance`} />
-    </Switch>
+    <MessageContextProvider>
+      <Switch>
+        <Route
+          path={`${path}/child-attendance`}
+          component={ChildAttendanceRouter}
+        />
+        <Route path={`${path}/staff`} component={StaffRouter} />
+        <Route
+          path={`${path}/staff-attendance`}
+          component={StaffAttendanceRouter}
+        />
+        <Route path={`${path}/messages`} component={MessagesRouter} />
+        <Redirect to={`${path}/child-attendance`} />
+      </Switch>
+    </MessageContextProvider>
   )
 }
 

--- a/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
@@ -94,8 +94,8 @@ export default function MessageEditorPage() {
           featureFlags.experimental?.messageAttachments ?? false
         }
         defaultSender={{
-          value: selectedAccount.id,
-          label: selectedAccount.name
+          value: selectedAccount.account.id,
+          label: selectedAccount.account.name
         }}
         deleteAttachment={deleteAttachment}
         draftContent={undefined}

--- a/frontend/src/employee-mobile-frontend/components/messages/MessagePreview.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessagePreview.tsx
@@ -39,7 +39,9 @@ export function MessagePreview({
           </Truncated>
         </Header>
         <TitleAndDate isRead={!hasUnreadMessages}>
-          <Truncated>{thread.title}</Truncated>
+          <Truncated data-qa={`message-preview-title`}>
+            {thread.title}
+          </Truncated>
           <span>{formatDateOrTime(lastMessage.sentAt)}</span>
         </TitleAndDate>
         <Truncated>

--- a/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
@@ -22,9 +22,8 @@ import { defaultMargins } from 'lib-components/white-space'
 
 export default function MessagesPage() {
   const history = useHistory()
-  const { unitId, groupId } = useParams<{
+  const { unitId } = useParams<{
     unitId: UUID
-    groupId: UUID | 'all'
   }>()
 
   function changeGroup(group: GroupInfo | undefined) {
@@ -38,10 +37,6 @@ export default function MessagesPage() {
     selectThread,
     selectedAccount
   } = useContext(MessageContext)
-
-  const selectedGroup =
-    groupAccounts.find(({ daycareGroup }) => daycareGroup?.id === groupId) ??
-    groupAccounts[0]
 
   const { i18n } = useTranslation()
   const onBack = useCallback(() => selectThread(undefined), [selectThread])
@@ -57,17 +52,17 @@ export default function MessagesPage() {
       <ThreadView
         thread={selectedThread}
         onBack={onBack}
-        senderAccountId={selectedAccount.id}
+        senderAccountId={selectedAccount.account.id}
       />
     </ContentArea>
   ) : !selectedThread && selectedAccount ? (
     <>
       <TopBarWithGroupSelector
         selectedGroup={
-          selectedGroup?.daycareGroup
+          selectedAccount?.daycareGroup
             ? {
-                id: selectedGroup.daycareGroup.id,
-                name: selectedGroup.daycareGroup.name
+                id: selectedAccount.daycareGroup.id,
+                name: selectedAccount.daycareGroup.name
               }
             : undefined
         }
@@ -94,7 +89,7 @@ export default function MessagesPage() {
                 hasUnreadMessages={thread.messages.some(
                   (item) =>
                     !item.readAt &&
-                    item.sender.id !== selectedAccount?.id &&
+                    item.sender.id !== selectedAccount?.account.id &&
                     !groupAccounts.some(
                       (ga) => ga.account.id === item.sender.id
                     )

--- a/frontend/src/employee-mobile-frontend/state/messages.tsx
+++ b/frontend/src/employee-mobile-frontend/state/messages.tsx
@@ -5,7 +5,6 @@
 import { Loading, Paged, Result } from 'lib-common/api'
 import {
   Message,
-  MessageAccount,
   MessageThread,
   NestedMessageAccount,
   ThreadReply
@@ -57,7 +56,7 @@ export interface MessagesState {
   pages: number | undefined
   setPages: (pages: number) => void
   groupAccounts: NestedMessageAccount[]
-  selectedAccount: MessageAccount | undefined
+  selectedAccount: NestedMessageAccount | undefined
   receivedMessages: Result<MessageThread[]>
   selectedUnit: SelectOption | undefined
   selectedThread: MessageThread | undefined
@@ -136,12 +135,12 @@ export const MessageContextProvider = React.memo(
         .getOrElse([])
     }, [nestedAccounts, unitId])
 
-    const selectedAccount: MessageAccount = useMemo(() => {
+    const selectedAccount: NestedMessageAccount = useMemo(() => {
       return (
         groupAccounts.find(
           ({ daycareGroup }) => daycareGroup?.id === groupId
         ) ?? groupAccounts[0]
-      )?.account
+      )
     }, [groupAccounts, groupId])
 
     const [receivedMessages, setReceivedMessages] = useState<
@@ -167,7 +166,7 @@ export const MessageContextProvider = React.memo(
 
     useEffect(() => {
       if (selectedAccount && !selectedThread) {
-        loadReceivedMessages(selectedAccount.id, page, PAGE_SIZE)
+        loadReceivedMessages(selectedAccount.account.id, page, PAGE_SIZE)
         reloadUnreadCounts()
       }
     }, [
@@ -183,7 +182,7 @@ export const MessageContextProvider = React.memo(
         setSelectedThread(thread)
         if (!thread) return
         if (!selectedAccount) throw new Error('Should never happen')
-        const { id: accountId } = selectedAccount
+        const { id: accountId } = selectedAccount.account
         void markThreadRead(accountId, thread.id)
       },
       [selectedAccount]


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- Fix badly placed message context (it needs group id)
- Use selectedAccount instead of selectedGroup to ensure group selector works concisely
- Add e2e-test for supervisor clicking through message boxes