### PR TITLE
EVAKA-FIX citizen message editor height in percentage

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -154,9 +154,9 @@ const Container = styled.div`
   background-color: ${colors.greyscale.white};
   @media (max-width: ${desktopMin}) {
     width: 100vw;
-    height: 100vh;
+    height: 100%;
     max-width: 100vh;
-    max-height: 100vh;
+    max-height: 100%;
     position: fixed;
     top: 0;
     left: 0;


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Replace vh with percentage to avoid height problems with ios safari (experimental)
