### PR TITLE
Reduce status timeouts in AsyncButton when running tests

### DIFF
--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -94,7 +94,7 @@ export default React.memo(function AsyncButton({
       ? setTimeout(() => onSuccessRef.current(), isAutomatedTest ? 10 : 500)
       : undefined
     const clearShowSuccess = showSuccess
-      ? setTimeout(() => setShowSuccess(false), isAutomatedTest ? 25 : 2000)
+      ? setTimeout(() => setShowSuccess(false), isAutomatedTest ? 250 : 2000)
       : undefined
 
     return () => {
@@ -105,7 +105,7 @@ export default React.memo(function AsyncButton({
 
   useEffect(() => {
     const clearShowFailure = showFailure
-      ? setTimeout(() => setShowFailure(false), isAutomatedTest ? 25 : 2000)
+      ? setTimeout(() => setShowFailure(false), isAutomatedTest ? 250 : 2000)
       : undefined
 
     return () => {

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -8,6 +8,7 @@ import { animated, useSpring } from 'react-spring'
 import classNames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck, faTimes } from 'lib-icons'
+import { isAutomatedTest } from 'lib-common/utils/helpers'
 import { StyledButton } from './Button'
 
 export type AsyncClickCallback = (
@@ -90,10 +91,10 @@ export default React.memo(function AsyncButton({
 
   useEffect(() => {
     const runOnSuccess = showSuccess
-      ? setTimeout(() => onSuccessRef.current(), 500)
+      ? setTimeout(() => onSuccessRef.current(), isAutomatedTest ? 10 : 500)
       : undefined
     const clearShowSuccess = showSuccess
-      ? setTimeout(() => setShowSuccess(false), 2000)
+      ? setTimeout(() => setShowSuccess(false), isAutomatedTest ? 25 : 2000)
       : undefined
 
     return () => {
@@ -104,7 +105,7 @@ export default React.memo(function AsyncButton({
 
   useEffect(() => {
     const clearShowFailure = showFailure
-      ? setTimeout(() => setShowFailure(false), 2000)
+      ? setTimeout(() => setShowFailure(false), isAutomatedTest ? 25 : 2000)
       : undefined
 
     return () => {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->