### PR TITLE
EVAKA-4317 deactivating service need options

### DIFF
--- a/frontend/src/e2e-playwright/specs/5_employee/child-information.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/child-information.spec.ts
@@ -5,7 +5,6 @@
 import config from 'e2e-test-common/config'
 import {
   insertDaycareGroupFixtures,
-  insertDaycarePlacementFixtures,
   resetDatabase
 } from 'e2e-test-common/dev-api'
 import {
@@ -13,11 +12,10 @@ import {
   initializeAreaAndPersonData
 } from 'e2e-test-common/dev-api/data-init'
 import {
-  createDaycarePlacementFixture,
   daycareGroupFixture,
   enduserDeceasedChildFixture,
   enduserNonSsnChildFixture,
-  uuidv4
+  Fixture
 } from 'e2e-test-common/dev-api/fixtures'
 import ChildInformationPage, {
   AdditionalInformationSection,
@@ -48,13 +46,12 @@ beforeEach(async () => {
 
   const unitId = fixtures.daycareFixture.id
   childId = fixtures.familyWithTwoGuardians.children[0].id
-
-  const daycarePlacementFixture = createDaycarePlacementFixture(
-    uuidv4(),
-    childId,
-    unitId
-  )
-  await insertDaycarePlacementFixtures([daycarePlacementFixture])
+  await Fixture.placement()
+    .with({
+      childId,
+      unitId
+    })
+    .save()
 
   page = await Page.open()
   await employeeLogin(page, 'ADMIN')

--- a/frontend/src/e2e-playwright/specs/5_employee/service-need.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/service-need.spec.ts
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import config from 'e2e-test-common/config'
+import { resetDatabase } from 'e2e-test-common/dev-api'
+import { initializeAreaAndPersonData } from 'e2e-test-common/dev-api/data-init'
+import {
+  EmployeeBuilder,
+  Fixture,
+  PlacementBuilder,
+  ServiceNeedOptionBuilder
+} from 'e2e-test-common/dev-api/fixtures'
+import ChildInformationPage from 'e2e-playwright/pages/employee/child-information'
+import { employeeLogin } from 'e2e-playwright/utils/user'
+import { UUID } from 'lib-common/types'
+import { Page } from '../../utils/page'
+
+let page: Page
+let childId: UUID
+let employee: EmployeeBuilder
+let placement: PlacementBuilder
+let activeServiceNeedOption: ServiceNeedOptionBuilder
+let inactiveServiceNeedOption: ServiceNeedOptionBuilder
+
+beforeEach(async () => {
+  await resetDatabase()
+  const fixtures = await initializeAreaAndPersonData()
+  const unitId = fixtures.daycareFixture.id
+  childId = fixtures.familyWithTwoGuardians.children[0].id
+  employee = await Fixture.employee().save()
+  placement = await Fixture.placement()
+    .with({
+      childId,
+      unitId
+    })
+    .save()
+  activeServiceNeedOption = await Fixture.serviceNeedOption()
+    .with({ validPlacementType: placement.data.type })
+    .save()
+  inactiveServiceNeedOption = await Fixture.serviceNeedOption()
+    .with({ validPlacementType: placement.data.type, active: false })
+    .save()
+
+  page = await Page.open()
+  await employeeLogin(page, 'ADMIN')
+})
+
+const openCollapsible = async () => {
+  await page.goto(config.employeeUrl + '/child-information/' + childId)
+  const childInformationPage = new ChildInformationPage(page)
+  await childInformationPage.waitUntilLoaded()
+  return await childInformationPage.openCollapsible('placements')
+}
+
+describe('Service need', () => {
+  test('add service need to a placement', async () => {
+    const section = await openCollapsible()
+
+    await section.addMissingServiceNeed(
+      placement.data.id,
+      activeServiceNeedOption.data.nameFi
+    )
+    await section.assertNthServiceNeedName(
+      0,
+      activeServiceNeedOption.data.nameFi
+    )
+  })
+
+  test('only active service need options can be selected', async () => {
+    const section = await openCollapsible()
+
+    await section.assertServiceNeedOptions(placement.data.id, [
+      activeServiceNeedOption.data.id
+    ])
+  })
+
+  test('inactive service need name is shown on placement', async () => {
+    await Fixture.serviceNeed()
+      .with({
+        placementId: placement.data.id,
+        optionId: inactiveServiceNeedOption.data.id,
+        confirmedBy: employee.data.id
+      })
+      .save()
+    const section = await openCollapsible()
+
+    await section.assertNthServiceNeedName(
+      0,
+      inactiveServiceNeedOption.data.nameFi
+    )
+  })
+})

--- a/frontend/src/e2e-test-common/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test-common/dev-api/fixtures.ts
@@ -35,6 +35,7 @@ import {
   insertChildFixtures,
   insertDaycareFixtures,
   insertDaycareGroupFixtures,
+  insertDaycarePlacementFixtures,
   insertDecisionFixtures,
   insertEmployeeFixture,
   insertEmployeePins,
@@ -1028,6 +1029,17 @@ export class Fixture {
     })
   }
 
+  static placement(): PlacementBuilder {
+    return new PlacementBuilder({
+      id: uuidv4(),
+      childId: 'not set',
+      unitId: 'not set',
+      type: 'DAYCARE',
+      startDate: LocalDate.today().formatIso(),
+      endDate: LocalDate.today().addYears(1).formatIso()
+    })
+  }
+
   static serviceNeed(): ServiceNeedBuilder {
     return new ServiceNeedBuilder({
       id: uuidv4(),
@@ -1346,6 +1358,32 @@ export class ServiceNeedOptionBuilder {
   // Note: shallow copy
   copy(): ServiceNeedOptionBuilder {
     return new ServiceNeedOptionBuilder({ ...this.data })
+  }
+}
+
+export class PlacementBuilder {
+  data: DaycarePlacement
+
+  constructor(data: DaycarePlacement) {
+    this.data = data
+  }
+
+  with(value: Partial<DaycarePlacement>): PlacementBuilder {
+    this.data = {
+      ...this.data,
+      ...value
+    }
+    return this
+  }
+
+  async save(): Promise<PlacementBuilder> {
+    await insertDaycarePlacementFixtures([this.data])
+    return this
+  }
+
+  // Note: shallow copy
+  copy(): PlacementBuilder {
+    return new PlacementBuilder({ ...this.data })
   }
 }
 

--- a/frontend/src/e2e-test-common/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test-common/dev-api/fixtures.ts
@@ -1061,7 +1061,8 @@ export class Fixture {
       validPlacementType: 'DAYCARE',
       voucherValueCoefficient: 0,
       voucherValueDescriptionFi: `Test service need option ${id}`,
-      voucherValueDescriptionSv: `Test service need option ${id}`
+      voucherValueDescriptionSv: `Test service need option ${id}`,
+      active: true
     })
   }
 

--- a/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
@@ -210,6 +210,7 @@ export default React.memo(function PlacementRow({
             }
           />
         }
+        data-qa={`placement-${placement.id}`}
       >
         <DataRow>
           <DataLabel>{i18n.childInformation.placements.startDate}</DataLabel>

--- a/frontend/src/employee-frontend/components/child-information/placements/ServiceNeeds.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/ServiceNeeds.tsx
@@ -61,7 +61,9 @@ export default React.memo(function ServiceNeeds({
 
   const options = serviceNeedOptions.filter(
     (option) =>
-      option.validPlacementType === placementType && !option.defaultOption
+      option.validPlacementType === placementType &&
+      !option.defaultOption &&
+      option.active
   )
 
   const placementHasNonDefaultServiceNeedOptions = serviceNeedOptions.some(

--- a/frontend/src/employee-frontend/components/child-information/placements/service-needs/MissingServiceNeedRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/service-needs/MissingServiceNeedRow.tsx
@@ -49,6 +49,7 @@ function MissingServiceNeedRow({
             text={t.addNewBtn}
             icon={faPlus}
             disabled={disabled}
+            data-qa="add-new-missing-service-need"
           />
         </RequireRole>
       </Td>

--- a/frontend/src/employee-frontend/components/child-information/placements/service-needs/ServiceNeedEditorRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/service-needs/ServiceNeedEditorRow.tsx
@@ -143,6 +143,7 @@ function ServiceNeedEditorRow({
               setForm({ ...form, optionId: optionId ?? undefined })
             }
             placeholder={t.optionPlaceholder}
+            data-qa="service-need-option-select"
           />
         </StyledTd>
         <StyledTd>
@@ -160,11 +161,13 @@ function ServiceNeedEditorRow({
               onClick={onCancel}
               text={i18n.common.cancel}
               disabled={submitting}
+              data-qa="service-need-cancel"
             />
             <InlineButton
               onClick={onSubmit}
               text={i18n.common.save}
               disabled={submitting || !formIsValid}
+              data-qa="service-need-save"
             />
           </FixedSpaceRow>
         </StyledTd>

--- a/frontend/src/employee-frontend/components/child-information/placements/service-needs/ServiceNeedReadRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/service-needs/ServiceNeedReadRow.tsx
@@ -25,11 +25,11 @@ function ServiceNeedReadRow({
 }: ServiceNeedReadRowProps) {
   const { i18n } = useTranslation()
   return (
-    <Tr>
+    <Tr data-qa="service-need-row">
       <Td>
         {serviceNeed.startDate.format()} - {serviceNeed.endDate.format()}
       </Td>
-      <Td>{serviceNeed.option.nameFi}</Td>
+      <Td data-qa="service-need-name">{serviceNeed.option.nameFi}</Td>
       <Td>{serviceNeed.shiftCare ? i18n.common.yes : i18n.common.no}</Td>
       <Td>
         <Tooltip tooltip={<span>{serviceNeed.confirmed?.name}</span>}>

--- a/frontend/src/lib-common/generated/api-types/serviceneed.ts
+++ b/frontend/src/lib-common/generated/api-types/serviceneed.ts
@@ -47,6 +47,7 @@ export interface ServiceNeedCreateRequest {
 * Generated from fi.espoo.evaka.serviceneed.ServiceNeedOption
 */
 export interface ServiceNeedOption {
+  active: boolean
   daycareHoursPerWeek: number
   defaultOption: boolean
   feeCoefficient: number

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/ServiceNeedTestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/ServiceNeedTestFixtures.kt
@@ -28,7 +28,8 @@ val snDefaultDaycare = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDefaultPartDayDaycare = ServiceNeedOption(
@@ -47,7 +48,8 @@ val snDefaultPartDayDaycare = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDefaultFiveYearOldsDaycare = ServiceNeedOption(
@@ -66,7 +68,8 @@ val snDefaultFiveYearOldsDaycare = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDefaultFiveYearOldsPartDayDaycare = ServiceNeedOption(
@@ -85,7 +88,8 @@ val snDefaultFiveYearOldsPartDayDaycare = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDefaultPreschool = ServiceNeedOption(
@@ -104,7 +108,8 @@ val snDefaultPreschool = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDefaultPreschoolDaycare = ServiceNeedOption(
@@ -123,7 +128,8 @@ val snDefaultPreschoolDaycare = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDefaultPreparatory = ServiceNeedOption(
@@ -142,7 +148,8 @@ val snDefaultPreparatory = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDefaultPreparatoryDaycare = ServiceNeedOption(
@@ -161,7 +168,8 @@ val snDefaultPreparatoryDaycare = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDefaultClub = ServiceNeedOption(
@@ -180,7 +188,8 @@ val snDefaultClub = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDefaultTemporaryDaycare = ServiceNeedOption(
@@ -199,7 +208,8 @@ val snDefaultTemporaryDaycare = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDefaultTemporaryPartDayDaycare = ServiceNeedOption(
@@ -218,7 +228,8 @@ val snDefaultTemporaryPartDayDaycare = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDaycareFullDay35 = ServiceNeedOption(
@@ -237,7 +248,8 @@ val snDaycareFullDay35 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDaycareFullDay25to35 = ServiceNeedOption(
@@ -256,7 +268,8 @@ val snDaycareFullDay25to35 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDaycareFullDayPartWeek25 = ServiceNeedOption(
@@ -275,7 +288,8 @@ val snDaycareFullDayPartWeek25 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDaycarePartDay25 = ServiceNeedOption(
@@ -294,7 +308,8 @@ val snDaycarePartDay25 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snPreschoolDaycare45 = ServiceNeedOption(
@@ -313,7 +328,8 @@ val snPreschoolDaycare45 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snPreschoolDaycarePartDay35to45 = ServiceNeedOption(
@@ -332,7 +348,8 @@ val snPreschoolDaycarePartDay35to45 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snPreschoolDaycarePartDay35 = ServiceNeedOption(
@@ -351,7 +368,8 @@ val snPreschoolDaycarePartDay35 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snPreparatoryDaycare50 = ServiceNeedOption(
@@ -370,7 +388,8 @@ val snPreparatoryDaycare50 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snPreparatoryDaycarePartDay40to50 = ServiceNeedOption(
@@ -389,7 +408,8 @@ val snPreparatoryDaycarePartDay40to50 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snPreparatoryDaycarePartDay40 = ServiceNeedOption(
@@ -408,7 +428,8 @@ val snPreparatoryDaycarePartDay40 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val snDaycareFiveYearOldsFullDayPartWeek25 = ServiceNeedOption(
@@ -427,7 +448,8 @@ val snDaycareFiveYearOldsFullDayPartWeek25 = ServiceNeedOption(
     feeDescriptionFi = "",
     feeDescriptionSv = "",
     voucherValueDescriptionFi = "",
-    voucherValueDescriptionSv = ""
+    voucherValueDescriptionSv = "",
+    active = true
 )
 
 val serviceNeedTestFixtures = listOf(

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
@@ -83,6 +83,7 @@ data class ServiceNeedOption(
     val feeDescriptionSv: String,
     val voucherValueDescriptionFi: String,
     val voucherValueDescriptionSv: String,
+    val active: Boolean,
     val updated: HelsinkiDateTime = HelsinkiDateTime.now()
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
@@ -213,7 +213,7 @@ SELECT
     active,
     updated
 FROM service_need_option
-ORDER BY display_order
+ORDER BY part_week, daycare_hours_per_week, part_day, name_fi
         """.trimIndent()
     )
         .mapTo<ServiceNeedOption>()

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
@@ -210,6 +210,7 @@ SELECT
     fee_description_sv,
     voucher_value_description_fi,
     voucher_value_description_sv,
+    active,
     updated
 FROM service_need_option
 ORDER BY display_order
@@ -239,6 +240,7 @@ SELECT
     fee_description_sv,
     voucher_value_description_fi,
     voucher_value_description_sv,
+    active,
     updated
 FROM service_need_option
 WHERE id = :id

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -471,8 +471,8 @@ fun Database.Transaction.insertServiceNeedOption(option: ServiceNeedOption) {
     createUpdate(
         // language=sql
         """
-INSERT INTO service_need_option (id, name_fi, name_sv, name_en, valid_placement_type, default_option, fee_coefficient, voucher_value_coefficient, occupancy_coefficient, daycare_hours_per_week, part_day, part_week, fee_description_fi, fee_description_sv, voucher_value_description_fi, voucher_value_description_sv, updated)
-VALUES (:id, :nameFi, :nameSv, :nameEn, :validPlacementType, :defaultOption, :feeCoefficient, :voucherValueCoefficient, :occupancyCoefficient, :daycareHoursPerWeek, :partDay, :partWeek, :feeDescriptionFi, :feeDescriptionSv, :voucherValueDescriptionFi, :voucherValueDescriptionSv, :updated)
+INSERT INTO service_need_option (id, name_fi, name_sv, name_en, valid_placement_type, default_option, fee_coefficient, voucher_value_coefficient, occupancy_coefficient, daycare_hours_per_week, part_day, part_week, fee_description_fi, fee_description_sv, voucher_value_description_fi, voucher_value_description_sv, active, updated)
+VALUES (:id, :nameFi, :nameSv, :nameEn, :validPlacementType, :defaultOption, :feeCoefficient, :voucherValueCoefficient, :occupancyCoefficient, :daycareHoursPerWeek, :partDay, :partWeek, :feeDescriptionFi, :feeDescriptionSv, :voucherValueDescriptionFi, :voucherValueDescriptionSv, :active, :updated)
 """
     )
         .bindKotlin(option)

--- a/service/src/main/resources/db/migration/V191__service_need_option_active_flag.sql
+++ b/service/src/main/resources/db/migration/V191__service_need_option_active_flag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE service_need_option ADD COLUMN active boolean NOT NULL DEFAULT true;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -188,3 +188,4 @@ V187__income_statement_gross_income_estimate_update.sql
 V188__daily_service_time_weekend.sql
 V189__curriculum_tables.sql
 V190__drop_authors_and_discussion_content_columns.sql
+V191__service_need_option_active_flag.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
A simple way to hide some service need options from the UI when the options shouldn't be selectable anymore but they also can't be deleted completely.

