### PR TITLE
Adds e2e test of moving a vasu doc to the reviewed state

### DIFF
--- a/frontend/src/e2e-playwright/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-playwright/pages/employee/vasu/vasu.ts
@@ -139,9 +139,38 @@ export class VasuPage extends VasuPageCommon {
   readonly finalizeButton = this.page.find(
     '[data-qa="transition-button-MOVED_TO_READY"]'
   )
+  readonly markReviewedButton = this.page.find(
+    '[data-qa="transition-button-MOVED_TO_REVIEWED"]'
+  )
   readonly modalOkButton = this.page.find('[data-qa="modal-okBtn"]')
+  readonly #vasuEventListLabels = this.page.findAll(
+    '[data-qa="vasu-event-list"] label'
+  )
+  readonly #vasuEventListValues = this.page.findAll(
+    '[data-qa="vasu-event-list"] span'
+  )
+  readonly #vasuEventListDocState = this.page.find(
+    '[data-qa="vasu-event-list"] [data-qa="vasu-state-chip"]'
+  )
 
-  get publishedDate(): Promise<string> {
-    return this.page.find('[data-qa="vasu-published-date"] span').innerText
-  }
+  documentState = () => this.#vasuEventListDocState.innerText
+
+  // The (first) label for the state chip has no corresponding span, so the index is off by one.
+  #valueForLabel = (label: string): Promise<string> =>
+    this.#vasuEventListLabels
+      .allInnerTexts()
+      .then((labels) =>
+        labels.reduce(
+          async (acc, l, ix) =>
+            l === label
+              ? await this.#vasuEventListValues.nth(ix - 1).innerText
+              : acc,
+          Promise.resolve('')
+        )
+      )
+
+  publishedToGuardiansDate = () =>
+    this.#valueForLabel('Viimeksi julkaistu huoltajalle')
+  publishedDate = () => this.#valueForLabel('Julkaistu Laadittu-tilaan')
+  reviewedDate = () => this.#valueForLabel('Julkaistu Arvioitu-tilaan')
 }

--- a/frontend/src/e2e-playwright/specs/5_employee/vasu.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/vasu.spec.ts
@@ -360,12 +360,40 @@ describe('Vasu document page', () => {
 
     test('Finalize a document', async () => {
       let vasuPage = await openDocument()
-      await waitUntilEqual(() => vasuPage.publishedDate, 'Ei merkintää')
+      await waitUntilEqual(
+        () => vasuPage.publishedToGuardiansDate(),
+        'Ei merkintää'
+      )
 
       await finalizeDocument()
       vasuPage = await openDocument()
+
+      await waitUntilEqual(() => vasuPage.documentState(), 'Laadittu')
       await waitUntilEqual(
-        () => vasuPage.publishedDate,
+        () => vasuPage.publishedDate(),
+        LocalDate.today().format()
+      )
+    })
+
+    const markDocumentReviewed = async () => {
+      const vasuPage = await openDocument()
+      await vasuPage.markReviewedButton.click()
+      await vasuPage.modalOkButton.click()
+      await vasuPage.modalOkButton.click()
+    }
+
+    test('Publish a document as reviewed', async () => {
+      let vasuPage = await openDocument()
+
+      await finalizeDocument()
+      await markDocumentReviewed()
+
+      vasuPage = await openDocument()
+      await vasuPage.assertDocumentVisible()
+
+      await waitUntilEqual(() => vasuPage.documentState(), 'Arvioitu')
+      await waitUntilEqual(
+        () => vasuPage.reviewedDate(),
         LocalDate.today().format()
       )
     })

--- a/frontend/src/employee-frontend/components/common/VasuStateChip.tsx
+++ b/frontend/src/employee-frontend/components/common/VasuStateChip.tsx
@@ -22,5 +22,9 @@ interface StateChipProps {
 }
 
 export function VasuStateChip({ labels, state }: StateChipProps) {
-  return <StaticChip color={vasuStateChip[state]}>{labels[state]}</StaticChip>
+  return (
+    <StaticChip color={vasuStateChip[state]} data-qa="vasu-state-chip">
+      {labels[state]}
+    </StaticChip>
+  )
 }

--- a/frontend/src/employee-frontend/components/vasu/sections/VasuEvents.tsx
+++ b/frontend/src/employee-frontend/components/vasu/sections/VasuEvents.tsx
@@ -29,26 +29,18 @@ const ChipContainer = styled.div`
   display: inline-flex;
 `
 
-function EventRow({
-  label,
-  date,
-  'data-qa': dataQa
-}: {
-  label: string
-  date: LocalDate | null
-  'data-qa'?: string
-}) {
+function EventRow({ label, date }: { label: string; date: LocalDate | null }) {
   const { i18n } = useTranslation()
 
   return (
-    <div data-qa={dataQa}>
+    <>
       <Label>{label}</Label>
       {date ? (
         <span>{date.format()}</span>
       ) : (
         <Dimmed>{i18n.vasu.noRecord}</Dimmed>
       )}
-    </div>
+    </>
   )
 }
 
@@ -83,7 +75,7 @@ export function VasuEvents({
   )
 
   return (
-    <Container opaque>
+    <Container opaque data-qa="vasu-event-list">
       <H2>{i18n.vasu.events[type]}</H2>
       <ListGrid labelWidth={labelWidth}>
         <Label>{i18n.vasu.state}</Label>
@@ -93,14 +85,12 @@ export function VasuEvents({
         <EventRow
           label={i18n.vasu.lastModified}
           date={LocalDate.fromSystemTzDate(modifiedAt)}
-          data-qa="vasu-modified-date"
         />
         <EventRow
           label={i18n.vasu.lastPublished}
           date={
             lastPublished ? LocalDate.fromSystemTzDate(lastPublished) : null
           }
-          data-qa="vasu-published-date"
         />
         {trackedDates.map(([label, date]) => (
           <EventRow key={label} label={label} date={date} />


### PR DESCRIPTION
Adds test for marking a vasu doc as reviewed and also refactors earlier test and `data-qa` attributes to preserve original
styling in the vasu document events list.
