### PR TITLE
EVAKA-3458 use more age symbols

### DIFF
--- a/frontend/src/employee-frontend/components/absences/AbsenceTable.tsx
+++ b/frontend/src/employee-frontend/components/absences/AbsenceTable.tsx
@@ -13,6 +13,8 @@ import StaffAttendance from './StaffAttendance'
 import { Translations, useTranslation } from '../../state/i18n'
 import Tooltip from '../../components/common/Tooltip'
 import { UUID } from 'lib-common/types'
+import AgeIndicatorIcon from '../common/AgeIndicatorIcon'
+import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 
 interface AbsenceRowProps {
   child: Child
@@ -53,21 +55,23 @@ const AbsenceTableRow = React.memo(function AbsenceTableRow({
   return (
     <tr>
       <td className={'absence-child-name hover-highlight'}>
-        <Tooltip
-          tooltipId={`tooltip_absence-child-name-${child.id}`}
-          tooltipText={`${child.lastName}, ${child.firstName}`}
-          place={'top'}
-          delayShow={750}
-        >
-          <Link
-            to={`/child-information/${child.id}`}
-            className={'absence-child-link'}
+        <FixedSpaceRow spacing="xs">
+          <AgeIndicatorIcon dateOfBirth={child.dob} />
+          <Tooltip
+            tooltipId={`tooltip_absence-child-name-${child.id}`}
+            tooltipText={`${child.lastName}, ${child.firstName}`}
+            place={'top'}
+            delayShow={750}
           >
-            {shortChildName(child.firstName, child.lastName, i18n)}
-          </Link>
-        </Tooltip>
+            <Link
+              to={`/child-information/${child.id}`}
+              className={'absence-child-link'}
+            >
+              {shortChildName(child.firstName, child.lastName, i18n)}
+            </Link>
+          </Tooltip>
+        </FixedSpaceRow>
       </td>
-      <td className={'hover-highlight'}>{child.dob.format()}</td>
       {dateCols.map((date) => {
         return operationDays.some((operationDay) =>
           operationDay.isEqual(date)
@@ -120,7 +124,6 @@ const AbsenceTableHead = React.memo(function AbsenceTableHead({
     <thead>
       <tr>
         <th>{i18n.absences.table.nameCol}</th>
-        <th>{i18n.absences.table.dobCol}</th>
         {dateCols.map((item) =>
           operationDays.some((operationDay) => operationDay.isEqual(item)) ? (
             <th

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -48,7 +48,7 @@ import PlacementCircle from 'lib-components/atoms/PlacementCircle'
 import { UserContext } from '../../state/user'
 import { hasRole, RequireRole } from '../../utils/roles'
 import { isPartDayPlacement } from '../../utils/placements'
-import AgeIndicatorIcon from '../common/AgeIndicatorIcon'
+import { AgeIndicatorIconWithTooltip } from '../common/AgeIndicatorIcon'
 import { ApplicationSummary } from 'lib-common/generated/api-types/application'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import { UUID } from 'lib-common/types'
@@ -206,23 +206,11 @@ const ApplicationsList = React.memo(function Applications({
       application.dateOfBirth &&
       startDateOrDueDate && (
         <FixedSpaceRow spacing="xs">
-          <Tooltip
-            tooltip={
-              <span>
-                {startDateOrDueDate.differenceInYears(application.dateOfBirth) <
-                3
-                  ? i18n.applications.list.lessthan3
-                  : i18n.applications.list.morethan3}
-              </span>
+          <AgeIndicatorIconWithTooltip
+            isUnder3={
+              startDateOrDueDate.differenceInYears(application.dateOfBirth) < 3
             }
-          >
-            <AgeIndicatorIcon
-              isUnder3={
-                startDateOrDueDate.differenceInYears(application.dateOfBirth) <
-                3
-              }
-            />
-          </Tooltip>
+          />
           <span>
             {application.socialSecurityNumber ||
               formatDate(application.dateOfBirth.toSystemTzDate())}

--- a/frontend/src/employee-frontend/components/common/AgeIndicatorIcon.tsx
+++ b/frontend/src/employee-frontend/components/common/AgeIndicatorIcon.tsx
@@ -7,10 +7,14 @@ import { fasArrowDown, fasArrowUp } from 'lib-icons'
 import LocalDate from 'lib-common/local-date'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import colors from 'lib-customizations/common'
+import Tooltip from 'lib-components/atoms/Tooltip'
+import { useTranslation } from '../../state/i18n'
 
 type Props = { isUnder3: boolean } | { dateOfBirth: LocalDate }
 
-export default React.memo(function AgeIndicatorIcon(props: Props) {
+export const AgeIndicatorIcon = React.memo(function AgeIndicatorIcon(
+  props: Props
+) {
   const under3 =
     'isUnder3' in props
       ? props.isUnder3
@@ -24,3 +28,30 @@ export default React.memo(function AgeIndicatorIcon(props: Props) {
     />
   )
 })
+
+export default AgeIndicatorIcon
+
+export const AgeIndicatorIconWithTooltip = React.memo(
+  function AgeIndicatorIconTooltip(props: Props) {
+    const { i18n } = useTranslation()
+
+    const under3 =
+      'isUnder3' in props
+        ? props.isUnder3
+        : LocalDate.today().differenceInYears(props.dateOfBirth) < 3
+
+    return (
+      <Tooltip
+        tooltip={
+          <span>
+            {under3
+              ? i18n.applications.list.lessthan3
+              : i18n.applications.list.morethan3}
+          </span>
+        }
+      >
+        <AgeIndicatorIcon isUnder3={under3} />
+      </Tooltip>
+    )
+  }
+)

--- a/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
@@ -55,12 +55,12 @@ function renderMissingGroupPlacementRow(
           {formatName(firstName, lastName, i18n, true)}
         </Link>
       </Td>
-      <Td data-qa="child-dob">
+      <Td>
         <FixedSpaceRow spacing="xs">
           <AgeIndicatorIconWithTooltip
             isUnder3={placementPeriod.start.differenceInYears(dateOfBirth) < 3}
           />
-          <span>{dateOfBirth.format()}</span>
+          <span data-qa="child-dob">{dateOfBirth.format()}</span>
         </FixedSpaceRow>
       </Td>
       <Td data-qa="placement-type">

--- a/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
@@ -25,6 +25,8 @@ import { UIContext } from '../../../state/ui'
 import { DaycareGroup } from '../../../types/unit'
 import { formatName } from '../../../utils'
 import { isPartDayPlacement } from '../../../utils/placements'
+import { AgeIndicatorIconWithTooltip } from '../../common/AgeIndicatorIcon'
+import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 
 function renderMissingGroupPlacementRow(
   missingPlacement: MissingGroupPlacement,
@@ -53,7 +55,14 @@ function renderMissingGroupPlacementRow(
           {formatName(firstName, lastName, i18n, true)}
         </Link>
       </Td>
-      <Td data-qa="child-dob">{dateOfBirth.format()}</Td>
+      <Td data-qa="child-dob">
+        <FixedSpaceRow spacing="xs">
+          <AgeIndicatorIconWithTooltip
+            isUnder3={placementPeriod.start.differenceInYears(dateOfBirth) < 3}
+          />
+          <span>{dateOfBirth.format()}</span>
+        </FixedSpaceRow>
+      </Td>
       <Td data-qa="placement-type">
         {placementType ? (
           careTypesFromPlacementType(placementType)

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
@@ -71,6 +71,7 @@ import { renderResult } from '../../../async-rendering'
 import { DataList } from '../../../common/DataList'
 import { StatusIconContainer } from '../../../common/StatusIconContainer'
 import NotesModal from '../notes/NotesModal'
+import { AgeIndicatorIconWithTooltip } from '../../../common/AgeIndicatorIcon'
 
 interface Props {
   unit: Unit
@@ -538,6 +539,17 @@ export default React.memo(function Group({
                             'DELETE'
                           ))
                     )
+
+                    const dateOfBirth =
+                      'type' in placement
+                        ? placement.child.dateOfBirth
+                        : placement.child.birthDate
+
+                    const placementStart =
+                      'type' in placement
+                        ? placement.startDate
+                        : placement.period.start
+
                     return (
                       <Tr
                         key={placement.id || ''}
@@ -556,9 +568,15 @@ export default React.memo(function Group({
                           </Link>
                         </Td>
                         <Td data-qa="child-dob">
-                          {'type' in placement
-                            ? placement.child.dateOfBirth.format()
-                            : placement.child.birthDate.format()}
+                          <FixedSpaceRow spacing="xs">
+                            <AgeIndicatorIconWithTooltip
+                              isUnder3={
+                                placementStart.differenceInYears(dateOfBirth) <
+                                3
+                              }
+                            />
+                            <span>{dateOfBirth.format()}</span>
+                          </FixedSpaceRow>
                         </Td>
                         <Td data-qa="placement-type">
                           {'type' in placement ? (

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
@@ -567,7 +567,7 @@ export default React.memo(function Group({
                             {formatPersonName(placement.child, i18n, true)}
                           </Link>
                         </Td>
-                        <Td data-qa="child-dob">
+                        <Td>
                           <FixedSpaceRow spacing="xs">
                             <AgeIndicatorIconWithTooltip
                               isUnder3={
@@ -575,7 +575,9 @@ export default React.memo(function Group({
                                 3
                               }
                             />
-                            <span>{dateOfBirth.format()}</span>
+                            <span data-qa="child-dob">
+                              {dateOfBirth.format()}
+                            </span>
                           </FixedSpaceRow>
                         </Td>
                         <Td data-qa="placement-type">

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
@@ -64,12 +64,12 @@ export default React.memo(function ReservationsTable({
             <Tr key={childName}>
               <NameTd>
                 <ChildName>
-                  <Link to={`/child-information/${childReservations.child.id}`}>
-                    {childName}
-                  </Link>
                   <AgeIndicatorIcon
                     dateOfBirth={childReservations.child.dateOfBirth}
                   />
+                  <Link to={`/child-information/${childReservations.child.id}`}>
+                    {childName}
+                  </Link>
                 </ChildName>
               </NameTd>
               {operationalDays.map((day) => (
@@ -120,7 +120,7 @@ const ChildName = styled.div`
   align-items: center;
 
   a {
-    margin-right: ${defaultMargins.xs};
+    margin-left: ${defaultMargins.xs};
   }
 `
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add age symbols here and there.
<img width="587" alt="Screenshot 2021-12-27 at 16 37 52" src="https://user-images.githubusercontent.com/3275771/147482564-342f8a8b-94a6-4cf3-9e00-cb05726cd6ee.png">

<img width="355" alt="Screenshot 2021-12-27 at 16 38 19" src="https://user-images.githubusercontent.com/3275771/147482557-d91c3633-a6b9-44dd-a635-a30fe6b3956b.png">
<img width="433" alt="Screenshot 2021-12-27 at 16 38 08" src="https://user-images.githubusercontent.com/3275771/147482561-66976d13-6ae2-4a9d-a48f-df9996d90ec3.png">
<img width="591" alt="Screenshot 2021-12-27 at 16 38 00" src="https://user-images.githubusercontent.com/3275771/147482562-4302c693-f1f2-4669-9d90-d4249ca21422.png">

