### PR TITLE
EVAKA-FIX: mobile message editor handles blocked guardians

### DIFF
--- a/frontend/src/e2e-playwright/pages/mobile/message-editor.ts
+++ b/frontend/src/e2e-playwright/pages/mobile/message-editor.ts
@@ -11,6 +11,7 @@ export default class MobileMessageEditorPage {
   #inputTitle = new TextInput(this.page.find('[data-qa="input-title"]'))
   #inputContent = new TextInput(this.page.find('[data-qa="input-content"]'))
   #sendMessageButton = this.page.find('[data-qa="send-message-btn"]')
+  noReceiversInfo = this.page.find('[data-qa="info-no-receivers"]')
 
   async getEditorState() {
     return this.page

--- a/frontend/src/e2e-playwright/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/messages.spec.ts
@@ -38,9 +38,10 @@ import MobileMessageEditorPage from '../../pages/mobile/message-editor'
 import MobileMessagesPage from '../../pages/mobile/messages'
 import ThreadViewPage from '../../pages/mobile/thread-view'
 import { waitUntilEqual } from '../../utils'
-import { enduserLogin } from '../../utils/user'
+import { employeeLogin, enduserLogin } from '../../utils/user'
 import MobileNav from '../../pages/mobile/mobile-nav'
 import UnreadMobileMessagesPage from '../../pages/mobile/unread-message-counts'
+import ChildInformationPage from '../../pages/employee/child-information-page'
 
 let page: Page
 let fixtures: AreaAndPersonFixtures
@@ -337,6 +338,25 @@ describe('Child message thread', () => {
   test('Staff without group access sees info that no accounts were found', async () => {
     await staff2LoginsToMessagesPage()
     await messagesPage.noAccountInfo.waitUntilVisible()
+  })
+
+  test('Employee sees info while trying to send message to child whose guardians are blocked', async () => {
+    // Add child's guardians to block list
+    const adminPage = await Page.open()
+    await employeeLogin(adminPage, 'ADMIN')
+    await adminPage.goto(`${config.employeeUrl}/child-information/${child.id}`)
+    const childInformationPage = new ChildInformationPage(adminPage)
+    await childInformationPage.addParentToBlockList(
+      fixtures.enduserGuardianFixture.id
+    )
+    await childInformationPage.addParentToBlockList(
+      fixtures.enduserChildJariOtherGuardianFixture.id
+    )
+
+    await listPage.selectChild(child.id)
+    await childPage.openMessageEditor()
+    await pinLoginPage.login(employeeName, pin)
+    await messageEditorPage.noReceiversInfo.waitUntilVisible()
   })
 })
 

--- a/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
@@ -290,6 +290,7 @@ export const fi = {
   messages: {
     title: 'Saapuneet viestit',
     inputPlaceholder: 'Kirjoita...',
+    newMessage: 'Uusi viesti',
     messageEditor: {
       newMessage: (unitName: string) => `Uusi viesti (${unitName})`,
       to: {
@@ -316,7 +317,8 @@ export const fi = {
     pinLockInfo:
       'Lukeaksesi viestit sinun tulee avata lukitus PIN-koodilla. Voit lukea vain oman ryhmäsi viestit.',
     noAccountAccess:
-      'Viestejä ei voi näyttää, koska sinua ei ole luvitettu ryhmään. Pyydä lupa esimieheltäsi.'
+      'Viestejä ei voi näyttää, koska sinua ei ole luvitettu ryhmään. Pyydä lupa esimieheltäsi.',
+    noReceivers: 'Vastaanottajalle ei voi lähettää viestiä'
   },
   mobile: {
     landerText1:


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Instead of plain white page, tell user that message can't be sent. 