### PR TITLE
EVAKA-4301 show child group info in mobile

### DIFF
--- a/frontend/src/e2e-playwright/pages/mobile/list-page.ts
+++ b/frontend/src/e2e-playwright/pages/mobile/list-page.ts
@@ -12,6 +12,11 @@ export default class MobileListPage {
     `[data-qa="unread-messages-indicator"]`
   )
 
+  async readChildGroupName(childId: UUID) {
+    const elem = this.page.find(`[data-qa="child-group-name-${childId}"]`)
+    return elem.innerText
+  }
+
   async selectChild(childId: UUID) {
     const elem = this.page.find(`[data-qa="child-${childId}"]`)
     return elem.click()

--- a/frontend/src/e2e-playwright/specs/6_mobile/child-attendances.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/child-attendances.spec.ts
@@ -242,4 +242,23 @@ describe('Child mobile attendance list', () => {
       total: 3
     })
   })
+
+  test('Group name is visible only when all-group selected', async () => {
+    const childId = enduserChildFixtureKaarina.id
+    await createPlacements(childId)
+    await createPlacements(enduserChildFixturePorriHatterRestricted.id)
+    await createPlacements(enduserChildFixtureJari.id, group2.id)
+
+    const mobileSignupUrl = await pairMobileDevice(fixtures.daycareFixture.id)
+    await page.goto(mobileSignupUrl)
+
+    await listPage.selectGroup('all')
+    await waitUntilEqual(
+      () => listPage.readChildGroupName(childId),
+      daycareGroupFixture.name.toUpperCase()
+    )
+
+    await listPage.selectGroup(daycareGroupFixture.id)
+    await waitUntilEqual(() => listPage.readChildGroupName(childId), '')
+  })
 })

--- a/frontend/src/employee-mobile-frontend/components/attendances/ChildListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/ChildListItem.tsx
@@ -145,7 +145,9 @@ export default React.memo(function ChildListItem({
             <Bold data-qa="child-name">
               {child.firstName} {child.lastName}
             </Bold>
-            <GroupName>{maybeGroupName}</GroupName>
+            <GroupName data-qa={`child-group-name-${child.id}`}>
+              {maybeGroupName}
+            </GroupName>
           </NameRow>
           <DetailsRow>
             <div>

--- a/frontend/src/employee-mobile-frontend/components/attendances/ChildListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/ChildListItem.tsx
@@ -76,6 +76,19 @@ const FixedSpaceRowWithLeftMargin = styled(FixedSpaceRow)`
   margin-left: ${defaultMargins.m};
 `
 
+const NameRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`
+
+const GroupName = styled.div`
+  color: ${colors.greyscale.dark};
+  font-size: 0.875em;
+  white-space: nowrap;
+  text-align: right;
+`
+
 interface ChildListItemProps {
   child: Child
   onClick?: () => void
@@ -111,6 +124,8 @@ export default React.memo(function ChildListItem({
     ? groupName
     : childReservationInfo(i18n, child)
 
+  const maybeGroupName = type && groupId === 'all' ? groupName : undefined
+
   return (
     <ChildBox data-qa={`child-${child.id}`}>
       <AttendanceLinkBox to={childAttendanceUrl}>
@@ -126,9 +141,12 @@ export default React.memo(function ChildListItem({
           )}
         </IconBox>
         <ChildBoxInfo onClick={onClick}>
-          <Bold data-qa="child-name">
-            {child.firstName} {child.lastName}
-          </Bold>
+          <NameRow>
+            <Bold data-qa="child-name">
+              {child.firstName} {child.lastName}
+            </Bold>
+            <GroupName>{maybeGroupName}</GroupName>
+          </NameRow>
           <DetailsRow>
             <div>
               {infoText}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Show group name when listing all children.
<img width="377" alt="Screenshot 2021-12-29 at 12 56 49" src="https://user-images.githubusercontent.com/3275771/147656134-85e41161-1fe2-498e-84be-7aa6f5c8a7ae.png">
