### PR TITLE
Refactor user creation in E2E tests

### DIFF
--- a/frontend/src/e2e-playwright/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-playwright/pages/employee/applications/application-read-view.ts
@@ -97,6 +97,7 @@ export default class ApplicationReadView {
 
     const submit = decision.find('[data-qa="decision-send-answer-button"]')
     await submit.click()
+    await submit.waitUntilHidden()
   }
 
   async assertApplicationStatus(text: string) {

--- a/frontend/src/e2e-playwright/specs/4_finance/fee-decisions.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/fee-decisions.spec.ts
@@ -38,16 +38,10 @@ beforeEach(async () => {
   await initializeAreaAndPersonData()
   const careArea = await Fixture.careArea().with(careArea2Fixture).save()
   await Fixture.daycare().with(daycare2Fixture).careArea(careArea).save()
-  page = await Page.open({ acceptDownloads: true })
+  const financeAdmin = await Fixture.employeeFinanceAdmin().save()
 
-  await Fixture.employee()
-    .with({
-      id: config.financeAdminAad,
-      externalId: `espoo-ad:${config.financeAdminAad}`,
-      roles: ['FINANCE_ADMIN']
-    })
-    .save()
-  await employeeLogin(page, 'FINANCE_ADMIN')
+  page = await Page.open({ acceptDownloads: true })
+  await employeeLogin(page, financeAdmin.data)
   await page.goto(config.employeeUrl)
 })
 

--- a/frontend/src/e2e-playwright/specs/4_finance/finance-basics.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/finance-basics.spec.ts
@@ -19,16 +19,10 @@ let nav: EmployeeNav
 
 beforeEach(async () => {
   await resetDatabase()
-  await Fixture.employee()
-    .with({
-      id: config.financeAdminAad,
-      externalId: `espoo-ad:${config.financeAdminAad}`,
-      roles: ['FINANCE_ADMIN']
-    })
-    .save()
+  const financeAdmin = await Fixture.employeeFinanceAdmin().save()
 
   page = await Page.open({ acceptDownloads: true })
-  await employeeLogin(page, 'FINANCE_ADMIN')
+  await employeeLogin(page, financeAdmin.data)
   await page.goto(config.employeeUrl)
 
   financeBasicsPage = new FinanceBasicsPage(page)

--- a/frontend/src/e2e-playwright/specs/4_finance/head-of-family-fee-decisions.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/head-of-family-fee-decisions.spec.ts
@@ -28,17 +28,10 @@ let guardianPage: GuardianInformationPage
 beforeEach(async () => {
   await resetDatabase()
   await initializeAreaAndPersonData()
+  const financeAdmin = await Fixture.employeeFinanceAdmin().save()
 
   page = await Page.open({ acceptDownloads: true })
-
-  await Fixture.employee()
-    .with({
-      id: config.financeAdminAad,
-      externalId: `espoo-ad:${config.financeAdminAad}`,
-      roles: ['FINANCE_ADMIN']
-    })
-    .save()
-  await employeeLogin(page, 'FINANCE_ADMIN')
+  await employeeLogin(page, financeAdmin.data)
 
   await page.goto(config.employeeUrl)
   guardianPage = new GuardianInformationPage(page)

--- a/frontend/src/e2e-playwright/specs/4_finance/income-staments.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/income-staments.spec.ts
@@ -47,14 +47,8 @@ beforeEach(async () => {
     }
   ])
 
-  await Fixture.employee()
-    .with({
-      id: config.financeAdminAad,
-      externalId: `espoo-ad:${config.financeAdminAad}`,
-      roles: ['FINANCE_ADMIN']
-    })
-    .save()
-  await employeeLogin(page, 'FINANCE_ADMIN')
+  const financeAdmin = await Fixture.employeeFinanceAdmin().save()
+  await employeeLogin(page, financeAdmin.data)
 
   await page.goto(config.employeeUrl)
   nav = new EmployeeNav(page)

--- a/frontend/src/e2e-playwright/specs/4_finance/invoices.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/invoices.spec.ts
@@ -78,14 +78,8 @@ beforeEach(async () => {
 
   page = await Page.open({ acceptDownloads: true })
 
-  await Fixture.employee()
-    .with({
-      id: config.financeAdminAad,
-      externalId: `espoo-ad:${config.financeAdminAad}`,
-      roles: ['FINANCE_ADMIN']
-    })
-    .save()
-  await employeeLogin(page, 'FINANCE_ADMIN')
+  const financeAdmin = await Fixture.employeeFinanceAdmin().save()
+  await employeeLogin(page, financeAdmin.data)
 
   await page.goto(config.employeeUrl)
   const nav = new EmployeeNav(page)

--- a/frontend/src/e2e-playwright/specs/4_finance/value-decisions.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/value-decisions.spec.ts
@@ -47,14 +47,8 @@ beforeEach(async () => {
 
   page = await Page.open({ acceptDownloads: true })
 
-  await Fixture.employee()
-    .with({
-      id: config.financeAdminAad,
-      externalId: `espoo-ad:${config.financeAdminAad}`,
-      roles: ['FINANCE_ADMIN']
-    })
-    .save()
-  await employeeLogin(page, 'FINANCE_ADMIN')
+  const financeAdmin = await Fixture.employeeFinanceAdmin().save()
+  await employeeLogin(page, financeAdmin.data)
   await page.goto(config.employeeUrl)
 })
 

--- a/frontend/src/e2e-playwright/specs/4_finance/voucher-reports.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/voucher-reports.spec.ts
@@ -51,9 +51,10 @@ beforeEach(async () => {
       '2020-12-31'
     )
   ])
+  const admin = await Fixture.employeeAdmin().save()
 
   page = await Page.open({ acceptDownloads: true })
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin.data)
   await page.goto(config.employeeUrl)
   await new EmployeeNav(page).openTab('reports')
 

--- a/frontend/src/e2e-playwright/specs/5_employee/absence.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/absence.spec.ts
@@ -10,10 +10,9 @@ import {
 } from 'e2e-test-common/dev-api/fixtures'
 import { UnitPage } from '../../pages/employee/units/unit'
 import { DaycarePlacement } from 'e2e-test-common/dev-api/types'
-import config from 'e2e-test-common/config'
 import {
-  initializeAreaAndPersonData,
-  AreaAndPersonFixtures
+  AreaAndPersonFixtures,
+  initializeAreaAndPersonData
 } from 'e2e-test-common/dev-api/data-init'
 import {
   insertDaycareGroupFixtures,
@@ -35,16 +34,6 @@ beforeEach(async () => {
   fixtures = await initializeAreaAndPersonData()
   await insertDefaultServiceNeedOptions()
   await insertDaycareGroupFixtures([daycareGroupFixture])
-  await Fixture.employee()
-    .with({
-      id: config.unitSupervisorAad,
-      externalId: `espoo-ad:${config.unitSupervisorAad}`,
-      firstName: 'Essi',
-      lastName: 'Esimies',
-      roles: []
-    })
-    .withDaycareAcl(fixtures.daycareFixture.id, 'UNIT_SUPERVISOR')
-    .save()
 
   daycarePlacementFixture = createDaycarePlacementFixture(
     uuidv4(),
@@ -52,9 +41,12 @@ beforeEach(async () => {
     fixtures.daycareFixture.id
   )
   await insertDaycarePlacementFixtures([daycarePlacementFixture])
+  const unitSupervisor = await Fixture.employeeUnitSupervisor(
+    fixtures.daycareFixture.id
+  ).save()
 
   page = await Page.open()
-  await employeeLogin(page, 'UNIT_SUPERVISOR')
+  await employeeLogin(page, unitSupervisor.data)
   unitPage = new UnitPage(page)
 })
 

--- a/frontend/src/e2e-playwright/specs/5_employee/application-attachments.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/application-attachments.spec.ts
@@ -30,18 +30,12 @@ beforeEach(async () => {
     fixtures.enduserGuardianFixture
   )
   await insertApplications([fixture])
-  await Fixture.employee()
-    .with({
-      id: config.serviceWorkerAad,
-      externalId: `espoo-ad:${config.serviceWorkerAad}`,
-      roles: ['SERVICE_WORKER']
-    })
-    .save()
+  const serviceWorker = await Fixture.employeeServiceWorker().save()
 
   page = await Page.open()
   applicationsPage = new ApplicationsPage(page)
 
-  await employeeLogin(page, 'SERVICE_WORKER')
+  await employeeLogin(page, serviceWorker.data)
   await page.goto(config.employeeUrl)
   await new EmployeeNav(page).applicationsTab.click()
 })

--- a/frontend/src/e2e-playwright/specs/5_employee/application-search.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/application-search.spec.ts
@@ -17,17 +17,20 @@ import ApplicationListView from '../../pages/employee/applications/application-l
 import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
 import config from 'e2e-test-common/config'
+import { EmployeeDetail } from '../../../e2e-test-common/dev-api/types'
 
 let fixtures: AreaAndPersonFixtures
+let admin: EmployeeDetail
 
 beforeEach(async () => {
   await resetDatabase()
   fixtures = await initializeAreaAndPersonData()
+  admin = (await Fixture.employeeAdmin().save()).data
 })
 
 async function openPage() {
   const page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin)
   await page.goto(config.adminUrl)
   return new ApplicationListView(page)
 }

--- a/frontend/src/e2e-playwright/specs/5_employee/applications.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/applications.spec.ts
@@ -24,18 +24,12 @@ beforeEach(async () => {
   await resetDatabase()
   familyWithDeadGuardian = (await initializeAreaAndPersonData())
     .familyWithDeadGuardian
-  await Fixture.employee()
-    .with({
-      id: config.serviceWorkerAad,
-      externalId: `espoo-ad:${config.serviceWorkerAad}`,
-      roles: ['SERVICE_WORKER']
-    })
-    .save()
+  const serviceWorker = await Fixture.employeeServiceWorker().save()
 
   page = await Page.open()
   applicationsPage = new ApplicationsPage(page)
 
-  await employeeLogin(page, 'SERVICE_WORKER')
+  await employeeLogin(page, serviceWorker.data)
   await page.goto(config.employeeUrl)
   await new EmployeeNav(page).applicationsTab.click()
 })

--- a/frontend/src/e2e-playwright/specs/5_employee/child-information.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/child-information.spec.ts
@@ -43,6 +43,7 @@ beforeEach(async () => {
 
   fixtures = await initializeAreaAndPersonData()
   await insertDaycareGroupFixtures([daycareGroupFixture])
+  const admin = await Fixture.employeeAdmin().save()
 
   const unitId = fixtures.daycareFixture.id
   childId = fixtures.familyWithTwoGuardians.children[0].id
@@ -54,7 +55,7 @@ beforeEach(async () => {
     .save()
 
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin.data)
   await page.goto(config.employeeUrl + '/child-information/' + childId)
   childInformationPage = new ChildInformationPage(page)
   await childInformationPage.waitUntilLoaded()
@@ -65,6 +66,7 @@ describe('Child Information - edit child information', () => {
     await page.goto(
       config.employeeUrl + '/child-information/' + enduserNonSsnChildFixture.id
     )
+    await childInformationPage.waitUntilLoaded()
     await childInformationPage.clickEdit()
     await childInformationPage.assertOphPersonOid('')
     await childInformationPage.setOphPersonOid('1.2.3')

--- a/frontend/src/e2e-playwright/specs/5_employee/create-person.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/create-person.spec.ts
@@ -8,15 +8,17 @@ import { employeeLogin } from 'e2e-playwright/utils/user'
 import PersonSearchPage from 'e2e-playwright/pages/employee/person-search'
 import LocalDate from 'lib-common/local-date'
 import { Page } from '../../utils/page'
+import { Fixture } from '../../../e2e-test-common/dev-api/fixtures'
 
 let page: Page
 let personSearchPage: PersonSearchPage
 
 beforeEach(async () => {
   await resetDatabase()
+  const admin = await Fixture.employeeAdmin().save()
 
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin.data)
   await page.goto(`${config.employeeUrl}/search`)
   personSearchPage = new PersonSearchPage(page)
 })

--- a/frontend/src/e2e-playwright/specs/5_employee/disable-ssn-adding.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/disable-ssn-adding.spec.ts
@@ -18,21 +18,16 @@ let serviceWorkerPersonSearchPage: PersonSearchPage
 beforeEach(async () => {
   await resetDatabase()
 
-  await Fixture.employee()
-    .with({
-      id: config.serviceWorkerAad,
-      externalId: `espoo-ad:${config.serviceWorkerAad}`,
-      roles: ['SERVICE_WORKER']
-    })
-    .save()
+  const admin = await Fixture.employeeAdmin().save()
+  const serviceWorker = await Fixture.employeeServiceWorker().save()
 
   adminPage = await Page.open()
-  await employeeLogin(adminPage, 'ADMIN')
+  await employeeLogin(adminPage, admin.data)
   await adminPage.goto(`${config.employeeUrl}/search`)
   adminPersonSearchPage = new PersonSearchPage(adminPage)
 
   serviceWorkerPage = await Page.open()
-  await employeeLogin(serviceWorkerPage, 'SERVICE_WORKER')
+  await employeeLogin(serviceWorkerPage, serviceWorker.data)
   await serviceWorkerPage.goto(`${config.employeeUrl}/search`)
   serviceWorkerPersonSearchPage = new PersonSearchPage(serviceWorkerPage)
 })

--- a/frontend/src/e2e-playwright/specs/5_employee/employee-dailynote.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/employee-dailynote.spec.ts
@@ -30,6 +30,7 @@ let unitPage: UnitPage
 beforeEach(async () => {
   await resetDatabase()
   fixtures = await initializeAreaAndPersonData()
+  const admin = await Fixture.employeeAdmin().save()
 
   await insertDefaultServiceNeedOptions()
 
@@ -60,7 +61,7 @@ beforeEach(async () => {
     .save()
 
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin.data)
 
   unitPage = new UnitPage(page)
 })

--- a/frontend/src/e2e-playwright/specs/5_employee/employee-pin.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/employee-pin.spec.ts
@@ -10,16 +10,19 @@ import { EmployeePinPage } from '../../pages/employee/employee-pin'
 import { Fixture } from '../../../e2e-test-common/dev-api/fixtures'
 import { employeeLogin } from 'e2e-playwright/utils/user'
 import { Page } from '../../utils/page'
+import { EmployeeDetail } from '../../../e2e-test-common/dev-api/types'
 
+let admin: EmployeeDetail
 let page: Page
 let nav: EmployeeNav
 let pinPage: EmployeePinPage
 
 beforeEach(async () => {
   await resetDatabase()
+  admin = (await Fixture.employeeAdmin().save()).data
 
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin)
   await page.goto(config.employeeUrl)
   nav = new EmployeeNav(page)
   pinPage = new EmployeePinPage(page)
@@ -45,7 +48,7 @@ describe('Employees PIN', () => {
     await Fixture.employeePin()
       .with({
         userId: undefined,
-        employeeExternalId: config.adminExternalId,
+        employeeExternalId: admin.externalId,
         pin: '2580',
         locked: true
       })

--- a/frontend/src/e2e-playwright/specs/5_employee/employee-reads-application.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/employee-reads-application.spec.ts
@@ -6,7 +6,7 @@ import {
   AreaAndPersonFixtures,
   initializeAreaAndPersonData
 } from 'e2e-test-common/dev-api/data-init'
-import { applicationFixture } from 'e2e-test-common/dev-api/fixtures'
+import { applicationFixture, Fixture } from 'e2e-test-common/dev-api/fixtures'
 import { insertApplications, resetDatabase } from 'e2e-test-common/dev-api'
 import ApplicationReadView from '../../pages/employee/applications/application-read-view'
 import { employeeLogin } from '../../utils/user'
@@ -19,9 +19,10 @@ let applicationReadView: ApplicationReadView
 beforeEach(async () => {
   await resetDatabase()
   fixtures = await initializeAreaAndPersonData()
+  const admin = await Fixture.employeeAdmin().save()
 
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin.data)
 
   applicationReadView = new ApplicationReadView(page)
 })

--- a/frontend/src/e2e-playwright/specs/5_employee/employees.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/employees.spec.ts
@@ -17,17 +17,13 @@ let employeesPage: EmployeesPage
 
 beforeEach(async () => {
   await resetDatabase()
-
-  await Fixture.employee()
-    .with({
-      firstName: 'Teppo',
-      lastName: 'Testaaja',
-      roles: ['SERVICE_WORKER']
-    })
+  const admin = await Fixture.employeeAdmin().save()
+  await Fixture.employeeServiceWorker()
+    .with({ firstName: 'Teppo', lastName: 'Testaaja' })
     .save()
 
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin.data)
   await page.goto(config.employeeUrl)
   nav = new EmployeeNav(page)
   employeesPage = new EmployeesPage(page)

--- a/frontend/src/e2e-playwright/specs/5_employee/guardian-information-page.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/guardian-information-page.spec.ts
@@ -7,18 +7,16 @@ import {
   initializeAreaAndPersonData
 } from 'e2e-test-common/dev-api/data-init'
 import {
-  Fixture,
-  invoiceFixture,
-  uuidv4
-} from 'e2e-test-common/dev-api/fixtures'
-import {
   applicationFixture,
   createDaycarePlacementFixture,
   daycareFixture,
   daycareGroupFixture,
   decisionFixture,
+  enduserChildFixtureJari,
   enduserGuardianFixture,
-  enduserChildFixtureJari
+  Fixture,
+  invoiceFixture,
+  uuidv4
 } from 'e2e-test-common/dev-api/fixtures'
 import {
   insertApplications,
@@ -31,7 +29,6 @@ import {
 import GuardianInformationPage from '../../pages/employee/guardian-information'
 import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
-import config from '../../../e2e-test-common/config'
 
 let fixtures: AreaAndPersonFixtures
 let page: Page
@@ -41,15 +38,7 @@ beforeEach(async () => {
   fixtures = await initializeAreaAndPersonData()
   await insertDaycareGroupFixtures([daycareGroupFixture])
 
-  await Fixture.employee()
-    .with({
-      id: config.adminAad,
-      externalId: config.adminExternalId,
-      firstName: 'Seppo',
-      lastName: 'Sorsa',
-      roles: ['ADMIN']
-    })
-    .save()
+  const admin = await Fixture.employeeAdmin().save()
 
   const daycarePlacementFixture = createDaycarePlacementFixture(
     uuidv4(),
@@ -67,12 +56,12 @@ beforeEach(async () => {
   await insertDecisionFixtures([
     {
       ...decisionFixture(application.id, startDate, startDate),
-      employeeId: config.adminAad
+      employeeId: admin.data.id
     }
   ])
 
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin.data)
 })
 
 describe('Employee - Guardian Information', () => {

--- a/frontend/src/e2e-playwright/specs/5_employee/income.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/income.spec.ts
@@ -13,6 +13,7 @@ import FridgeHeadInformationPage, {
 } from '../../pages/employee/fridge-head-information-page'
 import ErrorModal from '../../pages/employee/error-modal'
 import { Page } from '../../utils/page'
+import { Fixture } from '../../../e2e-test-common/dev-api/fixtures'
 
 let page: Page
 let personId: UUID
@@ -24,8 +25,10 @@ beforeEach(async () => {
   const fixtures = await initializeAreaAndPersonData()
   personId = fixtures.enduserGuardianFixture.id
 
+  const financeAdmin = await Fixture.employeeFinanceAdmin().save()
+
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, financeAdmin.data)
   await page.goto(config.employeeUrl + '/profile/' + personId)
 
   const fridgeHeadInformationPage = new FridgeHeadInformationPage(page)

--- a/frontend/src/e2e-playwright/specs/5_employee/paper-application.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/paper-application.spec.ts
@@ -6,7 +6,7 @@ import {
   AreaAndPersonFixtures,
   initializeAreaAndPersonData
 } from 'e2e-test-common/dev-api/data-init'
-import { daycareGroupFixture } from 'e2e-test-common/dev-api/fixtures'
+import { daycareGroupFixture, Fixture } from 'e2e-test-common/dev-api/fixtures'
 import {
   insertDaycareGroupFixtures,
   resetDatabase
@@ -28,9 +28,10 @@ beforeEach(async () => {
   await resetDatabase()
   fixtures = await initializeAreaAndPersonData()
   await insertDaycareGroupFixtures([daycareGroupFixture])
+  const admin = await Fixture.employeeAdmin().save()
 
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin.data)
 
   childInformationPage = new ChildInformationPage(page)
   await childInformationPage.navigateToChild(

--- a/frontend/src/e2e-playwright/specs/5_employee/pedagogical-document.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/pedagogical-document.spec.ts
@@ -12,6 +12,7 @@ import { initializeAreaAndPersonData } from 'e2e-test-common/dev-api/data-init'
 import {
   createDaycarePlacementFixture,
   daycareGroupFixture,
+  Fixture,
   uuidv4
 } from 'e2e-test-common/dev-api/fixtures'
 import ChildInformationPage, {
@@ -49,8 +50,10 @@ beforeEach(async () => {
   )
   await insertDaycarePlacementFixtures([daycarePlacementFixture])
 
+  const admin = await Fixture.employeeAdmin().save()
+
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin.data)
   await page.goto(config.employeeUrl + '/child-information/' + childId)
   childInformationPage = new ChildInformationPage(page)
 })

--- a/frontend/src/e2e-playwright/specs/5_employee/service-need.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/service-need.spec.ts
@@ -44,8 +44,10 @@ beforeEach(async () => {
     .with({ validPlacementType: placement.data.type, active: false })
     .save()
 
+  const admin = await Fixture.employeeAdmin().save()
+
   page = await Page.open()
-  await employeeLogin(page, 'ADMIN')
+  await employeeLogin(page, admin.data)
 })
 
 const openCollapsible = async () => {

--- a/frontend/src/e2e-playwright/specs/5_employee/unit-editor.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/unit-editor.spec.ts
@@ -22,9 +22,10 @@ describe('Employee - unit details', () => {
     await resetDatabase()
     const fixtures = await initializeAreaAndPersonData()
     daycare1 = fixtures.daycareFixture
+    const admin = await Fixture.employeeAdmin().save()
 
     page = await Page.open()
-    await employeeLogin(page, 'ADMIN')
+    await employeeLogin(page, admin.data)
     await page.goto(config.employeeUrl)
     await new EmployeeNav(page).openTab('units')
     unitsPage = new UnitsPage(page)
@@ -82,15 +83,10 @@ describe('Employee - unit editor validations and warnings', () => {
     await resetDatabase()
 
     const fixtures = await initializeAreaAndPersonData()
-    await Fixture.employee()
-      .with({
-        externalId: `espoo-ad:${config.adminExternalId}`,
-        roles: []
-      })
-      .save()
+    const admin = await Fixture.employeeAdmin().save()
 
     page = await Page.open()
-    await employeeLogin(page, 'ADMIN')
+    await employeeLogin(page, admin.data)
     await page.goto(config.employeeUrl)
     nav = new EmployeeNav(page)
     await nav.openTab('units')

--- a/frontend/src/e2e-playwright/specs/5_employee/vasu.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/vasu.spec.ts
@@ -14,6 +14,7 @@ import { initializeAreaAndPersonData } from 'e2e-test-common/dev-api/data-init'
 import {
   createDaycarePlacementFixture,
   daycareGroupFixture,
+  Fixture,
   uuidv4
 } from 'e2e-test-common/dev-api/fixtures'
 import ChildInformationPage, {
@@ -25,14 +26,18 @@ import { VasuEditPage, VasuPage } from '../../pages/employee/vasu/vasu'
 import LocalDate from 'lib-common/local-date'
 import { Page } from '../../utils/page'
 import { waitUntilEqual } from '../../utils'
+import { EmployeeDetail } from '../../../e2e-test-common/dev-api/types'
 
 let page: Page
+let admin: EmployeeDetail
 let childInformationPage: ChildInformationPage
 let childId: UUID
 let templateId: UUID
 
 beforeAll(async () => {
   await resetDatabase()
+
+  admin = (await Fixture.employeeAdmin().save()).data
 
   const fixtures = await initializeAreaAndPersonData()
   await insertDaycareGroupFixtures([daycareGroupFixture])
@@ -54,7 +59,7 @@ describe('Child Information - Vasu documents section', () => {
   let section: VasuAndLeopsSection
   beforeEach(async () => {
     page = await Page.open()
-    await employeeLogin(page, 'ADMIN')
+    await employeeLogin(page, admin)
     await page.goto(`${config.employeeUrl}/child-information/${childId}`)
     childInformationPage = new ChildInformationPage(page)
     section = await childInformationPage.openCollapsible('vasuAndLeops')
@@ -93,7 +98,7 @@ describe('Vasu document page', () => {
 
   beforeEach(async () => {
     page = await Page.open()
-    await employeeLogin(page, 'ADMIN')
+    await employeeLogin(page, admin)
   })
 
   describe('Fill out document', () => {
@@ -332,7 +337,7 @@ describe('Vasu document page', () => {
     describe('With a finalized document', () => {
       beforeAll(async () => {
         page = await Page.open()
-        await employeeLogin(page, 'ADMIN')
+        await employeeLogin(page, admin)
         await finalizeDocument()
       })
 

--- a/frontend/src/e2e-playwright/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/messages.spec.ts
@@ -296,8 +296,9 @@ describe('Child message thread', () => {
 
   test('Employee sees info while trying to send message to child whose guardians are blocked', async () => {
     // Add child's guardians to block list
+    const admin = await Fixture.employeeAdmin().save()
     const adminPage = await Page.open()
-    await employeeLogin(adminPage, 'ADMIN')
+    await employeeLogin(adminPage, admin.data)
     await adminPage.goto(`${config.employeeUrl}/child-information/${child.id}`)
     const childInformationPage = new ChildInformationPage(adminPage)
     const blocklistSection = await childInformationPage.openCollapsible(

--- a/frontend/src/e2e-playwright/specs/6_mobile/pairing.spec.ts
+++ b/frontend/src/e2e-playwright/specs/6_mobile/pairing.spec.ts
@@ -4,11 +4,10 @@
 
 import config from 'e2e-test-common/config'
 import {
-  initializeAreaAndPersonData,
-  AreaAndPersonFixtures
+  AreaAndPersonFixtures,
+  initializeAreaAndPersonData
 } from 'e2e-test-common/dev-api/data-init'
 import {
-  deleteEmployeeFixture,
   postPairing,
   postPairingResponse,
   resetDatabase
@@ -16,25 +15,17 @@ import {
 import { PairingFlow } from '../../pages/employee/mobile/pairing-flow'
 import { waitUntilTrue } from '../../utils'
 import { Page } from 'e2e-playwright/utils/page'
-import { Fixture } from 'e2e-test-common/dev-api/fixtures'
 
 let page: Page
 let pairingFlow: PairingFlow
 let fixtures: AreaAndPersonFixtures
 
 beforeEach(async () => {
-  page = await Page.open({ acceptDownloads: true })
-  pairingFlow = new PairingFlow(page)
   await resetDatabase()
   fixtures = await initializeAreaAndPersonData()
-  await deleteEmployeeFixture(config.supervisorExternalId)
-  await Fixture.employee()
-    .with({
-      externalId: config.supervisorExternalId,
-      roles: []
-    })
-    .withDaycareAcl(fixtures.daycareFixture.id, 'UNIT_SUPERVISOR')
-    .save()
+
+  page = await Page.open({ acceptDownloads: true })
+  pairingFlow = new PairingFlow(page)
 })
 
 describe('Mobile pairing', () => {

--- a/frontend/src/e2e-playwright/specs/8_access/access.spec.ts
+++ b/frontend/src/e2e-playwright/specs/8_access/access.spec.ts
@@ -22,58 +22,6 @@ let childInfo: ChildInformationPage
 beforeAll(async () => {
   await resetDatabase()
   fixtures = await initializeAreaAndPersonData()
-  await Fixture.employee()
-    .with({
-      id: config.serviceWorkerAad,
-      externalId: `espoo-ad:${config.serviceWorkerAad}`,
-      roles: ['SERVICE_WORKER']
-    })
-    .save()
-  await Fixture.employee()
-    .with({
-      id: config.financeAdminAad,
-      externalId: `espoo-ad:${config.financeAdminAad}`,
-      roles: ['FINANCE_ADMIN']
-    })
-    .save()
-  await Fixture.employee()
-    .with({
-      id: config.directorAad,
-      externalId: `espoo-ad:${config.directorAad}`,
-      roles: ['DIRECTOR']
-    })
-    .save()
-  await Fixture.employee()
-    .with({
-      id: config.reportViewerAad,
-      externalId: `espoo-ad:${config.reportViewerAad}`,
-      roles: ['REPORT_VIEWER']
-    })
-    .save()
-  await Fixture.employee()
-    .with({
-      id: config.unitSupervisorAad,
-      externalId: `espoo-ad:${config.unitSupervisorAad}`,
-      roles: []
-    })
-    .withDaycareAcl(fixtures.daycareFixture.id, 'UNIT_SUPERVISOR')
-    .save()
-  await Fixture.employee()
-    .with({
-      id: config.staffAad,
-      externalId: `espoo-ad:${config.staffAad}`,
-      roles: []
-    })
-    .withDaycareAcl(fixtures.daycareFixture.id, 'STAFF')
-    .save()
-  await Fixture.employee()
-    .with({
-      id: config.specialEducationTeacher,
-      externalId: `espoo-ad:${config.specialEducationTeacher}`,
-      roles: []
-    })
-    .withDaycareAcl(fixtures.daycareFixture.id, 'SPECIAL_EDUCATION_TEACHER')
-    .save()
   await Fixture.placement()
     .with({
       childId: fixtures.enduserChildFixtureJari.id,
@@ -89,7 +37,8 @@ beforeEach(async () => {
 
 describe('Child information page', () => {
   test('Admin sees every tab, except messaging', async () => {
-    await employeeLogin(page, 'ADMIN')
+    const admin = await Fixture.employeeAdmin().save()
+    await employeeLogin(page, admin.data)
     await page.goto(config.employeeUrl)
     await nav.tabsVisible({
       applications: true,
@@ -102,7 +51,8 @@ describe('Child information page', () => {
   })
 
   test('Service worker sees applications, units, search and reports tabs', async () => {
-    await employeeLogin(page, 'SERVICE_WORKER')
+    const serviceWorker = await Fixture.employeeServiceWorker().save()
+    await employeeLogin(page, serviceWorker.data)
     await page.goto(config.employeeUrl)
     await nav.tabsVisible({
       applications: true,
@@ -115,7 +65,8 @@ describe('Child information page', () => {
   })
 
   test('FinanceAdmin sees units, search, finance and reports tabs', async () => {
-    await employeeLogin(page, 'FINANCE_ADMIN')
+    const financeAdmin = await Fixture.employeeFinanceAdmin().save()
+    await employeeLogin(page, financeAdmin.data)
     await page.goto(config.employeeUrl)
     await nav.tabsVisible({
       applications: false,
@@ -128,7 +79,8 @@ describe('Child information page', () => {
   })
 
   test('Director sees only the reports tab', async () => {
-    await employeeLogin(page, 'DIRECTOR')
+    const director = await Fixture.employeeDirector().save()
+    await employeeLogin(page, director.data)
     await page.goto(config.employeeUrl)
     await nav.tabsVisible({
       applications: false,
@@ -141,7 +93,8 @@ describe('Child information page', () => {
   })
 
   test('Reports sees only the reports tab', async () => {
-    await employeeLogin(page, 'REPORT_VIEWER')
+    const reportViewer = await Fixture.employeeReportViewer().save()
+    await employeeLogin(page, reportViewer.data)
     await page.goto(config.employeeUrl)
     await nav.tabsVisible({
       applications: false,
@@ -154,7 +107,8 @@ describe('Child information page', () => {
   })
 
   test('Staff sees only the units and messaging tabs', async () => {
-    await employeeLogin(page, 'STAFF')
+    const staff = await Fixture.employeeStaff(fixtures.daycareFixture.id).save()
+    await employeeLogin(page, staff.data)
     await page.goto(config.employeeUrl)
     await nav.tabsVisible({
       applications: false,
@@ -167,7 +121,10 @@ describe('Child information page', () => {
   })
 
   test('Unit supervisor sees units, search, reports and messaging tabs', async () => {
-    await employeeLogin(page, 'UNIT_SUPERVISOR')
+    const unitSupervisor = await Fixture.employeeUnitSupervisor(
+      fixtures.daycareFixture.id
+    ).save()
+    await employeeLogin(page, unitSupervisor.data)
     await page.goto(config.employeeUrl)
     await nav.tabsVisible({
       applications: false,
@@ -182,7 +139,8 @@ describe('Child information page', () => {
 
 describe('Child information page sections', () => {
   test('Admin sees every collapsible section', async () => {
-    await employeeLogin(page, 'ADMIN')
+    const admin = await Fixture.employeeAdmin().save()
+    await employeeLogin(page, admin.data)
     await page.goto(
       `${config.employeeUrl}/child-information/${fixtures.enduserChildFixtureJari.id}`
     )
@@ -202,7 +160,8 @@ describe('Child information page sections', () => {
   })
 
   test('Service worker sees the correct sections', async () => {
-    await employeeLogin(page, 'SERVICE_WORKER')
+    const serviceWorker = await Fixture.employeeServiceWorker().save()
+    await employeeLogin(page, serviceWorker.data)
     await page.goto(
       `${config.employeeUrl}/child-information/${fixtures.enduserChildFixtureJari.id}`
     )
@@ -222,7 +181,8 @@ describe('Child information page sections', () => {
   })
 
   test('Finance admin sees the correct sections', async () => {
-    await employeeLogin(page, 'FINANCE_ADMIN')
+    const financeAdmin = await Fixture.employeeFinanceAdmin().save()
+    await employeeLogin(page, financeAdmin.data)
     await page.goto(
       `${config.employeeUrl}/child-information/${fixtures.enduserChildFixtureJari.id}`
     )
@@ -242,7 +202,8 @@ describe('Child information page sections', () => {
   })
 
   test('Staff sees the correct sections', async () => {
-    await employeeLogin(page, 'STAFF')
+    const staff = await Fixture.employeeStaff(fixtures.daycareFixture.id).save()
+    await employeeLogin(page, staff.data)
     await page.goto(
       `${config.employeeUrl}/child-information/${fixtures.enduserChildFixtureJari.id}`
     )
@@ -262,7 +223,10 @@ describe('Child information page sections', () => {
   })
 
   test('Unit supervisor sees the correct sections', async () => {
-    await employeeLogin(page, 'UNIT_SUPERVISOR')
+    const unitSupervisor = await Fixture.employeeUnitSupervisor(
+      fixtures.daycareFixture.id
+    ).save()
+    await employeeLogin(page, unitSupervisor.data)
     await page.goto(
       `${config.employeeUrl}/child-information/${fixtures.enduserChildFixtureJari.id}`
     )
@@ -282,7 +246,11 @@ describe('Child information page sections', () => {
   })
 
   test('Special education teacher sees the correct sections', async () => {
-    await employeeLogin(page, 'SPECIAL_EDUCATION_TEACHER')
+    const specialEducationTeacher =
+      await Fixture.employeeSpecialEducationTeacher(
+        fixtures.daycareFixture.id
+      ).save()
+    await employeeLogin(page, specialEducationTeacher.data)
     await page.goto(
       `${config.employeeUrl}/child-information/${fixtures.enduserChildFixtureJari.id}`
     )

--- a/frontend/src/e2e-test-common/config.ts
+++ b/frontend/src/e2e-test-common/config.ts
@@ -68,13 +68,15 @@ const config = {
   employeeLoginUrl: `${browserUrl}/employee/login`,
   devApiGwUrl: `${baseUrl ?? 'http://localhost:3020'}/api/internal/dev-api`,
   enduserUrl: browserUrl,
+  mobileBaseUrl: browserUrl,
+  mobileUrl: `${browserUrl}/employee/mobile`,
+  enduserMessagesUrl: `${browserUrl}/messages`,
+
+  // TODO: Remove these
   supervisorAad,
   supervisorExternalId: `espoo-ad:${supervisorAad}`,
   adminAad,
   adminExternalId: `espoo-ad:${adminAad}`,
-  mobileBaseUrl: browserUrl,
-  mobileUrl: `${browserUrl}/employee/mobile`,
-  enduserMessagesUrl: `${browserUrl}/messages`,
   serviceWorkerAad,
   financeAdminAad,
   directorAad,

--- a/frontend/src/e2e-test-common/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test-common/dev-api/fixtures.ts
@@ -3,32 +3,31 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { format } from 'date-fns'
-import config from '../config'
 import {
   Application,
+  AssistanceNeed,
   BackupCare,
   CareArea,
   Child,
   Daycare,
+  DaycareCaretakers,
   DaycareGroup,
+  DaycareGroupPlacement,
   DaycarePlacement,
   DecisionFixture,
+  DevIncome,
   EmployeeDetail,
+  EmployeePin,
   FeeDecision,
   FeeDecisionStatus,
   Invoice,
   OtherGuardianAgreementStatus,
+  PedagogicalDocument,
   PersonDetail,
   PersonDetailWithDependantsAndGuardians,
   PlacementPlan,
-  VoucherValueDecision,
-  DaycareGroupPlacement,
-  EmployeePin,
-  PedagogicalDocument,
   ServiceNeedFixture,
-  AssistanceNeed,
-  DaycareCaretakers,
-  DevIncome
+  VoucherValueDecision
 } from './types'
 import {
   insertAssistanceNeedFixtures,
@@ -59,15 +58,6 @@ import { ServiceNeedOption } from 'lib-common/generated/api-types/serviceneed'
 import { ScopedRole } from 'lib-common/api-types/employee-auth'
 import { UUID } from 'lib-common/types'
 import { ApplicationForm } from 'lib-common/generated/api-types/application'
-
-export const supervisor: EmployeeDetail = {
-  id: '552e5bde-92fb-4807-a388-40016f85f593',
-  externalId: config.supervisorExternalId,
-  firstName: 'Eva',
-  lastName: 'Esihenkilo',
-  email: 'eva.esihenkilo@evaka.test',
-  roles: ['SERVICE_WORKER', 'ADMIN']
-}
 
 export const careAreaFixture: CareArea = {
   id: '674dfb66-8849-489e-b094-e6a0ebfb3c71',
@@ -977,18 +967,96 @@ export class Fixture {
     return new EmployeeBuilder({
       id: uuidv4(),
       email: `email_${id}@evaka.test`,
-      externalId: `e2etest:${uuidv4()}`,
+      externalId: `espoo-ad:${uuidv4()}`,
       firstName: `first_name_${id}`,
       lastName: `last_name_${id}`,
       roles: []
     })
   }
 
+  static employeeAdmin(): EmployeeBuilder {
+    return Fixture.employee().with({
+      email: 'seppo.sorsa@evaka.test',
+      firstName: 'Seppo',
+      lastName: 'Sorsa',
+      roles: ['ADMIN']
+    })
+  }
+
+  static employeeFinanceAdmin(): EmployeeBuilder {
+    return Fixture.employee().with({
+      email: 'lasse.laskuttaja@evaka.test',
+      firstName: 'Lasse',
+      lastName: 'Laskuttaja',
+      roles: ['FINANCE_ADMIN']
+    })
+  }
+
+  static employeeDirector(): EmployeeBuilder {
+    return Fixture.employee().with({
+      email: 'hemmo.hallinto@evaka.test',
+      firstName: 'Hemmo',
+      lastName: 'Hallinto',
+      roles: ['DIRECTOR']
+    })
+  }
+
+  static employeeReportViewer(): EmployeeBuilder {
+    return Fixture.employee().with({
+      email: 'raisa.raportoija@evaka.test',
+      firstName: 'Raisa',
+      lastName: 'Raportoija',
+      roles: ['REPORT_VIEWER']
+    })
+  }
+
+  static employeeServiceWorker(): EmployeeBuilder {
+    return Fixture.employee().with({
+      email: 'paula.palveluohjaaja@evaka.test',
+      firstName: 'Paula',
+      lastName: 'Palveluohjaaja',
+      roles: ['SERVICE_WORKER']
+    })
+  }
+
+  static employeeUnitSupervisor(unitId: string): EmployeeBuilder {
+    return Fixture.employee()
+      .with({
+        email: 'essi.esimies@evaka.test',
+        firstName: 'Essi',
+        lastName: 'Esimies',
+        roles: []
+      })
+      .withDaycareAcl(unitId, 'UNIT_SUPERVISOR')
+  }
+
+  static employeeSpecialEducationTeacher(unitId: string): EmployeeBuilder {
+    return Fixture.employee()
+      .with({
+        email: 'erkki.erityisopettaja@evaka.test',
+        firstName: 'Erkki',
+        lastName: 'Erityisopettaja',
+        roles: []
+      })
+      .withDaycareAcl(unitId, 'SPECIAL_EDUCATION_TEACHER')
+  }
+
+  static employeeStaff(unitId: string): EmployeeBuilder {
+    return Fixture.employee()
+      .with({
+        email: 'kaisa.kasvattaja@evaka.test',
+        firstName: 'Kaisa',
+        lastName: 'Kasvattaja',
+        roles: []
+      })
+      .withDaycareAcl(unitId, 'STAFF')
+  }
+
   static decision(): DecisionBuilder {
     return new DecisionBuilder({
       id: uuidv4(),
       applicationId: nullUUID,
-      employeeId: supervisor.externalId,
+      employeeId: 'not set',
       unitId: nullUUID,
       type: 'DAYCARE',
       startDate: '2020-01-01',
@@ -1129,6 +1197,7 @@ abstract class FixtureBuilder<T> {
   }
 
   abstract copy(): FixtureBuilder<T>
+
   abstract save(): Promise<FixtureBuilder<T>>
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -75,7 +75,7 @@ class FeeDecisionController(
     ): ResponseEntity<Paged<FeeDecisionSummary>> {
         Audit.FeeDecisionSearch.log()
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         val maxPageSize = 5000
         if (body.pageSize > maxPageSize) throw BadRequest("Maximum page size is $maxPageSize")
         if (body.startDate != null && body.endDate != null && body.endDate < body.startDate)
@@ -107,7 +107,7 @@ class FeeDecisionController(
     fun confirmDrafts(db: Database, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<FeeDecisionId>): ResponseEntity<Unit> {
         Audit.FeeDecisionConfirm.log(targetId = feeDecisionIds)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         db.connect { dbc ->
             dbc.transaction { tx ->
                 val confirmedDecisions = service.confirmDrafts(tx, user, feeDecisionIds, Instant.now())
@@ -121,7 +121,7 @@ class FeeDecisionController(
     fun setSent(db: Database, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<FeeDecisionId>): ResponseEntity<Unit> {
         Audit.FeeDecisionMarkSent.log(targetId = feeDecisionIds)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         db.connect { dbc -> dbc.transaction { service.setSent(it, feeDecisionIds) } }
         return ResponseEntity.noContent().build()
     }
@@ -130,7 +130,7 @@ class FeeDecisionController(
     fun getDecisionPdf(db: Database, user: AuthenticatedUser, @PathVariable uuid: FeeDecisionId): ResponseEntity<ByteArray> {
         Audit.FeeDecisionPdfRead.log(targetId = uuid)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         val headers = HttpHeaders()
         val (filename, pdf) = db.connect { dbc -> dbc.read { service.getFeeDecisionPdf(it, uuid) } }
         headers.add("Content-Disposition", "attachment; filename=\"$filename\"")
@@ -142,7 +142,7 @@ class FeeDecisionController(
     fun getDecision(db: Database, user: AuthenticatedUser, @PathVariable uuid: FeeDecisionId): ResponseEntity<Wrapper<FeeDecisionDetailed>> {
         Audit.FeeDecisionRead.log(targetId = uuid)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         val res = db.connect { dbc -> dbc.read { it.getFeeDecision(uuid) } }
             ?: throw NotFound("No fee decision found with given ID ($uuid)")
         return ResponseEntity.ok(Wrapper(res))
@@ -156,7 +156,7 @@ class FeeDecisionController(
     ): ResponseEntity<Wrapper<List<FeeDecision>>> {
         Audit.FeeDecisionHeadOfFamilyRead.log(targetId = uuid)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         val res = db.connect { dbc ->
             dbc.read {
                 it.findFeeDecisionsForHeadOfFamily(
@@ -178,7 +178,7 @@ class FeeDecisionController(
     ): ResponseEntity<Unit> {
         Audit.FeeDecisionHeadOfFamilyCreateRetroactive.log(targetId = id)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         db.connect { dbc -> dbc.transaction { generator.createRetroactiveFeeDecisions(it, id, body.from) } }
         return ResponseEntity.noContent().build()
     }
@@ -192,7 +192,7 @@ class FeeDecisionController(
     ): ResponseEntity<Unit> {
         Audit.FeeDecisionSetType.log(targetId = uuid)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         db.connect { dbc -> dbc.transaction { service.setType(it, uuid, request.type) } }
         return ResponseEntity.noContent().build()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -61,7 +61,7 @@ class IncomeController(
     fun createIncome(db: Database, user: AuthenticatedUser, @RequestBody income: Income): ResponseEntity<IncomeId> {
         Audit.PersonIncomeCreate.log(targetId = income.personId)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         val period = try {
             DateRange(income.validFrom, income.validTo)
         } catch (e: Exception) {
@@ -94,7 +94,7 @@ class IncomeController(
     ): ResponseEntity<Unit> {
         Audit.PersonIncomeUpdate.log(targetId = incomeId)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -118,7 +118,7 @@ class IncomeController(
     fun deleteIncome(db: Database, user: AuthenticatedUser, @PathVariable incomeId: IncomeId): ResponseEntity<Unit> {
         Audit.PersonIncomeDelete.log(targetId = incomeId)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -138,7 +138,7 @@ class IncomeController(
     @GetMapping("/types")
     fun getTypes(user: AuthenticatedUser): ResponseEntity<Map<String, IncomeType>> {
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         return incomeTypesProvider.get().let { ResponseEntity.ok(it) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
@@ -66,7 +66,7 @@ class InvoiceController(
     ): ResponseEntity<Paged<InvoiceSummary>> {
         Audit.InvoicesSearch.log()
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         val maxPageSize = 5000
         if (body.pageSize > maxPageSize) throw BadRequest("Maximum page size is $maxPageSize")
         return db.connect { dbc ->
@@ -94,7 +94,7 @@ class InvoiceController(
     fun createDraftInvoices(db: Database, user: AuthenticatedUser): ResponseEntity<Unit> {
         Audit.InvoicesCreate.log()
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         db.connect { dbc -> dbc.transaction { it.createAllDraftInvoices() } }
         return ResponseEntity.noContent().build()
     }
@@ -103,7 +103,7 @@ class InvoiceController(
     fun deleteDraftInvoices(db: Database, user: AuthenticatedUser, @RequestBody invoiceIds: List<UUID>): ResponseEntity<Unit> {
         Audit.InvoicesDeleteDrafts.log(targetId = invoiceIds)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         db.connect { dbc -> dbc.transaction { it.deleteDraftInvoices(invoiceIds) } }
         return ResponseEntity.noContent().build()
     }
@@ -120,7 +120,7 @@ class InvoiceController(
     ): ResponseEntity<Unit> {
         Audit.InvoicesSend.log(targetId = invoiceIds)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         db.connect { dbc ->
             dbc.transaction {
                 service.sendInvoices(it, user, invoiceIds, invoiceDate, dueDate)
@@ -137,7 +137,7 @@ class InvoiceController(
     ): ResponseEntity<Unit> {
         Audit.InvoicesSendByDate.log()
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         db.connect { dbc ->
             dbc.transaction { tx ->
                 val invoiceIds = service.getInvoiceIds(tx, payload.from, payload.to, payload.areas)
@@ -151,7 +151,7 @@ class InvoiceController(
     fun markInvoicesSent(db: Database, user: AuthenticatedUser, @RequestBody invoiceIds: List<UUID>): ResponseEntity<Unit> {
         Audit.InvoicesMarkSent.log(targetId = invoiceIds)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         db.connect { dbc -> dbc.transaction { it.markManuallySent(user, invoiceIds) } }
         return ResponseEntity.noContent().build()
     }
@@ -160,7 +160,7 @@ class InvoiceController(
     fun getInvoice(db: Database, user: AuthenticatedUser, @PathVariable uuid: String): ResponseEntity<Wrapper<InvoiceDetailed>> {
         Audit.InvoicesRead.log(targetId = uuid)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         val parsedUuid = parseUUID(uuid)
         val res = db.connect { dbc -> dbc.read { it.getDetailedInvoice(parsedUuid) } }
             ?: throw NotFound("No invoice found with given ID ($uuid)")
@@ -175,7 +175,7 @@ class InvoiceController(
     ): ResponseEntity<Wrapper<List<Invoice>>> {
         Audit.InvoicesRead.log(targetId = uuid)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         val parsedUuid = parseUUID(uuid)
         val res = db.connect { dbc -> dbc.read { it.getHeadOfFamilyInvoices(parsedUuid) } }
         return ResponseEntity.ok(Wrapper(res))
@@ -190,7 +190,7 @@ class InvoiceController(
     ): ResponseEntity<Unit> {
         Audit.InvoicesUpdate.log(targetId = uuid)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         val parsedUuid = parseUUID(uuid)
         db.connect { dbc -> dbc.transaction { service.updateInvoice(it, parsedUuid, invoice) } }
         return ResponseEntity.noContent().build()
@@ -199,7 +199,7 @@ class InvoiceController(
     @GetMapping("/codes")
     fun getInvoiceCodes(db: Database, user: AuthenticatedUser): ResponseEntity<Wrapper<InvoiceCodes>> {
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.FINANCE_ADMIN)
         val codes = db.connect { dbc -> dbc.read { it.getInvoiceCodes() } }
         return ResponseEntity.ok(Wrapper(codes))
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -172,7 +172,7 @@ class PersonController(
     ): ResponseEntity<PersonJSON> {
         Audit.PersonUpdate.log(targetId = personId)
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN, UserRole.STAFF)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN, UserRole.STAFF)
 
         val userEditablePersonData = data
             .let {
@@ -249,7 +249,7 @@ class PersonController(
     ): ResponseEntity<PersonJSON> {
         Audit.PersonDetailsRead.log()
         @Suppress("DEPRECATION")
-        user.requireOneOfRoles(UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
+        user.requireOneOfRoles(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.UNIT_SUPERVISOR, UserRole.FINANCE_ADMIN)
 
         if (!isValidSSN(body.ssn)) throw BadRequest("Invalid SSN")
 


### PR DESCRIPTION
#### Summary

* A user now has to be created explicitly. The `employeeLogin` function doesn't create any users anymore.
* Add functions to easily create users for different roles with sane names (no `first_name.0_fasdfa` anymore). A readable name helps when debugging tests.
* Allow admin to call more endpoints in the service. This was required because an admin user is only granted the `ADMIN` role. Admins will be able to perform any action after the access control refactor anyway.