### PR TITLE
Lock all database tables before reset

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/DevDataInitializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/DevDataInitializer.kt
@@ -12,6 +12,7 @@ class DevDataInitializer(jdbi: Jdbi) {
     init {
         Database(jdbi).connect { db ->
             db.transaction { tx ->
+                tx.runDevScript("lock-database-nowait.sql")
                 tx.runDevScript("reset-database.sql")
                 tx.ensureDevData()
             }

--- a/service/src/main/resources/dev-data/lock-database-nowait.sql
+++ b/service/src/main/resources/dev-data/lock-database-nowait.sql
@@ -1,0 +1,16 @@
+-- SPDX-FileCopyrightText: 2017-2022 City of Espoo
+--
+-- SPDX-License-Identifier: LGPL-2.1-or-later
+
+CREATE OR REPLACE FUNCTION lock_database_nowait() RETURNS void AS $$
+BEGIN
+    EXECUTE (
+        SELECT 'LOCK TABLE ' || string_agg(quote_ident(table_name), ', ' ORDER BY table_name) || ' NOWAIT'
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+        AND table_type = 'BASE TABLE'
+    );
+END $$ LANGUAGE plpgsql;
+COMMENT ON FUNCTION lock_database_nowait() IS
+    'Obtains a strongest possible lock (ACCESS EXCLUSIVE) on all database tables.
+    If locking is not possible without waiting, aborts the current transaction.';


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

We first wait for all queries to finish as an optimization before using any locks. However, it's still possible a new query is started
asynchronously after this check, so we still want to lock all database tables before executing the reset.

Locking uses NOWAIT, so we back away immediately if our locking attempt fails and retry after a delay. This avoids potential deadlocks that could happen if we used normal locking that would compete with other running queries.

In our E2E tests there are 4 typical scenarios:

1. no queries are running when `/reset-db` is called -> no waiting is needed, locking succeeds immediately, and reset works
2. a query is running when `/reset-db` is called -> we wait until the query finishes, then locking succeeds immediately, and reset works
3. a query is started while `/reset-db` is executing *after the wait* but *before the lock*  -> locking fails and polls until it succeeds, and reset works
4. a query is started while `/reset-db` is executing *after the lock* -> since the database contents have been reset, the query probably fails. This shouldn't happen in practice and mostly leads to errors on logs