### PR TITLE
Fix application tooltip contrast

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/attendances/ChildListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/ChildListItem.tsx
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useContext } from 'react'
 import styled from 'styled-components'
-import { Bold } from 'lib-components/typography'
+import { Bold, InformationText } from 'lib-components/typography'
 import {
   AttendanceStatus,
   Child
@@ -23,7 +23,6 @@ import { GroupNote } from 'lib-common/generated/api-types/note'
 
 const ChildBox = styled.div`
   align-items: center;
-  color: ${colors.greyscale.darkest};
   display: flex;
   padding: ${defaultMargins.xs} ${defaultMargins.s};
   border-radius: 2px;
@@ -31,8 +30,8 @@ const ChildBox = styled.div`
 `
 
 const AttendanceLinkBox = styled(Link)`
-  align-items: center;
   display: flex;
+  align-items: center;
   width: 100%;
 `
 
@@ -82,9 +81,7 @@ const NameRow = styled.div`
   width: 100%;
 `
 
-const GroupName = styled.div`
-  color: ${colors.greyscale.dark};
-  font-size: 0.875em;
+const GroupName = styled(InformationText)`
   white-space: nowrap;
   text-align: right;
 `

--- a/frontend/src/lib-components/employee/notes/StaticStickyNote.tsx
+++ b/frontend/src/lib-components/employee/notes/StaticStickyNote.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -7,7 +7,7 @@ import { UUID } from 'lib-common/types'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import { ContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
-import { Light, P } from 'lib-components/typography'
+import { InformationText, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import React, { useCallback } from 'react'
 import { InlineAsyncButton } from './InlineAsyncButton'
@@ -41,9 +41,9 @@ export const StaticStickyNote = React.memo(function StaticStickyNote({
         {note.note}
       </P>
       <Gap size="xs" />
-      <Light data-qa="sticky-note-expires">
+      <InformationText data-qa="sticky-note-expires">
         {labels.validTo(note.expires.format())}
-      </Light>
+      </InformationText>
       <Gap size="xs" />
       <FixedSpaceRow justifyContent="flex-end">
         <InlineButton

--- a/frontend/src/lib-components/typography.ts
+++ b/frontend/src/lib-components/typography.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -170,13 +170,11 @@ export const Strong = styled.span`
 `
 
 export const Bold = styled.span`
-  color: ${(p) => p.theme.colors.greyscale.darkest};
   font-weight: ${fontWeights.semibold};
 `
 
 export const Light = styled.span`
   font-style: italic;
-  color: ${(p) => p.theme.colors.greyscale.dark};
 `
 
 export const Title = styled.span`


### PR DESCRIPTION
#### Summary

Checked that all `Bold` and `Light` usages were fine after removing the `color` property.