### PR TITLE
Wait for loading after navigating to a guardian information page

### DIFF
--- a/frontend/src/e2e-playwright/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-playwright/pages/employee/finance/finance-page.ts
@@ -379,6 +379,8 @@ export class IncomeStatementsPage {
 
   async openNthIncomeStatement(nth: number) {
     await this.#incomeStatementRows.nth(nth).find('a').click()
-    return new GuardianInformationPage(this.page)
+    const page = new GuardianInformationPage(this.page)
+    await page.waitUntilLoaded()
+    return page
   }
 }

--- a/frontend/src/e2e-playwright/pages/employee/guardian-information.ts
+++ b/frontend/src/e2e-playwright/pages/employee/guardian-information.ts
@@ -25,6 +25,7 @@ export default class GuardianInformationPage {
 
   async navigateToGuardian(personId: UUID) {
     await this.page.goto(config.employeeUrl + '/profile/' + personId)
+    await this.waitUntilLoaded()
   }
 
   async waitUntilLoaded() {

--- a/frontend/src/e2e-playwright/specs/4_finance/head-of-family-fee-decisions.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/head-of-family-fee-decisions.spec.ts
@@ -63,7 +63,6 @@ describe('Head of family fee decisions', () => {
     await createFeeDecisionFixture(sentAtSecond)
 
     await guardianPage.navigateToGuardian(enduserGuardianFixture.id)
-    await guardianPage.waitUntilLoaded()
     const feeDecisions = await guardianPage.openCollapsible('feeDecisions')
 
     await feeDecisions.checkFeeDecisionSentAt(0, sentAtThird)

--- a/frontend/src/e2e-playwright/specs/4_finance/income-staments.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/income-staments.spec.ts
@@ -67,7 +67,6 @@ describe('Income statements', () => {
     const personProfilePage = await incomeStatementsPage.openNthIncomeStatement(
       1
     )
-    await personProfilePage.waitUntilLoaded()
 
     const incomesSection = await personProfilePage.openCollapsible('incomes')
     await waitUntilFalse(() => incomesSection.isIncomeStatementHandled(0))

--- a/frontend/src/e2e-playwright/specs/5_employee/fridge-head-information.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/fridge-head-information.spec.ts
@@ -78,19 +78,16 @@ describe('Employee - Head of family details', () => {
     await guardianInformation.navigateToGuardian(
       fixtures.restrictedPersonFixture.id
     )
-    await guardianInformation.waitUntilLoaded()
     await guardianInformation.assertRestrictedDetails(true)
   })
 
   test('guardian does not have restriction details enabled', async () => {
     await guardianInformation.navigateToGuardian(regularPerson.id)
-    await guardianInformation.waitUntilLoaded()
     await guardianInformation.assertRestrictedDetails(false)
   })
 
   test('Zero-year-old child is shown as age 0', async () => {
     await guardianInformation.navigateToGuardian(regularPerson.id)
-    await guardianInformation.waitUntilLoaded()
     const children = await guardianInformation.openCollapsible('children')
 
     await children.addChild(

--- a/frontend/src/e2e-playwright/specs/5_employee/guardian-information-page.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/guardian-information-page.spec.ts
@@ -68,7 +68,6 @@ describe('Employee - Guardian Information', () => {
   test('guardian information is shown', async () => {
     const guardianPage = new GuardianInformationPage(page)
     await guardianPage.navigateToGuardian(fixtures.enduserGuardianFixture.id)
-    await guardianPage.waitUntilLoaded()
 
     const personInfoSection = guardianPage.getCollapsible('personInfo')
     await personInfoSection.assertPersonInfo(
@@ -115,7 +114,6 @@ describe('Employee - Guardian Information', () => {
 
     const guardianPage = new GuardianInformationPage(page)
     await guardianPage.navigateToGuardian(fixtures.enduserGuardianFixture.id)
-    await guardianPage.waitUntilLoaded()
 
     const invoiceSection = await guardianPage.openCollapsible('invoices')
     await invoiceSection.assertInvoiceCount(1)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Should fix missed clicks in E2E tests caused by sections loading unpredictably
