### PR TITLE
Add a separate Italic typography element

### DIFF
--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -29,7 +29,7 @@ import {
 } from 'lib-components/layout/Table'
 import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
 import Pagination from 'lib-components/Pagination'
-import { Bold, H1, Light } from 'lib-components/typography'
+import { Bold, H1, Italic, Light } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors, { applicationBasisColors } from 'lib-customizations/common'
 import {
@@ -338,10 +338,10 @@ const ApplicationsList = React.memo(function Applications({
                   <p key={`unit-pref-${i}`}>{unit.name}</p>
                 ))}
                 {application.currentPlacementUnit && (
-                  <Light>
+                  <Italic>
                     {i18n.applications.list.currentUnit}{' '}
                     {application.currentPlacementUnit.name}
-                  </Light>
+                  </Italic>
                 )}
               </div>
             }

--- a/frontend/src/lib-components/typography.ts
+++ b/frontend/src/lib-components/typography.ts
@@ -173,8 +173,13 @@ export const Bold = styled.span`
   font-weight: ${fontWeights.semibold};
 `
 
+export const Italic = styled.span`
+  font-style: italic;
+`
+
 export const Light = styled.span`
   font-style: italic;
+  color: ${({ theme: { colors } }) => colors.greyscale.dark};
 `
 
 export const Title = styled.span`


### PR DESCRIPTION
#### Summary
`Italic` is needed for cases where text is not on white background (ie. in `Tooltip`).
Revert `Light` to include dimmed color.

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

