### PR TITLE
EVAKA-4382 Sub tabs

### DIFF
--- a/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
+++ b/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
@@ -47,7 +47,7 @@ export default React.memo(function ApplyingRouter() {
         <>
           <Gap size="s" />
           <WhiteBg>
-            <Tabs tabs={tabs} dataQa="applying-subnavigation" />
+            <Tabs tabs={tabs} data-qa="applying-subnavigation" />
           </WhiteBg>
         </>
       )}

--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -186,7 +186,11 @@ function StaffAttendanceRouter() {
   return (
     <StaffAttendanceContextProvider>
       <Switch>
-        <Route exact path={path} component={StaffAttendancesPage} />
+        <Route
+          exact
+          path={`${path}/:tab(absent|present)`}
+          component={StaffAttendancesPage}
+        />
         <Route
           exact
           path={`${path}/external`}
@@ -208,7 +212,7 @@ function StaffAttendanceRouter() {
           path={`${path}/:employeeId/mark-departed`}
           component={StaffMarkDepartedPage}
         />
-        <Redirect to={path} />
+        <Redirect to={`${path}/absent`} />
       </Switch>
     </StaffAttendanceContextProvider>
   )

--- a/frontend/src/employee-mobile-frontend/components/attendances/AttendanceList.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/AttendanceList.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -9,7 +9,6 @@ import {
 import { UUID } from 'lib-common/types'
 import { ContentArea } from 'lib-components/layout/Container'
 import Tabs from 'lib-components/molecules/Tabs'
-import { Bold } from 'lib-components/typography'
 import React, { useMemo } from 'react'
 import { useTranslation } from '../../state/i18n'
 import ChildList from './ChildList'
@@ -60,12 +59,12 @@ export default React.memo(function AttendanceList({
     const url = `/units/${unitId}/groups/${groupId}/child-attendance/list`
 
     const getLabel = (title: string, count: number) => (
-      <Bold>
+      <>
         {title}
         <br />
         <span data-qa="count">{count}</span>/
         <span data-qa="total">{totalAttendances}</span>
-      </Bold>
+      </>
     )
 
     return [

--- a/frontend/src/employee-mobile-frontend/components/attendances/AttendancePageWrapper.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/AttendancePageWrapper.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -60,7 +60,7 @@ export default React.memo(function AttendancePageWrapper() {
       history.push(
         `/units/${unitId}/groups/${
           group?.id ?? 'all'
-        }/child-attendance/${attendanceStatus}/list`
+        }/child-attendance/list/${attendanceStatus}`
       )
     },
     [history, unitId, attendanceStatus]

--- a/frontend/src/employee-mobile-frontend/components/common/GroupSelectorBar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/GroupSelectorBar.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -18,6 +18,7 @@ import GroupSelector, { CountInfo } from './GroupSelector'
 const GroupContainer = styled.div`
   display: block;
   min-height: 48px;
+  margin-bottom: ${defaultMargins.xs};
 `
 
 const GroupSelectorButtonRow = styled.div`

--- a/frontend/src/lib-components/molecules/Tabs.tsx
+++ b/frontend/src/lib-components/molecules/Tabs.tsx
@@ -5,148 +5,99 @@
 import React from 'react'
 import { NavLink } from 'react-router-dom'
 import styled from 'styled-components'
+import { desktopMin } from '../breakpoints'
 import Container from '../layout/Container'
 import { fontWeights, NavLinkText } from '../typography'
+import { BaseProps } from '../utils'
 import { defaultMargins } from '../white-space'
 
-interface CommonProps {
+interface Tab {
+  id: string
+  link: string
+  label: string | JSX.Element
+  counter?: number
+}
+
+interface Props extends BaseProps {
   mobile?: boolean
-  dataQa?: string
+  tabs: Tab[]
 }
 
-interface LinkTabProps extends CommonProps {
-  tabs: Array<{
-    id: string
-    link: string
-    label: string | JSX.Element
-    counter?: number
-  }>
-  type?: 'links'
-}
-
-interface ButtonTabProps extends CommonProps {
-  tabs: Array<{
-    id: string
-    onClick: () => void
-    label: string | JSX.Element
-    active: boolean
-    counter?: number
-  }>
-  type: 'buttons'
-}
-
-type Props = LinkTabProps | ButtonTabProps
-
-function usesButtons(props: Props): props is ButtonTabProps {
-  return props.type === 'buttons'
-}
-
-export default React.memo(function Tabs(props: Props) {
-  const { mobile, dataQa } = props
-  const maxWidth = mobile ? `${100 / props.tabs.length}vw` : undefined
+export default React.memo(function Tabs({
+  mobile,
+  'data-qa': dataQa,
+  tabs
+}: Props) {
+  const maxWidth = mobile ? `${100 / tabs.length}vw` : undefined
   return (
     <Container>
-      <TabsContainer data-qa={dataQa}>
-        {usesButtons(props)
-          ? props.tabs.map(({ id, onClick, active, label, counter }) => (
-              <TabButtonContainer
-                key={id}
-                onClick={onClick}
-                data-qa={`${id}-tab`}
-                $maxWidth={maxWidth}
-                $mobile={mobile}
-                className={active ? 'active' : undefined}
-              >
-                <NavLinkText>{label}</NavLinkText>
-                {counter ? <TabCounter>{counter}</TabCounter> : null}
-              </TabButtonContainer>
-            ))
-          : props.tabs.map(({ id, link, label, counter }) => (
-              <TabLinkContainer
-                key={id}
-                to={link}
-                data-qa={`${id}-tab`}
-                $maxWidth={maxWidth}
-                $mobile={mobile}
-              >
-                <NavLinkText>{label}</NavLinkText>
-                {counter ? <TabCounter>{counter}</TabCounter> : null}
-              </TabLinkContainer>
-            ))}
+      <TabsContainer data-qa={dataQa} shadow={mobile}>
+        {tabs.map(({ id, link, label, counter }) => (
+          <TabLinkContainer
+            key={id}
+            to={link}
+            data-qa={`${id}-tab`}
+            $maxWidth={maxWidth}
+            $mobile={mobile}
+          >
+            <NavLinkText>{label}</NavLinkText>
+            {counter ? <TabCounter>{counter}</TabCounter> : null}
+          </TabLinkContainer>
+        ))}
       </TabsContainer>
     </Container>
   )
 })
 
-const TabsContainer = styled.div`
+const TabsContainer = styled.div<{ shadow?: boolean }>`
   display: flex;
   flex-direction: row;
+  ${(p) =>
+    p.shadow
+      ? `
+      box-shadow: 0 2px 6px 0 ${p.theme.colors.greyscale.lighter};
+      margin-bottom: ${defaultMargins.xxs};
+      `
+      : ''}
 `
 
-interface TabContainerProps {
+const TabLinkContainer = styled(NavLink)<{
   $maxWidth?: string
   $mobile?: boolean
-}
-
-const TabLinkContainer = styled(NavLink)<TabContainerProps>`
+}>`
   display: flex;
   flex-direction: row;
   justify-content: center;
-  align-content: center;
+  align-items: center;
   padding: 12px;
   flex-basis: content;
   flex-grow: 1;
-  background-color: ${({ theme: { colors } }) => colors.greyscale.white};
-  font-family: ${(p) =>
-    p.$mobile ? 'Open Sans, sans-serif' : 'Montserrat, sans-serif'};
-  font-size: ${(p) => (p.$mobile ? '14px' : '15px')};
+  background-color: ${(p) => p.theme.colors.greyscale.white};
   text-align: center;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  max-width: ${(p) => p.$maxWidth ?? 'none'};
+  max-width: ${(p) => p.$maxWidth ?? 'unset'};
+
+  min-height: 60px;
+  @media (min-width: ${desktopMin}) {
+    min-height: 48px;
+  }
+
+  border-bottom: ${(p) => (p.$mobile ? '3px solid transparent' : 'unset')};
 
   &.active {
     background-color: ${({ theme: { colors }, ...p }) =>
       p.$mobile ? colors.greyscale.white : `${colors.main.light}33`};
     border-bottom: ${({ theme: { colors }, ...p }) =>
-      p.$mobile ? `3px solid ${colors.main.dark}` : 'none'};
+      p.$mobile ? `3px solid ${colors.main.dark}` : 'unset'};
 
     ${NavLinkText} {
       color: ${(p) => p.theme.colors.main.dark};
       font-weight: ${fontWeights.bold};
     }
   }
-`
 
-const TabButtonContainer = styled.button<TabContainerProps>`
-  outline: none !important;
-  border: none;
-
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-content: center;
-  padding: 12px;
-  flex-basis: content;
-  flex-grow: 1;
-  background-color: ${({ theme: { colors } }) => colors.greyscale.white};
-  font-family: ${(p) =>
-    p.$mobile ? 'Open Sans, sans-serif' : 'Montserrat, sans-serif'};
-  font-size: ${(p) => (p.$mobile ? '14px' : '15px')};
-  text-align: center;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  max-width: ${(p) => (p.$maxWidth ? p.$maxWidth : 'none')};
-
-  &.active {
-    background-color: ${({ theme: { colors }, ...p }) =>
-      p.$mobile ? colors.greyscale.white : `${colors.main.light}33`};
-    border-bottom: ${({ theme: { colors }, ...p }) =>
-      p.$mobile ? `3px solid ${colors.main.dark}` : 'none'};
-
+  :hover {
     ${NavLinkText} {
       color: ${(p) => p.theme.colors.main.dark};
-      font-weight: ${fontWeights.bold};
     }
   }
 `

--- a/frontend/src/lib-components/typography.ts
+++ b/frontend/src/lib-components/typography.ts
@@ -204,7 +204,7 @@ export const NavLinkText = styled.span`
   font-family: Montserrat, sans-serif;
   font-weight: ${fontWeights.medium};
   font-size: 14px;
-  line-height: 1.5;
+  line-height: 16px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   text-decoration: none;


### PR DESCRIPTION
#### Summary

- Implement new sub tab styles
- Simplify tab css by removing all redundant properties mostly controlled by `NavLinkText`
- Simplify `Tabs` implementation by getting rid of button based sub tabs
- Implement staff attendance page with routes instead of local state
- Fix attendance status link when changing group on child attendance page

