### PR TITLE
Ensure evaka_user row is created for paper application guardians

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -29,6 +29,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.Paged
+import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -41,6 +42,7 @@ import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
+import fi.espoo.evaka.shared.security.upsertCitizenUser
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -151,6 +153,9 @@ class ApplicationControllerV2(
 
                 val guardian = tx.getPersonById(guardianId)
                     ?: throw BadRequest("Could not find the guardian with id $guardianId")
+
+                // If the guardian has never logged in to eVaka, evaka_user might not contain a row for them yet
+                tx.upsertCitizenUser(PersonId(guardianId))
 
                 val id = tx.insertApplication(
                     guardianId = guardianId,

--- a/service/src/main/resources/db/migration/V194__evaka_user_for_paper_application_guardians.sql
+++ b/service/src/main/resources/db/migration/V194__evaka_user_for_paper_application_guardians.sql
@@ -1,0 +1,7 @@
+INSERT INTO evaka_user (id, type, citizen_id, name)
+SELECT id, 'CITIZEN', id, first_name || ' ' || last_name
+FROM person
+WHERE id IN (
+    SELECT guardian_id FROM application
+)
+ON CONFLICT DO NOTHING;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -191,3 +191,4 @@ V190__drop_authors_and_discussion_content_columns.sql
 V191__service_need_option_active_flag.sql
 V192__terminate_placement.sql
 V193__invoice_codebtor.sql
+V194__evaka_user_for_paper_application_guardians.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

If a paper application is created for a guardian who has not logged in to eVaka, they might not yet have a row in `evaka_user`. This causes errors later when application `guardian_id` is used as income `modified_by`.

Fix future cases by adding `evaka_user` upsert, and existing cases by upserting using a migration.