### PR TITLE
Refactor NestedMessageAccount naming

### DIFF
--- a/frontend/src/employee-frontend/api/person.ts
+++ b/frontend/src/employee-frontend/api/person.ts
@@ -1,11 +1,14 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Failure, Result, Success } from 'lib-common/api'
 import { PersonApplicationSummary } from 'lib-common/generated/api-types/application'
 import { ChildResponse } from 'lib-common/generated/api-types/daycare'
-import { Recipient } from 'lib-common/generated/api-types/messaging'
+import {
+  EditRecipientRequest,
+  Recipient
+} from 'lib-common/generated/api-types/messaging'
 import {
   ContactInfo,
   CreatePersonBody,
@@ -178,12 +181,10 @@ export async function getChildRecipients(
 export async function updateChildRecipient(
   childId: UUID,
   recipientId: UUID,
-  blocklisted: boolean
+  data: EditRecipientRequest
 ): Promise<Result<void>> {
   return client
-    .put<void>(`/child/${childId}/recipients/${recipientId}`, {
-      blocklisted: blocklisted
-    })
+    .put<void>(`/child/${childId}/recipients/${recipientId}`, data)
     .then((v) => Success.of(v.data))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-frontend/components/Header.tsx
+++ b/frontend/src/employee-frontend/components/Header.tsx
@@ -17,7 +17,7 @@ import { combine } from 'lib-common/api'
 import { EvakaLogo } from 'lib-components/atoms/EvakaLogo'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import { desktopMin } from 'lib-components/breakpoints'
-import { isNestedGroupMessageAccount } from 'lib-components/employee/messages/types'
+import { isGroupMessageAccount } from 'lib-components/employee/messages/types'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { fontWeights, NavLinkText } from 'lib-components/typography'
 import { BaseProps } from 'lib-components/utils'
@@ -168,16 +168,16 @@ const UserPopup = styled.div`
 const Header = React.memo(function Header({ location }: RouteComponentProps) {
   const { i18n } = useTranslation()
   const { user, loggedIn } = useContext(UserContext)
-  const { nestedAccounts, unreadCountsByAccount } = useContext(MessageContext)
+  const { accounts, unreadCountsByAccount } = useContext(MessageContext)
   const [popupVisible, setPopupVisible] = useState(false)
 
   const unreadCount = useMemo<number>(
     () =>
-      combine(nestedAccounts, unreadCountsByAccount)
-        .map(([accounts, counts]) => {
+      combine(accounts, unreadCountsByAccount)
+        .map(([allAccounts, counts]) => {
           const [group, personal] = partition(
-            accounts,
-            isNestedGroupMessageAccount
+            allAccounts,
+            isGroupMessageAccount
           )
           return (personal.length > 0 ? personal : group).reduce(
             (sum, { account: { id: accountId } }) =>
@@ -187,7 +187,7 @@ const Header = React.memo(function Header({ location }: RouteComponentProps) {
           )
         })
         .getOrElse(0),
-    [nestedAccounts, unreadCountsByAccount]
+    [accounts, unreadCountsByAccount]
   )
 
   const path = location.pathname

--- a/frontend/src/employee-frontend/components/child-information/MessageBlocklist.tsx
+++ b/frontend/src/employee-frontend/components/child-information/MessageBlocklist.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -38,7 +38,9 @@ export default React.memo(function MessageBlocklist({ id, startOpen }: Props) {
   const onChange = useCallback(
     async (personId: UUID, checked: boolean) => {
       setSaving(true)
-      const res = await updateChildRecipient(id, personId, !checked)
+      const res = await updateChildRecipient(id, personId, {
+        blocklisted: !checked
+      })
       if (res.isFailure) {
         setErrorMessage({
           type: 'error',

--- a/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
+++ b/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { ReactNode, useContext, useState } from 'react'
 import styled from 'styled-components'
 import { NestedMessageAccount } from 'lib-common/generated/api-types/messaging'
-import { NestedGroupMessageAccount } from 'lib-components/employee/messages/types'
+import { GroupMessageAccount } from 'lib-components/employee/messages/types'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faChevronDown, faChevronUp } from 'lib-icons'
@@ -62,36 +62,35 @@ const CollapsibleMessageBoxesContainer = styled.div`
 `
 
 export default function GroupMessageAccountList({
-  nestedGroupAccounts,
+  accounts,
   activeView,
   setView
 }: {
-  nestedGroupAccounts: NestedGroupMessageAccount[]
+  accounts: GroupMessageAccount[]
   activeView: AccountView | undefined
   setView: (view: AccountView) => void
 }) {
   const { unreadCountsByAccount } = useContext(MessageContext)
-  const startCollapsed = (nestedAccount: NestedMessageAccount, i: number) =>
+  const startCollapsed = (acc: NestedMessageAccount, i: number) =>
     i > 0 &&
     ((unreadCountsByAccount.isSuccess &&
-      !unreadCountsByAccount.value.find(
-        (x) => x.accountId === nestedAccount.account.id
-      )?.unreadCount) ||
+      !unreadCountsByAccount.value.find((a) => a.accountId === acc.account.id)
+        ?.unreadCount) ||
       !unreadCountsByAccount.isSuccess)
 
   return (
     <CollapsibleMessageBoxesContainer>
-      {nestedGroupAccounts.map((nestedAcc, i) => (
+      {accounts.map((acc, i) => (
         <CollapsibleRow
-          key={nestedAcc.account.id}
-          startCollapsed={startCollapsed(nestedAcc, i)}
-          title={nestedAcc.daycareGroup.name}
+          key={acc.account.id}
+          startCollapsed={startCollapsed(acc, i)}
+          title={acc.daycareGroup.name}
         >
           {messageBoxes.map((view) => (
             <MessageBox
               key={view}
               view={view}
-              account={nestedAcc.account}
+              account={acc.account}
               activeView={activeView}
               setView={setView}
             />

--- a/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
+++ b/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
@@ -5,7 +5,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { ReactNode, useContext, useState } from 'react'
 import styled from 'styled-components'
-import { NestedMessageAccount } from 'lib-common/generated/api-types/messaging'
+import { AuthorizedMessageAccount } from 'lib-common/generated/api-types/messaging'
 import { GroupMessageAccount } from 'lib-components/employee/messages/types'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
@@ -71,7 +71,7 @@ export default function GroupMessageAccountList({
   setView: (view: AccountView) => void
 }) {
   const { unreadCountsByAccount } = useContext(MessageContext)
-  const startCollapsed = (acc: NestedMessageAccount, i: number) =>
+  const startCollapsed = (acc: AuthorizedMessageAccount, i: number) =>
     i > 0 &&
     ((unreadCountsByAccount.isSuccess &&
       !unreadCountsByAccount.value.find((a) => a.accountId === acc.account.id)

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -14,7 +14,7 @@ import {
   DraftContent,
   Message,
   MessageThread,
-  NestedMessageAccount,
+  AuthorizedMessageAccount,
   SentMessage,
   ThreadReply,
   UnreadCountByAccount
@@ -41,7 +41,7 @@ const PAGE_SIZE = 20
 type RepliesByThread = Record<UUID, string>
 
 export interface MessagesState {
-  accounts: Result<NestedMessageAccount[]>
+  accounts: Result<AuthorizedMessageAccount[]>
   selectedDraft: DraftContent | undefined
   setSelectedDraft: (draft: DraftContent | undefined) => void
   selectedAccount: AccountView | undefined
@@ -118,7 +118,7 @@ export const MessageContextProvider = React.memo(
       () =>
         user?.accessibleFeatures.messages
           ? getMessagingAccounts()
-          : Promise.resolve(Loading.of<NestedMessageAccount[]>()),
+          : Promise.resolve(Loading.of<AuthorizedMessageAccount[]>()),
       [user]
     )
 

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -41,7 +41,7 @@ const PAGE_SIZE = 20
 type RepliesByThread = Record<UUID, string>
 
 export interface MessagesState {
-  nestedAccounts: Result<NestedMessageAccount[]>
+  accounts: Result<NestedMessageAccount[]>
   selectedDraft: DraftContent | undefined
   setSelectedDraft: (draft: DraftContent | undefined) => void
   selectedAccount: AccountView | undefined
@@ -66,7 +66,7 @@ export interface MessagesState {
 }
 
 const defaultState: MessagesState = {
-  nestedAccounts: Loading.of(),
+  accounts: Loading.of(),
   selectedDraft: undefined,
   setSelectedDraft: () => undefined,
   selectedAccount: undefined,
@@ -262,7 +262,7 @@ export const MessageContextProvider = React.memo(
 
     const value = useMemo(
       () => ({
-        nestedAccounts: accounts,
+        accounts,
         selectedDraft,
         setSelectedDraft,
         selectedAccount,

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -38,7 +38,7 @@ const PanelContainer = styled.div`
 
 export default function MessagesPage() {
   const {
-    nestedAccounts,
+    accounts,
     selectedDraft,
     setSelectedDraft,
     selectedAccount,
@@ -55,16 +55,13 @@ export default function MessagesPage() {
 
   // pre-select first account on page load and on unit change
   useEffect(() => {
-    if (!nestedAccounts.isSuccess) {
+    if (!accounts.isSuccess) {
       return
     }
-    const { value: data } = nestedAccounts
+    const { value: data } = accounts
     const unitSelectionChange =
       selectedAccount &&
-      !data.find(
-        (nestedAccount) =>
-          nestedAccount.account.id === selectedAccount.account.id
-      )
+      !data.find((acc) => acc.account.id === selectedAccount.account.id)
     if ((!selectedAccount || unitSelectionChange) && data.length > 0) {
       setSelectedAccount({
         view: 'RECEIVED',
@@ -73,7 +70,7 @@ export default function MessagesPage() {
           data[0].account
       })
     }
-  }, [nestedAccounts, setSelectedAccount, selectedAccount])
+  }, [accounts, setSelectedAccount, selectedAccount])
 
   const [showEditor, setShowEditor] = useState<boolean>(false)
 
@@ -143,7 +140,7 @@ export default function MessagesPage() {
           />
         )}
         {showEditor &&
-          nestedAccounts.isSuccess &&
+          accounts.isSuccess &&
           selectedReceivers &&
           selectedAccount &&
           selectedUnit && (
@@ -165,7 +162,7 @@ export default function MessagesPage() {
                 ...i18n.common
               }}
               initDraftRaw={initDraft}
-              nestedAccounts={nestedAccounts.value}
+              accounts={accounts.value}
               onClose={onHide}
               onDiscard={onDiscard}
               onSend={onSend}

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -16,7 +16,7 @@ import {
   SelectorNode,
   unitAsSelectorNode
 } from 'lib-components/employee/messages/SelectorNode'
-import { isNestedGroupMessageAccount } from 'lib-components/employee/messages/types'
+import { isGroupMessageAccount } from 'lib-components/employee/messages/types'
 import { fontWeights, H1 } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
@@ -44,15 +44,13 @@ const AccountContainer = styled.div`
 `
 
 const HeaderContainer = styled.div`
-  padding: 12px ${defaultMargins.m};
-  padding-top: 0px;
-  padding-bottom: 0px;
+  padding: 0 ${defaultMargins.m};
 `
 
 const DashedLine = styled.hr`
   width: 100%;
   border: 1px dashed ${colors.greyscale.medium};
-  border-top-width: 0px;
+  border-top-width: 0;
 `
 
 const AccountSection = styled.section`
@@ -87,27 +85,23 @@ const Receivers = styled.div<{ active: boolean }>`
 `
 
 interface AccountsParams {
-  nestedAccounts: NestedMessageAccount[]
+  accounts: NestedMessageAccount[]
   setSelectedReceivers: React.Dispatch<
     React.SetStateAction<SelectorNode | undefined>
   >
 }
 
-function Accounts({ nestedAccounts, setSelectedReceivers }: AccountsParams) {
+function Accounts({ accounts, setSelectedReceivers }: AccountsParams) {
   const { i18n } = useTranslation()
   const { setSelectedAccount, selectedAccount, selectedUnit, setSelectedUnit } =
     useContext(MessageContext)
 
   const [personalAccount, groupAccounts, unitOptions] = useMemo(() => {
-    const nestedPersonalAccount = nestedAccounts.find(
-      (a) => !isNestedGroupMessageAccount(a)
-    )
-    const nestedGroupAccounts = nestedAccounts.filter(
-      isNestedGroupMessageAccount
-    )
-    const unitOptions = sortBy(
+    const personal = accounts.find((a) => !isGroupMessageAccount(a))
+    const groupAccs = accounts.filter(isGroupMessageAccount)
+    const unitOpts = sortBy(
       uniqBy(
-        nestedGroupAccounts.map(({ daycareGroup }) => ({
+        groupAccs.map(({ daycareGroup }) => ({
           value: daycareGroup.unitId,
           label: daycareGroup.unitName
         })),
@@ -115,8 +109,8 @@ function Accounts({ nestedAccounts, setSelectedReceivers }: AccountsParams) {
       ),
       (u) => u.label
     )
-    return [nestedPersonalAccount, nestedGroupAccounts, unitOptions]
-  }, [nestedAccounts])
+    return [personal, groupAccs, unitOpts]
+  }, [accounts])
 
   const unitSelectionEnabled = unitOptions.length > 1
 
@@ -150,7 +144,7 @@ function Accounts({ nestedAccounts, setSelectedReceivers }: AccountsParams) {
 
   return (
     <>
-      {nestedAccounts.length === 0 && (
+      {accounts.length === 0 && (
         <NoAccounts>{i18n.messages.sidePanel.noAccountAccess}</NoAccounts>
       )}
 
@@ -185,7 +179,7 @@ function Accounts({ nestedAccounts, setSelectedReceivers }: AccountsParams) {
             </UnitSelection>
           )}
           <GroupMessageAccountList
-            nestedGroupAccounts={visibleGroupAccounts}
+            accounts={visibleGroupAccounts}
             activeView={selectedAccount}
             setView={setSelectedAccount}
           />
@@ -207,11 +201,10 @@ export default React.memo(function Sidebar({
   showEditor
 }: Props) {
   const { i18n } = useTranslation()
-  const { nestedAccounts, selectedAccount, setSelectedAccount } =
+  const { accounts, selectedAccount, setSelectedAccount } =
     useContext(MessageContext)
 
-  const newMessageEnabled =
-    nestedAccounts.isSuccess && nestedAccounts.value.length > 0
+  const newMessageEnabled = accounts.isSuccess && accounts.value.length > 0
   return (
     <Container>
       <AccountContainer>
@@ -230,9 +223,9 @@ export default React.memo(function Sidebar({
             data-qa="new-message-btn"
           />
         </HeaderContainer>
-        {renderResult(nestedAccounts, (nestedAccounts) => (
+        {renderResult(accounts, (value) => (
           <Accounts
-            nestedAccounts={nestedAccounts}
+            accounts={value}
             setSelectedReceivers={setSelectedReceivers}
           />
         ))}

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import { Result } from 'lib-common/api'
 import {
   MessageReceiversResponse,
-  NestedMessageAccount
+  AuthorizedMessageAccount
 } from 'lib-common/generated/api-types/messaging'
 import Button from 'lib-components/atoms/buttons/Button'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
@@ -85,7 +85,7 @@ const Receivers = styled.div<{ active: boolean }>`
 `
 
 interface AccountsParams {
-  accounts: NestedMessageAccount[]
+  accounts: AuthorizedMessageAccount[]
   setSelectedReceivers: React.Dispatch<
     React.SetStateAction<SelectorNode | undefined>
   >

--- a/frontend/src/employee-frontend/components/messages/api.ts
+++ b/frontend/src/employee-frontend/components/messages/api.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -11,7 +11,7 @@ import {
   DraftContent,
   MessageReceiversResponse,
   MessageThread,
-  NestedMessageAccount,
+  AuthorizedMessageAccount,
   PostMessageBody,
   ReplyToMessageBody,
   SentMessage,
@@ -46,10 +46,10 @@ export async function getReceivers(
 }
 
 export async function getMessagingAccounts(): Promise<
-  Result<NestedMessageAccount[]>
+  Result<AuthorizedMessageAccount[]>
 > {
   return client
-    .get<JsonOf<NestedMessageAccount[]>>('/messages/my-accounts')
+    .get<JsonOf<AuthorizedMessageAccount[]>>('/messages/my-accounts')
     .then(({ data }) => Success.of(data))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-mobile-frontend/api/messages.ts
+++ b/frontend/src/employee-mobile-frontend/api/messages.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -10,7 +10,7 @@ import {
 import {
   MessageReceiversResponse,
   MessageThread,
-  NestedMessageAccount,
+  AuthorizedMessageAccount,
   PostMessageBody,
   ReplyToMessageBody,
   ThreadReply,
@@ -26,9 +26,9 @@ import { client } from './client'
 
 export async function getMessagingAccounts(
   unitId: UUID
-): Promise<Result<NestedMessageAccount[]>> {
+): Promise<Result<AuthorizedMessageAccount[]>> {
   return client
-    .get<JsonOf<NestedMessageAccount[]>>(
+    .get<JsonOf<AuthorizedMessageAccount[]>>(
       `/messages/mobile/my-accounts/${unitId}`
     )
     .then(({ data }) => Success.of(data))

--- a/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -48,8 +48,7 @@ export default function MessageEditorPage() {
 
   const history = useHistory()
 
-  const { nestedAccounts, selectedAccount, selectedUnit } =
-    useContext(MessageContext)
+  const { accounts, selectedAccount, selectedUnit } = useContext(MessageContext)
 
   const [sending, setSending] = useState(false)
 
@@ -98,7 +97,7 @@ export default function MessageEditorPage() {
     history.goBack()
   }, [history])
 
-  return renderResult(nestedAccounts, (accounts) =>
+  return renderResult(accounts, (accounts) =>
     selectedReceivers && selectedAccount && selectedUnit ? (
       <MessageEditor
         availableReceivers={selectedReceivers}
@@ -119,7 +118,7 @@ export default function MessageEditorPage() {
         }}
         initDraftRaw={initDraft}
         mobileVersion={true}
-        nestedAccounts={accounts}
+        accounts={accounts}
         onClose={onHide}
         onDiscard={onDiscard}
         onSend={onSend}

--- a/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
@@ -9,7 +9,7 @@ import { formatDateOrTime } from 'lib-common/date'
 import {
   Message,
   MessageThread,
-  NestedMessageAccount
+  AuthorizedMessageAccount
 } from 'lib-common/generated/api-types/messaging'
 import { UUID } from 'lib-common/types'
 import TextArea from 'lib-components/atoms/form/TextArea'
@@ -31,7 +31,7 @@ interface ThreadViewProps {
 
 const getAccountsInThread = (
   messages: Message[],
-  accounts: NestedMessageAccount[]
+  accounts: AuthorizedMessageAccount[]
 ) => {
   const allRecipients = messages.flatMap((m) => m.recipients)
 

--- a/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -31,11 +31,11 @@ interface ThreadViewProps {
 
 const getAccountsInThread = (
   messages: Message[],
-  groupAccounts: NestedMessageAccount[]
+  accounts: NestedMessageAccount[]
 ) => {
   const allRecipients = messages.flatMap((m) => m.recipients)
 
-  return groupAccounts.filter(({ account }) =>
+  return accounts.filter(({ account }) =>
     allRecipients.some((r) => r.id === account.id)
   )
 }

--- a/frontend/src/employee-mobile-frontend/state/messages.tsx
+++ b/frontend/src/employee-mobile-frontend/state/messages.tsx
@@ -15,7 +15,7 @@ import { Loading, Paged, Result } from 'lib-common/api'
 import {
   Message,
   MessageThread,
-  NestedMessageAccount,
+  AuthorizedMessageAccount,
   ThreadReply
 } from 'lib-common/generated/api-types/messaging'
 import { UUID } from 'lib-common/types'
@@ -49,14 +49,14 @@ const appendMessageAndMoveThreadToTopOfList =
     })
 
 export interface MessagesState {
-  accounts: Result<NestedMessageAccount[]>
+  accounts: Result<AuthorizedMessageAccount[]>
   loadAccounts: (unitId: UUID) => void
   page: number
   setPage: (page: number) => void
   pages: number | undefined
   setPages: (pages: number) => void
-  groupAccounts: NestedMessageAccount[]
-  selectedAccount: NestedMessageAccount | undefined
+  groupAccounts: AuthorizedMessageAccount[]
+  selectedAccount: AuthorizedMessageAccount | undefined
   receivedMessages: Result<MessageThread[]>
   selectedUnit: SelectOption | undefined
   selectedThread: MessageThread | undefined
@@ -104,9 +104,9 @@ export const MessageContextProvider = React.memo(
       [unitInfoResponse]
     )
 
-    const [accounts, setAccounts] = useState<Result<NestedMessageAccount[]>>(
-      Loading.of()
-    )
+    const [accounts, setAccounts] = useState<
+      Result<AuthorizedMessageAccount[]>
+    >(Loading.of())
 
     const getAccounts = useRestApi(getMessagingAccounts, setAccounts)
 
@@ -121,7 +121,7 @@ export const MessageContextProvider = React.memo(
       if (unitId && hasPinLogin) loadAccounts(unitId)
     }, [loadAccounts, unitId, user])
 
-    const groupAccounts: NestedMessageAccount[] = useMemo(() => {
+    const groupAccounts: AuthorizedMessageAccount[] = useMemo(() => {
       return accounts
         .map((acc) =>
           acc.filter(
@@ -132,7 +132,7 @@ export const MessageContextProvider = React.memo(
         .getOrElse([])
     }, [accounts, unitId])
 
-    const selectedAccount: NestedMessageAccount = useMemo(() => {
+    const selectedAccount: AuthorizedMessageAccount = useMemo(() => {
       return (
         groupAccounts.find(
           ({ daycareGroup }) => daycareGroup?.id === groupId

--- a/frontend/src/employee-mobile-frontend/state/messages.tsx
+++ b/frontend/src/employee-mobile-frontend/state/messages.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -49,8 +49,8 @@ const appendMessageAndMoveThreadToTopOfList =
     })
 
 export interface MessagesState {
-  nestedAccounts: Result<NestedMessageAccount[]>
-  loadNestedAccounts: (unitId: UUID) => void
+  accounts: Result<NestedMessageAccount[]>
+  loadAccounts: (unitId: UUID) => void
   page: number
   setPage: (page: number) => void
   pages: number | undefined
@@ -68,8 +68,8 @@ export interface MessagesState {
 }
 
 const defaultState: MessagesState = {
-  nestedAccounts: Loading.of(),
-  loadNestedAccounts: () => undefined,
+  accounts: Loading.of(),
+  loadAccounts: () => undefined,
   page: 1,
   setPage: () => undefined,
   pages: undefined,
@@ -104,16 +104,13 @@ export const MessageContextProvider = React.memo(
       [unitInfoResponse]
     )
 
-    const [nestedAccounts, setNestedMessagingAccounts] = useState<
-      Result<NestedMessageAccount[]>
-    >(Loading.of())
-
-    const getNestedAccounts = useRestApi(
-      getMessagingAccounts,
-      setNestedMessagingAccounts
+    const [accounts, setAccounts] = useState<Result<NestedMessageAccount[]>>(
+      Loading.of()
     )
 
-    const [loadNestedAccounts] = useDebouncedCallback(getNestedAccounts, 100)
+    const getAccounts = useRestApi(getMessagingAccounts, setAccounts)
+
+    const [loadAccounts] = useDebouncedCallback(getAccounts, 100)
 
     const { groupId } = useParams<{
       groupId: UUID | 'all'
@@ -121,19 +118,19 @@ export const MessageContextProvider = React.memo(
 
     useEffect(() => {
       const hasPinLogin = user.map((u) => u?.pinLoginActive).getOrElse(false)
-      if (unitId && hasPinLogin) loadNestedAccounts(unitId)
-    }, [loadNestedAccounts, unitId, user])
+      if (unitId && hasPinLogin) loadAccounts(unitId)
+    }, [loadAccounts, unitId, user])
 
     const groupAccounts: NestedMessageAccount[] = useMemo(() => {
-      return nestedAccounts
-        .map((nested) =>
-          nested.filter(
+      return accounts
+        .map((acc) =>
+          acc.filter(
             ({ account, daycareGroup }) =>
               account.type === 'GROUP' && daycareGroup?.unitId === unitId
           )
         )
         .getOrElse([])
-    }, [nestedAccounts, unitId])
+    }, [accounts, unitId])
 
     const selectedAccount: NestedMessageAccount = useMemo(() => {
       return (
@@ -219,8 +216,8 @@ export const MessageContextProvider = React.memo(
 
     const value = useMemo(
       () => ({
-        nestedAccounts,
-        loadNestedAccounts,
+        accounts,
+        loadAccounts,
         selectedAccount,
         groupAccounts,
         page,
@@ -237,8 +234,8 @@ export const MessageContextProvider = React.memo(
         replyState
       }),
       [
-        nestedAccounts,
-        loadNestedAccounts,
+        accounts,
+        loadAccounts,
         groupAccounts,
         selectedAccount,
         page,

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -18,6 +18,14 @@ export type AccountType =
   | 'CITIZEN'
 
 /**
+* Generated from fi.espoo.evaka.messaging.AuthorizedMessageAccount
+*/
+export interface AuthorizedMessageAccount {
+  account: MessageAccount
+  daycareGroup: Group | null
+}
+
+/**
 * Generated from fi.espoo.evaka.messaging.CitizenMessageBody
 */
 export interface CitizenMessageBody {
@@ -125,14 +133,6 @@ export interface MessageThread {
 export type MessageType = 
   | 'MESSAGE'
   | 'BULLETIN'
-
-/**
-* Generated from fi.espoo.evaka.messaging.NestedMessageAccount
-*/
-export interface NestedMessageAccount {
-  account: MessageAccount
-  daycareGroup: Group | null
-}
 
 /**
 * Generated from fi.espoo.evaka.messaging.MessageController.PostMessageBody

--- a/frontend/src/lib-components/employee/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/employee/messages/MessageEditor.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -34,7 +34,7 @@ import {
   updateSelector
 } from 'lib-components/employee/messages/SelectorNode'
 import {
-  isNestedGroupMessageAccount,
+  isGroupMessageAccount,
   SaveDraftParams
 } from 'lib-components/employee/messages/types'
 import { Draft, useDraft } from 'lib-components/employee/messages/useDraft'
@@ -125,7 +125,7 @@ interface Props {
   i18n: MessageEditorI18n & FileUploadI18n
   initDraftRaw: (accountId: string) => Promise<Result<string>>
   mobileVersion?: boolean
-  nestedAccounts: NestedMessageAccount[]
+  accounts: NestedMessageAccount[]
   onClose: (didChanges: boolean) => void
   onDiscard: (accountId: UUID, draftId: UUID) => void
   onSend: (accountId: UUID, msg: PostMessageBody) => void
@@ -149,7 +149,7 @@ export default React.memo(function MessageEditor({
   i18n,
   initDraftRaw,
   mobileVersion = false,
-  nestedAccounts,
+  accounts,
   onClose,
   onDiscard,
   onSend,
@@ -246,13 +246,13 @@ export default React.memo(function MessageEditor({
   )
   useEffect(
     function updateReceiversOnSenderChange() {
-      const nestedAccount = nestedAccounts.find(
+      const acc = accounts.find(
         (account) => account.account.id === message.sender.value
       )
-      if (!nestedAccount) {
+      if (!acc) {
         throw new Error('Selected sender was not found in accounts')
       }
-      if (!isNestedGroupMessageAccount(nestedAccount)) {
+      if (!isGroupMessageAccount(acc)) {
         setReceiverTree((previousReceivers) =>
           getSelectedBottomElements(previousReceivers).reduce(
             (acc, id) =>
@@ -261,7 +261,7 @@ export default React.memo(function MessageEditor({
           )
         )
       } else {
-        const groupId = nestedAccount.daycareGroup.id
+        const groupId = acc.daycareGroup.id
         const selection = getSubTree(availableReceivers, groupId)
         if (selection) {
           setReceiverTree((previousReceivers) =>
@@ -274,7 +274,7 @@ export default React.memo(function MessageEditor({
         }
       }
     },
-    [message.sender, nestedAccounts, availableReceivers]
+    [message.sender, accounts, availableReceivers]
   )
 
   const debouncedSaveStatus = useDebounce(saveStatus, 250)
@@ -339,22 +339,19 @@ export default React.memo(function MessageEditor({
 
   const senderOptions = useMemo(
     () =>
-      nestedAccounts
+      accounts
         .filter(
-          (nestedAccount: NestedMessageAccount) =>
-            !isNestedGroupMessageAccount(nestedAccount) ||
-            (isNestedGroupMessageAccount(nestedAccount) &&
-              !!getSelectorName(
-                nestedAccount.daycareGroup.id,
-                availableReceivers
-              ) &&
-              nestedAccount.daycareGroup.unitId === selectedUnit.value)
+          (acc: NestedMessageAccount) =>
+            !isGroupMessageAccount(acc) ||
+            (isGroupMessageAccount(acc) &&
+              !!getSelectorName(acc.daycareGroup.id, availableReceivers) &&
+              acc.daycareGroup.unitId === selectedUnit.value)
         )
-        .map((nestedAccount: NestedMessageAccount) => ({
-          value: nestedAccount.account.id,
-          label: nestedAccount.account.name
+        .map(({ account: { id, name } }: NestedMessageAccount) => ({
+          value: id,
+          label: name
         })),
-    [nestedAccounts, availableReceivers, selectedUnit.value]
+    [accounts, availableReceivers, selectedUnit.value]
   )
 
   const sendEnabled =

--- a/frontend/src/lib-components/employee/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/employee/messages/MessageEditor.tsx
@@ -10,7 +10,7 @@ import { Attachment } from 'lib-common/api-types/attachment'
 import { UpdateStateFn } from 'lib-common/form-state'
 import {
   DraftContent,
-  NestedMessageAccount,
+  AuthorizedMessageAccount,
   PostMessageBody,
   UpsertableDraftContent
 } from 'lib-common/generated/api-types/messaging'
@@ -125,7 +125,7 @@ interface Props {
   i18n: MessageEditorI18n & FileUploadI18n
   initDraftRaw: (accountId: string) => Promise<Result<string>>
   mobileVersion?: boolean
-  accounts: NestedMessageAccount[]
+  accounts: AuthorizedMessageAccount[]
   onClose: (didChanges: boolean) => void
   onDiscard: (accountId: UUID, draftId: UUID) => void
   onSend: (accountId: UUID, msg: PostMessageBody) => void
@@ -341,13 +341,13 @@ export default React.memo(function MessageEditor({
     () =>
       accounts
         .filter(
-          (acc: NestedMessageAccount) =>
+          (acc: AuthorizedMessageAccount) =>
             !isGroupMessageAccount(acc) ||
             (isGroupMessageAccount(acc) &&
               !!getSelectorName(acc.daycareGroup.id, availableReceivers) &&
               acc.daycareGroup.unitId === selectedUnit.value)
         )
-        .map(({ account: { id, name } }: NestedMessageAccount) => ({
+        .map(({ account: { id, name } }: AuthorizedMessageAccount) => ({
           value: id,
           label: name
         })),

--- a/frontend/src/lib-components/employee/messages/types.ts
+++ b/frontend/src/lib-components/employee/messages/types.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -12,14 +12,14 @@ import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
-export interface NestedGroupMessageAccount extends NestedMessageAccount {
+export interface GroupMessageAccount extends NestedMessageAccount {
   daycareGroup: Group
 }
 
-export const isNestedGroupMessageAccount = (
-  nestedAccount: NestedMessageAccount
-): nestedAccount is NestedGroupMessageAccount =>
-  nestedAccount.account.type === 'GROUP' && nestedAccount.daycareGroup != null
+export const isGroupMessageAccount = (
+  acc: NestedMessageAccount
+): acc is GroupMessageAccount =>
+  acc.account.type === 'GROUP' && acc.daycareGroup !== null
 
 export interface SaveDraftParams {
   accountId: UUID

--- a/frontend/src/lib-components/employee/messages/types.ts
+++ b/frontend/src/lib-components/employee/messages/types.ts
@@ -5,19 +5,19 @@
 import {
   Group,
   MessageReceiver,
-  NestedMessageAccount,
+  AuthorizedMessageAccount,
   UpsertableDraftContent
 } from 'lib-common/generated/api-types/messaging'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
-export interface GroupMessageAccount extends NestedMessageAccount {
+export interface GroupMessageAccount extends AuthorizedMessageAccount {
   daycareGroup: Group
 }
 
 export const isGroupMessageAccount = (
-  acc: NestedMessageAccount
+  acc: AuthorizedMessageAccount
 ): acc is GroupMessageAccount =>
   acc.account.type === 'GROUP' && acc.daycareGroup !== null
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -95,7 +95,7 @@ class MessageAccountQueriesTest : PureJdbiTest() {
         val accounts = db.transaction { it.getEmployeeMessageAccountIds(supervisorId) }
         assertEquals(3, accounts.size)
 
-        val accounts2 = db.read { it.getEmployeeNestedMessageAccounts(supervisorId) }
+        val accounts2 = db.read { it.getAuthorizedMessageAccountsForEmployee(supervisorId) }
         assertEquals(3, accounts2.size)
         val personalAccount =
             accounts2.find { it.account.type === AccountType.PERSONAL } ?: throw Error("Personal account not found")
@@ -123,7 +123,7 @@ class MessageAccountQueriesTest : PureJdbiTest() {
         val accounts = db.transaction { it.getEmployeeMessageAccountIds(employee1Id) }
         assertEquals(1, accounts.size)
 
-        val accounts2 = db.read { it.getEmployeeNestedMessageAccounts(employee1Id) }
+        val accounts2 = db.read { it.getAuthorizedMessageAccountsForEmployee(employee1Id) }
         assertEquals(1, accounts2.size)
         assertNull(accounts2.find { it.account.type === AccountType.PERSONAL })
 
@@ -139,7 +139,7 @@ class MessageAccountQueriesTest : PureJdbiTest() {
         val accounts = db.transaction { it.getEmployeeMessageAccountIds(employee2Id) }
         assertEquals(0, accounts.size)
 
-        val accounts2 = db.read { it.getEmployeeNestedMessageAccounts(employee2Id) }
+        val accounts2 = db.read { it.getAuthorizedMessageAccountsForEmployee(employee2Id) }
         assertEquals(0, accounts2.size)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
@@ -89,7 +89,7 @@ data class Group(
     val unitName: String,
 )
 
-data class NestedMessageAccount(
+data class AuthorizedMessageAccount(
     @Nested("account_")
     val account: MessageAccount,
     @Nested("group_")

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageAccountQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageAccountQueries.kt
@@ -41,7 +41,7 @@ fun Database.Read.getEmployeeMessageAccountIds(employeeId: EmployeeId): Set<Mess
         .toSet()
 }
 
-fun Database.Read.getEmployeeNestedMessageAccounts(employeeId: EmployeeId): Set<NestedMessageAccount> {
+fun Database.Read.getAuthorizedMessageAccountsForEmployee(employeeId: EmployeeId): Set<AuthorizedMessageAccount> {
     val accountIds = getEmployeeMessageAccountIds(employeeId)
 
     val sql = """
@@ -66,7 +66,7 @@ AND (
 """
     return this.createQuery(sql)
         .bind("accountIds", accountIds.toTypedArray())
-        .mapTo<NestedMessageAccount>()
+        .mapTo<AuthorizedMessageAccount>()
         .toSet()
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -49,10 +49,10 @@ class MessageController(
     private val messageService = MessageService(messageNotificationEmailService)
 
     @GetMapping("/my-accounts")
-    fun getAccountsByUser(db: Database, user: AuthenticatedUser): Set<NestedMessageAccount> {
+    fun getAccountsByUser(db: Database, user: AuthenticatedUser): Set<AuthorizedMessageAccount> {
         Audit.MessagingMyAccountsRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_USER_MESSAGE_ACCOUNTS)
-        return db.connect { dbc -> dbc.read { it.getEmployeeNestedMessageAccounts(EmployeeId(user.id)) } }
+        return db.connect { dbc -> dbc.read { it.getAuthorizedMessageAccountsForEmployee(EmployeeId(user.id)) } }
     }
 
     @GetMapping("/mobile/my-accounts/{unitId}")
@@ -60,12 +60,12 @@ class MessageController(
         db: Database,
         user: AuthenticatedUser,
         @PathVariable unitId: DaycareId
-    ): Set<NestedMessageAccount> {
+    ): Set<AuthorizedMessageAccount> {
         Audit.MessagingMyAccountsRead.log()
         @Suppress("DEPRECATION")
         acl.getRolesForUnit(user, unitId).requireOneOfRoles(UserRole.MOBILE)
         return if (user is AuthenticatedUser.MobileDevice && user.employeeId != null) {
-            db.connect { dbc -> dbc.read { it.getEmployeeNestedMessageAccounts(user.employeeId) } }
+            db.connect { dbc -> dbc.read { it.getAuthorizedMessageAccountsForEmployee(user.employeeId) } }
         } else setOf()
     }
 


### PR DESCRIPTION
#### Summary
- Remove `nested` prefix from all property and variable names
- Rename `NestedMessageAccount` interface to `AuthorizedMessageAccount`