### PR TITLE
EVAKA-4385 update input info visuals

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -30,9 +30,7 @@ import { useLang, useTranslation } from '../../../localization'
 import { ServiceNeedSectionProps } from './ServiceNeedSection'
 
 const Hyphenbox = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+  padding-top: 36px;
 `
 
 type ServiceTimeSubSectionProps = Omit<ServiceNeedSectionProps, 'type'>
@@ -202,7 +200,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
 
           <Gap size="s" />
 
-          <FixedSpaceRow spacing="m">
+          <FixedSpaceRow spacing="s">
             <FixedSpaceColumn spacing="xs">
               <Label htmlFor="daily-time-starts">
                 {t.applications.editor.serviceNeed.dailyTime.starts}
@@ -217,7 +215,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
               />
             </FixedSpaceColumn>
 
-            <Hyphenbox>-</Hyphenbox>
+            <Hyphenbox>–</Hyphenbox>
 
             <FixedSpaceColumn spacing="xs">
               <Label htmlFor="daily-time-ends">

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -27,9 +27,7 @@ import { useTranslation } from '../../../localization'
 import { ServiceNeedSectionProps } from './ServiceNeedSection'
 
 const Hyphenbox = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+  padding-top: 36px;
 `
 
 type ServiceTimeSubSectionProps = Omit<ServiceNeedSectionProps, 'type'>
@@ -137,7 +135,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
               />
             </FixedSpaceColumn>
 
-            <Hyphenbox>-</Hyphenbox>
+            <Hyphenbox>–</Hyphenbox>
 
             <FixedSpaceColumn spacing="xs">
               <Label htmlFor="daily-time-ends">

--- a/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkDeparted.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkDeparted.tsx
@@ -174,6 +174,7 @@ export default React.memo(function MarkDeparted() {
                   }
                 />
               </TimeWrapper>
+              <Gap size="xs" />
               {child && absentFrom.length > 0 ? (
                 <FixedSpaceColumn>
                   <AbsentFrom child={child} absentFrom={absentFrom} />

--- a/frontend/src/employee-mobile-frontend/components/attendances/components.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/components.tsx
@@ -116,7 +116,7 @@ export const TimeWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  font-size: 20px;
+  font-size: 60px;
   color: ${colors.main.dark};
   font-weight: ${fontWeights.semibold};
 

--- a/frontend/src/lib-components/atoms/form/InputField.tsx
+++ b/frontend/src/lib-components/atoms/form/InputField.tsx
@@ -60,7 +60,6 @@ export const StyledInput = styled.input<StyledInputProps>`
 
   &::placeholder {
     color: ${({ theme: { colors } }) => colors.greyscale.dark};
-    font-size: 15px;
     font-family: 'Open Sans', 'Arial', sans-serif;
   }
 
@@ -121,14 +120,13 @@ const InputIcon = styled.div`
 
 export const InputFieldUnderRow = styled.div`
   height: 16px;
-  padding: 0 12px;
   margin-top: ${defaultMargins.xxs};
   margin-bottom: -20px;
   display: flex;
   align-items: center;
   justify-content: flex-start;
 
-  font-size: 12px;
+  font-size: 1rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -141,7 +139,7 @@ export const InputFieldUnderRow = styled.div`
   }
 
   &.warning {
-    color: ${({ theme: { colors } }) => colors.accents.warningOrange};
+    color: ${({ theme: { colors } }) => colors.accents.orangeDark};
   }
 `
 

--- a/frontend/src/lib-components/atoms/form/InputField.tsx
+++ b/frontend/src/lib-components/atoms/form/InputField.tsx
@@ -6,111 +6,150 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import classNames from 'classnames'
 import React, { HTMLAttributes, RefObject, useState } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { faTimes } from 'lib-icons'
 import { tabletMin } from '../../breakpoints'
 import { BaseProps } from '../../utils'
 import { defaultMargins } from '../../white-space'
 import UnderRowStatusIcon, { InfoStatus } from '../StatusIcon'
+import IconButton from '../buttons/IconButton'
 
-const Wrapper = styled.div`
-  display: inline-block;
-  min-width: 0; // needed for correct overflow behavior
-`
-
-type InputWidth = 'xs' | 's' | 'm' | 'L' | 'XL' | 'full'
-
-const inputWidths: Record<InputWidth, string> = {
+const inputWidths = {
   xs: '60px',
   s: '120px',
   m: '240px',
   L: '480px',
   XL: '720px',
   full: '100%'
-}
+} as const
 
-interface StyledInputProps {
-  width: InputWidth
-  clearable: boolean
-  align?: 'left' | 'right'
-}
-export const StyledInput = styled.input<StyledInputProps>`
-  width: ${(p) => inputWidths[p.width]};
+type InputWidth = keyof typeof inputWidths
+
+const width = (width: InputWidth) => css`
+  width: ${inputWidths[width]};
+  max-width: ${inputWidths[width]};
 
   @media (max-width: ${tabletMin}) {
-    ${(p) => (p.width === 'L' || p.width === 'XL' ? 'width: 100%;' : '')}
+    ${width === 'L' || width === 'XL'
+      ? css`
+          width: 100%;
+          max-width: 100%;
+        `
+      : ''}
   }
 
   @media (max-width: 700px) {
-    ${(p) => (p.width === 'XL' ? 'width: 100%; min-width: 100%;' : '')}
+    ${width === 'XL'
+      ? css`
+          width: 100%;
+          max-width: 100%;
+        `
+      : ''}
   }
+`
 
-  border-style: none none solid none;
-  border-width: 1px;
-  border-color: ${({ theme: { colors } }) => colors.greyscale.dark};
-  border-radius: 2px;
+const Wrapper = styled.div<{ width: InputWidth }>`
+  position: relative;
+  display: inline-block;
+  min-width: 0; // needed for correct overflow behavior
+  ${(p) => width(p.width)}
+`
+
+interface StyledInputProps {
+  width: InputWidth
+  align?: 'left' | 'right'
+  icon?: boolean
+}
+
+export const StyledInput = styled.input<StyledInputProps>`
+  ${(p) => width(p.width)}
+  margin: 0;
+  border: none;
+  border-top: 2px solid transparent;
+  border-bottom: 1px solid ${({ theme: { colors } }) => colors.greyscale.dark};
+  border-radius: 0;
   outline: none;
-  box-sizing: border-box;
   text-align: ${(p) => p.align ?? 'left'};
   background-color: ${({ theme: { colors } }) => colors.greyscale.white};
-
   font-size: 1rem;
   color: ${({ theme: { colors } }) => colors.greyscale.darkest};
-  padding: 6px ${(p) => (p.clearable ? '36px' : '12px')} 6px 12px;
+  padding: 6px 10px;
+  ${({ icon }) =>
+    icon
+      ? css`
+          padding-right: calc(10px + 1rem + 12px);
+        `
+      : ''}
 
   &::placeholder {
     color: ${({ theme: { colors } }) => colors.greyscale.dark};
     font-family: 'Open Sans', 'Arial', sans-serif;
   }
 
-  &:focus {
-    border-width: 2px;
-    border-style: solid;
-    border-color: ${({ theme: { colors } }) => colors.main.primaryFocus};
-    margin-top: -2px;
-    margin-bottom: -1px;
-    padding-${(p) => (p.align === 'right' ? 'right' : 'left')}: 10px;
-  }
-
+  &:focus,
   &.success,
   &.warning {
-    border-width: 2px;
+    border-bottom-width: 2px;
     margin-bottom: -1px;
-    &:focus {
-      margin-bottom: -1px;
-    }
+  }
+
+  &:focus {
+    border: 2px solid ${({ theme: { colors } }) => colors.main.primaryFocus};
+    border-radius: 2px;
+    padding-left: 8px;
+    padding-right: 8px;
+    ${({ icon }) =>
+      icon
+        ? css`
+            padding-right: calc(8px + 1rem + 12px);
+          `
+        : ''}
   }
 
   &.success {
-    border-color: ${({ theme: { colors } }) => colors.accents.successGreen};
+    border-bottom-color: ${({ theme: { colors } }) =>
+      colors.accents.successGreen};
+
+    &:focus {
+      border-color: ${({ theme: { colors } }) => colors.accents.successGreen};
+    }
   }
 
   &.warning {
-    border-color: ${({ theme: { colors } }) => colors.accents.warningOrange};
+    border-bottom-color: ${({ theme: { colors } }) =>
+      colors.accents.warningOrange};
+
+    &:focus {
+      border-color: ${({ theme: { colors } }) => colors.accents.warningOrange};
+    }
   }
 
   &:read-only {
-    border-bottom-style: dotted;
+    border-bottom-style: dashed;
     color: ${({ theme: { colors } }) => colors.greyscale.dark};
     background: none;
   }
 `
 
-export const InputRow = styled.div`
-  position: relative;
-  width: 100%;
-`
-
-const InputIcon = styled.div`
-  font-size: 20px;
+const IconContainer = styled.div<{ clickable: boolean }>`
   position: absolute;
-  right: 8px;
+  right: 12px;
   top: 0;
   bottom: 0;
   display: flex;
-  align-items: center;
   justify-content: center;
-  cursor: pointer;
+  align-items: center;
+  font-size: 1rem;
+
+  ${(p) =>
+    !p.clickable
+      ? css`
+          pointer-events: none;
+        `
+      : ''}
+`
+
+const StyledIconButton = styled(IconButton)`
   color: ${({ theme: { colors } }) => colors.greyscale.dark};
 
   &:hover {
@@ -119,18 +158,12 @@ const InputIcon = styled.div`
 `
 
 export const InputFieldUnderRow = styled.div`
-  height: 16px;
-  margin-top: ${defaultMargins.xxs};
-  margin-bottom: -20px;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: flex-start;
-
   font-size: 1rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  width: fit-content;
+  line-height: 1rem;
+  margin-top: ${defaultMargins.xxs};
 
   color: ${({ theme: { colors } }) => colors.greyscale.dark};
 
@@ -141,10 +174,6 @@ export const InputFieldUnderRow = styled.div`
   &.warning {
     color: ${({ theme: { colors } }) => colors.accents.orangeDark};
   }
-`
-
-const Symbol = styled.span`
-  margin-left: ${defaultMargins.xxs};
 `
 
 export type InputInfo = {
@@ -214,8 +243,7 @@ export default React.memo(function InputField({
   inputRef,
   'aria-describedby': ariaId,
   required,
-  autoFocus,
-  wrapperClassName = undefined
+  autoFocus
 }: TextInputProps) {
   const [touched, setTouched] = useState(false)
 
@@ -224,54 +252,58 @@ export default React.memo(function InputField({
   const infoText = hideError ? undefined : info?.text
   const infoStatus = hideError ? undefined : info?.status
 
+  const showIcon = !!(clearable || icon || symbol)
+
   return (
-    <Wrapper className={wrapperClassName}>
-      <InputRow>
-        <StyledInput
-          autoComplete={autoComplete}
-          value={value}
-          onChange={(e) => {
-            e.preventDefault()
-            if (onChange && !readonly) onChange(e.target.value)
-          }}
-          onFocus={onFocus}
-          onBlur={(e) => {
-            setTouched(true)
-            onBlur && onBlur(e)
-          }}
-          onKeyPress={onKeyPress}
-          placeholder={placeholder}
-          readOnly={readonly}
-          disabled={readonly}
-          width={width}
-          clearable={clearable}
-          inputMode={inputMode}
-          align={align}
-          className={classNames(className, infoStatus)}
-          data-qa={dataQa}
-          type={type}
-          min={min}
-          max={max}
-          maxLength={maxLength}
-          step={step}
-          id={id}
-          aria-describedby={ariaId}
-          required={required ?? false}
-          ref={inputRef}
-          autoFocus={autoFocus}
-        />
-        {clearable && (
-          <InputIcon onClick={() => onChange && onChange('')}>
-            <FontAwesomeIcon icon={faTimes} />
-          </InputIcon>
-        )}
-        {!clearable && icon && (
-          <InputIcon>
+    <Wrapper className={className} width={width}>
+      <StyledInput
+        autoComplete={autoComplete}
+        value={value}
+        onChange={(e) => {
+          e.preventDefault()
+          if (onChange && !readonly) onChange(e.target.value)
+        }}
+        onFocus={onFocus}
+        onBlur={(e) => {
+          setTouched(true)
+          onBlur && onBlur(e)
+        }}
+        onKeyPress={onKeyPress}
+        placeholder={placeholder}
+        readOnly={readonly}
+        disabled={readonly}
+        width={width}
+        icon={showIcon}
+        inputMode={inputMode}
+        align={align}
+        className={classNames(className, infoStatus)}
+        data-qa={dataQa}
+        type={type}
+        min={min}
+        max={max}
+        maxLength={maxLength}
+        step={step}
+        id={id}
+        aria-describedby={ariaId}
+        required={required ?? false}
+        ref={inputRef}
+        autoFocus={autoFocus}
+      />
+      {showIcon && (
+        <IconContainer clickable={clearable}>
+          {clearable ? (
+            <StyledIconButton
+              icon={faTimes}
+              onClick={() => onChange && onChange('')}
+              altText="clear"
+            />
+          ) : icon ? (
             <FontAwesomeIcon icon={icon} />
-          </InputIcon>
-        )}
-        {!clearable && !icon && symbol ? <Symbol>{symbol}</Symbol> : null}
-      </InputRow>
+          ) : (
+            symbol
+          )}
+        </IconContainer>
+      )}
       {infoText && (
         <InputFieldUnderRow className={classNames(infoStatus)}>
           <span data-qa={dataQa ? `${dataQa}-info` : undefined}>

--- a/frontend/src/lib-components/atoms/form/TextArea.tsx
+++ b/frontend/src/lib-components/atoms/form/TextArea.tsx
@@ -156,8 +156,8 @@ const StyledTextArea = styled(TextareaAutosize)`
   }
 
   &.success {
-    border-bottom: 2px solid
-      ${({ theme: { colors } }) => colors.accents.successGreen};
+    border-bottom-color: ${({ theme: { colors } }) =>
+      colors.accents.successGreen};
 
     &:focus {
       border-color: ${({ theme: { colors } }) => colors.accents.successGreen};
@@ -165,8 +165,8 @@ const StyledTextArea = styled(TextareaAutosize)`
   }
 
   &.warning {
-    border-bottom: 2px solid
-      ${({ theme: { colors } }) => colors.accents.warningOrange};
+    border-bottom-color: ${({ theme: { colors } }) =>
+      colors.accents.warningOrange};
 
     &:focus {
       border-color: ${({ theme: { colors } }) => colors.accents.warningOrange};

--- a/frontend/src/lib-components/atoms/form/TextArea.tsx
+++ b/frontend/src/lib-components/atoms/form/TextArea.tsx
@@ -8,7 +8,7 @@ import TextareaAutosize from 'react-autosize-textarea'
 import styled from 'styled-components'
 import { BaseProps } from '../../utils'
 import UnderRowStatusIcon from '../StatusIcon'
-import { InputFieldUnderRow, InputInfo, InputRow } from './InputField'
+import { InputFieldUnderRow, InputInfo } from './InputField'
 
 interface TextAreaInputProps extends BaseProps {
   value: string
@@ -74,31 +74,29 @@ export default React.memo(function TextArea({
 
   return (
     <div className={wrapperClassName}>
-      <InputRow>
-        <StyledTextArea
-          value={value}
-          onChange={handleChange}
-          onFocus={onFocus}
-          onBlur={(e) => {
-            setTouched(true)
-            onBlur && onBlur(e)
-          }}
-          onKeyPress={onKeyPress}
-          placeholder={placeholder}
-          readOnly={readonly}
-          disabled={readonly}
-          maxLength={maxLength}
-          type={type}
-          autoFocus={autoFocus}
-          className={classNames(className, infoStatus)}
-          data-qa={dataQa}
-          id={id}
-          aria-describedby={ariaId}
-          required={required ?? false}
-          ref={inputRef}
-          rows={rows}
-        />
-      </InputRow>
+      <StyledTextArea
+        value={value}
+        onChange={handleChange}
+        onFocus={onFocus}
+        onBlur={(e) => {
+          setTouched(true)
+          onBlur && onBlur(e)
+        }}
+        onKeyPress={onKeyPress}
+        placeholder={placeholder}
+        readOnly={readonly}
+        disabled={readonly}
+        maxLength={maxLength}
+        type={type}
+        autoFocus={autoFocus}
+        className={classNames(className, infoStatus)}
+        data-qa={dataQa}
+        id={id}
+        aria-describedby={ariaId}
+        required={required ?? false}
+        ref={inputRef}
+        rows={rows}
+      />
       {infoText && (
         <InputFieldUnderRow className={classNames(infoStatus)}>
           <span data-qa={dataQa ? `${dataQa}-info` : undefined}>
@@ -114,14 +112,12 @@ export default React.memo(function TextArea({
 const StyledTextArea = styled(TextareaAutosize)`
   display: block;
   position: relative;
-  align-items: center;
-  justify-content: flex-start;
 
   width: 100%;
   max-width: 100%;
   height: 38px;
   min-height: 2.5em;
-  padding: calc(0.5em - 1px) calc(0.625em - 1px) calc(0.5em - 1px);
+  padding: 6px 10px;
 
   font-size: 1rem;
   font-family: 'Open Sans', Arial, sans-serif;
@@ -132,27 +128,25 @@ const StyledTextArea = styled(TextareaAutosize)`
   resize: none;
 
   background-color: transparent;
-  border: 2px solid transparent;
-  border-bottom: 1px solid ${({ theme: { colors } }) => colors.greyscale.medium};
+  margin: 0;
+  border: none;
+  border-top: 2px solid transparent;
+  border-bottom: 1px solid ${({ theme: { colors } }) => colors.greyscale.dark};
   border-radius: 0;
   box-shadow: none;
-
   outline: none;
 
-  &:focus {
-    border-width: 2px;
-    border-style: solid;
-    border-color: ${({ theme: { colors } }) => colors.main.primaryFocus};
-  }
-
+  &:focus,
   &.success,
   &.warning {
-    border-width: 2px;
-    margin-bottom: -1px;
+    border-bottom-width: 2px;
+  }
 
-    &:focus {
-      margin-bottom: -1px;
-    }
+  &:focus {
+    border: 2px solid ${({ theme: { colors } }) => colors.main.primaryFocus};
+    border-radius: 2px;
+    padding-left: 8px;
+    padding-right: 8px;
   }
 
   &.success {

--- a/frontend/src/lib-components/atoms/form/TimeInput.tsx
+++ b/frontend/src/lib-components/atoms/form/TimeInput.tsx
@@ -51,5 +51,6 @@ function onFocus(event: React.FocusEvent<HTMLInputElement>) {
 }
 
 const ShorterInput = styled(InputField)`
-  width: calc(3.4em + 24px);
+  width: calc(2.6em + 24px);
+  max-width: calc(2.6em + 24px);
 `

--- a/frontend/src/lib-components/molecules/PinInput.tsx
+++ b/frontend/src/lib-components/molecules/PinInput.tsx
@@ -106,7 +106,6 @@ export const PinInput = React.memo(function PinInput({
             inputMode="numeric"
             maxLength={1}
             invalid={invalid}
-            clearable={false}
             autoFocus={i === 0}
             value={pin[i]}
             ref={refs[i]}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
* Use `1rem` font size in input placeholder and info texts and a darker orange with warning text.
* Add proper padding to input's right side when the input contains a button, icon or a symbol.
* Let info text continue to multiple rows, but do not let it stretch vertically.
* Fix input positioning when focus borders are added.

