### PR TITLE
Use shorter `AsyncButton` animations in e2e tests

### DIFF
--- a/frontend/src/e2e-playwright/pages/employee/finance-basics.ts
+++ b/frontend/src/e2e-playwright/pages/employee/finance-basics.ts
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual } from 'e2e-playwright/utils'
+import { waitUntilTrue } from 'e2e-playwright/utils'
 import { FeeThresholds } from 'lib-common/api-types/finance'
-import { Page, TextInput } from '../../utils/page'
+import { AsyncButton, Page, TextInput } from '../../utils/page'
 
 export default class FinanceBasicsPage {
   constructor(private readonly page: Page) {}
@@ -107,7 +107,7 @@ export default class FinanceBasicsPage {
       siblingDiscount2Plus: new TextInput(
         this.page.find('[data-qa="sibling-discount-2-plus"]')
       ),
-      saveButton: this.page.find('[data-qa="save"]'),
+      saveButton: new AsyncButton(this.page.find('[data-qa="save"]')),
       fillInThresholds: async (feeThresholds: FeeThresholds) => {
         await this.feesSection.editor.validFromInput.fill(
           feeThresholds.validDuring.start.format()
@@ -144,10 +144,7 @@ export default class FinanceBasicsPage {
         )
       },
       assertSaveIsDisabled: async () => {
-        await waitUntilEqual(
-          () => this.feesSection.editor.saveButton.getAttribute('disabled'),
-          ''
-        )
+        await waitUntilTrue(() => this.feesSection.editor.saveButton.disabled)
       },
       save: async (retroactive: boolean) => {
         await this.feesSection.editor.saveButton.click()
@@ -156,10 +153,7 @@ export default class FinanceBasicsPage {
           await this.page.find('[data-qa="modal-okBtn"]').click()
         }
 
-        await waitUntilEqual(
-          () => this.feesSection.editor.saveButton.getAttribute('data-status'),
-          'success'
-        )
+        await this.feesSection.editor.saveButton.waitUntilHidden()
         await this.feesSection.spinner.waitUntilVisible()
       }
     }

--- a/frontend/src/e2e-playwright/pages/employee/finance-basics.ts
+++ b/frontend/src/e2e-playwright/pages/employee/finance-basics.ts
@@ -11,7 +11,9 @@ export default class FinanceBasicsPage {
 
   readonly feesSection = {
     root: this.page.find('[data-qa="fees-section"]'),
-    spinner: this.page.find('[data-qa="fees-section-spinner"]'),
+    rootLoaded: this.page.find(
+      '[data-qa="fees-section"][data-isloading="false"]'
+    ),
     createFeeThresholdsButton: this.page.find(
       '[data-qa="create-new-fee-thresholds"]'
     ),
@@ -154,7 +156,7 @@ export default class FinanceBasicsPage {
         }
 
         await this.feesSection.editor.saveButton.waitUntilHidden()
-        await this.feesSection.spinner.waitUntilVisible()
+        await this.feesSection.rootLoaded.waitUntilVisible()
       }
     }
   }

--- a/frontend/src/e2e-playwright/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-playwright/pages/employee/finance/finance-page.ts
@@ -84,7 +84,7 @@ export class FeeDecisionsPage {
 
   async sendFeeDecisions() {
     await this.#sendFeeDecisionsButton.click()
-    await this.#sendFeeDecisionsButton.waitUntilSuccessful()
+    await this.#sendFeeDecisionsButton.waitUntilIdle()
     await runPendingAsyncJobs()
   }
 
@@ -176,7 +176,7 @@ export class ValueDecisionsPage {
 
   async sendValueDecisions() {
     await this.#sendValueDecisionsButton.click()
-    await this.#sendValueDecisionsButton.waitUntilSuccessful()
+    await this.#sendValueDecisionsButton.waitUntilIdle()
     await runPendingAsyncJobs()
   }
 
@@ -283,7 +283,7 @@ export class InvoicesPage {
     await this.#openSendInvoicesDialogButton.click()
     await this.#sendInvoicesDialog.waitUntilVisible()
     await this.#sendInvoicesButton.click()
-    await this.#sendInvoicesButton.waitUntilSuccessful()
+    await this.#sendInvoicesButton.waitUntilHidden()
   }
 
   async showSentInvoices() {
@@ -336,13 +336,13 @@ export class InvoicesPage {
     await invoiceRow.unitPriceInput.fill('')
     await invoiceRow.unitPriceInput.type(this.formatFinnishDecimal(unitPrice))
     await this.#saveChangesButton.click()
-    await this.#saveChangesButton.waitUntilSuccessful()
+    await this.#saveChangesButton.waitUntilIdle()
   }
 
   async deleteInvoiceRow(index: number) {
     await this.#invoiceRow(index).deleteRowButton.click()
     await this.#saveChangesButton.click()
-    await this.#saveChangesButton.waitUntilSuccessful()
+    await this.#saveChangesButton.waitUntilIdle()
   }
 
   async assertInvoiceTotal(total: number) {
@@ -360,7 +360,7 @@ export class InvoicesPage {
 
   async markInvoiceSent() {
     await this.#markInvoiceSentButton.click()
-    await this.#markInvoiceSentButton.waitUntilSuccessful()
+    await this.#markInvoiceSentButton.waitUntilHidden()
   }
 
   private formatFinnishDecimal(number: number) {

--- a/frontend/src/e2e-playwright/utils/page.ts
+++ b/frontend/src/e2e-playwright/utils/page.ts
@@ -262,8 +262,8 @@ export class AsyncButton extends Element {
     return this.getAttribute('data-status')
   }
 
-  async waitUntilSuccessful() {
-    await waitUntilEqual(() => this.status(), 'success')
+  async waitUntilIdle() {
+    await waitUntilEqual(() => this.status(), '')
   }
 }
 

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames'
 import React, { useEffect, useRef, useState } from 'react'
 import { animated, useSpring } from 'react-spring'
 import styled, { useTheme } from 'styled-components'
+import { isAutomatedTest } from 'lib-common/utils/helpers'
 import { faCheck, faTimes } from 'lib-icons'
 import { StyledButton } from './Button'
 
@@ -90,10 +91,10 @@ export default React.memo(function AsyncButton({
 
   useEffect(() => {
     const runOnSuccess = showSuccess
-      ? setTimeout(() => onSuccessRef.current(), 500)
+      ? setTimeout(() => onSuccessRef.current(), isAutomatedTest ? 10 : 500)
       : undefined
     const clearShowSuccess = showSuccess
-      ? setTimeout(() => setShowSuccess(false), 2000)
+      ? setTimeout(() => setShowSuccess(false), isAutomatedTest ? 25 : 2000)
       : undefined
 
     return () => {
@@ -104,7 +105,7 @@ export default React.memo(function AsyncButton({
 
   useEffect(() => {
     const clearShowFailure = showFailure
-      ? setTimeout(() => setShowFailure(false), 2000)
+      ? setTimeout(() => setShowFailure(false), isAutomatedTest ? 25 : 2000)
       : undefined
 
     return () => {


### PR DESCRIPTION
#### Summary

This makes e2e faster, because animations took seconds and now they take milliseconds.

Some tests needed fixing that relied on seeing one of the transient `AsyncButton` states.
