### PR TITLE
Varda: remove unnecessarily strict application condition

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaQueries.kt
@@ -331,7 +331,6 @@ fun Database.Read.getEvakaServiceNeedInfoForVarda(id: ServiceNeedId): EvakaServi
                     FROM placement_plan pp
                     WHERE pp.unit_id = p.unit_id AND pp.application_id = a.id
                       AND daterange(pp.start_date, pp.end_date, '[]') && daterange(sn.start_date, sn.end_date, '[]')
-                      AND unit_confirmation_status = 'ACCEPTED'
                 )
             ORDER BY a.sentdate, a.id
             LIMIT 1


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Not all applications and placement proposals go through unit supervisors so this condition for finding a placement's application is unnecessarily strict. Just noticed this by accident.