### PR TITLE
EVAKA FIX finance decision queries after refactoring

### DIFF
--- a/frontend/src/e2e-playwright/pages/employee/guardian-information.ts
+++ b/frontend/src/e2e-playwright/pages/employee/guardian-information.ts
@@ -383,6 +383,22 @@ class FeeDecisionsSection extends Section {
   }
 }
 
+class VoucherValueDecisionsSection extends Section {
+  #voucherValueDecisionSentAt = this.findAll(
+    `[data-qa="voucher-value-decision-sent-at"]`
+  )
+
+  async checkVoucherValueDecisionSentAt(
+    nth: number,
+    expectedSentAt: LocalDate
+  ) {
+    await waitUntilEqual(
+      () => this.#voucherValueDecisionSentAt.nth(nth).innerText,
+      expectedSentAt.format('dd.MM.yyyy')
+    )
+  }
+}
+
 class InvoicesSection extends Section {
   #invoiceRows = this.findAll('[data-qa="table-invoice-row"]')
 
@@ -439,6 +455,10 @@ const collapsibles = {
   feeDecisions: {
     selector: '[data-qa="person-fee-decisions-collapsible"]',
     section: FeeDecisionsSection
+  },
+  voucherValueDecisions: {
+    selector: '[data-qa="person-voucher-value-decisions-collapsible"]',
+    section: VoucherValueDecisionsSection
   },
   invoices: {
     selector: '[data-qa="person-invoices-collapsible"]',

--- a/frontend/src/e2e-playwright/specs/4_finance/person-finance-decisions.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/person-finance-decisions.spec.ts
@@ -7,6 +7,7 @@ import { employeeLogin } from 'e2e-playwright/utils/user'
 import config from 'e2e-test-common/config'
 import {
   insertFeeDecisionFixtures,
+  insertVoucherValueDecisionFixtures,
   resetDatabase
 } from 'e2e-test-common/dev-api'
 import { initializeAreaAndPersonData } from 'e2e-test-common/dev-api/data-init'
@@ -16,7 +17,8 @@ import {
   enduserGuardianFixture,
   feeDecisionsFixture,
   Fixture,
-  uuidv4
+  uuidv4,
+  voucherValueDecisionsFixture
 } from 'e2e-test-common/dev-api/fixtures'
 import DateRange from 'lib-common/date-range'
 import LocalDate from 'lib-common/local-date'
@@ -37,7 +39,7 @@ beforeEach(async () => {
   guardianPage = new GuardianInformationPage(page)
 })
 
-describe('Head of family fee decisions', () => {
+describe('Person finance decisions', () => {
   test('Fee decisions are sorted by sent date', async () => {
     const sentAtFirst = LocalDate.today().subDays(3)
     const sentAtSecond = sentAtFirst.addDays(1)
@@ -68,5 +70,40 @@ describe('Head of family fee decisions', () => {
     await feeDecisions.checkFeeDecisionSentAt(0, sentAtThird)
     await feeDecisions.checkFeeDecisionSentAt(1, sentAtSecond)
     await feeDecisions.checkFeeDecisionSentAt(2, sentAtFirst)
+  })
+
+  test('Voucher value decisions are sorted by sent date', async () => {
+    const sentAtFirst = LocalDate.today().subDays(3)
+    const sentAtSecond = sentAtFirst.addDays(1)
+    const sentAtThird = sentAtSecond.addDays(1)
+
+    const createVoucherValueDecisionFixture = async (sentAt: LocalDate) => {
+      await insertVoucherValueDecisionFixtures([
+        voucherValueDecisionsFixture(
+          uuidv4(),
+          enduserGuardianFixture.id,
+          enduserChildFixtureKaarina.id,
+          daycareFixture.id,
+          null,
+          'SENT',
+          sentAt,
+          sentAt,
+          sentAt.toSystemTzDate()
+        )
+      ])
+    }
+
+    await createVoucherValueDecisionFixture(sentAtFirst)
+    await createVoucherValueDecisionFixture(sentAtThird)
+    await createVoucherValueDecisionFixture(sentAtSecond)
+
+    await guardianPage.navigateToGuardian(enduserGuardianFixture.id)
+    const voucherValueDecisions = await guardianPage.openCollapsible(
+      'voucherValueDecisions'
+    )
+
+    await voucherValueDecisions.checkVoucherValueDecisionSentAt(0, sentAtThird)
+    await voucherValueDecisions.checkVoucherValueDecisionSentAt(1, sentAtSecond)
+    await voucherValueDecisions.checkVoucherValueDecisionSentAt(2, sentAtFirst)
   })
 })

--- a/frontend/src/e2e-test-common/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test-common/dev-api/fixtures.ts
@@ -773,7 +773,8 @@ export const voucherValueDecisionsFixture = (
   partner: PersonDetail | null = null,
   status: 'DRAFT' | 'SENT' = 'DRAFT',
   validFrom = LocalDate.today().subYears(1),
-  validTo = LocalDate.today().addYears(1)
+  validTo = LocalDate.today().addYears(1),
+  sentAt: Date | null = null
 ): VoucherValueDecision => ({
   id,
   status,
@@ -808,7 +809,7 @@ export const voucherValueDecisionsFixture = (
   ageCoefficient: 1.0,
   capacityFactor: 1.0,
   voucherValue: 87000,
-  sentAt: null,
+  sentAt,
   approvedAt: null,
   approvedById: null,
   decisionNumber: null,

--- a/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
@@ -81,7 +81,7 @@ export default React.memo(function PersonFeeDecisions({ id, open }: Props) {
             </Tr>
           </Thead>
           <Tbody>
-            {_.orderBy(feeDecisions, ['sentAt', 'createdAt'], ['desc']).map(
+            {_.orderBy(feeDecisions, ['sentAt', 'validFrom'], ['desc']).map(
               (feeDecision: FeeDecision) => (
                 <Tr key={`${feeDecision.id}`} data-qa="table-fee-decision-row">
                   <Td>

--- a/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
@@ -81,30 +81,34 @@ export default React.memo(function PersonVoucherValueDecisions({
             </Tr>
           </Thead>
           <Tbody>
-            {orderBy(voucherValueDecisions, ['createdAt'], ['desc']).map(
-              (decision) => (
-                <Tr
-                  key={`${decision.id}`}
-                  data-qa="table-voucher-value-decision-row"
-                >
-                  <Td>
-                    {decision.child.lastName} {decision.child.firstName}
-                    <br />
-                    <Link to={`/finance/value-decisions/${decision.id}`}>
-                      {`${decision.validFrom.format()} - ${
-                        decision.validTo?.format() ?? ''
-                      }`}
-                    </Link>
-                  </Td>
-                  <Td>{decision.decisionNumber}</Td>
-                  <Td>{formatCents(decision.voucherValue)}</Td>
-                  <Td>{formatCents(decision.finalCoPayment)}</Td>
-                  <Td>{formatDate(decision.created)}</Td>
-                  <Td>{formatDate(decision.sentAt)}</Td>
-                  <Td>{i18n.valueDecision.status[decision.status]}</Td>
-                </Tr>
-              )
-            )}
+            {orderBy(
+              voucherValueDecisions,
+              ['sentAt', 'validFrom'],
+              ['desc']
+            ).map((decision) => (
+              <Tr
+                key={`${decision.id}`}
+                data-qa="table-voucher-value-decision-row"
+              >
+                <Td>
+                  {decision.child.lastName} {decision.child.firstName}
+                  <br />
+                  <Link to={`/finance/value-decisions/${decision.id}`}>
+                    {`${decision.validFrom.format()} - ${
+                      decision.validTo?.format() ?? ''
+                    }`}
+                  </Link>
+                </Td>
+                <Td>{decision.decisionNumber}</Td>
+                <Td>{formatCents(decision.voucherValue)}</Td>
+                <Td>{formatCents(decision.finalCoPayment)}</Td>
+                <Td>{formatDate(decision.created)}</Td>
+                <Td data-qa="voucher-value-decision-sent-at">
+                  {formatDate(decision.sentAt)}
+                </Td>
+                <Td>{i18n.valueDecision.status[decision.status]}</Td>
+              </Tr>
+            ))}
           </Tbody>
         </Table>
       ))}

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
@@ -24,7 +24,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.resetDatabase
-import fi.espoo.evaka.shared.utils.europeHelsinki
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.snDefaultDaycare
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
@@ -41,11 +41,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.time.ZonedDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -66,7 +64,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
     private val janFirst = LocalDate.of(2020, 1, 1)
     private val febFirst = LocalDate.of(2020, 2, 1)
 
-    private val janFreeze = ZonedDateTime.of(LocalDateTime.of(2020, 1, 21, 22, 0), europeHelsinki).toInstant()
+    private val janFreeze = HelsinkiDateTime.of(LocalDateTime.of(2020, 1, 21, 22, 0))
 
     @Test
     fun `unfrozen area voucher report includes value decisions that begin in the beginning of reports month`() {
@@ -154,7 +152,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest() {
         coPayment: Int,
         adultId: PersonId,
         child: DevPerson,
-        approvedAt: Instant = ZonedDateTime.of(validFrom, LocalTime.of(15, 0), europeHelsinki).toInstant()
+        approvedAt: HelsinkiDateTime = HelsinkiDateTime.of(validFrom, LocalTime.of(15, 0))
     ): VoucherValueDecision {
         val decision = db.transaction {
             val decision = createVoucherValueDecisionFixture(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -24,7 +24,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.resetDatabase
-import fi.espoo.evaka.shared.utils.europeHelsinki
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.snDefaultDaycare
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1
@@ -34,11 +34,9 @@ import fi.espoo.evaka.testDecisionMaker_1
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.time.ZonedDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -62,8 +60,8 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
     private val febFirst = LocalDate.of(2020, 2, 1)
     private val marFirst = LocalDate.of(2020, 3, 1)
 
-    private val janFreeze = ZonedDateTime.of(LocalDateTime.of(2020, 1, 21, 22, 0), europeHelsinki).toInstant()
-    private val febFreeze = ZonedDateTime.of(LocalDateTime.of(2020, 2, 21, 22, 0), europeHelsinki).toInstant()
+    private val janFreeze = HelsinkiDateTime.of(LocalDateTime.of(2020, 1, 21, 22, 0))
+    private val febFreeze = HelsinkiDateTime.of(LocalDateTime.of(2020, 2, 21, 22, 0))
 
     @Test
     fun `unfrozen service voucher report includes value decisions that begin in the beginning of reports month`() {
@@ -312,7 +310,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest() {
         unitId: DaycareId,
         value: Int,
         coPayment: Int,
-        approvedAt: Instant = ZonedDateTime.of(validFrom, LocalTime.of(15, 0), europeHelsinki).toInstant()
+        approvedAt: HelsinkiDateTime = HelsinkiDateTime.of(validFrom, LocalTime.of(15, 0))
     ): VoucherValueDecision {
         val decision = db.transaction {
             val decision = createVoucherValueDecisionFixture(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
@@ -343,7 +343,7 @@ fun Database.Read.searchFeeDecisions(
             LEFT JOIN person AS child ON part.child_id = child.id
             LEFT JOIN daycare AS placement_unit ON placement_unit.id = part.placement_unit_id
             LEFT JOIN (
-                SELECT fee_decision.id, sum(fee_decision_child.final_fee) sum
+                SELECT fee_decision.id, coalesce(sum(fee_decision_child.final_fee), 0) sum
                 FROM fee_decision
                 LEFT JOIN fee_decision_child ON fee_decision.id = fee_decision_child.fee_decision_id
                 GROUP BY fee_decision.id

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
@@ -21,10 +21,10 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.db.freeTextSearchQuery
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.mapToPaged
 import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.kotlin.mapTo
-import java.time.Instant
 import java.time.LocalDate
 
 fun Database.Transaction.upsertValueDecisions(decisions: List<VoucherValueDecision>) {
@@ -449,7 +449,7 @@ WHERE decision.head_of_family_id = :headOfFamilyId
 fun Database.Transaction.approveValueDecisionDraftsForSending(
     ids: List<VoucherValueDecisionId>,
     approvedBy: EmployeeId,
-    approvedAt: Instant
+    approvedAt: HelsinkiDateTime
 ) {
     // language=sql
     val sql =
@@ -530,7 +530,7 @@ fun Database.Transaction.setVoucherValueDecisionType(id: VoucherValueDecisionId,
         .execute()
 }
 
-fun Database.Transaction.markVoucherValueDecisionsSent(ids: List<VoucherValueDecisionId>, now: Instant) {
+fun Database.Transaction.markVoucherValueDecisionsSent(ids: List<VoucherValueDecisionId>, now: HelsinkiDateTime) {
     createUpdate("UPDATE voucher_value_decision SET status = :sent::voucher_value_decision_status, sent_at = :now WHERE id = ANY(:ids)")
         .bind("ids", ids.toTypedArray())
         .bind("sent", VoucherValueDecisionStatus.SENT)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
@@ -419,7 +419,7 @@ SELECT
     decision.decision_number,
     decision.valid_from,
     decision.valid_to,
-    decision.head_of_family_id,
+    decision.head_of_family_id AS head_id,
     decision.child_id,
     decision.child_date_of_birth,
     decision.final_co_payment,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
@@ -29,12 +29,12 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.message.IMessageProvider
 import fi.espoo.evaka.shared.message.langWithDefault
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Component
-import java.time.Instant
 import java.time.LocalDate
 
 @Component
@@ -109,7 +109,7 @@ class VoucherValueDecisionService(
             )
         )
 
-        tx.markVoucherValueDecisionsSent(listOf(decision.id), Instant.now())
+        tx.markVoucherValueDecisionsSent(listOf(decision.id), HelsinkiDateTime.now())
 
         return true
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.bindNullable
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import fi.espoo.evaka.shared.utils.europeHelsinki
@@ -118,7 +119,7 @@ class ServiceVoucherValueReportController(
     }
 }
 
-fun freezeVoucherValueReportRows(tx: Database.Transaction, year: Int, month: Int, takenAt: Instant) {
+fun freezeVoucherValueReportRows(tx: Database.Transaction, year: Int, month: Int, takenAt: HelsinkiDateTime) {
     val rows = tx.getServiceVoucherValues(year, month)
 
     val voucherValueReportSnapshotId =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -149,7 +149,7 @@ WHERE ca.unit_id = u.id AND NOT u.round_the_clock AND ca.departed IS NULL
                 it,
                 LocalDate.now(europeHelsinki).year,
                 LocalDate.now(europeHelsinki).monthValue,
-                Instant.now()
+                HelsinkiDateTime.now()
             )
         }
     }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
- Fix value decision query result mapping
- Order person finance decisions by `sentAt` first and `validFrom` second
- Add e2e-test for person voucher value decisions
- Fix fee decision query result mapping

