### PR TITLE
Make sure serviceNeedId is returned as uuid

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationQueriesSmokeTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationQueriesSmokeTest.kt
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.application
+
+import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.application.persistence.daycare.Adult
+import fi.espoo.evaka.application.persistence.daycare.Apply
+import fi.espoo.evaka.application.persistence.daycare.Child
+import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
+import fi.espoo.evaka.insertServiceNeedOptions
+import fi.espoo.evaka.shared.ApplicationId
+import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.auth.AclAuthorization
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.insertTestApplication
+import fi.espoo.evaka.shared.dev.insertTestApplicationForm
+import fi.espoo.evaka.shared.dev.insertTestCareArea
+import fi.espoo.evaka.shared.dev.insertTestDaycare
+import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.snDefaultDaycare
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import kotlin.test.assertEquals
+
+class ApplicationQueriesSmokeTest : PureJdbiTest() {
+    private lateinit var daycareId: DaycareId
+    private lateinit var applicationId: ApplicationId
+    private lateinit var form: DaycareFormV0
+
+    @BeforeAll
+    private fun beforeAll() {
+        db.transaction { tx ->
+            val areaId = tx.insertTestCareArea(DevCareArea())
+            val childId = tx.insertTestPerson(DevPerson())
+            val guardianId = tx.insertTestPerson(DevPerson())
+            daycareId = tx.insertTestDaycare(DevDaycare(areaId = areaId))
+            applicationId = tx.insertTestApplication(childId = childId, guardianId = guardianId)
+        }
+        form = DaycareFormV0(
+            type = ApplicationType.DAYCARE,
+            child = Child(
+                dateOfBirth = LocalDate.of(2020, 1, 1)
+            ),
+            guardian = Adult(),
+            apply = Apply(
+                preferredUnits = listOf(daycareId),
+            ),
+            preferredStartDate = LocalDate.of(2022, 1, 1),
+            serviceNeedOption = ServiceNeedOption(
+                id = snDefaultDaycare.id,
+                nameFi = snDefaultDaycare.nameFi,
+                nameEn = snDefaultDaycare.nameEn,
+                nameSv = snDefaultDaycare.nameSv
+            )
+        )
+        db.transaction {
+            it.insertServiceNeedOptions()
+            it.insertTestApplicationForm(applicationId, form)
+        }
+    }
+
+    @Test
+    fun `fetchApplicationSummaries returns service need information from applications correctly`() {
+        val applications = db.read {
+            it.fetchApplicationSummaries(
+                user = AuthenticatedUser.SystemInternalUser,
+                page = 1,
+                pageSize = 10,
+                sortBy = ApplicationSortColumn.STATUS,
+                sortDir = ApplicationSortDirection.ASC,
+                areas = emptyList(),
+                units = emptyList(),
+                basis = emptyList(),
+                type = ApplicationTypeToggle.ALL,
+                preschoolType = emptyList(),
+                statuses = ApplicationStatusOption.values().toList(),
+                dateType = emptyList(),
+                distinctions = emptyList(),
+                periodStart = null,
+                periodEnd = null,
+                transferApplications = TransferApplicationFilter.ALL,
+                voucherApplications = null,
+                authorizedUnitsForApplicationsWithAssistanceNeed = AclAuthorization.All,
+                authorizedUnitsForApplicationsWithoutAssistanceNeed = AclAuthorization.All,
+                canReadServiceWorkerNotes = true
+            )
+        }
+        val application = applications.data.single()
+        assertEquals(form.serviceNeedOption, application.serviceNeed)
+    }
+
+    @Test
+    fun `getApplicationUnitSummaries returns service need information from applications correctly`() {
+        val applications = db.read { it.getApplicationUnitSummaries(daycareId) }
+        val application = applications.single()
+        assertEquals(form.serviceNeedOption, application.serviceNeed)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -254,7 +254,7 @@ fun Database.Read.fetchApplicationSummaries(
             child.social_security_number,
             f.document,
             f.document ->> 'type' as type,
-            f.document -> 'serviceNeedOption' ->> 'id' as serviceNeedId,
+            (f.document -> 'serviceNeedOption' ->> 'id')::uuid as serviceNeedId,
             f.document -> 'serviceNeedOption' ->> 'nameFi' as serviceNeedNameFi,
             f.document -> 'serviceNeedOption' ->> 'nameSv' as serviceNeedNameSv,
             f.document -> 'serviceNeedOption' ->> 'nameEn' as serviceNeedNameEn,
@@ -680,7 +680,7 @@ fun Database.Read.getApplicationUnitSummaries(unitId: DaycareId): List<Applicati
         SELECT
             a.id,
             f.document ->> 'type' AS type,
-            f.document -> 'serviceNeedOption' ->> 'id' AS serviceNeedId,
+            (f.document -> 'serviceNeedOption' ->> 'id')::uuid as serviceNeedId,
             f.document -> 'serviceNeedOption' ->> 'nameFi' AS serviceNeedNameFi,
             f.document -> 'serviceNeedOption' ->> 'nameSv' AS serviceNeedNameSv,
             f.document -> 'serviceNeedOption' ->> 'nameEn' AS serviceNeedNameEn,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

jsonb ->> returns the data as `text`, so we need to cast it to uuid to make sure it can be deserialized as ServiceNeedOptionId