### PR TITLE
Fix child list items hidden behind nav bar

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/common/PageWithNavigation.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/PageWithNavigation.tsx
@@ -12,7 +12,8 @@ import TopBarWithGroupSelector, {
 
 const FlexibleDiv = styled.div`
   flex-grow: 1;
-  height: 100%;
+  display: block;
+  overflow: auto;
 `
 
 type PageWithNavigation = BottomNavbarProps & TopBarWithGroupSelectorProps


### PR DESCRIPTION
#### Summary
The recent refactoring of the views caused children to be hidden behind
the navigation bar in some instances.
