### PR TITLE
Replace invoice agreement_type with area_id

### DIFF
--- a/frontend/src/e2e-playwright/specs/4_finance/invoices.spec.ts
+++ b/frontend/src/e2e-playwright/specs/4_finance/invoices.spec.ts
@@ -130,11 +130,13 @@ describe('Invoices', () => {
       invoiceFixture(
         fixtures.enduserGuardianFixture.id,
         fixtures.enduserChildFixtureJari.id,
+        fixtures.careAreaFixture.id,
         'DRAFT'
       ),
       invoiceFixture(
         fixtures.familyWithRestrictedDetailsGuardian.guardian.id,
         fixtures.familyWithRestrictedDetailsGuardian.children[0].id,
+        fixtures.careAreaFixture.id,
         'DRAFT'
       )
     ])
@@ -154,6 +156,7 @@ describe('Invoices', () => {
       invoiceFixture(
         adultWithoutSSN.id,
         fixtures.enduserChildFixtureJari.id,
+        fixtures.careAreaFixture.id,
         'DRAFT'
       )
     ])

--- a/frontend/src/e2e-playwright/specs/5_employee/guardian-information-page.spec.ts
+++ b/frontend/src/e2e-playwright/specs/5_employee/guardian-information-page.spec.ts
@@ -106,6 +106,7 @@ describe('Employee - Guardian Information', () => {
       invoiceFixture(
         fixtures.enduserGuardianFixture.id,
         fixtures.enduserChildFixtureJari.id,
+        fixtures.careAreaFixture.id,
         'DRAFT',
         LocalDate.of(2020, 1, 1),
         LocalDate.of(2020, 1, 31)

--- a/frontend/src/e2e-test-common/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test-common/dev-api/fixtures.ts
@@ -820,6 +820,7 @@ export const voucherValueDecisionsFixture = (
 export const invoiceFixture = (
   adultId: UUID,
   childId: UUID,
+  areaId: UUID,
   status: Invoice['status'],
   periodStart = LocalDate.of(2019, 1, 1),
   periodEnd = LocalDate.of(2019, 1, 1)
@@ -828,7 +829,7 @@ export const invoiceFixture = (
   status,
   headOfFamily: adultId,
   codebtor: null,
-  agreementType: 200,
+  areaId,
   periodStart,
   periodEnd,
   invoiceDate: periodStart,

--- a/frontend/src/lib-common/generated/api-types/invoicing.ts
+++ b/frontend/src/lib-common/generated/api-types/invoicing.ts
@@ -318,7 +318,6 @@ export interface Invoice {
 * Generated from fi.espoo.evaka.invoicing.service.InvoiceCodes
 */
 export interface InvoiceCodes {
-  agreementTypes: number[]
   costCenters: string[]
   products: Product[]
   subCostCenters: string[]

--- a/frontend/src/lib-common/generated/api-types/invoicing.ts
+++ b/frontend/src/lib-common/generated/api-types/invoicing.ts
@@ -298,7 +298,7 @@ export type IncomeEffect =
 * Generated from fi.espoo.evaka.invoicing.domain.Invoice
 */
 export interface Invoice {
-  agreementType: number
+  areaId: UUID
   codebtor: UUID | null
   dueDate: LocalDate
   headOfFamily: UUID
@@ -329,6 +329,7 @@ export interface InvoiceCodes {
 export interface InvoiceDetailed {
   account: number
   agreementType: number
+  areaId: UUID
   codebtor: PersonDetailed | null
   dueDate: LocalDate
   headOfFamily: PersonDetailed

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/Helpers.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/Helpers.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.invoicing
 
 import fi.espoo.evaka.allAdults
+import fi.espoo.evaka.allAreas
 import fi.espoo.evaka.allChildren
 import fi.espoo.evaka.allDaycares
 import fi.espoo.evaka.allWorkers
@@ -79,7 +80,8 @@ fun toDetailed(invoice: Invoice): InvoiceDetailed = InvoiceDetailed(
     periodEnd = invoice.periodEnd,
     dueDate = invoice.dueDate,
     invoiceDate = invoice.invoiceDate,
-    agreementType = invoice.agreementType,
+    agreementType = allAreas.find { it.id == invoice.areaId }?.areaCode!!,
+    areaId = invoice.areaId,
     headOfFamily = allAdults.find { it.id == invoice.headOfFamily }!!.toPersonDetailed(),
     codebtor = allAdults.find { it.id == invoice.codebtor }?.toPersonDetailed(),
     rows = invoice.rows.map { row ->

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -71,13 +71,13 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         createInvoiceFixture(
             status = InvoiceStatus.DRAFT,
             headOfFamilyId = testAdult_1.id,
-            agreementType = testArea.areaCode!!,
+            areaId = testArea.id,
             rows = listOf(createInvoiceRowFixture(childId = testChild_1.id))
         ),
         createInvoiceFixture(
             status = InvoiceStatus.SENT,
             headOfFamilyId = testAdult_1.id,
-            agreementType = testArea.areaCode!!,
+            areaId = testArea.id,
             number = 5000000001L,
             period = DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 31)),
             rows = listOf(createInvoiceRowFixture(childId = testChild_1.id))
@@ -85,7 +85,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
         createInvoiceFixture(
             status = InvoiceStatus.DRAFT,
             headOfFamilyId = testAdult_2.id,
-            agreementType = testArea.areaCode!!,
+            areaId = testArea.id,
             period = DateRange(LocalDate.of(2018, 1, 1), LocalDate.of(2018, 1, 31)),
             rows = listOf(createInvoiceRowFixture(childId = testChild_2.id))
         )
@@ -276,7 +276,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
 
         assertEqualEnough(
             invoices.filter {
-                it.status == InvoiceStatus.DRAFT && it.agreementType == testArea.areaCode
+                it.status == InvoiceStatus.DRAFT && it.areaId == testArea.id
             }.map(::toSummary),
             deserializeListResult(result.get()).data
         )
@@ -557,7 +557,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
             createInvoiceFixture(
                 status = InvoiceStatus.DRAFT,
                 headOfFamilyId = testAdult_1.id,
-                agreementType = testArea.areaCode!!,
+                areaId = testArea.id,
                 rows = listOf(createInvoiceRowFixture(childId = testChild_1.id))
             )
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueriesTest.kt
@@ -29,20 +29,20 @@ class InvoiceQueriesTest : PureJdbiTest() {
         createInvoiceFixture(
             status = InvoiceStatus.DRAFT,
             headOfFamilyId = testAdult_1.id,
-            agreementType = testArea.areaCode!!,
+            areaId = testArea.id,
             rows = listOf(createInvoiceRowFixture(childId = testChild_1.id))
         ),
         createInvoiceFixture(
             status = InvoiceStatus.SENT,
             headOfFamilyId = testAdult_1.id,
-            agreementType = testArea.areaCode!!,
+            areaId = testArea.id,
             number = 5000000001L,
             rows = listOf(createInvoiceRowFixture(childId = testChild_2.id))
         ),
         createInvoiceFixture(
             status = InvoiceStatus.DRAFT,
             headOfFamilyId = testAdult_1.id,
-            agreementType = testArea.areaCode!!,
+            areaId = testArea.id,
             period = DateRange(LocalDate.of(2018, 1, 1), LocalDate.of(2018, 1, 31)),
             rows = listOf(createInvoiceRowFixture(childId = testChild_2.id))
         )
@@ -135,7 +135,7 @@ class InvoiceQueriesTest : PureJdbiTest() {
                     createInvoiceFixture(
                         status = InvoiceStatus.SENT,
                         headOfFamilyId = testAdult_1.id,
-                        agreementType = testArea.areaCode!!,
+                        areaId = testArea.id,
                         number = 5000000123L,
                         rows = listOf(createInvoiceRowFixture(testChild_1.id))
                     )
@@ -156,7 +156,7 @@ class InvoiceQueriesTest : PureJdbiTest() {
                     createInvoiceFixture(
                         status = InvoiceStatus.SENT,
                         headOfFamilyId = testAdult_1.id,
-                        agreementType = testArea.areaCode!!,
+                        areaId = testArea.id,
                         number = it,
                         rows = listOf(createInvoiceRowFixture(testChild_1.id))
                     )
@@ -222,7 +222,7 @@ class InvoiceQueriesTest : PureJdbiTest() {
                     createInvoiceFixture(
                         status = InvoiceStatus.DRAFT,
                         headOfFamilyId = testAdult_2.id,
-                        agreementType = testArea.areaCode!!,
+                        areaId = testArea.id,
                         rows = listOf(createInvoiceRowFixture(childId = testChild_1.id))
                     )
                 )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -63,7 +63,6 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
     @Autowired
     private lateinit var absenceService: AbsenceService
 
-    private val areaCode = 200
     private val costCenter = "31500"
     private val subCostCenter = "00"
 
@@ -104,7 +103,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest() {
         assertEquals(1, result.size)
         result.first().let { invoice ->
             assertEquals(testAdult_1.id, invoice.headOfFamily)
-            assertEquals(areaCode, invoice.agreementType)
+            assertEquals(testDaycare.areaId, invoice.areaId)
             assertEquals(2900, invoice.totalPrice)
             assertEquals(1, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
@@ -92,19 +92,19 @@ class InvoicingReportTest : FullApplicationTest() {
         createInvoiceFixture(
             status = InvoiceStatus.SENT,
             headOfFamilyId = testAdult_1.id,
-            agreementType = testArea.areaCode!!,
+            areaId = testArea.id,
             rows = listOf(createInvoiceRowFixture(childId = testChild_1.id))
         ),
         createInvoiceFixture(
             status = InvoiceStatus.SENT,
             headOfFamilyId = testAdult_2.id,
-            agreementType = testArea2.areaCode!!,
+            areaId = testArea2.id,
             rows = listOf(createInvoiceRowFixture(childId = testChild_2.id))
         ),
         createInvoiceFixture(
             status = InvoiceStatus.SENT,
             headOfFamilyId = testAdult_2.id,
-            agreementType = testArea2.areaCode!!,
+            areaId = testArea2.id,
             rows = listOf()
         )
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Invoices.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Invoices.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.placement.PlacementType.PRESCHOOL_DAYCARE
 import fi.espoo.evaka.placement.PlacementType.SCHOOL_SHIFT_CARE
 import fi.espoo.evaka.placement.PlacementType.TEMPORARY_DAYCARE
 import fi.espoo.evaka.placement.PlacementType.TEMPORARY_DAYCARE_PART_DAY
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.InvoiceId
 import fi.espoo.evaka.shared.InvoiceRowId
@@ -41,7 +42,7 @@ data class Invoice(
     val periodEnd: LocalDate,
     val dueDate: LocalDate = getDueDate(periodEnd),
     val invoiceDate: LocalDate = dueDate.minusWeeks(2),
-    val agreementType: Int,
+    val areaId: AreaId,
     val headOfFamily: PersonId,
     val codebtor: PersonId?,
     val rows: List<InvoiceRow>,
@@ -86,6 +87,7 @@ data class InvoiceDetailed(
     val dueDate: LocalDate,
     val invoiceDate: LocalDate,
     val agreementType: Int,
+    val areaId: AreaId,
     val headOfFamily: PersonDetailed,
     val codebtor: PersonDetailed?,
     val rows: List<InvoiceRowDetailed>,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -723,7 +723,7 @@ fun Database.Read.getChildrenWithHeadOfFamilies(
 fun Database.Read.getDaycareCodes(): Map<DaycareId, DaycareCodes> {
     val sql =
         """
-        SELECT daycare.id, daycare.cost_center, area.id AS area_id, area.area_code, area.sub_cost_center
+        SELECT daycare.id, daycare.cost_center, area.id AS area_id, area.sub_cost_center
         FROM daycare INNER JOIN care_area AS area ON daycare.care_area_id = area.id
     """
     return createQuery(sql)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -202,11 +202,11 @@ internal fun generateDraftInvoice(
 
     if (rows.isEmpty()) return null
 
-    val agreementType = rowStubs
+    val areaId = rowStubs
         .maxByOrNull { (_, stub) -> stub.child.dateOfBirth }!!
         .let { (_, stub) ->
-            daycareCodes[stub.placement.unit]?.areaCode
-                ?: error("Couldn't find areaCode for daycare (${stub.placement.unit})")
+            daycareCodes[stub.placement.unit]?.areaId
+                ?: error("Couldn't find areaId for daycare (${stub.placement.unit})")
         }
 
     return Invoice(
@@ -214,7 +214,7 @@ internal fun generateDraftInvoice(
         status = InvoiceStatus.DRAFT,
         periodStart = invoicePeriod.start,
         periodEnd = invoicePeriod.end!!,
-        agreementType = agreementType,
+        areaId = areaId,
         headOfFamily = headOfFamily,
         codebtor = codebtors[headOfFamily],
         rows = rows
@@ -723,7 +723,7 @@ fun Database.Read.getChildrenWithHeadOfFamilies(
 fun Database.Read.getDaycareCodes(): Map<DaycareId, DaycareCodes> {
     val sql =
         """
-        SELECT daycare.id, daycare.cost_center, area.area_code, area.sub_cost_center
+        SELECT daycare.id, daycare.cost_center, area.id AS area_id, area.area_code, area.sub_cost_center
         FROM daycare INNER JOIN care_area AS area ON daycare.care_area_id = area.id
     """
     return createQuery(sql)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceService.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.invoicing.domain.Invoice
 import fi.espoo.evaka.invoicing.domain.InvoiceStatus
 import fi.espoo.evaka.invoicing.domain.Product
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.InvoiceId
 import fi.espoo.evaka.shared.InvoiceRowId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -28,7 +29,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-data class DaycareCodes(val areaCode: Int?, val costCenter: String?, val subCostCenter: String?)
+data class DaycareCodes(val areaId: AreaId, val areaCode: Int?, val costCenter: String?, val subCostCenter: String?)
 
 data class InvoiceCodes(
     val products: List<Product>,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceService.kt
@@ -32,7 +32,6 @@ data class DaycareCodes(val areaCode: Int?, val costCenter: String?, val subCost
 
 data class InvoiceCodes(
     val products: List<Product>,
-    val agreementTypes: List<Int>,
     val subCostCenters: List<String>,
     val costCenters: List<String>
 )
@@ -111,12 +110,10 @@ fun Database.Transaction.markManuallySent(user: AuthenticatedUser, invoiceIds: L
 fun Database.Read.getInvoiceCodes(): InvoiceCodes {
     val daycareCodes = getDaycareCodes()
 
-    val specialAreaCode = 255
     val specialSubCostCenter = "06"
 
     return InvoiceCodes(
         Product.values().toList(),
-        daycareCodes.values.mapNotNull { it.areaCode }.plus(specialAreaCode).distinct().sorted().toList(),
         daycareCodes.values.mapNotNull { it.subCostCenter }.plus(specialSubCostCenter).distinct().sorted().toList(),
         daycareCodes.values.mapNotNull { it.costCenter }.distinct().sorted()
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceService.kt
@@ -29,7 +29,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-data class DaycareCodes(val areaId: AreaId, val areaCode: Int?, val costCenter: String?, val subCostCenter: String?)
+data class DaycareCodes(val areaId: AreaId, val costCenter: String?, val subCostCenter: String?)
 
 data class InvoiceCodes(
     val products: List<Product>,

--- a/service/src/main/resources/db/migration/V196__invoice_area_id.sql
+++ b/service/src/main/resources/db/migration/V196__invoice_area_id.sql
@@ -1,0 +1,12 @@
+ALTER TABLE invoice ADD COLUMN area_id uuid CONSTRAINT fk$area REFERENCES care_area (id);
+
+UPDATE invoice SET area_id = (
+    SELECT id
+    FROM care_area
+    WHERE area_code = agreement_type
+    ORDER BY id
+    LIMIT 1
+);
+
+ALTER TABLE invoice ALTER COLUMN area_id SET NOT NULL;
+ALTER TABLE invoice DROP COLUMN agreement_type;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -193,3 +193,4 @@ V192__terminate_placement.sql
 V193__invoice_codebtor.sql
 V194__evaka_user_for_paper_application_guardians.sql
 V195__evaka_user_decision_resolved_by.sql
+V196__invoice_area_id.sql

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
@@ -28,6 +28,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionServiceNeed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionType
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.FeeDecisionId
@@ -155,17 +156,6 @@ val testInvoiceRow = InvoiceRow(
     costCenter = "31450",
     subCostCenter = "01",
     product = Product.DAYCARE
-)
-
-val testInvoice = Invoice(
-    id = InvoiceId(uuid1),
-    status = InvoiceStatus.DRAFT,
-    periodStart = LocalDate.of(2019, 5, 1),
-    periodEnd = LocalDate.of(2019, 5, 31),
-    agreementType = 100,
-    headOfFamily = testDecision1.headOfFamilyId,
-    codebtor = null,
-    rows = listOf(testInvoiceRow)
 )
 
 val testIncome = Income(
@@ -300,7 +290,7 @@ fun createInvoiceRowFixture(childId: ChildId) = InvoiceRow(
 fun createInvoiceFixture(
     status: InvoiceStatus,
     headOfFamilyId: PersonId,
-    agreementType: Int,
+    areaId: AreaId,
     number: Long? = null,
     period: DateRange = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 1, 31)),
     rows: List<InvoiceRow>
@@ -308,7 +298,7 @@ fun createInvoiceFixture(
     id = InvoiceId(UUID.randomUUID()),
     status = status,
     number = number,
-    agreementType = agreementType,
+    areaId = areaId,
     headOfFamily = headOfFamilyId,
     codebtor = null,
     periodStart = period.start,

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/domain/InvoicesTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/domain/InvoicesTest.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.invoicing.domain
 
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.InvoiceId
 import fi.espoo.evaka.shared.PersonId
 import org.junit.jupiter.api.Test
@@ -19,7 +20,7 @@ class InvoicesTest {
             status = InvoiceStatus.DRAFT,
             periodStart = LocalDate.of(2019, 1, 1),
             periodEnd = LocalDate.of(2019, 1, 31),
-            agreementType = 100,
+            areaId = AreaId(UUID.randomUUID()),
             headOfFamily = PersonId(UUID.randomUUID()),
             codebtor = null,
             rows = listOf()
@@ -35,7 +36,7 @@ class InvoicesTest {
             status = InvoiceStatus.DRAFT,
             periodStart = LocalDate.of(2019, 7, 1),
             periodEnd = LocalDate.of(2019, 7, 31),
-            agreementType = 100,
+            areaId = AreaId(UUID.randomUUID()),
             headOfFamily = PersonId(UUID.randomUUID()),
             codebtor = null,
             rows = listOf()
@@ -51,7 +52,7 @@ class InvoicesTest {
             status = InvoiceStatus.DRAFT,
             periodStart = LocalDate.of(2019, 5, 1),
             periodEnd = LocalDate.of(2019, 5, 31),
-            agreementType = 100,
+            areaId = AreaId(UUID.randomUUID()),
             headOfFamily = PersonId(UUID.randomUUID()),
             codebtor = null,
             rows = listOf()
@@ -67,7 +68,7 @@ class InvoicesTest {
             status = InvoiceStatus.DRAFT,
             periodStart = LocalDate.of(2019, 1, 1),
             periodEnd = LocalDate.of(2019, 1, 31),
-            agreementType = 100,
+            areaId = AreaId(UUID.randomUUID()),
             headOfFamily = PersonId(UUID.randomUUID()),
             codebtor = null,
             rows = listOf()

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/integration/EspooInvoiceIntegrationClientTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/integration/EspooInvoiceIntegrationClientTest.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.invoicing.domain.InvoiceRowDetailed
 import fi.espoo.evaka.invoicing.domain.InvoiceStatus
 import fi.espoo.evaka.invoicing.domain.PersonDetailed
 import fi.espoo.evaka.invoicing.domain.Product
+import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.InvoiceId
 import fi.espoo.evaka.shared.InvoiceRowId
 import fi.espoo.evaka.shared.PersonId
@@ -128,6 +129,7 @@ class EspooInvoiceIntegrationClientTest {
         dueDate = LocalDate.of(2020, 2, 28),
         invoiceDate = LocalDate.of(2020, 2, 14),
         agreementType = 100,
+        areaId = AreaId(UUID.randomUUID()),
         headOfFamily = headOfFamily,
         codebtor = codebtor,
         number = 1L,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

* `invoice` table: `agreement_type` replaced by `area_id`
* `Invoice` type: `agreementType: Int` replaced by `areaId: AreaId`
* `InvoiceDetailed` type: `areaId: AreaId` added so it has both. Agreement type is joined from care_area in queries
