### PR TITLE
Configurable invoice product provider

### DIFF
--- a/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
@@ -10,6 +10,7 @@ import {
   Checkbox,
   DatePickerDeprecated,
   Page,
+  Select,
   TextInput
 } from '../../../utils/page'
 import GuardianInformationPage from '../guardian-information'
@@ -241,6 +242,7 @@ export class InvoicesPage {
       `[data-qa="invoice-details-invoice-row"]:nth-child(${index + 1})`
     )
     return {
+      productSelect: new Select(row.find('[data-qa="select-product"]')),
       costCenterInput: new TextInput(row.find('[data-qa="input-cost-center"]')),
       amountInput: new TextInput(row.find('[data-qa="input-amount"]')),
       unitPriceInput: new TextInput(row.find('[data-qa="input-price"]')),
@@ -323,12 +325,14 @@ export class InvoicesPage {
   }
 
   async addNewInvoiceRow(
+    product: string,
     costCenter: string,
     amount: number,
     unitPrice: number
   ) {
     await this.#addInvoiceRowButton.click()
     const invoiceRow = this.#invoiceRow(1)
+    await invoiceRow.productSelect.selectOption(product)
     await invoiceRow.costCenterInput.fill('')
     await invoiceRow.costCenterInput.type(costCenter)
     await invoiceRow.amountInput.fill('')

--- a/frontend/src/e2e-test/specs/4_finance/invoices.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/invoices.spec.ts
@@ -110,7 +110,7 @@ describe('Invoices', () => {
     await invoicesPage.createInvoiceDrafts()
     await invoicesPage.openFirstInvoice()
     await invoicesPage.assertInvoiceRowCount(1)
-    await invoicesPage.addNewInvoiceRow('12345', 10, 100)
+    await invoicesPage.addNewInvoiceRow('DAYCARE_INCREASE', '12345', 10, 100)
     await invoicesPage.navigateBackToInvoices()
     const originalInvoiceTotal = feeDecisionFixture.children.reduce(
       (sum, { finalFee }) => sum + finalFee / 100,

--- a/frontend/src/employee-frontend/components/invoice/InvoiceRowsSectionRow.tsx
+++ b/frontend/src/employee-frontend/components/invoice/InvoiceRowsSectionRow.tsx
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { Result } from 'lib-common/api'
 import { UpdateStateFn } from 'lib-common/form-state'
 
-import { InvoiceCodes, Product } from 'lib-common/generated/api-types/invoicing'
+import { InvoiceCodes } from 'lib-common/generated/api-types/invoicing'
 import LocalDate from 'lib-common/local-date'
 import { formatCents, parseCents } from 'lib-common/money'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
@@ -20,7 +20,7 @@ import DateRangeInput from '../common/DateRangeInput'
 import EuroInput from '../common/EuroInput'
 
 interface InvoiceRowStub {
-  product: Product
+  product: string
   description: string
   costCenter: string
   subCostCenter: string | null
@@ -58,11 +58,16 @@ function InvoiceRowSectionRow({
 }: Props) {
   const { i18n } = useTranslation()
 
-  const productOpts = invoiceCodes.map((codes) => codes.products).getOrElse([])
+  const products = useMemo(
+    () => invoiceCodes.map((codes) => codes.products).getOrElse([]),
+    [invoiceCodes]
+  )
+  const productOpts = useMemo(() => products.map(({ key }) => key), [products])
 
-  const subCostCenterOpts = invoiceCodes
-    .map((codes) => codes.subCostCenters)
-    .getOrElse([])
+  const subCostCenterOpts = useMemo(
+    () => invoiceCodes.map((codes) => codes.subCostCenters).getOrElse([]),
+    [invoiceCodes]
+  )
 
   const costCenterValueIsValid =
     costCenter === undefined ||
@@ -78,11 +83,13 @@ function InvoiceRowSectionRow({
             selectedItem={product}
             items={productOpts}
             onChange={(product) => (product ? update({ product }) : undefined)}
-            getItemLabel={(product) => i18n.product[product] ?? product}
+            getItemLabel={(product) =>
+              products.find(({ key }) => key === product)?.nameFi ?? ''
+            }
             data-qa="select-product"
           />
         ) : (
-          <div>{i18n.product[product] ?? product}</div>
+          <div>{products.find(({ key }) => key === product)?.nameFi ?? ''}</div>
         )}
       </Td>
       <Td>

--- a/frontend/src/lib-common/generated/api-types/invoicing.ts
+++ b/frontend/src/lib-common/generated/api-types/invoicing.ts
@@ -323,7 +323,7 @@ export interface Invoice {
 */
 export interface InvoiceCodes {
   costCenters: string[]
-  products: Product[]
+  products: ProductWithName[]
   subCostCenters: string[]
 }
 
@@ -378,7 +378,7 @@ export interface InvoiceRow {
   periodEnd: LocalDate
   periodStart: LocalDate
   price: number
-  product: Product
+  product: string
   subCostCenter: string | null
   unitPrice: number
 }
@@ -395,7 +395,7 @@ export interface InvoiceRowDetailed {
   periodEnd: LocalDate
   periodStart: LocalDate
   price: number
-  product: Product
+  product: string
   subCostCenter: string | null
   unitPrice: number
 }
@@ -487,21 +487,12 @@ export interface PersonDetailed {
 }
 
 /**
-* Generated from fi.espoo.evaka.invoicing.domain.Product
+* Generated from fi.espoo.evaka.invoicing.service.ProductWithName
 */
-export type Product = 
-  | 'DAYCARE'
-  | 'DAYCARE_DISCOUNT'
-  | 'DAYCARE_INCREASE'
-  | 'PRESCHOOL_WITH_DAYCARE'
-  | 'PRESCHOOL_WITH_DAYCARE_DISCOUNT'
-  | 'PRESCHOOL_WITH_DAYCARE_INCREASE'
-  | 'TEMPORARY_CARE'
-  | 'SCHOOL_SHIFT_CARE'
-  | 'SICK_LEAVE_100'
-  | 'SICK_LEAVE_50'
-  | 'ABSENCE'
-  | 'FREE_OF_CHARGE'
+export interface ProductWithName {
+  key: string
+  nameFi: string
+}
 
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.SearchFeeDecisionRequest

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -1833,22 +1833,6 @@ export const fi = {
       SCHOOL_SHIFT_CARE: 'Koululaisten vuorohoito'
     }
   },
-  product: {
-    DAYCARE: 'Varhaiskasvatus',
-    DAYCARE_DISCOUNT: 'Alennus (maksup.)',
-    DAYCARE_INCREASE: 'Korotus (maksup.)',
-    PRESCHOOL_WITH_DAYCARE: 'Varhaiskasvatus + Esiopetus',
-    SCHOOL_SHIFT_CARE: 'Koululaisten vuorohoito',
-    PRESCHOOL_WITH_DAYCARE_DISCOUNT: 'Alennus (maksup.)',
-    PRESCHOOL_WITH_DAYCARE_INCREASE: 'Korotus (maksup.)',
-    TEMPORARY_CARE: 'Tilapäinen varhaiskasvatus',
-    SICK_LEAVE_100: 'Laskuun vaikuttava poissaolo 100%',
-    SICK_LEAVE_50: 'Laskuun vaikuttava poissaolo 50%',
-    ABSENCE: 'Poissaolovähennys',
-    EU_CHEMICAL_AGENCY: 'Kemikaaliviraston varhaiskasvatuksen laskut',
-    OTHER_MUNICIPALITY: 'Ulkopaikkakuntalaisten lasten varhaiskasvatus',
-    FREE_OF_CHARGE: 'Poissaolovähennys'
-  },
   feeAlteration: {
     DISCOUNT: 'Alennus',
     INCREASE: 'Korotus',

--- a/service/codegen/src/main/kotlin/evaka/codegen/apitypes/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/apitypes/Config.kt
@@ -39,6 +39,7 @@ private val customClassesMapping: Map<String, TSMapping> = mapOf(
     "fi.espoo.evaka.dailyservicetimes.DailyServiceTimes" to TSMapping("DailyServiceTimes", "import { DailyServiceTimes } from '../../api-types/child/common'"),
     "fi.espoo.evaka.vasu.VasuQuestion" to TSMapping("VasuQuestion", "import { VasuQuestion } from '../../api-types/vasu'"),
     "fi.espoo.evaka.invoicing.domain.DecisionIncome" to TSMapping("DecisionIncome", "import { DecisionIncome } from '../../api-types/income'"),
+    "fi.espoo.evaka.invoicing.service.ProductKey" to TSMapping("string")
 )
 
 private val actionsMapping: Map<String, TSMapping> = Action::class.nestedClasses.associate { action ->

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestInvoiceProductProvider.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestInvoiceProductProvider.kt
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka
+
+import fi.espoo.evaka.invoicing.domain.FeeAlteration
+import fi.espoo.evaka.invoicing.service.InvoiceProductProvider
+import fi.espoo.evaka.invoicing.service.ProductKey
+import fi.espoo.evaka.invoicing.service.ProductWithName
+import fi.espoo.evaka.placement.PlacementType
+
+class TestInvoiceProductProvider : InvoiceProductProvider {
+    override val dailyRefund = ProductKey("DAILY_REFUND")
+    override val partMonthSickLeave = ProductKey("PART_MONTH_SICK_LEAVE")
+    override val fullMonthSickLeave = ProductKey("FULL_MONTH_SICK_LEAVE")
+    override val fullMonthAbsence = ProductKey("FULL_MONTH_ABSENCE")
+
+    override val products: List<ProductWithName> =
+        PlacementType.values()
+            .flatMap { placementType ->
+                val placementTypeProduct = mapToProduct(placementType)
+                FeeAlteration.Type.values()
+                    .map { feeAlterationType -> mapToFeeAlterationProduct(placementTypeProduct, feeAlterationType) }
+                    .plus(placementTypeProduct)
+            }
+            .plus(this.dailyRefund)
+            .plus(this.partMonthSickLeave)
+            .plus(this.fullMonthSickLeave)
+            .plus(this.fullMonthAbsence)
+            .map { ProductWithName(it, it.value) }
+
+    override fun mapToProduct(placementType: PlacementType) = ProductKey(placementType.name)
+
+    override fun mapToFeeAlterationProduct(
+        productKey: ProductKey,
+        feeAlterationType: FeeAlteration.Type
+    ) = ProductKey("${productKey.value}_${feeAlterationType.name}")
+}

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -23,7 +23,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.invoicing.domain.InvoiceDetailed
 import fi.espoo.evaka.invoicing.domain.InvoiceStatus
 import fi.espoo.evaka.invoicing.domain.InvoiceSummary
-import fi.espoo.evaka.invoicing.domain.Product
+import fi.espoo.evaka.invoicing.service.ProductKey
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.InvoiceId
@@ -692,7 +692,7 @@ class InvoiceIntegrationTest : FullApplicationTest() {
                     subCostCenter = "UPDATED"
                 )
             } + createInvoiceRowFixture(testChild_1.id).copy(
-                product = Product.PRESCHOOL_WITH_DAYCARE,
+                product = ProductKey("PRESCHOOL_WITH_DAYCARE"),
                 amount = 100,
                 unitPrice = 100000
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -9,11 +9,13 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import fi.espoo.evaka.BucketEnv
+import fi.espoo.evaka.TestInvoiceProductProvider
 import fi.espoo.evaka.emailclient.EvakaEmailMessageProvider
 import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
 import fi.espoo.evaka.invoicing.service.EspooIncomeTypesProvider
 import fi.espoo.evaka.invoicing.service.IncomeTypesProvider
+import fi.espoo.evaka.invoicing.service.InvoiceProductProvider
 import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
@@ -147,4 +149,7 @@ class SharedIntegrationTestConfig {
         daycareApplicationServiceNeedOptionsEnabled = false,
         citizenReservationThresholdHours = 150,
     )
+
+    @Bean
+    fun invoiceProductProvider(): InvoiceProductProvider = TestInvoiceProductProvider()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -10,7 +10,9 @@ import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.invoicing.integration.EspooInvoiceIntegrationClient
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
 import fi.espoo.evaka.invoicing.service.EspooIncomeTypesProvider
+import fi.espoo.evaka.invoicing.service.EspooInvoiceProducts
 import fi.espoo.evaka.invoicing.service.IncomeTypesProvider
+import fi.espoo.evaka.invoicing.service.InvoiceProductProvider
 import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.db.DevDataInitializer
 import fi.espoo.evaka.shared.job.DefaultJobSchedule
@@ -64,6 +66,9 @@ class EspooConfig {
 
     @Bean
     fun incomeTypesProvider(): IncomeTypesProvider = EspooIncomeTypesProvider()
+
+    @Bean
+    fun invoiceProductsProvider(): InvoiceProductProvider = EspooInvoiceProducts.Provider()
 
     @Bean
     fun featureConfig(): FeatureConfig = FeatureConfig(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
@@ -503,10 +503,10 @@ private fun Database.Transaction.insertInvoiceRows(invoiceRows: List<Pair<Invoic
             )
         """
 
-    val batch = prepareBatch(sql)
+    prepareBatch(sql)
         .also { batch ->
             invoiceRows.forEach { (invoiceId, rows) ->
-                rows.map { row ->
+                rows.forEach { row ->
                     batch
                         .bind("invoice_id", invoiceId)
                         .bind("id", row.id)
@@ -516,7 +516,7 @@ private fun Database.Transaction.insertInvoiceRows(invoiceRows: List<Pair<Invoic
                         .bind("unit_price", row.unitPrice)
                         .bind("period_start", row.periodStart)
                         .bind("period_end", row.periodEnd)
-                        .bind("product", row.product.toString())
+                        .bind("product", row.product)
                         .bind("cost_center", row.costCenter)
                         .bind("sub_cost_center", row.subCostCenter)
                         .bind("description", row.description)
@@ -524,8 +524,7 @@ private fun Database.Transaction.insertInvoiceRows(invoiceRows: List<Pair<Invoic
                 }
             }
         }
-
-    batch.execute()
+        .execute()
 }
 
 val toInvoice = { rv: RowView ->

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Placements.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Placements.kt
@@ -10,15 +10,6 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.ServiceNeedId
 import java.math.BigDecimal
 
-sealed class Placement(open val unit: DaycareId)
-
-data class PermanentPlacement(
-    override val unit: DaycareId,
-    val type: PlacementType
-) : Placement(unit)
-
-data class TemporaryPlacement(override val unit: DaycareId, val partDay: Boolean) : Placement(unit)
-
 data class UnitData(
     val id: DaycareId,
     val name: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/EspooInvoiceProducts.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/EspooInvoiceProducts.kt
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.invoicing.service
+
+import fi.espoo.evaka.invoicing.domain.FeeAlteration
+import fi.espoo.evaka.placement.PlacementType
+
+object EspooInvoiceProducts {
+    enum class Product(val nameFi: String, val code: String, val nameOnInvoiceFi: String, val nameOnInvoiceSv: String) {
+        DAYCARE("Varhaiskasvatus", "01001", "Varhaiskasvatus", "Småbarnspedagogik"),
+        DAYCARE_DISCOUNT("Alennus (maksup.)", "01001", "Alennus", "Avdrag"),
+        DAYCARE_INCREASE("Korotus (maksup.)", "01001", "Lisä", "Lisä"),
+        PRESCHOOL_WITH_DAYCARE("Varhaiskasvatus + Esiopetus", "01002", "Varhaiskasvatus + esiopetus", "Småbarnspedagogik + FKL"),
+        PRESCHOOL_WITH_DAYCARE_DISCOUNT("Alennus (maksup.)", "01002", "Alennus", "Avdrag"),
+        PRESCHOOL_WITH_DAYCARE_INCREASE("Korotus (maksup.)", "01002", "Lisä", "Lisä"),
+        TEMPORARY_CARE("Tilapäinen varhaiskasvatus", "01005", "Tilapäinen varhaiskasvatus", "Temporär småbarnspedagogik"),
+        SICK_LEAVE_100("Laskuun vaikuttava poissaolo 100%", "01101", "Laskuun vaikuttava poissaolo 100%", "Frånvaro som påverkar faktureringen 100%"),
+        SICK_LEAVE_50("Laskuun vaikuttava poissaolo 50%", "01102", "Laskuun vaikuttava poissaolo 50%", "Frånvaro som påverkar faktureringen 50%"),
+        ABSENCE("Poissaolovähennys", "01103", "Poissaolovähennys", "Avdrag annan frånvaro");
+
+        val key = ProductKey(this.name)
+    }
+
+    fun findProduct(key: ProductKey) = Product.values().find { it.key == key }
+        ?: error("Product with key $key not found")
+
+    class Provider : InvoiceProductProvider {
+        override val products = Product.values().map { ProductWithName(it.key, it.nameFi) }
+        override val dailyRefund = Product.ABSENCE.key
+        override val partMonthSickLeave = Product.SICK_LEAVE_50.key
+        override val fullMonthSickLeave = Product.SICK_LEAVE_100.key
+        override val fullMonthAbsence = Product.ABSENCE.key
+
+        override fun mapToProduct(placementType: PlacementType): ProductKey {
+            val product = when (placementType) {
+                PlacementType.DAYCARE,
+                PlacementType.DAYCARE_PART_TIME,
+                PlacementType.DAYCARE_FIVE_YEAR_OLDS,
+                PlacementType.DAYCARE_PART_TIME_FIVE_YEAR_OLDS ->
+                    Product.DAYCARE
+                PlacementType.PRESCHOOL_DAYCARE ->
+                    Product.PRESCHOOL_WITH_DAYCARE
+                PlacementType.PREPARATORY_DAYCARE ->
+                    Product.PRESCHOOL_WITH_DAYCARE
+                PlacementType.TEMPORARY_DAYCARE,
+                PlacementType.TEMPORARY_DAYCARE_PART_DAY ->
+                    Product.TEMPORARY_CARE
+                PlacementType.PRESCHOOL,
+                PlacementType.PREPARATORY,
+                PlacementType.CLUB,
+                PlacementType.SCHOOL_SHIFT_CARE ->
+                    error("No product mapping found for placement type $placementType")
+            }
+            return product.key
+        }
+
+        override fun mapToFeeAlterationProduct(
+            productKey: ProductKey,
+            feeAlterationType: FeeAlteration.Type
+        ): ProductKey {
+            val product = when (findProduct(productKey) to feeAlterationType) {
+                Product.DAYCARE to FeeAlteration.Type.DISCOUNT,
+                Product.DAYCARE to FeeAlteration.Type.RELIEF ->
+                    Product.DAYCARE_DISCOUNT
+                Product.DAYCARE to FeeAlteration.Type.INCREASE ->
+                    Product.DAYCARE_INCREASE
+                Product.PRESCHOOL_WITH_DAYCARE to FeeAlteration.Type.DISCOUNT,
+                Product.PRESCHOOL_WITH_DAYCARE to FeeAlteration.Type.RELIEF ->
+                    Product.PRESCHOOL_WITH_DAYCARE_DISCOUNT
+                Product.PRESCHOOL_WITH_DAYCARE to FeeAlteration.Type.INCREASE ->
+                    Product.PRESCHOOL_WITH_DAYCARE_INCREASE
+                else ->
+                    error("No product mapping found for product + fee alteration type combo ($productKey + $feeAlterationType)")
+            }
+            return product.key
+        }
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceProductProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceProductProvider.kt
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.invoicing.service
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.util.StdConverter
+import fi.espoo.evaka.invoicing.domain.FeeAlteration
+import fi.espoo.evaka.placement.PlacementType
+
+interface InvoiceProductProvider {
+    val products: List<ProductWithName>
+    val dailyRefund: ProductKey
+    val partMonthSickLeave: ProductKey
+    val fullMonthSickLeave: ProductKey
+    val fullMonthAbsence: ProductKey
+
+    fun mapToProduct(placementType: PlacementType): ProductKey
+    fun mapToFeeAlterationProduct(productKey: ProductKey, feeAlterationType: FeeAlteration.Type): ProductKey
+}
+
+@JsonSerialize(converter = ProductKey.ToJson::class)
+@JsonDeserialize(converter = ProductKey.FromJson::class)
+data class ProductKey(val value: String) {
+    class FromJson : StdConverter<String, ProductKey>() {
+        override fun convert(value: String): ProductKey = ProductKey(value)
+    }
+
+    class ToJson : StdConverter<ProductKey, String>() {
+        override fun convert(value: ProductKey): String = value.value
+    }
+}
+
+data class ProductWithName(val key: ProductKey, val nameFi: String)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -85,6 +85,7 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
     jdbi.registerArgument(externalIdArgumentFactory)
     jdbi.registerArgument(idArgumentFactory)
     jdbi.registerArgument(helsinkiDateTimeArgumentFactory)
+    jdbi.registerArgument(productKeyArgumentFactory)
     jdbi.register(finiteDateRangeColumnMapper)
     jdbi.register(dateRangeColumnMapper)
     jdbi.register(coordinateColumnMapper)
@@ -97,6 +98,7 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
         Id::class.java.isAssignableFrom(GenericTypes.getErasedType(type))
     }
     jdbi.register(helsinkiDateTimeColumnMapper)
+    jdbi.register(productKeyColumnMapper)
     jdbi.registerArrayType(UUID::class.java, "uuid")
     jdbi.registerArrayType { elementType, _ ->
         Optional.ofNullable(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionSummary
 import fi.espoo.evaka.invoicing.domain.PersonBasic
 import fi.espoo.evaka.invoicing.domain.PersonDetailed
 import fi.espoo.evaka.invoicing.domain.UnitData
+import fi.espoo.evaka.invoicing.service.ProductKey
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DatabaseTable
 import fi.espoo.evaka.shared.EmployeeId
@@ -82,6 +83,8 @@ val helsinkiDateTimeArgumentFactory = customArgumentFactory<HelsinkiDateTime>(Ty
     CustomObjectArgument(it.toZonedDateTime().toOffsetDateTime())
 }
 
+val productKeyArgumentFactory = customArgumentFactory<ProductKey>(Types.VARCHAR) { CustomStringArgument(it.value) }
+
 val finiteDateRangeColumnMapper = PgObjectColumnMapper {
     assert(it.type == "daterange")
     it.value?.let { value ->
@@ -118,6 +121,8 @@ val idColumnMapper = ColumnMapper<Id<*>> { r, columnNumber, _ -> r.getObject(col
 
 val helsinkiDateTimeColumnMapper =
     ColumnMapper { r, columnNumber, _ -> r.getObject(columnNumber, OffsetDateTime::class.java)?.let { HelsinkiDateTime.from(it.toInstant()) } }
+
+val productKeyColumnMapper = ColumnMapper { rs, columnNumber, _ -> ProductKey(rs.getString(columnNumber)) }
 
 class CustomArgumentFactory<T>(private val clazz: Class<T>, private val sqlType: Int, private inline val f: (T) -> Argument?) : ArgumentFactory.Preparable {
     override fun prepare(type: Type, config: ConfigRegistry): Optional<Function<Any?, Argument>> = Optional.ofNullable(

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
@@ -21,12 +21,12 @@ import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.invoicing.domain.Invoice
 import fi.espoo.evaka.invoicing.domain.InvoiceRow
 import fi.espoo.evaka.invoicing.domain.InvoiceStatus
-import fi.espoo.evaka.invoicing.domain.Product
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionPlacement
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionServiceNeed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionType
+import fi.espoo.evaka.invoicing.service.ProductKey
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.ChildId
@@ -163,7 +163,7 @@ val testInvoiceRow = InvoiceRow(
     unitPrice = 28900,
     costCenter = "31450",
     subCostCenter = "01",
-    product = Product.DAYCARE
+    product = ProductKey("DAYCARE")
 )
 
 val testIncome = Income(
@@ -288,7 +288,7 @@ fun createInvoiceRowFixture(childId: ChildId) = InvoiceRow(
     child = ChildWithDateOfBirth(childId, LocalDate.of(2017, 1, 1)),
     amount = 1,
     unitPrice = 28900,
-    product = Product.DAYCARE,
+    product = ProductKey("DAYCARE"),
     costCenter = "200",
     subCostCenter = "09",
     periodStart = LocalDate.of(2019, 1, 1),

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/integration/EspooInvoiceIntegrationClientTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/integration/EspooInvoiceIntegrationClientTest.kt
@@ -8,7 +8,7 @@ import fi.espoo.evaka.invoicing.domain.InvoiceDetailed
 import fi.espoo.evaka.invoicing.domain.InvoiceRowDetailed
 import fi.espoo.evaka.invoicing.domain.InvoiceStatus
 import fi.espoo.evaka.invoicing.domain.PersonDetailed
-import fi.espoo.evaka.invoicing.domain.Product
+import fi.espoo.evaka.invoicing.service.EspooInvoiceProducts
 import fi.espoo.evaka.shared.AreaId
 import fi.espoo.evaka.shared.InvoiceId
 import fi.espoo.evaka.shared.InvoiceRowId
@@ -147,7 +147,7 @@ class EspooInvoiceIntegrationClientTest {
         unitPrice = 10000,
         periodStart = LocalDate.of(2020, 1, 1),
         periodEnd = LocalDate.of(2020, 1, 31),
-        product = Product.DAYCARE,
+        product = EspooInvoiceProducts.Product.DAYCARE.key,
         costCenter = "12345",
         subCostCenter = "01",
         description = ""


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Make invoice products configurable by moving them behind `InvoiceProductProvider` interface.

The product `FREE_OF_CHARGE` is also removed from the Espoo implementation since it's identical to the `ABSENCE` product so a data migration must be done before deploying this commit.

