### PR TITLE
Fix checkbox behavior in decision draft view

### DIFF
--- a/frontend/src/employee-frontend/components/common/LabelValueList.tsx
+++ b/frontend/src/employee-frontend/components/common/LabelValueList.tsx
@@ -4,7 +4,7 @@
 
 import React, { Fragment, ReactNode } from 'react'
 import styled from 'styled-components'
-import { Label } from 'lib-components/typography'
+import { LabelLike } from 'lib-components/typography'
 
 type Spacing = 'small' | 'large'
 type LabelWidth = '25%' | 'fit-content(40%)'
@@ -66,7 +66,7 @@ const GridContainer = styled.div<{
   align-items: baseline;
 `
 
-const GridLabel = styled(Label)<{ index: number }>`
+const GridLabel = styled(LabelLike)<{ index: number }>`
   grid-column: 1;
   grid-row: ${({ index }) => index};
 `

--- a/frontend/src/lib-components/typography.ts
+++ b/frontend/src/lib-components/typography.ts
@@ -112,7 +112,7 @@ interface LabelProps {
   white?: boolean
 }
 
-export const Label = styled.label<LabelProps>`
+const labelMixin = css<LabelProps>`
   font-weight: ${fontWeights.semibold};
   color: ${(p) =>
     p.primary
@@ -121,6 +121,14 @@ export const Label = styled.label<LabelProps>`
       ? p.theme.colors.greyscale.white
       : p.theme.colors.greyscale.darkest};
   ${(p) => (p.inputRow ? 'margin-top: 6px;' : '')}
+`
+
+export const Label = styled.label<LabelProps>`
+  ${labelMixin}
+`
+
+export const LabelLike = styled.div<LabelProps>`
+  ${labelMixin}
 `
 
 type ParagraphProps = {


### PR DESCRIPTION
#### Summary

Having a <Checkbox> inside a <label> seems to break, because the <label> causes an unwanted automatic click in the child <input> element. Fix by preventing the label autoclick.
