### PR TITLE
Unify theme colors to match naming in eVaka design system

### DIFF
--- a/frontend/src/citizen-frontend/Footer.tsx
+++ b/frontend/src/citizen-frontend/Footer.tsx
@@ -81,6 +81,6 @@ const FooterContainer = styled(Container)`
 `
 
 const FooterLink = styled.a`
-  color: ${colors.main.primary};
+  color: ${colors.main.m2};
   text-decoration: none;
 `

--- a/frontend/src/citizen-frontend/applications/ChildApplicationsBlock.tsx
+++ b/frontend/src/citizen-frontend/applications/ChildApplicationsBlock.tsx
@@ -34,7 +34,7 @@ import { useTranslation } from '../localization'
 import { OverlayContext } from '../overlay/state'
 
 const StyledLink = styled(Link)`
-  color: ${colors.main.primary};
+  color: ${colors.main.m2};
   text-decoration: none;
 `
 
@@ -73,7 +73,7 @@ const Icon = styled(FontAwesomeIcon)`
 `
 
 const NoApplications = styled.p`
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 `
 
 interface ChildApplicationsBlockProps {
@@ -253,14 +253,14 @@ export default React.memo(function ChildApplicationsBlock({
 
                   {applicationStatus === 'WAITING_CONFIRMATION' && (
                     <ConfirmationContainer>
-                      <div color={colors.main.primary}>
+                      <div color={colors.main.m2}>
                         {t.applicationsList.confirmationLinkInstructions}
                       </div>
                       <StyledLink
                         to={`/decisions/by-application/${applicationId}`}
                       >
                         {t.applicationsList.confirmationLink}{' '}
-                        <Icon icon={faArrowRight} color={colors.main.primary} />
+                        <Icon icon={faArrowRight} color={colors.main.m2} />
                       </StyledLink>
                     </ConfirmationContainer>
                   )}

--- a/frontend/src/citizen-frontend/applications/editor/EditorSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/EditorSection.tsx
@@ -41,7 +41,7 @@ export default React.memo(function EditorSection(props: Props) {
                 <ErrorsIcon
                   content={props.validationErrors.toString()}
                   size="m"
-                  color={colors.accents.warningOrange}
+                  color={colors.status.warning}
                   aria-hidden="true"
                 />
               ) : null}

--- a/frontend/src/citizen-frontend/applications/editor/unit-preference/PreferredUnitBox.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/unit-preference/PreferredUnitBox.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -45,13 +45,13 @@ export default React.memo(function PreferredUnitBox({
     switch (unit.providerType) {
       case 'MUNICIPAL':
       case 'MUNICIPAL_SCHOOL':
-        return { color: colors.accents.turquoise }
+        return { color: colors.accents.a6turquoise }
       case 'PRIVATE':
       case 'PRIVATE_SERVICE_VOUCHER':
-        return { color: colors.accents.emerald }
+        return { color: colors.accents.a3emerald }
       case 'PURCHASED':
       case 'EXTERNAL_PURCHASED':
-        return { color: colors.main.lighter }
+        return { color: colors.main.m4 }
     }
   }
 
@@ -75,11 +75,11 @@ export default React.memo(function PreferredUnitBox({
           </FixedSpaceColumn>
           <FixedSpaceFlexWrap horizontalSpacing="xs" verticalSpacing="xs">
             {unit.language === 'sv' ? (
-              <StaticChip color={colors.accents.peach}>
+              <StaticChip color={colors.accents.a5orangeLight}>
                 {t.applications.editor.unitPreference.units.preferences.sv}
               </StaticChip>
             ) : (
-              <StaticChip color={colors.main.light}>
+              <StaticChip color={colors.main.m3}>
                 {t.applications.editor.unitPreference.units.preferences.fi}
               </StaticChip>
             )}
@@ -139,7 +139,7 @@ const noOp = () => undefined
 const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
-  border: 1px solid ${colors.main.primary};
+  border: 1px solid ${colors.main.m2};
   box-sizing: border-box;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.15);
   border-radius: 2px;
@@ -150,7 +150,7 @@ const MainColLeft = styled.div`
   font-family: Montserrat, sans-serif;
   font-style: normal;
   font-weight: ${fontWeights.light};
-  color: ${colors.main.primary};
+  color: ${colors.main.m2};
   text-align: center;
 
   font-size: 70px;

--- a/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
@@ -274,6 +274,6 @@ const FixedWidthDiv = styled.div`
 `
 
 const Info = styled(P)`
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   margin: 0;
 `

--- a/frontend/src/citizen-frontend/applications/editor/verification/ApplicationVerificationView.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/verification/ApplicationVerificationView.tsx
@@ -30,7 +30,7 @@ type DaycareApplicationVerificationViewProps = {
 }
 
 const AttachmentBox = styled.div`
-  border: 2px solid ${colors.main.light};
+  border: 2px solid ${colors.main.m3};
   padding: 0 ${defaultMargins.m};
   display: flex;
 `
@@ -64,11 +64,7 @@ export default React.memo(function ApplicationVerificationViewDaycare({
           : t.applications.editor.verification.notYetSaved}
         {missingAttachments && (
           <AttachmentBox>
-            <RoundIconStyled
-              content={faInfo}
-              color={colors.main.dark}
-              size="s"
-            />
+            <RoundIconStyled content={faInfo} color={colors.main.m1} size="s" />
             <div>
               <P>
                 <strong>

--- a/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
+++ b/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from '../localization'
 import MapView from '../map/MapView'
 
 const WhiteBg = styled.div`
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
 `
 
 export default React.memo(function ApplyingRouter() {

--- a/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -215,5 +215,5 @@ const validateForm = (
 }
 
 const Warning = styled.div`
-  color: ${(p) => p.theme.colors.accents.orangeDark};
+  color: ${(p) => p.theme.colors.accents.a2orangeDark};
 `

--- a/frontend/src/citizen-frontend/calendar/ActionPickerModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ActionPickerModal.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -66,7 +66,7 @@ const Container = styled.div`
 const Action = styled(Button)`
   border: none;
   background: none;
-  color: ${(p) => p.theme.colors.greyscale.white};
+  color: ${(p) => p.theme.colors.grayscale.g0};
   padding: 0;
   min-height: 0;
 `
@@ -77,8 +77,8 @@ const IconBackground = styled.div`
   align-items: center;
   width: 34px;
   height: 34px;
-  color: ${(p) => p.theme.colors.main.primary};
-  background: ${(p) => p.theme.colors.greyscale.white};
+  color: ${(p) => p.theme.colors.main.m2};
+  background: ${(p) => p.theme.colors.grayscale.g0};
   margin-left: ${defaultMargins.s};
   border-radius: 50%;
 `

--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -223,7 +223,7 @@ const StickyHeader = styled.div`
   top: ${headerHeightDesktop}px;
   z-index: 2;
   width: 100%;
-  background: ${({ theme }) => theme.colors.greyscale.white};
+  background: ${(p) => p.theme.colors.grayscale.g0};
   box-shadow: 0px 4px 8px 2px #0000000a;
 `
 
@@ -247,7 +247,7 @@ const Grid = styled.div<{ includeWeekends: boolean }>`
 `
 
 const HeadingCell = styled.div`
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   font-family: 'Open Sans', sans-serif;
   font-style: normal;
   padding: ${defaultMargins.xxs} ${defaultMargins.s};
@@ -259,28 +259,28 @@ const WeekNumber = styled(HeadingCell)`
 `
 
 const MonthTitle = styled(H2).attrs({ noMargin: true })`
-  color: ${({ theme }) => theme.colors.main.dark};
+  color: ${(p) => p.theme.colors.main.m1};
 `
 
 const DayCell = styled.div<{ today: boolean; selected: boolean }>`
   position: relative;
   min-height: 150px;
   padding: ${defaultMargins.s};
-  background: ${({ theme }) => theme.colors.greyscale.white};
-  outline: 1px solid ${colors.greyscale.lighter};
+  background: ${(p) => p.theme.colors.grayscale.g0};
+  outline: 1px solid ${colors.grayscale.g15};
   cursor: pointer;
   user-select: none;
 
   ${(p) =>
     p.today
       ? css`
-          border-left: 4px solid ${colors.accents.successGreen};
+          border-left: 4px solid ${colors.status.success};
           padding-left: calc(${defaultMargins.s} - 3px);
         `
       : ''}
 
-  ${({ selected }) =>
-    selected
+  ${(p) =>
+    p.selected
       ? css`
           box-shadow: 0px 2px 3px 2px #00000030;
           z-index: 1;
@@ -300,7 +300,7 @@ const DayCellHeader = styled.div`
 const DayCellDate = styled.div<{ inactive: boolean }>`
   font-family: Montserrat, sans-serif;
   font-style: normal;
-  color: ${(p) => (p.inactive ? colors.greyscale.dark : colors.main.dark)};
+  color: ${(p) => (p.inactive ? colors.grayscale.g70 : colors.main.m1)};
   font-weight: ${fontWeights.semibold};
   font-size: 1.25rem;
 `
@@ -315,5 +315,5 @@ const FadeOverlay = styled.div`
   height: calc(100% - 2px);
   z-index: 1;
   opacity: 0.8;
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
 `

--- a/frontend/src/citizen-frontend/calendar/CalendarModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarModal.tsx
@@ -31,7 +31,7 @@ export default React.memo(function CalendarModal({
 })
 
 const Modal = styled.div`
-  background: ${(p) => p.theme.colors.main.lighter};
+  background: ${(p) => p.theme.colors.main.m4};
   box-shadow: 0px 10px 24px 24px #0f0f0f14;
   z-index: 20;
   position: fixed;

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -544,12 +544,11 @@ const Reservations = React.memo(function Reservations({
 })
 
 const Content = styled.div<{ highlight: boolean }>`
-  background: ${(p) => p.theme.colors.greyscale.white};
+  background: ${(p) => p.theme.colors.grayscale.g0};
   padding: ${defaultMargins.L};
   padding-left: calc(${defaultMargins.L} - 4px);
   border-left: 4px solid
-    ${(p) =>
-      p.highlight ? p.theme.colors.accents.successGreen : 'transparent'};
+    ${(p) => (p.highlight ? p.theme.colors.status.success : 'transparent')};
 
   @media (max-width: ${tabletMin}) {
     padding: ${defaultMargins.s};
@@ -586,17 +585,17 @@ const Grid = styled.div`
 `
 
 const NoReservation = styled.span`
-  color: ${(p) => p.theme.colors.accents.orangeDark};
+  color: ${(p) => p.theme.colors.accents.a2orangeDark};
 `
 
 const Separator = styled.div`
-  border-top: 2px dotted ${(p) => p.theme.colors.greyscale.lighter};
+  border-top: 2px dotted ${(p) => p.theme.colors.grayscale.g15};
   margin: ${defaultMargins.s} 0;
 `
 
 const BottomBar = styled.div`
-  background: ${(p) => p.theme.colors.greyscale.white};
-  border-top: 2px solid ${({ theme }) => theme.colors.greyscale.lighter};
+  background: ${(p) => p.theme.colors.grayscale.g0};
+  border-top: 2px solid ${(p) => p.theme.colors.grayscale.g15};
 `
 
 const AbsenceButton = styled(InlineButton)`

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -705,14 +705,14 @@ const TimeInputGrid = styled.div`
 `
 
 const Week = styled.div`
-  color: ${({ theme }) => theme.colors.main.dark};
+  color: ${(p) => p.theme.colors.main.m1};
   font-weight: ${fontWeights.semibold};
   grid-column-start: 1;
   grid-column-end: 4;
 `
 
 const Separator = styled.div`
-  border-top: 2px dotted ${(p) => p.theme.colors.greyscale.lighter};
+  border-top: 2px dotted ${(p) => p.theme.colors.grayscale.g15};
   margin: ${defaultMargins.s} 0;
   grid-column-start: 1;
   grid-column-end: 4;

--- a/frontend/src/citizen-frontend/calendar/WeekElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/WeekElem.tsx
@@ -55,11 +55,11 @@ const WeekDiv = styled.div`
   justify-content: center;
   align-items: center;
   padding: ${defaultMargins.s} 0 ${defaultMargins.xs};
-  background-color: ${colors.main.lighter};
-  color: ${colors.main.dark};
+  background-color: ${colors.main.m4};
+  color: ${colors.main.m1};
   font-weight: ${fontWeights.semibold};
   font-size: 0.875rem;
-  border-bottom: 1px solid ${colors.greyscale.lighter};
+  border-bottom: 1px solid ${colors.grayscale.g15};
 `
 
 interface DayProps {
@@ -120,15 +120,15 @@ const DayElem = React.memo(function DayElem({
 const DayDiv = styled(FixedSpaceRow)<{ today: boolean }>`
   position: relative;
   padding: ${defaultMargins.s} ${defaultMargins.s};
-  border-bottom: 1px solid ${colors.greyscale.lighter};
+  border-bottom: 1px solid ${colors.grayscale.g15};
   border-left: 6px solid
-    ${(p) => (p.today ? colors.accents.successGreen : 'transparent')};
+    ${(p) => (p.today ? colors.status.success : 'transparent')};
   cursor: pointer;
 `
 
 const DayColumn = styled(FixedSpaceColumn)<{ inactive: boolean }>`
   width: 3rem;
-  color: ${(p) => (p.inactive ? colors.greyscale.dark : colors.main.dark)};
+  color: ${(p) => (p.inactive ? colors.grayscale.g70 : colors.main.m1)};
   font-weight: ${fontWeights.semibold};
 `
 
@@ -139,5 +139,5 @@ const HistoryOverlay = styled.div`
   width: 100%;
   height: 100%;
   opacity: 0.3;
-  background-color: ${colors.main.lighter};
+  background-color: ${colors.main.m4};
 `

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -41,7 +41,7 @@ export const NoReservation = React.memo(function NoReservation() {
 })
 
 const NoReservationNote = styled.span`
-  color: ${({ theme }) => theme.colors.accents.orangeDark};
+  color: ${(p) => p.theme.colors.accents.a2orangeDark};
 `
 
 const uniqueReservations = (

--- a/frontend/src/citizen-frontend/children/ChildHeader.tsx
+++ b/frontend/src/citizen-frontend/children/ChildHeader.tsx
@@ -45,7 +45,7 @@ export default React.memo(function ChildHeader({
           imageId ? `/api/application/citizen/child-images/${imageId}` : null
         }
         fallbackContent={farUser}
-        fallbackColor={colors.greyscale.lighter}
+        fallbackColor={colors.grayscale.g15}
         alt={t.children.childPicture}
       />
       <div>

--- a/frontend/src/citizen-frontend/children/ChildrenPage.tsx
+++ b/frontend/src/citizen-frontend/children/ChildrenPage.tsx
@@ -44,7 +44,7 @@ const ChildContainer = styled(ContentArea)`
   display: flex;
   align-items: center;
 
-  border-bottom: 1px solid ${colors.greyscale.lighter};
+  border-bottom: 1px solid ${colors.grayscale.g15};
   gap: ${defaultMargins.s};
   min-height: 80px;
   @media (min-width: ${desktopMin}) {
@@ -87,7 +87,7 @@ const ChildItem = React.memo(function ChildItem({ child }: { child: Child }) {
             : null
         }
         fallbackContent={faUser}
-        fallbackColor={colors.greyscale.lighter}
+        fallbackColor={colors.grayscale.g15}
         alt={t.children.childPicture}
       />
       <MobileAndTablet>

--- a/frontend/src/citizen-frontend/decisions/shared.tsx
+++ b/frontend/src/citizen-frontend/decisions/shared.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -18,7 +18,7 @@ import { Decision, DecisionSummary } from '../decisions/types'
 
 export const Status = styled.span`
   text-transform: uppercase;
-  color: ${colors.greyscale.darkest}
+  color: ${colors.grayscale.g100}
   font-size: 16px;
   font-weight: ${fontWeights.normal};
 `
@@ -26,15 +26,15 @@ export const Status = styled.span`
 export const decisionStatusIcon = {
   PENDING: {
     icon: faGavel,
-    color: colors.accents.warningOrange
+    color: colors.status.warning
   },
   ACCEPTED: {
     icon: faCheck,
-    color: colors.accents.successGreen
+    color: colors.status.success
   },
   REJECTED: {
     icon: faTimes,
-    color: colors.accents.dangerRed
+    color: colors.status.danger
   }
 }
 
@@ -43,27 +43,27 @@ export const applicationStatusIcon: {
 } = {
   PROCESSING: {
     icon: faPlay,
-    color: colors.main.dark
+    color: colors.main.m1
   },
   PENDING: {
     icon: faGavel,
-    color: colors.accents.warningOrange
+    color: colors.status.warning
   },
   ACCEPTED: {
     icon: faCheck,
-    color: colors.accents.successGreen
+    color: colors.status.success
   },
   REJECTED: {
     icon: faTimes,
-    color: colors.accents.dangerRed
+    color: colors.status.danger
   },
   CREATED: {
     icon: faFile,
-    color: colors.greyscale.dark
+    color: colors.grayscale.g70
   },
   SENT: {
     icon: faEnvelope,
-    color: colors.main.dark
+    color: colors.main.m1
   }
 }
 

--- a/frontend/src/citizen-frontend/header/AttentionIndicator.tsx
+++ b/frontend/src/citizen-frontend/header/AttentionIndicator.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -35,5 +35,5 @@ const Indicator = styled.div`
   bottom: -2px;
   right: -6px;
   border-radius: 6px;
-  background: ${({ theme }) => theme.colors.accents.warningOrange};
+  background: ${(p) => p.theme.colors.status.warning};
 `

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -136,7 +136,7 @@ const StyledNavLink = styled(NavLink)`
   border-bottom: 3px solid transparent;
 
   &.active {
-    border-color: ${colors.greyscale.white};
+    border-color: ${colors.grayscale.g0};
     font-weight: ${fontWeights.bold};
   }
 `
@@ -160,7 +160,7 @@ const Icon = styled(FontAwesomeIcon)`
 export const CircledChar = styled.div`
   width: ${defaultMargins.s};
   height: ${defaultMargins.s};
-  border: 1px solid ${colors.greyscale.white};
+  border: 1px solid ${colors.grayscale.g0};
   padding: 10px;
   display: flex;
   justify-content: center;
@@ -248,7 +248,7 @@ const UserMenu = React.memo(function UserMenu({ user }: { user: User }) {
             {showUserAttentionIndicator && (
               <RoundIcon
                 content={faExclamation}
-                color={theme.colors.accents.warningOrange}
+                color={theme.colors.status.warning}
                 size="s"
                 data-qa="personal-details-attention-indicator-desktop"
               />
@@ -307,8 +307,8 @@ const DropDown = styled.ul`
   list-style: none;
   margin: 0;
   padding: 0;
-  background: ${colors.greyscale.white};
-  box-shadow: 0 2px 6px 0 ${colors.greyscale.lighter};
+  background: ${colors.grayscale.g0};
+  box-shadow: 0 2px 6px 0 ${colors.grayscale.g15};
 `
 
 const DropDownItem = styled.button<{ selected: boolean }>`
@@ -321,7 +321,7 @@ const DropDownItem = styled.button<{ selected: boolean }>`
   cursor: pointer;
   font-family: Open Sans;
   color: ${({ selected }) =>
-    selected ? colors.main.dark : colors.greyscale.darkest};
+    selected ? colors.main.m1 : colors.grayscale.g100};
   font-size: 1em;
   font-weight: ${({ selected }) =>
     selected ? fontWeights.semibold : fontWeights.normal};
@@ -329,7 +329,7 @@ const DropDownItem = styled.button<{ selected: boolean }>`
   width: 100%;
 
   &:hover {
-    background: ${colors.main.lighter};
+    background: ${colors.main.m4};
   }
 `
 

--- a/frontend/src/citizen-frontend/header/Header.tsx
+++ b/frontend/src/citizen-frontend/header/Header.tsx
@@ -58,8 +58,8 @@ export default React.memo(function Header() {
 
 const HeaderContainer = styled.header<{ showMenu: boolean }>`
   z-index: 9;
-  color: ${colors.greyscale.white};
-  background-color: ${colors.main.primary};
+  color: ${colors.grayscale.g0};
+  background-color: ${colors.main.m2};
   position: ${({ showMenu }) => (showMenu ? 'fixed' : 'sticky')};
   top: 0;
   display: grid;

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -133,7 +133,7 @@ const Container = styled.div`
 
 const MenuButton = styled.button`
   background: transparent;
-  color: ${colors.greyscale.white};
+  color: ${colors.grayscale.g0};
   border: none;
   padding: 16px 18px;
   height: 100%;
@@ -150,7 +150,7 @@ const MenuContainer = styled.div`
   overflow-y: scroll;
   top: 0;
   right: 0;
-  background: ${colors.main.primary};
+  background: ${colors.main.m2};
   box-sizing: border-box;
   width: 100vw;
   height: 100%;
@@ -202,7 +202,7 @@ const LangListElement = styled.li`
 
 const LangButton = styled.button<{ active: boolean }>`
   background: transparent;
-  color: ${colors.greyscale.white};
+  color: ${colors.grayscale.g0};
   padding: ${defaultMargins.xs};
   font-family: Montserrat, sans-serif;
   font-size: 1em;
@@ -213,7 +213,7 @@ const LangButton = styled.button<{ active: boolean }>`
   border: none;
   border-bottom: 2px solid;
   border-color: ${(props) =>
-    props.active ? colors.greyscale.white : 'transparent'};
+    props.active ? colors.grayscale.g0 : 'transparent'};
 `
 
 const Navigation = React.memo(function Navigation({
@@ -298,12 +298,12 @@ const StyledNavLink = styled(NavLink)`
 
   &:hover {
     font-weight: ${fontWeights.bold};
-    border-color: ${colors.greyscale.white};
+    border-color: ${colors.grayscale.g0};
   }
 
   &.active {
     font-weight: ${fontWeights.bold};
-    border-color: ${colors.greyscale.white};
+    border-color: ${colors.grayscale.g0};
   }
 `
 
@@ -317,8 +317,8 @@ const UserContainer = styled.div`
 `
 
 const LogInLogOutButton = styled.button`
-  background: ${colors.main.dark};
-  color: ${colors.greyscale.white};
+  background: ${colors.main.m1};
+  color: ${colors.grayscale.g0};
   border: none;
   font-family: 'Open Sans', sans-serif;
   font-size: 1em;

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -1282,7 +1282,7 @@ const LabelError = styled(
       <span className={className}>
         <FontAwesomeIcon
           icon={fasExclamationTriangle}
-          color={colors.accents.warningOrange}
+          color={colors.status.warning}
         />
         {text}
       </span>
@@ -1291,7 +1291,7 @@ const LabelError = styled(
 )`
   font-size: 14px;
   font-weight: ${fontWeights.semibold};
-  color: ${(p) => p.theme.colors.accents.orangeDark};
+  color: ${(p) => p.theme.colors.accents.a2orangeDark};
 
   > :first-child {
     margin-right: ${defaultMargins.xs};

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
@@ -368,7 +368,7 @@ const UploadedFiles = React.memo(function UploadedFiles({
 })
 
 const FileIcon = styled(FontAwesomeIcon)`
-  color: ${(p) => p.theme.colors.main.primary};
+  color: ${(p) => p.theme.colors.main.m2};
   margin-right: ${defaultMargins.s};
 `
 

--- a/frontend/src/citizen-frontend/map/MapBox.tsx
+++ b/frontend/src/citizen-frontend/map/MapBox.tsx
@@ -286,7 +286,7 @@ const FooterWrapper = styled.div`
   left: 0;
   bottom: 0;
   width: fit-content;
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
   z-index: 999;
   margin-right: 250px;
 
@@ -332,7 +332,7 @@ const UnitDetails = styled.div`
   font-size: 14px;
   font-weight: ${fontWeights.semibold};
   line-height: 21px;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 `
 
 const UnitDetailsLeft = styled.div`

--- a/frontend/src/citizen-frontend/map/MobileTabs.tsx
+++ b/frontend/src/citizen-frontend/map/MobileTabs.tsx
@@ -17,7 +17,7 @@ const MobileTabContainer = styled.div`
     display: flex;
     justify-content: stretch;
     height: ${headerHeightMobile}px;
-    background-color: ${colors.greyscale.white};
+    background-color: ${colors.grayscale.g0};
 
     position: sticky;
     top: 60px;
@@ -30,11 +30,10 @@ const Tab = styled.div<{ active: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  border-bottom: 3px solid
-    ${(p) => (p.active ? colors.main.primary : 'transparent')};
+  border-bottom: 3px solid ${(p) => (p.active ? colors.main.m2 : 'transparent')};
   cursor: pointer;
 
-  color: ${colors.main.primary};
+  color: ${colors.main.m2};
   font-family: 'Montserrat', 'Open Sans', sans-serif;
   font-size: 14px;
   text-transform: uppercase;

--- a/frontend/src/citizen-frontend/map/SearchInput.tsx
+++ b/frontend/src/citizen-frontend/map/SearchInput.tsx
@@ -186,7 +186,7 @@ const OptionWrapper = styled.div`
 
   &:hover,
   &.focused {
-    background-color: ${colors.main.lighter};
+    background-color: ${colors.main.m4};
   }
 
   padding: ${defaultMargins.xxs} ${defaultMargins.s};
@@ -207,7 +207,7 @@ const OptionContents = React.memo(function Option({
       {isUnit && (
         <FontAwesomeIcon
           icon={fasMapMarkerAlt}
-          color={colors.main.primary}
+          color={colors.main.m2}
           style={{ fontSize: '24px' }}
         />
       )}
@@ -223,5 +223,5 @@ const SecondaryText = styled.span`
   font-size: 14px;
   line-height: 21px;
   font-weight: ${fontWeights.semibold};
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 `

--- a/frontend/src/citizen-frontend/map/SearchSection.tsx
+++ b/frontend/src/citizen-frontend/map/SearchSection.tsx
@@ -207,6 +207,6 @@ const PrivateUnitInfo = styled.span`
   font-weight: ${fontWeights.semibold};
   font-size: 14px;
   line-height: 21px;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   display: block;
 `

--- a/frontend/src/citizen-frontend/map/UnitList.tsx
+++ b/frontend/src/citizen-frontend/map/UnitList.tsx
@@ -141,7 +141,7 @@ const Wrapper = styled(ContentArea)`
 const Info = styled.div`
   font-size: 14px;
   font-weight: ${fontWeights.semibold};
-  color: ${colors.greyscale.medium};
+  color: ${colors.grayscale.g35};
 `
 
 const Centered = styled.div`

--- a/frontend/src/citizen-frontend/map/UnitListItem.tsx
+++ b/frontend/src/citizen-frontend/map/UnitListItem.tsx
@@ -50,13 +50,13 @@ const Wrapper = styled.div`
   margin: ${dM.xs} -${dM.s} -${dM.xs} -${dM.L};
 
   &:hover {
-    background-color: ${colors.main.lighter};
+    background-color: ${colors.main.m4};
   }
 
   &:after {
     content: '';
     width: calc(100% - ${dM.X3L});
-    background: ${colors.greyscale.lighter};
+    background: ${colors.grayscale.g15};
     height: 1px;
     display: block;
     position: absolute;
@@ -86,5 +86,5 @@ const UnitDetails = styled.div`
   font-weight: ${fontWeights.semibold};
   font-size: 14px;
   line-height: 21px;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 `

--- a/frontend/src/citizen-frontend/messages/EmptyThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/EmptyThreadView.tsx
@@ -19,11 +19,7 @@ export default React.memo(function EmptyThreadView({ inboxEmpty }: Props) {
   const i18n = useTranslation()
   return inboxEmpty ? (
     <EmptyThreadViewContainer data-qa="inbox-empty">
-      <FontAwesomeIcon
-        icon={faInbox}
-        size="7x"
-        color={colors.greyscale.medium}
-      />
+      <FontAwesomeIcon icon={faInbox} size="7x" color={colors.grayscale.g35} />
       <H3>{i18n.messages.emptyInbox}</H3>
     </EmptyThreadViewContainer>
   ) : (
@@ -36,7 +32,7 @@ export default React.memo(function EmptyThreadView({ inboxEmpty }: Props) {
 const EmptyThreadViewContainer = styled.div`
   text-align: center;
   width: 100%;
-  background: ${colors.greyscale.white};
+  background: ${colors.grayscale.g0};
   padding-top: 10%;
 
   display: none;

--- a/frontend/src/citizen-frontend/messages/MessageComponents.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageComponents.tsx
@@ -8,7 +8,7 @@ import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 
 export const MessageContainer = styled.div`
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
   padding: ${defaultMargins.s};
 
   @media (min-width: ${desktopMin}) {

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -151,7 +151,7 @@ const Container = styled.div`
   box-shadow: 0 8px 8px 8px rgba(15, 15, 15, 0.15);
   display: flex;
   flex-direction: column;
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
   @media (max-width: ${desktopMin}) {
     width: 100vw;
     height: 100%;
@@ -164,14 +164,14 @@ const Container = styled.div`
 `
 
 const ErrorMessage = styled.div`
-  color: ${colors.accents.dangerRed};
+  color: ${colors.status.danger};
 `
 
 const TopBar = styled.div`
   width: 100%;
   height: 60px;
-  background-color: ${colors.main.primary};
-  color: ${colors.greyscale.white};
+  background-color: ${colors.main.m2};
+  color: ${colors.grayscale.g0};
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/frontend/src/citizen-frontend/messages/MessageTypeChip.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageTypeChip.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -14,8 +14,8 @@ const Chip = styled(StaticChip)`
 `
 
 const chipColors: Record<MessageType, string> = {
-  MESSAGE: colors.accents.violet,
-  BULLETIN: colors.main.dark
+  MESSAGE: colors.accents.a4violet,
+  BULLETIN: colors.main.m1
 }
 
 interface Props {

--- a/frontend/src/citizen-frontend/messages/ThreadList.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadList.tsx
@@ -89,7 +89,7 @@ export default React.memo(function ThreadList({
             <SolidLine />
             <ThreadListContainer>
               <Gap size="s" />
-              <span style={{ color: `${colors.greyscale.dark}` }}>
+              <span style={{ color: `${colors.grayscale.g70}` }}>
                 {t.messages.noMessagesInfo}
               </span>
             </ThreadListContainer>
@@ -124,13 +124,13 @@ const MobileOnly = styled.div`
 
 const DottedLine = styled.hr`
   width: 100%;
-  border: 1px dashed ${colors.greyscale.medium};
+  border: 1px dashed ${colors.grayscale.g35};
   border-top-width: 0px;
 `
 
 const SolidLine = styled.hr`
   width: 100%;
-  border: 1px solid ${colors.greyscale.lighter};
+  border: 1px solid ${colors.grayscale.g15};
   border-top-width: 0px;
 `
 
@@ -142,7 +142,7 @@ const Container = styled.div`
   min-width: 35%;
   max-width: 400px;
   min-height: 500px;
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
   overflow-y: auto;
 
   @media (max-width: 750px) {

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -50,7 +50,7 @@ const TitleRow = styled.div`
 const StickyTitleRow = styled(TitleRow)`
   position: sticky;
   top: 0;
-  background: ${colors.greyscale.white};
+  background: ${colors.grayscale.g0};
   max-height: 215px; // fits roughly 5 rows of heading text with the chip and paddings
   overflow: auto;
 

--- a/frontend/src/citizen-frontend/pedagogical-documents/PedagogicalDocuments.tsx
+++ b/frontend/src/citizen-frontend/pedagogical-documents/PedagogicalDocuments.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -432,9 +432,7 @@ const ListItem = styled(FixedSpaceColumn)<{ documentIsRead: boolean }>`
     !p.documentIsRead && `padding-left: calc(${defaultMargins.s} - 6px)`};
   border-top: 1px solid #b1b1b1;
   border-left: ${(p) =>
-    p.documentIsRead
-      ? 'none'
-      : `6px solid ${p.theme.colors.accents.successGreen}`};
+    p.documentIsRead ? 'none' : `6px solid ${p.theme.colors.status.success}`};
   font-weight: ${fontWeights.semibold};
 
   & > div {

--- a/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
+++ b/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
@@ -439,7 +439,7 @@ const MandatoryValueMissingWarning = styled(
         {text}
         <FontAwesomeIcon
           icon={fasExclamationTriangle}
-          color={colors.accents.warningOrange}
+          color={colors.status.warning}
         />
       </Light>
     )

--- a/frontend/src/employee-frontend/components/Footer.tsx
+++ b/frontend/src/employee-frontend/components/Footer.tsx
@@ -56,7 +56,7 @@ export const Footer = React.memo(function Footer() {
               {i18n.footer.linkLabel}
             </a>
           </Content>
-          <EvakaLogo color={colors.main.dark} />
+          <EvakaLogo color={colors.main.m1} />
         </FooterContainer>
       </Container>
     </footer>

--- a/frontend/src/employee-frontend/components/Header.tsx
+++ b/frontend/src/employee-frontend/components/Header.tsx
@@ -87,7 +87,7 @@ function HeaderContainer({
     <HeaderWrapper data-qa={dataQa} className={className}>
       <NavbarContainer>
         <LogoLink to="/">
-          <EvakaLogo color={theme.colors.main.dark} />
+          <EvakaLogo color={theme.colors.main.m1} />
         </LogoLink>
         {children}
       </NavbarContainer>
@@ -103,10 +103,10 @@ const NavbarLink = styled(NavLink)`
   border-bottom: 4px solid transparent;
 
   &.active {
-    border-bottom: 4px solid ${(p) => p.theme.colors.main.primary};
+    border-bottom: 4px solid ${(p) => p.theme.colors.main.m2};
 
     ${NavLinkText} {
-      color: ${(p) => p.theme.colors.main.primary};
+      color: ${(p) => p.theme.colors.main.m2};
       font-weight: ${fontWeights.bold};
     }
   }
@@ -115,17 +115,17 @@ const NavbarLink = styled(NavLink)`
 const LogoutLink = styled.a`
   cursor: pointer;
   text-decoration: none;
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   display: flex;
   align-items: center;
   gap: ${defaultMargins.m};
 `
 
 const UnreadCount = styled.span`
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   font-weight: ${fontWeights.medium};
   margin-left: ${defaultMargins.xs};
-  border: 1px solid ${colors.main.dark};
+  border: 1px solid ${colors.main.m1};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -157,11 +157,11 @@ const UserPopup = styled.div`
   top: ${headerHeight};
   z-index: 5;
   padding: 24px 16px;
-  background: ${colors.greyscale.white};
+  background: ${colors.grayscale.g0};
   box-shadow: 0 4px 4px rgba(15, 15, 15, 0.25);
 
   a {
-    color: ${colors.greyscale.darkest};
+    color: ${colors.grayscale.g100};
   }
 `
 

--- a/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
+++ b/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
@@ -382,7 +382,7 @@ function UploadedFiles({ files }: { files: Attachment[] }) {
 }
 
 const FileIcon = styled(FontAwesomeIcon)`
-  color: ${(p) => p.theme.colors.main.primary};
+  color: ${(p) => p.theme.colors.main.m2};
   margin-right: ${defaultMargins.s};
 `
 

--- a/frontend/src/employee-frontend/components/MobilePairingModal.tsx
+++ b/frontend/src/employee-frontend/components/MobilePairingModal.tsx
@@ -39,7 +39,7 @@ const ResponseKey = styled.div`
   line-height: 30px;
   text-align: center;
   letter-spacing: 0.08em;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 `
 
 export default React.memo(function MobilePairingModal({

--- a/frontend/src/employee-frontend/components/Reports.tsx
+++ b/frontend/src/employee-frontend/components/Reports.tsx
@@ -73,7 +73,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.accents.warningOrange}
+                  color={colors.status.warning}
                   content={faCopy}
                 />
                 <LinkTitle to="/reports/duplicate-people">
@@ -97,7 +97,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.accents.warningOrange}
+                  color={colors.status.warning}
                   content={faUsers}
                 />
                 <LinkTitle to="/reports/family-conflicts">
@@ -121,7 +121,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.accents.warningOrange}
+                  color={colors.status.warning}
                   content={faUserAltSlash}
                 />
                 <LinkTitle to="/reports/missing-head-of-family">
@@ -145,7 +145,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.accents.warningOrange}
+                  color={colors.status.warning}
                   content={faClock}
                 />
                 <LinkTitle to="/reports/missing-service-need">
@@ -162,7 +162,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.accents.warningOrange}
+                  color={colors.status.warning}
                   content={faHome}
                 />
                 <LinkTitle to="/reports/partners-in-different-address">
@@ -179,7 +179,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.accents.peach}
+                  color={colors.accents.a5orangeLight}
                   content={faHome}
                 />
                 <LinkTitle to="/reports/children-in-different-address">
@@ -198,7 +198,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.main.primary}
+                  color={colors.main.m2}
                   content={faFileAlt}
                 />
                 <LinkTitle
@@ -216,11 +216,7 @@ function Reports() {
           >
             <ReportItem>
               <TitleRow>
-                <RoundIcon
-                  size="L"
-                  color={colors.main.primary}
-                  content={faGavel}
-                />
+                <RoundIcon size="L" color={colors.main.m2} content={faGavel} />
                 <LinkTitle data-qa="report-decisions" to="/reports/decisions">
                   {i18n.reports.decisions.title}
                 </LinkTitle>
@@ -235,7 +231,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.main.primary}
+                  color={colors.main.m2}
                   content={faPercentage}
                 />
                 <LinkTitle to="/reports/occupancies">
@@ -256,11 +252,7 @@ function Reports() {
           >
             <ReportItem>
               <TitleRow>
-                <RoundIcon
-                  size="L"
-                  color={colors.main.primary}
-                  content={faChild}
-                />
+                <RoundIcon size="L" color={colors.main.m2} content={faChild} />
                 <LinkTitle to="/reports/child-age-language">
                   {i18n.reports.childAgeLanguage.title}
                 </LinkTitle>
@@ -281,11 +273,7 @@ function Reports() {
           >
             <ReportItem>
               <TitleRow>
-                <RoundIcon
-                  size="L"
-                  color={colors.main.primary}
-                  content={faChild}
-                />
+                <RoundIcon size="L" color={colors.main.m2} content={faChild} />
                 <LinkTitle to="/reports/service-needs">
                   {i18n.reports.serviceNeeds.title}
                 </LinkTitle>
@@ -307,7 +295,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.main.primary}
+                  color={colors.main.m2}
                   content={faHandHolding}
                 />
                 <LinkTitle to="/reports/assistance-needs-and-actions">
@@ -324,7 +312,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.main.primary}
+                  color={colors.main.m2}
                   content={faEuroSign}
                 />
                 <LinkTitle to="/reports/invoices">
@@ -339,7 +327,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.main.primary}
+                  color={colors.main.m2}
                   content={faHourglassStart}
                 />
                 <LinkTitle to="/reports/starting-placements">
@@ -356,7 +344,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.main.primary}
+                  color={colors.main.m2}
                   content={faHourglassEnd}
                 />
                 <LinkTitle to="/reports/ended-placements">
@@ -373,7 +361,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.main.primary}
+                  color={colors.main.m2}
                   content={faDiagnoses}
                 />
                 <LinkTitle to="/reports/presences">
@@ -396,7 +384,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.main.primary}
+                  color={colors.main.m2}
                   content={faMoneyBillWave}
                 />
                 <LinkTitle
@@ -416,7 +404,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.main.primary}
+                  color={colors.main.m2}
                   content={faDatabase}
                 />
                 <LinkTitle to="/reports/raw">
@@ -431,7 +419,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.accents.warningOrange}
+                  color={colors.status.warning}
                   content={faUsers}
                 />
                 <LinkTitle
@@ -451,7 +439,7 @@ function Reports() {
               <TitleRow>
                 <RoundIcon
                   size="L"
-                  color={colors.accents.warningOrange}
+                  color={colors.status.warning}
                   content={faDiagnoses}
                 />
                 <LinkTitle

--- a/frontend/src/employee-frontend/components/UnitPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitPage.tsx
@@ -209,8 +209,8 @@ export const NotificationCounter = styled.div`
   align-items: center;
 
   border-radius: 50%;
-  background-color: ${({ theme: { colors } }) => colors.accents.warningOrange};
-  color: ${({ theme: { colors } }) => colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.status.warning};
+  color: ${(p) => p.theme.colors.grayscale.g0};
   margin-left: ${defaultMargins.xs};
   font-weight: ${fontWeights.bold};
   font-size: 0.75em;

--- a/frontend/src/employee-frontend/components/absences/Absences.tsx
+++ b/frontend/src/employee-frontend/components/absences/Absences.tsx
@@ -223,7 +223,7 @@ const AbsencesPage = styled.div`
   .table th {
     text-align: left;
     text-transform: uppercase;
-    color: ${colors.greyscale.dark};
+    color: ${colors.grayscale.g70};
     vertical-align: bottom;
 
     &.absence-header {
@@ -233,7 +233,7 @@ const AbsencesPage = styled.div`
 
   .table td {
     text-align: left;
-    color: ${colors.greyscale.darkest};
+    color: ${colors.grayscale.g100};
 
     &.absence-cell-wrapper {
       text-align: center;
@@ -292,7 +292,7 @@ const AbsencesPage = styled.div`
 
   .absence-cell-today,
   .table tr:hover .hover-highlight {
-    background-color: ${colors.greyscale.lightest};
+    background-color: ${colors.grayscale.g4};
 
     .absence-cell-selected {
       .absence-cell-left-weekend {
@@ -305,24 +305,24 @@ const AbsencesPage = styled.div`
     }
 
     .absence-cell-left-weekend {
-      border-top-color: ${colors.greyscale.lighter};
+      border-top-color: ${colors.grayscale.g15};
     }
 
     .absence-cell-right-weekend {
-      border-bottom-color: ${colors.greyscale.lighter};
+      border-bottom-color: ${colors.grayscale.g15};
     }
   }
 
   tr:hover .hover-highlight:first-child {
-    box-shadow: -8px 0 0 ${colors.greyscale.lightest};
+    box-shadow: -8px 0 0 ${colors.grayscale.g4};
   }
 
   tr:hover .hover-highlight:last-child {
-    box-shadow: 8px 0 0 ${colors.greyscale.lightest};
+    box-shadow: 8px 0 0 ${colors.grayscale.g4};
   }
 
   .absence-header-today {
-    background-color: ${colors.greyscale.lightest};
+    background-color: ${colors.grayscale.g4};
 
     @media print {
       background: none;
@@ -332,7 +332,7 @@ const AbsencesPage = styled.div`
   }
 
   .absence-header-weekend {
-    color: ${colors.greyscale.darkest} !important;
+    color: ${colors.grayscale.g100} !important;
   }
 
   .absence-cell {
@@ -390,7 +390,7 @@ const AbsencesPage = styled.div`
     }
 
     &-weekend {
-      border-top-color: ${colors.greyscale.lightest};
+      border-top-color: ${colors.grayscale.g4};
     }
 
     &-empty {
@@ -434,7 +434,7 @@ const AbsencesPage = styled.div`
     }
 
     &-weekend {
-      border-bottom-color: ${colors.greyscale.lightest};
+      border-bottom-color: ${colors.grayscale.g4};
     }
 
     &-empty {
@@ -443,7 +443,7 @@ const AbsencesPage = styled.div`
   }
 
   .absence-cell-selected {
-    border: 2px solid ${colors.main.primary};
+    border: 2px solid ${colors.main.m2};
     border-radius: 2px;
 
     .absence-cell-left,
@@ -486,8 +486,8 @@ const AbsencesPage = styled.div`
         font-size: 0.8rem;
         height: ${cellSize};
         width: ${cellSize};
-        border-color: ${colors.greyscale.medium};
-        color: ${colors.greyscale.darkest};
+        border-color: ${colors.grayscale.g35};
+        color: ${colors.grayscale.g100};
         display: block;
         box-shadow: none;
         max-width: 100%;
@@ -497,7 +497,7 @@ const AbsencesPage = styled.div`
         background-color: transparent;
 
         :disabled {
-          color: ${colors.greyscale.medium};
+          color: ${colors.grayscale.g35};
         }
 
         @media print {

--- a/frontend/src/employee-frontend/components/absences/StaffAttendance.tsx
+++ b/frontend/src/employee-frontend/components/absences/StaffAttendance.tsx
@@ -137,7 +137,7 @@ const StaffAttendanceRow = React.memo(function StaffAttendanceRow({
 
 const DisabledStaffIcon = styled(FontAwesomeIcon)`
   font-size: 15px;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 `
 
 const InactiveCell = ({ date }: { date: LocalDate }) => {

--- a/frontend/src/employee-frontend/components/ai/AIPage.tsx
+++ b/frontend/src/employee-frontend/components/ai/AIPage.tsx
@@ -48,8 +48,8 @@ export default React.memo(function AIPage() {
         : [],
       stepped: false,
       fill: false,
-      pointBackgroundColor: colors.accents.dangerRed,
-      borderColor: colors.accents.dangerRed
+      pointBackgroundColor: colors.status.danger,
+      borderColor: colors.status.danger
     },
     {
       label: 'childrenInOneOfPreferencesPercentage',
@@ -61,8 +61,8 @@ export default React.memo(function AIPage() {
         : [],
       stepped: false,
       fill: false,
-      pointBackgroundColor: colors.accents.warningOrange,
-      borderColor: colors.accents.warningOrange
+      pointBackgroundColor: colors.status.warning,
+      borderColor: colors.status.warning
     },
     {
       label: 'maxCapacityPercentage',
@@ -74,8 +74,8 @@ export default React.memo(function AIPage() {
         : [],
       stepped: false,
       fill: false,
-      pointBackgroundColor: colors.main.dark,
-      borderColor: colors.main.dark
+      pointBackgroundColor: colors.main.m1,
+      borderColor: colors.main.m1
     }
   ]
 

--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -583,7 +583,7 @@ export default React.memo(function ApplicationEditView({
                     <FontAwesomeIcon
                       size="sm"
                       icon={faExclamationTriangle}
-                      color={colors.accents.warningOrange}
+                      color={colors.status.warning}
                     />
                   </>
                 ) : null}

--- a/frontend/src/employee-frontend/components/application-page/ApplicationNoteBox.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationNoteBox.tsx
@@ -26,7 +26,7 @@ const NoteContainer = styled.div`
   display: flex;
   flex-direction: column;
   padding: ${defaultMargins.s};
-  background: ${colors.greyscale.white};
+  background: ${colors.grayscale.g0};
 `
 
 const TopBar = styled.div`

--- a/frontend/src/employee-frontend/components/application-page/ApplicationTitle.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationTitle.tsx
@@ -65,7 +65,7 @@ const TitleRow = styled.div`
   align-items: center;
 
   .title-labels {
-    color: ${colors.greyscale.medium};
+    color: ${colors.grayscale.g35};
     margin-left: ${defaultMargins.m};
     white-space: nowrap;
   }

--- a/frontend/src/employee-frontend/components/applications/ActionsMenu.tsx
+++ b/frontend/src/employee-frontend/components/applications/ActionsMenu.tsx
@@ -71,7 +71,7 @@ const Menu = styled.div`
   top: 0;
   right: 40px;
   z-index: 2;
-  background: ${colors.greyscale.white};
+  background: ${colors.grayscale.g0};
   box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
@@ -86,6 +86,6 @@ const MenuItem = styled.span`
   cursor: pointer;
 
   &:hover {
-    color: ${colors.greyscale.medium};
+    color: ${colors.grayscale.g35};
   }
 `

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -65,7 +65,7 @@ const TitleRowContainer = styled.div`
   position: sticky;
   top: 0;
   z-index: 3;
-  background: ${colors.greyscale.white};
+  background: ${colors.grayscale.g0};
 `
 
 interface PaginationWrapperProps {
@@ -166,19 +166,19 @@ const ApplicationsList = React.memo(function Applications({
       application.status === 'WAITING_PLACEMENT' &&
       !application.checkedByAdmin
     )
-      return colors.accents.warningOrange
+      return colors.status.warning
     if (
       application.status === 'WAITING_UNIT_CONFIRMATION' &&
       application.placementProposalStatus?.unitConfirmationStatus === 'ACCEPTED'
     )
-      return colors.accents.successGreen
+      return colors.status.success
     if (
       application.status === 'WAITING_UNIT_CONFIRMATION' &&
       application.placementProposalStatus?.unitConfirmationStatus === 'REJECTED'
     )
-      return colors.accents.dangerRed
+      return colors.status.danger
 
-    return colors.main.light
+    return colors.main.m3
   }
 
   const dateOfBirthInfo = (application: ApplicationSummary) => {

--- a/frontend/src/employee-frontend/components/applications/CircleIcon.tsx
+++ b/frontend/src/employee-frontend/components/applications/CircleIcon.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -15,14 +15,14 @@ const CircleIcon = styled.div`
   min-height: 34px;
   font-size: 24px;
   border-radius: 100%;
-  color: ${colors.greyscale.white};
+  color: ${colors.grayscale.g0};
 `
 
 export const CircleIconGreen = styled(CircleIcon)`
-  background-color: ${colors.accents.successGreen};
+  background-color: ${colors.status.success};
 `
 export const CircleIconRed = styled(CircleIcon)`
-  background-color: ${colors.accents.dangerRed};
+  background-color: ${colors.status.danger};
 `
 
 export const CircleIconSmallOrange = styled(CircleIcon)`
@@ -31,5 +31,5 @@ export const CircleIconSmallOrange = styled(CircleIcon)`
   width: 16px;
   height: 16px;
   font-size: 16px;
-  background-color: ${colors.accents.warningOrange};
+  background-color: ${colors.status.warning};
 `

--- a/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationRowInput.tsx
+++ b/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationRowInput.tsx
@@ -99,12 +99,11 @@ const RadioInput = styled.input`
 
 const RadioLabel = styled.label<{ selected: boolean }>`
   padding: 6px 22px;
-  border: 1px solid ${colors.main.primary};
-  color: ${colors.main.primary};
+  border: 1px solid ${colors.main.m2};
+  color: ${colors.main.m2};
 
-  ${({ selected }) => (selected ? `color: ${colors.greyscale.white};` : '')}
-  ${({ selected }) =>
-    selected ? `background-color: ${colors.main.primary};` : ''}
+  ${({ selected }) => (selected ? `color: ${colors.grayscale.g0};` : '')}
+  ${({ selected }) => (selected ? `background-color: ${colors.main.m2};` : '')}
 `
 
 const RadioLabelLeft = styled(RadioLabel)`

--- a/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -200,7 +200,7 @@ function CreatePlacementModal({ childId, reload }: Props) {
 
 const ValidationError = styled.div`
   font-size: 0.9em;
-  color: ${colors.accents.dangerRed};
+  color: ${colors.status.danger};
 `
 
 export default CreatePlacementModal

--- a/frontend/src/employee-frontend/components/child-information/placements/service-needs/MissingServiceNeedRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/service-needs/MissingServiceNeedRow.tsx
@@ -37,7 +37,7 @@ function MissingServiceNeedRow({
         {t.missing}{' '}
         <FontAwesomeIcon
           icon={faExclamationTriangle}
-          color={colors.accents.warningOrange}
+          color={colors.status.warning}
         />
       </InfoTd>
       <Td />
@@ -59,7 +59,7 @@ function MissingServiceNeedRow({
 
 const InfoTd = styled(Td)`
   vertical-align: middle;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   font-style: italic;
 `
 

--- a/frontend/src/employee-frontend/components/common/AgeIndicatorIcon.tsx
+++ b/frontend/src/employee-frontend/components/common/AgeIndicatorIcon.tsx
@@ -23,7 +23,7 @@ export const AgeIndicatorIcon = React.memo(function AgeIndicatorIcon(
   return (
     <RoundIcon
       content={under3 ? fasArrowDown : fasArrowUp}
-      color={under3 ? colors.accents.successGreen : colors.main.dark}
+      color={under3 ? colors.status.success : colors.main.m1}
       size="s"
     />
   )

--- a/frontend/src/employee-frontend/components/common/CheckedRowsInfo.tsx
+++ b/frontend/src/employee-frontend/components/common/CheckedRowsInfo.tsx
@@ -7,7 +7,7 @@ import { fontWeights } from 'lib-components/typography'
 import colors from 'lib-customizations/common'
 
 export const CheckedRowsInfo = styled.div`
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   font-style: italic;
   font-weight: ${fontWeights.bold};
   margin: 0 20px;

--- a/frontend/src/employee-frontend/components/common/Filters.tsx
+++ b/frontend/src/employee-frontend/components/common/Filters.tsx
@@ -136,7 +136,7 @@ const SearchInputContainer = styled.div`
 const SearchInput = styled.input<{ background?: string }>`
   width: 100%;
   border: none;
-  background: ${(p) => p.background ?? colors.greyscale.lightest};
+  background: ${(p) => p.background ?? colors.grayscale.g4};
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
@@ -146,19 +146,19 @@ const SearchInput = styled.input<{ background?: string }>`
   outline: none;
   margin-left: -38px;
   margin-right: -25px;
-  color: ${colors.greyscale.darkest};
+  color: ${colors.grayscale.g100};
 
   &::placeholder {
     font-style: italic;
     font-size: 17px;
-    color: ${colors.greyscale.dark};
+    color: ${colors.grayscale.g70};
   }
 
   &:focus {
     border-width: 2px;
     border-radius: 2px;
     border-style: solid;
-    border-color: ${colors.main.primaryFocus};
+    border-color: ${colors.main.m2Focus};
     margin-top: -2px;
     padding-left: 53px;
     margin-bottom: -2px;
@@ -166,7 +166,7 @@ const SearchInput = styled.input<{ background?: string }>`
 `
 
 const CustomIcon = styled(FontAwesomeIcon)`
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   margin: 0 0.5rem;
   position: relative;
   left: 10px;
@@ -176,7 +176,7 @@ const CustomIcon = styled(FontAwesomeIcon)`
 const CustomIconButton = styled(IconButton)`
   float: right;
   position: relative;
-  color: ${colors.greyscale.medium};
+  color: ${colors.grayscale.g35};
   right: 20px;
 `
 
@@ -443,7 +443,7 @@ export function FeeDecisionDateFilter({
             <Gap size="xs" horizontal />
             <FontAwesomeIcon
               icon={fasExclamationTriangle}
-              color={colors.accents.warningOrange}
+              color={colors.status.warning}
             />
           </span>
         </>
@@ -543,7 +543,7 @@ export function ValueDecisionDateFilter({
             <Gap size="xs" horizontal />
             <FontAwesomeIcon
               icon={fasExclamationTriangle}
-              color={colors.accents.warningOrange}
+              color={colors.status.warning}
             />
           </span>
         </>
@@ -641,7 +641,7 @@ export function InvoiceDateFilter({
             <Gap size="xs" horizontal />
             <FontAwesomeIcon
               icon={fasExclamationTriangle}
-              color={colors.accents.warningOrange}
+              color={colors.status.warning}
             />
           </span>
         </>
@@ -711,7 +711,7 @@ interface ApplicationTypeFilterProps {
 const CustomDiv = styled(FixedSpaceColumn)`
   margin-left: 18px;
   padding-left: 32px;
-  border-left: 1px solid ${colors.greyscale.dark};
+  border-left: 1px solid ${colors.grayscale.g70};
 `
 
 const ApplicationOpenIcon = styled(FontAwesomeIcon)`
@@ -753,7 +753,7 @@ export function ApplicationTypeFilter({
                     <ApplicationOpenIcon
                       icon={toggled === id ? faAngleUp : faAngleDown}
                       size="lg"
-                      color={colors.greyscale.dark}
+                      color={colors.grayscale.g70}
                     />
                   </>
                 }
@@ -849,7 +849,7 @@ export function ApplicationStatusFilter({
                   <ApplicationOpenIcon
                     icon={toggled === id ? faAngleUp : faAngleDown}
                     size="lg"
-                    color={colors.greyscale.dark}
+                    color={colors.grayscale.g70}
                   />
                 ) : undefined}
               </>
@@ -941,7 +941,7 @@ export function ApplicationDateFilter({
             <Gap size="xs" horizontal />
             <FontAwesomeIcon
               icon={fasExclamationTriangle}
-              color={colors.accents.warningOrange}
+              color={colors.status.warning}
             />
           </span>
         </>

--- a/frontend/src/employee-frontend/components/common/InputWarning.tsx
+++ b/frontend/src/employee-frontend/components/common/InputWarning.tsx
@@ -31,7 +31,7 @@ const WarningText = styled.span<{
   smaller?: boolean
   margin?: 'left' | 'right'
 }>`
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   font-style: italic;
   ${(props) =>
     props.margin === 'right' ? 'margin-right: 12px' : 'margin-left: 12px'};
@@ -42,6 +42,6 @@ const WarningIcon = () => (
   <FontAwesomeIcon
     icon={fasExclamationTriangle}
     size="1x"
-    color={colors.accents.warningOrange}
+    color={colors.status.warning}
   />
 )

--- a/frontend/src/employee-frontend/components/common/StatusIconContainer.tsx
+++ b/frontend/src/employee-frontend/components/common/StatusIconContainer.tsx
@@ -17,5 +17,5 @@ export const StatusIconContainer = styled.div<StatusIconContainerProps>`
   align-items: center;
   width: 30px;
   height: 30px;
-  color: ${colors.greyscale.white};
+  color: ${colors.grayscale.g0};
 `

--- a/frontend/src/employee-frontend/components/common/StatusLabel.tsx
+++ b/frontend/src/employee-frontend/components/common/StatusLabel.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -12,12 +12,11 @@ import { getStatusLabelByDateRange } from '../../utils/date'
 export type StatusLabelType = 'coming' | 'active' | 'completed' | 'conflict'
 
 const colorsByStatus: Record<StatusLabelType, string> = {
-  active: colors.accents.emerald,
-  coming: colors.accents.mint,
-  completed: colors.accents.lightBlue,
-  conflict: colors.accents.warningOrange
+  active: colors.accents.a3emerald,
+  coming: colors.accents.a7mint,
+  completed: colors.accents.a8lightBlue,
+  conflict: colors.status.warning
 }
-
 type Props =
   | {
       status: StatusLabelType

--- a/frontend/src/employee-frontend/components/common/StickyActionBar.tsx
+++ b/frontend/src/employee-frontend/components/common/StickyActionBar.tsx
@@ -35,11 +35,11 @@ const Bar = styled.div`
   justify-content: center;
   position: sticky;
   bottom: 0;
-  background: ${colors.greyscale.white};
+  background: ${colors.grayscale.g0};
   padding: 16px 0;
   margin: 0 -9999rem;
   margin-top: 50px;
-  box-shadow: 0px -8px 8px -6px ${colors.greyscale.lightest};
+  box-shadow: 0px -8px 8px -6px ${colors.grayscale.g4};
 `
 
 const Content = styled(Container)<Props>`

--- a/frontend/src/employee-frontend/components/common/Toolbar.tsx
+++ b/frontend/src/employee-frontend/components/common/Toolbar.tsx
@@ -92,7 +92,7 @@ function Toolbar({
           <FontAwesomeIcon
             icon={faExclamationTriangle}
             size="1x"
-            color={colors.accents.warningOrange}
+            color={colors.status.warning}
           />
         </Tooltip>
       )}
@@ -105,7 +105,7 @@ function Toolbar({
         >
           <FontAwesomeIcon
             icon={faSync}
-            color={disableAll ? colors.greyscale.medium : colors.main.primary}
+            color={disableAll ? colors.grayscale.g35 : colors.main.m2}
             size="lg"
           />
         </ToolbarButton>
@@ -119,7 +119,7 @@ function Toolbar({
         >
           <FontAwesomeIcon
             icon={faCopy}
-            color={disableAll ? colors.greyscale.medium : colors.main.primary}
+            color={disableAll ? colors.grayscale.g35 : colors.main.m2}
             size="lg"
           />
         </ToolbarButton>
@@ -133,7 +133,7 @@ function Toolbar({
         >
           <FontAwesomeIcon
             icon={faPen}
-            color={disableAll ? colors.greyscale.medium : colors.main.primary}
+            color={disableAll ? colors.grayscale.g35 : colors.main.m2}
             size="lg"
           />
         </ToolbarButton>
@@ -147,7 +147,7 @@ function Toolbar({
         >
           <FontAwesomeIcon
             icon={faTrash}
-            color={disableAll ? colors.greyscale.medium : colors.main.primary}
+            color={disableAll ? colors.grayscale.g35 : colors.main.m2}
             size="lg"
           />
         </ToolbarButton>

--- a/frontend/src/employee-frontend/components/common/Tooltip.tsx
+++ b/frontend/src/employee-frontend/components/common/Tooltip.tsx
@@ -21,29 +21,29 @@ const ContentWrapper = styled.div`
   width: fit-content;
 
   .type-dark {
-    background: ${colors.greyscale.dark};
-    color: ${colors.greyscale.white};
+    background: ${colors.grayscale.g70};
+    color: ${colors.grayscale.g0};
     font-family: 'Open Sans', 'Arial', sans-serif;
     padding: 8px 12px;
 
     &.place-right {
       &:after {
-        border-right-color: ${colors.greyscale.dark};
+        border-right-color: ${colors.grayscale.g70};
       }
     }
     &.place-left {
       &:after {
-        border-left-color: ${colors.greyscale.dark};
+        border-left-color: ${colors.grayscale.g70};
       }
     }
     &.place-top {
       &:after {
-        border-top-color: ${colors.greyscale.dark};
+        border-top-color: ${colors.grayscale.g70};
       }
     }
     &.place-bottom {
       &:after {
-        border-bottom-color: ${colors.greyscale.dark};
+        border-bottom-color: ${colors.grayscale.g70};
       }
     }
   }

--- a/frontend/src/employee-frontend/components/common/VasuStateChip.tsx
+++ b/frontend/src/employee-frontend/components/common/VasuStateChip.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -8,10 +8,10 @@ import { StaticChip } from 'lib-components/atoms/Chip'
 import colors from 'lib-customizations/common'
 
 const vasuStateChip: Record<VasuDocumentState, string> = {
-  DRAFT: colors.accents.peach,
-  READY: colors.accents.violet,
-  REVIEWED: colors.main.dark,
-  CLOSED: colors.greyscale.lighter
+  DRAFT: colors.accents.a5orangeLight,
+  READY: colors.accents.a4violet,
+  REVIEWED: colors.main.m1,
+  CLOSED: colors.grayscale.g15
 }
 
 type ChipLabels = Record<VasuDocumentState, string>

--- a/frontend/src/employee-frontend/components/common/WarningLabel.tsx
+++ b/frontend/src/employee-frontend/components/common/WarningLabel.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -35,6 +35,6 @@ const Wrapper = styled.div`
   text-align: center;
   line-height: 30px;
   font-weight: ${fontWeights.semibold};
-  background: ${colors.accents.dangerRed};
-  color: ${colors.greyscale.white};
+  background: ${colors.status.danger};
+  color: ${colors.grayscale.g0};
 `

--- a/frontend/src/employee-frontend/components/decision-draft/DecisionDraft.tsx
+++ b/frontend/src/employee-frontend/components/decision-draft/DecisionDraft.tsx
@@ -77,7 +77,7 @@ const WarningContainer = styled.div<{ visible: boolean }>`
 `
 
 const WarningText = styled.span<{ smaller?: boolean }>`
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   font-style: italic;
   margin-left: 12px;
   font-size: ${(props) => (props.smaller === true ? '0.8em' : '1em')};
@@ -87,7 +87,7 @@ const WarningIcon = () => (
   <FontAwesomeIcon
     icon={faExclamationTriangle}
     size="1x"
-    color={colors.accents.warningOrange}
+    color={colors.status.warning}
   />
 )
 

--- a/frontend/src/employee-frontend/components/fee-decision-details/Heading.tsx
+++ b/frontend/src/employee-frontend/components/fee-decision-details/Heading.tsx
@@ -210,7 +210,7 @@ export const TitleRow = styled.div`
 export const InfoMarkers = styled.span``
 
 const DisabledLink = styled.span`
-  color: ${colors.greyscale.medium};
+  color: ${colors.grayscale.g35};
 `
 
 const Cursive = styled.span`

--- a/frontend/src/employee-frontend/components/fee-decisions/Actions.tsx
+++ b/frontend/src/employee-frontend/components/fee-decisions/Actions.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -12,7 +12,7 @@ import { CheckedRowsInfo } from '../common/CheckedRowsInfo'
 import StickyActionBar from '../common/StickyActionBar'
 
 const ErrorMessage = styled.div`
-  color: ${(p) => p.theme.colors.accents.orangeDark};
+  color: ${(p) => p.theme.colors.accents.a2orangeDark};
   margin: 0 20px;
 `
 

--- a/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsEditor.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsEditor.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -400,7 +400,7 @@ const ButtonRow = styled(FixedSpaceRow)`
 `
 
 const ErrorDescription = styled.span`
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   font-style: italic;
 `
 
@@ -409,7 +409,7 @@ const MaxFeeError = styled(ErrorDescription)`
 `
 
 const SaveError = styled.span`
-  color: ${colors.accents.dangerRed};
+  color: ${colors.status.danger};
 `
 
 type ValidationErrors = Partial<

--- a/frontend/src/employee-frontend/components/invoices/Actions.tsx
+++ b/frontend/src/employee-frontend/components/invoices/Actions.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -16,11 +16,11 @@ import StickyActionBar from '../common/StickyActionBar'
 import { InvoicesActions } from './invoices-state'
 
 const ErrorMessage = styled.div`
-  color: ${colors.accents.dangerRed};
+  color: ${colors.status.danger};
 `
 
 const CheckedRowsInfo = styled.div`
-  color: ${colors.greyscale.medium};
+  color: ${colors.grayscale.g35};
   font-style: italic;
   font-weight: ${fontWeights.bold};
 `

--- a/frontend/src/employee-frontend/components/invoices/Invoices.tsx
+++ b/frontend/src/employee-frontend/components/invoices/Invoices.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -313,7 +313,7 @@ const InvoiceTableBody = React.memo(function InvoiceTableBody({
                 tooltipText={`${i18n.personProfile.restrictedDetails}`}
                 place="right"
               >
-                <StatusIconContainer color={colors.accents.dangerRed}>
+                <StatusIconContainer color={colors.status.danger}>
                   <FontAwesomeIcon icon={faExclamation} inverse />
                 </StatusIconContainer>
               </Tooltip>

--- a/frontend/src/employee-frontend/components/login-page/Login.tsx
+++ b/frontend/src/employee-frontend/components/login-page/Login.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -27,7 +27,7 @@ const LoginButton = styled.a`
   min-width: 100px;
   text-align: center;
   overflow-x: hidden;
-  border: 1px solid ${(p) => p.theme.colors.main.primary};
+  border: 1px solid ${(p) => p.theme.colors.main.m2};
   border-radius: 2px;
   outline: none;
   cursor: pointer;
@@ -38,8 +38,8 @@ const LoginButton = styled.a`
   text-transform: uppercase;
   white-space: nowrap;
   letter-spacing: 0.2px;
-  color: ${(p) => p.theme.colors.greyscale.white};
-  background-color: ${(p) => p.theme.colors.main.primary};
+  color: ${(p) => p.theme.colors.grayscale.g0};
+  background-color: ${(p) => p.theme.colors.main.m2};
   margin-right: 0;
   text-decoration: none;
   display: flex;
@@ -47,13 +47,13 @@ const LoginButton = styled.a`
   align-items: center;
 
   :hover {
-    background-color: ${(p) => p.theme.colors.main.primaryHover};
+    background-color: ${(p) => p.theme.colors.main.m2Hover};
   }
   :focus {
-    background-color: ${(p) => p.theme.colors.main.primaryFocus};
+    background-color: ${(p) => p.theme.colors.main.m2Focus};
   }
   :active {
-    background-color: ${(p) => p.theme.colors.main.primaryActive};
+    background-color: ${(p) => p.theme.colors.main.m2Active};
   }
 `
 

--- a/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
+++ b/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
@@ -45,7 +45,7 @@ function CollapsibleRow({
         <FontAwesomeIcon
           icon={expanded ? faChevronUp : faChevronDown}
           size="xs"
-          color={colors.greyscale.darkest}
+          color={colors.grayscale.g100}
         />
       </CollapseToggle>
       <Content visible={expanded}>{children}</Content>

--- a/frontend/src/employee-frontend/components/messages/MessageBox.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageBox.tsx
@@ -16,11 +16,11 @@ export const MessageBoxRow = styled.div<{ active: boolean }>`
   cursor: pointer;
   padding: 12px ${defaultMargins.m};
   font-weight: ${(p) => (p.active ? fontWeights.semibold : 'unset')};
-  background-color: ${(p) => (p.active ? colors.main.lighter : 'unset')};
+  background-color: ${(p) => (p.active ? colors.main.m4 : 'unset')};
 `
 
 const UnreadCount = styled.span`
-  color: ${colors.main.primary};
+  color: ${colors.main.m2};
   font-size: 14px;
   font-weight: ${fontWeights.semibold};
   padding-left: ${defaultMargins.xxs};

--- a/frontend/src/employee-frontend/components/messages/MessageComponents.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageComponents.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -15,15 +15,14 @@ export const MessageRow = styled.div<{ unread?: boolean }>`
   padding: ${defaultMargins.s};
   cursor: pointer;
   :first-child {
-    border-top: 1px solid ${colors.greyscale.lighter};
+    border-top: 1px solid ${colors.grayscale.g15};
   }
-  border-bottom: 1px solid ${colors.greyscale.lighter};
+  border-bottom: 1px solid ${colors.grayscale.g15};
   border-left: 6px solid
-    ${(p) => (p.unread ? colors.accents.successGreen : 'transparent')};
+    ${(p) => (p.unread ? colors.status.success : 'transparent')};
 `
 export const Participants = styled.div<{ unread?: boolean }>`
-  color: ${(p) =>
-    p.unread ? colors.greyscale.darkest : colors.greyscale.dark};
+  color: ${(p) => (p.unread ? colors.grayscale.g100 : colors.grayscale.g70)};
   font-weight: ${fontWeights.semibold};
 `
 export const Truncated = styled.div`

--- a/frontend/src/employee-frontend/components/messages/MessageTypeChip.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageTypeChip.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -15,8 +15,8 @@ const Chip = styled(StaticChip)`
 `
 
 const chipColors = {
-  MESSAGE: colors.accents.violet,
-  BULLETIN: colors.main.dark
+  MESSAGE: colors.accents.a4violet,
+  BULLETIN: colors.main.m1
 }
 
 export function MessageTypeChip({ type }: { type: MessageType }) {

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -35,7 +35,7 @@ const Container = styled.div`
   margin-right: ${defaultMargins.m};
 
   & > div {
-    background-color: ${colors.greyscale.white};
+    background-color: ${colors.grayscale.g0};
   }
 `
 const AccountContainer = styled.div`
@@ -49,7 +49,7 @@ const HeaderContainer = styled.div`
 
 const DashedLine = styled.hr`
   width: 100%;
-  border: 1px dashed ${colors.greyscale.medium};
+  border: 1px dashed ${colors.grayscale.g35};
   border-top-width: 0;
 `
 
@@ -57,13 +57,13 @@ const AccountSection = styled.section`
   padding: 12px 0;
 
   & + & {
-    border-top: 1px dashed ${colors.greyscale.dark};
+    border-top: 1px dashed ${colors.grayscale.g70};
   }
 `
 
 const AccountHeader = styled.div`
   padding: 12px ${defaultMargins.m};
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   font-family: 'Montserrat', sans-serif;
   font-size: 20px;
   font-weight: ${fontWeights.semibold};
@@ -81,7 +81,7 @@ const Receivers = styled.div<{ active: boolean }>`
   cursor: pointer;
   padding: 12px ${defaultMargins.m};
   font-weight: ${(p) => (p.active ? fontWeights.semibold : 'unset')};
-  background-color: ${(p) => (p.active ? colors.main.lighter : 'unset')};
+  background-color: ${(p) => (p.active ? colors.main.m4 : 'unset')};
 `
 
 interface AccountsParams {

--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -39,7 +39,7 @@ import { MessageTypeChip } from './MessageTypeChip'
 import { View } from './types-view'
 
 const MessageContainer = styled.div`
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
   padding: ${defaultMargins.L};
   margin-top: ${defaultMargins.s};
 
@@ -63,7 +63,7 @@ const StickyTitleRow = styled(TitleRow)`
   position: sticky;
   top: 0;
   padding: ${defaultMargins.L};
-  background: ${colors.greyscale.white};
+  background: ${colors.grayscale.g0};
   max-height: 100px;
   overflow: auto;
 
@@ -226,7 +226,7 @@ export function SingleThreadView({
           icon={faAngleLeft}
           text={i18n.common.goBack}
           onClick={goBack}
-          color={colors.main.primary}
+          color={colors.main.m2}
         />
       </ContentArea>
       <Gap size="xs" />

--- a/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
@@ -172,7 +172,7 @@ export default React.memo(function ThreadListContainer({
         (view === 'SENT' && sentMessages.isLoading) ||
         (view === 'DRAFTS' && messageDrafts.isLoading)
       }
-      iconColor={colors.greyscale.medium}
+      iconColor={colors.grayscale.g35}
       text={i18n.messages.emptyInbox}
     />
   )

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemHeader.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemHeader.tsx
@@ -28,7 +28,7 @@ const Button = styled(IconButton)`
 `
 
 const ToggleButton = styled(Button)`
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 `
 
 const Row = styled(FixedSpaceRow)`

--- a/frontend/src/employee-frontend/components/person-shared/person-details/AddSsnModal.tsx
+++ b/frontend/src/employee-frontend/components/person-shared/person-details/AddSsnModal.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -17,7 +17,7 @@ import { isSsnValid } from '../../../utils/validation/validations'
 const Error = styled.div`
   display: flex;
   justify-content: center;
-  color: ${colors.accents.dangerRed};
+  color: ${colors.status.danger};
   margin: 20px;
 `
 

--- a/frontend/src/employee-frontend/components/placement-draft/PlacementDraftRow.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/PlacementDraftRow.tsx
@@ -56,13 +56,13 @@ const OverlapError = styled.span`
   font-size: 12px;
   font-style: italic;
   font-weight: ${fontWeights.normal};
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   margin-bottom: auto;
   margin-top: auto;
 
   svg {
     font-size: 1rem;
-    color: ${colors.accents.warningOrange};
+    color: ${colors.status.warning};
     margin-left: 10px;
     margin-right: 10px;
   }

--- a/frontend/src/employee-frontend/components/placement-draft/Placements.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/Placements.tsx
@@ -68,7 +68,7 @@ export default React.memo(function Placements({ placements }: Props) {
                 <Gap size="xxs" horizontal />
                 <FontAwesomeIcon
                   icon={fasExclamationTriangle}
-                  color={colors.accents.warningOrange}
+                  color={colors.status.warning}
                 />
               </>
             )}

--- a/frontend/src/employee-frontend/components/placement-draft/UnitCard.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/UnitCard.tsx
@@ -31,7 +31,7 @@ const Numbers = styled.div`
 
 const Number = styled(H1)`
   margin: 0;
-  color: ${colors.main.primary};
+  color: ${colors.main.m2};
 `
 const formatPercentage = (num?: number | null) =>
   num ? `${num.toFixed(1).replace('.', ',')} %` : '–'
@@ -77,13 +77,12 @@ const Card = styled.div<{ selected: boolean }>`
   flex-direction: column;
   align-items: center;
 
-  border-color: ${(p) =>
-    p.selected ? colors.main.primary : colors.greyscale.medium};
+  border-color: ${(p) => (p.selected ? colors.main.m2 : colors.grayscale.g35)};
   border-width: 2px;
   border-style: solid;
   border-radius: 4px;
-  background: ${colors.greyscale.white};
-  box-shadow: 0 4px 4px 0 ${colors.greyscale.darkest}26; // 26 = 15 % opacity
+  background: ${colors.grayscale.g0};
+  box-shadow: 0 4px 4px 0 ${colors.grayscale.g100}26; // 26 = 15 % opacity
   padding: ${defaultMargins.L};
   flex: 1 0 30%;
   max-width: calc(33% - 1.5rem);

--- a/frontend/src/employee-frontend/components/reports/DuplicatePeople.tsx
+++ b/frontend/src/employee-frontend/components/reports/DuplicatePeople.tsx
@@ -30,7 +30,7 @@ interface RowProps {
 }
 
 const StyledRow = styled(Tr)<RowProps>`
-  ${(props) => (props.odd ? `background: ${colors.main.lighter};` : '')}
+  ${(props) => (props.odd ? `background: ${colors.main.m4};` : '')}
 `
 const NoWrapTd = styled(Td)`
   white-space: nowrap;

--- a/frontend/src/employee-frontend/components/reports/Occupancies.tsx
+++ b/frontend/src/employee-frontend/components/reports/Occupancies.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -417,7 +417,7 @@ const Legend = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  color: ${({ theme }) => theme.colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 `
 
 export default Occupancies

--- a/frontend/src/employee-frontend/components/reports/ReportDownload.tsx
+++ b/frontend/src/employee-frontend/components/reports/ReportDownload.tsx
@@ -18,7 +18,7 @@ const RowRightAligned = styled.div`
 `
 
 const DisabledLink = styled.span`
-  color: ${colors.greyscale.medium};
+  color: ${colors.grayscale.g35};
 `
 
 const LinkText = styled.span`

--- a/frontend/src/employee-frontend/components/reports/VoucherServiceProviderUnit.tsx
+++ b/frontend/src/employee-frontend/components/reports/VoucherServiceProviderUnit.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -56,7 +56,7 @@ const FilterWrapper = styled.div`
 
 const LockedDate = styled(FixedSpaceRow)`
   float: right;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   margin-bottom: ${defaultMargins.xs};
 `
 
@@ -93,12 +93,12 @@ const TypeIndicator = styled.div<{ type: VoucherReportRowType | 'NEW' }>`
   right: -1px;
   background-color: ${(p) =>
     p.type === 'REFUND'
-      ? colors.accents.warningOrange
+      ? colors.status.warning
       : p.type === 'CORRECTION'
-      ? colors.accents.peach
+      ? colors.accents.a5orangeLight
       : p.type === 'NEW'
-      ? colors.main.primary
-      : colors.greyscale.white};
+      ? colors.main.m2
+      : colors.grayscale.g0};
 `
 
 const StyledTh = styled(Th)`

--- a/frontend/src/employee-frontend/components/reports/VoucherServiceProviders.tsx
+++ b/frontend/src/employee-frontend/components/reports/VoucherServiceProviders.tsx
@@ -46,7 +46,7 @@ const FilterWrapper = styled.div`
 
 const LockedDate = styled(FixedSpaceRow)`
   float: right;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   margin-bottom: ${defaultMargins.xs};
 `
 

--- a/frontend/src/employee-frontend/components/reports/common.tsx
+++ b/frontend/src/employee-frontend/components/reports/common.tsx
@@ -21,7 +21,7 @@ export const TableScrollableWrapper = styled.div`
   th {
     position: sticky;
     top: 0;
-    background: ${colors.greyscale.white};
+    background: ${colors.grayscale.g0};
     z-index: 2;
   }
 `
@@ -46,7 +46,7 @@ export const TableFooter = styled.tfoot`
   td {
     position: sticky;
     bottom: 0;
-    background: ${colors.greyscale.lightest};
+    background: ${colors.grayscale.g4};
     z-index: 2;
   }
 `

--- a/frontend/src/employee-frontend/components/unit/TabWaitingConfirmation.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabWaitingConfirmation.tsx
@@ -111,7 +111,7 @@ export default React.memo(function TabWaitingConfirmation() {
                         )}
                       </Link>
                     ) : (
-                      <P noMargin color={colors.greyscale.medium}>
+                      <P noMargin color={colors.grayscale.g35}>
                         {formatName(
                           p.child.firstName,
                           p.child.lastName,
@@ -124,7 +124,7 @@ export default React.memo(function TabWaitingConfirmation() {
                   <Td
                     data-qa="child-dob"
                     color={
-                      p.rejectedByCitizen ? colors.greyscale.medium : undefined
+                      p.rejectedByCitizen ? colors.grayscale.g35 : undefined
                     }
                   >
                     {p.child.dateOfBirth.format()}

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
@@ -325,7 +325,7 @@ export default React.memo(function Group({
             active={childNote != null || notes.childStickyNotes.length > 0}
             data-qa={`daycare-daily-note-icon-${placement.child.id}`}
             content={faStickyNote}
-            color={colors.main.primary}
+            color={colors.main.m2}
             size="m"
             onClick={() =>
               setNotesModal({
@@ -507,7 +507,7 @@ export default React.memo(function Group({
                           >
                             <FontAwesomeIcon
                               icon={faStickyNote}
-                              color={colors.greyscale.dark}
+                              color={colors.grayscale.g70}
                             />
                           </Tooltip>
                         </IconContainer>
@@ -649,7 +649,7 @@ export default React.memo(function Group({
                                 }
                               >
                                 <StatusIconContainer
-                                  color={colors.accents.warningOrange}
+                                  color={colors.status.warning}
                                 >
                                   <FontAwesomeIcon icon={faTimes} inverse />
                                 </StatusIconContainer>
@@ -663,7 +663,7 @@ export default React.memo(function Group({
                                 }
                               >
                                 <StatusIconContainer
-                                  color={colors.accents.successGreen}
+                                  color={colors.status.success}
                                 >
                                   <FontAwesomeIcon icon={faCheck} inverse />
                                 </StatusIconContainer>
@@ -795,7 +795,7 @@ const Toolbar = styled.div`
 `
 
 const DaycareGroup = styled.div`
-  border: ${colors.greyscale.medium} solid 1px;
+  border: ${colors.grayscale.g35} solid 1px;
   padding: 16px;
   margin-bottom: 16px;
 `

--- a/frontend/src/employee-frontend/components/unit/tab-groups/notes/NotesModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/notes/NotesModal.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -69,11 +69,11 @@ const Tab = styled.div<{ active?: boolean }>`
   border-bottom-width: 2px;
   border-bottom-style: solid;
   border-bottom-color: ${({ active, theme }) =>
-    active ? theme.colors.main.primary : 'transparent'};
+    active ? theme.colors.main.m2 : 'transparent'};
 
   font-size: 15px;
   font-weight: ${fontWeights.bold};
-  color: ${({ theme }) => theme.colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
   text-transform: uppercase;
   cursor: pointer;
 `
@@ -212,7 +212,7 @@ export default React.memo(function NotesModal({
           {indicator && (
             <>
               <Gap horizontal size="xs" />
-              <RoundIcon content="" color={colors.main.light} size="xs" />
+              <RoundIcon content="" color={colors.main.m3} size="xs" />
             </>
           )}
         </Tab>

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyCard.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyCard.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -23,12 +23,12 @@ const Card = styled.div<CardProps>`
   cursor: pointer;
   border-left-style: solid;
   border-left-color: ${(props) =>
-    props.active ? props.color : colors.greyscale.lighter};
+    props.active ? props.color : colors.grayscale.g15};
   border-left-width: 10px;
   width: 100%;
   margin: 10px;
   padding: 10px 10px 10px 25px;
-  box-shadow: 0px 2px 4px 1px ${colors.greyscale.lighter};
+  box-shadow: 0px 2px 4px 1px ${colors.grayscale.g15};
 `
 
 const HeaderContainer = styled.div`
@@ -79,12 +79,12 @@ export default React.memo(function OccupancyCard({
 
   const color =
     type == 'confirmed'
-      ? colors.main.dark
+      ? colors.main.m1
       : type == 'planned'
-      ? colors.accents.turquoise
+      ? colors.accents.a6turquoise
       : type == 'realized'
-      ? colors.accents.successGreen
-      : colors.greyscale.lighter
+      ? colors.status.success
+      : colors.grayscale.g15
 
   return (
     <Card color={color} active={active} onClick={() => onClick()}>
@@ -94,7 +94,7 @@ export default React.memo(function OccupancyCard({
         </Title>
         <FontAwesomeIcon
           icon={active ? faEye : faEyeSlash}
-          color={active ? colors.main.dark : colors.greyscale.lighter}
+          color={active ? colors.main.m1 : colors.grayscale.g15}
           size="lg"
         />
       </HeaderContainer>
@@ -109,7 +109,7 @@ export default React.memo(function OccupancyCard({
               <IconContainer>
                 <FontAwesomeIcon
                   icon={faArrowDown}
-                  color={active ? color : colors.greyscale.lighter}
+                  color={active ? color : colors.grayscale.g15}
                 />
               </IconContainer>
               <Value data-qa={`occupancies-minimum-${type}`}>
@@ -126,7 +126,7 @@ export default React.memo(function OccupancyCard({
               <IconContainer>
                 <FontAwesomeIcon
                   icon={faArrowUp}
-                  color={active ? color : colors.greyscale.lighter}
+                  color={active ? color : colors.grayscale.g15}
                 />
               </IconContainer>
               <Value data-qa={`occupancies-maximum-${type}`}>

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -79,8 +79,8 @@ export default React.memo(function OccupancyDayGraph({ occupancy }: Props) {
         spanGaps: true,
         stepped: 'before',
         fill: false,
-        pointBackgroundColor: colors.accents.successGreen,
-        borderColor: colors.accents.successGreen
+        pointBackgroundColor: colors.status.success,
+        borderColor: colors.status.success
       }
     ]
   }

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyGraph.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -15,7 +15,7 @@ defaults.font = {
   family: '"Open Sans", "Arial", sans-serif',
   ...defaults.font
 }
-defaults.color = colors.greyscale.darkest
+defaults.color = colors.grayscale.g100
 
 type DatePoint = { x: Date; y: number | null | undefined }
 
@@ -113,8 +113,8 @@ export default React.memo(function OccupancyGraph({
       data: getGraphData(occupancies),
       stepped: true,
       fill: false,
-      pointBackgroundColor: colors.main.dark,
-      borderColor: colors.main.dark
+      pointBackgroundColor: colors.main.m1,
+      borderColor: colors.main.m1
     })
   if (planned)
     datasets.push({
@@ -122,8 +122,8 @@ export default React.memo(function OccupancyGraph({
       data: getGraphData(plannedOccupancies),
       stepped: true,
       fill: false,
-      pointBackgroundColor: colors.accents.turquoise,
-      borderColor: colors.accents.turquoise
+      pointBackgroundColor: colors.accents.a6turquoise,
+      borderColor: colors.accents.a6turquoise
     })
   if (realized)
     datasets.push({
@@ -131,8 +131,8 @@ export default React.memo(function OccupancyGraph({
       data: getGraphData(realizedOccupancies),
       stepped: true,
       fill: false,
-      pointBackgroundColor: colors.accents.successGreen,
-      borderColor: colors.accents.successGreen
+      pointBackgroundColor: colors.status.success,
+      borderColor: colors.status.success
     })
 
   return (

--- a/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
@@ -127,7 +127,7 @@ const FormPart = styled.div`
 `
 
 const FormError = styled.div`
-  color: ${colors.accents.dangerRed};
+  color: ${colors.status.danger};
   margin-bottom: 20px;
 `
 

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -23,7 +23,7 @@ export default React.memo(function AbsenceDay({ type }: Props) {
         <FixedSpaceRow spacing="xs" alignItems="center">
           <RoundIcon
             content={faThermometer}
-            color={colors.accents.violet}
+            color={colors.accents.a4violet}
             size="m"
           />
           <div>{i18n.absences.absenceTypes.SICKLEAVE}</div>
@@ -34,7 +34,7 @@ export default React.memo(function AbsenceDay({ type }: Props) {
   return (
     <AbsenceCell>
       <FixedSpaceRow spacing="xs" alignItems="center">
-        <RoundIcon content="–" color={colors.main.primary} size="m" />
+        <RoundIcon content="–" color={colors.main.m2} size="m" />
         <div>
           {i18n.absences.absenceTypes[type] ??
             i18n.absences.absenceTypes.OTHER_ABSENCE}

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -627,14 +627,14 @@ const TimeInputGrid = styled.div`
 `
 
 const Week = styled.div`
-  color: ${({ theme }) => theme.colors.main.dark};
+  color: ${(p) => p.theme.colors.main.m1};
   font-weight: ${fontWeights.semibold};
   grid-column-start: 1;
   grid-column-end: 4;
 `
 
 const Separator = styled.div`
-  border-top: 2px dotted ${(p) => p.theme.colors.greyscale.lighter};
+  border-top: 2px dotted ${(p) => p.theme.colors.grayscale.g15};
   margin: ${defaultMargins.s} 0;
   grid-column-start: 1;
   grid-column-end: 4;

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
@@ -107,11 +107,11 @@ const CustomTh = styled(Th)`
 
 const DateTh = styled(CustomTh)<{ faded: boolean }>`
   width: 0; // causes the column to take as little space as possible
-  ${({ faded }) => (faded ? `color: ${colors.greyscale.medium};` : '')}
+  ${({ faded }) => (faded ? `color: ${colors.grayscale.g35};` : '')}
 `
 
 const StyledTd = styled(Td)`
-  border-right: 1px solid ${colors.greyscale.medium};
+  border-right: 1px solid ${colors.grayscale.g35};
   vertical-align: middle;
 `
 

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -124,5 +124,5 @@ const WeekPicker = styled.div`
 
 const WeekPickerButton = styled(IconButton)`
   margin: 0 ${defaultMargins.s};
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 `

--- a/frontend/src/employee-frontend/components/vasu/VasuStateTransitionButtons.tsx
+++ b/frontend/src/employee-frontend/components/vasu/VasuStateTransitionButtons.tsx
@@ -140,7 +140,7 @@ export function VasuStateTransitionButtons({
       </ButtonContainer>
       {(state === 'DRAFT' || state === 'READY') && (
         <PublishingDisclaimer alignItems="center" spacing="xs">
-          <RoundIcon content="!" color={colors.main.primary} size="m" />
+          <RoundIcon content="!" color={colors.main.m2} size="m" />
           <span>{i18n.vasu.transitions.vasuIsPublishedToGuardians}</span>
         </PublishingDisclaimer>
       )}

--- a/frontend/src/employee-frontend/components/vasu/components/FollowupQuestion.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/FollowupQuestion.tsx
@@ -212,7 +212,7 @@ const FollowupQuestionContainer = styled.div<{ editable: boolean }>`
   ${(p) =>
     p.editable &&
     css`
-      border-left: 5px solid ${colors.main.dark};
+      border-left: 5px solid ${colors.main.m1};
       box-shadow: 0px -4px 4px rgba(15, 15, 15, 0.1);
       width: calc(100% + 2 * ${defaultMargins.L});
       padding: ${defaultMargins.L};

--- a/frontend/src/employee-frontend/components/vasu/sections/DynamicSections.tsx
+++ b/frontend/src/employee-frontend/components/vasu/sections/DynamicSections.tsx
@@ -305,7 +305,7 @@ export const SectionContent = styled(ContentArea)<{
 }>`
   border-left: 5px solid
     ${({ highlighted, theme }) =>
-      highlighted ? theme.colors.main.dark : 'transparent'};
+      highlighted ? theme.colors.main.m1 : 'transparent'};
   padding: ${defaultMargins.L};
   padding-left: calc(${defaultMargins.L} - 5px);
   ${({ padBottom }) =>

--- a/frontend/src/employee-frontend/components/vasu/templates/VasuTemplateEditor.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/VasuTemplateEditor.tsx
@@ -708,11 +708,11 @@ const ElementContainer = styled.div`
   position: relative;
   padding: 24px 80px 24px 24px;
 
-  border: dashed 1px ${colors.greyscale.white};
+  border: dashed 1px ${colors.grayscale.g0};
   border-radius: 8px;
 
   &:hover {
-    border-color: ${colors.greyscale.medium};
+    border-color: ${colors.grayscale.g35};
   }
 
   &:not(:hover) {
@@ -729,7 +729,7 @@ const ElementContainer = styled.div`
 `
 
 const QuestionDetails = styled.i`
-  color: ${({ theme }) => theme.colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 `
 
 const AddNewContainer = styled.div<{ showOnHover: boolean }>`

--- a/frontend/src/employee-frontend/components/voucher-value-decision/VoucherValueDecisionHeading.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decision/VoucherValueDecisionHeading.tsx
@@ -159,7 +159,7 @@ const TitleRow = styled.div`
 `
 
 const DisabledLink = styled.span`
-  color: ${colors.greyscale.medium};
+  color: ${colors.grayscale.g35};
 `
 
 const Cursive = styled.span`

--- a/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionActions.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionActions.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -12,7 +12,7 @@ import { CheckedRowsInfo } from '../common/CheckedRowsInfo'
 import StickyActionBar from '../common/StickyActionBar'
 
 const ErrorMessage = styled.div`
-  color: ${(p) => p.theme.colors.accents.orangeDark};
+  color: ${(p) => p.theme.colors.accents.a2orangeDark};
   margin: 0 20px;
 `
 

--- a/frontend/src/employee-mobile-frontend/components/UnitList.tsx
+++ b/frontend/src/employee-mobile-frontend/components/UnitList.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -76,5 +76,5 @@ export default React.memo(function UnitList() {
 const UnitContainer = styled(Link)`
   display: flex;
   flex-direction: column;
-  color: ${({ theme }) => theme.colors.greyscale.darkest};
+  color: ${(p) => p.theme.colors.grayscale.g100};
 `

--- a/frontend/src/employee-mobile-frontend/components/attendances/AttendancePageWrapper.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/AttendancePageWrapper.tsx
@@ -165,7 +165,7 @@ const ChildSearch = React.memo(function Search({
           value={freeText}
           setValue={setFreeText}
           placeholder={i18n.attendances.searchPlaceholder}
-          background={colors.greyscale.white}
+          background={colors.grayscale.g0}
           setShowSearch={toggleShow}
           searchResults={searchResults}
         />
@@ -181,7 +181,7 @@ const ChildSearch = React.memo(function Search({
 
 const SearchContainer = animated(styled.div`
   position: absolute;
-  background: ${colors.greyscale.lightest};
+  background: ${colors.grayscale.g4};
   width: 100vw;
   overflow: hidden;
   z-index: ${zIndex.searchBar};

--- a/frontend/src/employee-mobile-frontend/components/attendances/ChildList.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/ChildList.tsx
@@ -90,7 +90,7 @@ const Li = styled.li`
   &:after {
     content: '';
     width: calc(100% - ${defaultMargins.s});
-    background: ${colors.greyscale.lighter};
+    background: ${colors.grayscale.g15};
     height: 1px;
     display: block;
     position: absolute;

--- a/frontend/src/employee-mobile-frontend/components/attendances/ChildListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/ChildListItem.tsx
@@ -26,7 +26,7 @@ const ChildBox = styled.div`
   display: flex;
   padding: ${defaultMargins.xs} ${defaultMargins.s};
   border-radius: 2px;
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
 `
 
 const AttendanceLinkBox = styled(Link)`
@@ -51,7 +51,7 @@ export const IconBox = styled.div<{ type: AttendanceStatus }>`
   background-color: ${(props) => attendanceColors[props.type]};
   border-radius: 50%;
   box-shadow: 0 0 0 2px ${(props) => attendanceColors[props.type]};
-  border: 2px solid ${colors.greyscale.white};
+  border: 2px solid ${colors.grayscale.g0};
 `
 
 const DetailsRow = styled.div`
@@ -59,7 +59,7 @@ const DetailsRow = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   font-size: 0.875em;
   width: 100%;
 `
@@ -132,7 +132,7 @@ export default React.memo(function ChildListItem({
           ) : (
             <RoundIcon
               content={farUser}
-              color={type ? attendanceColors[type] : colors.main.dark}
+              color={type ? attendanceColors[type] : colors.main.m1}
               size="XL"
             />
           )}
@@ -150,7 +150,7 @@ export default React.memo(function ChildListItem({
             <div>
               {infoText}
               {child.backup && (
-                <RoundIcon content="V" size="m" color={colors.main.dark} />
+                <RoundIcon content="V" size="m" color={colors.main.m1} />
               )}
             </div>
             <FixedSpaceRowWithLeftMargin>
@@ -161,7 +161,7 @@ export default React.memo(function ChildListItem({
                 >
                   <RoundIcon
                     content={farStickyNote}
-                    color={colors.accents.pink}
+                    color={colors.accents.a9pink}
                     size="m"
                   />
                 </Link>
@@ -173,7 +173,7 @@ export default React.memo(function ChildListItem({
                 >
                   <RoundIcon
                     content={farUsers}
-                    color={colors.main.lighter}
+                    color={colors.main.m4}
                     size="m"
                   />
                 </Link>

--- a/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkAbsent.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkAbsent.tsx
@@ -140,7 +140,7 @@ export default React.memo(function MarkAbsent() {
               <span>
                 <RoundIcon
                   content={farStickyNote}
-                  color={colors.main.dark}
+                  color={colors.main.m1}
                   size="m"
                 />
               </span>

--- a/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkDeparted.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkDeparted.tsx
@@ -245,7 +245,7 @@ export default React.memo(function MarkDeparted() {
                 <span>
                   <RoundIcon
                     content={farStickyNote}
-                    color={colors.main.dark}
+                    color={colors.main.m1}
                     size="m"
                   />
                 </span>

--- a/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkPresent.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkPresent.tsx
@@ -125,7 +125,7 @@ export default React.memo(function MarkPresent() {
               <span>
                 <RoundIcon
                   content={farStickyNote}
-                  color={colors.main.dark}
+                  color={colors.main.m1}
                   size="m"
                 />
               </span>

--- a/frontend/src/employee-mobile-frontend/components/attendances/child-info/AttendanceChildPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/child-info/AttendanceChildPage.tsx
@@ -204,7 +204,7 @@ export default React.memo(function AttendanceChildPage() {
                   <RoundIcon
                     size="L"
                     content={faCalendarTimes}
-                    color={colors.main.primary}
+                    color={colors.main.m2}
                   />
                   <LinkButtonText>
                     {i18n.attendances.actions.markAbsentBeforehand}
@@ -292,7 +292,7 @@ export default React.memo(function AttendanceChildPage() {
 })
 
 const ChildStatus = styled.div`
-  color: ${colors.greyscale.medium};
+  color: ${colors.grayscale.g35};
   top: 10px;
   position: relative;
 `
@@ -311,7 +311,7 @@ const CustomTitle = styled.h2`
   font-size: 20px;
   line-height: 30px;
   margin-top: 0;
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   text-align: center;
   margin-bottom: ${defaultMargins.xs};
 `
@@ -323,7 +323,7 @@ const GroupName = styled.div`
   font-size: 15px;
   line-height: 22px;
   text-transform: uppercase;
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   letter-spacing: 0.05rem;
 `
 
@@ -365,12 +365,12 @@ const BottomButtonWrapper = styled.div`
   align-items: center;
   justify-content: center;
   min-height: 74px;
-  background: ${colors.greyscale.lightest};
+  background: ${colors.grayscale.g4};
 `
 const LinkButtonWithIcon = styled(Link)``
 
 const LinkButtonText = styled.span`
-  color: ${colors.main.primary};
+  color: ${colors.main.m2};
   margin-left: ${defaultMargins.s};
   font-weight: ${fontWeights.semibold};
   font-size: 16px;
@@ -378,7 +378,7 @@ const LinkButtonText = styled.span`
 `
 
 const Shadow = styled.div`
-  box-shadow: 0 4px 4px 0 ${colors.greyscale.lighter};
+  box-shadow: 0 4px 4px 0 ${colors.grayscale.g15};
   z-index: 1;
   display: flex;
   flex-direction: column;

--- a/frontend/src/employee-mobile-frontend/components/attendances/child-info/ChildButtons.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/child-info/ChildButtons.tsx
@@ -48,7 +48,7 @@ export default React.memo(function ChildButtons({
           >
             <RoundIcon
               content={faComments}
-              color={colors.main.primary}
+              color={colors.main.m2}
               size="XL"
               label={i18n.childButtons.newMessage}
             />
@@ -62,7 +62,7 @@ export default React.memo(function ChildButtons({
         >
           <RoundIcon
             content={faPen}
-            color={colors.main.primary}
+            color={colors.main.m2}
             size="XL"
             label={i18n.common.dailyNotes}
             bubble={noteFound}
@@ -75,7 +75,7 @@ export default React.memo(function ChildButtons({
         >
           <RoundIcon
             content={faChild}
-            color={colors.main.primary}
+            color={colors.main.m2}
             size="XL"
             label={i18n.common.information}
           />

--- a/frontend/src/employee-mobile-frontend/components/attendances/components.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/components.tsx
@@ -64,7 +64,7 @@ export const ArrivalTime = styled.span`
   line-height: 27px;
   letter-spacing: 0em;
   display: flex;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 
   span:first-child {
     margin-right: ${defaultMargins.xs};
@@ -79,7 +79,7 @@ export const CustomHorizontalLine = styled(HorizontalLine)`
 
 export const ServiceTime = styled.div`
   padding: ${defaultMargins.xxs};
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   text-align: center;
 `
 
@@ -103,7 +103,7 @@ export const DailyNotes = styled.div`
 `
 
 export const BackButtonInline = styled(InlineButton)`
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   margin-top: ${defaultMargins.s};
   margin-left: ${defaultMargins.s};
   margin-bottom: ${defaultMargins.s};
@@ -117,12 +117,12 @@ export const TimeWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   font-size: 60px;
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   font-weight: ${fontWeights.semibold};
 
   input {
     font-size: 60px;
-    color: ${colors.main.dark};
+    color: ${colors.main.m1};
     font-family: Montserrat, sans-serif;
     font-weight: ${fontWeights.light};
     border-bottom: none;

--- a/frontend/src/employee-mobile-frontend/components/attendances/notes/ChildNotes.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/notes/ChildNotes.tsx
@@ -52,7 +52,7 @@ const NoteTypeTab = ({
       <RoundIcon
         data-qa={`${dataQa}-indicator`}
         content={String(noteCount)}
-        color={colors.accents.warningOrange}
+        color={colors.status.warning}
         size="xs"
       />
     )}
@@ -238,10 +238,9 @@ const Tab = styled.div<TabProps>`
   text-transform: uppercase;
 
   background: ${(props) =>
-    props.selected ? colors.main.lighter : colors.greyscale.white};
+    props.selected ? colors.main.m4 : colors.grayscale.g0};
 
-  color: ${(props) =>
-    props.selected ? colors.main.dark : colors.greyscale.dark};
+  color: ${(props) => (props.selected ? colors.main.m1 : colors.grayscale.g70)};
 `
 
 const TopRow = styled.div`

--- a/frontend/src/employee-mobile-frontend/components/attendances/notes/DailyNote.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/notes/DailyNote.tsx
@@ -103,12 +103,12 @@ const NotesTitle = styled(Title)`
   font-family: Montserrat, sans-serif;
   font-size: 18px;
   font-weight: ${fontWeights.medium};
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   margin-top: 0;
   margin-bottom: 0;
 `
 
 const DailyNoteWrapper = styled.span`
   margin-left: 16px;
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
 `

--- a/frontend/src/employee-mobile-frontend/components/attendances/notes/DailyNotesTab.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/notes/DailyNotesTab.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -58,7 +58,7 @@ const Time = styled.div`
 const StickyActionContainer = styled.section`
   position: sticky;
   bottom: 0;
-  background-color: ${({ theme }) => theme.colors.greyscale.lightest};
+  background-color: ${(p) => p.theme.colors.grayscale.g4};
   padding: ${defaultMargins.s};
 `
 

--- a/frontend/src/employee-mobile-frontend/components/common/BottomModalMenu.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/BottomModalMenu.tsx
@@ -18,7 +18,7 @@ const MenuBackground = styled.div`
   bottom: 0;
   width: 100%;
   min-height: 20%;
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
   box-shadow: 0 -4px 4px rgba(0, 0, 0, 0.1);
   padding: 24px 16px;
 `
@@ -29,7 +29,7 @@ const TopRow = styled.div`
   align-items: center;
   margin-bottom: 16px;
 
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   font-style: normal;
   font-weight: ${fontWeights.semibold};
   font-size: 16px;

--- a/frontend/src/employee-mobile-frontend/components/common/BottomNavbar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/BottomNavbar.tsx
@@ -45,7 +45,7 @@ const Root = styled.div`
   justify-content: space-evenly;
   align-items: center;
 
-  background: ${colors.greyscale.white};
+  background: ${colors.grayscale.g0};
   box-shadow: 0px -4px 10px rgba(0, 0, 0, 0.15);
   margin-bottom: 0 !important;
 `
@@ -60,14 +60,14 @@ const Button = styled.div`
 `
 
 const CustomIcon = styled(FontAwesomeIcon)<{ selected: boolean }>`
-  color: ${(p) => (p.selected ? colors.main.dark : colors.greyscale.dark)};
+  color: ${(p) => (p.selected ? colors.main.m1 : colors.grayscale.g70)};
   height: 24px !important;
   width: 24px !important;
   margin: 0;
 `
 
 const IconText = styled.span<{ selected: boolean }>`
-  color: ${(p) => (p.selected ? colors.main.dark : colors.greyscale.dark)};
+  color: ${(p) => (p.selected ? colors.main.m1 : colors.grayscale.g70)};
   font-size: 14px;
   font-weight: ${fontWeights.semibold};
 `
@@ -193,5 +193,5 @@ const UnreadMessagesIndicator = styled.div`
   width: ${defaultMargins.s};
   height: ${defaultMargins.s};
   border-radius: 100%;
-  background-color: ${colors.accents.warningOrange};
+  background-color: ${colors.status.warning};
 `

--- a/frontend/src/employee-mobile-frontend/components/common/FreeTextSearch.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/FreeTextSearch.tsx
@@ -23,7 +23,7 @@ const SearchInput = styled.input<{ background?: string; showClose: boolean }>`
   width: 100%;
   border: none;
   font-size: 1rem;
-  background: ${(p) => p.background ?? colors.greyscale.lightest};
+  background: ${(p) => p.background ?? colors.grayscale.g4};
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
@@ -33,24 +33,24 @@ const SearchInput = styled.input<{ background?: string; showClose: boolean }>`
   outline: none;
   margin-left: -38px;
   margin-right: ${(p) => (p.showClose ? '-25px' : '0')};
-  color: ${colors.greyscale.darkest};
+  color: ${colors.grayscale.g100};
   height: 100%;
 
   &::placeholder {
-    color: ${colors.greyscale.dark};
+    color: ${colors.grayscale.g70};
   }
 
   &:focus {
     border-width: 2px;
     border-radius: 2px;
     border-style: solid;
-    border-color: ${colors.main.primaryFocus};
+    border-color: ${colors.main.m2Focus};
     padding-left: 53px;
   }
 `
 
 const CustomIcon = styled(FontAwesomeIcon)`
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
   margin: 0 0.5rem;
   position: relative;
   left: 10px;
@@ -61,7 +61,7 @@ const CustomIcon = styled(FontAwesomeIcon)`
 const CustomIconButton = styled(IconButton)`
   float: right;
   position: relative;
-  color: ${colors.greyscale.medium};
+  color: ${colors.grayscale.g35};
   right: 20px;
 `
 

--- a/frontend/src/employee-mobile-frontend/components/common/GroupSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/GroupSelector.tsx
@@ -89,7 +89,7 @@ const Info = styled.span`
   font-weight: ${fontWeights.semibold};
   font-size: 14px;
   line-height: 21px;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 `
 
 const Wrapper = styled.div`

--- a/frontend/src/employee-mobile-frontend/components/common/GroupSelectorBar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/GroupSelectorBar.tsx
@@ -39,8 +39,8 @@ const GroupSelectorButton = styled(InlineButton)`
 `
 
 const GroupSelectorWrapper = animated(styled.div`
-  background-color: ${colors.greyscale.white};
-  box-shadow: 0 2px 6px 0 ${colors.greyscale.lighter};
+  background-color: ${colors.grayscale.g0};
+  box-shadow: 0 2px 6px 0 ${colors.grayscale.g15};
   position: absolute;
   display: flex;
   flex-direction: column;

--- a/frontend/src/employee-mobile-frontend/components/common/TopBar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/TopBar.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -26,16 +26,14 @@ const StickyTopBar = styled.section<{ invertedColors?: boolean }>`
   align-items: center;
   flex-shrink: 0;
 
-  background: ${({ theme, invertedColors }) =>
-    invertedColors
-      ? theme.colors.greyscale.lightest
-      : theme.colors.main.primary};
-  color: ${({ theme, invertedColors }) =>
-    invertedColors ? theme.colors.main.dark : theme.colors.greyscale.white};
+  background: ${(p) =>
+    p.invertedColors ? p.theme.colors.grayscale.g4 : p.theme.colors.main.m2};
+  color: ${(p) =>
+    p.invertedColors ? p.theme.colors.main.m1 : p.theme.colors.grayscale.g0};
 
   button {
-    color: ${({ theme, invertedColors }) =>
-      invertedColors ? theme.colors.main.dark : theme.colors.greyscale.white};
+    color: ${(p) =>
+      p.invertedColors ? p.theme.colors.main.m1 : p.theme.colors.grayscale.g0};
   }
 `
 

--- a/frontend/src/employee-mobile-frontend/components/common/top-bar/UserMenu.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/top-bar/UserMenu.tsx
@@ -25,9 +25,9 @@ const UserMenuContainer = styled.div`
   display: flex;
   flex-direction: column;
 
-  background-color: ${colors.greyscale.white};
-  color: ${colors.greyscale.darkest};
-  box-shadow: 0 4px 4px 0 ${colors.greyscale.lighter};
+  background-color: ${colors.grayscale.g0};
+  color: ${colors.grayscale.g100};
+  box-shadow: 0 4px 4px 0 ${colors.grayscale.g15};
 `
 
 interface Props {
@@ -44,11 +44,7 @@ export const UserMenu = React.memo(function UserMenu(props: Props) {
       <Gap size="xxs" />
 
       <FixedSpaceRow justifyContent="flex-start">
-        <FontAwesomeIcon
-          icon={faUserUnlock}
-          size="lg"
-          color={colors.main.dark}
-        />{' '}
+        <FontAwesomeIcon icon={faUserUnlock} size="lg" color={colors.main.m1} />{' '}
         <span data-qa="full-name">{props.name}</span>
       </FixedSpaceRow>
 

--- a/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
@@ -105,7 +105,7 @@ export default function MessagesPage() {
           ) : (
             <EmptyMessageFolder
               loading={receivedMessages.isLoading}
-              iconColor={colors.greyscale.medium}
+              iconColor={colors.grayscale.g35}
               text={i18n.messages.emptyInbox}
             />
           )}
@@ -131,7 +131,7 @@ export default function MessagesPage() {
         ) : (
           <EmptyMessageFolder
             loading={false}
-            iconColor={colors.greyscale.medium}
+            iconColor={colors.grayscale.g35}
             text={i18n.messages.emptyInbox}
           />
         )}
@@ -143,7 +143,7 @@ export default function MessagesPage() {
 
 export const HeaderContainer = styled.div`
   padding: ${defaultMargins.m} ${defaultMargins.s};
-  border-bottom: 1px solid ${colors.greyscale.lighter};
+  border-bottom: 1px solid ${colors.grayscale.g15};
 `
 
 const NoAccounts = styled.div`

--- a/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
@@ -135,16 +135,16 @@ const RoundIconButton = styled.button`
   min-height: ${defaultMargins.L};
   max-width: ${defaultMargins.L};
   max-height: ${defaultMargins.L};
-  background: ${colors.main.primary};
+  background: ${colors.main.m2};
   border: none;
   border-radius: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: ${colors.greyscale.white};
+  color: ${colors.grayscale.g0};
   &:disabled {
-    background: ${colors.greyscale.lighter};
+    background: ${colors.grayscale.g15};
   }
 `
 
@@ -156,13 +156,13 @@ const MessageContainer = styled.div<{ ours: boolean }>`
       ? `
       border-bottom-right-radius: 2px;
       align-self: flex-end;
-      background-color: ${colors.main.primary};
-      color: ${colors.greyscale.white};
+      background-color: ${colors.main.m2};
+      color: ${colors.grayscale.g0};
     `
       : `
       border-bottom-left-radius: 2px;
       align-self: flex-start;
-      background-color: ${colors.main.lighter};
+      background-color: ${colors.main.m4};
     `}
   padding: ${defaultMargins.s};
   margin: ${defaultMargins.xs};
@@ -171,7 +171,7 @@ const MessageContainer = styled.div<{ ours: boolean }>`
 const SentDate = styled.div<{ white: boolean }>`
   font-size: 14px;
   font-weight: ${fontWeights.semibold};
-  color: ${(p) => (p.white ? colors.greyscale.white : colors.greyscale.dark)};
+  color: ${(p) => (p.white ? colors.grayscale.g0 : colors.grayscale.g70)};
 `
 
 const TitleRow = styled.div`
@@ -210,7 +210,7 @@ const ThreadViewReplyContainer = styled.div`
   width: 100%;
   display: flex;
   align-items: center;
-  background: ${colors.greyscale.white};
+  background: ${colors.grayscale.g0};
   margin-top: auto;
   padding: ${defaultMargins.xxs} ${defaultMargins.xs} ${defaultMargins.xs};
 `
@@ -225,7 +225,7 @@ const ThreadViewReply = styled.div`
     width: 100%;
   }
   .thread-view-input {
-    background: ${colors.greyscale.lightest};
+    background: ${colors.grayscale.g4};
     border-radius: ${defaultMargins.m};
   }
   .thread-view-input:not(:focus) {

--- a/frontend/src/employee-mobile-frontend/components/messages/UnreadMessagesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/UnreadMessagesPage.tsx
@@ -100,7 +100,7 @@ const UnreadCountNumber = React.memo(function UnreadCountNumber({
 const LinkToGroupMessages = styled(Link)`
   font-size: ${fontSizesMobile.h2};
   font-weight: bold;
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   margin: ${defaultMargins.xs} 0;
 `
 
@@ -123,7 +123,7 @@ const UnreadCountNumberCircle = styled.div`
   font-weight: bold;
   width: ${defaultMargins.m};
   height: ${defaultMargins.m};
-  border: 1px solid ${colors.greyscale.darkest};
+  border: 1px solid ${colors.grayscale.g100};
   border-radius: 100%;
 `
 

--- a/frontend/src/employee-mobile-frontend/components/mobile/PairingWizard.tsx
+++ b/frontend/src/employee-mobile-frontend/components/mobile/PairingWizard.tsx
@@ -44,7 +44,7 @@ const PhaseTitle = styled.h1`
   font-size: 20px;
   line-height: 30px;
   text-align: center;
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
 `
 
 export const ResponseKey = styled.div`
@@ -55,7 +55,7 @@ export const ResponseKey = styled.div`
   line-height: 30px;
   text-align: center;
   letter-spacing: 0.08em;
-  color: ${colors.greyscale.dark};
+  color: ${colors.grayscale.g70};
 `
 
 const Bottom = styled.div``

--- a/frontend/src/employee-mobile-frontend/components/mobile/components.tsx
+++ b/frontend/src/employee-mobile-frontend/components/mobile/components.tsx
@@ -14,7 +14,7 @@ export const FullHeightContainer = styled(Container)<{ spaced?: boolean }>`
   height: 100%;
   display: flex;
   flex-direction: column;
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
   padding: ${defaultMargins.s};
   ${(p) => (p.spaced ? 'justify-content: space-between;' : '')}
 `
@@ -34,13 +34,12 @@ export const WideLinkButton = styled(Link)<{ $primary?: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  background: ${(p) =>
-    p.$primary ? colors.main.primary : colors.greyscale.white};
-  color: ${(p) => (p.$primary ? colors.greyscale.white : colors.main.primary)};
+  background: ${(p) => (p.$primary ? colors.main.m2 : colors.grayscale.g0)};
+  color: ${(p) => (p.$primary ? colors.grayscale.g0 : colors.main.m2)};
 `
 
 export const BackButton = styled(IconButton)`
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   position: absolute;
 `
 

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffListItem.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -17,15 +17,15 @@ const StaffBox = styled.div`
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
-  color: ${colors.greyscale.darkest};
+  color: ${colors.grayscale.g100};
   padding: ${defaultMargins.xs} ${defaultMargins.s};
   border-radius: 2px;
-  background-color: ${colors.greyscale.white};
+  background-color: ${colors.grayscale.g0};
 
   &:after {
     content: '';
     width: calc(100% - ${defaultMargins.s});
-    background: ${colors.greyscale.lighter};
+    background: ${colors.grayscale.g15};
     height: 1px;
     display: block;
     margin: 8px 0 -8px;
@@ -52,13 +52,13 @@ const StaffBoxInfo = styled.div`
 
 export const IconBox = styled.div<{ present: boolean }>`
   background-color: ${(p) =>
-    p.present ? colors.accents.successGreen : colors.accents.turquoise};
+    p.present ? colors.status.success : colors.accents.a6turquoise};
   border-radius: 50%;
   box-shadow: ${(p) =>
     p.present
-      ? `0 0 0 2px ${colors.accents.successGreen}`
-      : `0 0 0 2px ${colors.accents.turquoise}`};
-  border: 2px solid ${colors.greyscale.white};
+      ? `0 0 0 2px ${colors.status.success}`
+      : `0 0 0 2px ${colors.accents.a6turquoise}`};
+  border: 2px solid ${colors.grayscale.g0};
 `
 
 export default React.memo(function StaffListItem({
@@ -81,9 +81,7 @@ export default React.memo(function StaffListItem({
         <IconBox present={present}>
           <RoundIcon
             content={farUser}
-            color={
-              present ? colors.accents.successGreen : colors.accents.turquoise
-            }
+            color={present ? colors.status.success : colors.accents.a6turquoise}
             size="XL"
           />
         </IconBox>

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/components/EmployeeCardBackground.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/components/EmployeeCardBackground.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -15,7 +15,7 @@ import { IconBox } from '../StaffListItem'
 import { Staff } from '../staff'
 
 function getColorByStatus(present: boolean) {
-  return present ? colors.accents.successGreen : colors.accents.turquoise
+  return present ? colors.status.success : colors.accents.a6turquoise
 }
 
 function getBackgroundColorByStatus(present: boolean) {
@@ -30,7 +30,7 @@ const Center = styled.div`
 `
 
 const EmployeeStatus = styled.div`
-  color: ${colors.greyscale.medium};
+  color: ${colors.grayscale.g35};
   top: 10px;
   position: relative;
 `

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/components/StaffMemberPageContainer.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/components/StaffMemberPageContainer.tsx
@@ -19,7 +19,7 @@ const BackButtonMargin = styled(BackButton)`
 `
 
 const Shadow = styled.div`
-  box-shadow: 0 4px 4px 0 ${colors.greyscale.lighter};
+  box-shadow: 0 4px 4px 0 ${colors.grayscale.g15};
   z-index: 1;
   display: flex;
   flex-direction: column;

--- a/frontend/src/employee-mobile-frontend/components/staff/PlusMinus.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff/PlusMinus.tsx
@@ -55,7 +55,7 @@ export default function PlusMinus({
 }
 
 const Root = styled.div`
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
   display: flex;
   justify-content: center;
 `
@@ -71,5 +71,5 @@ const TextButton = styled.button`
   outline: none;
   background-color: transparent;
   font-size: 48px;
-  color: ${colors.main.dark};
+  color: ${colors.main.m1};
 `

--- a/frontend/src/employee-mobile-frontend/components/staff/StaffAttendanceEditor.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff/StaffAttendanceEditor.tsx
@@ -147,7 +147,7 @@ const Subtitle = styled.h2`
   font-size: 16px;
   line-height: 24px;
   margin: 0;
-  color: ${colors.greyscale.darkest};
+  color: ${colors.grayscale.g100};
   text-align: center;
 `
 

--- a/frontend/src/lib-common/theme.ts
+++ b/frontend/src/lib-common/theme.ts
@@ -1,40 +1,64 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 export interface Theme {
   colors: {
     main: {
-      dark: string // main 1
-      primary: string // main 2
-      primaryHover: string
-      primaryActive: string
-      primaryFocus: string
-      light: string // main 3
-      lighter: string // main 4
+      /** Main 1 (Dark variant) */
+      m1: string
+      /** Main 2 (Primary) */
+      m2: string
+      /** Main 2 (Primary hover) */
+      m2Hover: string
+      /** Main 2 (Primary active) */
+      m2Active: string
+      /** Main 2 (Primary focus) */
+      m2Focus: string
+      /** Main 3 (Light variant) */
+      m3: string
+      /** Main 4 (Lighter variant) */
+      m4: string
     }
-    greyscale: {
-      darkest: string // 100
-      dark: string // 70
-      medium: string // 35
-      lighter: string // 15
-      lightest: string // 4
-      white: string // 0
+    grayscale: {
+      /** Grayscale-100 */
+      g100: string
+      /** Grayscale-70 */
+      g70: string
+      /** Grayscale-35 */
+      g35: string
+      /** Grayscale-15 */
+      g15: string
+      /** Grayscale-4 */
+      g4: string
+      /** Grayscale-0 */
+      g0: string
+    }
+    status: {
+      danger: string
+      warning: string
+      success: string
+      info: string
     }
     accents: {
-      dangerRed: string // 1
-      warningOrange: string // 2
-      successGreen: string // 3
-      infoBlue: string // 4
-      greenDark: string // 5
-      orangeDark: string // 6
-      emerald: string // 7
-      violet: string // 8
-      peach: string // 9
-      turquoise: string // 10
-      mint: string // 11
-      lightBlue: string // 12
-      pink: string // 13
+      /** Accent 5 */
+      a1greenDark: string
+      /** Accent 6 */
+      a2orangeDark: string
+      /** Accent 7 */
+      a3emerald: string
+      /** Accent 8 */
+      a4violet: string
+      /** Accent 9 */
+      a5orangeLight: string
+      /** Accent 10 */
+      a6turquoise: string
+      /** Accent 11 */
+      a7mint: string
+      /** Accent 12 */
+      a8lightBlue: string
+      /** Accent 13 */
+      a9pink: string
     }
   }
   typography: {

--- a/frontend/src/lib-common/themes/espoo-theme.ts
+++ b/frontend/src/lib-common/themes/espoo-theme.ts
@@ -5,42 +5,44 @@
 import { Theme } from 'lib-common/theme'
 
 const blueColors = {
-  dark: '#00358a',
-  primary: '#0047b6',
-  light: '#4d7fcc',
-  lighter: '#d9e4f4'
+  m1: '#00358a',
+  m2: '#0047b6',
+  m3: '#4d7fcc',
+  m4: '#d9e4f4'
 }
 
 const theme: Theme = {
   colors: {
     main: {
       ...blueColors,
-      primaryHover: blueColors.dark,
-      primaryActive: blueColors.dark,
-      primaryFocus: blueColors.light
+      m2Hover: blueColors.m1,
+      m2Active: blueColors.m1,
+      m2Focus: blueColors.m3
     },
-    greyscale: {
-      darkest: '#091c3b',
-      dark: '#536076',
-      medium: '#a9b0bb',
-      lighter: '#dadde2',
-      lightest: '#f7f7f7',
-      white: '#ffffff'
+    grayscale: {
+      g100: '#091c3b',
+      g70: '#536076',
+      g35: '#a9b0bb',
+      g15: '#dadde2',
+      g4: '#f7f7f7',
+      g0: '#ffffff'
+    },
+    status: {
+      danger: '#ff4f57',
+      warning: '#ff8e31',
+      success: '#70c673',
+      info: blueColors.m3
     },
     accents: {
-      dangerRed: '#ff4f57',
-      warningOrange: '#ff8e31',
-      successGreen: '#70c673',
-      infoBlue: blueColors.light,
-      greenDark: '#014b30',
-      orangeDark: '#ad581a',
-      emerald: '#148190',
-      violet: '#8f41b9',
-      peach: '#ffc386',
-      turquoise: '#7ff6fc',
-      mint: '#bcfdce',
-      lightBlue: '#c9d4dd',
-      pink: '#fca5c7'
+      a1greenDark: '#014b30',
+      a2orangeDark: '#ad581a',
+      a3emerald: '#148190',
+      a4violet: '#8f41b9',
+      a5orangeLight: '#ffc386',
+      a6turquoise: '#7ff6fc',
+      a7mint: '#bcfdce',
+      a8lightBlue: '#c9d4dd',
+      a9pink: '#fca5c7'
     }
   },
   typography: {

--- a/frontend/src/lib-components/atoms/Chip.tsx
+++ b/frontend/src/lib-components/atoms/Chip.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -24,14 +24,18 @@ export const StaticChip = styled.div<{ color: string }>`
   border: 1px solid ${(p) => p.color};
   border-radius: 1000px;
   background-color: ${(p) => p.color};
-  color: ${({ theme: { colors }, ...p }) =>
-    readableColor(p.color, colors.greyscale.white, colors.greyscale.darkest)};
+  color: ${(p) =>
+    readableColor(
+      p.color,
+      p.theme.colors.grayscale.g0,
+      p.theme.colors.grayscale.g100
+    )};
   padding: ${defaultMargins.xxs}
     calc(${defaultMargins.xs} + ${defaultMargins.xxs});
 
   outline: none;
   &:focus {
-    outline: 2px solid ${({ theme: { colors } }) => colors.main.light};
+    outline: 2px solid ${(p) => p.theme.colors.main.m3};
     outline-offset: 2px;
   }
 `
@@ -132,7 +136,7 @@ const SelectionChipWrapper = styled.div`
 
   &:focus,
   &:focus-within {
-    border: 2px solid ${({ theme: { colors } }) => colors.main.dark};
+    border: 2px solid ${(p) => p.theme.colors.main.m1};
     border-radius: 1000px;
     margin: -2px;
   }
@@ -146,12 +150,12 @@ const SelectionChipInnerWrapper = styled.div`
   position: relative;
   border-radius: 1000px;
   padding: 0 calc(${defaultMargins.xs} + ${defaultMargins.xxs});
-  background-color: ${({ theme: { colors } }) => colors.greyscale.white};
-  color: ${({ theme: { colors } }) => colors.main.primary};
-  border: 1px solid ${({ theme: { colors } }) => colors.main.primary};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
+  color: ${(p) => p.theme.colors.main.m2};
+  border: 1px solid ${(p) => p.theme.colors.main.m2};
   &.checked {
-    background-color: ${({ theme: { colors } }) => colors.main.primary};
-    color: ${({ theme: { colors } }) => colors.greyscale.white};
+    background-color: ${(p) => p.theme.colors.main.m2};
+    color: ${(p) => p.theme.colors.grayscale.g0};
   }
 
   @media (max-width: ${tabletMin}) {
@@ -181,7 +185,7 @@ const IconWrapper = styled.div`
   height: 32px;
 
   font-size: 24px;
-  color: ${({ theme: { colors } }) => colors.greyscale.white};
+  color: ${(p) => p.theme.colors.grayscale.g0};
 `
 
 export const ChipWrapper = styled.div<{ noMargin?: boolean }>`

--- a/frontend/src/lib-components/atoms/HorizontalLine.tsx
+++ b/frontend/src/lib-components/atoms/HorizontalLine.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -13,7 +13,7 @@ const HorizontalLine = styled.hr<{ slim?: boolean; dashed?: boolean }>`
   border: none;
   border-bottom-width: 1px;
   border-bottom-style: ${(p) => (p.dashed ? 'dashed' : 'solid')};
-  border-bottom-color: ${(p) => p.theme.colors.greyscale.lighter};
+  border-bottom-color: ${(p) => p.theme.colors.grayscale.g15};
 
   @media (max-width: ${tabletMin}) {
     margin-block-start: ${(p) =>

--- a/frontend/src/lib-components/atoms/Loader.tsx
+++ b/frontend/src/lib-components/atoms/Loader.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -20,7 +20,7 @@ const Spinner = styled.div`
   font-weight: ${fontWeights.normal};
   border-collapse: collapse;
   border-spacing: 0;
-  color: ${(p) => p.theme.colors.greyscale.darkest};
+  color: ${(p) => p.theme.colors.grayscale.g100};
   text-align: left !important;
   line-height: 1.3em;
   box-sizing: inherit;
@@ -30,8 +30,8 @@ const Spinner = styled.div`
   margin: 2em;
   font-size: 10px;
   text-indent: -9999em;
-  border: 8px solid ${(p) => p.theme.colors.main.light}32; // hex 32 is 0.2 alpha
-  border-left-color: ${(p) => p.theme.colors.main.light};
+  border: 8px solid ${(p) => p.theme.colors.main.m3}32; // hex 32 is 0.2 alpha
+  border-left-color: ${(p) => p.theme.colors.main.m3};
   transform: translateZ(0);
   animation: ${rotate} 1.1s linear infinite;
 `
@@ -42,7 +42,7 @@ const Wrapper = styled.div`
   font-weight: ${fontWeights.normal};
   border-collapse: collapse;
   border-spacing: 0;
-  color: ${(p) => p.theme.colors.greyscale.darkest};
+  color: ${(p) => p.theme.colors.grayscale.g100};
   text-align: left !important;
   line-height: 1.3em;
   box-sizing: inherit;

--- a/frontend/src/lib-components/atoms/PlacementCircle.tsx
+++ b/frontend/src/lib-components/atoms/PlacementCircle.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -13,7 +13,7 @@ const Circle = styled.div`
   min-height: 34px;
   max-width: 34px;
   max-height: 34px;
-  background-color: ${({ theme: { colors } }) => colors.main.dark};
+  background-color: ${(p) => p.theme.colors.main.m1};
   border-radius: 100%;
 `
 
@@ -24,7 +24,7 @@ const HalfCircle = styled.div`
   min-height: 34px;
   max-width: 17px;
   max-height: 34px;
-  background-color: ${({ theme: { colors } }) => colors.main.dark};
+  background-color: ${(p) => p.theme.colors.main.m1};
   border-top-left-radius: 17px;
   border-bottom-left-radius: 17px;
 `

--- a/frontend/src/lib-components/atoms/RoundIcon.tsx
+++ b/frontend/src/lib-components/atoms/RoundIcon.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -38,9 +38,9 @@ const IconContainer = styled.div<IconContainerProps>`
   align-items: center;
 
   border-radius: 100%;
-  border: 2px solid ${(props) => props.color};
-  background-color: ${({ theme: { colors } }) => colors.greyscale.white};
-  color: ${({ theme: { colors } }) => colors.greyscale.darkest};
+  border: 2px solid ${(p) => p.color};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
+  color: ${(p) => p.theme.colors.grayscale.g100};
   user-select: none;
 
   font-family: Montserrat, sans-serif;
@@ -48,18 +48,22 @@ const IconContainer = styled.div<IconContainerProps>`
 
   &.active {
     background-color: ${(props) => props.color};
-    color: ${({ theme: { colors }, color }) =>
-      readableColor(color, colors.greyscale.white, colors.greyscale.darkest)};
+    color: ${(p) =>
+      readableColor(
+        p.color,
+        p.theme.colors.grayscale.g0,
+        p.theme.colors.grayscale.g100
+      )};
   }
 
   &.clickable:hover {
-    background-color: ${(props) => shade(0.2, props.color)};
-    border-color: ${(props) => shade(0.2, props.color)};
-    color: ${({ theme: { colors }, color }) =>
+    background-color: ${(p) => shade(0.2, p.color)};
+    border-color: ${(p) => shade(0.2, p.color)};
+    color: ${(p) =>
       readableColor(
-        shade(0.2, color),
-        colors.greyscale.white,
-        colors.greyscale.darkest
+        shade(0.2, p.color),
+        p.theme.colors.grayscale.g0,
+        p.theme.colors.grayscale.g100
       )};
     cursor: pointer;
   }
@@ -250,9 +254,9 @@ const Circle = styled.span<{ smaller: boolean; color?: string }>`
   font-size: ${(p) => (p.smaller ? '12px' : '16px')};
   line-height: ${(p) => (p.smaller ? '10px' : '13px')};
   border-radius: 10px;
-  background-color: ${({ theme: { colors }, ...p }) =>
-    p.color ? p.color : colors.accents.successGreen};
-  color: ${({ theme: { colors } }) => colors.greyscale.white};
+  background-color: ${(p) =>
+    p.color ? p.color : p.theme.colors.status.success};
+  color: ${(p) => p.theme.colors.grayscale.g0};
   display: inline-block;
   position: absolute;
   right: -3px;

--- a/frontend/src/lib-components/atoms/RoundImage.tsx
+++ b/frontend/src/lib-components/atoms/RoundImage.tsx
@@ -20,7 +20,7 @@ const ImageContainer = styled.div<SizeProps>`
   align-items: center;
   border-radius: 50%;
 
-  background-color: ${(p) => p.theme.colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   color: ${(p) => p.color};
 
   font-size: ${(p) => fontSizeByIconSize(p.size)}px;

--- a/frontend/src/lib-components/atoms/StatusIcon.tsx
+++ b/frontend/src/lib-components/atoms/StatusIcon.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -29,14 +29,11 @@ export default React.memo(function UnderRowStatusIcon({
       {status === 'warning' && (
         <FontAwesomeIcon
           icon={fasExclamationTriangle}
-          color={colors.accents.warningOrange}
+          color={colors.status.warning}
         />
       )}
       {status === 'success' && (
-        <FontAwesomeIcon
-          icon={fasCheckCircle}
-          color={colors.accents.successGreen}
-        />
+        <FontAwesomeIcon icon={fasCheckCircle} color={colors.status.success} />
       )}
     </StatusIcon>
   )

--- a/frontend/src/lib-components/atoms/Tooltip.tsx
+++ b/frontend/src/lib-components/atoms/Tooltip.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -94,11 +94,11 @@ const TooltipPositioner = styled.div<{ position: Position }>`
 `
 
 const TooltipDiv = styled.div`
-  color: ${({ theme: { colors } }) => colors.greyscale.white};
+  color: ${(p) => p.theme.colors.grayscale.g0};
   font-size: 15px;
   line-height: 22px;
 
-  background-color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  background-color: ${(p) => p.theme.colors.grayscale.g70};
   padding: ${defaultMargins.s};
   border-radius: 2px;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
@@ -166,12 +166,12 @@ const Beak = styled.div<{ position: Position }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 
-  top: ${({ position }) => beakPositions(position).top};
-  bottom: ${({ position }) => beakPositions(position).bottom};
-  left: ${({ position }) => beakPositions(position).left};
-  right: ${({ position }) => beakPositions(position).right};
+  top: ${(p) => beakPositions(p.position).top};
+  bottom: ${(p) => beakPositions(p.position).bottom};
+  left: ${(p) => beakPositions(p.position).left};
+  right: ${(p) => beakPositions(p.position).right};
 `
 
 type Position = 'top' | 'bottom' | 'right' | 'left'

--- a/frontend/src/lib-components/atoms/UnorderedList.tsx
+++ b/frontend/src/lib-components/atoms/UnorderedList.tsx
@@ -11,7 +11,7 @@ export default styled.ul<{ spacing?: SpacingSize | string }>`
 
   li {
     &::marker {
-      color: ${({ theme: { colors } }) => colors.main.light};
+      color: ${(p) => p.theme.colors.main.m3};
     }
     margin-bottom: ${(p) =>
       p.spacing

--- a/frontend/src/lib-components/atoms/buttons/AddButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AddButton.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -28,19 +28,19 @@ const StyledButton = styled.button`
   cursor: pointer;
 
   &.disabled {
-    color: ${({ theme: { colors } }) => colors.greyscale.dark};
+    color: ${(p) => p.theme.colors.grayscale.g70};
     cursor: not-allowed;
 
     .icon-wrapper-inner {
-      background: ${({ theme: { colors } }) => colors.greyscale.dark};
+      background: ${(p) => p.theme.colors.grayscale.g70};
     }
   }
 
   &.darker:not(.disabled) {
-    color: ${({ theme: { colors } }) => colors.main.primaryActive};
+    color: ${(p) => p.theme.colors.main.m2Active};
 
     .icon-wrapper-inner {
-      background: ${({ theme: { colors } }) => colors.main.primaryActive};
+      background: ${(p) => p.theme.colors.main.m2Active};
     }
   }
 
@@ -55,7 +55,7 @@ const StyledButton = styled.button`
   }
 
   &:focus .icon-wrapper-outer {
-    border: 2px solid ${({ theme: { colors } }) => colors.main.primaryFocus};
+    border: 2px solid ${(p) => p.theme.colors.main.m2Focus};
     border-radius: 100%;
   }
 
@@ -67,9 +67,9 @@ const StyledButton = styled.button`
     align-items: center;
 
     font-size: 18px;
-    color: ${({ theme: { colors } }) => colors.greyscale.white};
+    color: ${(p) => p.theme.colors.grayscale.g0};
     font-weight: ${fontWeights.normal};
-    background: ${({ theme: { colors } }) => colors.main.primary};
+    background: ${(p) => p.theme.colors.main.m2};
     border-radius: 100%;
   }
 
@@ -81,7 +81,7 @@ const StyledButton = styled.button`
     }
   }
 
-  ${({ theme }) => defaultButtonTextStyle(theme)}
+  ${(p) => defaultButtonTextStyle(p.theme)}
 `
 
 export interface AddButtonProps extends BaseProps {

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -160,7 +160,7 @@ export default React.memo(function AsyncButton({
               )
             }}
           >
-            <FontAwesomeIcon icon={faCheck} color={colors.main.primary} />
+            <FontAwesomeIcon icon={faCheck} color={colors.main.m2} />
           </IconWrapper>
           <IconWrapper
             style={{
@@ -168,7 +168,7 @@ export default React.memo(function AsyncButton({
               transform: cross.opacity.interpolate((x) => `scale(${x ?? 0})`)
             }}
           >
-            <FontAwesomeIcon icon={faTimes} color={colors.accents.dangerRed} />
+            <FontAwesomeIcon icon={faTimes} color={colors.status.danger} />
           </IconWrapper>
         </IconContainer>
         <span>
@@ -202,8 +202,8 @@ const Spinner = animated(styled.div`
   width: 20px;
   height: 20px;
 
-  border: 2px solid ${({ theme: { colors } }) => colors.greyscale.lighter};
-  border-left-color: ${({ theme: { colors } }) => colors.main.primary};
+  border: 2px solid ${(p) => p.theme.colors.grayscale.g15};
+  border-left-color: ${(p) => p.theme.colors.main.m2};
   animation: spin 1s infinite linear;
 
   @keyframes spin {

--- a/frontend/src/lib-components/atoms/buttons/Button.tsx
+++ b/frontend/src/lib-components/atoms/buttons/Button.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -19,9 +19,9 @@ export const StyledButton = styled.button`
   text-align: center;
   overflow-x: hidden;
 
-  border: 1px solid ${({ theme: { colors } }) => colors.main.primary};
+  border: 1px solid ${(p) => p.theme.colors.main.m2};
   border-radius: 2px;
-  background: ${({ theme: { colors } }) => colors.greyscale.white};
+  background: ${(p) => p.theme.colors.grayscale.g0};
 
   outline: none;
   cursor: pointer;
@@ -31,40 +31,40 @@ export const StyledButton = styled.button`
   }
 
   &:focus {
-    outline: 2px solid ${({ theme: { colors } }) => colors.main.primaryFocus};
+    outline: 2px solid ${(p) => p.theme.colors.main.m2Focus};
     outline-offset: 2px;
   }
 
   &:hover {
-    color: ${({ theme: { colors } }) => colors.main.primaryHover};
-    border-color: ${({ theme: { colors } }) => colors.main.primaryHover};
+    color: ${(p) => p.theme.colors.main.m2Hover};
+    border-color: ${(p) => p.theme.colors.main.m2Hover};
   }
 
   &:active {
-    color: ${({ theme: { colors } }) => colors.main.primaryActive};
-    border-color: ${({ theme: { colors } }) => colors.main.primaryActive};
+    color: ${(p) => p.theme.colors.main.m2Active};
+    border-color: ${(p) => p.theme.colors.main.m2Active};
   }
 
   &.disabled {
-    color: ${({ theme: { colors } }) => colors.greyscale.dark};
-    border-color: ${({ theme: { colors } }) => colors.greyscale.dark};
+    color: ${(p) => p.theme.colors.grayscale.g70};
+    border-color: ${(p) => p.theme.colors.grayscale.g70};
   }
 
   &.primary {
-    color: ${({ theme: { colors } }) => colors.greyscale.white};
-    background: ${({ theme: { colors } }) => colors.main.primary};
+    color: ${(p) => p.theme.colors.grayscale.g0};
+    background: ${(p) => p.theme.colors.main.m2};
 
     &:hover {
-      background: ${({ theme: { colors } }) => colors.main.primaryHover};
+      background: ${(p) => p.theme.colors.main.m2Hover};
     }
 
     &:active {
-      background: ${({ theme: { colors } }) => colors.main.primaryActive};
+      background: ${(p) => p.theme.colors.main.m2Active};
     }
 
     &.disabled {
-      border-color: ${({ theme: { colors } }) => colors.greyscale.medium};
-      background: ${({ theme: { colors } }) => colors.greyscale.medium};
+      border-color: ${(p) => p.theme.colors.grayscale.g35};
+      background: ${(p) => p.theme.colors.grayscale.g35};
     }
   }
 
@@ -72,7 +72,7 @@ export const StyledButton = styled.button`
     width: fit-content;
   }
 
-  ${({ theme }) => defaultButtonTextStyle(theme)}
+  ${(p) => defaultButtonTextStyle(p.theme)}
   letter-spacing: 0.2px;
 `
 

--- a/frontend/src/lib-components/atoms/buttons/CheckIconButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/CheckIconButton.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -16,7 +16,7 @@ const StyledButton = styled.button`
   width: 34px;
   height: 34px;
   font-size: 24px;
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
   border: none;
   background: none;
   outline: none;
@@ -25,8 +25,8 @@ const StyledButton = styled.button`
   cursor: pointer;
 
   &.active {
-    color: ${({ theme: { colors } }) => colors.greyscale.white};
-    background-color: ${({ theme: { colors } }) => colors.accents.successGreen};
+    color: ${(p) => p.theme.colors.grayscale.g0};
+    background-color: ${(p) => p.theme.colors.status.success};
     border-radius: 100%;
   }
 `

--- a/frontend/src/lib-components/atoms/buttons/CrossIconButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/CrossIconButton.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -16,7 +16,7 @@ const StyledButton = styled.button`
   width: 34px;
   height: 34px;
   font-size: 24px;
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
   border: none;
   background: none;
   outline: none;
@@ -25,8 +25,8 @@ const StyledButton = styled.button`
   cursor: pointer;
 
   &.active {
-    color: ${({ theme: { colors } }) => colors.greyscale.white};
-    background-color: ${({ theme: { colors } }) => colors.accents.dangerRed};
+    color: ${(p) => p.theme.colors.grayscale.g0};
+    background-color: ${(p) => p.theme.colors.status.danger};
     border-radius: 100%;
   }
 `

--- a/frontend/src/lib-components/atoms/buttons/IconButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/IconButton.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -69,12 +69,12 @@ const StyledButton = styled.button<ButtonProps>`
         return '20px'
     }
   }};
-  color: ${({ theme: { colors }, ...props }) =>
-    props.gray
-      ? colors.greyscale.dark
-      : props.white
-      ? colors.greyscale.white
-      : colors.main.primary};
+  color: ${(p) =>
+    p.gray
+      ? p.theme.colors.grayscale.g70
+      : p.white
+      ? p.theme.colors.grayscale.g0
+      : p.theme.colors.main.m2};
   border: none;
   border-radius: 100%;
   background: none;
@@ -84,7 +84,7 @@ const StyledButton = styled.button<ButtonProps>`
   margin: -6px;
 
   &:focus {
-    border: 2px solid ${({ theme: { colors } }) => colors.main.primaryFocus};
+    border: 2px solid ${(p) => p.theme.colors.main.m2Focus};
   }
 
   .icon-wrapper {
@@ -95,24 +95,24 @@ const StyledButton = styled.button<ButtonProps>`
   }
 
   &:hover .icon-wrapper {
-    color: ${({ theme: { colors }, ...props }) =>
-      props.gray
-        ? colors.greyscale.dark
-        : props.white
-        ? colors.greyscale.white
-        : colors.main.primaryHover};
+    color: ${(p) =>
+      p.gray
+        ? p.theme.colors.grayscale.g70
+        : p.white
+        ? p.theme.colors.grayscale.g0
+        : p.theme.colors.main.m2Hover};
   }
 
   &:active .icon-wrapper {
-    color: ${({ theme: { colors }, ...props }) =>
-      props.gray ? colors.greyscale.darkest : colors.main.primaryActive};
+    color: ${(p) =>
+      p.gray ? p.theme.colors.grayscale.g100 : p.theme.colors.main.m2Active};
   }
 
   &.disabled {
     cursor: not-allowed;
 
     .icon-wrapper {
-      color: ${({ theme: { colors } }) => colors.greyscale.medium};
+      color: ${(p) => p.theme.colors.grayscale.g35};
     }
   }
 `

--- a/frontend/src/lib-components/atoms/buttons/InlineButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/InlineButton.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -25,25 +25,25 @@ const StyledButton = styled.button<{ color?: string; iconRight?: boolean }>`
   cursor: pointer;
 
   &:hover {
-    color: ${({ theme: { colors } }) => colors.main.primaryHover};
+    color: ${(p) => p.theme.colors.main.m2Hover};
   }
 
   &:active {
-    color: ${({ theme: { colors } }) => colors.main.primaryActive};
+    color: ${(p) => p.theme.colors.main.m2Active};
   }
 
   &:focus {
-    outline: 2px solid ${({ theme: { colors } }) => colors.main.primaryFocus};
+    outline: 2px solid ${(p) => p.theme.colors.main.m2Focus};
     outline-offset: 2px;
   }
 
   &.disabled {
-    color: ${({ theme: { colors } }) => colors.greyscale.dark};
+    color: ${(p) => p.theme.colors.grayscale.g70};
     cursor: not-allowed;
   }
 
   &.darker:not(.disabled) {
-    color: ${({ theme: { colors } }) => colors.main.dark};
+    color: ${(p) => p.theme.colors.main.m1};
   }
 
   svg {
@@ -52,8 +52,8 @@ const StyledButton = styled.button<{ color?: string; iconRight?: boolean }>`
     font-size: 1.25em;
   }
 
-  ${({ theme }) => defaultButtonTextStyle(theme)}
-  color: ${(p) => p.color ?? p.theme.colors.main.primary};
+  ${(p) => defaultButtonTextStyle(p.theme)}
+  color: ${(p) => p.color ?? p.theme.colors.main.m2};
 `
 
 export interface InlineButtonProps extends BaseProps {

--- a/frontend/src/lib-components/atoms/buttons/ReturnButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/ReturnButton.tsx
@@ -49,7 +49,7 @@ export default React.memo(function ReturnButton({
         onClick={() => history.goBack()}
         data-qa={dataQa}
         disabled={history.length <= 1}
-        color={colors.main.dark}
+        color={colors.main.m1}
       />
     </ReturnButtonWrapper>
   )

--- a/frontend/src/lib-components/atoms/buttons/button-commons.tsx
+++ b/frontend/src/lib-components/atoms/buttons/button-commons.tsx
@@ -6,7 +6,7 @@ import { DefaultTheme } from 'styled-components'
 import { fontWeights } from '../../typography'
 
 export const defaultButtonTextStyle = ({ colors }: DefaultTheme) => `
-  color: ${colors.main.primary};
+  color: ${colors.main.m2};
   font-family: 'Open Sans', sans-serif;
   font-size: 1em;
   line-height: normal;

--- a/frontend/src/lib-components/atoms/dropdowns/Combobox.tsx
+++ b/frontend/src/lib-components/atoms/dropdowns/Combobox.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -34,7 +34,7 @@ interface MenuItemProps<T> {
 const InputWrapper = styled.div`
   display: flex;
   align-items: center;
-  background-color: ${(p) => p.theme.colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   ${borderStyles};
   &.active {
     border-color: transparent;
@@ -59,9 +59,9 @@ const Menu = styled.div`
     display: none;
   }
 
-  border: 1px solid ${(p) => p.theme.colors.greyscale.dark};
+  border: 1px solid ${(p) => p.theme.colors.grayscale.g70};
   border-radius: ${borderRadius};
-  background-color: ${(p) => p.theme.colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   max-height: 300px;
   overflow-y: auto;
 `
@@ -75,7 +75,7 @@ const MenuItem = styled.div`
   padding: 8px 10px;
 
   &.highlighted {
-    background-color: ${(p) => p.theme.colors.main.lighter};
+    background-color: ${(p) => p.theme.colors.main.m4};
   }
 
   &.clickable {
@@ -93,29 +93,29 @@ const Input = styled.input`
   outline: 0;
 
   &:read-only {
-    color: ${(p) => p.theme.colors.greyscale.dark};
+    color: ${(p) => p.theme.colors.grayscale.g70};
   }
 `
 
 const Separator = styled.div`
   width: 1px;
   margin: 5px 0 5px;
-  border-left: 1px solid ${(p) => p.theme.colors.greyscale.lighter};
+  border-left: 1px solid ${(p) => p.theme.colors.grayscale.g15};
 `
 
 const Button = styled.button`
-  color: ${(p) => p.theme.colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 
   &:hover {
-    color: ${(p) => p.theme.colors.main.primaryHover};
+    color: ${(p) => p.theme.colors.main.m2Hover};
   }
 
   &:active {
-    color: ${(p) => p.theme.colors.main.primaryActive};
+    color: ${(p) => p.theme.colors.main.m2Active};
   }
 
   &:disabled {
-    color: ${(p) => p.theme.colors.greyscale.dark};
+    color: ${(p) => p.theme.colors.grayscale.g70};
     cursor: not-allowed;
   }
 

--- a/frontend/src/lib-components/atoms/dropdowns/Select.tsx
+++ b/frontend/src/lib-components/atoms/dropdowns/Select.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -87,8 +87,8 @@ const Wrapper = styled.div`
 
 const StyledSelect = styled.select`
   appearance: none;
-  color: ${({ theme }) => theme.colors.greyscale.darkest};
-  background-color: ${({ theme }) => theme.colors.greyscale.white};
+  color: ${(p) => p.theme.colors.grayscale.g100};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   display: block;
   font-size: 1rem;
   width: 100%;

--- a/frontend/src/lib-components/atoms/dropdowns/shared.ts
+++ b/frontend/src/lib-components/atoms/dropdowns/shared.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -28,7 +28,7 @@ export const Root = styled.div`
   border: 2px solid transparent;
 
   &.active {
-    border-color: ${({ theme: { colors } }) => colors.main.primaryActive};
+    border-color: ${(p) => p.theme.colors.main.m2Active};
   }
   &.full-width {
     width: 100%;
@@ -37,6 +37,6 @@ export const Root = styled.div`
 `
 
 export const borderStyles = css`
-  border: 1px solid ${({ theme: { colors } }) => colors.greyscale.dark};
+  border: 1px solid ${(p) => p.theme.colors.grayscale.g70};
   border-radius: ${borderRadius};
 `

--- a/frontend/src/lib-components/atoms/form/Checkbox.tsx
+++ b/frontend/src/lib-components/atoms/form/Checkbox.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -28,19 +28,19 @@ const Wrapper = styled.div`
     cursor: not-allowed;
 
     label {
-      color: ${({ theme: { colors } }) => colors.greyscale.medium};
+      color: ${(p) => p.theme.colors.grayscale.g35};
       cursor: not-allowed;
     }
   }
 
   &:hover:not(.disabled) {
     input:checked {
-      border-color: ${({ theme: { colors } }) => colors.main.primaryHover};
-      background-color: ${({ theme: { colors } }) => colors.main.primaryHover};
+      border-color: ${(p) => p.theme.colors.main.m2Hover};
+      background-color: ${(p) => p.theme.colors.main.m2Hover};
     }
 
     input:not(:checked) {
-      border-color: ${({ theme: { colors } }) => colors.greyscale.darkest};
+      border-color: ${(p) => p.theme.colors.grayscale.g100};
     }
   }
 `
@@ -60,27 +60,27 @@ const CheckboxInput = styled.input`
   border-radius: 2px;
   border-width: 1px;
   border-style: solid;
-  border-color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  border-color: ${(p) => p.theme.colors.grayscale.g70};
   margin: 0;
 
-  background-color: ${({ theme: { colors } }) => colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
 
   &:checked {
-    border-color: ${({ theme: { colors } }) => colors.main.primary};
-    background-color: ${({ theme: { colors } }) => colors.main.primary};
+    border-color: ${(p) => p.theme.colors.main.m2};
+    background-color: ${(p) => p.theme.colors.main.m2};
 
     &:disabled {
-      background-color: ${({ theme: { colors } }) => colors.greyscale.medium};
+      background-color: ${(p) => p.theme.colors.grayscale.g35};
     }
   }
 
   &:focus {
     border-width: 2px;
-    border-color: ${({ theme: { colors } }) => colors.main.primaryFocus};
+    border-color: ${(p) => p.theme.colors.main.m2Focus};
   }
 
   &:disabled {
-    border-color: ${({ theme: { colors } }) => colors.greyscale.medium};
+    border-color: ${(p) => p.theme.colors.grayscale.g35};
   }
 `
 
@@ -96,7 +96,7 @@ const IconWrapper = styled.div`
   height: ${diameter};
 
   font-size: 25px;
-  color: ${({ theme: { colors } }) => colors.greyscale.white};
+  color: ${(p) => p.theme.colors.grayscale.g0};
 `
 
 interface CommonProps extends BaseProps {

--- a/frontend/src/lib-components/atoms/form/InputField.tsx
+++ b/frontend/src/lib-components/atoms/form/InputField.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -66,13 +66,13 @@ export const StyledInput = styled.input<StyledInputProps>`
   margin: 0;
   border: none;
   border-top: 2px solid transparent;
-  border-bottom: 1px solid ${({ theme: { colors } }) => colors.greyscale.dark};
+  border-bottom: 1px solid ${(p) => p.theme.colors.grayscale.g70};
   border-radius: 0;
   outline: none;
   text-align: ${(p) => p.align ?? 'left'};
-  background-color: ${({ theme: { colors } }) => colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   font-size: 1rem;
-  color: ${({ theme: { colors } }) => colors.greyscale.darkest};
+  color: ${(p) => p.theme.colors.grayscale.g100};
   padding: 6px 10px;
   ${({ icon }) =>
     icon
@@ -82,7 +82,7 @@ export const StyledInput = styled.input<StyledInputProps>`
       : ''}
 
   &::placeholder {
-    color: ${({ theme: { colors } }) => colors.greyscale.dark};
+    color: ${(p) => p.theme.colors.grayscale.g70};
     font-family: 'Open Sans', 'Arial', sans-serif;
   }
 
@@ -94,7 +94,7 @@ export const StyledInput = styled.input<StyledInputProps>`
   }
 
   &:focus {
-    border: 2px solid ${({ theme: { colors } }) => colors.main.primaryFocus};
+    border: 2px solid ${(p) => p.theme.colors.main.m2Focus};
     border-radius: 2px;
     padding-left: 8px;
     padding-right: 8px;
@@ -107,26 +107,24 @@ export const StyledInput = styled.input<StyledInputProps>`
   }
 
   &.success {
-    border-bottom-color: ${({ theme: { colors } }) =>
-      colors.accents.successGreen};
+    border-bottom-color: ${(p) => p.theme.colors.status.success};
 
     &:focus {
-      border-color: ${({ theme: { colors } }) => colors.accents.successGreen};
+      border-color: ${(p) => p.theme.colors.status.success};
     }
   }
 
   &.warning {
-    border-bottom-color: ${({ theme: { colors } }) =>
-      colors.accents.warningOrange};
+    border-bottom-color: ${(p) => p.theme.colors.status.warning};
 
     &:focus {
-      border-color: ${({ theme: { colors } }) => colors.accents.warningOrange};
+      border-color: ${(p) => p.theme.colors.status.warning};
     }
   }
 
   &:read-only {
     border-bottom-style: dashed;
-    color: ${({ theme: { colors } }) => colors.greyscale.dark};
+    color: ${(p) => p.theme.colors.grayscale.g70};
     background: none;
   }
 `
@@ -150,10 +148,10 @@ const IconContainer = styled.div<{ clickable: boolean }>`
 `
 
 const StyledIconButton = styled(IconButton)`
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 
   &:hover {
-    color: ${({ theme: { colors } }) => colors.greyscale.darkest};
+    color: ${(p) => p.theme.colors.grayscale.g100};
   }
 `
 
@@ -165,14 +163,14 @@ export const InputFieldUnderRow = styled.div`
   line-height: 1rem;
   margin-top: ${defaultMargins.xxs};
 
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 
   &.success {
-    color: ${({ theme: { colors } }) => colors.accents.greenDark};
+    color: ${(p) => p.theme.colors.accents.a1greenDark};
   }
 
   &.warning {
-    color: ${({ theme: { colors } }) => colors.accents.orangeDark};
+    color: ${(p) => p.theme.colors.accents.a2orangeDark};
   }
 `
 

--- a/frontend/src/lib-components/atoms/form/MultiSelect.tsx
+++ b/frontend/src/lib-components/atoms/form/MultiSelect.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -131,7 +131,7 @@ const OptionWrapper = styled.div`
 
   &:hover,
   &.focused {
-    background-color: ${({ theme: { colors } }) => colors.main.lighter};
+    background-color: ${(p) => p.theme.colors.main.m4};
   }
 
   padding: ${defaultMargins.xxs} ${defaultMargins.s};
@@ -161,5 +161,5 @@ const SecondaryText = styled.span`
   font-size: 14px;
   line-height: 21px;
   font-weight: ${fontWeights.semibold};
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 `

--- a/frontend/src/lib-components/atoms/form/Radio.tsx
+++ b/frontend/src/lib-components/atoms/form/Radio.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -27,18 +27,18 @@ const Wrapper = styled.div<SizeProps>`
     cursor: not-allowed;
 
     label {
-      color: ${({ theme: { colors } }) => colors.greyscale.medium};
+      color: ${(p) => p.theme.colors.grayscale.g35};
       cursor: not-allowed;
     }
   }
 
   &:hover:not(.disabled) {
     input:checked {
-      border-color: ${({ theme: { colors } }) => colors.main.primaryHover};
-      background-color: ${({ theme: { colors } }) => colors.main.primaryHover};
+      border-color: ${(p) => p.theme.colors.main.m2Hover};
+      background-color: ${(p) => p.theme.colors.main.m2Hover};
     }
     input:not(:checked) {
-      border-color: ${({ theme: { colors } }) => colors.greyscale.darkest};
+      border-color: ${(p) => p.theme.colors.grayscale.g100};
     }
   }
 `
@@ -61,25 +61,25 @@ const RadioInput = styled.input<SizeProps>`
   border-radius: 100%;
   border-width: 1px;
   border-style: solid;
-  border-color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  border-color: ${(p) => p.theme.colors.grayscale.g70};
   margin: 0;
 
   &:checked {
-    border-color: ${({ theme: { colors } }) => colors.main.primary};
-    background-color: ${({ theme: { colors } }) => colors.main.primary};
+    border-color: ${(p) => p.theme.colors.main.m2};
+    background-color: ${(p) => p.theme.colors.main.m2};
 
     &:disabled {
-      background-color: ${({ theme: { colors } }) => colors.greyscale.medium};
+      background-color: ${(p) => p.theme.colors.grayscale.g35};
     }
   }
 
   &:focus {
     border-width: 2px;
-    border-color: ${({ theme: { colors } }) => colors.main.primaryFocus};
+    border-color: ${(p) => p.theme.colors.main.m2Focus};
   }
 
   &:disabled {
-    border-color: ${({ theme: { colors } }) => colors.greyscale.medium};
+    border-color: ${(p) => p.theme.colors.grayscale.g35};
   }
 `
 
@@ -95,7 +95,7 @@ const IconWrapper = styled.div<SizeProps>`
   height: ${(p) => (p.small ? '30px' : diameter)};
 
   font-size: ${(p) => (p.small ? '20px' : '25px')};
-  color: ${({ theme: { colors } }) => colors.greyscale.white};
+  color: ${(p) => p.theme.colors.grayscale.g0};
 `
 
 type RadioProps = BaseProps & {

--- a/frontend/src/lib-components/atoms/form/TextArea.tsx
+++ b/frontend/src/lib-components/atoms/form/TextArea.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -121,7 +121,7 @@ const StyledTextArea = styled(TextareaAutosize)`
 
   font-size: 1rem;
   font-family: 'Open Sans', Arial, sans-serif;
-  color: ${(p) => p.theme.colors.greyscale.darkest};
+  color: ${(p) => p.theme.colors.grayscale.g100};
   line-height: 1.5;
   overflow: hidden;
   overflow-wrap: break-word;
@@ -131,7 +131,7 @@ const StyledTextArea = styled(TextareaAutosize)`
   margin: 0;
   border: none;
   border-top: 2px solid transparent;
-  border-bottom: 1px solid ${({ theme: { colors } }) => colors.greyscale.dark};
+  border-bottom: 1px solid ${(p) => p.theme.colors.grayscale.g70};
   border-radius: 0;
   box-shadow: none;
   outline: none;
@@ -143,27 +143,25 @@ const StyledTextArea = styled(TextareaAutosize)`
   }
 
   &:focus {
-    border: 2px solid ${({ theme: { colors } }) => colors.main.primaryFocus};
+    border: 2px solid ${(p) => p.theme.colors.main.m2Focus};
     border-radius: 2px;
     padding-left: 8px;
     padding-right: 8px;
   }
 
   &.success {
-    border-bottom-color: ${({ theme: { colors } }) =>
-      colors.accents.successGreen};
+    border-bottom-color: ${(p) => p.theme.colors.status.success};
 
     &:focus {
-      border-color: ${({ theme: { colors } }) => colors.accents.successGreen};
+      border-color: ${(p) => p.theme.colors.status.success};
     }
   }
 
   &.warning {
-    border-bottom-color: ${({ theme: { colors } }) =>
-      colors.accents.warningOrange};
+    border-bottom-color: ${(p) => p.theme.colors.status.warning};
 
     &:focus {
-      border-color: ${({ theme: { colors } }) => colors.accents.warningOrange};
+      border-color: ${(p) => p.theme.colors.status.warning};
     }
   }
 `

--- a/frontend/src/lib-components/atoms/state/ErrorSegment.tsx
+++ b/frontend/src/lib-components/atoms/state/ErrorSegment.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -14,8 +14,8 @@ const StyledSegment = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background: ${({ theme: { colors } }) => colors.greyscale.lightest};
-  color: ${({ theme: { colors } }) => colors.greyscale.medium};
+  background: ${(p) => p.theme.colors.grayscale.g4};
+  color: ${(p) => p.theme.colors.grayscale.g35};
 
   div {
     display: flex;

--- a/frontend/src/lib-components/atoms/state/Spinner.tsx
+++ b/frontend/src/lib-components/atoms/state/Spinner.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -16,9 +16,8 @@ export const Spinner = styled.div<{ zIndex?: number }>`
   height: ${spinnerSize};
   ${({ zIndex }) => (zIndex ? `z-index: ${zIndex};` : '')}
 
-  border: 5px solid ${({ theme: { colors } }) =>
-    transparentize(0.8, colors.main.primary)};
-  border-left-color: ${({ theme: { colors } }) => colors.main.primary};
+  border: 5px solid ${(p) => transparentize(0.8, p.theme.colors.main.m2)};
+  border-left-color: ${(p) => p.theme.colors.main.m2};
   animation: spin 1.1s infinite linear;
 
   &:after {
@@ -69,7 +68,7 @@ const SpinnerOverlayRoot = styled.div`
   left: 0;
   bottom: 0;
   min-height: 80px;
-  background-color: ${(p) => p.theme.colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   opacity: 0.8;
   z-index: ${spinnerOverlayZIndex};
   display: flex;

--- a/frontend/src/lib-components/employee/messages/EmptyMessageFolder.tsx
+++ b/frontend/src/lib-components/employee/messages/EmptyMessageFolder.tsx
@@ -37,6 +37,6 @@ export default React.memo(function EmptyMessagesFolder({
 const EmptyThreadViewContainer = styled.div`
   text-align: center;
   width: 100%;
-  background: ${(p) => p.theme.colors.greyscale.white};
+  background: ${(p) => p.theme.colors.grayscale.g0};
   padding-top: 10%;
 `

--- a/frontend/src/lib-components/employee/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/employee/messages/MessageEditor.tsx
@@ -583,7 +583,7 @@ const Container = styled.div`
   box-shadow: 0 8px 8px 8px rgba(15, 15, 15, 0.15);
   display: flex;
   flex-direction: column;
-  background-color: ${(p) => p.theme.colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   overflow: auto;
 
   &.fullscreen {
@@ -600,7 +600,7 @@ const ContainerMobile = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  background-color: ${(p) => p.theme.colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   overflow: auto;
   height: 100vh;
 `
@@ -608,8 +608,8 @@ const ContainerMobile = styled.div`
 const TopBar = styled.div`
   width: 100%;
   height: 60px;
-  background-color: ${(p) => p.theme.colors.main.primary};
-  color: ${(p) => p.theme.colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.main.m2};
+  color: ${(p) => p.theme.colors.grayscale.g0};
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -619,8 +619,8 @@ const TopBar = styled.div`
 const TopBarMobile = styled.div`
   width: 100%;
   height: 60px;
-  background-color: ${(p) => p.theme.colors.greyscale.lightest};
-  color: ${(p) => p.theme.colors.main.primary};
+  background-color: ${(p) => p.theme.colors.grayscale.g4};
+  color: ${(p) => p.theme.colors.main.m2};
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -638,7 +638,7 @@ const MessageAreaMobile = styled.textarea`
   width: 100%;
   resize: none;
   flex-grow: 1;
-  border: 1px solid ${(p) => p.theme.colors.greyscale.dark};
+  border: 1px solid ${(p) => p.theme.colors.grayscale.g70};
   min-height: 100px;
 `
 
@@ -669,7 +669,7 @@ const StyledTextArea = styled.textarea`
 
 const BottomBar = styled.div`
   width: 100%;
-  border-top: 1px solid ${(p) => p.theme.colors.greyscale.medium};
+  border-top: 1px solid ${(p) => p.theme.colors.grayscale.g35};
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -678,7 +678,7 @@ const BottomBar = styled.div`
 
 const BottomBarMobile = styled.div`
   width: 100%;
-  border-top: 1px solid ${(p) => p.theme.colors.greyscale.medium};
+  border-top: 1px solid ${(p) => p.theme.colors.grayscale.g35};
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/frontend/src/lib-components/layout/Container.tsx
+++ b/frontend/src/lib-components/layout/Container.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -67,12 +67,14 @@ export const ContentArea = styled.section<ContentAreaProps>`
     padding-right: ${(p) => spacing(p.paddingHorizontal, defaultMargins.L)};
     padding-left: ${(p) => spacing(p.paddingHorizontal, defaultMargins.L)};
   }
-  background-color: ${({ theme: { colors }, ...props }) =>
-    props.opaque ? 'white' : props.blue ? colors.main.lighter : 'transparent'};
+  background-color: ${(p) =>
+    p.opaque ? 'white' : p.blue ? p.theme.colors.main.m4 : 'transparent'};
   position: relative;
   ${(p) => (p.fullHeight ? `min-height: 100vh` : '')}
-  ${({ theme: { colors }, ...p }) =>
-    p.shadow ? `box-shadow: 0px 4px 4px 0px ${colors.greyscale.lighter}` : ''}
+  ${(p) =>
+    p.shadow
+      ? `box-shadow: 0px 4px 4px 0px ${p.theme.colors.grayscale.g15}`
+      : ''}
 `
 
 type CollapsibleContentAreaProps = ContentAreaProps & {
@@ -169,7 +171,7 @@ const TitleWrapper = styled.div`
 `
 
 const TitleIcon = styled(FontAwesomeIcon)`
-  color: ${({ theme: { colors } }) => colors.main.primary};
+  color: ${(p) => p.theme.colors.main.m2};
   height: 24px !important;
   width: 24px !important;
 `

--- a/frontend/src/lib-components/layout/StickyFooter.tsx
+++ b/frontend/src/lib-components/layout/StickyFooter.tsx
@@ -22,7 +22,7 @@ export default React.memo(function StickyFooter({ children }: Props) {
 const Footer = styled.footer`
   position: sticky;
   bottom: 0;
-  background-color: ${({ theme: { colors } }) => colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.1);
 
   @media print {

--- a/frontend/src/lib-components/layout/Table.tsx
+++ b/frontend/src/lib-components/layout/Table.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -15,8 +15,8 @@ import { fontWeights } from '../typography'
 import { defaultMargins, Gap } from '../white-space'
 
 export const Table = styled.table`
-  background-color: ${({ theme: { colors } }) => colors.greyscale.white};
-  color: ${({ theme: { colors } }) => colors.greyscale.darkest};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
+  color: ${(p) => p.theme.colors.grayscale.g100};
   width: 100%;
   border-collapse: collapse;
 `
@@ -29,20 +29,19 @@ interface ThProps {
 
 export const Th = styled.th<ThProps>`
   font-size: 14px;
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
   font-weight: ${fontWeights.bold};
   line-height: 1.3em;
   text-transform: uppercase;
   vertical-align: middle;
   border-style: solid;
-  border-color: ${({ theme: { colors } }) => colors.greyscale.lighter};
+  border-color: ${(p) => p.theme.colors.grayscale.g15};
   border-width: 0 0 1px;
   padding: ${defaultMargins.s};
   text-align: left;
   position: ${(p) => (p.sticky ? 'sticky' : 'static')};
   top: ${(p) => (p.sticky && p.top ? p.top : 'auto')};
-  background: ${({ theme: { colors }, ...p }) =>
-    p.sticky ? colors.greyscale.white : 'none'};
+  background: ${(p) => (p.sticky ? p.theme.colors.grayscale.g0 : 'none')};
 `
 
 export const Td = styled.td<{
@@ -52,7 +51,7 @@ export const Td = styled.td<{
 }>`
   line-height: 1.3em;
   border-style: solid;
-  border-color: ${({ theme: { colors } }) => colors.greyscale.lighter};
+  border-color: ${(p) => p.theme.colors.grayscale.g15};
   border-width: 0 0 1px;
   padding: ${defaultMargins.s};
   vertical-align: ${(p) => p.verticalAlign ?? 'top'};
@@ -98,7 +97,7 @@ interface SortableProps {
 const CustomButton = styled.button`
   display: flex;
   font-size: 14px;
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
   border: none;
   background: none;
   outline: none;
@@ -117,7 +116,7 @@ export const SortableTh = React.memo(function SortableTh({
   top
 }: SortableProps) {
   const {
-    colors: { greyscale }
+    colors: { grayscale }
   } = useTheme()
   return (
     <Th sticky={sticky} top={top}>
@@ -127,12 +126,12 @@ export const SortableTh = React.memo(function SortableTh({
         <SortableIconContainer>
           <FontAwesomeIcon
             icon={sorted === 'ASC' ? fasChevronUp : faChevronUp}
-            color={sorted === 'ASC' ? greyscale.dark : greyscale.medium}
+            color={sorted === 'ASC' ? grayscale.g70 : grayscale.g35}
             size="xs"
           />
           <FontAwesomeIcon
             icon={sorted === 'DESC' ? fasChevronDown : faChevronDown}
-            color={sorted === 'DESC' ? greyscale.dark : greyscale.medium}
+            color={sorted === 'DESC' ? grayscale.g70 : grayscale.g35}
             size="xs"
           />
         </SortableIconContainer>

--- a/frontend/src/lib-components/molecules/CollapsibleSection.tsx
+++ b/frontend/src/lib-components/molecules/CollapsibleSection.tsx
@@ -25,7 +25,7 @@ const Wrapper = styled.div`
 const Row = styled.div`
   display: flex;
   align-items: center;
-  color: ${(p) => p.theme.colors.greyscale.medium};
+  color: ${(p) => p.theme.colors.grayscale.g35};
   margin-bottom: ${defaultMargins.m};
 
   &.fitted {
@@ -40,13 +40,13 @@ const Row = styled.div`
     cursor: pointer;
 
     h3 {
-      color: ${(p) => p.theme.colors.main.primaryHover};
+      color: ${(p) => p.theme.colors.main.m2Hover};
     }
   }
 `
 
 const IconWrapper = styled.div`
-  color: ${(p) => p.theme.colors.greyscale.medium};
+  color: ${(p) => p.theme.colors.grayscale.g35};
   font-size: 28px;
   width: 35px;
   margin-right: ${defaultMargins.s};
@@ -117,7 +117,7 @@ export default React.memo(function CollapsibleSection({
         <ToggleWrapper data-qa="collapsible-trigger">
           <FontAwesomeIcon
             icon={collapsed ? faAngleDown : faAngleUp}
-            color={colors.main.primary}
+            color={colors.main.m2}
           />
         </ToggleWrapper>
       </Row>

--- a/frontend/src/lib-components/molecules/DatePickerDeprecated.tsx
+++ b/frontend/src/lib-components/molecules/DatePickerDeprecated.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -36,8 +36,8 @@ const StyledInput = styled.input`
   padding-top: calc(0.5em - 1px);
   position: relative;
   height: 2.5em;
-  border-color: ${({ theme: { colors } }) => colors.greyscale.dark};
-  color: ${({ theme: { colors } }) => colors.greyscale.darkest};
+  border-color: ${(p) => p.theme.colors.grayscale.g70};
+  color: ${(p) => p.theme.colors.grayscale.g100};
   display: block;
   box-shadow: none;
   max-width: 100%;
@@ -51,7 +51,7 @@ const StyledInput = styled.input`
   :focus {
     padding-bottom: calc(calc(0.5em - 1px) - 1px);
     border-bottom-width: 2px;
-    border-color: ${({ theme: { colors } }) => colors.main.primary};
+    border-color: ${(p) => p.theme.colors.main.m2};
     outline: none;
   }
 `
@@ -84,7 +84,7 @@ const DatePickerContainer = styled.div`
     right: 0;
     &::after {
       background-color: transparent;
-      color: ${({ theme: { colors } }) => colors.greyscale.lighter};
+      color: ${(p) => p.theme.colors.grayscale.g15};
       font-size: 25px;
     }
   }

--- a/frontend/src/lib-components/molecules/ExpandingInfo.tsx
+++ b/frontend/src/lib-components/molecules/ExpandingInfo.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -24,7 +24,7 @@ const InfoBoxContainer = styled(Container)<{ fullWidth?: boolean }>`
     }
   }
 
-  background-color: ${({ theme: { colors } }) => colors.main.lighter};
+  background-color: ${(p) => p.theme.colors.main.m4};
   overflow: hidden;
   ${({ fullWidth }) =>
     fullWidth
@@ -48,7 +48,7 @@ const InfoBoxContentArea = styled(ContentArea)`
 
 const InfoContainer = styled.div`
   flex-grow: 1;
-  color: ${({ theme: { colors } }) => colors.greyscale.darkest};
+  color: ${(p) => p.theme.colors.grayscale.g100};
   padding: 0 ${defaultMargins.s};
 `
 
@@ -119,7 +119,7 @@ export const InfoButton = React.memo(function InfoButton({
       data-qa={dataQa}
       margin={margin ?? 'zero'}
       content={fasInfo}
-      color={colors.main.dark}
+      color={colors.main.m1}
       size="s"
       onClick={onClick}
       tabindex={0}
@@ -147,7 +147,7 @@ export const ExpandingInfoBox = React.memo(function ExpandingInfoBox({
   return (
     <InfoBoxContainer className={className} fullWidth={fullWidth}>
       <InfoBoxContentArea opaque={false}>
-        <RoundIcon content={fasInfo} color={colors.main.dark} size="s" />
+        <RoundIcon content={fasInfo} color={colors.main.m1} size="s" />
 
         <InfoContainer data-qa={dataQa ? `${dataQa}-text` : undefined}>
           {info}

--- a/frontend/src/lib-components/molecules/FileDownloadButton.tsx
+++ b/frontend/src/lib-components/molecules/FileDownloadButton.tsx
@@ -18,7 +18,7 @@ import { fileIcon } from './FileUpload'
 const DownloadButton = styled.button`
   background: none;
   border: none;
-  color: ${({ theme: { colors } }) => colors.main.dark};
+  color: ${(p) => p.theme.colors.main.m1};
   cursor: pointer;
   font-size: 1rem;
   padding: 0;

--- a/frontend/src/lib-components/molecules/FileUpload.tsx
+++ b/frontend/src/lib-components/molecules/FileUpload.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -97,7 +97,7 @@ interface FileUploadProps {
 
 const FileUploadContainer = styled.div<{ slim: boolean }>`
   display: flex;
-  flex-direction: ${({ slim }) => (slim ? 'column' : 'row')};
+  flex-direction: ${(p) => (p.slim ? 'column' : 'row')};
   flex-wrap: wrap;
   align-items: flex-start;
 `
@@ -106,8 +106,8 @@ const FileInputLabel = styled.label`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background: ${({ theme: { colors } }) => colors.greyscale.lightest};
-  border: 1px dashed ${({ theme: { colors } }) => colors.greyscale.medium};
+  background: ${(p) => p.theme.colors.grayscale.g4};
+  border: 1px dashed ${(p) => p.theme.colors.grayscale.g35};
   border-radius: 8px;
   width: min(500px, 70vw);
   padding: 24px;
@@ -164,14 +164,14 @@ const File = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 `
 
 const FileIcon = styled(FontAwesomeIcon)`
   margin-right: ${defaultMargins.xs};
   font-size: 20px;
   flex: 0;
-  color: ${({ theme: { colors } }) => colors.main.primary};
+  color: ${(p) => p.theme.colors.main.m2};
 `
 
 const FileDetails = styled.div`
@@ -191,7 +191,7 @@ const FileHeader = styled.div`
 
 const ProgressBarContainer = styled.div`
   position: relative;
-  background: ${({ theme: { colors } }) => colors.greyscale.medium};
+  background: ${(p) => p.theme.colors.grayscale.g35};
   height: 3px;
   border-radius: 1px;
 `
@@ -205,7 +205,7 @@ const ProgressBar = styled.div<ProgressBarProps>`
   position: absolute;
   top: 0;
   left: 0;
-  background: ${({ theme: { colors } }) => colors.main.dark};
+  background: ${(p) => p.theme.colors.main.m1};
   height: 3px;
   border-radius: 1px;
   transition: width 0.5s ease-out;
@@ -218,14 +218,14 @@ const FileDeleteButton = styled(IconButton)`
   padding: 4px;
   margin-left: 12px;
   min-width: 32px;
-  color: ${({ theme: { colors } }) => colors.greyscale.medium};
+  color: ${(p) => p.theme.colors.grayscale.g35};
 
   &:hover {
-    color: ${({ theme: { colors } }) => colors.main.dark};
+    color: ${(p) => p.theme.colors.main.m1};
   }
 
   &:disabled {
-    color: ${({ theme: { colors } }) => colors.greyscale.lighter};
+    color: ${(p) => p.theme.colors.grayscale.g15};
     cursor: not-allowed;
   }
 `
@@ -234,14 +234,14 @@ const ProgressBarDetails = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 `
 
 const ProgressBarError = styled.div`
-  color: ${({ theme: { colors } }) => colors.accents.orangeDark};
+  color: ${(p) => p.theme.colors.accents.a2orangeDark};
   margin-top: 3px;
   svg {
-    color: ${({ theme: { colors } }) => colors.accents.warningOrange};
+    color: ${(p) => p.theme.colors.status.warning};
     margin-left: 8px;
   }
 `

--- a/frontend/src/lib-components/molecules/MessageBoxes.tsx
+++ b/frontend/src/lib-components/molecules/MessageBoxes.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -127,7 +127,7 @@ export const InfoBox = React.memo(function InfoBox({
       title={title}
       message={message}
       icon={notNullIcon}
-      color={theme.colors.accents.infoBlue}
+      color={theme.colors.status.info}
       width={wide ? '100%' : 'fit-content'}
       thin={thin}
       noMargin={noMargin}
@@ -153,15 +153,13 @@ export const AlertBox = React.memo(function AlertBox({
   noMargin,
   ...props
 }: AlertBoxProps) {
-  const {
-    colors: { accents: accentColors }
-  } = useTheme()
+  const { colors } = useTheme()
   return (
     <MessageBox
       title={title}
       message={message}
       icon={faExclamation}
-      color={accentColors.warningOrange}
+      color={colors.status.warning}
       width={wide ? '100%' : 'fit-content'}
       thin={thin}
       noMargin={noMargin}

--- a/frontend/src/lib-components/molecules/MessageReplyEditor.tsx
+++ b/frontend/src/lib-components/molecules/MessageReplyEditor.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -18,10 +18,10 @@ import { defaultMargins } from '../white-space'
 const MultiRowTextArea = styled(TextArea)`
   height: unset;
   margin-top: ${defaultMargins.xs};
-  border: 1px solid ${({ theme: { colors } }) => colors.greyscale.medium};
+  border: 1px solid ${(p) => p.theme.colors.grayscale.g35};
 
   &:focus {
-    border: 1px solid ${({ theme: { colors } }) => colors.greyscale.medium};
+    border: 1px solid ${(p) => p.theme.colors.grayscale.g35};
   }
 `
 const EditorRow = styled.div`
@@ -31,14 +31,13 @@ const EditorRow = styled.div`
 `
 
 const Recipient = styled.span<{ selected: boolean; toggleable: boolean }>`
-  cursor: ${({ toggleable }) => (toggleable ? 'pointer' : 'default')};;
-  padding: 0 ${({ selected }) => (selected ? '12px' : defaultMargins.xs)};
-  background-color: ${({ theme: { colors }, selected }) =>
-    selected ? colors.greyscale.lighter : 'unset'};
+  cursor: ${(p) => (p.toggleable ? 'pointer' : 'default')};;
+  padding: 0 ${(p) => (p.selected ? '12px' : defaultMargins.xs)};
+  background-color: ${(p) =>
+    p.selected ? p.theme.colors.grayscale.g15 : 'unset'};
   border-radius: 1000px;
   font-weight: ${fontWeights.semibold};
-  color: ${({ theme: { colors }, selected }) =>
-    selected ? 'unset' : colors.main.primary};
+  color: ${(p) => (p.selected ? 'unset' : p.theme.colors.main.m2)};
 
   & > :last-child {
     margin-left: ${defaultMargins.xs};

--- a/frontend/src/lib-components/molecules/PinInput.tsx
+++ b/frontend/src/lib-components/molecules/PinInput.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -18,14 +18,14 @@ import { defaultMargins } from '../white-space'
 
 const SingleNumberInput = styled(StyledInput)<{ invalid?: boolean }>`
   border: 1px solid
-    ${({ theme, invalid }) =>
-      invalid ? theme.colors.accents.dangerRed : theme.colors.main.primary};
+    ${(p) =>
+      p.invalid ? p.theme.colors.status.danger : p.theme.colors.main.m2};
   text-align: center;
 
   font-family: 'Montserrat', sans-serif;
   font-size: 2rem;
   font-weight: ${fontWeights.semibold};
-  color: ${(p) => p.theme.colors.main.dark};
+  color: ${(p) => p.theme.colors.main.m1};
 `
 
 const Centered = styled.div`

--- a/frontend/src/lib-components/molecules/ReloadNotification.tsx
+++ b/frontend/src/lib-components/molecules/ReloadNotification.tsx
@@ -46,7 +46,7 @@ export default function ReloadNotification({ apiVersion, i18n }: Props) {
   }, [maybeShow])
 
   return show ? (
-    <Toast icon={faInfo} iconColor={theme.colors.main.dark} onClose={close}>
+    <Toast icon={faInfo} iconColor={theme.colors.main.m1} onClose={close}>
       <div>{i18n.title}</div>
       <div>
         <InlineButton

--- a/frontend/src/lib-components/molecules/Tabs.tsx
+++ b/frontend/src/lib-components/molecules/Tabs.tsx
@@ -55,7 +55,7 @@ const TabsContainer = styled.div<{ shadow?: boolean }>`
   ${(p) =>
     p.shadow
       ? `
-      box-shadow: 0 2px 6px 0 ${p.theme.colors.greyscale.lighter};
+      box-shadow: 0 2px 6px 0 ${p.theme.colors.grayscale.g15};
       margin-bottom: ${defaultMargins.xxs};
       `
       : ''}
@@ -72,7 +72,7 @@ const TabLinkContainer = styled(NavLink)<{
   padding: 12px;
   flex-basis: content;
   flex-grow: 1;
-  background-color: ${(p) => p.theme.colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   text-align: center;
   max-width: ${(p) => p.$maxWidth ?? 'unset'};
 
@@ -84,20 +84,20 @@ const TabLinkContainer = styled(NavLink)<{
   border-bottom: ${(p) => (p.$mobile ? '3px solid transparent' : 'unset')};
 
   &.active {
-    background-color: ${({ theme: { colors }, ...p }) =>
-      p.$mobile ? colors.greyscale.white : `${colors.main.light}33`};
-    border-bottom: ${({ theme: { colors }, ...p }) =>
-      p.$mobile ? `3px solid ${colors.main.dark}` : 'unset'};
+    background-color: ${(p) =>
+      p.$mobile ? p.theme.colors.grayscale.g0 : `${p.theme.colors.main.m3}33`};
+    border-bottom: ${(p) =>
+      p.$mobile ? `3px solid ${p.theme.colors.main.m1}` : 'unset'};
 
     ${NavLinkText} {
-      color: ${(p) => p.theme.colors.main.dark};
+      color: ${(p) => p.theme.colors.main.m1};
       font-weight: ${fontWeights.bold};
     }
   }
 
   :hover {
     ${NavLinkText} {
-      color: ${(p) => p.theme.colors.main.dark};
+      color: ${(p) => p.theme.colors.main.m1};
     }
   }
 `
@@ -110,8 +110,8 @@ const TabCounter = styled.div`
   align-items: center;
 
   border-radius: 50%;
-  background-color: ${({ theme: { colors } }) => colors.accents.warningOrange};
-  color: ${({ theme: { colors } }) => colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.status.warning};
+  color: ${(p) => p.theme.colors.grayscale.g0};
   margin-left: ${defaultMargins.xs};
   font-weight: ${fontWeights.bold};
   font-size: 1em;

--- a/frontend/src/lib-components/molecules/ThreadListItem.tsx
+++ b/frontend/src/lib-components/molecules/ThreadListItem.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -34,14 +34,14 @@ export const Container = styled.div<{ isRead: boolean; active: boolean }>`
   text-align: left;
   width: 100%;
 
-  background-color: ${({ theme: { colors } }) => colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   padding: ${defaultMargins.s} ${defaultMargins.m};
   cursor: pointer;
 
-  border: 1px solid ${({ theme: { colors } }) => colors.greyscale.lighter};
+  border: 1px solid ${(p) => p.theme.colors.grayscale.g15};
 
   &:focus {
-    border: 2px solid ${({ theme: { colors } }) => colors.main.primaryFocus};
+    border: 2px solid ${(p) => p.theme.colors.main.m2Focus};
     margin: -1px 0;
     padding: ${defaultMargins.s} calc(${defaultMargins.m} - 1px);
   }
@@ -49,14 +49,13 @@ export const Container = styled.div<{ isRead: boolean; active: boolean }>`
   ${(p) =>
     !p.isRead
       ? `
-    border-left-color: ${p.theme.colors.main.light} !important;
+    border-left-color: ${p.theme.colors.main.m3} !important;
     border-left-width: 6px !important;
     padding-left: calc(${defaultMargins.m} - 6px) !important;
   `
       : ''}
 
-  ${(p) =>
-    p.active ? `background-color: ${p.theme.colors.main.lighter};` : ''}
+  ${(p) => (p.active ? `background-color: ${p.theme.colors.main.m4};` : '')}
 `
 
 export const ThreadContainer = styled.div`

--- a/frontend/src/lib-components/molecules/Toast.tsx
+++ b/frontend/src/lib-components/molecules/Toast.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -42,7 +42,7 @@ const ToastRoot = styled.div`
   right: 16px;
   width: 360px;
   padding: 16px;
-  background-color: ${(p) => p.theme.colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   border-radius: 16px;
   box-shadow: 4px 4px 8px rgba(15, 15, 15, 0.15),
     -2px 0 4px rgba(15, 15, 15, 0.15);
@@ -53,5 +53,5 @@ const CloseButton = styled(IconButton)`
   position: absolute;
   top: ${defaultMargins.s};
   right: ${defaultMargins.s};
-  color: ${(p) => p.theme.colors.main.primary};
+  color: ${(p) => p.theme.colors.main.m2};
 `

--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
@@ -34,7 +34,7 @@ const DayPickerPositioner = styled.div<{ openAbove?: boolean }>`
 `
 
 const DayPickerDiv = styled.div`
-  background-color: ${({ theme: { colors } }) => colors.greyscale.white};
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
   padding: ${defaultMargins.s} 0;
   border-radius: 2px;
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);

--- a/frontend/src/lib-components/molecules/modals/BaseModal.tsx
+++ b/frontend/src/lib-components/molecules/modals/BaseModal.tsx
@@ -88,7 +88,7 @@ const CloseButton = styled(IconButton)`
   position: absolute;
   top: ${defaultMargins.s};
   right: ${defaultMargins.s};
-  color: ${({ theme }) => theme.colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 `
 
 const ModalContainer = styled.div<{
@@ -98,7 +98,7 @@ const ModalContainer = styled.div<{
   position: relative;
   width: min(500px, calc(100vw - 2 * ${defaultMargins.xxs}));
   max-height: calc(100vh - 2 * ${defaultMargins.s});
-  background: ${(p) => p.theme.colors.greyscale.white};
+  background: ${(p) => p.theme.colors.grayscale.g0};
   overflow-x: visible;
   box-shadow: 0 15px 75px 0 rgba(0, 0, 0, 0.5);
   border-radius: 2px;
@@ -143,18 +143,18 @@ const ModalWrapper = styled.div<{ zIndex?: number }>`
 `
 
 const ModalIcon = styled.div<{ color?: IconColor }>`
-  background: ${({ theme: { colors }, ...props }) => {
-    switch (props.color) {
+  background: ${(p) => {
+    switch (p.color) {
       case 'blue':
-        return colors.accents.infoBlue
+        return p.theme.colors.status.info
       case 'orange':
-        return colors.accents.warningOrange
+        return p.theme.colors.status.warning
       case 'green':
-        return colors.accents.successGreen
+        return p.theme.colors.status.success
       case 'red':
-        return colors.accents.dangerRed
+        return p.theme.colors.status.danger
       default:
-        return colors.accents.infoBlue
+        return p.theme.colors.status.info
     }
   }};
   font-size: 36px;
@@ -163,7 +163,7 @@ const ModalIcon = styled.div<{ color?: IconColor }>`
   height: 60px;
   width: 60px;
   text-align: center;
-  color: ${(p) => p.theme.colors.greyscale.white};
+  color: ${(p) => p.theme.colors.grayscale.g0};
   margin: auto;
 `
 

--- a/frontend/src/lib-components/typography.ts
+++ b/frontend/src/lib-components/typography.ts
@@ -33,76 +33,144 @@ type HeadingProps = BaseProps & {
 }
 
 export const H1 = styled.h1<HeadingProps>`
-  color: ${({ theme: { colors }, ...p }) =>
+  color: ${(p) =>
     p.primary || p.primary === undefined
-      ? colors.main.dark
-      : colors.greyscale.darkest};
+      ? p.theme.colors.main.m1
+      : p.theme.colors.grayscale.g100};
   font-size: ${(p) => (p.smaller ? fontSizesMobile.h1 : '36px')};
   font-family: Montserrat, sans-serif;
-  font-weight: ${({ theme: { typography } }) => typography.h1.weight};
-  ${(p) => (!p.fitted ? `margin-bottom: ${defaultMargins.m};` : '')}
-  ${(p) => (p.centered ? `text-align: center;` : '')}
-  ${(p) => (p.noMargin ? `margin: 0;` : '')}
+  font-weight: ${(p) => p.theme.typography.h1.weight};
+  ${(p) =>
+    !p.fitted
+      ? css`
+          margin-bottom: ${defaultMargins.m};
+        `
+      : ''}
+  ${(p) =>
+    p.centered
+      ? css`
+          text-align: center;
+        `
+      : ''}
+  ${(p) =>
+    p.noMargin
+      ? css`
+          margin: 0;
+        `
+      : ''}
 
   @media (max-width: 600px) {
     font-size: ${fontSizesMobile.h1};
-    ${({ theme: { typography } }) =>
-      typography.h1.mobile?.weight &&
-      `font-weight: ${typography.h1.mobile?.weight};`}
+    ${(p) =>
+      p.theme.typography.h1.mobile?.weight &&
+      css`
+        font-weight: ${p.theme.typography.h1.mobile?.weight};
+      `}
   }
 `
 
 export const H2 = styled.h2<HeadingProps>`
-  color: ${({ theme: { colors }, ...p }) =>
-    p.primary ? colors.main.dark : colors.greyscale.darkest};
+  color: ${(p) =>
+    p.primary ? p.theme.colors.main.m1 : p.theme.colors.grayscale.g100};
   font-size: ${(p) => (p.smaller ? fontSizesMobile.h2 : '24px')};
   font-family: Montserrat, sans-serif;
-  font-weight: ${({ theme: { typography } }) => typography.h2.weight};
-  ${(p) => (!p.fitted ? `margin-bottom: ${defaultMargins.s};` : '')}
-  ${(p) => (p.centered ? `text-align: center;` : '')}
-  ${(p) => (p.noMargin ? `margin: 0;` : '')}
+  font-weight: ${(p) => p.theme.typography.h2.weight};
+  ${(p) =>
+    !p.fitted
+      ? css`
+          margin-bottom: ${defaultMargins.s};
+        `
+      : ''}
+  ${(p) =>
+    p.centered
+      ? css`
+          text-align: center;
+        `
+      : ''}
+  ${(p) =>
+    p.noMargin
+      ? css`
+          margin: 0;
+        `
+      : ''}
 
   @media (max-width: 600px) {
     font-size: ${fontSizesMobile.h2};
-    ${({ theme: { typography } }) =>
-      typography.h2.mobile?.weight &&
-      `font-weight: ${typography.h2.mobile?.weight};`}
+    ${(p) =>
+      p.theme.typography.h2.mobile?.weight &&
+      css`
+        font-weight: ${p.theme.typography.h2.mobile?.weight};
+      `}
   }
 `
 
 export const H3 = styled.h3<HeadingProps>`
-  color: ${({ theme: { colors }, ...p }) =>
-    p.primary ? colors.main.dark : colors.greyscale.darkest};
+  color: ${(p) =>
+    p.primary ? p.theme.colors.main.m1 : p.theme.colors.grayscale.g100};
   font-size: ${(p) => (p.smaller ? fontSizesMobile.h3 : '20px')};
   font-family: Montserrat, sans-serif;
-  font-weight: ${({ theme: { typography } }) => typography.h3.weight};
-  ${(p) => (!p.fitted ? `margin-bottom: ${defaultMargins.s};` : '')}
-  ${(p) => (p.centered ? `text-align: center;` : '')}
-  ${(p) => (p.noMargin ? `margin: 0;` : '')}
+  font-weight: ${(p) => p.theme.typography.h3.weight};
+  ${(p) =>
+    !p.fitted
+      ? css`
+          margin-bottom: ${defaultMargins.s};
+        `
+      : ''}
+  ${(p) =>
+    p.centered
+      ? css`
+          text-align: center;
+        `
+      : ''}
+  ${(p) =>
+    p.noMargin
+      ? css`
+          margin: 0;
+        `
+      : ''}
 
   @media (max-width: 600px) {
     font-size: ${fontSizesMobile.h3};
-    ${({ theme: { typography } }) =>
-      typography.h3.mobile?.weight &&
-      `font-weight: ${typography.h3.mobile?.weight};`}
+    ${(p) =>
+      p.theme.typography.h3.mobile?.weight &&
+      css`
+        font-weight: ${p.theme.typography.h3.mobile?.weight};
+      `}
   }
 `
 
 export const H4 = styled.h4<HeadingProps>`
-  color: ${({ theme: { colors }, ...p }) =>
-    p.primary ? colors.main.dark : colors.greyscale.darkest};
+  color: ${(p) =>
+    p.primary ? p.theme.colors.main.m1 : p.theme.colors.grayscale.g100};
   font-size: ${(p) => (p.smaller ? fontSizesMobile.h4 : '18px')};
   font-family: Montserrat, sans-serif;
-  font-weight: ${({ theme: { typography } }) => typography.h4.weight};
-  ${(p) => (!p.fitted ? `margin-bottom: ${defaultMargins.s};` : '')}
-  ${(p) => (p.centered ? `text-align: center;` : '')}
-  ${(p) => (p.noMargin ? `margin: 0;` : '')}
+  font-weight: ${(p) => p.theme.typography.h4.weight};
+  ${(p) =>
+    !p.fitted
+      ? css`
+          margin-bottom: ${defaultMargins.s};
+        `
+      : ''}
+  ${(p) =>
+    p.centered
+      ? css`
+          text-align: center;
+        `
+      : ''}
+  ${(p) =>
+    p.noMargin
+      ? css`
+          margin: 0;
+        `
+      : ''}
 
   @media (max-width: 600px) {
     font-size: ${fontSizesMobile.h4};
-    ${({ theme: { typography } }) =>
-      typography.h4.mobile?.weight &&
-      `font-weight: ${typography.h4.mobile?.weight};`}
+    ${(p) =>
+      p.theme.typography.h4.mobile?.weight &&
+      css`
+        font-weight: ${p.theme.typography.h4.mobile?.weight};
+      `}
   }
 `
 
@@ -116,10 +184,10 @@ const labelMixin = css<LabelProps>`
   font-weight: ${fontWeights.semibold};
   color: ${(p) =>
     p.primary
-      ? p.theme.colors.main.dark
+      ? p.theme.colors.main.m1
       : p.white
-      ? p.theme.colors.greyscale.white
-      : p.theme.colors.greyscale.darkest};
+      ? p.theme.colors.grayscale.g0
+      : p.theme.colors.grayscale.g100};
   ${(p) => (p.inputRow ? 'margin-top: 6px;' : '')}
 `
 
@@ -141,7 +209,7 @@ type ParagraphProps = {
 }
 
 export const P = styled.p<ParagraphProps>`
-  ${(p) => (p.centered ? 'text-align: center;' : '')};
+  ${(p) => (p.centered ? `text-align: center;` : '')};
   max-width: ${(p) => p.width || '960px'};
   ${(p) =>
     p.noMargin ? `margin: 0` : `margin-block: ${p.fitted ? `0` : '1.5em'}`};
@@ -149,31 +217,31 @@ export const P = styled.p<ParagraphProps>`
   ${(p) => (p.color ? `color: ${p.color};` : '')};
 
   strong {
-    color: ${(p) => p.theme.colors.greyscale.darkest};
+    color: ${(p) => p.theme.colors.grayscale.g100};
     font-weight: ${fontWeights.semibold};
   }
 
   a {
-    color: ${(p) => p.theme.colors.main.primary};
+    color: ${(p) => p.theme.colors.main.m2};
   }
 
   a:hover {
-    color: ${(p) => p.theme.colors.main.dark};
+    color: ${(p) => p.theme.colors.main.m1};
     cursor: pointer;
     text-decoration: underline;
   }
 
   a:focus {
-    outline: 1px solid ${(p) => p.theme.colors.main.light};
+    outline: 1px solid ${(p) => p.theme.colors.main.m3};
   }
 
   a:visited {
-    color: ${(p) => p.theme.colors.accents.violet};
+    color: ${(p) => p.theme.colors.accents.a4violet};
   }
 `
 
 export const Dimmed = styled.span`
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 `
 
 export const Strong = styled.span`
@@ -190,13 +258,13 @@ export const Italic = styled.span`
 
 export const Light = styled.span`
   font-style: italic;
-  color: ${({ theme: { colors } }) => colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
 `
 
 export const Title = styled.span<{ primary?: boolean }>`
   font-family: Montserrat, sans-serif;
   color: ${(p) =>
-    p.primary ? p.theme.colors.main.primary : p.theme.colors.greyscale.darkest};
+    p.primary ? p.theme.colors.main.m1 : p.theme.colors.grayscale.g100};
   font-size: 20px;
   font-weight: ${fontWeights.semibold};
 `
@@ -206,11 +274,11 @@ export const BigNumber = styled.span`
   font-size: 60px;
   font-weight: ${fontWeights.light};
   line-height: 73px;
-  color: ${(p) => p.theme.colors.main.dark};
+  color: ${(p) => p.theme.colors.main.m1};
 `
 
 export const InformationText = styled.span<{ centered?: boolean }>`
-  color: ${(p) => p.theme.colors.greyscale.dark};
+  color: ${(p) => p.theme.colors.grayscale.g70};
   font-size: 14px;
   font-weight: ${fontWeights.semibold};
   ${(p) =>
@@ -222,7 +290,7 @@ export const InformationText = styled.span<{ centered?: boolean }>`
 `
 
 export const NavLinkText = styled.span`
-  color: ${(p) => p.theme.colors.greyscale.darkest};
+  color: ${(p) => p.theme.colors.grayscale.g100};
   cursor: pointer;
   font-family: Montserrat, sans-serif;
   font-weight: ${fontWeights.medium};

--- a/frontend/src/lib-customizations/common.tsx
+++ b/frontend/src/lib-customizations/common.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -18,48 +18,48 @@ export { theme }
 
 export const { colors } = theme
 
-const { main, greyscale, accents } = colors
+const { main, grayscale, accents, status } = colors
 
 export const absenceColors = {
-  UNKNOWN_ABSENCE: accents.turquoise,
-  OTHER_ABSENCE: greyscale.darkest,
-  SICKLEAVE: accents.pink,
-  PLANNED_ABSENCE: accents.successGreen,
-  PARENTLEAVE: accents.peach,
-  FORCE_MAJEURE: accents.dangerRed,
-  TEMPORARY_RELOCATION: accents.warningOrange,
-  TEMPORARY_VISITOR: accents.warningOrange,
-  NO_ABSENCE: accents.lightBlue
+  UNKNOWN_ABSENCE: accents.a6turquoise,
+  OTHER_ABSENCE: grayscale.g100,
+  SICKLEAVE: accents.a9pink,
+  PLANNED_ABSENCE: status.success,
+  PARENTLEAVE: accents.a5orangeLight,
+  FORCE_MAJEURE: status.danger,
+  TEMPORARY_RELOCATION: status.warning,
+  TEMPORARY_VISITOR: status.warning,
+  NO_ABSENCE: accents.a8lightBlue
 }
 
 export const attendanceColors = {
-  ABSENT: colors.greyscale.medium,
-  DEPARTED: colors.main.light,
-  PRESENT: colors.accents.successGreen,
-  COMING: colors.accents.peach
+  ABSENT: grayscale.g35,
+  DEPARTED: main.m3,
+  PRESENT: status.success,
+  COMING: accents.a5orangeLight
 }
 
 export const applicationBasisColors = {
-  ADDITIONAL_INFO: main.dark,
-  ASSISTANCE_NEED: accents.turquoise,
-  CLUB_CARE: accents.orangeDark,
-  DAYCARE: accents.warningOrange,
-  DUPLICATE_APPLICATION: accents.emerald,
-  EXTENDED_CARE: main.light,
-  HAS_ATTACHMENTS: accents.pink,
-  SIBLING_BASIS: accents.successGreen,
-  URGENT: accents.dangerRed
+  ADDITIONAL_INFO: main.m1,
+  ASSISTANCE_NEED: accents.a6turquoise,
+  CLUB_CARE: accents.a2orangeDark,
+  DAYCARE: status.warning,
+  DUPLICATE_APPLICATION: accents.a3emerald,
+  EXTENDED_CARE: main.m3,
+  HAS_ATTACHMENTS: accents.a9pink,
+  SIBLING_BASIS: status.success,
+  URGENT: status.danger
 }
 
 export const careTypeColors = {
-  'backup-care': colors.accents.peach,
-  club: colors.greyscale.lighter,
-  daycare: colors.accents.successGreen,
-  daycare5yo: colors.accents.greenDark,
-  preparatory: colors.accents.turquoise,
-  preschool: colors.main.dark,
-  'school-shift-care': colors.greyscale.dark,
-  temporary: colors.accents.violet
+  'backup-care': accents.a5orangeLight,
+  club: grayscale.g15,
+  daycare: status.success,
+  daycare5yo: accents.a1greenDark,
+  preparatory: accents.a6turquoise,
+  preschool: main.m1,
+  'school-shift-care': grayscale.g70,
+  temporary: accents.a4violet
 }
 
 export const translationsMergeCustomizer = (


### PR DESCRIPTION
#### Summary

- Add design system numbering to main, grayscale and accent colors
  - The colors are numbered in eVaka Design System, so this helps in communicating with UX.
- Move actual status accent colors to colors.status
- Rename greyscale -> grayscale
