### PR TITLE
Fix ImageEditor layout

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/attendances/child-info/ImageEditor.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/child-info/ImageEditor.tsx
@@ -126,8 +126,6 @@ export default React.memo(function ImageEditor({
 
   return (
     <Container>
-      <Gap />
-
       <CropWrapper>
         <ReactCrop
           src={image}
@@ -136,7 +134,6 @@ export default React.memo(function ImageEditor({
           onChange={(c) => setCrop(c)}
           onComplete={setCompletedCrop}
           circularCrop
-          style={{ maxHeight: '100%' }}
         />
         <canvas
           ref={previewCanvasRef}
@@ -176,9 +173,7 @@ const Container = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: stretch;
-  height: 100%;
-  max-height: 100%;
-  overflow: hidden;
+  margin: ${defaultMargins.m};
 `
 
 const ButtonRow = styled(FixedSpaceRow)`
@@ -190,7 +185,6 @@ const ButtonRow = styled(FixedSpaceRow)`
 const CropWrapper = styled.div`
   flex-grow: 1;
   flex-shrink: 1;
-  height: 100px;
 
   .ReactCrop .ord-nw {
     top: -24px;


### PR DESCRIPTION
#### Summary

Remove weird height and overflow settings from `ImageEditor`. Previously the canvas would (sometimes) only be 100px tall.
Also add some horizontal margin to allow scrolling the view if image is very narrow compared to the device screen.

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

