### PR TITLE
EVAKA-4378 Reservation calendar highlights and borders

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
@@ -3,13 +3,25 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import styled from 'styled-components'
 import { AbsenceType } from 'lib-common/generated/enums'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
-import colors from 'lib-customizations/common'
+import { defaultMargins } from 'lib-components/white-space'
+import { absenceColors } from 'lib-customizations/common'
 import { faThermometer } from 'lib-icons'
 import { useTranslation } from '../../../state/i18n'
+
+const absenceIcons = {
+  UNKNOWN_ABSENCE: '?',
+  OTHER_ABSENCE: '-',
+  SICKLEAVE: faThermometer,
+  PLANNED_ABSENCE: 'P',
+  PARENTLEAVE: '-',
+  FORCE_MAJEURE: '-',
+  TEMPORARY_RELOCATION: '-',
+  TEMPORARY_VISITOR: '-',
+  NO_ABSENCE: '-'
+} as const
 
 interface Props {
   type: AbsenceType
@@ -17,36 +29,14 @@ interface Props {
 
 export default React.memo(function AbsenceDay({ type }: Props) {
   const { i18n } = useTranslation()
-  if (type === 'SICKLEAVE')
-    return (
-      <AbsenceCell>
-        <FixedSpaceRow spacing="xs" alignItems="center">
-          <RoundIcon
-            content={faThermometer}
-            color={colors.accents.a4violet}
-            size="m"
-          />
-          <div>{i18n.absences.absenceTypes.SICKLEAVE}</div>
-        </FixedSpaceRow>
-      </AbsenceCell>
-    )
-
   return (
-    <AbsenceCell>
-      <FixedSpaceRow spacing="xs" alignItems="center">
-        <RoundIcon content="–" color={colors.main.m2} size="m" />
-        <div>
-          {i18n.absences.absenceTypes[type] ??
-            i18n.absences.absenceTypes.OTHER_ABSENCE}
-        </div>
-      </FixedSpaceRow>
-    </AbsenceCell>
+    <FixedSpaceRow spacing={defaultMargins.xs} alignItems="center">
+      <RoundIcon
+        content={absenceIcons[type]}
+        color={absenceColors[type]}
+        size="m"
+      />
+      <span>{i18n.absences.absenceTypes[type]}</span>
+    </FixedSpaceRow>
   )
 })
-
-const AbsenceCell = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-style: italic;
-`

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
@@ -36,7 +36,7 @@ export default React.memo(function AbsenceDay({ type }: Props) {
         color={absenceColors[type]}
         size="m"
       />
-      <span>{i18n.absences.absenceTypes[type]}</span>
+      <span>{i18n.absences.absenceTypesShort[type]}</span>
     </FixedSpaceRow>
   )
 })

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -17,6 +17,7 @@ import {
 import { fontWeights } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import { colors } from 'lib-customizations/common'
+import { useTranslation } from '../../../state/i18n'
 import AbsenceDay from './AbsenceDay'
 
 interface Props {
@@ -25,6 +26,8 @@ interface Props {
 }
 
 export default React.memo(function ChildDay({ day, childReservations }: Props) {
+  const { i18n } = useTranslation()
+
   const dailyData = childReservations.dailyData[day.date.formatIso()]
 
   if (!dailyData) return null
@@ -71,10 +74,14 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
           </>
         ) : serviceTimesAvailable && serviceTimeOfDay === null ? (
           /* else if daily service times are known but there is none for this day of week, show day off */
-          <ReservationTime>Vapaapäivä</ReservationTime>
+          <ReservationTime>
+            {i18n.unit.attendanceReservations.dayOff}
+          </ReservationTime>
         ) : (
           /* else show no reservation */
-          <ReservationTime warning>Sop.aika puuttuu</ReservationTime>
+          <ReservationTime warning>
+            {i18n.unit.attendanceReservations.missingServiceTime}
+          </ReservationTime>
         )}
       </TimesRow>
       {dailyData.reservations.length > 1 && (

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import {
   getTimesOnWeekday,
   isIrregular,
@@ -15,7 +15,8 @@ import {
   OperationalDay
 } from 'lib-common/api-types/reservations'
 import { fontWeights } from 'lib-components/typography'
-import { defaultMargins, Gap } from 'lib-components/white-space'
+import { defaultMargins } from 'lib-components/white-space'
+import { colors } from 'lib-customizations/common'
 import AbsenceDay from './AbsenceDay'
 
 interface Props {
@@ -36,7 +37,7 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
     return null
 
   if (dailyData.absence && !dailyData.attendance)
-    return <AbsenceDay type={dailyData.absence.type} />
+    return <AbsenceDay type={dailyData.absence.type} /> // TODO render on top row
 
   const serviceTimes = childReservations.child.dailyServiceTimes
   const serviceTimesAvailable =
@@ -52,20 +53,15 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
 
   return (
     <DateCell>
-      <AttendanceTimesRow>
-        <TimeCell>{dailyData.attendance?.startTime ?? '–'}</TimeCell>
-        <TimeCell>{dailyData.attendance?.endTime ?? '–'}</TimeCell>
-      </AttendanceTimesRow>
-      <Gap size="xxs" />
-      <ReservationTimesRow>
+      <TimesRow>
         {dailyData.reservations.length > 0 ? (
           /* show actual reservation if it exists */
           <>
             <ReservationTime>
-              {dailyData.reservations[0].startTime ?? '–'}
+              {dailyData.reservations[0].startTime}
             </ReservationTime>
             <ReservationTime>
-              {dailyData.reservations[0].endTime ?? '–'}
+              {dailyData.reservations[0].endTime}
             </ReservationTime>
           </>
         ) : serviceTimesAvailable && serviceTimeOfDay ? (
@@ -79,19 +75,25 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
           <ReservationTime>Vapaapäivä</ReservationTime>
         ) : (
           /* else show no reservation */
-          <ReservationTime>Ei varausta</ReservationTime>
+          <ReservationTime warning>Sop.aika puuttuu</ReservationTime>
         )}
-      </ReservationTimesRow>
+      </TimesRow>
       {dailyData.reservations.length > 1 ? (
-        <ReservationTimesRow>
+        <TimesRow>
           <ReservationTime>
             {dailyData.reservations[1].startTime ?? '–'}
           </ReservationTime>
           <ReservationTime>
             {dailyData.reservations[1].endTime ?? '–'}
           </ReservationTime>
-        </ReservationTimesRow>
+        </TimesRow>
       ) : null}
+      <TimesRow>
+        <AttendanceTime>
+          {dailyData.attendance?.startTime ?? '–'}
+        </AttendanceTime>
+        <AttendanceTime>{dailyData.attendance?.endTime ?? '–'}</AttendanceTime>
+      </TimesRow>
     </DateCell>
   )
 })
@@ -103,28 +105,32 @@ const DateCell = styled.div`
   justify-content: center;
 `
 
-export const TimesRow = styled.div`
+const TimesRow = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
   justify-content: space-evenly;
-`
+  padding: ${defaultMargins.xs};
+  gap: ${defaultMargins.xs};
 
-const AttendanceTimesRow = styled(TimesRow)`
-  font-weight: ${fontWeights.semibold};
-`
-
-const ReservationTimesRow = styled(TimesRow)``
-
-export const TimeCell = styled.div`
-  min-width: 54px;
-  text-align: center;
-
-  &:not(:first-child) {
-    margin-left: ${defaultMargins.xs};
+  :nth-child(even) {
+    background: ${colors.grayscale.g4};
   }
 `
 
-const ReservationTime = styled(TimeCell)`
-  font-style: italic;
+const TimeCell = styled.div`
+  flex: 1 0 54px;
+  text-align: center;
+`
+
+const AttendanceTime = styled(TimeCell)`
+  font-weight: ${fontWeights.semibold};
+`
+
+const ReservationTime = styled(TimeCell)<{ warning?: boolean }>`
+  ${(p) =>
+    p.warning &&
+    css`
+      color: ${colors.accents.a2orangeDark};
+    `};
 `

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -36,9 +36,6 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
   )
     return null
 
-  if (dailyData.absence && !dailyData.attendance)
-    return <AbsenceDay type={dailyData.absence.type} /> // TODO render on top row
-
   const serviceTimes = childReservations.child.dailyServiceTimes
   const serviceTimesAvailable =
     serviceTimes !== null && !isVariableTime(serviceTimes)
@@ -54,7 +51,9 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
   return (
     <DateCell>
       <TimesRow>
-        {dailyData.reservations.length > 0 ? (
+        {dailyData.absence ? (
+          <AbsenceDay type={dailyData.absence.type} />
+        ) : dailyData.reservations.length > 0 ? (
           /* show actual reservation if it exists */
           <>
             <ReservationTime>
@@ -78,7 +77,7 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
           <ReservationTime warning>Sop.aika puuttuu</ReservationTime>
         )}
       </TimesRow>
-      {dailyData.reservations.length > 1 ? (
+      {dailyData.reservations.length > 1 && (
         <TimesRow>
           <ReservationTime>
             {dailyData.reservations[1].startTime ?? '–'}
@@ -87,7 +86,7 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
             {dailyData.reservations[1].endTime ?? '–'}
           </ReservationTime>
         </TimesRow>
-      ) : null}
+      )}
       <TimesRow>
         <AttendanceTime>
           {dailyData.attendance?.startTime ?? '–'}

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
 import { Link } from 'react-router-dom'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import {
   Child,
   ChildReservations,
@@ -13,13 +13,13 @@ import {
 import LocalDate from 'lib-common/local-date'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
-import { H4 } from 'lib-components/typography'
+import { fontWeights, H4 } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faCalendarPlus } from 'lib-icons'
 import { useTranslation } from '../../../state/i18n'
 import AgeIndicatorIcon from '../../common/AgeIndicatorIcon'
-import ChildDay, { TimeCell, TimesRow } from './ChildDay'
+import ChildDay from './ChildDay'
 
 interface Props {
   operationalDays: OperationalDay[]
@@ -43,17 +43,15 @@ export default React.memo(function ReservationsTable({
           <CustomTh>{i18n.unit.attendanceReservations.childName}</CustomTh>
           {operationalDays.map(({ date, isHoliday }) => (
             <DateTh key={date.formatIso()} faded={isHoliday}>
-              <Date>
+              <Date centered highlight={date.isToday()}>
                 {`${
                   i18n.datePicker.weekdaysShort[date.getIsoDayOfWeek() - 1]
                 } ${date.format('dd.MM.')}`}
               </Date>
-              <TimesRow>
-                <TimeCell>
-                  {i18n.unit.attendanceReservations.startTime}
-                </TimeCell>
-                <TimeCell>{i18n.unit.attendanceReservations.endTime}</TimeCell>
-              </TimesRow>
+              <DayHeader>
+                <span>{i18n.unit.attendanceReservations.startTime}</span>
+                <span>{i18n.unit.attendanceReservations.endTime}</span>
+              </DayHeader>
             </DateTh>
           ))}
           <CustomTh />
@@ -80,9 +78,9 @@ export default React.memo(function ReservationsTable({
                 </ChildName>
               </NameTd>
               {operationalDays.map((day) => (
-                <StyledTd key={day.date.formatIso()}>
+                <DayTd key={day.date.formatIso()}>
                   <ChildDay day={day} childReservations={childReservations} />
-                </StyledTd>
+                </DayTd>
               ))}
               <StyledTd>
                 <IconButton
@@ -101,18 +99,27 @@ export default React.memo(function ReservationsTable({
 })
 
 const CustomTh = styled(Th)`
-  border: none;
   vertical-align: bottom;
 `
 
 const DateTh = styled(CustomTh)<{ faded: boolean }>`
   width: 0; // causes the column to take as little space as possible
-  ${({ faded }) => (faded ? `color: ${colors.grayscale.g35};` : '')}
+  ${(p) => (p.faded ? `color: ${colors.grayscale.g35};` : '')}
+`
+
+const DayHeader = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+  gap: ${defaultMargins.xs};
 `
 
 const StyledTd = styled(Td)`
   border-right: 1px solid ${colors.grayscale.g35};
   vertical-align: middle;
+`
+
+const DayTd = styled(StyledTd)`
+  padding: 0;
 `
 
 const NameTd = styled(StyledTd)`
@@ -131,7 +138,12 @@ const ChildName = styled.div`
   }
 `
 
-const Date = styled(H4)`
-  text-align: center;
+const Date = styled(H4)<{ highlight: boolean }>`
   margin: 0 0 ${defaultMargins.s};
+  ${(p) =>
+    p.highlight &&
+    css`
+      color: ${colors.main.m2};
+      font-weight: ${fontWeights.semibold};
+    `}
 `

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2080,6 +2080,17 @@ export const fi = {
       FORCE_MAJEURE: 'Maksuton päivä',
       NO_ABSENCE: 'Ei poissaoloa'
     },
+    absenceTypesShort: {
+      OTHER_ABSENCE: 'Muu',
+      SICKLEAVE: 'Sairaus',
+      UNKNOWN_ABSENCE: 'Ilmoittamaton',
+      PLANNED_ABSENCE: 'Suunniteltu',
+      TEMPORARY_RELOCATION: 'Varasijoitus',
+      TEMPORARY_VISITOR: 'Varalapsi',
+      PARENTLEAVE: 'Isyysvapaa',
+      FORCE_MAJEURE: 'Maksuton',
+      NO_ABSENCE: 'Ei poissa'
+    },
     careTypes: {
       SCHOOL_SHIFT_CARE: 'Koululaisten vuorohoito',
       PRESCHOOL: 'Esiopetus',

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -1611,7 +1611,9 @@ export const fi = {
           WEEKLY: 'Viikoittain',
           IRREGULAR: 'Epäsäännöllinen'
         }
-      }
+      },
+      dayOff: 'Vapaapäivä',
+      missingServiceTime: 'Sop.aika puuttuu'
     },
     error: {
       placement: {


### PR DESCRIPTION
#### Summary

- Swap rows
  - first row is for absence/reservation/service time
  - second row is for attendance time
- Highlight attendance rows
- Highlight current day in table header
- Fix borders

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

