### PR TITLE
Fix Suomi.fi printing nullability

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/sficlient/SoapStackIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/sficlient/SoapStackIntegrationTest.kt
@@ -115,6 +115,7 @@ class SoapStackIntegrationTest {
         serviceIdentifier = "service",
         certificateCommonName = "common-name",
         printing = SfiPrintingEnv(
+            enabled = true,
             forcePrintForElectronicUser = false,
             printingProvider = "provider",
             billingId = "billing-id",
@@ -192,11 +193,12 @@ class SoapStackIntegrationTest {
             assertEquals(env.contactPerson.email, viranomainen.yhteyshenkilo.sahkoposti)
             assertEquals(env.contactPerson.phone, viranomainen.yhteyshenkilo.matkapuhelin)
 
-            assertTrue(request.isLahetaTulostukseen)
-            assertEquals(env.printing?.printingProvider, request.tulostustoimittaja)
+            assertEquals(env.printing.enabled, request.isLahetaTulostukseen)
+            assertEquals(env.printing.forcePrintForElectronicUser, request.isPaperi)
+            assertEquals(env.printing.printingProvider, request.tulostustoimittaja)
 
-            assertEquals(env.printing?.billingId, request.laskutus.tunniste)
-            assertEquals(env.printing?.billingPassword?.value, request.laskutus.salasana)
+            assertEquals(env.printing.billingId, request.laskutus.tunniste)
+            assertEquals(env.printing.billingPassword?.value, request.laskutus.salasana)
 
             assertEquals(1, request.kohteet.kohde.size)
             val kohde = request.kohteet.kohde[0]

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -381,11 +381,8 @@ data class SfiEnv(
     val certificateCommonName: String,
     /**
      * Configuration for sending messages on real paper (vs digital messages).
-     *
-     * If not configured, real paper messages are never sent.
-     * If configured, real paper messages may be sent.
      */
-    val printing: SfiPrintingEnv?,
+    val printing: SfiPrintingEnv,
     /**
      * Contact details for a person in the organization making API requests.
      *
@@ -412,15 +409,20 @@ data class SfiEnv(
             authorityIdentifier = env.lookup("evaka.integration.sfi.authority_identifier", "evaka.integration.sfi.message.authority_identifier", "fi.espoo.evaka.msg.sfi.message.authorityIdentifier"),
             serviceIdentifier = env.lookup("evaka.integration.sfi.service_identifier", "evaka.integration.sfi.message.service_identifier", "fi.espoo.evaka.msg.sfi.message.serviceIdentifier"),
             certificateCommonName = env.lookup("evaka.integration.sfi.certificate_common_name", "evaka.integration.sfi.message.certificate_common_name", "fi.espoo.evaka.msg.sfi.message.certificateCommonName"),
-            printing = if (env.lookup<Boolean?>("evaka.integration.sfi.printing.enabled", "fi.espoo.evaka.msg.sfi.printing.enablePrinting") == true) {
-                SfiPrintingEnv.fromEnvironment(env)
-            } else null,
+            printing = SfiPrintingEnv.fromEnvironment(env),
             contactPerson = SfiContactPersonEnv.fromEnvironment(env)
         )
     }
 }
 
 data class SfiPrintingEnv(
+    /**
+     * If false, real paper messages are never sent.
+     * If true, real paper messages may be sent.
+     *
+     * Even if printing is disabled, printing provider and billing id are marked as required fields by Suomi.fi.
+     */
+    val enabled: Boolean,
     /**
      * Force messages to be sent on paper, even if the recipient has a digital mailbox.
      */
@@ -442,6 +444,7 @@ data class SfiPrintingEnv(
 ) {
     companion object {
         fun fromEnvironment(env: Environment) = SfiPrintingEnv(
+            enabled = env.lookup("evaka.integration.sfi.printing.enabled", "fi.espoo.evaka.msg.sfi.printing.enablePrinting") ?: false,
             forcePrintForElectronicUser = env.lookup("evaka.integration.sfi.printing.force_print_for_electronic_user", "fi.espoo.evaka.msg.sfi.printing.forcePrintForElectronicUser") ?: false,
             printingProvider = env.lookup("evaka.integration.sfi.printing.provider", "fi.espoo.evaka.msg.sfi.printing.printingProvider"),
             billingId = env.lookup("evaka.integration.sfi.printing.billing.id", "fi.espoo.evaka.msg.sfi.printing.billingId"),

--- a/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiMessagesSoapClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiMessagesSoapClient.kt
@@ -136,16 +136,12 @@ class SfiMessagesSoapClient(
                 }
             }
             kysely = KyselyWS2A().apply {
-                if (sfiEnv.printing != null) {
-                    isLahetaTulostukseen = true
-                    tulostustoimittaja = sfiEnv.printing.printingProvider
-                    isPaperi = sfiEnv.printing.forcePrintForElectronicUser
-                    laskutus = KyselyWS2A.Laskutus().apply {
-                        tunniste = sfiEnv.printing.billingId
-                        salasana = sfiEnv.printing.billingPassword?.value?.takeIf { it.isNotBlank() }
-                    }
-                } else {
-                    isLahetaTulostukseen = false
+                isLahetaTulostukseen = sfiEnv.printing.enabled
+                tulostustoimittaja = sfiEnv.printing.printingProvider
+                isPaperi = sfiEnv.printing.forcePrintForElectronicUser
+                laskutus = KyselyWS2A.Laskutus().apply {
+                    tunniste = sfiEnv.printing.billingId
+                    salasana = sfiEnv.printing.billingPassword?.value?.takeIf { it.isNotBlank() }
                 }
                 kohteet = ArrayOfKohdeWS2A().apply {
                     kohde += KohdeWS2A().apply {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The SOAP API requires printing provider + billing ID, even if printing is disabled. :man_shrugging: 