### PR TITLE
Highlight attendance time differences in unit calendar week view

### DIFF
--- a/frontend/src/employee-frontend/api/unit.ts
+++ b/frontend/src/employee-frontend/api/unit.ts
@@ -23,11 +23,7 @@ import {
   ServiceNeed,
   ServiceNeedOptionSummary
 } from 'lib-common/generated/api-types/serviceneed'
-import {
-  AbsenceType,
-  ApplicationStatus,
-  PlacementType
-} from 'lib-common/generated/enums'
+import { ApplicationStatus, PlacementType } from 'lib-common/generated/enums'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
@@ -871,12 +867,6 @@ export async function getUnitAttendanceReservations(
       })
     )
     .catch((e) => Failure.fromError(e))
-}
-
-export interface DailyChildData {
-  reservation: { startTime: string; endTime: string } | null
-  attendance: { startTime: string; endTime: string | null } | null
-  absence: { type: AbsenceType } | null
 }
 
 const mapChildReservationJson = (

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -46,17 +46,21 @@ function attendanceTimeDiffers(
   return timeToMinutes(first) - timeToMinutes(second) > thresholdMinutes
 }
 
+type ReservationOrServiceTime =
+  | (TimeRange & { type: 'reservation' | 'service-time' })
+  | undefined
 const getReservationOrServiceTimeOfDay = (
   reservations: Reservation[],
   serviceTimeOfDay: TimeRange | null
-): TimeRange | undefined =>
+): ReservationOrServiceTime =>
   reservations.length > 0
     ? {
         start: reservations[0].startTime,
-        end: reservations[0].endTime
+        end: reservations[0].endTime,
+        type: 'reservation'
       }
     : serviceTimeOfDay
-    ? serviceTimeOfDay
+    ? { ...serviceTimeOfDay, type: 'service-time' }
     : undefined
 
 interface Props {
@@ -94,6 +98,7 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
     dailyData.reservations,
     serviceTimeOfDay
   )
+  const maybeAsterisk = expectedTimeForThisDay?.type === 'service-time' && '*'
 
   return (
     <DateCell>
@@ -103,8 +108,14 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
         ) : expectedTimeForThisDay ? (
           /* show actual reservation or service time if exists */
           <>
-            <ReservationTime>{expectedTimeForThisDay.start}</ReservationTime>
-            <ReservationTime>{expectedTimeForThisDay.end}</ReservationTime>
+            <ReservationTime>
+              {expectedTimeForThisDay.start}
+              {maybeAsterisk}
+            </ReservationTime>
+            <ReservationTime>
+              {expectedTimeForThisDay.end}
+              {maybeAsterisk}
+            </ReservationTime>
           </>
         ) : serviceTimesAvailable && serviceTimeOfDay === null ? (
           /* else if daily service times are known but there is none for this day of week, show day off */

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -98,7 +98,8 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
     dailyData.reservations,
     serviceTimeOfDay
   )
-  const maybeAsterisk = expectedTimeForThisDay?.type === 'service-time' && '*'
+  const maybeServiceTimeIndicator =
+    expectedTimeForThisDay?.type === 'service-time' && ' (s)'
 
   return (
     <DateCell>
@@ -110,11 +111,11 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
           <>
             <ReservationTime>
               {expectedTimeForThisDay.start}
-              {maybeAsterisk}
+              {maybeServiceTimeIndicator}
             </ReservationTime>
             <ReservationTime>
               {expectedTimeForThisDay.end}
-              {maybeAsterisk}
+              {maybeServiceTimeIndicator}
             </ReservationTime>
           </>
         ) : serviceTimesAvailable && serviceTimeOfDay === null ? (
@@ -184,6 +185,7 @@ const TimesRow = styled.div`
 const TimeCell = styled.div<{ warning?: boolean }>`
   flex: 1 0 54px;
   text-align: center;
+  white-space: nowrap;
   ${(p) =>
     p.warning &&
     css`

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -36,16 +36,14 @@ function timeToMinutes(expected: string): number {
  * reservations that span multiple days.
  */
 function attendanceTimeDiffers(
-  expected: string | null | undefined,
-  actual: string | null | undefined,
+  first: string | null | undefined,
+  second: string | null | undefined,
   thresholdMinutes = 15
 ): boolean {
-  if (!(expected && actual)) {
+  if (!(first && second)) {
     return false
   }
-  return (
-    Math.abs(timeToMinutes(expected) - timeToMinutes(actual)) > thresholdMinutes
-  )
+  return timeToMinutes(first) - timeToMinutes(second) > thresholdMinutes
 }
 
 const getReservationOrServiceTimeOfDay = (
@@ -141,8 +139,8 @@ export default React.memo(function ChildDay({ day, childReservations }: Props) {
         </AttendanceTime>
         <AttendanceTime
           warning={attendanceTimeDiffers(
-            expectedTimeForThisDay?.end,
-            dailyData.attendance?.endTime
+            dailyData.attendance?.endTime,
+            expectedTimeForThisDay?.end
           )}
         >
           {dailyData.attendance?.endTime ?? '–'}

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
@@ -66,7 +66,7 @@ export default React.memo(function ReservationsTable({
           const childName = `${childReservations.child.firstName} ${childReservations.child.lastName}`
 
           return (
-            <Tr key={childName}>
+            <Tr key={childReservations.child.id}>
               <NameTd>
                 <ChildName>
                   <AgeIndicatorIcon

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
@@ -43,6 +43,7 @@ export default React.memo(function ReservationsTable({
           <CustomTh>{i18n.unit.attendanceReservations.childName}</CustomTh>
           {operationalDays.map(({ date, isHoliday }) => (
             <DateTh
+              shrink
               key={date.formatIso()}
               faded={isHoliday}
               highlight={date.isToday()}
@@ -58,7 +59,7 @@ export default React.memo(function ReservationsTable({
               </DayHeader>
             </DateTh>
           ))}
-          <CustomTh />
+          <CustomTh shrink />
         </Tr>
       </Thead>
       <Tbody>
@@ -105,12 +106,16 @@ export default React.memo(function ReservationsTable({
   )
 })
 
-const CustomTh = styled(Th)`
+const CustomTh = styled(Th)<{ shrink?: boolean }>`
   vertical-align: bottom;
+  ${(p) =>
+    p.shrink &&
+    css`
+      width: 0; // causes the column to take as little space as possible
+    `}
 `
 
 const DateTh = styled(CustomTh)<{ faded: boolean; highlight: boolean }>`
-  width: 0; // causes the column to take as little space as possible
   ${(p) => p.faded && `color: ${colors.grayscale.g35};`}
   ${(p) => p.highlight && `border-bottom: 2px solid ${colors.main.m3};`}
 `

--- a/frontend/src/lib-common/api-types/reservations.ts
+++ b/frontend/src/lib-common/api-types/reservations.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -45,7 +45,7 @@ export interface Child {
 
 interface DailyChildData {
   reservations: Reservation[]
-  attendance: AttendanceTimes
+  attendance: AttendanceTimes | null
   absence: { type: AbsenceType } | null
 }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Highlight differences in expected and actual attendance times in week view.

The calculation is "best effort" based on two `HH:mm` local time strings without date part. This is only used for highlighting in the calendar so edge cases are expected and might not matter much. The functionality can be improved once the reservation data model supports reservations that span multiple days.