### PR TITLE
Use Title typography component instead of H3 in unit calendar titles

### DIFF
--- a/frontend/src/employee-frontend/components/absences/PeriodPicker.tsx
+++ b/frontend/src/employee-frontend/components/absences/PeriodPicker.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -6,7 +6,7 @@ import React from 'react'
 import styled from 'styled-components'
 import LocalDate from 'lib-common/local-date'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
-import { H3 } from 'lib-components/typography'
+import { Title } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { faChevronLeft, faChevronRight } from 'lib-icons'
 import { useTranslation } from '../../state/i18n'
@@ -35,7 +35,7 @@ export default React.memo(function PeriodPicker({ onChange, date }: Props) {
         gray
       />
       <Gap horizontal size="L" />
-      <PeriodTitle data-qa="period-picker-month" noMargin>
+      <PeriodTitle primary centered data-qa="period-picker-month">
         {i18n.datePicker.months[date.getMonth() - 1]} {date.getYear()}
       </PeriodTitle>
       <Gap horizontal size="L" />
@@ -62,8 +62,7 @@ const Container = styled.div`
   }
 `
 
-const PeriodTitle = styled(H3)`
+const PeriodTitle = styled(Title)`
   text-transform: capitalize;
-  min-width: 12ch;
-  text-align: center;
+  min-width: 14ch;
 `

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -14,7 +14,7 @@ import { useApiState } from 'lib-common/utils/useRestApi'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
-import { H3 } from 'lib-components/typography'
+import { H3, Title } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faChevronLeft, faChevronRight } from 'lib-icons'
@@ -32,6 +32,9 @@ const legendAbsenceTypes: AbsenceType[] = [
   'PARENTLEAVE',
   'FORCE_MAJEURE'
 ]
+
+const formatWeekTitle = (dateRange: FiniteDateRange) =>
+  `${dateRange.start.format('dd.MM.')} - ${dateRange.end.format()}`
 
 interface Props {
   unitId: UUID
@@ -87,11 +90,9 @@ export default React.memo(function UnitAttendanceReservationsView({
                 onClick={() => setSelectedDate(selectedDate.addDays(-7))}
                 size="s"
               />
-              <H3 noMargin>
-                {`${dateRange.start.format(
-                  'dd.MM.'
-                )} - ${dateRange.end.format()}`}
-              </H3>
+              <WeekTitle primary centered>
+                {formatWeekTitle(dateRange)}
+              </WeekTitle>
               <WeekPickerButton
                 icon={faChevronRight}
                 onClick={() => setSelectedDate(selectedDate.addDays(7))}
@@ -147,4 +148,8 @@ const WeekPicker = styled.div`
 const WeekPickerButton = styled(IconButton)`
   margin: 0 ${defaultMargins.s};
   color: ${colors.grayscale.g70};
+`
+
+const WeekTitle = styled(Title)`
+  min-width: 14ch;
 `

--- a/frontend/src/lib-components/typography.ts
+++ b/frontend/src/lib-components/typography.ts
@@ -261,12 +261,17 @@ export const Light = styled.span`
   color: ${(p) => p.theme.colors.grayscale.g70};
 `
 
-export const Title = styled.span<{ primary?: boolean }>`
+export const Title = styled.span<{ primary?: boolean; centered?: boolean }>`
   font-family: Montserrat, sans-serif;
-  color: ${(p) =>
-    p.primary ? p.theme.colors.main.m1 : p.theme.colors.grayscale.g100};
   font-size: 20px;
   font-weight: ${fontWeights.semibold};
+  color: ${(p) =>
+    p.primary ? p.theme.colors.main.m1 : p.theme.colors.grayscale.g100};
+  ${(p) =>
+    p.centered &&
+    css`
+      text-align: center;
+    `}
 `
 
 export const BigNumber = styled.span<{ centered?: boolean }>`
@@ -276,11 +281,10 @@ export const BigNumber = styled.span<{ centered?: boolean }>`
   line-height: 73px;
   color: ${(p) => p.theme.colors.main.m1};
   ${(p) =>
-    p.centered
-      ? css`
-          text-align: center;
-        `
-      : ''}
+    p.centered &&
+    css`
+      text-align: center;
+    `}
 `
 
 export const InformationText = styled.span<{ centered?: boolean }>`


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

