### PR TITLE
Use date-fns locale in weekday formatting

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -33,7 +33,7 @@ import {
   faTrash,
   faUserMinus
 } from 'lib-icons'
-import { useTranslation } from '../localization'
+import { useLang, useTranslation } from '../localization'
 import CalendarModal from './CalendarModal'
 import TimeRangeInput, { TimeRange, validateTimeRange } from './TimeRangeInput'
 import { postReservations } from './api'
@@ -109,6 +109,7 @@ export default React.memo(function DayView({
   openAbsenceModal
 }: Props) {
   const i18n = useTranslation()
+  const [lang] = useLang()
 
   const childrenWithReservations = useMemo(
     () => getChildrenWithReservations(date, reservationsResponse),
@@ -161,9 +162,7 @@ export default React.memo(function DayView({
             onClick={navigateToPrevDate}
             disabled={!previousDate}
           />
-          <DayOfWeek>{`${
-            i18n.common.datetime.weekdaysShort[date.getIsoDayOfWeek() - 1]
-          } ${date.format('d.M.yyyy')}`}</DayOfWeek>
+          <DayOfWeek>{date.format('EEEEEE d.M.yyyy', lang)}</DayOfWeek>
           <IconButton
             icon={faChevronRight}
             onClick={navigateToNextDate}

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -331,15 +331,7 @@ export default React.memo(function ReservationModal({
                 ) : null}
                 {includedDays.includes(date.getIsoDayOfWeek()) && (
                   <TimeInputs
-                    label={
-                      <Label>
-                        {`${
-                          i18n.common.datetime.weekdaysShort[
-                            date.getIsoDayOfWeek() - 1
-                          ]
-                        } ${date.format('d.M.')}`}
-                      </Label>
-                    }
+                    label={<Label>{date.format('EEEEEE d.M.', lang)}</Label>}
                     times={
                       formData.irregularTimes[date.formatIso()] ?? [
                         {

--- a/frontend/src/citizen-frontend/calendar/WeekElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/WeekElem.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -15,7 +15,7 @@ import {
 import { fontWeights } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
-import { useTranslation } from '../localization'
+import { useLang, useTranslation } from '../localization'
 import { WeeklyData } from './CalendarListView'
 import { Reservations } from './calendar-elements'
 
@@ -73,7 +73,7 @@ const DayElem = React.memo(function DayElem({
   selectDate,
   dayIsReservable
 }: DayProps) {
-  const i18n = useTranslation()
+  const [lang] = useLang()
   const ref = useRef<HTMLDivElement>()
 
   useEffect(() => {
@@ -100,13 +100,7 @@ const DayElem = React.memo(function DayElem({
       data-qa={`mobile-calendar-day-${dailyReservations.date.formatIso()}`}
     >
       <DayColumn spacing="xxs" inactive={!dayIsReservable(dailyReservations)}>
-        <div>
-          {
-            i18n.common.datetime.weekdaysShort[
-              dailyReservations.date.getIsoDayOfWeek() - 1
-            ]
-          }
-        </div>
+        <div>{dailyReservations.date.format('EEEEEE', lang)}</div>
         <div>{dailyReservations.date.format('d.M.')}</div>
       </DayColumn>
       <div data-qa="reservations">

--- a/frontend/src/employee-frontend/components/absences/AbsenceTable.tsx
+++ b/frontend/src/employee-frontend/components/absences/AbsenceTable.tsx
@@ -20,7 +20,7 @@ import { Cell, CellPart } from '../../types/absence'
 import AgeIndicatorIcon from '../common/AgeIndicatorIcon'
 import AbsenceCell, { DisabledCell } from './AbsenceCell'
 import StaffAttendance from './StaffAttendance'
-import { getMonthDays, getRange, getWeekDay } from './utils'
+import { getMonthDays, getRange } from './utils'
 
 interface AbsenceRowProps {
   absenceChild: AbsenceChild
@@ -195,7 +195,7 @@ const AbsenceTableHead = React.memo(function AbsenceTableHead({
   operationDays,
   reservationEnabled
 }: AbsenceHeadProps) {
-  const { i18n } = useTranslation()
+  const { i18n, lang } = useTranslation()
   return (
     <thead>
       <tr>
@@ -209,7 +209,7 @@ const AbsenceTableHead = React.memo(function AbsenceTableHead({
                 'absence-header-weekend': item.isWeekend()
               })}
             >
-              <div>{getWeekDay(i18n, item)}</div>
+              <div>{item.format('EEEEEE', lang)}</div>
               <div>{item.getDate()}</div>
             </th>
           ) : (

--- a/frontend/src/employee-frontend/components/absences/utils.ts
+++ b/frontend/src/employee-frontend/components/absences/utils.ts
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import LocalDate from 'lib-common/local-date'
-import { Translations } from 'lib-customizations/employee'
-import { DayOfWeek } from '../../types'
 
 export function getRange(num: number) {
   const nums = []
@@ -14,14 +12,6 @@ export function getRange(num: number) {
     i++
   }
   return nums
-}
-
-export function dateIsDayOfWeek(date: LocalDate, dayOfWeek: DayOfWeek) {
-  return date.getIsoDayOfWeek() == dayOfWeek
-}
-
-export function getWeekDay(i18n: Translations, date: LocalDate) {
-  return i18n.datePicker.weekdaysShort[date.getIsoDayOfWeek() - 1]
 }
 
 export function getMonthDays(date: LocalDate): LocalDate[] {

--- a/frontend/src/employee-frontend/components/invoice/AbsencesModal.tsx
+++ b/frontend/src/employee-frontend/components/invoice/AbsencesModal.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -17,7 +17,7 @@ import { getAbsencesByChild } from '../../api/invoicing'
 import PeriodPicker from '../../components/absences/PeriodPicker'
 import ColorInfoItem from '../../components/common/ColorInfoItem'
 import Tooltip from '../../components/common/Tooltip'
-import { Translations, useTranslation } from '../../state/i18n'
+import { Lang, Translations, useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
 import { AbsenceTypes, billableCareTypes } from '../../types/absence'
 import { formatName } from '../../utils'
@@ -60,7 +60,7 @@ interface Props {
 }
 
 export default React.memo(function AbsencesModal({ child, date }: Props) {
-  const { i18n } = useTranslation()
+  const { i18n, lang } = useTranslation()
   const { clearUiMode } = useContext(UIContext)
   const [selectedDate, setSelectedDate] = useState<LocalDate>(date)
   const [absences] = useApiState(
@@ -112,7 +112,7 @@ export default React.memo(function AbsencesModal({ child, date }: Props) {
                         absences,
                         absenceType,
                         'free',
-                        i18n
+                        lang
                       )}
                       place="left"
                       className="absence-tooltip"
@@ -128,7 +128,7 @@ export default React.memo(function AbsencesModal({ child, date }: Props) {
                         absences,
                         absenceType,
                         'paid',
-                        i18n
+                        lang
                       )}
                       place="right"
                       className="absence-tooltip"
@@ -173,7 +173,7 @@ function createTooltipText(
   absences: Absence[],
   absenceType: AbsenceType,
   type: 'free' | 'paid',
-  i18n: Translations
+  lang: Lang
 ) {
   const absencesList = absences
     .filter((abs: Absence) => abs.absenceType === absenceType)
@@ -182,11 +182,6 @@ function createTooltipText(
         ? billableCareTypes.includes(abs.careType)
         : !billableCareTypes.includes(abs.careType)
     })
-    .map(
-      (abs: Absence) =>
-        `${
-          i18n.datePicker.weekdaysShort[abs.date.getIsoDayOfWeek() - 1]
-        } ${abs.date.format()}`
-    )
+    .map(({ date }) => date.format('EEEEEE dd.MM.yyyy', lang))
   return absencesList.join('<br />')
 }

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
@@ -286,15 +286,7 @@ export default React.memo(function ReservationModalSingleChild({
                 ) : null}
                 {includedDays.includes(date.getIsoDayOfWeek()) && (
                   <TimeInputs
-                    label={
-                      <Label>
-                        {`${
-                          i18n.common.datetime.weekdaysShort[
-                            date.getIsoDayOfWeek() - 1
-                          ]
-                        } ${date.format('d.M.')}`}
-                      </Label>
-                    }
+                    label={<Label>{date.format('EEEEEE d.M.', lang)}</Label>}
                     times={
                       formData.irregularTimes[date.formatIso()] ?? [
                         {

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
@@ -34,7 +34,7 @@ export default React.memo(function ReservationsTable({
   onMakeReservationForChild,
   selectedDate
 }: Props) {
-  const { i18n } = useTranslation()
+  const { i18n, lang } = useTranslation()
 
   return (
     <Table>
@@ -49,9 +49,7 @@ export default React.memo(function ReservationsTable({
               highlight={date.isToday()}
             >
               <Date centered highlight={date.isToday()}>
-                {`${
-                  i18n.datePicker.weekdaysShort[date.getIsoDayOfWeek() - 1]
-                } ${date.format('dd.MM.')}`}
+                {date.format('EEEEEE dd.MM.', lang)}
               </Date>
               <DayHeader>
                 <span>{i18n.unit.attendanceReservations.startTime}</span>

--- a/frontend/src/lib-common/local-date.ts
+++ b/frontend/src/lib-common/local-date.ts
@@ -28,12 +28,13 @@ import {
   startOfWeek,
   getISOWeek
 } from 'date-fns'
-import { DateFormat, formatDate } from './date'
+import { DateFormat, DateFormatWithWeekday, formatDate } from './date'
 import { isAutomatedTest, mockNow } from './utils/helpers'
 
 const isoPattern = /^([0-9]+)-([0-9]+)-([0-9]+)$/
 const fiPattern = /^(\d{2})\.(\d{2})\.(\d{4})$/
 
+type Lang = 'fi' | 'sv' | 'en'
 export default class LocalDate {
   private constructor(
     readonly year: number,
@@ -142,8 +143,12 @@ export default class LocalDate {
   differenceInDays(other: LocalDate): number {
     return differenceInDays(this.toSystemTzDate(), other.toSystemTzDate())
   }
-  format(pattern?: DateFormat): string {
-    return formatDate(this.toSystemTzDate(), pattern)
+  format<T extends DateFormat | DateFormatWithWeekday>(
+    ...params: T extends DateFormatWithWeekday
+      ? [DateFormatWithWeekday, Lang]
+      : [DateFormat?]
+  ): string {
+    return formatDate(this.toSystemTzDate(), ...params)
   }
   /**
    * <a href="https://date-fns.org/docs/format">date-fns format()</a>


### PR DESCRIPTION
#### Summary

Use date-fns locales when formatting dates with week days.

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

