### PR TITLE
Fix time input right border cut off

### DIFF
--- a/frontend/src/lib-components/atoms/form/TimeInput.tsx
+++ b/frontend/src/lib-components/atoms/form/TimeInput.tsx
@@ -51,6 +51,6 @@ function onFocus(event: React.FocusEvent<HTMLInputElement>) {
 }
 
 const ShorterInput = styled(InputField)`
-  width: calc(2.6em + 24px);
-  max-width: calc(2.6em + 24px);
+  width: calc(2.8em + 24px);
+  max-width: calc(2.8em + 24px);
 `


### PR DESCRIPTION
#### Summary

Make room so that the right edge of wide numbers fits in the time input read view

<img width="483" alt="Screenshot 2022-02-01 at 8 54 07" src="https://user-images.githubusercontent.com/158767/151925162-6c53c3d6-8847-4802-875b-06a094be2700.png">

