### PR TITLE
Fix reservation operational day check

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -300,7 +300,7 @@ private fun Database.Transaction.insertValidReservations(userId: UUID, requests:
         WHERE 
             pl.child_id = :childId AND 
             daterange(pl.start_date, pl.end_date, '[]') @> :date AND 
-            extract(DOW FROM :date) = ANY(d.operation_days) AND 
+            extract(isodow FROM :date) = ANY(d.operation_days) AND
             (d.round_the_clock OR NOT EXISTS(SELECT 1 FROM holiday h WHERE h.date = :date)) AND
             NOT EXISTS(SELECT 1 FROM absence ab WHERE ab.child_id = :childId AND ab.date = :date)
         ON CONFLICT DO NOTHING;

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -293,7 +293,7 @@ private fun Database.Transaction.insertValidReservations(userId: PersonId, reque
         WHERE 
             pl.child_id = :childId AND 
             daterange(pl.start_date, pl.end_date, '[]') @> :date AND 
-            extract(DOW FROM :date) = ANY(d.operation_days) AND 
+            extract(isodow FROM :date) = ANY(d.operation_days) AND
             (d.round_the_clock OR NOT EXISTS(SELECT 1 FROM holiday h WHERE h.date = :date)) AND
             NOT EXISTS(SELECT 1 FROM absence ab WHERE ab.child_id = :childId AND ab.date = :date)
         ON CONFLICT DO NOTHING;


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Use ISO day of week when doing operational day checks in reservations. In practice makes Sunday reservable.

