### PR TITLE
Update group table service needs

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { Action } from 'lib-common/generated/action'
 import { UnitBackupCare } from 'lib-common/generated/api-types/backupcare'
+import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import PlacementCircle from 'lib-components/atoms/PlacementCircle'
 import Title from 'lib-components/atoms/Title'
@@ -72,8 +73,8 @@ function renderMissingGroupPlacementRow(
               featureFlags.groupsTableServiceNeedsEnabled
                 ? serviceNeeds
                     .filter((sn) =>
-                      gap.overlaps(
-                        new FiniteDateRange(sn.startDate, sn.endDate)
+                      new FiniteDateRange(sn.startDate, sn.endDate).includes(
+                        LocalDate.today()
                       )
                     )
                     .map((sn) => sn.option.nameFi)

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
@@ -16,6 +16,7 @@ import {
   ChildDailyNote,
   NotesByGroupResponse
 } from 'lib-common/generated/api-types/note'
+import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { formatPercentage } from 'lib-common/utils/number'
 import { useApiState } from 'lib-common/utils/useRestApi'
@@ -624,14 +625,9 @@ export default React.memo(function Group({
                                   ? placement.serviceNeeds
                                       .filter((sn) =>
                                         new FiniteDateRange(
-                                          placement.startDate,
-                                          placement.endDate
-                                        ).overlaps(
-                                          new FiniteDateRange(
-                                            sn.startDate,
-                                            sn.endDate
-                                          )
-                                        )
+                                          sn.startDate,
+                                          sn.endDate
+                                        ).includes(LocalDate.today())
                                       )
                                       .map((sn) => sn.option.nameFi)
                                       .join(' / ')


### PR DESCRIPTION
#### Summary

Show only current service need in group tables.

Note: This doesn't affect Espoo because `groupsTableServiceNeedsEnabled` feature flag is false.