### PR TITLE
Refactor reservation model

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -13,6 +13,7 @@ import {
   ReservationsResponse
 } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
+import { validateTimeRange } from 'lib-common/reservations'
 import { UUID } from 'lib-common/types'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
@@ -35,7 +36,7 @@ import {
 } from 'lib-icons'
 import { useLang, useTranslation } from '../localization'
 import CalendarModal from './CalendarModal'
-import TimeRangeInput, { TimeRange, validateTimeRange } from './TimeRangeInput'
+import TimeRangeInput, { TimeRangeWithErrors } from './TimeRangeInput'
 import { postReservations } from './api'
 
 interface Props {
@@ -261,10 +262,10 @@ export default React.memo(function DayView({
 
 type EditorState = {
   child: ReservationChild
-  reservations: TimeRange[]
+  reservations: TimeRangeWithErrors[]
 }
 
-const emptyReservation: TimeRange = {
+const emptyReservation: TimeRangeWithErrors = {
   startTime: '',
   endTime: '',
   errors: { startTime: undefined, endTime: undefined }
@@ -273,7 +274,7 @@ const emptyReservation: TimeRange = {
 function reservationToTimeRange({
   startTime,
   endTime
-}: Reservation): TimeRange {
+}: Reservation): TimeRangeWithErrors {
   return { ...emptyReservation, startTime, endTime }
 }
 
@@ -319,7 +320,7 @@ function useEditState(
                   ...childState,
                   reservations: childState.reservations.map((timeRange, i) =>
                     index === i
-                      ? validateTimeRange({
+                      ? addTimeRangeValidationErrors({
                           ...timeRange,
                           [field]: value
                         })
@@ -541,6 +542,16 @@ const Reservations = React.memo(function Reservations({
     </NoReservation>
   )
 })
+
+export function addTimeRangeValidationErrors(
+  timeRange: TimeRangeWithErrors
+): TimeRangeWithErrors {
+  return {
+    startTime: timeRange.startTime,
+    endTime: timeRange.endTime,
+    errors: validateTimeRange(timeRange)
+  }
+}
 
 const Content = styled.div<{ highlight: boolean }>`
   background: ${(p) => p.theme.colors.grayscale.g0};

--- a/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
+++ b/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
@@ -3,35 +3,15 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useMemo } from 'react'
-import { ErrorKey, regexp, TIME_REGEXP } from 'lib-common/form-validation'
+import { ErrorKey } from 'lib-common/form-validation'
 import TimeInput from 'lib-components/atoms/form/TimeInput'
 import { errorToInputInfo } from '../input-info-helper'
 import { useTranslation } from '../localization'
 
-export interface TimeRange {
+export interface TimeRangeWithErrors {
   startTime: string
   endTime: string
   errors: { startTime: ErrorKey | undefined; endTime: ErrorKey | undefined }
-}
-
-export function validateTimeRange({
-  startTime,
-  endTime
-}: TimeRange): TimeRange {
-  return {
-    startTime,
-    endTime,
-    errors: {
-      startTime:
-        startTime === '' && endTime !== ''
-          ? 'required'
-          : regexp(startTime, TIME_REGEXP, 'timeFormat'),
-      endTime:
-        startTime === '' && endTime !== ''
-          ? 'required'
-          : regexp(endTime, TIME_REGEXP, 'timeFormat')
-    }
-  }
 }
 
 export default React.memo(function TimeRangeInput({
@@ -39,7 +19,7 @@ export default React.memo(function TimeRangeInput({
   onChange,
   'data-qa': dataQa
 }: {
-  value: TimeRange
+  value: TimeRangeWithErrors
   onChange: (field: 'startTime' | 'endTime') => (value: string) => void
   'data-qa'?: string
 }) {

--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
@@ -35,6 +35,8 @@ const placementStartDate = LocalDate.today().subWeeks(4)
 const placementEndDate = LocalDate.today().addWeeks(4)
 const groupId: UUID = uuidv4()
 
+const mockedTime = LocalDate.of(2022, 1, 31).toSystemTzDate()
+
 beforeEach(async () => {
   await resetDatabase()
 
@@ -77,6 +79,9 @@ beforeEach(async () => {
       endDate: placementEndDate.formatIso()
     })
     .save()
+
+  page = await Page.open({ mockedTime })
+  await employeeLogin(page, unitSupervisor)
 })
 
 const loadUnitCalendarPage = async (): Promise<UnitCalendarPage> => {
@@ -86,11 +91,6 @@ const loadUnitCalendarPage = async (): Promise<UnitCalendarPage> => {
 }
 
 describe('Unit group calendar', () => {
-  beforeEach(async () => {
-    page = await Page.open()
-    await employeeLogin(page, unitSupervisor)
-  })
-
   test('Employee sees row for child', async () => {
     calendarPage = await loadUnitCalendarPage()
     await calendarPage.selectMode('week')
@@ -106,11 +106,6 @@ describe('Unit group calendar', () => {
 })
 
 describe('Unit group calendar for shift care unit', () => {
-  beforeEach(async () => {
-    page = await Page.open()
-    await employeeLogin(page, unitSupervisor)
-  })
-
   test('Employee can add two reservations for day and sees two rows', async () => {
     calendarPage = await loadUnitCalendarPage()
 
@@ -122,13 +117,13 @@ describe('Unit group calendar for shift care unit', () => {
     const startDate = LocalDate.today().startOfWeek()
     await reservationModal.setStartDate(startDate.format())
     await reservationModal.setEndDate(startDate.format())
-    await reservationModal.setStartTime('10:00', 0)
-    await reservationModal.setEndTime('16:00', 0)
+    await reservationModal.setStartTime('00:00', 0)
+    await reservationModal.setEndTime('12:00', 0)
 
     await reservationModal.addNewTimeRow(0)
 
     await reservationModal.setStartTime('20:00', 1)
-    await reservationModal.setEndTime('08:00', 1)
+    await reservationModal.setEndTime('00:00', 1)
 
     await reservationModal.save()
 
@@ -164,22 +159,23 @@ describe('Unit group calendar for shift care unit', () => {
 
     await reservationModal.setStartDate(startDate.format())
     await reservationModal.setEndDate(startDate.format())
-    await reservationModal.setStartTime('10:00', 0)
-    await reservationModal.setEndTime('16:00', 0)
+    await reservationModal.setStartTime('00:00', 0)
+    await reservationModal.setEndTime('12:00', 0)
 
     await reservationModal.addNewTimeRow(0)
 
     await reservationModal.setStartTime('20:00', 1)
-    await reservationModal.setEndTime('08:00', 1)
+    await reservationModal.setEndTime('00:00', 1)
 
     await reservationModal.save()
 
     await waitUntilEqual(() => calendarPage.childRowCount(child1Fixture.id), 2)
 
     const expectedReservations = [
-      ['10:00', '16:00', startDate],
-      ['20:00', '00:00', startDate],
-      ['00:00', '08:00', startDate.addDays(1)]
+      ['00:00', '12:00', startDate],
+      ['20:00', '23:59', startDate],
+      ['00:00', '12:00', startDate.addDays(1)],
+      ['20:00', '23:59', startDate.addDays(1)]
     ]
 
     await Promise.all(

--- a/frontend/src/employee-mobile-frontend/api/attendances.ts
+++ b/frontend/src/employee-mobile-frontend/api/attendances.ts
@@ -191,8 +191,8 @@ export async function deleteAbsenceRange(
 }
 
 function compareByProperty(
-  a: JsonOf<Child>,
-  b: JsonOf<Child>,
+  a: Child,
+  b: Child,
   property: 'firstName' | 'lastName'
 ) {
   if (a[property] < b[property]) {
@@ -209,9 +209,7 @@ function deserializeAttendanceResponse(
 ): AttendanceResponse {
   {
     return {
-      children: [...data.children]
-        .sort((a, b) => compareByProperty(a, b, 'lastName'))
-        .sort((a, b) => compareByProperty(a, b, 'firstName'))
+      children: data.children
         .map((attendanceChild) => {
           return {
             ...attendanceChild,
@@ -233,9 +231,15 @@ function deserializeAttendanceResponse(
               ...note,
               modifiedAt: new Date(note.modifiedAt),
               expires: LocalDate.parseIso(note.expires)
+            })),
+            reservations: attendanceChild.reservations.map((reservation) => ({
+              startTime: new Date(reservation.startTime),
+              endTime: new Date(reservation.endTime)
             }))
           }
-        }),
+        })
+        .sort((a, b) => compareByProperty(a, b, 'lastName'))
+        .sort((a, b) => compareByProperty(a, b, 'firstName')),
       groupNotes: data.groupNotes.map((groupNote) => ({
         ...groupNote,
         modifiedAt: new Date(groupNote.modifiedAt),

--- a/frontend/src/employee-mobile-frontend/components/attendances/AttendanceDailyServiceTimes.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/AttendanceDailyServiceTimes.tsx
@@ -7,6 +7,7 @@ import { DailyServiceTimes } from 'lib-common/api-types/child/common'
 import { AttendanceReservation } from 'lib-common/generated/api-types/attendance'
 import { useTranslation } from '../../state/i18n'
 import { getTodaysServiceTimes } from '../../utils/dailyServiceTimes'
+import { Reservations } from './Reservations'
 import { ServiceTime } from './components'
 
 interface Props {
@@ -24,13 +25,7 @@ export default React.memo(function AttendanceDailyServiceTimes({
   return (
     <ServiceTime>
       {reservations.length > 0 ? (
-        `${
-          reservations.length > 1
-            ? i18n.attendances.serviceTime.reservations
-            : i18n.attendances.serviceTime.reservation
-        } ${reservations
-          .map(({ startTime, endTime }) => `${startTime}-${endTime}`)
-          .join(', ')}`
+        <Reservations i18n={i18n} reservations={reservations} />
       ) : todaysTimes === 'not_set' ? (
         <em>{i18n.attendances.serviceTime.notSet}</em>
       ) : todaysTimes === 'not_today' ? (

--- a/frontend/src/employee-mobile-frontend/components/attendances/ChildListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/ChildListItem.tsx
@@ -20,6 +20,7 @@ import { farStickyNote, farUser, farUsers } from 'lib-icons'
 import { Translations, useTranslation } from '../../state/i18n'
 import { UnitContext } from '../../state/unit'
 import { getTodaysServiceTimes } from '../../utils/dailyServiceTimes'
+import { Reservations } from './Reservations'
 
 const ChildBox = styled.div`
   align-items: center;
@@ -191,13 +192,7 @@ const childReservationInfo = (
   { reservations, dailyServiceTimes }: Child
 ): React.ReactNode => {
   if (reservations.length > 0) {
-    return `${
-      reservations.length > 1
-        ? i18n.attendances.serviceTime.reservationsShort
-        : i18n.attendances.serviceTime.reservationShort
-    } ${reservations
-      .map(({ startTime, endTime }) => `${startTime}-${endTime}`)
-      .join(', ')}`
+    return <Reservations i18n={i18n} reservations={reservations} />
   }
 
   const todaysServiceTime = getTodaysServiceTimes(dailyServiceTimes)

--- a/frontend/src/employee-mobile-frontend/components/attendances/Reservations.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/Reservations.tsx
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React, { Fragment } from 'react'
+import styled from 'styled-components'
+import { formatDate, formatTime } from 'lib-common/date'
+import { AttendanceReservation } from 'lib-common/generated/api-types/attendance'
+import LocalDate from 'lib-common/local-date'
+import { Translations } from '../../state/i18n'
+
+interface Props {
+  i18n: Translations
+  reservations: AttendanceReservation[]
+}
+
+export const Reservations = React.memo(function Reservations({
+  i18n,
+  reservations
+}: Props) {
+  if (reservations.length === 0) {
+    return null
+  }
+
+  const label =
+    reservations.length === 1
+      ? i18n.attendances.serviceTime.reservation
+      : i18n.attendances.serviceTime.reservations
+
+  return (
+    <>
+      <span>{label}:</span>
+      <Whitespace />
+      {reservations.map(({ startTime, endTime }, index) => {
+        const startDatePart = datePart(startTime, i18n)
+        const endDatePart = datePart(endTime, i18n)
+
+        return (
+          <Fragment key={startTime.toISOString()}>
+            {index !== 0 && <Separator />}
+            <span>{formatTime(startTime)}</span>
+            {startDatePart && (
+              <>
+                <Whitespace />
+                <DatePart>{startDatePart}</DatePart>
+              </>
+            )}
+            <Dash />
+            <span>{formatTime(endTime)}</span>
+            {endDatePart && (
+              <>
+                <Whitespace />
+                <DatePart>{endDatePart}</DatePart>
+              </>
+            )}
+          </Fragment>
+        )
+      })}
+    </>
+  )
+})
+
+function datePart(dateTime: Date, i18n: Translations): string | undefined {
+  const localDate = LocalDate.fromSystemTzDate(dateTime)
+  if (localDate.isToday()) {
+    return undefined
+  }
+
+  const datePart = localDate.isEqual(LocalDate.today().addDays(1))
+    ? i18n.attendances.serviceTime.tomorrow
+    : localDate.isEqual(LocalDate.today().subDays(1))
+    ? i18n.attendances.serviceTime.yesterday
+    : formatDate(dateTime, 'd.M.')
+
+  return `(${datePart})`
+}
+
+const Dash = React.memo(function Dash() {
+  return (
+    <>
+      <Whitespace />–<Whitespace />
+    </>
+  )
+})
+
+const Separator = React.memo(function Separator() {
+  return (
+    <>
+      ,<Whitespace />
+    </>
+  )
+})
+
+const DatePart = styled.span`
+  color: ${({ theme }) => theme.colors.grayscale.g35};
+`
+
+const Whitespace = styled.span`
+  ::before {
+    content: ' ';
+  }
+`

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -44,8 +44,8 @@ export interface ArrivalRequest {
 * Generated from fi.espoo.evaka.attendance.AttendanceReservation
 */
 export interface AttendanceReservation {
-  endTime: string
-  startTime: string
+  endTime: Date
+  startTime: Date
 }
 
 /**
@@ -89,7 +89,6 @@ export interface Child {
   lastName: string
   placementType: PlacementType
   preferredName: string | null
-  reservation: AttendanceReservation | null
   reservations: AttendanceReservation[]
   status: AttendanceStatus
   stickyNotes: ChildStickyNote[]

--- a/frontend/src/lib-common/reservations.ts
+++ b/frontend/src/lib-common/reservations.ts
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import FiniteDateRange from './finite-date-range'
+import { ErrorKey, regexp, TIME_REGEXP } from './form-validation'
+import {
+  DailyReservationRequest,
+  TimeRange
+} from './generated/api-types/reservations'
+import LocalDate from './local-date'
+import { UUID } from './types'
+
+export type Repetition = 'DAILY' | 'WEEKLY' | 'IRREGULAR'
+
+export interface ReservationFormData {
+  selectedChildren: UUID[]
+  startDate: string
+  endDate: string
+  repetition: Repetition
+  dailyTimes: TimeRanges
+  weeklyTimes: Array<TimeRanges | undefined>
+  irregularTimes: Record<string, TimeRanges | undefined>
+}
+
+export type TimeRanges = [TimeRange] | [TimeRange, TimeRange]
+
+export interface TimeRangeErrors {
+  startTime: ErrorKey | undefined
+  endTime: ErrorKey | undefined
+}
+
+type ReservationErrors = Partial<
+  Record<
+    keyof Omit<
+      ReservationFormData,
+      'dailyTimes' | 'weeklyTimes' | 'irregularTimes'
+    >,
+    ErrorKey
+  > & {
+    dailyTimes: TimeRangeErrors[]
+  } & {
+    weeklyTimes: Array<TimeRangeErrors[] | undefined>
+  } & {
+    irregularTimes: Record<string, TimeRangeErrors[] | undefined>
+  }
+>
+
+export type ValidationResult =
+  | { errors: ReservationErrors }
+  | { errors: undefined; requestPayload: DailyReservationRequest[] }
+
+export function validateForm(
+  reservableDays: FiniteDateRange | null,
+  formData: ReservationFormData
+): ValidationResult {
+  const errors: ReservationErrors = {}
+
+  if (formData.selectedChildren.length < 1) {
+    errors['selectedChildren'] = 'required'
+  }
+
+  const startDate = LocalDate.parseFiOrNull(formData.startDate)
+  if (startDate === null || reservableDays === null) {
+    errors['startDate'] = 'validDate'
+  } else if (startDate.isBefore(reservableDays.start)) {
+    errors['startDate'] = 'dateTooEarly'
+  }
+
+  const endDate = LocalDate.parseFiOrNull(formData.endDate)
+  if (endDate === null || reservableDays === null) {
+    errors['endDate'] = 'validDate'
+  } else if (startDate && endDate.isBefore(startDate)) {
+    errors['endDate'] = 'dateTooEarly'
+  } else if (endDate.isAfter(reservableDays.end)) {
+    errors['endDate'] = 'dateTooLate'
+  }
+
+  if (formData.repetition === 'DAILY') {
+    errors['dailyTimes'] = formData.dailyTimes.map(validateTimeRange)
+  }
+
+  if (formData.repetition === 'WEEKLY') {
+    errors['weeklyTimes'] = formData.weeklyTimes.map((times) =>
+      times ? times.map(validateTimeRange) : undefined
+    )
+  }
+
+  if (formData.repetition === 'IRREGULAR') {
+    errors['irregularTimes'] = Object.fromEntries(
+      Object.entries(formData.irregularTimes).map(([date, times]) => [
+        date,
+        times ? times.map(validateTimeRange) : undefined
+      ])
+    )
+  }
+
+  if (errorsExist(errors)) {
+    return { errors }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const dateRange = new FiniteDateRange(startDate!, endDate!)
+  const dates = [...dateRange.dates()]
+
+  return {
+    errors: undefined,
+    requestPayload: formData.selectedChildren.flatMap((childId) => {
+      switch (formData.repetition) {
+        case 'DAILY':
+          return dates.map((date) => ({
+            childId,
+            date,
+            reservations: filterEmpty(formData.dailyTimes)
+          }))
+        case 'WEEKLY':
+          return dates.map((date) => ({
+            childId,
+            date,
+            reservations: filterEmpty(
+              formData.weeklyTimes[date.getIsoDayOfWeek() - 1]
+            )
+          }))
+        case 'IRREGULAR':
+          return Object.entries(formData.irregularTimes)
+            .filter(([isoDate]) => {
+              const date = LocalDate.tryParseIso(isoDate)
+              return date && dateRange.includes(date)
+            })
+            .map(([isoDate, times]) => ({
+              childId,
+              date: LocalDate.parseIso(isoDate),
+              reservations: filterEmpty(times)
+            }))
+      }
+    })
+  }
+}
+
+function filterEmpty(times: TimeRanges | undefined) {
+  return times?.filter(({ startTime, endTime }) => startTime && endTime) ?? null
+}
+
+function errorsExist(errors: ReservationErrors): boolean {
+  const {
+    dailyTimes: dailyErrors,
+    weeklyTimes: weeklyErrors,
+    irregularTimes: shiftCareErrors,
+    ...otherErrors
+  } = errors
+
+  for (const error of Object.values(otherErrors)) {
+    if (error) return true
+  }
+
+  if (dailyErrors?.some((error) => error.startTime || error.endTime)) {
+    return true
+  }
+
+  for (const errors of weeklyErrors ?? []) {
+    if (errors?.some((error) => error.startTime || error.endTime)) return true
+  }
+
+  for (const errors of Object.values(shiftCareErrors ?? {})) {
+    if (errors?.some((error) => error.startTime || error.endTime)) return true
+  }
+
+  return false
+}
+
+export function validateTimeRange(timeRange: TimeRange): TimeRangeErrors {
+  let startTime: ErrorKey | undefined
+  if (timeRange.startTime === '' && timeRange.endTime !== '') {
+    startTime = 'timeRequired'
+  }
+  startTime =
+    startTime ?? regexp(timeRange.startTime, TIME_REGEXP, 'timeFormat')
+
+  let endTime: ErrorKey | undefined
+  if (timeRange.endTime === '' && timeRange.startTime !== '') {
+    endTime = 'timeRequired'
+  }
+  endTime = endTime ?? regexp(timeRange.endTime, TIME_REGEXP, 'timeFormat')
+
+  if (
+    !startTime &&
+    !endTime &&
+    timeRange.startTime !== '' &&
+    timeRange.endTime !== '' &&
+    timeRange.endTime !== '00:00' &&
+    timeRange.endTime <= timeRange.startTime
+  ) {
+    endTime = 'timeFormat'
+  }
+
+  return { startTime, endTime }
+}

--- a/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
@@ -150,10 +150,8 @@ export const fi = {
     arrived: 'Saapui',
     departed: 'Lähti',
     serviceTime: {
-      reservation: 'Varaus tänään',
-      reservations: 'Varaukset tänään',
-      reservationShort: 'Varaus',
-      reservationsShort: 'Varaukset',
+      reservation: 'Varaus',
+      reservations: 'Varaukset',
       serviceToday: (start: string, end: string) =>
         `Varhaiskasvatusaika tänään ${start}-${end}`,
       serviceTodayShort: (start: string, end: string) =>
@@ -163,7 +161,9 @@ export const fi = {
       notSet: 'Varhaiskasvatusaikaa ei asetettuna',
       notSetShort: 'Sop.aika puuttuu',
       variableTimes: 'Vaihteleva varhaiskasvatusaika',
-      variableTimesShort: 'Sop.aika vaihtelee'
+      variableTimesShort: 'Sop.aika vaihtelee',
+      yesterday: 'eilen',
+      tomorrow: 'huomenna'
     },
     notes: {
       day: 'Päivä',

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
@@ -47,10 +47,7 @@ data class Child(
     val stickyNotes: List<ChildStickyNote>,
     val imageUrl: String?,
     val reservations: List<AttendanceReservation>
-) {
-    // Added for backwards compatibility. Remove when employee mobile clients are guaranteed to be recent enough.
-    val reservation = reservations.firstOrNull()
-}
+)
 
 enum class AttendanceStatus {
     COMING, PRESENT, DEPARTED, ABSENT
@@ -73,4 +70,4 @@ data class ChildAbsence(
     val category: AbsenceCategory
 )
 
-data class AttendanceReservation(val startTime: String, val endTime: String)
+data class AttendanceReservation(val startTime: HelsinkiDateTime, val endTime: HelsinkiDateTime)

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -427,7 +427,7 @@ private fun Database.Read.getAttendancesResponse(unitId: DaycareId, instant: Hel
     val childrenBasics = fetchChildrenBasics(unitId, instant)
     val dailyNotesForChildrenInUnit = getChildDailyNotesInUnit(unitId)
     val stickyNotesForChildrenInUnit = getChildStickyNotesForUnit(unitId)
-    val attendanceReservations = fetchAttendanceReservations(unitId, instant.toLocalDate())
+    val attendanceReservations = fetchAttendanceReservations(unitId, instant)
 
     val children = childrenBasics.map { child ->
         val placementBasics = ChildPlacementBasics(child.placementType, child.dateOfBirth)
@@ -450,7 +450,7 @@ private fun Database.Read.getAttendancesResponse(unitId: DaycareId, instant: Hel
             dailyNote = dailyNote,
             stickyNotes = stickyNotes,
             imageUrl = child.imageUrl,
-            reservations = attendanceReservations[child.id] ?: listOf()
+            reservations = attendanceReservations[child.id] ?.sortedBy { it.startTime } ?: listOf()
         )
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -336,25 +336,30 @@ fun Database.Transaction.deleteAbsencesByFiniteDateRange(childId: ChildId, dateR
 
 fun Database.Read.fetchAttendanceReservations(
     unitId: DaycareId,
-    date: LocalDate
+    now: HelsinkiDateTime
 ): Map<ChildId, List<AttendanceReservation>> = createQuery(
     """
     SELECT
         child.id AS child_id,
-        to_char(res.start_time, 'HH24:MI') AS start_time,
-        to_char(res.end_time, 'HH24:MI') AS end_time
+        coalesce(real_start.date, res.date) AS start_date,
+        coalesce(real_start.start_time, res.start_time) AS start_time,
+        coalesce(real_end.date, res.date) AS end_date,
+        coalesce(real_end.end_time, res.end_time) AS end_time
     FROM attendance_reservation res
     JOIN person child ON res.child_id = child.id
     JOIN placement ON child.id = placement.child_id AND res.date BETWEEN placement.start_date AND placement.end_date
+    LEFT JOIN attendance_reservation real_start ON res.start_time = '00:00'::time AND res.child_id = real_start.child_id AND real_start.end_time = '23:59'::time AND res.date = real_start.date + 1
+    LEFT JOIN attendance_reservation real_end ON res.end_time = '23:59'::time AND res.child_id = real_end.child_id AND real_end.start_time = '00:00'::time AND res.date = real_end.date - 1
     WHERE res.date = :date AND placement.unit_id = :unitId
     """.trimIndent()
 )
     .bind("unitId", unitId)
-    .bind("date", date)
+    .bind("date", now.toLocalDate())
+    .bind("time", now.toLocalTime())
     .map { ctx ->
         ctx.mapColumn<ChildId>("child_id") to AttendanceReservation(
-            ctx.mapColumn("start_time"),
-            ctx.mapColumn("end_time")
+            HelsinkiDateTime.of(ctx.mapColumn("start_date"), ctx.mapColumn("start_time")),
+            HelsinkiDateTime.of(ctx.mapColumn("end_date"), ctx.mapColumn("end_time"))
         )
     }
     .groupBy { (childId, _) -> childId }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -341,12 +341,12 @@ fun Database.Read.fetchAttendanceReservations(
     """
     SELECT
         child.id AS child_id,
-        to_char((res.start_time AT TIME ZONE 'Europe/Helsinki')::time, 'HH24:MI') AS start_time,
-        to_char((res.end_time AT TIME ZONE 'Europe/Helsinki')::time, 'HH24:MI') AS end_time
+        to_char(res.start_time, 'HH24:MI') AS start_time,
+        to_char(res.end_time, 'HH24:MI') AS end_time
     FROM attendance_reservation res
     JOIN person child ON res.child_id = child.id
-    JOIN placement ON child.id = placement.child_id AND res.start_date BETWEEN placement.start_date AND placement.end_date
-    WHERE res.start_date = :date AND placement.unit_id = :unitId
+    JOIN placement ON child.id = placement.child_id AND res.date BETWEEN placement.start_date AND placement.end_date
+    WHERE res.date = :date AND placement.unit_id = :unitId
     """.trimIndent()
 )
     .bind("unitId", unitId)

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -93,7 +93,7 @@ class AttendanceReservationController(private val ac: AccessControl) {
             ac.requirePermissionFor(user, Action.Child.CREATE_ATTENDANCE_RESERVATION, childId)
         }
 
-        db.connect { dbc -> dbc.transaction { createReservationsAsEmployee(it, user.id, body) } }
+        db.connect { dbc -> dbc.transaction { createReservationsAsEmployee(it, user.id, body.validate()) } }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -196,11 +196,11 @@ LEFT JOIN LATERAL (
     SELECT
         jsonb_agg(
             jsonb_build_object(
-                'startTime', to_char((ar.start_time AT TIME ZONE 'Europe/Helsinki')::time, 'HH24:MI'),
-                'endTime', to_char((ar.end_time AT TIME ZONE 'Europe/Helsinki')::time, 'HH24:MI')
+                'startTime', to_char(ar.start_time, 'HH24:MI'),
+                'endTime', to_char(ar.end_time, 'HH24:MI')
             ) ORDER BY ar.start_time ASC
         ) AS reservations
-    FROM attendance_reservation ar WHERE ar.child_id = g.child_id AND ar.start_date = t::date
+    FROM attendance_reservation ar WHERE ar.child_id = g.child_id AND ar.date = t::date
 ) ar ON true
 LEFT JOIN LATERAL (
     SELECT a.absence_type FROM absence a WHERE a.child_id = g.child_id AND a.date = t::date LIMIT 1
@@ -284,8 +284,8 @@ fun createReservationsAsCitizen(tx: Database.Transaction, userId: PersonId, rese
 private fun Database.Transaction.insertValidReservations(userId: PersonId, requests: List<DailyReservationRequest>) {
     val batch = prepareBatch(
         """
-        INSERT INTO attendance_reservation (child_id, start_time, end_time, created_by)
-        SELECT :childId, :start, :end, :userId
+        INSERT INTO attendance_reservation (child_id, date, start_time, end_time, created_by)
+        SELECT :childId, :date, :start, :end, :userId
         FROM placement pl
         LEFT JOIN backup_care bc ON daterange(bc.start_date, bc.end_date, '[]') @> :date AND bc.child_id = :childId
         JOIN daycare d ON d.id = coalesce(bc.unit_id, pl.unit_id) AND 'RESERVATIONS' = ANY(d.enabled_pilot_features)
@@ -302,19 +302,12 @@ private fun Database.Transaction.insertValidReservations(userId: PersonId, reque
 
     requests.forEach { request ->
         request.reservations?.forEach { res ->
-            val start = HelsinkiDateTime.of(
-                date = request.date,
-                time = res.startTime
-            )
-            val end = HelsinkiDateTime.of(
-                date = if (res.endTime.isAfter(res.startTime)) request.date else request.date.plusDays(1),
-                time = res.endTime
-            )
             batch
                 .bind("userId", userId)
                 .bind("childId", request.childId)
-                .bind("start", start)
-                .bind("end", end)
+                .bind("date", request.date)
+                .bind("start", res.startTime)
+                .bind("end", res.endTime)
                 .bind("date", request.date)
                 .add()
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -88,10 +88,7 @@ class ReservationControllerCitizen(
         db.connect { dbc ->
             dbc.transaction { tx ->
                 val reservableDays = getReservableDays(HelsinkiDateTime.now(), featureConfig.citizenReservationThresholdHours)
-                if (body.any { !reservableDays.includes(it.date) }) {
-                    throw BadRequest("Some days are not reservable", "NON_RESERVABLE_DAYS")
-                }
-                createReservationsAsCitizen(tx, PersonId(user.id), body)
+                createReservationsAsCitizen(tx, PersonId(user.id), body.validate(reservableDays))
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -6,6 +6,8 @@ package fi.espoo.evaka.reservations
 
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -15,10 +17,31 @@ data class DailyReservationRequest(
     val reservations: List<TimeRange>?
 )
 
+fun List<DailyReservationRequest>.validate(reservableDates: FiniteDateRange? = null): List<DailyReservationRequest> {
+    if (reservableDates != null && this.any { !reservableDates.includes(it.date) }) {
+        throw BadRequest("Some days are not reservable", "NON_RESERVABLE_DAYS")
+    }
+
+    return this.map {
+        it.copy(reservations = it.reservations?.map(::convertMidnightEndTime)?.onEach(::validateReservationTimeRange))
+    }
+}
+
 data class TimeRange(
     val startTime: LocalTime,
     val endTime: LocalTime,
 )
+
+fun validateReservationTimeRange(timeRange: TimeRange) {
+    if (timeRange.endTime <= timeRange.startTime) {
+        throw BadRequest("Reservation start (${timeRange.startTime}) must be before end (${timeRange.endTime})")
+    }
+}
+
+fun convertMidnightEndTime(timeRange: TimeRange) =
+    if (timeRange.endTime == LocalTime.of(0, 0).withNano(0).withSecond(0))
+        timeRange.copy(endTime = LocalTime.of(23, 59))
+    else timeRange
 
 fun Database.Transaction.clearOldAbsences(childDatePairs: List<Pair<ChildId, LocalDate>>) {
     val batch = prepareBatch(

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -33,12 +33,7 @@ fun Database.Transaction.clearOldAbsences(childDatePairs: List<Pair<ChildId, Loc
 }
 
 fun Database.Transaction.clearOldReservations(reservations: List<Pair<ChildId, LocalDate>>) {
-    val batch = prepareBatch(
-        """
-        DELETE FROM attendance_reservation 
-        WHERE child_id = :childId AND start_date = :date
-        """.trimIndent()
-    )
+    val batch = prepareBatch("DELETE FROM attendance_reservation WHERE child_id = :childId AND date = :date")
 
     reservations.forEach { (childId, date) ->
         batch

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -70,6 +70,7 @@ import org.postgresql.util.PGobject
 import org.springframework.core.io.ClassPathResource
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 
 private val logger = KotlinLogging.logger { }
@@ -1060,16 +1061,17 @@ RETURNING id
 data class DevReservation(
     val id: AttendanceReservationId = AttendanceReservationId(UUID.randomUUID()),
     val childId: ChildId,
-    val startTime: HelsinkiDateTime,
-    val endTime: HelsinkiDateTime,
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
     val createdBy: EvakaUserId
 )
 
 fun Database.Transaction.insertTestReservation(reservation: DevReservation) = insertTestDataRow(
     reservation,
     """
-INSERT INTO attendance_reservation (id, child_id, start_time, end_time, created_by)
-VALUES (:id, :childId, :startTime, :endTime, :createdBy)
+INSERT INTO attendance_reservation (id, child_id, date, start_time, end_time, created_by)
+VALUES (:id, :childId, :date, :startTime, :endTime, :createdBy)
 RETURNING id
 """
 ).let(::AttendanceReservationId)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
@@ -168,4 +168,9 @@ data class HelsinkiDateTimeRange(val start: HelsinkiDateTime, val end: HelsinkiD
             val end = minOf(this.end, other.end)
             HelsinkiDateTimeRange(start, end)
         } else null
+
+    companion object {
+        fun of(date: LocalDate, startTime: LocalTime, endTime: LocalTime) =
+            HelsinkiDateTimeRange(HelsinkiDateTime.of(date, startTime), HelsinkiDateTime.of(date, endTime))
+    }
 }

--- a/service/src/main/resources/db/migration/V205__single_date_reservations.sql
+++ b/service/src/main/resources/db/migration/V205__single_date_reservations.sql
@@ -1,0 +1,42 @@
+ALTER TABLE attendance_reservation
+    ADD COLUMN date date,
+    ADD COLUMN start_time_2 time,
+    ADD COLUMN end_time_2 time;
+
+ALTER TABLE attendance_reservation DROP CONSTRAINT attendance_reservation_no_overlap;
+
+UPDATE attendance_reservation SET date = (start_time AT TIME ZONE 'Europe/Helsinki')::date;
+UPDATE attendance_reservation SET start_time_2 = (start_time AT TIME ZONE 'Europe/Helsinki')::time;
+-- Just use old end time when its date is the same as start time's
+UPDATE attendance_reservation SET end_time_2 = (end_time AT TIME ZONE 'Europe/Helsinki')::time
+WHERE (end_time AT TIME ZONE 'Europe/Helsinki')::date = (start_time AT TIME ZONE 'Europe/Helsinki')::date;
+-- Split reservations into two when end time is on another date compared to start time
+UPDATE attendance_reservation SET end_time_2 = '23:59'::time
+WHERE (end_time AT TIME ZONE 'Europe/Helsinki')::date != (start_time AT TIME ZONE 'Europe/Helsinki')::date;
+INSERT INTO attendance_reservation (created, updated, child_id, start_time, end_time, created_by, date, start_time_2, end_time_2)
+(SELECT
+    created, updated, child_id, start_time, end_time, created_by,
+    (end_time AT TIME ZONE 'Europe/Helsinki')::date AS date,
+    '00:00'::time AS start_time_2,
+    (end_time AT TIME ZONE 'Europe/Helsinki')::time AS end_time_2
+FROM attendance_reservation
+WHERE (end_time AT TIME ZONE 'Europe/Helsinki')::date != (start_time AT TIME ZONE 'Europe/Helsinki')::date
+AND (end_time AT TIME ZONE 'Europe/Helsinki')::time - '00:00'::time > INTERVAL '5 minutes');
+
+ALTER TABLE attendance_reservation
+    DROP COLUMN start_date,
+    DROP COLUMN start_time,
+    DROP COLUMN end_time;
+
+ALTER TABLE attendance_reservation RENAME COLUMN start_time_2 TO start_time;
+ALTER TABLE attendance_reservation RENAME COLUMN end_time_2 TO end_time;
+
+ALTER TABLE attendance_reservation
+    ALTER COLUMN date SET NOT NULL,
+    ALTER COLUMN start_time SET NOT NULL,
+    ALTER COLUMN end_time SET NOT NULL;
+
+ALTER TABLE attendance_reservation ADD CONSTRAINT attendance_reservation_start_before_end CHECK (start_time < end_time);
+ALTER TABLE attendance_reservation ADD CONSTRAINT attendance_reservation_no_overlap EXCLUDE USING gist (child_id WITH =, tsrange(date + start_time, date + end_time) WITH &&);
+CREATE INDEX idx$reservation_child ON attendance_reservation (child_id);
+CREATE INDEX idx$reservation_date_and_times ON attendance_reservation (date, start_time, end_time);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -202,3 +202,4 @@ V201__contract_days_per_month.sql
 V202__absence_type_enum.sql
 V203__absence_category.sql
 V204__holiday_periods.sql
+V205__single_date_reservations.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Refactor reservation modal to only allow single date reservations. This is what users were already doing so it's more intuitive and it makes all kinds of calendar views simpler. Reservations starting at `00:00` or ending at `23:59` are combined with each other in employee mobile so that units that are open around the clock get a better picture of a child's real reservations.

