### PR TITLE
EVAKA-4152 FREE_ABSENCE AbsenceType

### DIFF
--- a/frontend/src/employee-frontend/components/absences/AbsenceLegend.tsx
+++ b/frontend/src/employee-frontend/components/absences/AbsenceLegend.tsx
@@ -21,7 +21,8 @@ const absenceTypesInLegend: CalendarAbsenceType[] = [
   'SICKLEAVE',
   'TEMPORARY_RELOCATION',
   'PARENTLEAVE',
-  'FORCE_MAJEURE'
+  'FORCE_MAJEURE',
+  'FREE_ABSENCE'
 ]
 
 const AbsenceLegendRow = styled.div`

--- a/frontend/src/employee-frontend/components/absences/Absences.tsx
+++ b/frontend/src/employee-frontend/components/absences/Absences.tsx
@@ -364,6 +364,10 @@ const AbsencesPage = styled.div`
       border-top-color: ${absenceColors.FORCE_MAJEURE};
     }
 
+    &-FREE_ABSENCE {
+      border-top-color: ${absenceColors.FREE_ABSENCE};
+    }
+
     &-weekend {
       border-top-color: ${colors.grayscale.g4};
     }
@@ -406,6 +410,10 @@ const AbsencesPage = styled.div`
 
     &-FORCE_MAJEURE {
       border-bottom-color: ${absenceColors.FORCE_MAJEURE};
+    }
+
+    &-FREE_ABSENCE {
+      border-bottom-color: ${absenceColors.FREE_ABSENCE};
     }
 
     &-weekend {

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -47,7 +47,8 @@ const legendAbsenceTypes: AbsenceType[] = [
   'UNKNOWN_ABSENCE',
   'PLANNED_ABSENCE',
   'PARENTLEAVE',
-  'FORCE_MAJEURE'
+  'FORCE_MAJEURE',
+  'FREE_ABSENCE'
 ]
 
 const formatWeekTitle = (dateRange: FiniteDateRange) =>

--- a/frontend/src/employee-frontend/types/absence.ts
+++ b/frontend/src/employee-frontend/types/absence.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -17,7 +17,8 @@ export const AbsenceTypes: AbsenceType[] = [
   'UNKNOWN_ABSENCE',
   'PLANNED_ABSENCE',
   'PARENTLEAVE',
-  'FORCE_MAJEURE'
+  'FORCE_MAJEURE',
+  'FREE_ABSENCE'
 ]
 
 export const defaultAbsenceType = 'SICKLEAVE'

--- a/frontend/src/employee-mobile-frontend/components/attendances/AbsenceSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/AbsenceSelector.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -7,7 +7,16 @@ import { AbsenceType } from 'lib-common/generated/api-types/daycare'
 import { ChipWrapper, ChoiceChip } from 'lib-components/atoms/Chip'
 import { Gap } from 'lib-components/white-space'
 import { useTranslation } from '../../state/i18n'
-import { AbsenceTypes } from '../../types'
+
+const allSelectableAbsenceTypes: AbsenceType[] = [
+  'OTHER_ABSENCE',
+  'SICKLEAVE',
+  'UNKNOWN_ABSENCE',
+  'PLANNED_ABSENCE'
+]
+const selectableAbsenceTypesWithoutUnknown = allSelectableAbsenceTypes.filter(
+  (type) => type !== 'UNKNOWN_ABSENCE'
+)
 
 interface Props {
   selectedAbsenceType: AbsenceType | undefined
@@ -20,16 +29,13 @@ interface Props {
 export default function AbsenceSelector({
   selectedAbsenceType,
   setSelectedAbsenceType,
-  noUnknownAbsences
+  noUnknownAbsences = false
 }: Props) {
   const { i18n } = useTranslation()
 
-  const absenceTypes = AbsenceTypes.filter(
-    (type) =>
-      type !== 'PARENTLEAVE' &&
-      type !== 'FORCE_MAJEURE' &&
-      !(noUnknownAbsences && type === 'UNKNOWN_ABSENCE')
-  )
+  const absenceTypes = noUnknownAbsences
+    ? selectableAbsenceTypesWithoutUnknown
+    : allSelectableAbsenceTypes
 
   return (
     <Fragment>

--- a/frontend/src/employee-mobile-frontend/types/index.ts
+++ b/frontend/src/employee-mobile-frontend/types/index.ts
@@ -1,14 +1,10 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { AttendanceStatus } from 'lib-common/generated/api-types/attendance'
-import {
-  AbsenceCategory,
-  AbsenceType
-} from 'lib-common/generated/api-types/daycare'
+import { AbsenceCategory } from 'lib-common/generated/api-types/daycare'
 import { PlacementType } from 'lib-common/generated/enums'
-import LocalDate from 'lib-common/local-date'
 import { Translations } from '../state/i18n'
 
 export type ChildAttendanceUIState =
@@ -31,15 +27,6 @@ export function mapChildAttendanceUIState(
       return 'ABSENT'
   }
 }
-
-export const AbsenceTypes: AbsenceType[] = [
-  'OTHER_ABSENCE',
-  'SICKLEAVE',
-  'UNKNOWN_ABSENCE',
-  'PLANNED_ABSENCE',
-  'PARENTLEAVE',
-  'FORCE_MAJEURE'
-]
 
 export function formatCategory(
   category: AbsenceCategory,
@@ -84,9 +71,4 @@ export function formatCategory(
     case 'SCHOOL_SHIFT_CARE':
       return i18n.absences.careTypes.SCHOOL_SHIFT_CARE
   }
-}
-
-export interface AbsenceBackupCare {
-  childId: string
-  date: LocalDate
 }

--- a/frontend/src/lib-common/generated/api-types/daycare.ts
+++ b/frontend/src/lib-common/generated/api-types/daycare.ts
@@ -76,6 +76,7 @@ export type AbsenceType =
   | 'PLANNED_ABSENCE'
   | 'PARENTLEAVE'
   | 'FORCE_MAJEURE'
+  | 'FREE_ABSENCE'
 
 /**
 * Generated from fi.espoo.evaka.daycare.service.AbsenceUpsert

--- a/frontend/src/lib-customizations/common.tsx
+++ b/frontend/src/lib-customizations/common.tsx
@@ -33,6 +33,7 @@ export const absenceColors = {
   PLANNED_ABSENCE: status.success,
   PARENTLEAVE: accents.a5orangeLight,
   FORCE_MAJEURE: status.danger,
+  FREE_ABSENCE: accents.a7mint,
   TEMPORARY_RELOCATION: status.warning,
   TEMPORARY_VISITOR: status.warning,
   NO_ABSENCE: accents.a8lightBlue
@@ -45,6 +46,7 @@ export const absenceIcons = {
   PLANNED_ABSENCE: 'P',
   PARENTLEAVE: faBabyCarriage,
   FORCE_MAJEURE: faEuroSign,
+  FREE_ABSENCE: faEuroSign,
   TEMPORARY_RELOCATION: '-',
   TEMPORARY_VISITOR: '-',
   NO_ABSENCE: '-'

--- a/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
@@ -98,6 +98,7 @@ export const fi = {
       TEMPORARY_VISITOR: 'Varalapsi läsnä',
       PARENTLEAVE: 'Isyysvapaa',
       FORCE_MAJEURE: 'Maksuton päivä',
+      FREE_ABSENCE: 'Maksuton poissaolo',
       NO_ABSENCE: 'Ei poissaoloa'
     },
     careTypes: {

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2086,6 +2086,7 @@ export const fi = {
       TEMPORARY_VISITOR: 'Varalapsi läsnä',
       PARENTLEAVE: 'Isyysvapaa',
       FORCE_MAJEURE: 'Maksuton päivä',
+      FREE_ABSENCE: 'Maksuton poissaolo',
       NO_ABSENCE: 'Ei poissaoloa'
     },
     absenceTypesShort: {
@@ -2096,6 +2097,7 @@ export const fi = {
       TEMPORARY_RELOCATION: 'Varasijoitus',
       PARENTLEAVE: 'Isyysvapaa',
       FORCE_MAJEURE: 'Maksuton',
+      FREE_ABSENCE: 'Maksuton',
       NO_ABSENCE: 'Ei poissa'
     },
     careTypes: {
@@ -2132,6 +2134,7 @@ export const fi = {
         TEMPORARY_VISITOR: 'Varalapsi läsnä',
         PARENTLEAVE: 'Isyysvapaa',
         FORCE_MAJEURE: 'Maksuton päivä (rajoitettu käyttö)',
+        FREE_ABSENCE: 'Maksuton poissaolo',
         NO_ABSENCE: 'Ei poissaoloa'
       },
       free: 'Maksuton',

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -245,7 +245,8 @@ enum class AbsenceType : DatabaseEnum {
     UNKNOWN_ABSENCE,
     PLANNED_ABSENCE,
     PARENTLEAVE,
-    FORCE_MAJEURE;
+    FORCE_MAJEURE,
+    FREE_ABSENCE;
 
     override val sqlType: String = "absence_type"
 }

--- a/service/src/main/resources/db/migration/V206__free_absence_type.sql
+++ b/service/src/main/resources/db/migration/V206__free_absence_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE absence_type ADD VALUE 'FREE_ABSENCE';

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -203,3 +203,4 @@ V202__absence_type_enum.sql
 V203__absence_category.sql
 V204__holiday_periods.sql
 V205__single_date_reservations.sql
+V206__free_absence_type.sql


### PR DESCRIPTION
#### Summary

Add `FREE_ABSENCE` absence type to be used with free summer holiday periods. Currently it works just like `FORCE_MAJEURE`.
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

