### PR TITLE
Minor week calendar fixes

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -299,7 +299,6 @@ private fun toChildDayRows(rows: List<UnitAttendanceReservations.QueryRow>, serv
                 )
             )
         }
-        .sortedBy { "${it.child.firstName} ${it.child.lastName}" }
 }
 
 fun createReservationsAsEmployee(tx: Database.Transaction, userId: UUID, reservations: List<DailyReservationRequest>) {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- sort in frontend instead of backend. There's no big advantage in sorting in backend. It's clearer to have the sort order close to the place where data is shown instead of making the sort order a "hidden" part of the API contract
- sort by last+first name
- format in last+first format
- show only one first name, so week/month calendar views are more consistent