### PR TITLE
Remove default role mappings

### DIFF
--- a/frontend/src/e2e-test/specs/8_access/access.spec.ts
+++ b/frontend/src/e2e-test/specs/8_access/access.spec.ts
@@ -173,7 +173,7 @@ describe('Child information page sections', () => {
       backupCares: true,
       familyContacts: false,
       applications: true,
-      messageBlocklist: false,
+      messageBlocklist: true,
       dailyServiceTimes: true,
       vasuAndLeops: false,
       pedagogicalDocuments: false
@@ -194,7 +194,7 @@ describe('Child information page sections', () => {
       backupCares: true,
       familyContacts: false,
       applications: false,
-      messageBlocklist: false,
+      messageBlocklist: true,
       dailyServiceTimes: true,
       vasuAndLeops: false,
       pedagogicalDocuments: false
@@ -215,7 +215,7 @@ describe('Child information page sections', () => {
       backupCares: true,
       familyContacts: true,
       applications: false,
-      messageBlocklist: false,
+      messageBlocklist: true,
       dailyServiceTimes: true,
       vasuAndLeops: false,
       pedagogicalDocuments: true
@@ -238,7 +238,7 @@ describe('Child information page sections', () => {
       backupCares: true,
       familyContacts: true,
       applications: false,
-      messageBlocklist: false,
+      messageBlocklist: true,
       dailyServiceTimes: true,
       vasuAndLeops: true,
       pedagogicalDocuments: true
@@ -262,7 +262,7 @@ describe('Child information page sections', () => {
       backupCares: true,
       familyContacts: true,
       applications: false,
-      messageBlocklist: false,
+      messageBlocklist: true,
       dailyServiceTimes: true,
       vasuAndLeops: true,
       pedagogicalDocuments: true

--- a/frontend/src/employee-frontend/components/ChildInformation.tsx
+++ b/frontend/src/employee-frontend/components/ChildInformation.tsx
@@ -157,7 +157,18 @@ const layouts: Layouts<typeof components> = {
     { component: 'daily-service-times', open: false },
     { component: 'assistance', open: false },
     { component: 'applications', open: false },
-    { component: 'family-contacts', open: false }
+    { component: 'family-contacts', open: false },
+
+    { component: 'message-blocklist', open: false },
+    { component: 'vasuAndLeops' as keyof typeof components, open: false },
+    {
+      component: 'pedagogicalDocuments' as keyof typeof components,
+      open: false
+    },
+    ...(featureFlags.childIncomeEnabled
+      ? [{ component: 'income' as const, open: false }]
+      : []),
+    { component: 'fee-alterations', open: false }
   ],
   ['FINANCE_ADMIN']: [
     ...(featureFlags.childIncomeEnabled
@@ -167,7 +178,17 @@ const layouts: Layouts<typeof components> = {
     { component: 'guardiansAndParents', open: false },
     { component: 'placements', open: false },
     { component: 'backup-care', open: false },
-    { component: 'daily-service-times', open: false }
+    { component: 'daily-service-times', open: false },
+
+    { component: 'family-contacts', open: false },
+    { component: 'message-blocklist', open: false },
+    { component: 'vasuAndLeops' as keyof typeof components, open: false },
+    {
+      component: 'pedagogicalDocuments' as keyof typeof components,
+      open: false
+    },
+    { component: 'assistance', open: false },
+    { component: 'applications', open: false }
   ],
   ['UNIT_SUPERVISOR']: [
     { component: 'guardiansAndParents', open: false },
@@ -180,7 +201,14 @@ const layouts: Layouts<typeof components> = {
     {
       component: 'pedagogicalDocuments' as keyof typeof components,
       open: false
-    }
+    },
+
+    { component: 'message-blocklist', open: false },
+    { component: 'applications', open: false },
+    ...(featureFlags.childIncomeEnabled
+      ? [{ component: 'income' as const, open: false }]
+      : []),
+    { component: 'fee-alterations', open: false }
   ],
   ['STAFF']: [
     { component: 'family-contacts', open: true },
@@ -191,7 +219,16 @@ const layouts: Layouts<typeof components> = {
     {
       component: 'pedagogicalDocuments' as keyof typeof components,
       open: false
-    }
+    },
+
+    { component: 'guardiansAndParents', open: false },
+    { component: 'message-blocklist', open: false },
+    { component: 'assistance', open: false },
+    { component: 'applications', open: false },
+    ...(featureFlags.childIncomeEnabled
+      ? [{ component: 'income' as const, open: false }]
+      : []),
+    { component: 'fee-alterations', open: false }
   ],
   ['SPECIAL_EDUCATION_TEACHER']: [
     { component: 'family-contacts', open: true },
@@ -203,7 +240,15 @@ const layouts: Layouts<typeof components> = {
     },
     { component: 'backup-care', open: false },
     { component: 'daily-service-times', open: false },
-    { component: 'assistance', open: false }
+    { component: 'assistance', open: false },
+
+    { component: 'guardiansAndParents', open: false },
+    { component: 'message-blocklist', open: false },
+    { component: 'applications', open: false },
+    ...(featureFlags.childIncomeEnabled
+      ? [{ component: 'income' as const, open: false }]
+      : []),
+    { component: 'fee-alterations', open: false }
   ]
 }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -25,6 +25,8 @@ import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.dev.runDevScript
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
+import fi.espoo.evaka.shared.security.PermittedRoleActions
+import fi.espoo.evaka.shared.security.StaticPermittedRoleActions
 import fi.espoo.evaka.shared.template.EvakaTemplateProvider
 import fi.espoo.evaka.shared.template.ITemplateProvider
 import fi.espoo.voltti.auth.JwtKeys
@@ -154,6 +156,9 @@ class SharedIntegrationTestConfig {
     @Bean
     fun invoiceGenerator(productProvider: InvoiceProductProvider): InvoiceGenerator =
         InvoiceGenerator(DefaultDraftInvoiceGenerator(productProvider))
+
+    @Bean
+    fun permittedRoleActions(): PermittedRoleActions = StaticPermittedRoleActions()
 }
 
 val testFeatureConfig = FeatureConfig(

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -21,6 +21,8 @@ import fi.espoo.evaka.shared.job.DefaultJobSchedule
 import fi.espoo.evaka.shared.job.JobSchedule
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
+import fi.espoo.evaka.shared.security.PermittedRoleActions
+import fi.espoo.evaka.shared.security.StaticPermittedRoleActions
 import fi.espoo.evaka.shared.template.EvakaTemplateProvider
 import fi.espoo.evaka.shared.template.ITemplateProvider
 import org.jdbi.v3.core.Jdbi
@@ -88,6 +90,9 @@ class EspooConfig {
     fun tomcatCustomizer() = WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
         it.setDisableMBeanRegistry(false)
     }
+
+    @Bean
+    fun permittedRoleActions(): PermittedRoleActions = StaticPermittedRoleActions()
 }
 
 data class EspooEnv(val invoiceIntegrationEnabled: Boolean) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/SecurityConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/SecurityConfig.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.shared.config
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.PermittedRoleActions
-import fi.espoo.evaka.shared.security.StaticPermittedRoleActions
 import org.jdbi.v3.core.Jdbi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -16,9 +15,6 @@ import org.springframework.context.annotation.Configuration
 class SecurityConfig {
     @Bean
     fun accessControlList(jdbi: Jdbi): AccessControlList = AccessControlList(jdbi)
-
-    @Bean
-    fun permittedRoleActions(): PermittedRoleActions = StaticPermittedRoleActions()
 
     @Bean
     fun accessControl(permittedRoleActions: PermittedRoleActions, acl: AccessControlList, jdbi: Jdbi): AccessControl =


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

`PermittedRoleActions` must now be provided by city-specific configuration