### PR TITLE
Refactor attendance database model

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
@@ -107,13 +107,6 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
     }
 
     @Test
-    fun `post return to coming - error when departed`() {
-        givenChildPlacement(PlacementType.PRESCHOOL_DAYCARE)
-        givenChildDeparted()
-        returnToComingAssertFail(409)
-    }
-
-    @Test
     fun `get child departure info - preschool daycare placement and present from preschool start`() {
         val arrived = LocalTime.of(9, 0)
         givenChildPlacement(PlacementType.PRESCHOOL_DAYCARE)
@@ -328,27 +321,6 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest() {
         assertNotNull(child.attendance!!.arrived)
         assertNull(child.attendance!!.departed)
         assertTrue(child.absences.isEmpty())
-    }
-
-    @Test
-    fun `post return to present - error when coming`() {
-        givenChildPlacement(PlacementType.PRESCHOOL_DAYCARE)
-        givenChildComing()
-        returnToPresentAssertFail(409)
-    }
-
-    @Test
-    fun `post return to present - error when present`() {
-        givenChildPlacement(PlacementType.PRESCHOOL_DAYCARE)
-        givenChildPresent()
-        returnToPresentAssertFail(409)
-    }
-
-    @Test
-    fun `post return to present - error when absent`() {
-        givenChildPlacement(PlacementType.PRESCHOOL_DAYCARE)
-        givenChildAbsent(AbsenceType.UNKNOWN_ABSENCE, AbsenceCategory.BILLABLE, AbsenceCategory.NONBILLABLE)
-        returnToPresentAssertFail(409)
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
@@ -155,7 +155,7 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
         val child = expectOneChild()
         assertEquals(AttendanceStatus.PRESENT, child.status)
         assertNotNull(child.attendance)
-        assertEquals(arrived, child.attendance!!.arrived)
+        assertEquals(arrived.withTime(arrived.toLocalTime().withSecond(0).withNano(0)), child.attendance!!.arrived)
         assertNull(child.attendance!!.departed)
         assertEquals(0, child.absences.size)
     }
@@ -175,8 +175,8 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
         val child = expectOneChild()
         assertEquals(AttendanceStatus.DEPARTED, child.status)
         assertNotNull(child.attendance)
-        assertEquals(arrived, child.attendance!!.arrived)
-        assertEquals(departed, child.attendance!!.departed)
+        assertEquals(arrived.withTime(arrived.toLocalTime().withSecond(0).withNano(0)), child.attendance!!.arrived)
+        assertEquals(departed.withTime(departed.toLocalTime().withSecond(0).withNano(0)), child.attendance!!.departed)
         assertEquals(0, child.absences.size)
     }
 
@@ -256,7 +256,7 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
         val child = expectOneChild()
         assertEquals(AttendanceStatus.PRESENT, child.status)
         assertNotNull(child.attendance)
-        assertEquals(arrived, child.attendance!!.arrived)
+        assertEquals(arrived.withTime(arrived.toLocalTime().withSecond(0).withNano(0)), child.attendance!!.arrived)
         assertNull(child.attendance!!.departed)
         assertEquals(0, child.absences.size)
     }
@@ -276,8 +276,8 @@ class GetAttendancesIntegrationTest : FullApplicationTest() {
         val child = expectOneChild()
         assertEquals(AttendanceStatus.DEPARTED, child.status)
         assertNotNull(child.attendance)
-        assertEquals(arrived, child.attendance!!.arrived)
-        assertEquals(departed, child.attendance!!.departed)
+        assertEquals(arrived.withTime(arrived.toLocalTime().withSecond(0).withNano(0)), child.attendance!!.arrived)
+        assertEquals(departed.withTime(departed.toLocalTime().withSecond(0).withNano(0)), child.attendance!!.departed)
         assertEquals(0, child.absences.size)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -207,11 +207,11 @@ private fun Database.Read.getAttendanceReservationData(unitId: DaycareId, dateRa
         SELECT
             jsonb_agg(
                 jsonb_build_object(
-                    'startTime', to_char((GREATEST(att.arrived, t) AT TIME ZONE 'Europe/Helsinki')::time, 'HH24:MI'),
-                    'endTime', to_char((LEAST(att.departed, t + INTERVAL '1 day') AT TIME ZONE 'Europe/Helsinki')::time, 'HH24:MI')
-                ) ORDER BY att.arrived ASC
+                    'startTime', to_char(att.start_time, 'HH24:MI'),
+                    'endTime', to_char(att.end_time, 'HH24:MI')
+                ) ORDER BY att.start_time ASC
             ) AS attendances
-        FROM child_attendance att WHERE att.child_id = p.id AND ((att.arrived AT TIME ZONE 'Europe/Helsinki')::date = t::date OR DATE_TRUNC('day', att.departed, 'Europe/Helsinki') = t)
+        FROM child_attendance att WHERE att.child_id = p.id AND att.date = t::date
     ) attendances ON true
     LEFT JOIN LATERAL (
         SELECT

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -205,12 +205,11 @@ LEFT JOIN LATERAL (
     SELECT
         jsonb_agg(
             jsonb_build_object(
-                'startTime', to_char(greatest(ca.arrived AT TIME ZONE 'Europe/Helsinki', t), 'HH24:MI'),
-                'endTime', to_char(least(ca.departed AT TIME ZONE 'Europe/Helsinki', t + interval '1 day' - interval '1 minute'), 'HH24:MI')
-            ) ORDER BY ca.arrived ASC
+                'startTime', to_char(ca.start_time, 'HH24:MI'),
+                'endTime', to_char(ca.end_time, 'HH24:MI')
+            ) ORDER BY ca.start_time ASC
         ) AS attendances
-    FROM child_attendance ca WHERE ca.child_id = g.child_id
-    AND daterange((ca.arrived AT TIME ZONE 'Europe/Helsinki')::date, (ca.departed AT TIME ZONE 'Europe/Helsinki')::date, '[]') @> t::date
+    FROM child_attendance ca WHERE ca.child_id = g.child_id AND ca.date = t::date
 ) ca ON true
 LEFT JOIN LATERAL (
     SELECT a.absence_type FROM absence a WHERE a.child_id = g.child_id AND a.date = t::date LIMIT 1

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -77,9 +77,9 @@ class ScheduledJobs(
                 // language=SQL
                 """
 UPDATE child_attendance ca
-SET departed = ((arrived AT TIME ZONE 'Europe/Helsinki')::date + time '23:59') AT TIME ZONE 'Europe/Helsinki'
+SET end_time = '23:59'::time
 FROM daycare u
-WHERE ca.unit_id = u.id AND NOT u.round_the_clock AND ca.departed IS NULL
+WHERE ca.unit_id = u.id AND NOT u.round_the_clock AND ca.end_time IS NULL
                 """.trimIndent()
             ).execute()
         }

--- a/service/src/main/resources/db/migration/V209__single_date_attendances.sql
+++ b/service/src/main/resources/db/migration/V209__single_date_attendances.sql
@@ -1,0 +1,45 @@
+ALTER TABLE child_attendance
+    ADD COLUMN date date,
+    ADD COLUMN start_time time,
+    ADD COLUMN end_time time DEFAULT NULL;
+
+WITH attendance AS (
+    DELETE FROM child_attendance RETURNING *
+)
+INSERT INTO child_attendance (child_id, arrived, departed, created, updated, unit_id, date, start_time, end_time)
+SELECT child_id, date + start_time, date + end_time, created, updated, unit_id, date, start_time, end_time
+FROM (
+    SELECT
+        child_id, created, updated, unit_id,
+        t::date AS date,
+        date_trunc('minute', (CASE WHEN (arrived AT TIME ZONE 'Europe/Helsinki')::date < t::date THEN '00:00'::time ELSE (arrived AT TIME ZONE 'Europe/Helsinki')::time END))::time AS start_time,
+        date_trunc('minute', (CASE WHEN (departed AT TIME ZONE 'Europe/Helsinki')::date > t::date THEN '23:59'::time ELSE (departed AT TIME ZONE 'Europe/Helsinki')::time END))::time AS end_time
+    FROM attendance
+    JOIN LATERAL (SELECT generate_series(arrived::date, departed::date, '1 day') t) t ON true
+    WHERE departed IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        child_id, created, updated, unit_id,
+        (arrived AT TIME ZONE 'Europe/Helsinki')::date,
+        (arrived AT TIME ZONE 'Europe/Helsinki')::time,
+        NULL
+    FROM attendance
+    WHERE departed IS NULL
+) a;
+
+ALTER TABLE child_attendance
+    DROP CONSTRAINT child_attendance_no_overlaps,
+    DROP COLUMN arrived,
+    DROP COLUMN departed;
+
+ALTER TABLE child_attendance
+    ALTER COLUMN date SET NOT NULL,
+    ALTER COLUMN start_time SET NOT NULL;
+
+ALTER TABLE child_attendance ADD CONSTRAINT child_attendance_time_resolution CHECK (EXTRACT(SECOND FROM start_time) = 0 AND EXTRACT(SECOND FROM end_time) = 0);
+ALTER TABLE child_attendance ADD CONSTRAINT child_attendance_start_before_end CHECK (start_time < end_time);
+ALTER TABLE child_attendance ADD CONSTRAINT child_attendance_no_overlap EXCLUDE USING gist (child_id WITH =, tsrange(date + start_time, date + end_time) WITH &&);
+CREATE INDEX idx$attendance_child ON child_attendance (child_id);
+CREATE INDEX idx$attendance_date_and_times ON child_attendance (date, start_time, end_time);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -206,3 +206,4 @@ V205__single_date_reservations.sql
 V206__free_absence_type.sql
 V207__free_holiday_period.sql
 V208__child_income_type.sql
+V209__single_date_attendances.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Split longer attendances by date. Employee mobile should work more or less like it used to. One difference is that departed children that arrived two days before are shown to have arrived the day before at 00:00 in the child's profile because finding the real arrival time in sql was not trivial for me.


