### PR TITLE
EVAKA-4162 Add optional free period to holiday period

### DIFF
--- a/frontend/src/e2e-test/pages/employee/holiday-periods.ts
+++ b/frontend/src/e2e-test/pages/employee/holiday-periods.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { DatePicker, Page, TextInput } from '../../utils/page'
+import { Checkbox, DatePicker, Page, TextInput } from '../../utils/page'
 
 export class HolidayPeriodsPage {
   constructor(private readonly page: Page) {}
@@ -46,6 +46,18 @@ export class HolidayPeriodsPage {
     ),
     descriptionLinkEn: new TextInput(
       this.page.findByDataQa('input-description-link-en')
+    ),
+    freePeriodDeadline: new TextInput(
+      this.page.findByDataQa('input-free-period-deadline')
+    ),
+    freePeriodQuestion: new TextInput(
+      this.page.findByDataQa('input-free-period-question-label-fi')
+    ),
+    freePeriodOptions: new TextInput(
+      this.page.findByDataQa('input-free-period-options')
+    ),
+    freePeriodOptionLabel: new TextInput(
+      this.page.findByDataQa('input-free-period-option-label-fi')
     )
   }
 
@@ -60,12 +72,23 @@ export class HolidayPeriodsPage {
     end?: string
     reservationDeadline?: string
     showReservationBannerFrom?: string
+    freePeriodDeadline?: string
+    freePeriodQuestion?: string
+    freePeriodOptions?: string
+    freePeriodOptionLabel?: string
   }) {
     for (const [key, val] of Object.entries(params)) {
       if (val !== undefined) {
         await this.#inputs[key as keyof typeof params].fill(val)
       }
     }
+  }
+
+  toggleFreePeriod(check = true) {
+    const checkbox = new Checkbox(
+      this.page.findByDataQa('input-use-free-absence-period')
+    )
+    return check ? checkbox.check() : checkbox.uncheck()
   }
 
   async submit() {

--- a/frontend/src/e2e-test/specs/5_employee/holiday-period.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/holiday-period.spec.ts
@@ -121,7 +121,7 @@ describe('Holiday periods page', () => {
       freePeriodDeadline: '15.4.2022',
       freePeriodQuestion:
         'Ovatko lapsenne 31.5.–29.8. välillä poissa yhtenäisesti 8 viikkoa?',
-      freePeriodOptions: '30.05.2022 - 31.05.2022, 30.06.2022 - 31.07.2022',
+      freePeriodOptions: '30.05.2022 - 31.5.2022, 30.6.2022 - 31.7.2022',
       freePeriodOptionLabel: 'Lapsi on poissa 8 viikkoa aikavälillä'
     })
 

--- a/frontend/src/e2e-test/specs/5_employee/holiday-period.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/holiday-period.spec.ts
@@ -103,4 +103,33 @@ describe('Holiday periods page', () => {
       Object.values(descriptions)
     )
   })
+
+  test('Holiday periods can have an optional free period', async () => {
+    await holidayPeriodsPage.clickAddButton()
+    await holidayPeriodsPage.fillForm({
+      start: '31.5.2022',
+      end: '29.8.2022',
+      reservationDeadline: '3.5.2022',
+      showReservationBannerFrom: '15.2.2022',
+      description:
+        'Pyydämme ilmoittamaan 3.5. mennessä lapsenne kesälomat. Jos lapsi on ennalta ilmoitetusti yhtenäisesti poissa 8 viikon ajan 31.5.–29.8. välillä, niin asiakasmaksu hyvitetään kesä- ja heinäkuulta.'
+    })
+
+    await holidayPeriodsPage.toggleFreePeriod()
+
+    await holidayPeriodsPage.fillForm({
+      freePeriodDeadline: '15.4.2022',
+      freePeriodQuestion:
+        'Ovatko lapsenne 31.5.–29.8. välillä poissa yhtenäisesti 8 viikkoa?',
+      freePeriodOptions: '30.05.2022 - 31.05.2022, 30.06.2022 - 31.07.2022',
+      freePeriodOptionLabel: 'Lapsi on poissa 8 viikkoa aikavälillä'
+    })
+
+    await holidayPeriodsPage.submit()
+
+    await waitUntilEqual(
+      () => holidayPeriodsPage.visiblePeriods,
+      ['31.05.2022 - 29.08.2022']
+    )
+  })
 })

--- a/frontend/src/employee-frontend/components/absences/AbsenceLegend.tsx
+++ b/frontend/src/employee-frontend/components/absences/AbsenceLegend.tsx
@@ -21,7 +21,8 @@ const absenceTypesInLegend: CalendarAbsenceType[] = [
   'SICKLEAVE',
   'TEMPORARY_RELOCATION',
   'PARENTLEAVE',
-  'FORCE_MAJEURE'
+  'FORCE_MAJEURE',
+  'FREE_ABSENCE'
 ]
 
 const AbsenceLegendRow = styled.div`

--- a/frontend/src/employee-frontend/components/absences/Absences.tsx
+++ b/frontend/src/employee-frontend/components/absences/Absences.tsx
@@ -364,6 +364,10 @@ const AbsencesPage = styled.div`
       border-top-color: ${absenceColors.FORCE_MAJEURE};
     }
 
+    &-FREE_ABSENCE {
+      border-top-color: ${absenceColors.FREE_ABSENCE};
+    }
+
     &-weekend {
       border-top-color: ${colors.grayscale.g4};
     }
@@ -406,6 +410,10 @@ const AbsencesPage = styled.div`
 
     &-FORCE_MAJEURE {
       border-bottom-color: ${absenceColors.FORCE_MAJEURE};
+    }
+
+    &-FREE_ABSENCE {
+      border-bottom-color: ${absenceColors.FREE_ABSENCE};
     }
 
     &-weekend {

--- a/frontend/src/employee-frontend/components/holiday-periods/HolidayPeriodForm.tsx
+++ b/frontend/src/employee-frontend/components/holiday-periods/HolidayPeriodForm.tsx
@@ -66,8 +66,9 @@ const parseFiniteDateRange = (range: string): FiniteDateRange | null => {
 
 const parseDateRanges = (s: string) =>
   s
-    .split(',')
+    .split(/[,\n]/)
     .map((s) => s.trim())
+    .filter(Boolean)
     .map(parseFiniteDateRange)
     .filter(Boolean) as FiniteDateRange[]
 
@@ -520,7 +521,7 @@ export default React.memo(function HolidayPeriodForm({
             <Gap horizontal />
             <InformationText>
               {parseDateRanges(form.freePeriodOptions)
-                .map((r) => r.format())
+                .map((r) => r.formatCompact())
                 .join(', ')}
             </InformationText>
 

--- a/frontend/src/employee-frontend/components/holiday-periods/api.ts
+++ b/frontend/src/employee-frontend/components/holiday-periods/api.ts
@@ -19,6 +19,7 @@ const mapHolidayPeriod = ({
   showReservationBannerFrom,
   period,
   reservationDeadline,
+  freePeriod,
   ...rest
 }: JsonOf<HolidayPeriod>): HolidayPeriod => ({
   ...rest,
@@ -26,7 +27,16 @@ const mapHolidayPeriod = ({
   updated: new Date(updated),
   reservationDeadline: LocalDate.parseIso(reservationDeadline),
   showReservationBannerFrom: LocalDate.parseIso(showReservationBannerFrom),
-  period: FiniteDateRange.parseJson(period)
+  period: FiniteDateRange.parseJson(period),
+  freePeriod: freePeriod
+    ? {
+        ...freePeriod,
+        deadline: LocalDate.parseIso(freePeriod.deadline),
+        periodOptions: freePeriod.periodOptions.map((opt) =>
+          FiniteDateRange.parseJson(opt)
+        )
+      }
+    : null
 })
 
 export function getHolidayPeriods(): Promise<Result<HolidayPeriod[]>> {

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -47,7 +47,8 @@ const legendAbsenceTypes: AbsenceType[] = [
   'UNKNOWN_ABSENCE',
   'PLANNED_ABSENCE',
   'PARENTLEAVE',
-  'FORCE_MAJEURE'
+  'FORCE_MAJEURE',
+  'FREE_ABSENCE'
 ]
 
 const formatWeekTitle = (dateRange: FiniteDateRange) =>

--- a/frontend/src/employee-frontend/types/absence.ts
+++ b/frontend/src/employee-frontend/types/absence.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -17,7 +17,8 @@ export const AbsenceTypes: AbsenceType[] = [
   'UNKNOWN_ABSENCE',
   'PLANNED_ABSENCE',
   'PARENTLEAVE',
-  'FORCE_MAJEURE'
+  'FORCE_MAJEURE',
+  'FREE_ABSENCE'
 ]
 
 export const defaultAbsenceType = 'SICKLEAVE'

--- a/frontend/src/employee-mobile-frontend/components/attendances/AbsenceSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/AbsenceSelector.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -7,7 +7,16 @@ import { AbsenceType } from 'lib-common/generated/api-types/daycare'
 import { ChipWrapper, ChoiceChip } from 'lib-components/atoms/Chip'
 import { Gap } from 'lib-components/white-space'
 import { useTranslation } from '../../state/i18n'
-import { AbsenceTypes } from '../../types'
+
+const allSelectableAbsenceTypes: AbsenceType[] = [
+  'OTHER_ABSENCE',
+  'SICKLEAVE',
+  'UNKNOWN_ABSENCE',
+  'PLANNED_ABSENCE'
+]
+const selectableAbsenceTypesWithoutUnknown = allSelectableAbsenceTypes.filter(
+  (type) => type !== 'UNKNOWN_ABSENCE'
+)
 
 interface Props {
   selectedAbsenceType: AbsenceType | undefined
@@ -20,16 +29,13 @@ interface Props {
 export default function AbsenceSelector({
   selectedAbsenceType,
   setSelectedAbsenceType,
-  noUnknownAbsences
+  noUnknownAbsences = false
 }: Props) {
   const { i18n } = useTranslation()
 
-  const absenceTypes = AbsenceTypes.filter(
-    (type) =>
-      type !== 'PARENTLEAVE' &&
-      type !== 'FORCE_MAJEURE' &&
-      !(noUnknownAbsences && type === 'UNKNOWN_ABSENCE')
-  )
+  const absenceTypes = noUnknownAbsences
+    ? selectableAbsenceTypesWithoutUnknown
+    : allSelectableAbsenceTypes
 
   return (
     <Fragment>

--- a/frontend/src/employee-mobile-frontend/types/index.ts
+++ b/frontend/src/employee-mobile-frontend/types/index.ts
@@ -1,14 +1,10 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { AttendanceStatus } from 'lib-common/generated/api-types/attendance'
-import {
-  AbsenceCategory,
-  AbsenceType
-} from 'lib-common/generated/api-types/daycare'
+import { AbsenceCategory } from 'lib-common/generated/api-types/daycare'
 import { PlacementType } from 'lib-common/generated/enums'
-import LocalDate from 'lib-common/local-date'
 import { Translations } from '../state/i18n'
 
 export type ChildAttendanceUIState =
@@ -31,15 +27,6 @@ export function mapChildAttendanceUIState(
       return 'ABSENT'
   }
 }
-
-export const AbsenceTypes: AbsenceType[] = [
-  'OTHER_ABSENCE',
-  'SICKLEAVE',
-  'UNKNOWN_ABSENCE',
-  'PLANNED_ABSENCE',
-  'PARENTLEAVE',
-  'FORCE_MAJEURE'
-]
 
 export function formatCategory(
   category: AbsenceCategory,
@@ -84,9 +71,4 @@ export function formatCategory(
     case 'SCHOOL_SHIFT_CARE':
       return i18n.absences.careTypes.SCHOOL_SHIFT_CARE
   }
-}
-
-export interface AbsenceBackupCare {
-  childId: string
-  date: LocalDate
 }

--- a/frontend/src/lib-common/generated/api-types/daycare.ts
+++ b/frontend/src/lib-common/generated/api-types/daycare.ts
@@ -76,6 +76,7 @@ export type AbsenceType =
   | 'PLANNED_ABSENCE'
   | 'PARENTLEAVE'
   | 'FORCE_MAJEURE'
+  | 'FREE_ABSENCE'
 
 /**
 * Generated from fi.espoo.evaka.daycare.service.AbsenceUpsert

--- a/frontend/src/lib-common/generated/api-types/holidaypediod.ts
+++ b/frontend/src/lib-common/generated/api-types/holidaypediod.ts
@@ -11,12 +11,23 @@ import { Translatable } from './shared'
 import { UUID } from '../../types'
 
 /**
+* Generated from fi.espoo.evaka.holidaypediod.FreeAbsencePeriod
+*/
+export interface FreeAbsencePeriod {
+  deadline: LocalDate
+  periodOptionLabel: Translatable
+  periodOptions: FiniteDateRange[]
+  questionLabel: Translatable
+}
+
+/**
 * Generated from fi.espoo.evaka.holidaypediod.HolidayPeriod
 */
 export interface HolidayPeriod {
   created: Date
   description: Translatable
   descriptionLink: Translatable
+  freePeriod: FreeAbsencePeriod | null
   id: UUID
   period: FiniteDateRange
   reservationDeadline: LocalDate
@@ -30,6 +41,7 @@ export interface HolidayPeriod {
 export interface HolidayPeriodBody {
   description: Translatable
   descriptionLink: Translatable
+  freePeriod: FreeAbsencePeriod | null
   period: FiniteDateRange
   reservationDeadline: LocalDate
   showReservationBannerFrom: LocalDate

--- a/frontend/src/lib-common/local-date.ts
+++ b/frontend/src/lib-common/local-date.ts
@@ -32,7 +32,7 @@ import { DateFormat, DateFormatWithWeekday, formatDate } from './date'
 import { isAutomatedTest, mockNow } from './utils/helpers'
 
 const isoPattern = /^([0-9]+)-([0-9]+)-([0-9]+)$/
-const fiPattern = /^(\d{2})\.(\d{2})\.(\d{4})$/
+const fiPattern = /^(\d{1,2})\.(\d{1,2})\.(\d{4})$/
 
 type Lang = 'fi' | 'sv' | 'en'
 export default class LocalDate {

--- a/frontend/src/lib-customizations/common.tsx
+++ b/frontend/src/lib-customizations/common.tsx
@@ -33,6 +33,7 @@ export const absenceColors = {
   PLANNED_ABSENCE: status.success,
   PARENTLEAVE: accents.a5orangeLight,
   FORCE_MAJEURE: status.danger,
+  FREE_ABSENCE: accents.a7mint,
   TEMPORARY_RELOCATION: status.warning,
   TEMPORARY_VISITOR: status.warning,
   NO_ABSENCE: accents.a8lightBlue
@@ -45,6 +46,7 @@ export const absenceIcons = {
   PLANNED_ABSENCE: 'P',
   PARENTLEAVE: faBabyCarriage,
   FORCE_MAJEURE: faEuroSign,
+  FREE_ABSENCE: faEuroSign,
   TEMPORARY_RELOCATION: '-',
   TEMPORARY_VISITOR: '-',
   NO_ABSENCE: '-'

--- a/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
@@ -98,6 +98,7 @@ export const fi = {
       TEMPORARY_VISITOR: 'Varalapsi läsnä',
       PARENTLEAVE: 'Isyysvapaa',
       FORCE_MAJEURE: 'Maksuton päivä',
+      FREE_ABSENCE: 'Maksuton poissaolo',
       NO_ABSENCE: 'Ei poissaoloa'
     },
     careTypes: {

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2086,6 +2086,7 @@ export const fi = {
       TEMPORARY_VISITOR: 'Varalapsi läsnä',
       PARENTLEAVE: 'Isyysvapaa',
       FORCE_MAJEURE: 'Maksuton päivä',
+      FREE_ABSENCE: 'Maksuton poissaolo',
       NO_ABSENCE: 'Ei poissaoloa'
     },
     absenceTypesShort: {
@@ -2096,6 +2097,7 @@ export const fi = {
       TEMPORARY_RELOCATION: 'Varasijoitus',
       PARENTLEAVE: 'Isyysvapaa',
       FORCE_MAJEURE: 'Maksuton',
+      FREE_ABSENCE: 'Maksuton',
       NO_ABSENCE: 'Ei poissa'
     },
     careTypes: {
@@ -2132,6 +2134,7 @@ export const fi = {
         TEMPORARY_VISITOR: 'Varalapsi läsnä',
         PARENTLEAVE: 'Isyysvapaa',
         FORCE_MAJEURE: 'Maksuton päivä (rajoitettu käyttö)',
+        FREE_ABSENCE: 'Maksuton poissaolo',
         NO_ABSENCE: 'Ei poissaoloa'
       },
       free: 'Maksuton',
@@ -3013,6 +3016,15 @@ export const fi = {
     descriptionLink: 'Lisätietolinkki',
     period: 'Aikaväli',
     showReservationBannerFrom: 'Näytetään alkaen',
-    reservationDeadline: 'Varaukset viimeistään'
+    reservationDeadline: 'Varaukset viimeistään',
+    freePeriodQuestionLabel: 'Ilmaisen kauden kysymys',
+    freePeriodQuestionLabelPlaceholder:
+      'Esim. Ovatko lapsenne 30.5.–31.8. välillä poissa yhtenäisesti 8 viikkoa?',
+    freePeriodOptionLabel: 'Ilmaisen kauden valinnan kysymys',
+    freePeriodOptionLabelPlaceholder:
+      'Esim. Lapset ovat 8 viikkoa poissa aikavälillä',
+    freePeriodOptions: 'Ilmaisien kausien vaihtoehdot',
+    freePeriodOptionsPlaceholder:
+      '30.05.2022-24.08.2022, 06.06.2022-31.08.2022 (huom. formaatti!)'
   }
 }

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -3024,7 +3024,6 @@ export const fi = {
     freePeriodOptionLabelPlaceholder:
       'Esim. Lapset ovat 8 viikkoa poissa aikavälillä',
     freePeriodOptions: 'Ilmaisien kausien vaihtoehdot',
-    freePeriodOptionsPlaceholder:
-      '30.05.2022-24.08.2022, 06.06.2022-31.08.2022 (huom. formaatti!)'
+    freePeriodOptionsPlaceholder: '30.5.2022-24.8.2022, 6.6.2022-31.8.2022'
   }
 }

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -3024,6 +3024,7 @@ export const fi = {
     freePeriodOptionLabelPlaceholder:
       'Esim. Lapset ovat 8 viikkoa poissa aikavälillä',
     freePeriodOptions: 'Ilmaisien kausien vaihtoehdot',
-    freePeriodOptionsPlaceholder: '30.5.2022-24.8.2022, 6.6.2022-31.8.2022'
+    freePeriodOptionsPlaceholder:
+      '30.5.2022-24.8.2022, 6.6.2022-31.8.2022, pilkuilla tai rivinvaihdoilla erotettuna'
   }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -245,7 +245,8 @@ enum class AbsenceType : DatabaseEnum {
     UNKNOWN_ABSENCE,
     PLANNED_ABSENCE,
     PARENTLEAVE,
-    FORCE_MAJEURE;
+    FORCE_MAJEURE,
+    FREE_ABSENCE;
 
     override val sqlType: String = "absence_type"
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/holidaypediod/HolidayPeriod.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidaypediod/HolidayPeriod.kt
@@ -8,8 +8,21 @@ import fi.espoo.evaka.shared.HolidayPeriodId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.Translatable
+import org.jdbi.v3.core.mapper.Nested
+import org.jdbi.v3.core.mapper.PropagateNull
 import org.jdbi.v3.json.Json
 import java.time.LocalDate
+
+data class FreeAbsencePeriod(
+    @PropagateNull
+    val deadline: LocalDate,
+    @Json
+    val questionLabel: Translatable, // "Will your children be on holiday for 8 consecutive weeks during...?"
+
+    val periodOptions: List<FiniteDateRange>,
+    @Json
+    val periodOptionLabel: Translatable
+)
 
 data class HolidayPeriod(
     val id: HolidayPeriodId,
@@ -22,6 +35,8 @@ data class HolidayPeriod(
     val description: Translatable,
     @Json
     val descriptionLink: Translatable,
+    @Nested("free_period")
+    val freePeriod: FreeAbsencePeriod?
 )
 
 data class HolidayPeriodBody(
@@ -32,4 +47,6 @@ data class HolidayPeriodBody(
     val description: Translatable,
     @Json
     val descriptionLink: Translatable,
+    @Nested("free_period")
+    val freePeriod: FreeAbsencePeriod?
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
@@ -622,13 +622,17 @@ class DraftInvoiceGenerator(
         absences: List<AbsenceStub>,
         dailyFeeDivisor: Int,
     ): Int {
-        val forceMajeureAbsences = absences.filter { it.absenceType == AbsenceType.FORCE_MAJEURE }
-        val forceMajeureDays = forceMajeureAbsences.filter { period.includes(it.date) }
+        val forceMajeureAndFreeAbsences = absences
+            .filter { it.absenceType == AbsenceType.FORCE_MAJEURE || it.absenceType == AbsenceType.FREE_ABSENCE }
+            .map { it.date }
+        val forceMajeureDays = forceMajeureAndFreeAbsences.filter { period.includes(it) }
 
-        val parentLeaveAbsences = absences.filter { it.absenceType == AbsenceType.PARENTLEAVE }
-        val parentLeaveDays = parentLeaveAbsences
-            .filter { ChronoUnit.YEARS.between(child.dateOfBirth, it.date) < 2 }
-            .filter { period.includes(it.date) }
+        val parentLeaveAbsences = absences.filter { it.absenceType == AbsenceType.PARENTLEAVE }.map { it.date }
+        val parentLeaveDays = if (parentLeaveAbsences.isNotEmpty())
+            parentLeaveAbsences
+                .filter { ChronoUnit.YEARS.between(child.dateOfBirth, it) < 2 }
+                .filter { period.includes(it) }
+        else listOf()
 
         return minOf(forceMajeureDays.size + parentLeaveDays.size, dailyFeeDivisor)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecision
 import fi.espoo.evaka.invoicing.domain.FeeDecisionDetailed
 import fi.espoo.evaka.invoicing.domain.FeeDecisionSummary
 import fi.espoo.evaka.shared.Id
+import fi.espoo.evaka.shared.domain.FiniteDateRange
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.array.SqlArrayType
 import org.jdbi.v3.core.generic.GenericType
@@ -30,6 +31,7 @@ import org.jdbi.v3.jackson2.Jackson2Config
 import org.jdbi.v3.jackson2.Jackson2Plugin
 import org.jdbi.v3.json.Json
 import org.jdbi.v3.postgres.PostgresPlugin
+import org.postgresql.util.PGobject
 import java.lang.reflect.Type
 import java.sql.ResultSet
 import java.util.Optional
@@ -101,6 +103,12 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
     jdbi.register(helsinkiDateTimeColumnMapper)
     jdbi.register(productKeyColumnMapper)
     jdbi.registerArrayType(UUID::class.java, "uuid")
+    jdbi.registerArrayType(FiniteDateRange::class.java, "daterange") {
+        PGobject().apply {
+            type = "daterange"
+            value = "[${it.start},${it.end}]"
+        }
+    }
     jdbi.registerArrayType { elementType, _ ->
         Optional.ofNullable(
             (elementType as? Class<*>)?.let { elementClass ->

--- a/service/src/main/resources/db/migration/V206__free_absence_type.sql
+++ b/service/src/main/resources/db/migration/V206__free_absence_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE absence_type ADD VALUE 'FREE_ABSENCE';

--- a/service/src/main/resources/db/migration/V207__free_holiday_period.sql
+++ b/service/src/main/resources/db/migration/V207__free_holiday_period.sql
@@ -1,0 +1,5 @@
+ALTER TABLE holiday_period
+    ADD COLUMN free_period_deadline            date,
+    ADD COLUMN free_period_question_label      jsonb,
+    ADD COLUMN free_period_period_options      daterange[],
+    ADD COLUMN free_period_period_option_label jsonb;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -203,3 +203,5 @@ V202__absence_type_enum.sql
 V203__absence_category.sql
 V204__holiday_periods.sql
 V205__single_date_reservations.sql
+V206__free_absence_type.sql
+V207__free_holiday_period.sql


### PR DESCRIPTION
#### Summary

- Add FREE_ABSENCE absence type to be used with free summer holiday periods
- Support optional free period in admin's holiday period UI

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

