### PR TITLE
Upgrade font awesome from 6.0 beta to release

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -117,7 +117,7 @@ target the private registry in `yarn.lock`.
 Next, fetch the packages with:
 
 ```sh
-npm pack @fortawesome/pro-light-svg-icons@6.0.0-beta2 --userconfig=<path to your .npmrc>
+npm pack @fortawesome/pro-light-svg-icons@6.0.0 --userconfig=<path to your .npmrc>
 # repeat for all packages listed under ./unpack-pro-icons.sh
 ```
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,9 +23,9 @@
   },
   "dependencies": {
     "@evaka/eslint-plugin": "link:eslint-plugin",
-    "@fortawesome/fontawesome-svg-core": "1.3.0-beta2",
-    "@fortawesome/free-regular-svg-icons": "6.0.0-beta2",
-    "@fortawesome/free-solid-svg-icons": "6.0.0-beta2",
+    "@fortawesome/fontawesome-svg-core": "1.3.0",
+    "@fortawesome/free-regular-svg-icons": "6.0.0",
+    "@fortawesome/free-solid-svg-icons": "6.0.0",
     "@fortawesome/react-fontawesome": "0.1.17",
     "@sentry/browser": "^6.17.5",
     "@sentry/react": "^6.17.5",
@@ -125,9 +125,9 @@
     "yargs": "^17.3.1"
   },
   "peerDependencies": {
-    "@fortawesome/pro-light-svg-icons": "^6.0.0-beta2",
-    "@fortawesome/pro-regular-svg-icons": "^6.0.0-beta2",
-    "@fortawesome/pro-solid-svg-icons": "^6.0.0-beta2"
+    "@fortawesome/pro-light-svg-icons": "^6.0.0",
+    "@fortawesome/pro-regular-svg-icons": "^6.0.0",
+    "@fortawesome/pro-solid-svg-icons": "^6.0.0"
   },
   "peerDependenciesMeta": {
     "@fortawesome/pro-light-svg-icons": {

--- a/frontend/unpack-pro-icons.sh
+++ b/frontend/unpack-pro-icons.sh
@@ -1,10 +1,10 @@
 #!/bin/sh -eu
 
-# SPDX-FileCopyrightText: 2017-2021 City of Espoo
+# SPDX-FileCopyrightText: 2017-2022 City of Espoo
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-VERSION=6.0.0-beta2
+VERSION=6.0.0
 
 unpack() {
   NAME=${1}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1532,37 +1532,37 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@fortawesome/fontawesome-common-types@npm:^0.3.0-beta2":
-  version: 0.3.0-beta2
-  resolution: "@fortawesome/fontawesome-common-types@npm:0.3.0-beta2"
-  checksum: d7d3014dc4a6e2c900b18d7a9df5a8303098f5455c9fe75c4dbc0cc0682ac6c21e2a61e1a8d77064d9c9fdfe7a9917a7a088f54e28adaed6fed814f474eca869
+"@fortawesome/fontawesome-common-types@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@fortawesome/fontawesome-common-types@npm:0.3.0"
+  checksum: f08280e2e6c7df5cf2c80c88092828b367bb824ec21a6ba0e5d290ebf86038de166622152c8845a0aeaeff70bd54df7af17f1ef26dea7b832fdebdcc37412c37
   languageName: node
   linkType: hard
 
-"@fortawesome/fontawesome-svg-core@npm:1.3.0-beta2":
-  version: 1.3.0-beta2
-  resolution: "@fortawesome/fontawesome-svg-core@npm:1.3.0-beta2"
+"@fortawesome/fontawesome-svg-core@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@fortawesome/fontawesome-svg-core@npm:1.3.0"
   dependencies:
-    "@fortawesome/fontawesome-common-types": ^0.3.0-beta2
-  checksum: 4433876838befdab4d2cfbc4463cc21defb883eae1f50a527f8a55476350ad82f6b6924b9178538e5665e00dfb1c3a2d1767ef555dfc8337ee8d6943d645ea55
+    "@fortawesome/fontawesome-common-types": ^0.3.0
+  checksum: 78be521be3aac56cf81695c5f3fefda8a0e0dcbd37cd734f09b74a3657dd9c073cb86c5adf60a4904e584936fe9a63ee913d932c03105092bd8c44bb92f3aad6
   languageName: node
   linkType: hard
 
-"@fortawesome/free-regular-svg-icons@npm:6.0.0-beta2":
-  version: 6.0.0-beta2
-  resolution: "@fortawesome/free-regular-svg-icons@npm:6.0.0-beta2"
+"@fortawesome/free-regular-svg-icons@npm:6.0.0":
+  version: 6.0.0
+  resolution: "@fortawesome/free-regular-svg-icons@npm:6.0.0"
   dependencies:
-    "@fortawesome/fontawesome-common-types": ^0.3.0-beta2
-  checksum: 391524048539bdd7289c7cecbd74c5414f8a3353f62729fc768e53c15dae6f1cd53df44736c39cb3773ec45a9f470085d76f0546f8317eec8c6f527b75f71317
+    "@fortawesome/fontawesome-common-types": ^0.3.0
+  checksum: a1e25cdf58051f63d7254dd165b97381c9fbdedcccd0079aa83f0400cf37b74a980f8a6f8870d7cd462063bc718d505389087837af3439877a200a02f9b2ff0f
   languageName: node
   linkType: hard
 
-"@fortawesome/free-solid-svg-icons@npm:6.0.0-beta2":
-  version: 6.0.0-beta2
-  resolution: "@fortawesome/free-solid-svg-icons@npm:6.0.0-beta2"
+"@fortawesome/free-solid-svg-icons@npm:6.0.0":
+  version: 6.0.0
+  resolution: "@fortawesome/free-solid-svg-icons@npm:6.0.0"
   dependencies:
-    "@fortawesome/fontawesome-common-types": ^0.3.0-beta2
-  checksum: 8757eb7b2f2d0bf25d9b731a9d5b8c63917edd4d2dd022f0d2d75fd7854fb5a34aecd329cd5fe4dfc09b3443562a0a5562f639257f8cc7340cdb3c99f14f6b90
+    "@fortawesome/fontawesome-common-types": ^0.3.0
+  checksum: af00e4245e20283f74c37e3c44a247d086ef54cd57e8e0b26178e82d4f400514e405dff6e6d0fd67d50be873180e41c5347f1baaee7a6506228f88390204064a
   languageName: node
   linkType: hard
 
@@ -5630,9 +5630,9 @@ __metadata:
     "@babel/core": ^7.17.0
     "@babel/preset-env": ^7.16.11
     "@evaka/eslint-plugin": "link:eslint-plugin"
-    "@fortawesome/fontawesome-svg-core": 1.3.0-beta2
-    "@fortawesome/free-regular-svg-icons": 6.0.0-beta2
-    "@fortawesome/free-solid-svg-icons": 6.0.0-beta2
+    "@fortawesome/fontawesome-svg-core": 1.3.0
+    "@fortawesome/free-regular-svg-icons": 6.0.0
+    "@fortawesome/free-solid-svg-icons": 6.0.0
     "@fortawesome/react-fontawesome": 0.1.17
     "@playwright/test": ^1.18.1
     "@sentry/browser": ^6.17.5
@@ -5726,9 +5726,9 @@ __metadata:
     webpack-pwa-manifest: ^4.3.0
     yargs: ^17.3.1
   peerDependencies:
-    "@fortawesome/pro-light-svg-icons": ^6.0.0-beta2
-    "@fortawesome/pro-regular-svg-icons": ^6.0.0-beta2
-    "@fortawesome/pro-solid-svg-icons": ^6.0.0-beta2
+    "@fortawesome/pro-light-svg-icons": ^6.0.0
+    "@fortawesome/pro-regular-svg-icons": ^6.0.0
+    "@fortawesome/pro-solid-svg-icons": ^6.0.0
   peerDependenciesMeta:
     "@fortawesome/pro-light-svg-icons":
       optional: true


### PR DESCRIPTION
#### Summary

- Upgraded the packages from beta to release
- Fetched and uploaded the `6.0.0` packages to S3 as documented in the [README](https://github.com/espoon-voltti/evaka/tree/master/frontend#using-professional-icons)

