### PR TITLE
EVAKA-4162 Show 'report holiday' option when holiday banner is active

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -11,7 +11,6 @@ import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal
 import { featureFlags } from 'lib-customizations/citizen'
 import { theme } from 'lib-customizations/common'
 import CitizenReloadNotification from './CitizenReloadNotification'
-import CtaBanner from './CtaBanner'
 import ApplicationCreation from './applications/ApplicationCreation'
 import ApplicationEditor from './applications/editor/ApplicationEditor'
 import ApplicationReadView from './applications/read-view/ApplicationReadView'
@@ -24,6 +23,8 @@ import ChildPage from './children/ChildPage'
 import ChildrenPage from './children/ChildrenPage'
 import DecisionResponseList from './decisions/decision-response-page/DecisionResponseList'
 import Header from './header/Header'
+import CtaBanner from './holiday-periods/CtaBanner'
+import { HolidayPeriodsContextProvider } from './holiday-periods/state'
 import IncomeStatementEditor from './income-statements/IncomeStatementEditor'
 import IncomeStatementView from './income-statements/IncomeStatementView'
 import IncomeStatements from './income-statements/IncomeStatements'
@@ -51,89 +52,91 @@ export default function App() {
               <OverlayContextProvider>
                 <MessageContextProvider>
                   <PedagogicalDocumentsContextProvider>
-                    <Header />
-                    <CtaBanner />
-                    <Main>
-                      <Switch>
-                        <Route path="/applying" component={ApplyingRouter} />
-                        <Route
-                          exact
-                          path="/applications/new/:childId"
-                          component={requireAuth(ApplicationCreation)}
-                        />
-                        <Route
-                          exact
-                          path="/applications/:applicationId"
-                          component={requireAuth(ApplicationReadView)}
-                        />
-                        <Route
-                          exact
-                          path="/personal-details"
-                          component={requireAuth(PersonalDetails, false)}
-                        />
-                        <Route
-                          exact
-                          path="/income"
-                          component={requireAuth(IncomeStatements)}
-                        />
-                        <Route
-                          exact
-                          path="/income/:incomeStatementId/edit"
-                          component={requireAuth(IncomeStatementEditor)}
-                        />
-                        <Route
-                          exact
-                          path="/income/:incomeStatementId"
-                          component={requireAuth(IncomeStatementView)}
-                        />
-                        <Route
-                          exact
-                          path="/applications/:applicationId/edit"
-                          component={requireAuth(ApplicationEditor)}
-                        />
-                        {featureFlags.experimental?.placementTermination && (
+                    <HolidayPeriodsContextProvider>
+                      <Header />
+                      <CtaBanner />
+                      <Main>
+                        <Switch>
+                          <Route path="/applying" component={ApplyingRouter} />
                           <Route
                             exact
-                            path="/children/:childId"
-                            component={requireAuth(ChildPage)}
+                            path="/applications/new/:childId"
+                            component={requireAuth(ApplicationCreation)}
                           />
-                        )}
-                        {featureFlags.experimental?.placementTermination && (
                           <Route
                             exact
-                            path="/children"
-                            component={requireAuth(ChildrenPage)}
+                            path="/applications/:applicationId"
+                            component={requireAuth(ApplicationReadView)}
                           />
-                        )}
-                        <Route
-                          exact
-                          path="/decisions/by-application/:applicationId"
-                          component={requireAuth(DecisionResponseList)}
-                        />
-                        <Route
-                          exact
-                          path="/messages"
-                          component={requireAuth(MessagesPage, false)}
-                        />
-                        <Route
-                          exact
-                          path="/calendar"
-                          component={requireAuth(CalendarPage, false)}
-                        />
-                        <Route
-                          exact
-                          path="/pedagogical-documents"
-                          component={requireAuth(PedagogicalDocuments)}
-                        />
-                        <Route path="/">
-                          <HandleRedirection />
-                        </Route>
-                      </Switch>
-                    </Main>
-                    <GlobalInfoDialog />
-                    <GlobalErrorDialog />
-                    <CitizenReloadNotification />
-                    <LoginErrorModal translations={i18n.login.failedModal} />
+                          <Route
+                            exact
+                            path="/personal-details"
+                            component={requireAuth(PersonalDetails, false)}
+                          />
+                          <Route
+                            exact
+                            path="/income"
+                            component={requireAuth(IncomeStatements)}
+                          />
+                          <Route
+                            exact
+                            path="/income/:incomeStatementId/edit"
+                            component={requireAuth(IncomeStatementEditor)}
+                          />
+                          <Route
+                            exact
+                            path="/income/:incomeStatementId"
+                            component={requireAuth(IncomeStatementView)}
+                          />
+                          <Route
+                            exact
+                            path="/applications/:applicationId/edit"
+                            component={requireAuth(ApplicationEditor)}
+                          />
+                          {featureFlags.experimental?.placementTermination && (
+                            <Route
+                              exact
+                              path="/children/:childId"
+                              component={requireAuth(ChildPage)}
+                            />
+                          )}
+                          {featureFlags.experimental?.placementTermination && (
+                            <Route
+                              exact
+                              path="/children"
+                              component={requireAuth(ChildrenPage)}
+                            />
+                          )}
+                          <Route
+                            exact
+                            path="/decisions/by-application/:applicationId"
+                            component={requireAuth(DecisionResponseList)}
+                          />
+                          <Route
+                            exact
+                            path="/messages"
+                            component={requireAuth(MessagesPage, false)}
+                          />
+                          <Route
+                            exact
+                            path="/calendar"
+                            component={requireAuth(CalendarPage, false)}
+                          />
+                          <Route
+                            exact
+                            path="/pedagogical-documents"
+                            component={requireAuth(PedagogicalDocuments)}
+                          />
+                          <Route path="/">
+                            <HandleRedirection />
+                          </Route>
+                        </Switch>
+                      </Main>
+                      <GlobalInfoDialog />
+                      <GlobalErrorDialog />
+                      <CitizenReloadNotification />
+                      <LoginErrorModal translations={i18n.login.failedModal} />
+                    </HolidayPeriodsContextProvider>
                   </PedagogicalDocumentsContextProvider>
                 </MessageContextProvider>
               </OverlayContextProvider>

--- a/frontend/src/citizen-frontend/calendar/ActionPickerModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ActionPickerModal.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import LocalDate from 'lib-common/local-date'
 import Button from 'lib-components/atoms/buttons/Button'
 import ModalBackground from 'lib-components/molecules/modals/ModalBackground'
-import { defaultMargins, Gap } from 'lib-components/white-space'
+import { defaultMargins } from 'lib-components/white-space'
 import { faCalendarPlus, faTreePalm, faUserMinus } from 'lib-icons'
 import { useTranslation } from '../localization'
 
@@ -44,14 +44,12 @@ export default React.memo(function ActionPickerModal({
             </IconBackground>
           </Action>
         )}
-        <Gap size="s" />
         <Action onClick={onCreateAbsences} data-qa="calendar-action-absences">
           {i18n.calendar.newAbsence}
           <IconBackground>
             <FontAwesomeIcon icon={faUserMinus} size="1x" />
           </IconBackground>
         </Action>
-        <Gap size="s" />
         <Action
           onClick={openReservations}
           data-qa="calendar-action-reservations"
@@ -74,6 +72,7 @@ const Container = styled.div`
   flex-direction: column;
   justify-content: flex-end;
   align-items: flex-end;
+  gap: ${defaultMargins.s};
 `
 
 const Action = styled(Button)`

--- a/frontend/src/citizen-frontend/calendar/ActionPickerModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ActionPickerModal.tsx
@@ -9,19 +9,23 @@ import LocalDate from 'lib-common/local-date'
 import Button from 'lib-components/atoms/buttons/Button'
 import ModalBackground from 'lib-components/molecules/modals/ModalBackground'
 import { defaultMargins, Gap } from 'lib-components/white-space'
-import { faCalendarPlus, faUserMinus } from 'lib-icons'
+import { faCalendarPlus, faTreePalm, faUserMinus } from 'lib-icons'
 import { useTranslation } from '../localization'
 
 interface Props {
   close: () => void
   openReservations: () => void
   openAbsences: (initialDate: LocalDate | undefined) => void
+  openHolidays: () => void
+  isHolidayFormActive: boolean
 }
 
 export default React.memo(function ActionPickerModal({
   close,
   openReservations,
-  openAbsences
+  openAbsences,
+  openHolidays,
+  isHolidayFormActive
 }: Props) {
   const i18n = useTranslation()
   const onCreateAbsences = useCallback(
@@ -32,6 +36,15 @@ export default React.memo(function ActionPickerModal({
   return (
     <ModalBackground onClick={close}>
       <Container>
+        {isHolidayFormActive && (
+          <Action onClick={openHolidays} data-qa="calendar-action-holidays">
+            {i18n.calendar.newHoliday}
+            <IconBackground>
+              <FontAwesomeIcon icon={faTreePalm} size="1x" />
+            </IconBackground>
+          </Action>
+        )}
+        <Gap size="s" />
         <Action onClick={onCreateAbsences} data-qa="calendar-action-absences">
           {i18n.calendar.newAbsence}
           <IconBackground>

--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -13,7 +13,7 @@ import Container, { ContentArea } from 'lib-components/layout/Container'
 import { fontWeights, H1, H2 } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
-import { faCalendarPlus, faUserMinus } from 'lib-icons'
+import { faCalendarPlus, faTreePalm, faUserMinus } from 'lib-icons'
 import { useTranslation } from '../localization'
 import { asWeeklyData, WeeklyData } from './CalendarListView'
 import { Reservations } from './calendar-elements'
@@ -22,6 +22,8 @@ export interface Props {
   dailyData: DailyReservationData[]
   onCreateReservationClicked: () => void
   onCreateAbsencesClicked: (initialDate: LocalDate | undefined) => void
+  onReportHolidaysClicked: () => void
+  isHolidayFormActive: boolean
   selectedDate: LocalDate | undefined
   selectDate: (date: LocalDate) => void
   includeWeekends: boolean
@@ -32,6 +34,8 @@ export default React.memo(function CalendarGridView({
   dailyData,
   onCreateReservationClicked,
   onCreateAbsencesClicked,
+  onReportHolidaysClicked,
+  isHolidayFormActive,
   selectedDate,
   selectDate,
   includeWeekends,
@@ -65,6 +69,15 @@ export default React.memo(function CalendarGridView({
           <PageHeaderRow>
             <H1 noMargin>{i18n.calendar.title}</H1>
             <div>
+              {isHolidayFormActive && (
+                <InlineButton
+                  onClick={onReportHolidaysClicked}
+                  text={i18n.calendar.newHoliday}
+                  icon={faTreePalm}
+                  data-qa="open-holiday-modal"
+                />
+              )}
+              <Gap size="L" horizontal />
               <InlineButton
                 onClick={onCreateAbsences}
                 text={i18n.calendar.newAbsence}

--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -11,7 +11,7 @@ import { scrollToPos } from 'lib-common/utils/scrolling'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { fontWeights, H1, H2 } from 'lib-components/typography'
-import { defaultMargins, Gap } from 'lib-components/white-space'
+import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faCalendarPlus, faTreePalm, faUserMinus } from 'lib-icons'
 import { useTranslation } from '../localization'
@@ -77,14 +77,12 @@ export default React.memo(function CalendarGridView({
                   data-qa="open-holiday-modal"
                 />
               )}
-              <Gap size="L" horizontal />
               <InlineButton
                 onClick={onCreateAbsences}
                 text={i18n.calendar.newAbsence}
                 icon={faUserMinus}
                 data-qa="open-absences-modal"
               />
-              <Gap size="L" horizontal />
               <InlineButton
                 onClick={onCreateReservationClicked}
                 text={i18n.calendar.newReservationBtn}
@@ -244,6 +242,10 @@ const PageHeaderRow = styled(ContentArea).attrs({ opaque: false })`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  & > div {
+    display: flex;
+    gap: ${defaultMargins.L};
+  }
 `
 
 const gridPattern = (includeWeekends: boolean) => css`

--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -68,7 +68,7 @@ export default React.memo(function CalendarGridView({
         <Container>
           <PageHeaderRow>
             <H1 noMargin>{i18n.calendar.title}</H1>
-            <div>
+            <ButtonContainer>
               {isHolidayFormActive && (
                 <InlineButton
                   onClick={onReportHolidaysClicked}
@@ -89,7 +89,7 @@ export default React.memo(function CalendarGridView({
                 icon={faCalendarPlus}
                 data-qa="open-reservations-modal"
               />
-            </div>
+            </ButtonContainer>
           </PageHeaderRow>
         </Container>
       </StickyHeader>
@@ -242,10 +242,11 @@ const PageHeaderRow = styled(ContentArea).attrs({ opaque: false })`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  & > div {
-    display: flex;
-    gap: ${defaultMargins.L};
-  }
+`
+
+const ButtonContainer = styled.div`
+  display: flex;
+  gap: ${defaultMargins.L};
 `
 
 const gridPattern = (includeWeekends: boolean) => css`

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useMemo } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import { Result } from 'lib-common/api'
@@ -97,12 +97,15 @@ export default React.memo(function CalendarPage() {
     [data]
   )
 
-  const isHolidayFormActive: boolean = holidayPeriods.mapAll({
-    loading: () => false,
-    failure: () => false,
-    success: ([holidayPeriods]) =>
-      holidayPeriods != undefined && holidayPeriods != null
-  })
+  const isHolidayFormActive: boolean = useMemo(
+    () =>
+      holidayPeriods.mapAll({
+        loading: () => false,
+        failure: () => false,
+        success: (holidayPeriods) => holidayPeriods.length > 0
+      }),
+    [holidayPeriods]
+  )
 
   if (!user || !user.accessibleFeatures.reservations) return null
 

--- a/frontend/src/citizen-frontend/calendar/HolidayModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/HolidayModal.tsx
@@ -3,12 +3,10 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import { UnwrapResult } from 'citizen-frontend/async-rendering'
+import { renderResult } from 'citizen-frontend/async-rendering'
 import { useLang, useTranslation } from 'citizen-frontend/localization'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
-import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
-import Spinner from 'lib-components/atoms/state/Spinner'
 import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
 import { useHolidayPeriods } from '../holiday-periods/state'
 
@@ -42,14 +40,9 @@ export const HolidayModal = React.memo(function HolidayModal({
       rejectAction={close}
       rejectLabel={i18n.common.cancel}
     >
-      <UnwrapResult
-        result={holidayPeriods}
-        loading={() => <Spinner />}
-        failure={() => (
-          <ErrorSegment title={i18n.common.errors.genericGetError} />
-        )}
-      >
-        {([holidayPeriod]) =>
+      {renderResult(
+        holidayPeriods,
+        ([holidayPeriod]) =>
           holidayPeriod && (
             <>
               <div>
@@ -68,8 +61,7 @@ export const HolidayModal = React.memo(function HolidayModal({
                 .join(', ')}
             </>
           )
-        }
-      </UnwrapResult>
+      )}
     </AsyncFormModal>
   )
 })

--- a/frontend/src/citizen-frontend/calendar/HolidayModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/HolidayModal.tsx
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback } from 'react'
+import React from 'react'
 import { UnwrapResult } from 'citizen-frontend/async-rendering'
 import { useLang, useTranslation } from 'citizen-frontend/localization'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
-import { Translatable } from 'lib-common/generated/api-types/shared'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import Spinner from 'lib-components/atoms/state/Spinner'
@@ -27,8 +26,6 @@ export const HolidayModal = React.memo(function HolidayModal({
   const i18n = useTranslation()
   const [lang] = useLang()
   const { holidayPeriods } = useHolidayPeriods()
-
-  const translate = useCallback((t: Translatable) => t[lang], [lang])
 
   return (
     <AsyncFormModal
@@ -56,10 +53,10 @@ export const HolidayModal = React.memo(function HolidayModal({
           holidayPeriod && (
             <>
               <div>
-                <div>{translate(holidayPeriod.description)}</div>
+                <div>{holidayPeriod.description[lang]}</div>
                 <ExternalLink
                   text={i18n.calendar.holidayModal.additionalInformation}
-                  href={translate(holidayPeriod.descriptionLink)}
+                  href={holidayPeriod.descriptionLink[lang]}
                   newTab
                 />
               </div>

--- a/frontend/src/citizen-frontend/calendar/HolidayModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/HolidayModal.tsx
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React, { useCallback } from 'react'
+import { UnwrapResult } from 'citizen-frontend/async-rendering'
+import { useLang, useTranslation } from 'citizen-frontend/localization'
+import { ReservationChild } from 'lib-common/generated/api-types/reservations'
+import { Translatable } from 'lib-common/generated/api-types/shared'
+import ExternalLink from 'lib-components/atoms/ExternalLink'
+import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
+import { useHolidayPeriods } from '../holiday-periods/state'
+
+interface Props {
+  close: () => void
+  reload: () => void
+  availableChildren: ReservationChild[]
+}
+
+export const HolidayModal = React.memo(function HolidayModal({
+  close,
+  reload,
+  availableChildren
+}: Props) {
+  const i18n = useTranslation()
+  const [lang] = useLang()
+  const { holidayPeriods } = useHolidayPeriods()
+
+  const translate = useCallback((t: Translatable) => t[lang], [lang])
+
+  return (
+    <AsyncFormModal
+      mobileFullScreen
+      title={i18n.calendar.holidayModal.title}
+      resolveAction={(_cancel) => {
+        return Promise.resolve()
+      }}
+      onSuccess={() => {
+        close()
+        reload()
+      }}
+      resolveLabel={i18n.common.confirm}
+      rejectAction={close}
+      rejectLabel={i18n.common.cancel}
+    >
+      <UnwrapResult
+        result={holidayPeriods}
+        loading={() => null}
+        failure={() => null}
+      >
+        {([holidayPeriod]) =>
+          holidayPeriod && (
+            <>
+              <div>
+                <div>{translate(holidayPeriod.description)}</div>
+                <ExternalLink
+                  text={i18n.calendar.holidayModal.additionalInformation}
+                  href={translate(holidayPeriod.descriptionLink)}
+                  newTab
+                />
+              </div>
+              {availableChildren
+                .map(
+                  (child) =>
+                    child.preferredName || child.firstName.split(' ')[0]
+                )
+                .join(', ')}
+            </>
+          )
+        }
+      </UnwrapResult>
+    </AsyncFormModal>
+  )
+})
+
+export default HolidayModal

--- a/frontend/src/citizen-frontend/calendar/HolidayModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/HolidayModal.tsx
@@ -8,6 +8,8 @@ import { useLang, useTranslation } from 'citizen-frontend/localization'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
 import { Translatable } from 'lib-common/generated/api-types/shared'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
+import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
+import Spinner from 'lib-components/atoms/state/Spinner'
 import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
 import { useHolidayPeriods } from '../holiday-periods/state'
 
@@ -45,8 +47,10 @@ export const HolidayModal = React.memo(function HolidayModal({
     >
       <UnwrapResult
         result={holidayPeriods}
-        loading={() => null}
-        failure={() => null}
+        loading={() => <Spinner />}
+        failure={() => (
+          <ErrorSegment title={i18n.common.errors.genericGetError} />
+        )}
       >
         {([holidayPeriod]) =>
           holidayPeriod && (

--- a/frontend/src/citizen-frontend/holiday-periods/CtaBanner.tsx
+++ b/frontend/src/citizen-frontend/holiday-periods/CtaBanner.tsx
@@ -4,20 +4,18 @@
 
 import React from 'react'
 import styled from 'styled-components'
-import { Success } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import LocalDate from 'lib-common/local-date'
 import { useDataStatus } from 'lib-common/utils/result-to-data-status'
-import { useApiState } from 'lib-common/utils/useRestApi'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import Container from 'lib-components/layout/Container'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faTreePalm } from 'lib-icons'
-import { UnwrapResult } from './async-rendering'
-import { useUser } from './auth/state'
-import { getActionRequiringHolidayPeriods } from './header/holiday-periods/api'
-import { useTranslation } from './localization'
+import { UnwrapResult } from '../async-rendering'
+import { useUser } from '../auth/state'
+import { useTranslation } from '../localization'
+import { useHolidayPeriods } from './state'
 
 const BannerBackground = styled.div`
   background-color: ${colors.grayscale.g0};
@@ -57,13 +55,7 @@ const HolidayPeriodBanner = React.memo(function HolidayPeriodBanner({
 
 export default React.memo(function CtaBanner() {
   const user = useUser()
-  const [holidayPeriods] = useApiState(
-    () =>
-      user
-        ? getActionRequiringHolidayPeriods()
-        : Promise.resolve(Success.of([])),
-    [user]
-  )
+  const { holidayPeriods } = useHolidayPeriods()
   const status = useDataStatus(holidayPeriods)
 
   if (!user) return null

--- a/frontend/src/citizen-frontend/holiday-periods/api.ts
+++ b/frontend/src/citizen-frontend/holiday-periods/api.ts
@@ -6,7 +6,7 @@ import { Failure, Result, Success } from 'lib-common/api'
 import { deserializeHolidayPeriod } from 'lib-common/api-types/holiday-period'
 import { HolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
 import { JsonOf } from 'lib-common/json'
-import { client } from '../../api-client'
+import { client } from '../api-client'
 
 export function getActionRequiringHolidayPeriods(): Promise<
   Result<HolidayPeriod[]>

--- a/frontend/src/citizen-frontend/holiday-periods/state.tsx
+++ b/frontend/src/citizen-frontend/holiday-periods/state.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React, { createContext, useMemo, useContext } from 'react'
+import { useUser } from 'citizen-frontend/auth/state'
+import { Loading, Result, Success } from 'lib-common/api'
+import { HolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
+import { useApiState } from 'lib-common/utils/useRestApi'
+import { getActionRequiringHolidayPeriods } from './api'
+
+export interface HolidayPeriodsState {
+  holidayPeriods: Result<HolidayPeriod[]>
+}
+
+const defaultState: HolidayPeriodsState = {
+  holidayPeriods: Loading.of()
+}
+
+export const HolidayPeriodsContext =
+  createContext<HolidayPeriodsState>(defaultState)
+
+export const HolidayPeriodsContextProvider = React.memo(
+  function HolidayPeriodsContextContextProvider({
+    children
+  }: {
+    children: React.ReactNode
+  }) {
+    const user = useUser()
+    const [holidayPeriods] = useApiState(
+      () =>
+        user
+          ? getActionRequiringHolidayPeriods()
+          : Promise.resolve(Success.of([])),
+      [user]
+    )
+
+    const value = useMemo(
+      () => ({
+        holidayPeriods
+      }),
+      [holidayPeriods]
+    )
+
+    return (
+      <HolidayPeriodsContext.Provider value={value}>
+        {children}
+      </HolidayPeriodsContext.Provider>
+    )
+  }
+)
+
+export const useHolidayPeriods = () => useContext(HolidayPeriodsContext)

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -14,18 +14,18 @@ export default class CitizenCalendarPage {
     private readonly type: 'desktop' | 'mobile'
   ) {}
 
-  #openCalendarActionsModal = this.page.find(
-    '[data-qa="open-calendar-actions-modal"]'
+  #openCalendarActionsModal = this.page.findByDataQa(
+    'open-calendar-actions-modal'
   )
   #dayCell = (date: LocalDate) =>
-    this.page.find(`[data-qa="${this.type}-calendar-day-${date.formatIso()}"]`)
+    this.page.findByDataQa(`${this.type}-calendar-day-${date.formatIso()}`)
 
   async openReservationsModal() {
     if (this.type === 'mobile') {
       await this.#openCalendarActionsModal.click()
-      await this.page.find('[data-qa="calendar-action-reservations"]').click()
+      await this.page.findByDataQa('calendar-action-reservations').click()
     } else {
-      await this.page.find('[data-qa="open-reservations-modal"]').click()
+      await this.page.findByDataQa('open-reservations-modal').click()
     }
     return new ReservationsModal(this.page)
   }
@@ -33,11 +33,22 @@ export default class CitizenCalendarPage {
   async openAbsencesModal() {
     if (this.type === 'mobile') {
       await this.#openCalendarActionsModal.click()
-      await this.page.find('[data-qa="calendar-action-absences"]').click()
+      await this.page.findByDataQa('calendar-action-absences').click()
     } else {
-      await this.page.find('[data-qa="open-absences-modal"]').click()
+      await this.page.findByDataQa('open-absences-modal').click()
     }
     return new AbsencesModal(this.page)
+  }
+
+  async assertHolidayModalButtonVisible() {
+    if (this.type === 'mobile') {
+      await this.#openCalendarActionsModal.click()
+      await this.page
+        .findByDataQa('calendar-action-holidays')
+        .waitUntilVisible()
+    } else {
+      await this.page.findByDataQa('open-holiday-modal').click()
+    }
   }
 
   async openDayView(date: LocalDate) {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
@@ -47,7 +47,7 @@ beforeEach(async () => {
     .child(child1)
     .daycare(daycare)
     .with({
-      startDate: LocalDate.today().formatIso(),
+      startDate: LocalDate.of(2022, 1, 1).formatIso(),
       endDate: LocalDate.of(2036, 6, 30).formatIso()
     })
     .save()

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
@@ -13,6 +13,7 @@ import {
   enduserGuardianFixture,
   Fixture
 } from '../../dev-api/fixtures'
+import CitizenCalendarPage from '../../pages/citizen/citizen-calendar'
 import CitizenHeader from '../../pages/citizen/citizen-header'
 import { Page } from '../../utils/page'
 import { enduserLogin } from '../../utils/user'
@@ -46,27 +47,39 @@ beforeEach(async () => {
     .child(child1)
     .daycare(daycare)
     .with({
-      startDate: LocalDate.of(2035, 1, 1).formatIso(),
+      startDate: LocalDate.today().formatIso(),
       endDate: LocalDate.of(2036, 6, 30).formatIso()
     })
     .save()
 })
 
 describe('Holiday periods', () => {
-  test('A banner will prompt for holiday reservations is shown', async () => {
-    await Fixture.holidayPeriod()
-      .with({
-        period,
-        reservationDeadline: LocalDate.of(2035, 12, 6),
-        showReservationBannerFrom: LocalDate.today(),
-        description: {
-          en: 'Please submit your reservations for 18.12.2035 - 8.1.2036 asap',
-          fi: 'Ystävällisesti pyydän tekemään varauksenne ajalle 18.12.2035 - 8.1.2036 heti kun mahdollista, kuitenkin viimeistään 6.12.',
-          sv: 'Vänligen samma på svenska för 18.12.2035 - 8.1.2036'
-        }
-      })
-      .save()
-    await enduserLogin(page)
-    await header.assertHolidayPeriodBannerIsShown(true)
+  describe('Holiday period questionnaire is active', () => {
+    beforeEach(async () => {
+      await Fixture.holidayPeriod()
+        .with({
+          period,
+          reservationDeadline: LocalDate.of(2035, 12, 6),
+          showReservationBannerFrom: LocalDate.today(),
+          description: {
+            en: 'Please submit your reservations for 18.12.2035 - 8.1.2036 asap',
+            fi: 'Ystävällisesti pyydän tekemään varauksenne ajalle 18.12.2035 - 8.1.2036 heti kun mahdollista, kuitenkin viimeistään 6.12.',
+            sv: 'Vänligen samma på svenska för 18.12.2035 - 8.1.2036'
+          }
+        })
+        .save()
+    })
+
+    test('A banner will prompt for holiday reservations is shown', async () => {
+      await enduserLogin(page)
+      await header.assertHolidayPeriodBannerIsShown(true)
+    })
+
+    test('The calendar page should show a button for reporting holidays', async () => {
+      await enduserLogin(page)
+      await header.selectTab('calendar')
+      const calendar = new CitizenCalendarPage(page, 'desktop')
+      await calendar.assertHolidayModalButtonVisible()
+    })
   })
 })

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -195,6 +195,7 @@ const en: Translations = {
       PLANNED_ABSENCE: 'Planned day off'
     },
     newReservationOrAbsence: 'Reservation / Absence',
+    newHoliday: 'Report holiday',
     newAbsence: 'Report absence',
     newReservationBtn: 'Make a reservation',
     noReservation: 'No reservations',
@@ -231,6 +232,10 @@ const en: Translations = {
         OTHER_ABSENCE: 'Other absence',
         PLANNED_ABSENCE: 'Regular day off/shift care'
       }
+    },
+    holidayModal: {
+      title: 'Report holiday',
+      additionalInformation: 'Read more'
     }
   },
   messages: {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -194,6 +194,7 @@ export default {
       PLANNED_ABSENCE: 'Vapaapäivä'
     },
     newReservationOrAbsence: 'Varaus / Poissaolo',
+    newHoliday: 'Ilmoita loma',
     newAbsence: 'Ilmoita poissaolo',
     newReservationBtn: 'Tee varaus',
     noReservation: 'Ei varausta',
@@ -230,6 +231,10 @@ export default {
         OTHER_ABSENCE: 'Muu poissaolo',
         PLANNED_ABSENCE: 'Säännöllinen vapaapäivä/vuorohoito'
       }
+    },
+    holidayModal: {
+      title: 'Ilmoita loma',
+      additionalInformation: 'Lisätietoja'
     }
   },
   messages: {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -195,6 +195,7 @@ const sv: Translations = {
       PLANNED_ABSENCE: 'Ledig dag'
     },
     newReservationOrAbsence: 'Reservation / Frånvaro',
+    newHoliday: 'Meddela semester',
     newAbsence: 'Anmäl frånvaro',
     newReservationBtn: 'Reservera',
     noReservation: 'Ingen reservation',
@@ -231,6 +232,10 @@ const sv: Translations = {
         OTHER_ABSENCE: 'Annan frånvaro',
         PLANNED_ABSENCE: 'Vanlig ledig dag/skiftvård'
       }
+    },
+    holidayModal: {
+      title: 'Meddela semester',
+      additionalInformation: 'Läs mera'
     }
   },
   messages: {


### PR DESCRIPTION
Shows the "report holiday" action in the citizen calendar view.

The action currently opens a modal with some dummy contents. The form itself will be implemented in future PRs.