### PR TITLE
EVAKA-4162 Hide CTA banner on non-relevant pages

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -25,7 +25,6 @@ import ChildPage from './children/ChildPage'
 import ChildrenPage from './children/ChildrenPage'
 import DecisionResponseList from './decisions/decision-response-page/DecisionResponseList'
 import Header from './header/Header'
-import CtaBanner from './holiday-periods/CtaBanner'
 import { HolidayPeriodsContextProvider } from './holiday-periods/state'
 import ChildIncomeStatementEditor from './income-statements/ChildIncomeStatementEditor'
 import ChildIncomeStatementView from './income-statements/ChildIncomeStatementView'
@@ -58,7 +57,6 @@ export default function App() {
                   <PedagogicalDocumentsContextProvider>
                     <HolidayPeriodsContextProvider>
                       <Header />
-                      <CtaBanner />
                       <Main>
                         <Switch>
                           <Route path="/applying" component={ApplyingRouter} />

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -32,6 +32,7 @@ import CalendarGridView from './CalendarGridView'
 import CalendarListView from './CalendarListView'
 import DayView from './DayView'
 import HolidayModal from './HolidayModal'
+import HolidayPeriodBanner from './HolidayPeriodBanner'
 import ReservationModal from './ReservationModal'
 import { getReservations } from './api'
 
@@ -44,7 +45,7 @@ async function getReservationsDefaultRange(): Promise<
   )
 }
 
-export default React.memo(function CalendarPage() {
+const Page = React.memo(function CalendarPage() {
   const history = useHistory()
   const location = useLocation()
   const user = useUser()
@@ -119,84 +120,89 @@ export default React.memo(function CalendarPage() {
 
   if (!user || !user.accessibleFeatures.reservations) return null
 
-  return (
+  return renderResult(data, (response) => (
     <>
-      {renderResult(data, (response) => (
-        <>
-          <MobileAndTablet>
-            <ContentArea opaque paddingVertical="zero" paddingHorizontal="zero">
-              <CalendarListView
-                dailyData={response.dailyData}
-                onHoverButtonClick={openPickActionModal}
-                selectDate={selectDate}
-                dayIsReservable={dayIsReservable}
-                dayIsHolidayPeriod={dayIsHolidayPeriod}
-              />
-            </ContentArea>
-          </MobileAndTablet>
-          <DesktopOnly>
-            <Gap size="s" />
-            <CalendarGridView
-              dailyData={response.dailyData}
-              onCreateReservationClicked={openReservationModal}
-              onCreateAbsencesClicked={openAbsenceModal}
-              onReportHolidaysClicked={openHolidayModal}
-              isHolidayFormActive={isHolidayFormActive}
-              selectedDate={selectedDate}
-              selectDate={selectDate}
-              includeWeekends={response.includesWeekends}
-              dayIsReservable={dayIsReservable}
-            />
-          </DesktopOnly>
-          {selectedDate && (
-            <DayView
-              date={selectedDate}
-              reservationsResponse={response}
-              selectDate={selectDate}
-              reloadData={loadDefaultRange}
-              close={closeDayView}
-              openAbsenceModal={openAbsenceModal}
-            />
-          )}
-          {openModal?.type === 'pickAction' && (
-            <ActionPickerModal
-              close={closeModal}
-              openReservations={openReservationModal}
-              openAbsences={openAbsenceModal}
-              openHolidays={openHolidayModal}
-              isHolidayFormActive={isHolidayFormActive}
-            />
-          )}
-          {openModal?.type === 'reservations' && (
-            <ReservationModal
-              onClose={closeModal}
-              availableChildren={response.children}
-              onReload={loadDefaultRange}
-              reservableDays={response.reservableDays}
-            />
-          )}
-          {openModal?.type === 'absences' && (
-            <AbsenceModal
-              close={closeModal}
-              initialDate={openModal.initialDate}
-              reload={loadDefaultRange}
-              availableChildren={response.children}
-            />
-          )}
-          {openModal?.type === 'holidays' && (
-            <HolidayModal
-              close={closeModal}
-              reload={loadDefaultRange}
-              availableChildren={response.children}
-            />
-          )}
-        </>
-      ))}
-      <Footer />
+      <HolidayPeriodBanner />
+      <MobileAndTablet>
+        <ContentArea opaque paddingVertical="zero" paddingHorizontal="zero">
+          <CalendarListView
+            dailyData={response.dailyData}
+            onHoverButtonClick={openPickActionModal}
+            selectDate={selectDate}
+            dayIsReservable={dayIsReservable}
+            dayIsHolidayPeriod={dayIsHolidayPeriod}
+          />
+        </ContentArea>
+      </MobileAndTablet>
+      <DesktopOnly>
+        <Gap size="s" />
+        <CalendarGridView
+          dailyData={response.dailyData}
+          onCreateReservationClicked={openReservationModal}
+          onCreateAbsencesClicked={openAbsenceModal}
+          onReportHolidaysClicked={openHolidayModal}
+          isHolidayFormActive={isHolidayFormActive}
+          selectedDate={selectedDate}
+          selectDate={selectDate}
+          includeWeekends={response.includesWeekends}
+          dayIsReservable={dayIsReservable}
+        />
+      </DesktopOnly>
+      {selectedDate && (
+        <DayView
+          date={selectedDate}
+          reservationsResponse={response}
+          selectDate={selectDate}
+          reloadData={loadDefaultRange}
+          close={closeDayView}
+          openAbsenceModal={openAbsenceModal}
+        />
+      )}
+      {openModal?.type === 'pickAction' && (
+        <ActionPickerModal
+          close={closeModal}
+          openReservations={openReservationModal}
+          openAbsences={openAbsenceModal}
+          openHolidays={openHolidayModal}
+          isHolidayFormActive={isHolidayFormActive}
+        />
+      )}
+      {openModal?.type === 'reservations' && (
+        <ReservationModal
+          onClose={closeModal}
+          availableChildren={response.children}
+          onReload={loadDefaultRange}
+          reservableDays={response.reservableDays}
+        />
+      )}
+      {openModal?.type === 'absences' && (
+        <AbsenceModal
+          close={closeModal}
+          initialDate={openModal.initialDate}
+          reload={loadDefaultRange}
+          availableChildren={response.children}
+        />
+      )}
+      {openModal?.type === 'holidays' && (
+        <HolidayModal
+          close={closeModal}
+          reload={loadDefaultRange}
+          availableChildren={response.children}
+        />
+      )}
     </>
-  )
+  ))
 })
 
 const DesktopOnly = styled(Desktop)`
   position: relative;
 `
+
+export default React.memo(function CalendarPageWrapper() {
+  return (
+    <>
+      <Page />
+      <Footer />
+    </>
+  )
+})

--- a/frontend/src/citizen-frontend/calendar/HolidayPeriodBanner.tsx
+++ b/frontend/src/citizen-frontend/calendar/HolidayPeriodBanner.tsx
@@ -9,6 +9,7 @@ import FiniteDateRange from 'lib-common/finite-date-range'
 import LocalDate from 'lib-common/local-date'
 import { useDataStatus } from 'lib-common/utils/result-to-data-status'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
+import { desktopMin } from 'lib-components/breakpoints'
 import Container from 'lib-components/layout/Container'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
@@ -16,12 +17,17 @@ import { faTreePalm } from 'lib-icons'
 
 import { UnwrapResult } from '../async-rendering'
 import { useUser } from '../auth/state'
+import { headerHeightDesktop, headerHeightMobile } from '../header/const'
+import { useHolidayPeriods } from '../holiday-periods/state'
 import { useTranslation } from '../localization'
 
-import { isHolidayFormCurrentlyActive } from './holiday-period'
-import { useHolidayPeriods } from './state'
-
 const BannerBackground = styled.div`
+  position: sticky;
+  z-index: 2;
+  top: ${headerHeightMobile}px;
+  @media (min-width: ${desktopMin}) {
+    top: ${headerHeightDesktop}px;
+  }
   background-color: ${colors.grayscale.g0};
 `
 
@@ -31,7 +37,6 @@ const Banner = styled(Container)`
   align-items: center;
   gap: ${defaultMargins.s};
   padding: ${defaultMargins.s};
-  margin-top: 1px;
 `
 
 interface HolidayPeriodBannerProps {
@@ -57,12 +62,14 @@ const HolidayPeriodBanner = React.memo(function HolidayPeriodBanner({
   )
 })
 
-export default React.memo(function CtaBanner() {
+export default React.memo(function BannerWrapper() {
   const user = useUser()
-  const { holidayPeriods } = useHolidayPeriods()
-  const status = useDataStatus(holidayPeriods)
+  const { activePeriod } = useHolidayPeriods()
+  const status = useDataStatus(activePeriod)
 
-  if (!user) return null
+  if (!user) {
+    return null
+  }
 
   return (
     <BannerBackground
@@ -70,12 +77,11 @@ export default React.memo(function CtaBanner() {
       data-status={status}
     >
       <UnwrapResult
-        result={holidayPeriods}
+        result={activePeriod}
         loading={() => null}
         failure={() => null}
       >
-        {(periods) => {
-          const activePeriod = periods.find(isHolidayFormCurrentlyActive)
+        {(activePeriod) => {
           return activePeriod ? (
             <HolidayPeriodBanner
               period={activePeriod.period}

--- a/frontend/src/citizen-frontend/holiday-periods/state.tsx
+++ b/frontend/src/citizen-frontend/holiday-periods/state.tsx
@@ -10,13 +10,16 @@ import { HolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
 import { useApiState } from 'lib-common/utils/useRestApi'
 
 import { getHolidayPeriods } from './api'
+import { isHolidayFormCurrentlyActive } from './holiday-period'
 
 export interface HolidayPeriodsState {
   holidayPeriods: Result<HolidayPeriod[]>
+  activePeriod: Result<HolidayPeriod | undefined>
 }
 
 const defaultState: HolidayPeriodsState = {
-  holidayPeriods: Loading.of()
+  holidayPeriods: Loading.of(),
+  activePeriod: Loading.of()
 }
 
 export const HolidayPeriodsContext =
@@ -36,7 +39,10 @@ export const HolidayPeriodsContextProvider = React.memo(
 
     const value = useMemo(
       () => ({
-        holidayPeriods
+        holidayPeriods,
+        activePeriod: holidayPeriods.map((periods) =>
+          periods.find(isHolidayFormCurrentlyActive)
+        )
       }),
       [holidayPeriods]
     )

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -72,6 +72,17 @@ export default class CitizenCalendarPage {
       ].join(', ')
     )
   }
+
+  async getHolidayBannerContent(): Promise<string> {
+    const bannerContainer = this.page.findByDataQa(
+      'holiday-period-banner-container'
+    )
+    await waitUntilEqual(
+      () => bannerContainer.getAttribute('data-status'),
+      'success'
+    )
+    return bannerContainer.findByDataQa('holiday-period-banner').innerText
+  }
 }
 
 class ReservationsModal {

--- a/frontend/src/e2e-test/pages/citizen/citizen-header.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-header.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 
 export default class CitizenHeader {
@@ -115,18 +114,5 @@ export default class CitizenHeader {
     }
 
     await personalDetailsLink.click()
-  }
-
-  async assertHolidayPeriodBannerIsShown(visible: boolean) {
-    const bannerContainer = this.page.findByDataQa(
-      'holiday-period-banner-container'
-    )
-    await waitUntilEqual(
-      () => bannerContainer.getAttribute('data-status'),
-      'success'
-    )
-
-    const banner = bannerContainer.findByDataQa('holiday-period-banner')
-    return visible ? banner.waitUntilVisible() : banner.waitUntilHidden()
   }
 }

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
@@ -15,12 +15,10 @@ import {
   Fixture
 } from '../../dev-api/fixtures'
 import CitizenCalendarPage from '../../pages/citizen/citizen-calendar'
-import CitizenHeader from '../../pages/citizen/citizen-header'
 import { Page } from '../../utils/page'
 import { enduserLogin } from '../../utils/user'
 
 let page: Page
-let header: CitizenHeader
 
 const period = new FiniteDateRange(
   LocalDate.of(2035, 12, 18),
@@ -31,7 +29,6 @@ const child = enduserChildFixtureJari
 beforeEach(async () => {
   await resetDatabase()
   page = await Page.open()
-  header = new CitizenHeader(page)
 
   const daycare = await Fixture.daycare()
     .with(daycareFixture)
@@ -71,14 +68,16 @@ describe('Holiday periods', () => {
         .save()
     })
 
-    test('A banner will prompt for holiday reservations is shown', async () => {
+    test('A holiday reservations banner is shown on calendar page', async () => {
       await enduserLogin(page)
-      await header.assertHolidayPeriodBannerIsShown(true)
+      const calendar = new CitizenCalendarPage(page, 'desktop')
+      expect(await calendar.getHolidayBannerContent()).toEqual(
+        'Ilmoita lomat ja tee varaukset 18.12.2035-08.01.2036 välille viimeistään 06.12.2035.'
+      )
     })
 
     test('The calendar page should show a button for reporting holidays', async () => {
       await enduserLogin(page)
-      await header.selectTab('calendar')
       const calendar = new CitizenCalendarPage(page, 'desktop')
       await calendar.assertHolidayModalButtonVisible()
     })


### PR DESCRIPTION
#### Summary

Banner would be rendered on top of the sub navigation on applications page. Just hide the banner on non-relevant pages instead of trying to adapt the absolute-positioned map view to changing available viewport area.
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

