### PR TITLE
EVAKA-4403 child age indicator tooltips

### DIFF
--- a/frontend/src/employee-frontend/components/absences/AbsenceTable.tsx
+++ b/frontend/src/employee-frontend/components/absences/AbsenceTable.tsx
@@ -19,7 +19,7 @@ import { fasExclamationTriangle } from 'lib-icons'
 import Tooltip from '../../components/common/Tooltip'
 import { Translations, useTranslation } from '../../state/i18n'
 import { Cell, CellPart } from '../../types/absence'
-import AgeIndicatorIcon from '../common/AgeIndicatorIcon'
+import { AgeIndicatorIcon } from '../common/AgeIndicatorIcon'
 
 import AbsenceCell, { DisabledCell } from './AbsenceCell'
 import StaffAttendance from './StaffAttendance'

--- a/frontend/src/employee-frontend/components/absences/Absences.tsx
+++ b/frontend/src/employee-frontend/components/absences/Absences.tsx
@@ -252,13 +252,17 @@ const AbsencesPage = styled.div`
 
   .absence-child-name {
     white-space: nowrap;
-    overflow: hidden;
-    width: 130px;
-    max-width: 130px;
 
-    @media screen and (min-width: 1216px) {
-      width: 206px;
-      max-width: 206px;
+    a {
+      display: inline-block;
+      overflow: hidden;
+      width: 100px;
+      max-width: 100px;
+
+      @media screen and (min-width: 1216px) {
+        width: 176px;
+        max-width: 176px;
+      }
     }
   }
 

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -56,7 +56,7 @@ import { SortByApplications } from '../../types/application'
 import { formatName } from '../../utils'
 import { isPartDayPlacement } from '../../utils/placements'
 import { hasRole, RequireRole } from '../../utils/roles'
-import { AgeIndicatorIconWithTooltip } from '../common/AgeIndicatorIcon'
+import { AgeIndicatorIcon } from '../common/AgeIndicatorIcon'
 import { CareTypeChip } from '../common/CareTypeLabel'
 
 import { CircleIconGreen, CircleIconRed } from './CircleIcon'
@@ -200,7 +200,7 @@ const ApplicationsList = React.memo(function Applications({
       application.dateOfBirth &&
       startDateOrDueDate && (
         <FixedSpaceRow spacing="xs">
-          <AgeIndicatorIconWithTooltip
+          <AgeIndicatorIcon
             isUnder3={
               startDateOrDueDate.differenceInYears(application.dateOfBirth) < 3
             }

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -204,6 +204,7 @@ const ApplicationsList = React.memo(function Applications({
             isUnder3={
               startDateOrDueDate.differenceInYears(application.dateOfBirth) < 3
             }
+            tooltipText="placement-start"
           />
           <span>
             {application.socialSecurityNumber ||

--- a/frontend/src/employee-frontend/components/common/AgeIndicatorIcon.tsx
+++ b/frontend/src/employee-frontend/components/common/AgeIndicatorIcon.tsx
@@ -6,54 +6,43 @@ import React from 'react'
 
 import LocalDate from 'lib-common/local-date'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
-import Tooltip from 'lib-components/atoms/Tooltip'
+import Tooltip, { TooltipProps } from 'lib-components/atoms/Tooltip'
 import colors from 'lib-customizations/common'
 import { fasArrowDown, fasArrowUp } from 'lib-icons'
 
 import { useTranslation } from '../../state/i18n'
 
-type Props = { isUnder3: boolean } | { dateOfBirth: LocalDate }
+type Props = { position?: TooltipProps['position'] } & (
+  | { isUnder3: boolean }
+  | { dateOfBirth: LocalDate }
+)
 
-export const AgeIndicatorIcon = React.memo(function AgeIndicatorIcon(
+export const AgeIndicatorIcon = React.memo(function AgeIndicatorIconTooltip(
   props: Props
 ) {
+  const { i18n } = useTranslation()
+
   const under3 =
     'isUnder3' in props
       ? props.isUnder3
       : LocalDate.today().differenceInYears(props.dateOfBirth) < 3
 
   return (
-    <RoundIcon
-      content={under3 ? fasArrowDown : fasArrowUp}
-      color={under3 ? colors.status.success : colors.main.m1}
-      size="s"
-    />
+    <Tooltip
+      tooltip={
+        <span>
+          {under3
+            ? i18n.applications.list.lessthan3
+            : i18n.applications.list.morethan3}
+        </span>
+      }
+      position={props.position}
+    >
+      <RoundIcon
+        content={under3 ? fasArrowDown : fasArrowUp}
+        color={under3 ? colors.status.success : colors.main.m1}
+        size="s"
+      />
+    </Tooltip>
   )
 })
-
-export default AgeIndicatorIcon
-
-export const AgeIndicatorIconWithTooltip = React.memo(
-  function AgeIndicatorIconTooltip(props: Props) {
-    const { i18n } = useTranslation()
-
-    const under3 =
-      'isUnder3' in props
-        ? props.isUnder3
-        : LocalDate.today().differenceInYears(props.dateOfBirth) < 3
-
-    return (
-      <Tooltip
-        tooltip={
-          <span>
-            {under3
-              ? i18n.applications.list.lessthan3
-              : i18n.applications.list.morethan3}
-          </span>
-        }
-      >
-        <AgeIndicatorIcon isUnder3={under3} />
-      </Tooltip>
-    )
-  }
-)

--- a/frontend/src/employee-frontend/components/common/AgeIndicatorIcon.tsx
+++ b/frontend/src/employee-frontend/components/common/AgeIndicatorIcon.tsx
@@ -12,14 +12,15 @@ import { fasArrowDown, fasArrowUp } from 'lib-icons'
 
 import { useTranslation } from '../../state/i18n'
 
-type Props = { position?: TooltipProps['position'] } & (
-  | { isUnder3: boolean }
-  | { dateOfBirth: LocalDate }
-)
+type Props = {
+  position?: TooltipProps['position']
+  tooltipText?: 'placement-start'
+} & ({ isUnder3: boolean } | { dateOfBirth: LocalDate })
 
-export const AgeIndicatorIcon = React.memo(function AgeIndicatorIconTooltip(
-  props: Props
-) {
+export const AgeIndicatorIcon = React.memo(function AgeIndicatorIconTooltip({
+  tooltipText,
+  ...props
+}: Props) {
   const { i18n } = useTranslation()
 
   const under3 =
@@ -27,17 +28,17 @@ export const AgeIndicatorIcon = React.memo(function AgeIndicatorIconTooltip(
       ? props.isUnder3
       : LocalDate.today().differenceInYears(props.dateOfBirth) < 3
 
+  const tooltip =
+    tooltipText === 'placement-start'
+      ? under3
+        ? i18n.ageIndicator.under3AtPlacementStart
+        : i18n.ageIndicator.over3AtPlacementStart
+      : under3
+      ? i18n.ageIndicator.under3
+      : i18n.ageIndicator.over3
+
   return (
-    <Tooltip
-      tooltip={
-        <span>
-          {under3
-            ? i18n.applications.list.lessthan3
-            : i18n.applications.list.morethan3}
-        </span>
-      }
-      position={props.position}
-    >
+    <Tooltip tooltip={<span>{tooltip}</span>} position={props.position}>
       <RoundIcon
         content={under3 ? fasArrowDown : fasArrowUp}
         color={under3 ? colors.status.success : colors.main.m1}

--- a/frontend/src/employee-frontend/components/reports/VoucherServiceProviderUnit.tsx
+++ b/frontend/src/employee-frontend/components/reports/VoucherServiceProviderUnit.tsx
@@ -48,7 +48,7 @@ import {
 import ReportDownload from '../../components/reports/ReportDownload'
 import { useTranslation } from '../../state/i18n'
 import { formatName } from '../../utils'
-import AgeIndicatorIcon from '../common/AgeIndicatorIcon'
+import { AgeIndicatorIcon } from '../common/AgeIndicatorIcon'
 
 import { FilterLabel, FilterRow, TableScrollable } from './common'
 
@@ -433,20 +433,10 @@ function VoucherServiceProviderUnit() {
                             )}
                           </Link>
                           <FixedSpaceRow spacing="xs">
-                            <Tooltip
-                              tooltip={
-                                <div>
-                                  {
-                                    i18n.reports.voucherServiceProviderUnit[
-                                      under3YearsOld ? 'under3' : 'atLeast3'
-                                    ]
-                                  }
-                                </div>
-                              }
+                            <AgeIndicatorIcon
+                              isUnder3={under3YearsOld}
                               position="right"
-                            >
-                              <AgeIndicatorIcon isUnder3={under3YearsOld} />
-                            </Tooltip>
+                            />
                             <span>{row.childDateOfBirth.format()}</span>
                           </FixedSpaceRow>
                         </FixedSpaceColumn>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
@@ -26,7 +26,7 @@ import { UIContext } from '../../../state/ui'
 import { DaycareGroup } from '../../../types/unit'
 import { formatName } from '../../../utils'
 import { isPartDayPlacement } from '../../../utils/placements'
-import { AgeIndicatorIconWithTooltip } from '../../common/AgeIndicatorIcon'
+import { AgeIndicatorIcon } from '../../common/AgeIndicatorIcon'
 import { CareTypeChip } from '../../common/CareTypeLabel'
 
 function renderMissingGroupPlacementRow(
@@ -58,7 +58,7 @@ function renderMissingGroupPlacementRow(
       </Td>
       <Td>
         <FixedSpaceRow spacing="xs">
-          <AgeIndicatorIconWithTooltip
+          <AgeIndicatorIcon
             isUnder3={placementPeriod.start.differenceInYears(dateOfBirth) < 3}
           />
           <span data-qa="child-dob">{dateOfBirth.format()}</span>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
@@ -46,6 +46,8 @@ function renderMissingGroupPlacementRow(
     placementType
   } = missingPlacement
 
+  const childIsUnder3 = placementPeriod.start.differenceInYears(dateOfBirth) < 3
+
   return (
     <Tr
       key={`${childId}:${gap.start.formatIso()}`}
@@ -59,7 +61,8 @@ function renderMissingGroupPlacementRow(
       <Td>
         <FixedSpaceRow spacing="xs">
           <AgeIndicatorIcon
-            isUnder3={placementPeriod.start.differenceInYears(dateOfBirth) < 3}
+            isUnder3={childIsUnder3}
+            tooltipText="placement-start"
           />
           <span data-qa="child-dob">{dateOfBirth.format()}</span>
         </FixedSpaceRow>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
@@ -69,7 +69,7 @@ import { rangesOverlap } from '../../../../utils/date'
 import { isPartDayPlacement } from '../../../../utils/placements'
 import { requireRole } from '../../../../utils/roles'
 import { renderResult } from '../../../async-rendering'
-import { AgeIndicatorIconWithTooltip } from '../../../common/AgeIndicatorIcon'
+import { AgeIndicatorIcon } from '../../../common/AgeIndicatorIcon'
 import { CareTypeChip } from '../../../common/CareTypeLabel'
 import { DataList } from '../../../common/DataList'
 import { StatusIconContainer } from '../../../common/StatusIconContainer'
@@ -593,7 +593,7 @@ export default React.memo(function Group({
                         </Td>
                         <Td>
                           <FixedSpaceRow spacing="xs">
-                            <AgeIndicatorIconWithTooltip
+                            <AgeIndicatorIcon
                               isUnder3={
                                 filters.startDate.differenceInYears(
                                   dateOfBirth

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationsTable.tsx
@@ -23,7 +23,7 @@ import { faCalendarPlus } from 'lib-icons'
 
 import { useTranslation } from '../../../state/i18n'
 import { formatName } from '../../../utils'
-import AgeIndicatorIcon from '../../common/AgeIndicatorIcon'
+import { AgeIndicatorIcon } from '../../common/AgeIndicatorIcon'
 
 import ChildDay from './ChildDay'
 

--- a/frontend/src/lib-components/atoms/Tooltip.tsx
+++ b/frontend/src/lib-components/atoms/Tooltip.tsx
@@ -178,7 +178,7 @@ const Beak = styled.div<{ position: Position }>`
 
 type Position = 'top' | 'bottom' | 'right' | 'left'
 
-type TooltipProps = BaseProps & {
+export type TooltipProps = BaseProps & {
   children: React.ReactNode
   tooltip: React.ReactNode
   position?: Position

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -263,8 +263,8 @@ export const fi = {
       status: 'Tila',
       note: 'Huom',
       basis: 'Perusteet',
-      lessthan3: 'Alle 3-vuotias hoidontarpeen alkaessa',
-      morethan3: 'Yli 3-vuotias hoidontarpeen alkaessa',
+      lessthan3: 'Alle 3-vuotias',
+      morethan3: 'Yli 3-vuotias',
       currentUnit: 'Nyk.',
       addNote: 'Lisää muistiinpano',
       serviceWorkerNote: 'Palveluohjauksen huomio'

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2531,8 +2531,6 @@ export const fi = {
       serviceNeed: 'Palveluntarve',
       capacityFactor: 'Tuen tarve',
       partTime: 'Osa/Koko',
-      under3: 'Alle 3-vuotias',
-      atLeast3: 'Vähintään 3-vuotias',
       type: {
         NEW: 'Uusi päätös',
         REFUND: 'Hyvitys',

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -233,6 +233,12 @@ export const fi = {
       returnMessage: 'Palaa takaisin'
     }
   },
+  ageIndicator: {
+    under3: 'Alle 3-vuotias',
+    over3: 'Yli 3-vuotias',
+    under3AtPlacementStart: 'Alle 3-vuotias sijoituksen alkaessa',
+    over3AtPlacementStart: 'Yli 3-vuotias sijoituksen alkaessa'
+  },
   applications: {
     list: {
       title: 'Hakemukset',
@@ -263,8 +269,6 @@ export const fi = {
       status: 'Tila',
       note: 'Huom',
       basis: 'Perusteet',
-      lessthan3: 'Alle 3-vuotias',
-      morethan3: 'Yli 3-vuotias',
       currentUnit: 'Nyk.',
       addNote: 'Lisää muistiinpano',
       serviceWorkerNote: 'Palveluohjauksen huomio'
@@ -1471,6 +1475,8 @@ export const fi = {
       title: 'Ryhmää odottavat lapset',
       name: 'Nimi',
       birthday: 'Syntymäaika',
+      under3: 'Alle 3-vuotias sijoituksen alkaessa',
+      over3: 'Yli 3-vuotias sijoituksen alkaessa',
       placementDuration: 'Sijoitettu yksikköön',
       missingGroup: 'Ryhmä puuttuu',
       type: 'Toimintamuoto',


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
* Delete the age indicator variant without a tooltip.
* Change default tooltip text to a shorter and more generic variant.
* Replace the word "hoito" in the tooltip texts in application and ungrouped children lists.

