### PR TITLE
Fix invalid DOM nesting on login page

### DIFF
--- a/frontend/src/citizen-frontend/LoginPage.tsx
+++ b/frontend/src/citizen-frontend/LoginPage.tsx
@@ -55,13 +55,11 @@ export default React.memo(function LoginPage() {
             <Gap size="m" />
             <P noMargin>{i18n.loginPage.applying.mapText}</P>
             <Gap size="xs" />
-            <P noMargin>
-              <MapLink to="/map">
-                <FontAwesomeIcon icon={farMap} />
-                <Gap size="xs" horizontal />
-                {i18n.loginPage.applying.mapLink}
-              </MapLink>
-            </P>
+            <MapLink to="/map">
+              <FontAwesomeIcon icon={farMap} />
+              <Gap size="xs" horizontal />
+              {i18n.loginPage.applying.mapLink}
+            </MapLink>
           </ContentArea>
         </FixedSpaceColumn>
       </Container>


### PR DESCRIPTION

#### Summary

Fixes `<div> cannot appear as a descendant of <p>` error on login page.

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

