### PR TITLE
Fix citizen reservations endpoint

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { AbsenceType } from 'lib-common/generated/api-types/daycare'
 import {
+  OpenTimeRange,
   ReservationChild,
   ReservationsResponse,
   TimeRange
@@ -60,7 +61,7 @@ interface ChildWithReservations {
   child: ReservationChild
   absence: AbsenceType | undefined
   reservations: TimeRange[]
-  attendances: TimeRange[]
+  attendances: OpenTimeRange[]
   reservationEditable: boolean
 }
 
@@ -251,7 +252,7 @@ export default React.memo(function DayView({
                       ? attendances
                           .map(
                             ({ startTime, endTime }) =>
-                              `${startTime} – ${endTime}`
+                              `${startTime} – ${endTime ?? ''}`
                           )
                           .join(', ')
                       : '–'}

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -24,7 +24,7 @@ export interface AbsenceRequest {
 */
 export interface ChildDailyData {
   absence: AbsenceType | null
-  attendances: TimeRange[]
+  attendances: OpenTimeRange[]
   childId: UUID
   reservations: TimeRange[]
 }
@@ -45,6 +45,14 @@ export interface DailyReservationRequest {
   childId: UUID
   date: LocalDate
   reservations: TimeRange[] | null
+}
+
+/**
+* Generated from fi.espoo.evaka.reservations.OpenTimeRange
+*/
+export interface OpenTimeRange {
+  endTime: string | null
+  startTime: string
 }
 
 /**

--- a/frontend/src/lib-common/reservations.ts
+++ b/frontend/src/lib-common/reservations.ts
@@ -6,6 +6,7 @@ import FiniteDateRange from './finite-date-range'
 import { ErrorKey, regexp, TIME_REGEXP } from './form-validation'
 import {
   DailyReservationRequest,
+  OpenTimeRange,
   TimeRange
 } from './generated/api-types/reservations'
 import LocalDate from './local-date'
@@ -228,13 +229,13 @@ export function attendanceTimeDiffers(
 
 export function reservationsAndAttendancesDiffer(
   reservations: TimeRange[],
-  attendances: TimeRange[]
+  attendances: OpenTimeRange[]
 ): boolean {
   return reservations.some((reservation) => {
     const matchingAttendance = attendances.find(
       (attendance) =>
         attendance.startTime <= reservation.endTime &&
-        reservation.startTime <= attendance.endTime
+        (!attendance.endTime || reservation.startTime <= attendance.endTime)
     )
 
     if (!matchingAttendance) return false

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -146,7 +146,7 @@ data class ChildDailyData(
     val childId: ChildId,
     val absence: AbsenceType?,
     val reservations: List<TimeRange>,
-    val attendances: List<TimeRange>
+    val attendances: List<OpenTimeRange>
 )
 
 data class ReservationChild(

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -44,10 +44,25 @@ class TimeRangeSerializer : JsonSerializer<TimeRange>() {
         gen.writeObjectField("endTime", value.endTime.format())
         gen.writeEndObject()
     }
-
-    private fun LocalTime.format() = "${padWithZeros(hour)}:${padWithZeros(minute)}"
-    private fun padWithZeros(hoursOrMinutes: Int) = hoursOrMinutes.toString().padStart(2, '0')
 }
+
+@JsonSerialize(using = OpenTimeRangeSerializer::class)
+data class OpenTimeRange(
+    val startTime: LocalTime,
+    val endTime: LocalTime?,
+)
+
+class OpenTimeRangeSerializer : JsonSerializer<OpenTimeRange>() {
+    override fun serialize(value: OpenTimeRange, gen: JsonGenerator, serializers: SerializerProvider) {
+        gen.writeStartObject()
+        gen.writeObjectField("startTime", value.startTime.format())
+        gen.writeObjectField("endTime", value.endTime?.format())
+        gen.writeEndObject()
+    }
+}
+
+private fun LocalTime.format() = "${padWithZeros(hour)}:${padWithZeros(minute)}"
+private fun padWithZeros(hoursOrMinutes: Int) = hoursOrMinutes.toString().padStart(2, '0')
 
 fun validateReservationTimeRange(timeRange: TimeRange) {
     if (timeRange.endTime <= timeRange.startTime) {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
A time range with non-nullable `endTime` was used for citizen attendances although attendances might not have a end time set yet.

