### PR TITLE
Income statement improvements and fixes

### DIFF
--- a/frontend/src/citizen-frontend/income-statements/ChildrenIncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildrenIncomeStatements.tsx
@@ -68,7 +68,7 @@ const ChildIncomeStatementsTable = React.memo(
     )
 
     return (
-      <>
+      <div key={child.id}>
         {renderResult(incomeStatements, ({ data, pages }) =>
           data.length > 0 ? (
             <>
@@ -131,6 +131,7 @@ const ChildIncomeStatementsTable = React.memo(
                 currentPage={page}
                 setPage={setPage}
                 label={t.common.page}
+                hideIfOnlyOnePage={true}
               />
             </>
           ) : (
@@ -140,7 +141,7 @@ const ChildIncomeStatementsTable = React.memo(
             />
           )
         )}
-      </>
+      </div>
     )
   }
 )

--- a/frontend/src/citizen-frontend/income-statements/ChildrenIncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildrenIncomeStatements.tsx
@@ -68,7 +68,7 @@ const ChildIncomeStatementsTable = React.memo(
     )
 
     return (
-      <div key={child.id}>
+      <>
         {renderResult(incomeStatements, ({ data, pages }) =>
           data.length > 0 ? (
             <>
@@ -141,7 +141,7 @@ const ChildIncomeStatementsTable = React.memo(
             />
           )
         )}
-      </div>
+      </>
     )
   }
 )

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
@@ -188,6 +188,7 @@ export default React.memo(function IncomeStatements() {
                 currentPage={page}
                 setPage={setPage}
                 label={t.common.page}
+                hideIfOnlyOnePage={true}
               />
             </>
           ))}

--- a/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
@@ -15,6 +15,7 @@ import {
   Select,
   TextInput
 } from '../../../utils/page'
+import ChildInformationPage from '../child-information'
 import GuardianInformationPage from '../guardian-information'
 
 export class FinancePage {
@@ -382,9 +383,16 @@ export class IncomeStatementsPage {
     return this.#incomeStatementRows.count()
   }
 
-  async openNthIncomeStatement(nth: number) {
+  async openNthIncomeStatementForGuardian(nth: number) {
     await this.#incomeStatementRows.nth(nth).find('a').click()
     const page = new GuardianInformationPage(this.page)
+    await page.waitUntilLoaded()
+    return page
+  }
+
+  async openNthIncomeStatementForChild(nth: number) {
+    await this.#incomeStatementRows.nth(nth).find('a').click()
+    const page = new ChildInformationPage(this.page)
     await page.waitUntilLoaded()
     return page
   }

--- a/frontend/src/e2e-test/specs/4_finance/income-staments.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/income-staments.spec.ts
@@ -65,9 +65,8 @@ describe('Income statements', () => {
 
     let incomeStatementsPage = await navigateToIncomeStatements()
     await waitUntilEqual(() => incomeStatementsPage.getRowCount(), 2)
-    const personProfilePage = await incomeStatementsPage.openNthIncomeStatement(
-      1
-    )
+    const personProfilePage =
+      await incomeStatementsPage.openNthIncomeStatementForGuardian(1)
 
     const incomesSection = await personProfilePage.openCollapsible('incomes')
     await waitUntilFalse(() => incomesSection.isIncomeStatementHandled(0))
@@ -103,7 +102,7 @@ describe('Income statements', () => {
     await insertIncomeStatements(enduserChildFixtureJari.id, [
       {
         type: 'CHILD_INCOME',
-        otherInfo: 'Test other info',
+        otherInfo: 'Test info',
         startDate: LocalDate.today(),
         endDate: LocalDate.today(),
         attachmentIds: []
@@ -117,5 +116,12 @@ describe('Income statements', () => {
       `${enduserChildFixtureJari.firstName} ${enduserChildFixtureJari.lastName}`,
       'lapsen tulotiedot'
     )
+
+    const profilePage =
+      await incomeStatementsPage.openNthIncomeStatementForChild(0)
+    const incomeSection = await profilePage.openCollapsible('income')
+    await incomeSection.assertIncomeStatementRowCount(1)
+    const incomeStatementPage = await incomeSection.openIncomeStatement(0)
+    await incomeStatementPage.assertChildIncomeStatement('Test info', 0)
   })
 })

--- a/frontend/src/e2e-test/specs/5_employee/child-income.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-income.spec.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { UUID } from 'lib-common/types'
+
+import config from '../../config'
+import { resetDatabase } from '../../dev-api'
+import { initializeAreaAndPersonData } from '../../dev-api/data-init'
+import { Fixture } from '../../dev-api/fixtures'
+import ChildInformationPage from '../../pages/employee/child-information'
+import { IncomeSection } from '../../pages/employee/guardian-information'
+import { waitUntilEqual } from '../../utils'
+import { Page } from '../../utils/page'
+import { employeeLogin } from '../../utils/user'
+
+let page: Page
+let personId: UUID
+let incomesSection: IncomeSection
+
+beforeEach(async () => {
+  await resetDatabase()
+
+  const fixtures = await initializeAreaAndPersonData()
+  personId = fixtures.enduserChildFixtureJari.id
+
+  const financeAdmin = await Fixture.employeeFinanceAdmin().save()
+
+  page = await Page.open()
+  await employeeLogin(page, financeAdmin.data)
+  await page.goto(config.employeeUrl + '/child-information/' + personId)
+
+  const childInformationPage = new ChildInformationPage(page)
+  incomesSection = await childInformationPage.openCollapsible('income')
+})
+
+describe('Child Income', () => {
+  it('Create a new max fee accepted income', async () => {
+    await incomesSection.openNewIncomeForm()
+
+    await incomesSection.fillIncomeStartDate('1.1.2020')
+    await incomesSection.fillIncomeEndDate('31.1.2020')
+    await incomesSection.chooseIncomeEffect('MAX_FEE_ACCEPTED')
+    await incomesSection.save()
+
+    await waitUntilEqual(() => incomesSection.incomeListItemCount(), 1)
+  })
+
+  it('Create a new income with main income', async () => {
+    await incomesSection.openNewIncomeForm()
+
+    await incomesSection.fillIncomeStartDate('1.1.2020')
+    await incomesSection.fillIncomeEndDate('31.1.2020')
+    await incomesSection.chooseIncomeEffect('INCOME')
+
+    await incomesSection.fillIncome('MAIN_INCOME', '5000')
+    await incomesSection.save()
+
+    await waitUntilEqual(() => incomesSection.incomeListItemCount(), 1)
+    await waitUntilEqual(() => incomesSection.getIncomeSum(), '5000 €')
+    await waitUntilEqual(() => incomesSection.getExpensesSum(), '0 €')
+  })
+})

--- a/frontend/src/employee-frontend/components/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/PersonProfile.tsx
@@ -82,7 +82,7 @@ const layouts: Layouts<typeof components> = {
     { component: 'dependants', open: false },
     { component: 'applications', open: false },
     { component: 'decisions', open: false },
-    { component: 'income', open: true },
+    { component: 'income', open: false },
     { component: 'fee-decisions', open: false },
     { component: 'invoices', open: false },
     { component: 'voucherValueDecisions', open: false }

--- a/frontend/src/lib-customizations/common.tsx
+++ b/frontend/src/lib-customizations/common.tsx
@@ -22,7 +22,7 @@ export const mergeCustomizer = (
   original: unknown,
   customized: unknown
 ): unknown =>
-  isArray(original) || React.isValidElement(original as never)
+  isArray(customized) || React.isValidElement(customized as never)
     ? customized
     : undefined // fall back to default merge logic
 


### PR DESCRIPTION
#### Summary
- E2E tests for finance income statement list opening the correct profile page for child income statement and child income editor
- Hide citizen income statement Pagination page number if only 1
- Close person profile income section by default for admin
- Fix react missing key warnings related with translation mangling
