### PR TITLE
Fix backup e2e tests with another +1 year hack

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -943,8 +943,8 @@ export function createBackupCareFixture(
     childId,
     unitId: unitId,
     period: {
-      start: '2022-02-01',
-      end: '2022-02-03'
+      start: '2023-02-01',
+      end: '2023-02-03'
     }
   }
 }

--- a/frontend/src/e2e-test/specs/5_employee/backup-care.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/backup-care.spec.ts
@@ -59,14 +59,14 @@ describe('Employee - Backup care', () => {
     await groupsPage.missingPlacementsSection.assertRowFields(0, {
       childName: `${childFixture.lastName} ${childFixture.firstName}`,
       dateOfBirth: LocalDate.parseIso(childFixture.dateOfBirth).format(),
-      placementDuration: '01.02.2022 - 03.02.2022',
-      groupMissingDuration: '01.02.2022 - 03.02.2022'
+      placementDuration: '01.02.2023 - 03.02.2023',
+      groupMissingDuration: '01.02.2023 - 03.02.2023'
     })
   })
 
   test('backup care child can be placed into a group and removed from it', async () => {
     await groupsPage.selectPeriod('1 year')
-    await groupsPage.setFilterStartDate('01.01.2022')
+    await groupsPage.setFilterStartDate('01.01.2023')
 
     // open the group placement modal and submit it with default values
     await groupsPage.missingPlacementsSection.createGroupPlacementForChild(0)
@@ -82,7 +82,7 @@ describe('Employee - Backup care', () => {
     const childRow = group.childRow(childFixture.id)
     await childRow.assertFields({
       childName: `${childFixture.lastName} ${childFixture.firstName}`,
-      placementDuration: '01.02.2022- 03.02.2022'
+      placementDuration: '01.02.2023- 03.02.2023'
     })
 
     // after removing the child is again visible at missing groups and no longer at the group
@@ -92,8 +92,8 @@ describe('Employee - Backup care', () => {
     await groupsPage.missingPlacementsSection.assertRowFields(0, {
       childName: `${childFixture.lastName} ${childFixture.firstName}`,
       dateOfBirth: LocalDate.parseIso(childFixture.dateOfBirth).format(),
-      placementDuration: '01.02.2022 - 03.02.2022',
-      groupMissingDuration: '01.02.2022 - 03.02.2022'
+      placementDuration: '01.02.2023 - 03.02.2023',
+      groupMissingDuration: '01.02.2023 - 03.02.2023'
     })
 
     group = await groupsPage.openGroupCollapsible(daycareGroupFixture.id)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The real fix would be to replace acl_views (that use `current_date`) with parameterized queries / functions, but this is not currently easy to do
