### PR TITLE
Fix voucher value report for annulled decisions

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -529,7 +529,12 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest() {
     }
 
     private fun endDecisions(now: LocalDate) {
-        db.transaction { voucherValueDecisionService.endDecisionsWithEndedPlacements(it, now) }
+        db.transaction {
+            voucherValueDecisionService.endDecisionsWithEndedPlacements(
+                it,
+                HelsinkiDateTime.of(now, LocalTime.of(12, 0))
+            )
+        }
     }
 
     private fun getPdfStatus(decisionId: VoucherValueDecisionId, user: AuthenticatedUser.Employee): Int {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGenerator.kt
@@ -89,7 +89,7 @@ internal fun Database.Transaction.handleFeeDecisionChanges(
 
     val updatedDecisions = updateExistingDecisions(from, newDrafts, existingDrafts, activeDecisions)
     deleteFeeDecisions(existingDrafts.map { it.id })
-    upsertFeeDecisions(updatedDecisions)
+    upsertFeeDecisions(updatedDecisions.updatedDrafts + updatedDecisions.updatedActiveDecisions)
 }
 
 private fun generateFeeDecisions(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -332,12 +332,17 @@ internal fun <Decision : FinanceDecision<Decision>> mergeDecisions(
         .map { it.withRandomId() }
 }
 
+data class UpdatedExistingDecisions<Decision : FinanceDecision<Decision>>(
+    val updatedDrafts: List<Decision>,
+    val updatedActiveDecisions: List<Decision>
+)
+
 internal fun <Decision : FinanceDecision<Decision>> updateExistingDecisions(
     from: LocalDate,
     newDrafts: List<Decision>,
     existingDrafts: List<Decision>,
     activeDecisions: List<Decision>
-): List<Decision> {
+): UpdatedExistingDecisions<Decision> {
     val draftsWithUpdatedDates = filterOrUpdateStaleDrafts(existingDrafts, DateRange(from, null))
         .map { it.withRandomId() }
 
@@ -346,7 +351,7 @@ internal fun <Decision : FinanceDecision<Decision>> updateExistingDecisions(
         newDrafts + draftsWithUpdatedDates
     )
 
-    return mergedDrafts + withUpdatedEndDates
+    return UpdatedExistingDecisions(updatedDrafts = mergedDrafts, updatedActiveDecisions = withUpdatedEndDates)
 }
 
 internal fun <Decision : FinanceDecision<Decision>> filterOrUpdateStaleDrafts(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.invoicing.data.getFeeAlterationsFrom
 import fi.espoo.evaka.invoicing.data.getFeeThresholds
 import fi.espoo.evaka.invoicing.data.getIncomesFrom
 import fi.espoo.evaka.invoicing.data.lockValueDecisionsForChild
+import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionEndDates
 import fi.espoo.evaka.invoicing.data.upsertValueDecisions
 import fi.espoo.evaka.invoicing.domain.ChildWithDateOfBirth
 import fi.espoo.evaka.invoicing.domain.FeeAlteration
@@ -37,6 +38,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.asDistinctPeriods
 import fi.espoo.evaka.shared.domain.mergePeriods
 import org.jdbi.v3.core.kotlin.mapTo
@@ -95,7 +97,8 @@ internal fun Database.Transaction.handleValueDecisionChanges(
 
     val updatedDecisions = updateExistingDecisions(from, newDrafts, existingDrafts, activeDecisions)
     deleteValueDecisions(existingDrafts.map { it.id })
-    upsertValueDecisions(updatedDecisions)
+    upsertValueDecisions(updatedDecisions.updatedDrafts)
+    updateVoucherValueDecisionEndDates(updatedDecisions.updatedActiveDecisions, HelsinkiDateTime.now())
 }
 
 private fun generateNewValueDecisions(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -154,8 +154,7 @@ WHERE ca.unit_id = u.id AND NOT u.round_the_clock AND ca.end_time IS NULL
     }
 
     fun endOutdatedVoucherValueDecisions(db: Database.Connection) {
-        val now = LocalDate.now()
-        db.transaction { voucherValueDecisionService.endDecisionsWithEndedPlacements(it, now) }
+        db.transaction { voucherValueDecisionService.endDecisionsWithEndedPlacements(it, HelsinkiDateTime.now()) }
     }
 
     fun removeExpiredNotes(db: Database.Connection) {

--- a/service/src/main/resources/db/migration/V212__voucher_value_decision_annulment_and_validity_timestamps.sql
+++ b/service/src/main/resources/db/migration/V212__voucher_value_decision_annulment_and_validity_timestamps.sql
@@ -1,0 +1,5 @@
+ALTER TABLE voucher_value_decision
+    ADD COLUMN annulled_at timestamp with time zone,
+    ADD COLUMN validity_updated_at timestamp with time zone;
+
+UPDATE voucher_value_decision SET annulled_at = updated WHERE status = 'ANNULLED'::voucher_value_decision_status;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -209,3 +209,4 @@ V208__child_income_type.sql
 V209__single_date_attendances.sql
 V210__absence_categories.sql
 V211__holiday_period_questionnaires.sql
+V212__voucher_value_decision_annulment_and_validity_timestamps.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Fix voucher value report so that it correctly refunds annulled decisions or decisions that have had their end date updated because a child has left daycare.

Couldn't come up with any new test cases, but I'm still unsure whether these changes take every single case into account.

