### PR TITLE
EVAKA-4162 Make holiday banner sticky by modifying page layout

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -6,7 +6,9 @@ import { ErrorBoundary } from '@sentry/react'
 import React, { ReactNode, useCallback, useContext } from 'react'
 import { Route, BrowserRouter, Redirect, Switch } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
+import styled from 'styled-components'
 
+import { desktopMin } from 'lib-components/breakpoints'
 import ErrorPage from 'lib-components/molecules/ErrorPage'
 import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
 import { featureFlags } from 'lib-customizations/citizen'
@@ -26,6 +28,7 @@ import ChildPage from './children/ChildPage'
 import ChildrenPage from './children/ChildrenPage'
 import DecisionResponseList from './decisions/decision-response-page/DecisionResponseList'
 import Header from './header/Header'
+import { headerHeightDesktop, headerHeightMobile } from './header/const'
 import { HolidayPeriodsContextProvider } from './holiday-periods/state'
 import ChildIncomeStatementEditor from './income-statements/ChildIncomeStatementEditor'
 import ChildIncomeStatementView from './income-statements/ChildIncomeStatementView'
@@ -243,12 +246,21 @@ function HandleRedirection() {
   )
 }
 
+const ScrollableMain = styled.main`
+  height: calc(100% - ${headerHeightMobile}px);
+  overflow: auto;
+
+  @media (min-width: ${desktopMin}) {
+    height: calc(100% - ${headerHeightDesktop}px);
+  }
+`
+
 function Main({ children }: { children: ReactNode }) {
   const { user } = useContext(AuthContext)
   const render = useCallback(() => <>{children}</>, [children])
   return (
-    <main>
+    <ScrollableMain id="main">
       <UnwrapResult result={user}>{render}</UnwrapResult>
-    </main>
+    </ScrollableMain>
   )
 }

--- a/frontend/src/citizen-frontend/calendar/HolidayPeriodBanner.tsx
+++ b/frontend/src/citizen-frontend/calendar/HolidayPeriodBanner.tsx
@@ -17,17 +17,14 @@ import { faTreePalm } from 'lib-icons'
 
 import { UnwrapResult } from '../async-rendering'
 import { useUser } from '../auth/state'
-import { headerHeightDesktop, headerHeightMobile } from '../header/const'
+import { bannerHeightDesktop } from '../header/const'
 import { useHolidayPeriods } from '../holiday-periods/state'
 import { useTranslation } from '../localization'
 
 const BannerBackground = styled.div`
   position: sticky;
   z-index: 2;
-  top: ${headerHeightMobile}px;
-  @media (min-width: ${desktopMin}) {
-    top: ${headerHeightDesktop}px;
-  }
+  top: 0;
   background-color: ${colors.grayscale.g0};
 `
 
@@ -37,6 +34,10 @@ const Banner = styled(Container)`
   align-items: center;
   gap: ${defaultMargins.s};
   padding: ${defaultMargins.s};
+
+  @media (min-width: ${desktopMin}) {
+    height: ${bannerHeightDesktop}px;
+  }
 `
 
 interface HolidayPeriodBannerProps {

--- a/frontend/src/citizen-frontend/calendar/WeekElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/WeekElem.tsx
@@ -5,10 +5,8 @@
 import React, { useEffect, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
-import { headerHeightMobile } from 'citizen-frontend/header/const'
 import { DailyReservationData } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
-import { scrollToPos } from 'lib-common/utils/scrolling'
 import {
   FixedSpaceColumn,
   FixedSpaceRow
@@ -17,7 +15,9 @@ import { fontWeights } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 
+import { headerHeightMobile } from '../header/const'
 import { useLang, useTranslation } from '../localization'
+import { scrollMainToPos } from '../utils'
 
 import { WeeklyData } from './CalendarListView'
 import { Reservations } from './calendar-elements'
@@ -90,7 +90,10 @@ const DayElem = React.memo(function DayElem({
 
       if (pos) {
         const offset = headerHeightMobile + 16
-        scrollToPos({ left: 0, top: pos - offset })
+        scrollMainToPos({
+          left: 0,
+          top: pos - offset
+        })
       }
     }
   }, [])

--- a/frontend/src/citizen-frontend/header/Header.tsx
+++ b/frontend/src/citizen-frontend/header/Header.tsx
@@ -63,8 +63,6 @@ const HeaderContainer = styled.header<{ showMenu: boolean }>`
   z-index: 9;
   color: ${colors.grayscale.g0};
   background-color: ${colors.main.m2};
-  position: ${({ showMenu }) => (showMenu ? 'fixed' : 'sticky')};
-  top: 0;
   display: grid;
   grid: minmax(60px, min-content) / repeat(3, minmax(100px, 1fr));
   height: ${headerHeightMobile}px;

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -38,7 +38,7 @@ import { langs, useLang, useTranslation } from '../localization'
 
 import AttentionIndicator from './AttentionIndicator'
 import { CircledChar } from './DesktopNav'
-import { getLogoutUri } from './const'
+import { getLogoutUri, headerHeightMobile } from './const'
 
 type Props = {
   showMenu: boolean
@@ -149,15 +149,14 @@ const MenuButton = styled.button`
 const MenuContainer = styled.div`
   position: fixed;
   overflow-y: scroll;
-  top: 0;
+  top: ${headerHeightMobile}px;
   right: 0;
   background: ${colors.main.m2};
   box-sizing: border-box;
   width: 100vw;
-  height: 100%;
-  padding: calc(52px + ${defaultMargins.s}) ${defaultMargins.s}
-    ${defaultMargins.s} ${defaultMargins.s};
-  z-index: -1;
+  height: calc(100% - ${headerHeightMobile}px);
+  padding: ${defaultMargins.s};
+  z-index: 5;
   display: flex;
   flex-direction: column;
 `

--- a/frontend/src/citizen-frontend/header/const.ts
+++ b/frontend/src/citizen-frontend/header/const.ts
@@ -23,3 +23,4 @@ export const getLogoutUri = (user: User) =>
 
 export const headerHeightDesktop = 80
 export const headerHeightMobile = 60
+export const bannerHeightDesktop = 66

--- a/frontend/src/citizen-frontend/index.css
+++ b/frontend/src/citizen-frontend/index.css
@@ -8,6 +8,8 @@ body {
   font-family: 'Open Sans', 'Arial', sans-serif;
   background-color: #f5f5f5;
   margin: 0;
+  height: 100vh;
+  overflow: hidden;
 }
 
 input,
@@ -40,4 +42,8 @@ a {
   color: #0050bb;
   cursor: pointer;
   text-decoration: none;
+}
+
+#app {
+  height: 100%;
 }

--- a/frontend/src/citizen-frontend/utils.ts
+++ b/frontend/src/citizen-frontend/utils.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { scrollElementToPos } from 'lib-common/utils/scrolling'
+
+export const scrollMainToPos = (opts: ScrollToOptions) =>
+  scrollElementToPos(document.getElementById('main'), opts)

--- a/frontend/src/lib-common/utils/scrolling.ts
+++ b/frontend/src/lib-common/utils/scrolling.ts
@@ -10,6 +10,14 @@ export function scrollToPos(options: ScrollToOptions, timeout = 0) {
   scrollWithTimeout(() => options, timeout)
 }
 
+export function scrollElementToPos(
+  element: HTMLElement | null,
+  options: ScrollToOptions,
+  timeout = 0
+) {
+  scrollWithTimeout(() => options, timeout, element)
+}
+
 export function scrollToTop(timeout = 0) {
   scrollWithTimeout(() => ({ top: 0, left: 0 }), timeout)
 }
@@ -34,13 +42,18 @@ export function scrollRefIntoView(
 
 function scrollWithTimeout(
   getOptions: () => ScrollToOptions | undefined,
-  timeout = 0
+  timeout = 0,
+  element: HTMLElement | null = null
 ) {
   if (isAutomatedTest) return
 
   withTimeout(() => {
     const opts = getOptions()
-    if (opts) window.scrollTo({ behavior: 'smooth', ...opts })
+    if (opts) {
+      element
+        ? element.scrollTo({ behavior: 'smooth', ...opts })
+        : window.scrollTo({ behavior: 'smooth', ...opts })
+    }
   }, timeout)
 }
 


### PR DESCRIPTION
The layout of the page was modified to always keep the header on top without using `position: sticky`. This is done by making the `main` element of the page scrollable, instead of scrolling the whole page including the header.

This MIGHT have an impact on the different pages in the citizen frontend. Everything I tested works, but I appreciate if you take it for a spin!