### PR TITLE
Require service test jobs for frontend install

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -1312,6 +1312,8 @@ workflows:
             - apigw_build_and_push_image
             - proxy_build_and_push_image
             - service_build_and_push_image
+            - service_test
+            - service_integration_test
           matrix:
             parameters:
               target_env: [dev, test, staging, prod]


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Previously circle would deploy even if service test or integration test jobs failed.

