### PR TITLE
Remove AuthenticatedUser.WeakCitizen

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -53,7 +54,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest() {
     private val validClubForm = ClubFormV0.fromForm2(validClubApplication.form, false, false)
 
     private val serviceWorker = AuthenticatedUser.Employee(testAdult_1.id.raw, setOf(UserRole.SERVICE_WORKER))
-    private val endUser = AuthenticatedUser.Citizen(testAdult_1.id.raw)
+    private val endUser = AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG)
     private val guardian = testAdult_1.copy(email = "john.doe@espootest.com")
     private val guardianAsDaycareAdult = Adult(
         firstName = guardian.firstName,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -40,6 +40,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevPerson
@@ -133,7 +134,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             service.initializeApplicationForm(
                 tx,
-                AuthenticatedUser.Citizen(testAdult_1.id.raw),
+                AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG),
                 today,
                 applicationId,
                 ApplicationType.DAYCARE,
@@ -163,7 +164,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         db.transaction { tx ->
             service.initializeApplicationForm(
                 tx,
-                AuthenticatedUser.Citizen(testAdult_1.id.raw),
+                AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG),
                 today,
                 applicationId,
                 ApplicationType.DAYCARE,
@@ -194,7 +195,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val applicationDate = secondTerm.applicationPeriod.start.minusWeeks(1)
             service.initializeApplicationForm(
                 tx,
-                AuthenticatedUser.Citizen(testAdult_1.id.raw),
+                AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG),
                 applicationDate,
                 applicationId,
                 ApplicationType.PRESCHOOL,
@@ -210,7 +211,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             val applicationDate = secondTerm.applicationPeriod.start
             service.initializeApplicationForm(
                 tx,
-                AuthenticatedUser.Citizen(testAdult_1.id.raw),
+                AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG),
                 applicationDate,
                 applicationId,
                 ApplicationType.PRESCHOOL,
@@ -301,14 +302,14 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         assertDueDate(applicationId, null) // missing attachment
 
         // when
-        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id.raw)))
+        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG)))
         db.transaction { tx ->
             tx.createUpdate("UPDATE attachment SET received_at = :receivedAt WHERE application_id = :applicationId")
                 .bind("applicationId", applicationId)
                 .bind("receivedAt", now.minusWeeks(1))
                 .execute()
         }
-        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id.raw)))
+        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG)))
         // then
         assertDueDate(applicationId, now.plusWeeks(2).toLocalDate()) // end date >= earliest attachment.receivedAt
     }
@@ -326,8 +327,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
             )
         }
         // when
-        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id.raw), AttachmentType.EXTENDED_CARE))
-        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id.raw), AttachmentType.URGENCY))
+        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG), AttachmentType.EXTENDED_CARE))
+        assertTrue(uploadAttachment(applicationId, AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG), AttachmentType.URGENCY))
 
         // then
         assertDueDate(applicationId, null) // application not sent
@@ -1913,7 +1914,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
         db.transaction { tx ->
             // when
-            val user = AuthenticatedUser.Citizen(testAdult_5.id.raw)
+            val user = AuthenticatedUser.Citizen(testAdult_5.id.raw, CitizenAuthLevel.STRONG)
             service.acceptDecision(
                 tx,
                 user,
@@ -1942,7 +1943,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
         workflowForPreschoolDaycareDecisions()
 
         db.transaction { tx ->
-            val user = AuthenticatedUser.Citizen(testAdult_1.id.raw)
+            val user = AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG)
             // when
             assertThrows<Forbidden> {
                 service.acceptDecision(
@@ -1964,7 +1965,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest() {
 
         db.transaction { tx ->
             // when
-            val user = AuthenticatedUser.Citizen(testAdult_1.id.raw)
+            val user = AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG)
             assertThrows<Forbidden> {
                 service.rejectDecision(
                     tx,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationUpdateIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.attachment.AttachmentType
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestApplication
@@ -28,7 +29,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ApplicationUpdateIntegrationTest : FullApplicationTest() {
-    private val citizen = AuthenticatedUser.Citizen(testAdult_1.id.raw)
+    private val citizen = AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG)
     private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id.raw, setOf(UserRole.SERVICE_WORKER))
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
@@ -52,7 +53,7 @@ class GetApplicationIntegrationTests : FullApplicationTest() {
     lateinit var scheduledJobs: ScheduledJobs
 
     private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id.raw, setOf(UserRole.SERVICE_WORKER))
-    private val endUser = AuthenticatedUser.Citizen(testAdult_1.id.raw)
+    private val endUser = AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG)
     private val testSpecialEducationTeacherId = EmployeeId(UUID.randomUUID())
     private val testSpecialEducationTeacher = AuthenticatedUser.Employee(testSpecialEducationTeacherId.raw, setOf())
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationSummaryIntegrationTests.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevPerson
@@ -79,7 +80,7 @@ class GetApplicationSummaryIntegrationTests : FullApplicationTest() {
         }
 
         if (attachment) {
-            uploadAttachment(applicationId, AuthenticatedUser.Citizen(guardian.id.raw))
+            uploadAttachment(applicationId, AuthenticatedUser.Citizen(guardian.id.raw, CitizenAuthLevel.STRONG))
         }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attachments/AttachmentsControllerIntegrationTest.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.IncomeStatementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.testAdult_5
@@ -28,7 +29,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class AttachmentsControllerIntegrationTest : FullApplicationTest() {
-    private val user = AuthenticatedUser.Citizen(testAdult_5.id.raw)
+    private val user = AuthenticatedUser.Citizen(testAdult_5.id.raw, CitizenAuthLevel.STRONG)
 
     @BeforeEach
     private fun beforeEach() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.daycare.AbstractIntegrationTest
 import fi.espoo.evaka.daycare.createChild
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Forbidden
@@ -65,7 +66,7 @@ class ChildrenControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `get additional info throws forbidden with enduser`() {
-        assertThrows<Forbidden> { getAdditionalInfo(AuthenticatedUser.Citizen(UUID.randomUUID())) }
+        assertThrows<Forbidden> { getAdditionalInfo(AuthenticatedUser.Citizen(UUID.randomUUID(), CitizenAuthLevel.STRONG)) }
     }
 
     fun getAdditionalInfo(user: AuthenticatedUser) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionResolutionIntegrationTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -58,7 +59,7 @@ data class DecisionResolutionTestCase(val isServiceWorker: Boolean, val isAccept
 
 class DecisionResolutionIntegrationTest : FullApplicationTest() {
     private val serviceWorker = AuthenticatedUser.Employee(testDecisionMaker_1.id.raw, setOf(UserRole.SERVICE_WORKER))
-    private val endUser = AuthenticatedUser.Citizen(testAdult_1.id.raw)
+    private val endUser = AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG)
     private val applicationId = ApplicationId(UUID.randomUUID())
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.HolidayPeriodId
 import fi.espoo.evaka.shared.HolidayQuestionnaireId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.resetDatabase
@@ -56,7 +57,7 @@ class HolidayPeriodControllerCitizenIntegrationTest : FullApplicationTest() {
 
     private final val child1 = testChild_1
     private final val parent = testAdult_1
-    private final val authenticatedParent = AuthenticatedUser.Citizen(parent.id.raw)
+    private final val authenticatedParent = AuthenticatedUser.Citizen(parent.id.raw, CitizenAuthLevel.STRONG)
 
     @BeforeEach
     fun setUp() {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizenIntegrationTest.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.IncomeStatementId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevEmployee
@@ -38,7 +39,7 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 
 class IncomeStatementControllerCitizenIntegrationTest : FullApplicationTest() {
-    private val citizen = AuthenticatedUser.Citizen(testAdult_1.id.raw)
+    private val citizen = AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG)
 
     @BeforeEach
     fun beforeEach() {
@@ -461,7 +462,7 @@ class IncomeStatementControllerCitizenIntegrationTest : FullApplicationTest() {
 
     @Test
     fun `create an income statement with someone else's attachment`() {
-        val someoneElse = AuthenticatedUser.Citizen(testAdult_2.id.raw)
+        val someoneElse = AuthenticatedUser.Citizen(testAdult_2.id.raw, CitizenAuthLevel.STRONG)
         val attachmentId = uploadAttachment(someoneElse)
 
         createIncomeStatement(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.shared.MessageThreadId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
@@ -75,10 +76,10 @@ class MessageIntegrationTest : FullApplicationTest() {
     private val employee2Id = EmployeeId(UUID.randomUUID())
     private val employee1 = AuthenticatedUser.Employee(id = employee1Id.raw, roles = setOf(UserRole.UNIT_SUPERVISOR))
     private val employee2 = AuthenticatedUser.Employee(id = employee2Id.raw, roles = setOf(UserRole.UNIT_SUPERVISOR))
-    private val person1 = AuthenticatedUser.Citizen(id = person1Id.raw)
-    private val person2 = AuthenticatedUser.Citizen(id = person2Id.raw)
-    private val person3 = AuthenticatedUser.Citizen(id = person3Id.raw)
-    private val person4 = AuthenticatedUser.Citizen(id = person4Id.raw)
+    private val person1 = AuthenticatedUser.Citizen(id = person1Id.raw, CitizenAuthLevel.STRONG)
+    private val person2 = AuthenticatedUser.Citizen(id = person2Id.raw, CitizenAuthLevel.STRONG)
+    private val person3 = AuthenticatedUser.Citizen(id = person3Id.raw, CitizenAuthLevel.STRONG)
+    private val person4 = AuthenticatedUser.Citizen(id = person4Id.raw, CitizenAuthLevel.STRONG)
     private val groupId = GroupId(UUID.randomUUID())
     private val placementStart = LocalDate.now().minusDays(30)
     private val placementEnd = LocalDate.now().plusDays(30)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentIntegrationTest.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PedagogicalDocumentId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -54,7 +55,7 @@ class PedagogicalDocumentIntegrationTest : FullApplicationTest() {
     private val groupStaffId = EmployeeId(UUID.randomUUID())
     private val groupStaff = AuthenticatedUser.Employee(groupStaffId.raw, setOf())
 
-    private val guardian = AuthenticatedUser.Citizen(testAdult_1.id.raw)
+    private val guardian = AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG)
 
     val groupId = GroupId(UUID.randomUUID())
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.pis.createParentship
 import fi.espoo.evaka.pis.getParentships
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
 import fi.espoo.evaka.shared.db.Database
@@ -204,7 +205,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to get parentships`() {
-        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID(), CitizenAuthLevel.STRONG)
         db.transaction { tx ->
             tx.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
         }
@@ -213,7 +214,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to update parentship`() {
-        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID(), CitizenAuthLevel.STRONG)
         val parentship = db.transaction { tx ->
             tx.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
         }
@@ -225,7 +226,7 @@ class ParentshipControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to delete parentship`() {
-        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID(), CitizenAuthLevel.STRONG)
         val parentship = db.transaction { tx ->
             tx.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PartnershipsControllerIntegrationTest.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.pis.getPartnershipsForPerson
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
 import fi.espoo.evaka.shared.db.Database
@@ -211,7 +212,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to get partnerships`() {
-        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID(), CitizenAuthLevel.STRONG)
         db.transaction { tx ->
             tx.createPartnership(person.id, partner.id, LocalDate.now(), LocalDate.now().plusDays(200))
         }
@@ -223,7 +224,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to create a partnership`() {
-        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID(), CitizenAuthLevel.STRONG)
         val startDate = LocalDate.now()
         val endDate = startDate.plusDays(200)
         val reqBody =
@@ -236,7 +237,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to update partnerships`() {
-        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID(), CitizenAuthLevel.STRONG)
         val partnership = db.transaction { tx ->
             tx.createPartnership(person.id, partner.id, LocalDate.now(), LocalDate.now().plusDays(200))
         }
@@ -250,7 +251,7 @@ class PartnershipsControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `error is thrown if enduser tries to delete a partnership`() {
-        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID(), CitizenAuthLevel.STRONG)
         val partnership = db.transaction { tx ->
             tx.createPartnership(person.id, partner.id, LocalDate.now(), LocalDate.now().plusDays(200))
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.pis.service.ContactInfo
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevPerson
@@ -56,7 +57,7 @@ class PersonControllerIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `End user cannot end update end user's contact info`() {
-        val user = AuthenticatedUser.Citizen(UUID.randomUUID())
+        val user = AuthenticatedUser.Citizen(UUID.randomUUID(), CitizenAuthLevel.STRONG)
         assertThrows<Forbidden> {
             controller.updateContactInfo(Database(jdbi), user, PersonId(UUID.randomUUID()), contactInfo)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizenIntegrationTest.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
@@ -45,7 +46,7 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest() {
     private final val child = testChild_1
     private final val child2 = testChild_2
     private final val parent = testAdult_1
-    private final val authenticatedParent = AuthenticatedUser.Citizen(parent.id.raw)
+    private final val authenticatedParent = AuthenticatedUser.Citizen(parent.id.raw, CitizenAuthLevel.STRONG)
 
     private final val daycareId = testDaycare.id
     private final val daycare2Id = testDaycare2.id

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.resetDatabase
@@ -212,7 +213,7 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
     private fun postReservations(request: List<DailyReservationRequest>, expectedStatus: Int? = 200) {
         val (_, res, _) = http.post("/citizen/reservations")
             .jsonBody(jsonMapper.writeValueAsString(request))
-            .asUser(AuthenticatedUser.Citizen(testAdult_1.id.raw))
+            .asUser(AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG))
             .withMockedTime(HelsinkiDateTime.of(mockToday, LocalTime.of(0, 0)))
             .response()
 
@@ -222,7 +223,7 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
     private fun postAbsences(request: AbsenceRequest) {
         val (_, res, _) = http.post("/citizen/absences")
             .jsonBody(jsonMapper.writeValueAsString(request))
-            .asUser(AuthenticatedUser.Citizen(testAdult_1.id.raw))
+            .asUser(AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG))
             .withMockedTime(HelsinkiDateTime.of(mockToday, LocalTime.of(0, 0)))
             .response()
 
@@ -237,7 +238,7 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
             )
             }"
         )
-            .asUser(AuthenticatedUser.Citizen(testAdult_1.id.raw))
+            .asUser(AuthenticatedUser.Citizen(testAdult_1.id.raw, CitizenAuthLevel.STRONG))
             .responseObject<ReservationsResponse>(jsonMapper)
 
         assertEquals(200, res.statusCode)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -25,6 +25,7 @@ import fi.espoo.evaka.placement.insertPlacement
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.updateExactlyOne
@@ -75,7 +76,7 @@ class ScheduledJobsTest : FullApplicationTest() {
     fun `Draft application and attachments older than 30 days is cleaned up`() {
         val id_to_be_deleted = ApplicationId(UUID.randomUUID())
         val id_not_to_be_deleted = ApplicationId(UUID.randomUUID())
-        val user = AuthenticatedUser.Citizen(testAdult_5.id.raw)
+        val user = AuthenticatedUser.Citizen(testAdult_5.id.raw, CitizenAuthLevel.STRONG)
 
         db.transaction { tx ->
             tx.insertApplication(guardian = testAdult_5, applicationId = id_to_be_deleted)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -1019,14 +1019,6 @@ WHERE application_id = :applicationId
         .mapTo<ApplicationAttachment>()
         .toList()
 
-fun Database.Read.isOwnApplication(user: AuthenticatedUser.Citizen, applicationId: ApplicationId): Boolean {
-    return this.createQuery("SELECT 1 FROM application WHERE id = :id AND guardian_id = :userId")
-        .bind("id", applicationId)
-        .bind("userId", user.id)
-        .mapTo<Int>()
-        .any()
-}
-
 fun Database.Transaction.cancelAllActiveTransferApplicationsAfterDate(childId: ChildId, preferredStartDateMinDate: LocalDate): List<ApplicationId> = createUpdate(
     //language=sql
     """

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
@@ -28,24 +28,18 @@ sealed class AuthenticatedUser : RoleContainer {
     val idHash: HashCode
         get() = Hashing.sha256().hashString(id.toString(), Charsets.UTF_8)
 
-    data class Citizen(override val id: UUID) : AuthenticatedUser() {
-        val authLevel: CitizenAuthLevel
-            get() = CitizenAuthLevel.STRONG
+    data class Citizen(override val id: UUID, val authLevel: CitizenAuthLevel) : AuthenticatedUser() {
         override val evakaUserId: EvakaUserId
             get() = EvakaUserId(id)
-        override val roles: Set<UserRole> = setOf(UserRole.END_USER)
+        override val roles: Set<UserRole> = when (authLevel) {
+            CitizenAuthLevel.STRONG -> setOf(UserRole.END_USER)
+            CitizenAuthLevel.WEAK -> setOf(UserRole.CITIZEN_WEAK)
+        }
         override val isEndUser = true
-        override val type = AuthenticatedUserType.citizen
-    }
-
-    data class WeakCitizen(override val id: UUID) : AuthenticatedUser() {
-        val authLevel: CitizenAuthLevel
-            get() = CitizenAuthLevel.WEAK
-        override val evakaUserId: EvakaUserId
-            get() = EvakaUserId(id)
-        override val roles: Set<UserRole> = setOf(UserRole.CITIZEN_WEAK)
-        override val isEndUser = true
-        override val type = AuthenticatedUserType.citizen_weak
+        override val type = when (authLevel) {
+            CitizenAuthLevel.STRONG -> AuthenticatedUserType.citizen
+            CitizenAuthLevel.WEAK -> AuthenticatedUserType.citizen_weak
+        }
     }
 
     data class Employee private constructor(override val id: UUID, val globalRoles: Set<UserRole>, val allScopedRoles: Set<UserRole>) : AuthenticatedUser() {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUser.kt
@@ -18,7 +18,6 @@ import java.util.UUID
 sealed class AuthenticatedUser : RoleContainer {
     open val isEndUser = false
     open val isAdmin = false
-    open val isSystemInternalUser = false
 
     abstract val id: UUID
     abstract val type: AuthenticatedUserType
@@ -66,7 +65,6 @@ sealed class AuthenticatedUser : RoleContainer {
         override val evakaUserId: EvakaUserId
             get() = EvakaUserId(id)
         override val roles: Set<UserRole> = emptySet()
-        override val isSystemInternalUser = true
         override val type = AuthenticatedUserType.system
         override fun toString(): String = "SystemInternalUser"
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonDeserializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonDeserializer.kt
@@ -16,8 +16,8 @@ class AuthenticatedUserJsonDeserializer : JsonDeserializer<AuthenticatedUser>() 
     override fun deserialize(p: JsonParser, ctx: DeserializationContext): AuthenticatedUser {
         val user = p.readValueAs(AllFields::class.java)
         return when (user.type) {
-            AuthenticatedUserType.citizen -> AuthenticatedUser.Citizen(user.id!!)
-            AuthenticatedUserType.citizen_weak -> AuthenticatedUser.WeakCitizen(user.id!!)
+            AuthenticatedUserType.citizen -> AuthenticatedUser.Citizen(user.id!!, CitizenAuthLevel.STRONG)
+            AuthenticatedUserType.citizen_weak -> AuthenticatedUser.Citizen(user.id!!, CitizenAuthLevel.WEAK)
             AuthenticatedUserType.employee -> AuthenticatedUser.Employee(user.id!!, user.globalRoles + user.allScopedRoles)
             AuthenticatedUserType.mobile -> AuthenticatedUser.MobileDevice(user.id!!, user.employeeId)
             AuthenticatedUserType.system -> AuthenticatedUser.SystemInternalUser

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonSerializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonSerializer.kt
@@ -18,9 +18,6 @@ class AuthenticatedUserJsonSerializer : JsonSerializer<AuthenticatedUser>() {
             is AuthenticatedUser.Citizen -> {
                 gen.writeObjectField("id", value.id.toString())
             }
-            is AuthenticatedUser.WeakCitizen -> {
-                gen.writeObjectField("id", value.id.toString())
-            }
             is AuthenticatedUser.Employee -> {
                 gen.writeObjectField("id", value.id.toString())
                 gen.writeObjectField("globalRoles", value.globalRoles)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/JwtTokens.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/JwtTokens.kt
@@ -21,8 +21,8 @@ fun DecodedJWT.toAuthenticatedUser(): AuthenticatedUser? = this.subject?.let { s
         .map { enumValueOf<UserRole>(it.removePrefix("ROLE_")) }
         .toSet()
     return when (type) {
-        AuthenticatedUserType.citizen -> AuthenticatedUser.Citizen(id)
-        AuthenticatedUserType.citizen_weak -> AuthenticatedUser.WeakCitizen(id)
+        AuthenticatedUserType.citizen -> AuthenticatedUser.Citizen(id, CitizenAuthLevel.STRONG)
+        AuthenticatedUserType.citizen_weak -> AuthenticatedUser.Citizen(id, CitizenAuthLevel.WEAK)
         AuthenticatedUserType.employee -> AuthenticatedUser.Employee(id, roles)
         AuthenticatedUserType.mobile -> AuthenticatedUser.MobileDevice(id, employeeId)
         AuthenticatedUserType.system -> AuthenticatedUser.SystemInternalUser

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
@@ -65,18 +65,18 @@ class HttpFilterConfig {
             chain.doFilter(request, response)
         }
 
-        private fun HttpServletRequest.requiresAuthentication(): Boolean {
-            if (isHealthCheck()) return false
-            if (requestURI.startsWith("/public/")) return false
-            if (mockIntegrationEnabled && requestURI.startsWith("/mock-integration/")) return false
-            if (devApiEnabled && requestURI.startsWith("/dev-api/")) return false
-            return true
+        private fun HttpServletRequest.requiresAuthentication(): Boolean = when {
+            isHealthCheck() -> false
+            requestURI.startsWith("/public/") -> false
+            mockIntegrationEnabled && requestURI.startsWith("/mock-integration/") -> false
+            devApiEnabled && requestURI.startsWith("/dev-api/") -> false
+            else -> true
         }
 
-        private fun HttpServletRequest.isAuthorized(user: AuthenticatedUser): Boolean {
-            if (requestURI.startsWith("/system/")) return user is AuthenticatedUser.SystemInternalUser
-            if (requestURI.startsWith("/citizen/")) return user is AuthenticatedUser.Citizen
-            return true
+        private fun HttpServletRequest.isAuthorized(user: AuthenticatedUser): Boolean = when {
+            requestURI.startsWith("/system/") -> user is AuthenticatedUser.SystemInternalUser
+            requestURI.startsWith("/citizen/") -> user is AuthenticatedUser.Citizen
+            else -> true
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
@@ -68,7 +68,6 @@ class HttpFilterConfig {
         private fun HttpServletRequest.requiresAuthentication(): Boolean {
             if (isHealthCheck()) return false
             if (requestURI.startsWith("/public/")) return false
-            if (requestURI.startsWith("/varda-dev/")) return false
             if (mockIntegrationEnabled && requestURI.startsWith("/mock-integration/")) return false
             if (devApiEnabled && requestURI.startsWith("/dev-api/")) return false
             return true

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
@@ -75,7 +75,8 @@ class HttpFilterConfig {
         }
 
         private fun HttpServletRequest.isAuthorized(user: AuthenticatedUser): Boolean {
-            if (requestURI.startsWith("/system/")) return user.isSystemInternalUser
+            if (requestURI.startsWith("/system/")) return user is AuthenticatedUser.SystemInternalUser
+            if (requestURI.startsWith("/citizen/")) return user is AuthenticatedUser.Citizen
             return true
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/SpringMvcConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/SpringMvcConfig.kt
@@ -47,7 +47,6 @@ class SpringMvcConfig(private val jdbi: Jdbi, private val env: EvakaEnv) : WebMv
         resolvers.add(asArgumentResolver<AuthenticatedUser.Employee?>(::resolveAuthenticatedUser))
         resolvers.add(asArgumentResolver<AuthenticatedUser.MobileDevice?>(::resolveAuthenticatedUser))
         resolvers.add(asArgumentResolver<AuthenticatedUser.SystemInternalUser?>(::resolveAuthenticatedUser))
-        resolvers.add(asArgumentResolver<AuthenticatedUser.WeakCitizen?>(::resolveAuthenticatedUser))
         resolvers.add(asArgumentResolver<AuthenticatedUser?>(::resolveAuthenticatedUser))
         resolvers.add(asArgumentResolver { _, webRequest -> webRequest.getDatabaseInstance() })
         resolvers.add(asArgumentResolver { _, webRequest -> webRequest.getEvakaClock() })

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -114,6 +114,7 @@ import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
 import fi.espoo.evaka.shared.async.VardaAsyncJob
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.psqlCause
@@ -377,7 +378,7 @@ class DevApi(
                     tx.fetchApplicationDetails(decision.applicationId) ?: throw NotFound("application not found")
                 applicationStateService.rejectDecision(
                     tx,
-                    AuthenticatedUser.Citizen(application.guardianId.raw),
+                    AuthenticatedUser.Citizen(application.guardianId.raw, CitizenAuthLevel.STRONG),
                     application.id,
                     id,
                     isEnduser = true


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- model strong vs weak authentication using `.authLevel` property
- restrict `/citizen/` paths to `AuthenticatedUser.Citizen`
- minor cleanups