### PR TITLE
Set evaka-service connection (and keep-alive) timeout to 70s

### DIFF
--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -44,6 +44,8 @@ spring:
       max-request-size: "10MB"
 server:
   port: 8888
+  tomcat:
+    connection-timeout: "70s"
 management:
   endpoints:
     enabled-by-default: false


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The timeout must be longer than the ALB keep alive timeout (60s).
