### PR TITLE
Use short statement/lock timeouts

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -13,6 +13,7 @@ import org.springframework.core.io.UrlResource
 import software.amazon.awssdk.regions.Region
 import java.net.URI
 import java.security.KeyStore
+import java.time.Duration
 import java.time.LocalDate
 import java.util.Locale
 
@@ -81,6 +82,7 @@ data class DatabaseEnv(
     val flywayUsername: String,
     val flywayPassword: Sensitive<String>,
     val leakDetectionThreshold: Long,
+    val defaultStatementTimeout: Duration,
     val maximumPoolSize: Int,
     val logSql: Boolean
 ) {
@@ -95,6 +97,7 @@ data class DatabaseEnv(
                 "evaka.database.leak_detection_threshold",
                 "spring.datasource.hikari.leak-detection-threshold"
             ) ?: 0,
+            defaultStatementTimeout = env.lookup("evaka.database.default_statement_timeout") ?: Duration.ofSeconds(60),
             maximumPoolSize = env.lookup("evaka.database.maximum_pool_size", "spring.datasource.hikari.maximumPoolSize")
                 ?: 10,
             logSql = env.lookup("evaka.database.log_sql") ?: false

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -31,6 +31,7 @@ import fi.espoo.evaka.shared.domain.mergePeriods
 import fi.espoo.evaka.shared.domain.operationalDays
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.time.LocalDate
 import java.time.Month
 import java.time.temporal.TemporalAdjusters
@@ -38,6 +39,8 @@ import java.time.temporal.TemporalAdjusters
 @Component
 class InvoiceGenerator(private val draftInvoiceGenerator: DraftInvoiceGenerator) {
     fun createAndStoreAllDraftInvoices(tx: Database.Transaction, range: DateRange = getPreviousMonthRange()) {
+        tx.setStatementTimeout(Duration.ofMinutes(10))
+        tx.setLockTimeout(Duration.ofSeconds(15))
         tx.createUpdate("LOCK TABLE invoice IN EXCLUSIVE MODE").execute()
         val invoiceCalculationData = calculateInvoiceData(tx, range)
         val invoices = draftInvoiceGenerator.generateDraftInvoices(

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
@@ -34,7 +34,12 @@ class ApplicationsReportController(private val accessControl: AccessControl, pri
         accessControl.requirePermissionFor(user, Action.Global.READ_APPLICATIONS_REPORT)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
 
-        return db.connect { dbc -> dbc.read { it.getApplicationsRows(from, to, acl.getAuthorizedUnits(user)) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getApplicationsRows(from, to, acl.getAuthorizedUnits(user))
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
@@ -39,6 +39,7 @@ class AssistanceNeedsAndActionsReportController(private val acl: AccessControlLi
         accessControl.requirePermissionFor(user, Action.Global.READ_ASSISTANCE_NEEDS_AND_ACTIONS_REPORT)
         return db.connect { dbc ->
             dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                 AssistanceNeedsAndActionsReport(
                     bases = it.getAssistanceBasisOptions(),
                     actions = it.getAssistanceActionOptions(),

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
@@ -29,7 +29,12 @@ class ChildAgeLanguageReportController(private val acl: AccessControlList, priva
     ): List<ChildAgeLanguageReportRow> {
         Audit.ChildAgeLanguageReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_CHILD_AGE_AND_LANGUAGE_REPORT)
-        return db.connect { dbc -> dbc.read { it.getChildAgeLanguageRows(date, acl.getAuthorizedUnits(user)) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getChildAgeLanguageRows(date, acl.getAuthorizedUnits(user))
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
@@ -31,7 +31,12 @@ class ChildrenInDifferentAddressReportController(
     ): List<ChildrenInDifferentAddressReportRow> {
         Audit.ChildrenInDifferentAddressReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_CHILD_IN_DIFFERENT_ADDRESS_REPORT)
-        return db.connect { dbc -> dbc.read { it.getChildrenInDifferentAddressRows(acl.getAuthorizedUnits(user)) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getChildrenInDifferentAddressRows(acl.getAuthorizedUnits(user))
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/Common.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/Common.kt
@@ -7,6 +7,9 @@ package fi.espoo.evaka.reports
 import org.jdbi.v3.core.mapper.ColumnMapper
 import org.jdbi.v3.core.statement.StatementContext
 import java.sql.ResultSet
+import java.time.Duration
+
+val REPORT_STATEMENT_TIMEOUT: Duration = Duration.ofMinutes(10)
 
 fun getPrimaryUnitType(careTypes: Set<String>): UnitType? {
     if (careTypes.contains("FAMILY")) return UnitType.FAMILY

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DecisionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DecisionsReport.kt
@@ -32,7 +32,12 @@ class DecisionsReportController(private val accessControl: AccessControl) {
         accessControl.requirePermissionFor(user, Action.Global.READ_DECISIONS_REPORT)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
 
-        return db.connect { dbc -> dbc.read { it.getDecisionsRows(FiniteDateRange(from, to)) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getDecisionsRows(FiniteDateRange(from, to))
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
@@ -23,7 +23,12 @@ class DuplicatePeopleReportController(private val accessControl: AccessControl) 
     fun getDuplicatePeopleReport(db: Database, user: AuthenticatedUser): List<DuplicatePeopleReportRow> {
         Audit.DuplicatePeopleReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_DUPLICATE_PEOPLE_REPORT)
-        return db.connect { dbc -> dbc.read { it.getDuplicatePeople() } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getDuplicatePeople()
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
@@ -30,7 +30,12 @@ class EndedPlacementsReportController(private val accessControl: AccessControl) 
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 
-        return db.connect { dbc -> dbc.read { it.getEndedPlacementsRows(from, to) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getEndedPlacementsRows(from, to)
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
@@ -24,7 +24,12 @@ class FamilyConflictReportController(private val acl: AccessControlList, private
     fun getFamilyConflictsReport(db: Database, user: AuthenticatedUser): List<FamilyConflictReportRow> {
         Audit.FamilyConflictReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_FAMILY_CONFLICT_REPORT)
-        return db.connect { dbc -> dbc.read { it.getFamilyConflicts(acl.getAuthorizedUnits(user)) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getFamilyConflicts(acl.getAuthorizedUnits(user))
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
@@ -28,7 +28,12 @@ class FamilyContactReportController(private val accessControl: AccessControl) {
     ): List<FamilyContactReportRow> {
         Audit.FamilyContactReportRead.log()
         accessControl.requirePermissionFor(user, Action.Unit.READ_FAMILY_CONTACT_REPORT, unitId)
-        return db.connect { dbc -> dbc.read { it.getFamilyContacts(unitId) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getFamilyContacts(unitId)
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
@@ -37,7 +37,12 @@ class InvoiceReportController(private val accessControl: AccessControl) {
     ): InvoiceReport {
         Audit.InvoicesReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_INVOICE_REPORT)
-        return db.connect { dbc -> dbc.read { it.getInvoiceReportWithRows(getMonthPeriod(date)) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getInvoiceReportWithRows(getMonthPeriod(date))
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
@@ -31,7 +31,12 @@ class MissingHeadOfFamilyReportController(private val acl: AccessControlList, pr
     ): List<MissingHeadOfFamilyReportRow> {
         Audit.MissingHeadOfFamilyReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_MISSING_HEAD_OF_FAMILY_REPORT)
-        return db.connect { dbc -> dbc.read { it.getMissingHeadOfFamilyRows(from, to, acl.getAuthorizedUnits(user)) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getMissingHeadOfFamilyRows(from, to, acl.getAuthorizedUnits(user))
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
@@ -34,7 +34,12 @@ class MissingServiceNeedReportController(private val acl: AccessControlList, pri
         accessControl.requirePermissionFor(user, Action.Global.READ_MISSING_SERVICE_NEED_REPORT)
         if (to != null && to.isBefore(from)) throw BadRequest("Invalid time range")
 
-        return db.connect { dbc -> dbc.read { it.getMissingServiceNeedRows(from, to, acl.getAuthorizedUnits(user)) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getMissingServiceNeedRows(from, to, acl.getAuthorizedUnits(user))
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -44,6 +44,7 @@ class OccupancyReportController(private val accessControl: AccessControl, privat
 
         return db.connect { dbc ->
             dbc.read { tx ->
+                tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                 tx.calculateUnitOccupancyReport(
                     LocalDate.now(),
                     careAreaId,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
@@ -30,7 +30,12 @@ class PartnersInDifferentAddressReportController(
     ): List<PartnersInDifferentAddressReportRow> {
         Audit.PartnersInDifferentAddressReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_PARTNERS_IN_DIFFERENT_ADDRESS_REPORT)
-        return db.connect { dbc -> dbc.read { it.getPartnersInDifferentAddressRows(acl.getAuthorizedUnits(user)) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getPartnersInDifferentAddressRows(acl.getAuthorizedUnits(user))
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
@@ -30,7 +30,12 @@ class PlacementSketchingReportController(private val accessControl: AccessContro
     ): List<PlacementSketchingReportRow> {
         Audit.PlacementSketchingReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_PLACEMENT_SKETCHING_REPORT)
-        return db.connect { dbc -> dbc.read { it.getPlacementSketchingReportRows(placementStartDate, earliestPreferredStartDate) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getPlacementSketchingReportRows(placementStartDate, earliestPreferredStartDate)
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
@@ -34,7 +34,12 @@ class PresenceReportController(private val accessControl: AccessControl) {
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
         if (to.isAfter(from.plusDays(MAX_NUMBER_OF_DAYS.toLong()))) throw BadRequest("Period is too long. Use maximum of $MAX_NUMBER_OF_DAYS days")
 
-        return db.connect { dbc -> dbc.read { it.getPresenceRows(from, to) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getPresenceRows(from, to)
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -38,7 +38,12 @@ class RawReportController(private val accessControl: AccessControl) {
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
         if (to.isAfter(from.plusDays(7))) throw BadRequest("Time range too long")
 
-        return db.connect { dbc -> dbc.read { it.getRawRows(from, to) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getRawRows(from, to)
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
@@ -27,7 +27,12 @@ class ServiceNeedReport(private val acl: AccessControlList, private val accessCo
     ): List<ServiceNeedReportRow> {
         Audit.ServiceNeedReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_SERVICE_NEED_REPORT)
-        return db.connect { dbc -> dbc.read { it.getServiceNeedRows(date, acl.getAuthorizedUnits(user)) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getServiceNeedRows(date, acl.getAuthorizedUnits(user))
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -56,6 +56,7 @@ class ServiceVoucherValueReportController(
 
         return db.connect { dbc ->
             dbc.read { tx ->
+                tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                 val snapshotTime = tx.getSnapshotDate(year, month)
                 val rows = if (snapshotTime != null) {
                     tx.getSnapshotVoucherValues(year, month, areaId = areaId, unitIds = authorization.ids)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/SextetReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/SextetReport.kt
@@ -31,6 +31,7 @@ class SextetReportController(private val accessControl: AccessControl) {
 
         return db.connect { dbc ->
             dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                 it.sextetReport(
                     LocalDate.of(year, 1, 1),
                     LocalDate.of(year, 12, 31),

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
@@ -29,7 +29,12 @@ class StartingPlacementsReportController(private val accessControl: AccessContro
     ): List<StartingPlacementsRow> {
         Audit.StartingPlacementsReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_STARTING_PLACEMENTS_REPORT)
-        return db.connect { dbc -> dbc.read { it.getStartingPlacementsRows(year, month) } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getStartingPlacementsRows(year, month)
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
@@ -25,7 +25,12 @@ class VardaErrorReport(private val accessControl: AccessControl) {
     ): List<VardaErrorReportRow> {
         Audit.VardaReportRead.log()
         accessControl.requirePermissionFor(user, Action.Global.READ_VARDA_REPORT)
-        return db.connect { dbc -> dbc.read { it.getVardaErrors() } }
+        return db.connect { dbc ->
+            dbc.read {
+                it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                it.getVardaErrors()
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -179,7 +179,3 @@ class AsyncJobRunner<T : AsyncJobPayload>(val payloadType: KClass<T>, private va
         this.executor.shutdownNow()
     }
 }
-
-private fun Database.Transaction.setLockTimeout(duration: Duration) = createUpdate(
-    "SET LOCAL lock_timeout = <durationInMs>"
-).define("durationInMs", "'${duration.toMillis()}ms'").execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
@@ -42,6 +42,7 @@ class DatabaseConfig {
             }
         return HikariDataSource(
             HikariConfig().apply {
+                connectionInitSql = "SET SESSION statement_timeout = '${env.defaultStatementTimeout.toMillis()}ms'"
                 jdbcUrl = env.url
                 username = env.username
                 password = env.password.value


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- migrations are *not* affected, since they are executed before this configuration is used
- 1 minute is a reasonable default for REST endpoints that are triggered by a user
- reports are an exception and use 10 minutes
- invoice generation also uses 10 minutes, although it would be surprising if any of the individual queries exceeded the 1 minute default timeout