### PR TITLE
EVAKA-4162 Save holiday questionnaire answers

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -50,7 +50,11 @@ const Page = React.memo(function CalendarPage() {
   const location = useLocation()
   const user = useUser()
 
-  const { holidayPeriods, activeFixedPeriodQuestionnaire } = useHolidayPeriods()
+  const {
+    holidayPeriods,
+    activeFixedPeriodQuestionnaire,
+    refreshQuestionnaires
+  } = useHolidayPeriods()
 
   const [data, loadDefaultRange] = useApiState(getReservationsDefaultRange, [])
   const [openModal, setOpenModal] = useState<
@@ -76,6 +80,11 @@ const Page = React.memo(function CalendarPage() {
     []
   )
   const closeModal = useCallback(() => setOpenModal(undefined), [])
+
+  const refreshOnQuestionnaireAnswer = useCallback(() => {
+    refreshQuestionnaires()
+    loadDefaultRange()
+  }, [loadDefaultRange, refreshQuestionnaires])
 
   const dateParam = new URLSearchParams(location.search).get('day')
   const selectedDate = dateParam ? LocalDate.tryParseIso(dateParam) : undefined
@@ -186,10 +195,11 @@ const Page = React.memo(function CalendarPage() {
         >
           <FixedPeriodSelectionModal
             close={closeModal}
-            reload={loadDefaultRange}
+            reload={refreshOnQuestionnaireAnswer}
             questionnaire={questionnaire.questionnaire}
             availableChildren={response.children}
             eligibleChildren={questionnaire.eligibleChildren}
+            previousAnswers={questionnaire.previousAnswers}
           />
         </RequireAuth>
       )}

--- a/frontend/src/citizen-frontend/calendar/holiday-modal/FixedPeriodSelectionModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/holiday-modal/FixedPeriodSelectionModal.tsx
@@ -10,7 +10,8 @@ import { useLang, useTranslation } from 'citizen-frontend/localization'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import {
   FixedPeriodQuestionnaire,
-  FixedPeriodsBody
+  FixedPeriodsBody,
+  HolidayQuestionnaireAnswer
 } from 'lib-common/generated/api-types/holidayperiod'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
 import { formatPreferredName } from 'lib-common/names'
@@ -24,8 +25,18 @@ import { PeriodSelector } from './PeriodSelector'
 
 type FormState = FixedPeriodsBody['fixedPeriods']
 
-const initializeForm = (children: ReservationChild[]): FormState =>
-  children.reduce((acc, child) => ({ ...acc, [child.id]: null }), {})
+const initializeForm = (
+  children: ReservationChild[],
+  previousAnswers: HolidayQuestionnaireAnswer[]
+): FormState =>
+  children.reduce(
+    (acc, child) => ({
+      ...acc,
+      [child.id]:
+        previousAnswers.find((a) => a.childId === child.id)?.fixedPeriod ?? null
+    }),
+    {}
+  )
 
 interface Props {
   close: () => void
@@ -33,6 +44,7 @@ interface Props {
   questionnaire: FixedPeriodQuestionnaire
   availableChildren: ReservationChild[]
   eligibleChildren: UUID[]
+  previousAnswers: HolidayQuestionnaireAnswer[]
 }
 
 export default React.memo(function FixedPeriodSelectionModal({
@@ -40,13 +52,14 @@ export default React.memo(function FixedPeriodSelectionModal({
   reload,
   questionnaire,
   availableChildren,
-  eligibleChildren
+  eligibleChildren,
+  previousAnswers
 }: Props) {
   const i18n = useTranslation()
   const [lang] = useLang()
 
   const [fixedPeriods, setFixedPeriods] = useState<FormState>(() =>
-    initializeForm(availableChildren)
+    initializeForm(availableChildren, previousAnswers)
   )
 
   const selectPeriod = useCallback(

--- a/frontend/src/citizen-frontend/holiday-periods/api.ts
+++ b/frontend/src/citizen-frontend/holiday-periods/api.ts
@@ -4,11 +4,11 @@
 
 import { Failure, Result, Success } from 'lib-common/api'
 import {
-  deserializeFixedPeriodQuestionnaireAndChildren,
+  deserializeActiveQuestionnaire,
   deserializeHolidayPeriod
 } from 'lib-common/api-types/holiday-period'
 import {
-  FixedPeriodQuestionnaireWithChildren,
+  ActiveQuestionnaire,
   FixedPeriodsBody,
   HolidayPeriod
 } from 'lib-common/generated/api-types/holidayperiod'
@@ -25,15 +25,11 @@ export function getHolidayPeriods(): Promise<Result<HolidayPeriod[]>> {
 }
 
 export function getActiveQuestionnaires(): Promise<
-  Result<FixedPeriodQuestionnaireWithChildren[]>
+  Result<ActiveQuestionnaire[]>
 > {
   return client
-    .get<JsonOf<FixedPeriodQuestionnaireWithChildren[]>>(
-      `/citizen/holiday-period/questionnaire`
-    )
-    .then((res) =>
-      Success.of(res.data.map(deserializeFixedPeriodQuestionnaireAndChildren))
-    )
+    .get<JsonOf<ActiveQuestionnaire[]>>(`/citizen/holiday-period/questionnaire`)
+    .then((res) => Success.of(res.data.map(deserializeActiveQuestionnaire)))
     .catch((e) => Failure.fromError(e))
 }
 

--- a/frontend/src/citizen-frontend/holiday-periods/state.tsx
+++ b/frontend/src/citizen-frontend/holiday-periods/state.tsx
@@ -9,7 +9,7 @@ import { useUser } from 'citizen-frontend/auth/state'
 import { combine, Loading, Result, Success } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import {
-  FixedPeriodQuestionnaireWithChildren,
+  ActiveQuestionnaire,
   HolidayPeriod
 } from 'lib-common/generated/api-types/holidayperiod'
 import LocalDate from 'lib-common/local-date'
@@ -25,18 +25,18 @@ export type HolidayBanner =
 
 export interface HolidayPeriodsState {
   holidayPeriods: Result<HolidayPeriod[]>
-  activeFixedPeriodQuestionnaire: Result<
-    FixedPeriodQuestionnaireWithChildren | undefined
-  >
+  activeFixedPeriodQuestionnaire: Result<ActiveQuestionnaire | undefined>
   questionnaireAvailable: QuestionnaireAvailability
   holidayBanner: Result<HolidayBanner>
+  refreshQuestionnaires: () => void
 }
 
 const defaultState: HolidayPeriodsState = {
   holidayPeriods: Loading.of(),
   activeFixedPeriodQuestionnaire: Loading.of(),
   questionnaireAvailable: false,
-  holidayBanner: Loading.of()
+  holidayBanner: Loading.of(),
+  refreshQuestionnaires: () => null
 }
 
 export const HolidayPeriodsContext =
@@ -53,7 +53,7 @@ export const HolidayPeriodsContextProvider = React.memo(
       () => (user ? getHolidayPeriods() : Promise.resolve(Success.of([]))),
       [user]
     )
-    const [activeQuestionnaires] = useApiState(
+    const [activeQuestionnaires, refreshQuestionnaires] = useApiState(
       () =>
         user ? getActiveQuestionnaires() : Promise.resolve(Success.of([])),
       [user]
@@ -99,13 +99,15 @@ export const HolidayPeriodsContextProvider = React.memo(
         activeFixedPeriodQuestionnaire,
         holidayPeriods,
         questionnaireAvailable,
-        holidayBanner
+        holidayBanner,
+        refreshQuestionnaires
       }),
       [
         activeFixedPeriodQuestionnaire,
         holidayPeriods,
         questionnaireAvailable,
-        holidayBanner
+        holidayBanner,
+        refreshQuestionnaires
       ]
     )
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -316,6 +316,17 @@ class HolidayModal extends Element {
     await this.markNoHolidays([child])
   }
 
+  async assertSelectedFixedPeriods(
+    values: { child: { id: string }; option: string }[]
+  ) {
+    for (const { child, option } of values) {
+      await waitUntilEqual(
+        () => this.#childHolidaySelect(child.id).selectedOption,
+        option
+      )
+    }
+  }
+
   async assertNotEligible(child: { id: string }) {
     await this.#childSection(child.id)
       .findByDataQa('not-eligible')

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
@@ -211,10 +211,11 @@ describe('Holiday periods', () => {
       await assertFreeAbsences(false)
 
       let holidayModal = await calendar.openHolidayModal()
-      await holidayModal.markHolidays([
+      const selections = [
         { child, option: '26.12.2035 - 01.01.2036' },
         { child: child2, option: '26.12.2035 - 01.01.2036' }
-      ])
+      ]
+      await holidayModal.markHolidays(selections)
 
       await assertFreeAbsences(true)
 
@@ -223,7 +224,13 @@ describe('Holiday periods', () => {
       await dayView.assertAbsence(child2.id, 'Poissa')
 
       holidayModal = await calendar.openHolidayModal()
+      await holidayModal.assertSelectedFixedPeriods(selections)
       await holidayModal.markNoHolidays([child, child2])
+
+      holidayModal = await calendar.openHolidayModal()
+      await holidayModal.assertSelectedFixedPeriods(
+        selections.map((s) => ({ ...s, option: 'Ei maksutonta poissaoloa' }))
+      )
 
       await assertFreeAbsences(false)
     })

--- a/frontend/src/lib-common/api-types/holiday-period.ts
+++ b/frontend/src/lib-common/api-types/holiday-period.ts
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import {
+  ActiveQuestionnaire,
   FixedPeriodQuestionnaire,
-  FixedPeriodQuestionnaireWithChildren,
   HolidayPeriod
 } from 'lib-common/generated/api-types/holidayperiod'
 
@@ -42,10 +42,15 @@ export const deserializeFixedPeriodQuestionnaire = ({
   periodOptions: periodOptions.map((o) => FiniteDateRange.parseJson(o))
 })
 
-export const deserializeFixedPeriodQuestionnaireAndChildren = ({
+export const deserializeActiveQuestionnaire = ({
   questionnaire,
-  eligibleChildren
-}: JsonOf<FixedPeriodQuestionnaireWithChildren>): FixedPeriodQuestionnaireWithChildren => ({
+  eligibleChildren,
+  previousAnswers
+}: JsonOf<ActiveQuestionnaire>): ActiveQuestionnaire => ({
   questionnaire: deserializeFixedPeriodQuestionnaire(questionnaire),
-  eligibleChildren
+  eligibleChildren,
+  previousAnswers: previousAnswers.map(({ fixedPeriod, ...rest }) => ({
+    ...rest,
+    fixedPeriod: fixedPeriod ? FiniteDateRange.parseJson(fixedPeriod) : null
+  }))
 })

--- a/frontend/src/lib-common/generated/api-types/holidayperiod.ts
+++ b/frontend/src/lib-common/generated/api-types/holidayperiod.ts
@@ -12,6 +12,15 @@ import { Translatable } from './shared'
 import { UUID } from '../../types'
 
 /**
+* Generated from fi.espoo.evaka.holidayperiod.ActiveQuestionnaire
+*/
+export interface ActiveQuestionnaire {
+  eligibleChildren: UUID[]
+  previousAnswers: HolidayQuestionnaireAnswer[]
+  questionnaire: FixedPeriodQuestionnaire
+}
+
+/**
 * Generated from fi.espoo.evaka.holidayperiod.FixedPeriodQuestionnaire
 */
 export interface FixedPeriodQuestionnaire {
@@ -47,14 +56,6 @@ export interface FixedPeriodQuestionnaireBody {
 }
 
 /**
-* Generated from fi.espoo.evaka.holidayperiod.FixedPeriodQuestionnaireWithChildren
-*/
-export interface FixedPeriodQuestionnaireWithChildren {
-  eligibleChildren: UUID[]
-  questionnaire: FixedPeriodQuestionnaire
-}
-
-/**
 * Generated from fi.espoo.evaka.holidayperiod.FixedPeriodsBody
 */
 export interface FixedPeriodsBody {
@@ -76,6 +77,15 @@ export interface HolidayPeriod {
 export interface HolidayPeriodBody {
   period: FiniteDateRange
   reservationDeadline: LocalDate | null
+}
+
+/**
+* Generated from fi.espoo.evaka.holidayperiod.HolidayQuestionnaireAnswer
+*/
+export interface HolidayQuestionnaireAnswer {
+  childId: UUID
+  fixedPeriod: FiniteDateRange | null
+  questionnaireId: UUID
 }
 
 /**

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2359,6 +2359,7 @@ export const fi = {
         'fridge_child.child_id': 'Päämiehiä',
         'fridge_child.head_of_child': 'Jääkaappi- lapsia',
         'fridge_partner.person_id': 'Jääkaappi- puolisoja',
+        'holiday_questionnaire_answer.child_id': 'Kyselyvastauksia',
         'income.person_id': 'Tulo- tietoja',
         'income_statement.person_id': 'Tulo -ilmoituksia',
         'invoice.codebtor': 'Laskuja (kanssa -velallinen)',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/PersonIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/PersonIntegrationTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -119,6 +119,7 @@ class PersonIntegrationTest : PureJdbiTest() {
             PersonReference("fridge_child", "child_id"),
             PersonReference("fridge_child", "head_of_child"),
             PersonReference("fridge_partner", "person_id"),
+            PersonReference("holiday_questionnaire_answer", "child_id"),
             PersonReference("income", "person_id"),
             PersonReference("income_statement", "person_id"),
             PersonReference("invoice", "codebtor"),

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaires.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaires.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.holidayperiod
 
 import fi.espoo.evaka.daycare.service.AbsenceType
+import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.HolidayPeriodId
 import fi.espoo.evaka.shared.HolidayQuestionnaireId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -60,4 +61,10 @@ data class FixedPeriodQuestionnaireBody(
     val periodOptions: List<FiniteDateRange>,
     @Json
     val periodOptionLabel: Translatable,
+)
+
+data class HolidayQuestionnaireAnswer(
+    val questionnaireId: HolidayQuestionnaireId,
+    val childId: ChildId,
+    val fixedPeriod: FiniteDateRange?
 )

--- a/service/src/main/resources/db/migration/V215__holiday_questionnaire_answer.sql
+++ b/service/src/main/resources/db/migration/V215__holiday_questionnaire_answer.sql
@@ -1,0 +1,22 @@
+ALTER TABLE absence
+    ADD COLUMN questionnaire_id uuid
+        CONSTRAINT fk$holiday_questionnaire REFERENCES holiday_period_questionnaire ON DELETE SET NULL;
+
+CREATE INDEX idx$absence_questionnaire ON absence (questionnaire_id);
+
+CREATE TABLE holiday_questionnaire_answer (
+    id               uuid PRIMARY KEY         DEFAULT ext.uuid_generate_v1mc(),
+    created          timestamp with time zone DEFAULT now() NOT NULL,
+    updated          timestamp with time zone DEFAULT now() NOT NULL,
+    modified_by      uuid
+        CONSTRAINT fk$evaka_user REFERENCES evaka_user ON DELETE RESTRICT,
+    questionnaire_id uuid
+        CONSTRAINT fk$questionnaire REFERENCES holiday_period_questionnaire ON DELETE RESTRICT,
+    child_id         uuid
+        CONSTRAINT fk$child REFERENCES child ON DELETE RESTRICT,
+    fixed_period     daterange
+);
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON holiday_questionnaire_answer FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();
+
+CREATE INDEX idx$questionnaire_answer_questionnaire ON holiday_questionnaire_answer (questionnaire_id);
+CREATE UNIQUE INDEX uniq$questionnaire_answer_child_questionnaire ON holiday_questionnaire_answer (child_id, questionnaire_id);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -212,3 +212,4 @@ V211__holiday_period_questionnaires.sql
 V212__voucher_value_decision_annulment_and_validity_timestamps.sql
 V213__child_income.sql
 V214__child_attendance_indexes.sql
+V215__holiday_questionnaire_answer.sql


### PR DESCRIPTION
#### Summary

Save holiday questionnaire answers to their own database table. Use the saved answers to prefill holiday modal. In the future, the saved answers can be utilized in holiday banner hiding logic and reporting.
Also tie absences created from the questionnaire to the questionnaire for easier detection when deleting previous answers.

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

