### PR TITLE
Remove mobile device soft delete functionality

### DIFF
--- a/frontend/src/e2e-test/dev-api/index.ts
+++ b/frontend/src/e2e-test/dev-api/index.ts
@@ -746,7 +746,6 @@ interface MobileDevice {
   id: UUID
   unitId: UUID
   name: string
-  deleted: boolean
   longTermToken: UUID
 }
 

--- a/frontend/src/e2e-test/utils/mobile.ts
+++ b/frontend/src/e2e-test/utils/mobile.ts
@@ -18,7 +18,6 @@ export async function pairMobileDevice(unitId: UUID): Promise<string> {
     id: uuidv4(),
     unitId,
     name: 'testMobileDevice',
-    deleted: false,
     longTermToken
   })
   return `${config.mobileBaseUrl}/api/internal/auth/mobile-e2e-signup?token=${longTermToken}`

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemControllerTest.kt
@@ -49,24 +49,13 @@ class SystemControllerTest : FullApplicationTest() {
         assertEquals(MobileDeviceIdentity(id = deviceId, longTermToken = token), result.get())
     }
 
-    @Test
-    fun `mobile identity endpoint doesn't return deleted mobile devices`() {
-        val token = UUID.randomUUID()
-        db.transaction { it.insertTestDevice(longTermToken = token, deleted = true) }
-
-        val (_, res, _) = http.get("/system/mobile-identity/$token").asUser(AuthenticatedUser.SystemInternalUser)
-            .response()
-        assertEquals(404, res.statusCode)
-    }
-
-    private fun Database.Transaction.insertTestDevice(longTermToken: UUID? = null, deleted: Boolean = false): MobileDeviceId {
+    private fun Database.Transaction.insertTestDevice(longTermToken: UUID? = null): MobileDeviceId {
         val id = MobileDeviceId(UUID.randomUUID())
         insertTestMobileDevice(
             DevMobileDevice(
                 id = id,
                 unitId = unitId,
                 longTermToken = longTermToken,
-                deleted = deleted
             )
         )
         return id

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
@@ -83,7 +83,7 @@ class MobileDevicesController(private val accessControl: AccessControl) {
     ) {
         Audit.MobileDevicesDelete.log(targetId = id)
         accessControl.requirePermissionFor(user, Action.MobileDevice.DELETE, id)
-        db.connect { dbc -> dbc.transaction { it.softDeleteDevice(id) } }
+        db.connect { dbc -> dbc.transaction { it.deleteDevice(id) } }
     }
 
     @PostMapping("/mobile-devices/pin-login")

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -199,8 +199,8 @@ RETURNING id
 fun Database.Transaction.insertTestMobileDevice(device: DevMobileDevice) = insertTestDataRow(
     device,
     """
-INSERT INTO mobile_device (id, unit_id, name, deleted, long_term_token)
-VALUES (:id, :unitId, :name, :deleted, :longTermToken)
+INSERT INTO mobile_device (id, unit_id, name, long_term_token)
+VALUES (:id, :unitId, :name, :longTermToken)
 RETURNING id
     """
 ).let(::MobileDeviceId)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -777,29 +777,14 @@ RETURNING id
         }
     }
 
-    data class MobileDeviceReq(
-        val id: MobileDeviceId,
-        val unitId: DaycareId,
-        val name: String,
-        val deleted: Boolean,
-        val longTermToken: UUID
-    )
-
     @PostMapping("/mobile/devices")
     fun postMobileDevice(
         db: Database,
-        @RequestBody body: MobileDeviceReq
+        @RequestBody body: DevMobileDevice
     ) {
         db.connect { dbc ->
             dbc.transaction {
-                it.createUpdate(
-                    """
-INSERT INTO mobile_device (id, unit_id, name, deleted, long_term_token)
-VALUES(:id, :unitId, :name, :deleted, :longTermToken)
-                    """.trimIndent()
-                )
-                    .bindKotlin(body)
-                    .execute()
+                it.insertTestMobileDevice(body)
             }
         }
     }
@@ -1440,7 +1425,6 @@ data class DevMobileDevice(
     val id: MobileDeviceId = MobileDeviceId(UUID.randomUUID()),
     val unitId: DaycareId,
     val name: String = "Laite",
-    val deleted: Boolean = false,
     val longTermToken: UUID? = null
 )
 

--- a/service/src/main/resources/db/migration/R__acl_views.sql
+++ b/service/src/main/resources/db/migration/R__acl_views.sql
@@ -14,14 +14,13 @@ CREATE VIEW daycare_acl_view(employee_id, daycare_id, role) AS (
 
     SELECT id, unit_id, 'MOBILE'
     FROM mobile_device
-    WHERE deleted = false AND unit_id IS NOT NULL
+    WHERE unit_id IS NOT NULL
 
     UNION ALL
 
     SELECT mobile_device.id, daycare_acl.daycare_id, 'MOBILE'
     FROM daycare_acl
     JOIN mobile_device ON daycare_acl.employee_id = mobile_device.employee_id
-    WHERE mobile_device.deleted = false
 );
 
 CREATE VIEW daycare_group_acl_view(employee_id, daycare_group_id, role) AS (

--- a/service/src/main/resources/db/migration/V216__mobile_device_hard_delete.sql
+++ b/service/src/main/resources/db/migration/V216__mobile_device_hard_delete.sql
@@ -1,0 +1,10 @@
+DELETE FROM pairing WHERE mobile_device_id IN (SELECT id FROM mobile_device WHERE deleted IS TRUE);
+DELETE FROM mobile_device WHERE deleted IS TRUE;
+DROP INDEX idx$mobile_device_unit;
+
+ALTER TABLE mobile_device DROP COLUMN deleted;
+
+ALTER TABLE pairing DROP CONSTRAINT pairing_mobile_device_id_fkey;
+ALTER TABLE pairing ADD CONSTRAINT fk$mobile_device FOREIGN KEY (mobile_device_id) REFERENCES mobile_device (id) ON DELETE CASCADE;
+
+CREATE INDEX idx$mobile_device_unit ON mobile_device (unit_id);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -213,3 +213,4 @@ V212__voucher_value_decision_annulment_and_validity_timestamps.sql
 V213__child_income.sql
 V214__child_attendance_indexes.sql
 V215__holiday_questionnaire_answer.sql
+V216__mobile_device_hard_delete.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This is no longer needed, since the corresponding evaka_user row remains even after the mobile device is deleted, so "who did this" columns in various tables will still work.

