### PR TITLE
EVAKA-4455 Reorder unit page tabs and move utilisation chart

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -5,7 +5,9 @@
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
+import { waitUntilEqual } from '../../../utils'
 import {
+  Element,
   Modal,
   Page,
   Select,
@@ -25,11 +27,9 @@ export class UnitAttendancesPage {
     this.page.find(`[data-qa="ellipsis-menu-${childId}"]`)
   #editInline = this.page.find('[data-qa="menu-item-edit-row"]')
 
-  async waitUntilLoaded() {
-    await this.page
-      .find('[data-qa="unit-groups-page"][data-loading="false"]')
-      .waitUntilVisible()
-  }
+  occupancies = new UnitOccupanciesSection(
+    this.page.find('[data-qa="occupancies"]')
+  )
 
   async selectMode(mode: 'week' | 'month') {
     const foo = new SelectionChip(
@@ -168,5 +168,39 @@ export class ReservationModal extends Modal {
     await this.setStartTime('00:00', 1)
     await this.setEndTime('08:00', 1)
     await this.save()
+  }
+}
+
+export class UnitOccupanciesSection extends Element {
+  #elem = (
+    which: 'minimum' | 'maximum' | 'no-valid-values',
+    type: 'confirmed' | 'planned'
+  ) => this.find(`[data-qa="occupancies-${which}-${type}"]`)
+
+  async assertNoValidValues() {
+    await this.#elem('no-valid-values', 'confirmed').waitUntilVisible()
+    await this.#elem('no-valid-values', 'planned').waitUntilVisible()
+  }
+
+  async assertConfirmed(minimum: string, maximum: string) {
+    await waitUntilEqual(
+      () => this.#elem('minimum', 'confirmed').innerText,
+      minimum
+    )
+    await waitUntilEqual(
+      () => this.#elem('maximum', 'confirmed').innerText,
+      maximum
+    )
+  }
+
+  async assertPlanned(minimum: string, maximum: string) {
+    await waitUntilEqual(
+      () => this.#elem('minimum', 'planned').innerText,
+      minimum
+    )
+    await waitUntilEqual(
+      () => this.#elem('maximum', 'planned').innerText,
+      maximum
+    )
   }
 }

--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -13,7 +13,7 @@ import {
   TextInput
 } from '../../../utils/page'
 
-export class UnitCalendarPage {
+export class UnitAttendancesPage {
   constructor(private readonly page: Page) {}
 
   #reservationCell = (date: LocalDate, row: number) =>

--- a/frontend/src/e2e-test/pages/employee/units/unit-diary-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-diary-page.ts
@@ -19,9 +19,9 @@ import {
 export class UnitDiaryPage {
   constructor(private page: Page) {}
 
-  #unitName = this.page.find('[data-qa="calendar-unit-name"]')
+  #unitName = this.page.find('[data-qa="attendances-unit-name"]')
   #groupSelector = new Select(
-    this.page.find('[data-qa="calendar-group-select"]')
+    this.page.find('[data-qa="attendances-group-select"]')
   )
   #childRows = this.page.findAll('[data-qa="absence-child-row"]')
 

--- a/frontend/src/e2e-test/pages/employee/units/unit.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit.ts
@@ -32,15 +32,10 @@ type UnitProviderType =
 export class UnitPage {
   constructor(private readonly page: Page) {}
 
-  #unitName = this.page.find('[data-qa="unit-name"]')
-  #visitingAddress = this.page.find('[data-qa="unit-visiting-address"]')
-
   #unitInfoTab = this.page.find('[data-qa="unit-info-tab"]')
   #groupsTab = this.page.find('[data-qa="groups-tab"]')
   #attendancesTab = this.page.find('[data-qa="attendances-tab"]')
   #applicationProcessTab = this.page.find('[data-qa="application-process-tab"]')
-
-  #unitDetailsLink = this.page.find('[data-qa="unit-details-link"]')
 
   static async openUnit(page: Page, id: string): Promise<UnitPage> {
     await page.goto(`${config.employeeUrl}/units/${id}`)
@@ -50,56 +45,18 @@ export class UnitPage {
   }
 
   async navigateToUnit(id: string) {
-    await this.page.goto(`${config.employeeUrl}/units/${id}`)
+    await this.page.goto(`${config.employeeUrl}/units/${id}/unit-info`)
   }
 
   async waitUntilLoaded() {
     await this.page
-      .find('[data-qa="unit-information"][data-isloading="false"]')
-      .waitUntilVisible()
-    await this.page
-      .find('[data-qa="daycare-acl"][data-isloading="false"]')
+      .find('[data-qa="unit-attendances"][data-isloading="false"]')
       .waitUntilVisible()
   }
 
-  occupancies = new UnitOccupanciesSection(
-    this.page.find('[data-qa="occupancies"]')
-  )
-
-  async assertUnitName(expectedName: string) {
-    await waitUntilEqual(() => this.#unitName.innerText, expectedName)
-  }
-
-  async assertVisitingAddress(expectedAddress: string) {
-    await waitUntilEqual(() => this.#visitingAddress.innerText, expectedAddress)
-  }
-
-  async openUnitInformation() {
+  async openUnitInformation(): Promise<UnitInfoPage> {
     await this.#unitInfoTab.click()
-  }
-
-  supervisorAcl = new AclSection(
-    this.page,
-    this.page.find('[data-qa="daycare-acl-supervisors"]')
-  )
-  specialEducationTeacherAcl = new AclSection(
-    this.page,
-    this.page.find('[data-qa="daycare-acl-set"]')
-  )
-  staffAcl = new StaffAclSection(
-    this.page,
-    this.page.find('[data-qa="daycare-acl-staff"]')
-  )
-  mobileAcl = new MobileDevicesSection(
-    this.page,
-    this.page.find('[data-qa="daycare-mobile-devices"]')
-  )
-
-  async openUnitDetails(): Promise<UnitDetailsPage> {
-    await this.#unitDetailsLink.click()
-    const unitDetails = new UnitDetailsPage(this.page)
-    await unitDetails.waitUntilLoaded()
-    return unitDetails
+    return new UnitInfoPage(this.page)
   }
 
   async openApplicationProcessTab(): Promise<ApplicationProcessPage> {
@@ -121,37 +78,50 @@ export class UnitPage {
   }
 }
 
-export class UnitOccupanciesSection extends Element {
-  #elem = (
-    which: 'minimum' | 'maximum' | 'no-valid-values',
-    type: 'confirmed' | 'planned'
-  ) => this.find(`[data-qa="occupancies-${which}-${type}"]`)
+export class UnitInfoPage {
+  constructor(private readonly page: Page) {}
 
-  async assertNoValidValues() {
-    await this.#elem('no-valid-values', 'confirmed').waitUntilVisible()
-    await this.#elem('no-valid-values', 'planned').waitUntilVisible()
+  #unitName = this.page.find('[data-qa="unit-name"]')
+  #visitingAddress = this.page.find('[data-qa="unit-visiting-address"]')
+
+  async waitUntilLoaded() {
+    await this.page
+      .find('[data-qa="unit-information"][data-isloading="false"]')
+      .waitUntilVisible()
   }
 
-  async assertConfirmed(minimum: string, maximum: string) {
-    await waitUntilEqual(
-      () => this.#elem('minimum', 'confirmed').innerText,
-      minimum
-    )
-    await waitUntilEqual(
-      () => this.#elem('maximum', 'confirmed').innerText,
-      maximum
-    )
+  async assertUnitName(expectedName: string) {
+    await waitUntilEqual(() => this.#unitName.innerText, expectedName)
   }
 
-  async assertPlanned(minimum: string, maximum: string) {
-    await waitUntilEqual(
-      () => this.#elem('minimum', 'planned').innerText,
-      minimum
-    )
-    await waitUntilEqual(
-      () => this.#elem('maximum', 'planned').innerText,
-      maximum
-    )
+  async assertVisitingAddress(expectedAddress: string) {
+    await waitUntilEqual(() => this.#visitingAddress.innerText, expectedAddress)
+  }
+
+  supervisorAcl = new AclSection(
+    this.page,
+    this.page.find('[data-qa="daycare-acl-supervisors"]')
+  )
+  specialEducationTeacherAcl = new AclSection(
+    this.page,
+    this.page.find('[data-qa="daycare-acl-set"]')
+  )
+  staffAcl = new StaffAclSection(
+    this.page,
+    this.page.find('[data-qa="daycare-acl-staff"]')
+  )
+  mobileAcl = new MobileDevicesSection(
+    this.page,
+    this.page.find('[data-qa="daycare-mobile-devices"]')
+  )
+
+  #unitDetailsLink = this.page.find('[data-qa="unit-details-link"]')
+
+  async openUnitDetails(): Promise<UnitDetailsPage> {
+    await this.#unitDetailsLink.click()
+    const unitDetails = new UnitDetailsPage(this.page)
+    await unitDetails.waitUntilLoaded()
+    return unitDetails
   }
 }
 

--- a/frontend/src/e2e-test/pages/employee/units/unit.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit.ts
@@ -18,7 +18,7 @@ import {
   TextInput
 } from '../../../utils/page'
 
-import { UnitCalendarPage } from './unit-calendar-page'
+import { UnitAttendancesPage } from './unit-attendances-page'
 import { UnitGroupsPage } from './unit-groups-page'
 
 type UnitProviderType =
@@ -37,7 +37,7 @@ export class UnitPage {
 
   #unitInfoTab = this.page.find('[data-qa="unit-info-tab"]')
   #groupsTab = this.page.find('[data-qa="groups-tab"]')
-  #calendarTab = this.page.find('[data-qa="calendar-tab"]')
+  #attendancesTab = this.page.find('[data-qa="attendances-tab"]')
   #applicationProcessTab = this.page.find('[data-qa="application-process-tab"]')
 
   #unitDetailsLink = this.page.find('[data-qa="unit-details-link"]')
@@ -114,9 +114,9 @@ export class UnitPage {
     return section
   }
 
-  async openCalendarPage(): Promise<UnitCalendarPage> {
-    await this.#calendarTab.click()
-    const section = new UnitCalendarPage(this.page)
+  async openAttendancesPage(): Promise<UnitAttendancesPage> {
+    await this.#attendancesTab.click()
+    const section = new UnitAttendancesPage(this.page)
     return section
   }
 }

--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
@@ -17,15 +17,15 @@ import { Child, Daycare, EmployeeDetail } from '../../dev-api/types'
 import { UnitPage } from '../../pages/employee/units/unit'
 import {
   ReservationModal,
-  UnitCalendarPage
-} from '../../pages/employee/units/unit-calendar-page'
+  UnitAttendancesPage
+} from '../../pages/employee/units/unit-attendances-page'
 import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
 
 let page: Page
 let unitPage: UnitPage
-let calendarPage: UnitCalendarPage
+let calendarPage: UnitAttendancesPage
 let reservationModal: ReservationModal
 let child1Fixture: Child
 let child1DaycarePlacementId: UUID
@@ -84,10 +84,10 @@ beforeEach(async () => {
   await employeeLogin(page, unitSupervisor)
 })
 
-const loadUnitCalendarPage = async (): Promise<UnitCalendarPage> => {
+const loadUnitCalendarPage = async (): Promise<UnitAttendancesPage> => {
   unitPage = new UnitPage(page)
   await unitPage.navigateToUnit(daycare.id)
-  return await unitPage.openCalendarPage()
+  return await unitPage.openAttendancesPage()
 }
 
 describe('Unit group calendar', () => {

--- a/frontend/src/e2e-test/specs/5_employee/unit-acl.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-acl.spec.ts
@@ -62,56 +62,60 @@ describe('Employee - unit ACL', () => {
   test('Unit supervisors can be added/deleted', async () => {
     await employeeLogin(page, admin)
     const unitPage = await UnitPage.openUnit(page, daycareId)
-    await unitPage.supervisorAcl.assertRows([expectedAclRows.esko])
+    const unitInfoPage = await unitPage.openUnitInformation()
+    await unitInfoPage.supervisorAcl.assertRows([expectedAclRows.esko])
 
-    await unitPage.supervisorAcl.addAcl(yrjo.email)
-    await unitPage.supervisorAcl.assertRows([
+    await unitInfoPage.supervisorAcl.addAcl(yrjo.email)
+    await unitInfoPage.supervisorAcl.assertRows([
       expectedAclRows.esko,
       expectedAclRows.yrjo
     ])
 
-    await unitPage.supervisorAcl.addAcl(pete.email)
-    await unitPage.supervisorAcl.assertRows([
+    await unitInfoPage.supervisorAcl.addAcl(pete.email)
+    await unitInfoPage.supervisorAcl.assertRows([
       expectedAclRows.esko,
       expectedAclRows.yrjo,
       expectedAclRows.pete
     ])
 
-    await unitPage.supervisorAcl.deleteAcl(yrjo.id)
-    await unitPage.supervisorAcl.assertRows([
+    await unitInfoPage.supervisorAcl.deleteAcl(yrjo.id)
+    await unitInfoPage.supervisorAcl.assertRows([
       expectedAclRows.esko,
       expectedAclRows.pete
     ])
 
-    await unitPage.supervisorAcl.deleteAcl(esko.id)
-    await unitPage.supervisorAcl.assertRows([expectedAclRows.pete])
+    await unitInfoPage.supervisorAcl.deleteAcl(esko.id)
+    await unitInfoPage.supervisorAcl.assertRows([expectedAclRows.pete])
   })
 
   test('User can add and delete special education teachers', async () => {
     await employeeLogin(page, admin)
     const unitPage = await UnitPage.openUnit(page, daycareId)
-    await unitPage.supervisorAcl.assertRows([expectedAclRows.esko])
+    const unitInfoPage = await unitPage.openUnitInformation()
+    await unitInfoPage.supervisorAcl.assertRows([expectedAclRows.esko])
 
-    await unitPage.specialEducationTeacherAcl.assertRows([])
+    await unitInfoPage.specialEducationTeacherAcl.assertRows([])
 
-    await unitPage.specialEducationTeacherAcl.addAcl(pete.email)
-    await unitPage.specialEducationTeacherAcl.assertRows([expectedAclRows.pete])
+    await unitInfoPage.specialEducationTeacherAcl.addAcl(pete.email)
+    await unitInfoPage.specialEducationTeacherAcl.assertRows([
+      expectedAclRows.pete
+    ])
 
-    await unitPage.specialEducationTeacherAcl.addAcl(yrjo.email)
-    await unitPage.specialEducationTeacherAcl.assertRows([
+    await unitInfoPage.specialEducationTeacherAcl.addAcl(yrjo.email)
+    await unitInfoPage.specialEducationTeacherAcl.assertRows([
       expectedAclRows.pete,
       expectedAclRows.yrjo
     ])
 
-    await unitPage.specialEducationTeacherAcl.deleteAcl(pete.id)
-    await unitPage.specialEducationTeacherAcl.deleteAcl(yrjo.id)
+    await unitInfoPage.specialEducationTeacherAcl.deleteAcl(pete.id)
+    await unitInfoPage.specialEducationTeacherAcl.deleteAcl(yrjo.id)
 
-    await unitPage.specialEducationTeacherAcl.assertRows([])
+    await unitInfoPage.specialEducationTeacherAcl.assertRows([])
   })
 
   test('Staff can be added and assigned/removed to/from groups', async () => {
     async function toggleGroups() {
-      const row = unitPage.staffAcl.getRow(pete.id)
+      const row = unitInfoPage.staffAcl.getRow(pete.id)
       const rowEditor = await row.edit()
       await rowEditor.toggleStaffGroups([groupId])
       await rowEditor.save()
@@ -123,17 +127,18 @@ describe('Employee - unit ACL', () => {
 
     await employeeLogin(page, esko)
     const unitPage = await UnitPage.openUnit(page, daycareId)
-    await unitPage.staffAcl.addAcl(expectedAclRows.pete.email)
+    const unitInfoPage = await unitPage.openUnitInformation()
+    await unitInfoPage.staffAcl.addAcl(expectedAclRows.pete.email)
 
-    await unitPage.staffAcl.assertRows([
+    await unitInfoPage.staffAcl.assertRows([
       { ...expectedAclRows.pete, groups: [] }
     ])
     await toggleGroups()
-    await unitPage.staffAcl.assertRows([
+    await unitInfoPage.staffAcl.assertRows([
       { ...expectedAclRows.pete, groups: ['Testailijat'] }
     ])
     await toggleGroups()
-    await unitPage.staffAcl.assertRows([
+    await unitInfoPage.staffAcl.assertRows([
       { ...expectedAclRows.pete, groups: [] }
     ])
   })
@@ -141,8 +146,9 @@ describe('Employee - unit ACL', () => {
   test('User can add a mobile device unit side', async () => {
     await employeeLogin(page, admin)
     const unitPage = await UnitPage.openUnit(page, daycareId)
+    const unitInfoPage = await unitPage.openUnitInformation()
 
-    await unitPage.mobileAcl.addMobileDevice('Testilaite')
-    await unitPage.mobileAcl.assertDeviceExists('Testilaite')
+    await unitInfoPage.mobileAcl.addMobileDevice('Testilaite')
+    await unitInfoPage.mobileAcl.assertDeviceExists('Testilaite')
   })
 })

--- a/frontend/src/e2e-test/specs/5_employee/unit-editor.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-editor.spec.ts
@@ -8,7 +8,11 @@ import { initializeAreaAndPersonData } from '../../dev-api/data-init'
 import { Fixture } from '../../dev-api/fixtures'
 import { Daycare } from '../../dev-api/types'
 import EmployeeNav from '../../pages/employee/employee-nav'
-import { UnitEditor, UnitPage } from '../../pages/employee/units/unit'
+import {
+  UnitEditor,
+  UnitInfoPage,
+  UnitPage
+} from '../../pages/employee/units/unit'
 import UnitsPage from '../../pages/employee/units/units'
 import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
@@ -46,9 +50,9 @@ describe('Employee - unit details', () => {
     )
 
     await unitEditorPage.submit()
-    const unitPage = new UnitPage(page)
-    await unitPage.waitUntilLoaded()
-    await unitPage.assertUnitName('Uusi Kerho')
+    const unitInfoPage = new UnitInfoPage(page)
+    await unitInfoPage.waitUntilLoaded()
+    await unitInfoPage.assertUnitName('Uusi Kerho')
   })
 
   test('Admin can edit unit details', async () => {
@@ -75,7 +79,7 @@ describe('Employee - unit details', () => {
 
 describe('Employee - unit editor validations and warnings', () => {
   let page: Page
-  let unitPage: UnitPage
+  let unitInfoPage: UnitInfoPage
   let unitEditorPage: UnitEditor
 
   beforeEach(async () => {
@@ -86,8 +90,9 @@ describe('Employee - unit editor validations and warnings', () => {
 
     page = await Page.open()
     await employeeLogin(page, admin.data)
-    unitPage = await UnitPage.openUnit(page, fixtures.daycareFixture.id)
-    const unitDetailsPage = await unitPage.openUnitDetails()
+    const unitPage = await UnitPage.openUnit(page, fixtures.daycareFixture.id)
+    unitInfoPage = await unitPage.openUnitInformation()
+    const unitDetailsPage = await unitInfoPage.openUnitDetails()
     unitEditorPage = await unitDetailsPage.edit()
   })
 

--- a/frontend/src/e2e-test/specs/5_employee/units.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/units.spec.ts
@@ -70,8 +70,9 @@ describe('Employee - Units', () => {
     })
 
     const unitPage = await unitsPage.nthUnitRow(0).openUnit()
-    await unitPage.assertUnitName(unitFixture.name)
-    await unitPage.assertVisitingAddress(
+    const unitInfoPage = await unitPage.openUnitInformation()
+    await unitInfoPage.assertUnitName(unitFixture.name)
+    await unitInfoPage.assertVisitingAddress(
       `${unitFixture.streetAddress}, ${unitFixture.postalCode} ${unitFixture.postOffice}`
     )
   })
@@ -159,7 +160,8 @@ describe('Employee - Units', () => {
 
   test('Unit occupancy rates cannot be determined when no caretaker', async () => {
     const unitPage = await UnitPage.openUnit(page, unitFixture.id)
-    await unitPage.occupancies.assertNoValidValues()
+    const unitAttendancePage = await unitPage.openAttendancesPage()
+    await unitAttendancePage.occupancies.assertNoValidValues()
   })
 
   test('Unit occupancy rates are correct with properly set caretaker counts', async () => {
@@ -172,8 +174,15 @@ describe('Employee - Units', () => {
       .save()
 
     const unitPage = await UnitPage.openUnit(page, unitFixture.id)
-    await unitPage.occupancies.assertConfirmed('Min. 14,3 %', 'Max. 14,3 %')
-    await unitPage.occupancies.assertPlanned('Min. 14,3 %', 'Max. 14,3 %')
+    const unitAttendancePage = await unitPage.openAttendancesPage()
+    await unitAttendancePage.occupancies.assertConfirmed(
+      'Min. 14,3 %',
+      'Max. 14,3 %'
+    )
+    await unitAttendancePage.occupancies.assertPlanned(
+      'Min. 14,3 %',
+      'Max. 14,3 %'
+    )
   })
 
   test('Units list hides closed units unless toggled to show', async () => {

--- a/frontend/src/employee-frontend/components/UnitPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitPage.tsx
@@ -145,8 +145,8 @@ const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
     [id, i18n, unitData, unitInformation]
   )
 
-  const RedirectToUnitInfo = useCallback(
-    () => <Redirect to={`/units/${id}/unit-info`} />,
+  const RedirectToAttendances = useCallback(
+    () => <Redirect to={`/units/${id}/attendances`} />,
     [id]
   )
 
@@ -187,7 +187,7 @@ const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
               />
             )}
           />
-          <Route path="/" render={() => <RedirectToUnitInfo />} />
+          <Route path="/" render={() => <RedirectToAttendances />} />
         </Switch>
       </Container>
     </>

--- a/frontend/src/employee-frontend/components/UnitPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitPage.tsx
@@ -107,9 +107,9 @@ const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
   const tabs = useMemo(
     () => [
       {
-        id: 'unit-info',
-        link: `/units/${id}/unit-info`,
-        label: i18n.unit.tabs.unitInfo
+        id: 'calendar',
+        link: `/units/${id}/calendar`,
+        label: i18n.unit.tabs.attendances
       },
       {
         id: 'groups',
@@ -118,11 +118,6 @@ const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
         counter: unitData
           .map((data) => data.missingGroupPlacements.length)
           .getOrElse(undefined)
-      },
-      {
-        id: 'calendar',
-        link: `/units/${id}/calendar`,
-        label: i18n.unit.tabs.calendar
       },
       ...(unitInformation.isSuccess &&
       unitInformation.value.permittedActions.has('READ_DETAILED')
@@ -140,7 +135,12 @@ const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
                 .getOrElse(0)
             }
           ]
-        : [])
+        : []),
+      {
+        id: 'unit-info',
+        link: `/units/${id}/unit-info`,
+        label: i18n.unit.tabs.unitInfo
+      }
     ],
     [id, i18n, unitData, unitInformation]
   )

--- a/frontend/src/employee-frontend/components/UnitPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitPage.tsx
@@ -34,7 +34,7 @@ import { TitleContext, TitleState } from '../state/title'
 import { UnitContext, UnitContextProvider } from '../state/unit'
 
 import TabApplicationProcess from './unit/TabApplicationProcess'
-import TabCalendar from './unit/TabCalendar'
+import TabAttendances from './unit/TabAttendances'
 
 const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
   const { i18n } = useTranslation()
@@ -107,8 +107,8 @@ const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
   const tabs = useMemo(
     () => [
       {
-        id: 'calendar',
-        link: `/units/${id}/calendar`,
+        id: 'attendances',
+        link: `/units/${id}/attendances`,
         label: i18n.unit.tabs.attendances
       },
       {
@@ -174,8 +174,8 @@ const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
           />
           <Route
             exact
-            path="/units/:id/calendar"
-            render={() => <TabCalendar />}
+            path="/units/:id/attendances"
+            render={() => <TabAttendances />}
           />
           <Route
             exact

--- a/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
@@ -310,7 +310,7 @@ export default React.memo(function PlacementRow({
               {currentGroupPlacement?.groupId &&
               currentGroupPlacement?.groupName ? (
                 <Link
-                  to={`/units/${placement.daycare.id}/calendar?group=${currentGroupPlacement.groupId}`}
+                  to={`/units/${placement.daycare.id}/attendances?group=${currentGroupPlacement.groupId}`}
                 >
                   {currentGroupPlacement.groupName}
                 </Link>

--- a/frontend/src/employee-frontend/components/unit/TabAttendances.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabAttendances.tsx
@@ -21,7 +21,7 @@ import { UnitContext } from '../../state/unit'
 import { UUID_REGEX } from '../../utils/validation/validations'
 import Absences from '../absences/Absences'
 
-import GroupSelector from './tab-calendar/GroupSelector'
+import GroupSelector from './tab-attendances/GroupSelector'
 import UnitAttendanceReservationsView from './unit-reservations/UnitAttendanceReservationsView'
 
 type Mode = 'week' | 'month'
@@ -38,7 +38,7 @@ const GroupSelectorWrapper = styled.div`
   margin-bottom: ${defaultMargins.m};
 `
 
-export default React.memo(function TabCalendar() {
+export default React.memo(function TabAttendances() {
   const { i18n } = useTranslation()
   const { id: unitId } = useParams<{ id: UUID }>()
   const { unitInformation } = useContext(UnitContext)
@@ -62,14 +62,14 @@ export default React.memo(function TabCalendar() {
   return (
     <ContentArea opaque>
       <TopRow>
-        <H2>{i18n.unit.calendar.title}</H2>
+        <H2>{i18n.unit.attendances.title}</H2>
         {reservationEnabled && (
           <FixedSpaceRow spacing="xs">
             {(['week', 'month'] as const).map((m) => (
               <ChoiceChip
                 key={m}
                 data-qa={`choose-calendar-mode-${m}`}
-                text={i18n.unit.calendar.modes[m]}
+                text={i18n.unit.attendances.modes[m]}
                 selected={mode === m}
                 onChange={() => setMode(m)}
               />
@@ -78,7 +78,7 @@ export default React.memo(function TabCalendar() {
         )}
       </TopRow>
 
-      <H3 noMargin data-qa="calendar-unit-name">
+      <H3 noMargin data-qa="attendances-unit-name">
         {unitInformation.isSuccess ? unitInformation.value.daycare.name : ' '}
       </H3>
       <Gap size="xs" />
@@ -87,7 +87,7 @@ export default React.memo(function TabCalendar() {
           unitId={unitId}
           selected={groupId}
           onSelect={setGroupId}
-          data-qa="calendar-group-select"
+          data-qa="attendances-group-select"
         />
       </GroupSelectorWrapper>
 

--- a/frontend/src/employee-frontend/components/unit/TabUnitInformation.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabUnitInformation.tsx
@@ -4,32 +4,19 @@
 
 import React, { useContext, useMemo } from 'react'
 
-import { isLoading, Result } from 'lib-common/api'
+import { isLoading } from 'lib-common/api'
 import { ContentArea } from 'lib-components/layout/Container'
-import {
-  FixedSpaceColumn,
-  FixedSpaceRow
-} from 'lib-components/layout/flex-helpers'
-import { H2, H3, Label } from 'lib-components/typography'
+import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import { H2 } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
-import { UnitData } from '../../api/unit'
-import UnitDataFilters from '../../components/unit/UnitDataFilters'
-import Occupancy from '../../components/unit/tab-unit-information/Occupancy'
 import UnitAccessControl from '../../components/unit/tab-unit-information/UnitAccessControl'
 import UnitInformation from '../../components/unit/tab-unit-information/UnitInformation'
-import { useTranslation } from '../../state/i18n'
 import { UnitContext } from '../../state/unit'
-import { UserContext } from '../../state/user'
-import { requireRole } from '../../utils/roles'
 import { renderResult } from '../async-rendering'
-import { DataList } from '../common/DataList'
 
 export default React.memo(function TabUnitInformation() {
-  const { i18n } = useTranslation()
-  const { roles } = useContext(UserContext)
-  const { unitInformation, unitData, filters, setFilters } =
-    useContext(UnitContext)
+  const { unitInformation, unitData } = useContext(UnitContext)
 
   const groups = useMemo(
     () =>
@@ -52,43 +39,6 @@ export default React.memo(function TabUnitInformation() {
       >
         <H2 data-qa="unit-name">{unitInformation.daycare.name}</H2>
         <Gap size="xxs" />
-        <H3>{i18n.unit.occupancies}</H3>
-        <Gap size="s" />
-        <FixedSpaceRow alignItems="center">
-          <Label>{i18n.unit.filters.title}</Label>
-          <UnitDataFilters
-            canEdit={requireRole(
-              roles,
-              'ADMIN',
-              'SERVICE_WORKER',
-              'UNIT_SUPERVISOR',
-              'FINANCE_ADMIN'
-            )}
-            filters={filters}
-            setFilters={setFilters}
-          />
-        </FixedSpaceRow>
-        <Gap size="s" />
-        <DataList>
-          <div>
-            <label>{i18n.unit.info.caretakers.titleLabel}</label>
-            <span data-qa="unit-total-caretaker-count">
-              <Caretakers unitData={unitData} />
-            </span>
-          </div>
-        </DataList>
-        <Gap />
-        {renderResult(unitData, (unitData) =>
-          unitData.unitOccupancies ? (
-            <Occupancy
-              filters={filters}
-              occupancies={unitData.unitOccupancies}
-            />
-          ) : null
-        )}
-      </ContentArea>
-
-      <ContentArea opaque>
         <UnitInformation
           unit={unitInformation.daycare}
           permittedActions={unitInformation.permittedActions}
@@ -107,30 +57,4 @@ export default React.memo(function TabUnitInformation() {
       )}
     </FixedSpaceColumn>
   ))
-})
-
-const Caretakers = React.memo(function Caretakers({
-  unitData
-}: {
-  unitData: Result<UnitData>
-}) {
-  const { i18n } = useTranslation()
-
-  const formatNumber = (num: number) =>
-    parseFloat(num.toFixed(2)).toLocaleString()
-
-  return unitData
-    .map((unitData) => {
-      const min = formatNumber(unitData.caretakers.unitCaretakers.minimum)
-      const max = formatNumber(unitData.caretakers.unitCaretakers.maximum)
-
-      return min === max ? (
-        <span>
-          {min} {i18n.unit.info.caretakers.unitOfValue}
-        </span>
-      ) : (
-        <span>{`${min} - ${max} ${i18n.unit.info.caretakers.unitOfValue}`}</span>
-      )
-    })
-    .getOrElse(null)
 })

--- a/frontend/src/employee-frontend/components/unit/tab-attendances/GroupSelector.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-attendances/GroupSelector.tsx
@@ -55,7 +55,7 @@ export default React.memo(function GroupSelector({
       groups
         .map((gs) =>
           item === 'no-group'
-            ? i18n.unit.calendar.noGroup
+            ? i18n.unit.attendances.noGroup
             : gs.find(({ id }) => id === item)?.name ?? ''
         )
         .getOrElse(''),

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
@@ -425,7 +425,7 @@ export default React.memo(function Group({
             </>
           )}
           {permittedActions.has('READ_ABSENCES') && (
-            <Link to={`/units/${unit.id}/calendar?group=${group.id}`}>
+            <Link to={`/units/${unit.id}/attendances?group=${group.id}`}>
               <InlineButton
                 icon={faCalendarAlt}
                 text={i18n.unit.groups.diaryButton}

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -1352,7 +1352,7 @@ export const fi = {
     tabs: {
       unitInfo: 'Yksikön tiedot',
       groups: 'Ryhmät',
-      calendar: 'Kalenteri',
+      attendances: 'Läsnäolot',
       applicationProcess: 'Hakuprosessi'
     },
     create: 'Luo uusi yksikkö',

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -1502,7 +1502,7 @@ export const fi = {
       endDate: 'Päättymispäivämäärä',
       groupName: 'Ryhmä'
     },
-    calendar: {
+    attendances: {
       title: 'Varaukset ja läsnäolot',
       noGroup: 'Ei ryhmää',
       modes: {


### PR DESCRIPTION
* Rearranges the tabs on the unit page.
* Makes the attendances tab the default (renamed from calendar to attendances).
* Moves the utilisation chart from the unit information tab to the unit attendances tab.