### PR TITLE
Add guardian blocklist mechanism

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonQueries.kt
@@ -445,7 +445,7 @@ fun Database.Read.getTransferablePersonReferences(): List<PersonReference> {
             join pg_attribute attr on attr.attrelid = source.oid and attr.attnum = ANY(const.conkey)
         where const.contype = 'f' 
             and target.relname in ('person', 'child') 
-            and source.relname not in ('person', 'child', 'guardian', 'message_account')
+            and source.relname not in ('person', 'child', 'guardian', 'guardian_blocklist', 'message_account')
             and source.relname not like 'old_%'
         order by source.relname, attr.attname
     """.trimIndent()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -1090,3 +1090,14 @@ VALUES (:id, :childId, :date, :startTime, :endTime, :createdBy)
 RETURNING id
 """
 ).let(::AttendanceReservationId)
+
+fun Database.Transaction.insertTestGuardianBlocklistEntry(entry: DevGuardianBlocklistEntry) {
+    createUpdate(
+        """
+INSERT INTO guardian_blocklist (guardian_id, child_id)
+VALUES (:guardianId, :childId)
+        """.trimIndent()
+    )
+        .bindKotlin(entry)
+        .execute()
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1485,3 +1485,5 @@ data class PostVasuDocBody(
     val childId: ChildId,
     val templateId: VasuTemplateId
 )
+
+data class DevGuardianBlocklistEntry(val guardianId: PersonId, val childId: ChildId)

--- a/service/src/main/resources/db/migration/V217__guardian_blocklist.sql
+++ b/service/src/main/resources/db/migration/V217__guardian_blocklist.sql
@@ -1,0 +1,11 @@
+CREATE TABLE guardian_blocklist (
+    guardian_id uuid NOT NULL CONSTRAINT fk$guardian REFERENCES person (id) ON DELETE CASCADE,
+    child_id uuid NOT NULL CONSTRAINT fk$child REFERENCES person (id) ON DELETE CASCADE,
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    updated timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON guardian_blocklist FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();
+
+CREATE UNIQUE INDEX uniq$guardian_blocklist_guardian_child ON guardian_blocklist (guardian_id, child_id);
+CREATE INDEX idx$guardian_blocklist_child ON guardian_blocklist (child_id);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -214,3 +214,4 @@ V213__child_income.sql
 V214__child_attendance_indexes.sql
 V215__holiday_questionnaire_answer.sql
 V216__mobile_device_hard_delete.sql
+V217__guardian_blocklist.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

If a row is in `guardian_blocklist` table, the corresponding guardian<->child relation is never created when processing VTJ data