### PR TITLE
EVAKA HOTFIX message box under mobile keyboard

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -157,7 +157,7 @@ const Container = styled.div`
   @media (max-width: ${desktopMin}) {
     width: 100vw;
     height: 100%;
-    max-width: 100vh;
+    max-width: 100vw;
     max-height: 100%;
     position: fixed;
     top: 0;

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -162,6 +162,7 @@ const Container = styled.div`
     position: fixed;
     top: 0;
     left: 0;
+    overflow-y: scroll;
   }
 `
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Tested on my android device that had the bug.

- Fix message box staying under keyboard on some mobile devices
- Use correct max-width value

