### PR TITLE
Drop dependant views using cascade

### DIFF
--- a/service/src/main/resources/db/migration/V216__mobile_device_hard_delete.sql
+++ b/service/src/main/resources/db/migration/V216__mobile_device_hard_delete.sql
@@ -2,7 +2,8 @@ DELETE FROM pairing WHERE mobile_device_id IN (SELECT id FROM mobile_device WHER
 DELETE FROM mobile_device WHERE deleted IS TRUE;
 DROP INDEX idx$mobile_device_unit;
 
-ALTER TABLE mobile_device DROP COLUMN deleted;
+-- Some ACL views depend on the deleted column, so CASCADE must be used
+ALTER TABLE mobile_device DROP COLUMN deleted CASCADE;
 
 ALTER TABLE pairing DROP CONSTRAINT pairing_mobile_device_id_fkey;
 ALTER TABLE pairing ADD CONSTRAINT fk$mobile_device FOREIGN KEY (mobile_device_id) REFERENCES mobile_device (id) ON DELETE CASCADE;


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

They are recreated after the migration, since R__acl_views.sql has changed