### PR TITLE
Enable browserslist

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2020 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -134,7 +134,15 @@ function baseConfig({ isDevelopment, isDevServer }, { name, publicPath }) {
             {
               loader: 'babel-loader',
               options: {
-                presets: ['@babel/preset-env'],
+                presets: [
+                  [
+                    '@babel/preset-env',
+                    {
+                      corejs: '3.21',
+                      useBuiltIns: 'entry'
+                    }
+                  ]
+                ],
                 plugins: [
                   [
                     'babel-plugin-styled-components',


### PR DESCRIPTION
#### Summary

Enable browserslist by adding `useBuiltIns: 'entry'` option to `@babel/preset-env` config.
Previously the browserslist section was ignored and the whole `core-js` was imported. Now it just imports the required polyfills based on the target environment defined by browserslist.

I considered `useBuiltIns: usage` but we would need to be splitting bundles to gain any advantages. The bundle size just ended up being bigger.

```
// debug: true output
Using targets: {
  "android": "97",
  "chrome": "74",
  "edge": "79",
  "firefox": "67",
  "ios": "12.2",
  "opera": "60",
  "safari": "12.1",
  "samsung": "9.2"
}
```

Difference in bundle size was minimal, which is a good thing because only a handful of now redundant polyfills were removed.


before:
```
Entrypoint main [big] 1.86 MiB (20.8 MiB)
  – vendor.7e903b786d0bbc2c4d47.js 1.09 MiB
  – main.ac4c472083e587eae75b.js 793 KiB
```
after:
```
Entrypoint main [big] 1.81 MiB (20.5 MiB)
  – vendor.7ae4a5d4258be7142173.js 1.03 MiB
  – main.22b9a261ac34eec1230d.js 794 KiB
```
