### PR TITLE
Citizen reservation fixes

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -302,23 +302,19 @@ const Week = React.memo(function Week({
   return (
     <>
       <WeekNumber>{week.weekNumber}</WeekNumber>
-      {week.dailyReservations.map((d) => {
-        const selected =
-          selectedDate !== undefined && d.date.isEqual(selectedDate)
-        return (
-          <Day
-            key={`${d.date.formatIso()}${month}${year}`}
-            day={d}
-            childData={childData}
-            holidayPeriods={holidayPeriods}
-            todayRef={todayRef}
-            dateType={dateType(year, month, d.date)}
-            selected={selected}
-            selectDate={selectDate}
-            dayIsReservable={dayIsReservable}
-          />
-        )
-      })}
+      {week.dailyReservations.map((d) => (
+        <Day
+          key={`${d.date.formatIso()}${month}${year}`}
+          day={d}
+          childData={childData}
+          holidayPeriods={holidayPeriods}
+          todayRef={todayRef}
+          dateType={dateType(year, month, d.date)}
+          selected={selectedDate !== undefined && d.date.isEqual(selectedDate)}
+          selectDate={selectDate}
+          dayIsReservable={dayIsReservable}
+        />
+      ))}
     </>
   )
 })

--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -141,6 +141,9 @@ export default React.memo(function CalendarGridView({
                   {w.dailyReservations.map((d) => {
                     const dateIsOnMonth = d.date.month === month
                     const isToday = d.date.isToday() && dateIsOnMonth
+                    const markedByEmployee =
+                      d.children.length > 0 &&
+                      d.children.every((c) => c.markedByEmployee)
 
                     return dateIsOnMonth ? (
                       <DayCell
@@ -151,6 +154,7 @@ export default React.memo(function CalendarGridView({
                           }
                         }}
                         today={isToday}
+                        markedByEmployee={markedByEmployee}
                         holidayPeriod={holidayPeriods.some((p) =>
                           p.includes(d.date)
                         )}
@@ -316,6 +320,7 @@ const MonthTitle = styled(H2).attrs({ noMargin: true })`
 
 const DayCell = styled.button<{
   today: boolean
+  markedByEmployee: boolean
   selected: boolean
   holidayPeriod: boolean
 }>`
@@ -327,7 +332,9 @@ const DayCell = styled.button<{
   min-height: 150px;
   padding: ${defaultMargins.s};
   background-color: ${(p) =>
-    p.holidayPeriod
+    p.markedByEmployee
+      ? p.theme.colors.grayscale.g15
+      : p.holidayPeriod
       ? p.theme.colors.accents.a10powder
       : p.theme.colors.grayscale.g0};
   border: none;
@@ -341,7 +348,7 @@ const DayCell = styled.button<{
           border-left: 4px solid ${colors.status.success};
           padding-left: calc(${defaultMargins.s} - 3px);
         `
-      : ''}
+      : ''};
 
   ${(p) =>
     p.selected
@@ -349,7 +356,7 @@ const DayCell = styled.button<{
           box-shadow: 0 2px 3px 2px #00000030;
           z-index: 1;
         `
-      : ''}
+      : ''};
 
   :focus {
     box-shadow: 0 0 0 4px ${(p) => p.theme.colors.main.m2Focus};

--- a/frontend/src/citizen-frontend/calendar/CalendarListView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarListView.tsx
@@ -7,7 +7,10 @@ import _ from 'lodash'
 import React, { useMemo } from 'react'
 import styled from 'styled-components'
 
-import { DailyReservationData } from 'lib-common/generated/api-types/reservations'
+import {
+  DailyReservationData,
+  ReservationChild
+} from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
 import Button from 'lib-components/atoms/buttons/Button'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
@@ -19,6 +22,7 @@ import { useTranslation } from '../localization'
 import WeekElem from './WeekElem'
 
 export interface Props {
+  childData: ReservationChild[]
   dailyData: DailyReservationData[]
   onHoverButtonClick: () => void
   selectDate: (date: LocalDate) => void
@@ -27,6 +31,7 @@ export interface Props {
 }
 
 export default React.memo(function CalendarListView({
+  childData,
   dailyData,
   dayIsHolidayPeriod,
   onHoverButtonClick,
@@ -43,6 +48,7 @@ export default React.memo(function CalendarListView({
           <WeekElem
             {...w}
             key={w.dailyReservations[0].date.formatIso()}
+            childData={childData}
             selectDate={selectDate}
             dayIsReservable={dayIsReservable}
             dayIsHolidayPeriod={dayIsHolidayPeriod}

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -132,6 +132,7 @@ const Page = React.memo(function CalendarPage() {
       <MobileAndTablet>
         <ContentArea opaque paddingVertical="zero" paddingHorizontal="zero">
           <CalendarListView
+            childData={response.children}
             dailyData={response.dailyData}
             onHoverButtonClick={openPickActionModal}
             selectDate={selectDate}
@@ -143,6 +144,7 @@ const Page = React.memo(function CalendarPage() {
       <DesktopOnly>
         <Gap size="s" />
         <CalendarGridView
+          childData={response.children}
           dailyData={response.dailyData}
           onCreateReservationClicked={openReservationModal}
           onCreateAbsencesClicked={openAbsenceModal}

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -53,6 +53,7 @@ import {
 import ModalAccessibilityWrapper from '../ModalAccessibilityWrapper'
 import { useLang, useTranslation } from '../localization'
 
+import { RoundChildImage } from './RoundChildImages'
 import TimeRangeInput, { TimeRangeWithErrors } from './TimeRangeInput'
 import { postReservations } from './api'
 
@@ -243,9 +244,23 @@ export default React.memo(function DayView({
               return (
                 <div key={child.id} data-qa={`reservations-of-${child.id}`}>
                   {childIndex !== 0 ? <Separator /> : null}
-                  <H3 noMargin data-qa="child-name">
-                    {formatPreferredName(child)}
-                  </H3>
+                  <FixedSpaceRow>
+                    <FixedSpaceColumn>
+                      <RoundChildImage
+                        imageId={child.imageId}
+                        initialLetter={
+                          (child.preferredName || child.firstName || '?')[0]
+                        }
+                        colorIndex={childIndex}
+                        size={48}
+                      />
+                    </FixedSpaceColumn>
+                    <FixedSpaceColumn spacing="zero" justifyContent="center">
+                      <H3 noMargin data-qa="child-name">
+                        {formatPreferredName(child)}
+                      </H3>
+                    </FixedSpaceColumn>
+                  </FixedSpaceRow>
                   <Gap size="s" />
                   <Grid>
                     <Label>{i18n.calendar.reservation}</Label>

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -139,6 +139,7 @@ export default React.memo(function DayView({
 
   const {
     editable,
+    absenceEditable,
     editing,
     startEditing,
     editorState,
@@ -291,12 +292,14 @@ export default React.memo(function DayView({
             />
           ) : null}
         </Content>
-        <AbsenceButton
-          text={i18n.calendar.newAbsence}
-          icon={faUserMinus}
-          onClick={onCreateAbsence}
-          data-qa="create-absence"
-        />
+        {absenceEditable && (
+          <AbsenceButton
+            text={i18n.calendar.newAbsence}
+            icon={faUserMinus}
+            onClick={onCreateAbsence}
+            data-qa="create-absence"
+          />
+        )}
         <ModalCloseButton
           close={navigate(close)}
           closeLabel={i18n.common.closeModal}
@@ -324,13 +327,24 @@ function useEditState(
   reservableDays: FiniteDateRange[],
   reloadData: () => void
 ) {
-  const editable = useMemo(
+  const today = LocalDate.today()
+
+  const anyChildReservable = useMemo(
     () =>
-      reservableDays.some((r) => r.includes(date)) &&
       childrenWithReservations.some(
         ({ reservationEditable }) => reservationEditable
       ),
-    [date, reservableDays, childrenWithReservations]
+    [childrenWithReservations]
+  )
+
+  const editable = useMemo(
+    () => anyChildReservable && reservableDays.some((r) => r.includes(date)),
+    [anyChildReservable, reservableDays, date]
+  )
+
+  const absenceEditable = useMemo(
+    () => anyChildReservable && date.isEqualOrAfter(today),
+    [anyChildReservable, date, today]
   )
 
   const [editing, setEditing] = useState(false)
@@ -476,6 +490,7 @@ function useEditState(
 
   return {
     editable,
+    absenceEditable,
     editing,
     startEditing,
     editorState,

--- a/frontend/src/citizen-frontend/calendar/HistoryOverlay.tsx
+++ b/frontend/src/citizen-frontend/calendar/HistoryOverlay.tsx
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import styled from 'styled-components'
+
+export const HistoryOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.6;
+  background-color: ${(p) => p.theme.colors.grayscale.g0};
+`

--- a/frontend/src/citizen-frontend/calendar/RoundChildImages.tsx
+++ b/frontend/src/citizen-frontend/calendar/RoundChildImages.tsx
@@ -122,20 +122,23 @@ export function getPresentChildImages(
   childData: ReservationChild[],
   day: DailyReservationData
 ): ChildImageData[] {
-  return childData
-    .map((child, index) => [child, index] as const)
-    .filter(([child, _]) =>
-      day.children.some(
-        (dc) =>
-          dc.childId === child.id &&
-          dc.absence === null &&
-          (dc.reservations.length > 0 || dc.attendances.length > 0)
+  return (
+    childData
+      // Save the index first, so that each child has the same index every time, regardless of the below filtering
+      .map((child, index) => [child, index] as const)
+      .filter(([child, _]) =>
+        day.children.some(
+          (dc) =>
+            dc.childId === child.id &&
+            dc.absence === null &&
+            (dc.reservations.length > 0 || dc.attendances.length > 0)
+        )
       )
-    )
-    .map(([child, index]) => ({
-      childId: child.id,
-      imageId: child.imageId,
-      initialLetter: (child.preferredName || child.firstName || '?')[0],
-      colorIndex: index
-    }))
+      .map(([child, index]) => ({
+        childId: child.id,
+        imageId: child.imageId,
+        initialLetter: (child.preferredName || child.firstName || '?')[0],
+        colorIndex: index
+      }))
+  )
 }

--- a/frontend/src/citizen-frontend/calendar/RoundChildImages.tsx
+++ b/frontend/src/citizen-frontend/calendar/RoundChildImages.tsx
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+import styled, { css } from 'styled-components'
+
+import {
+  DailyReservationData,
+  ReservationChild
+} from 'lib-common/generated/api-types/reservations'
+import { UUID } from 'lib-common/types'
+import { fontWeights } from 'lib-components/typography'
+import { theme } from 'lib-customizations/common'
+
+export interface ChildImageData {
+  childId: UUID
+  imageId: UUID | null
+  initialLetter: string
+  colorIndex: number
+}
+
+export interface Props {
+  images: ChildImageData[]
+  imageSize: number
+  imageBorder: number
+  imageOverlap: number
+}
+
+export default React.memo(function RoundChildImages({
+  images,
+  imageSize,
+  imageBorder,
+  imageOverlap
+}: Props) {
+  return (
+    <RoundChildImagesContainer>
+      {images.map((image, index) => (
+        <Overlap key={image.childId} overlap={imageOverlap} index={index}>
+          <RoundChildImage
+            imageId={image.imageId}
+            initialLetter={image.initialLetter}
+            colorIndex={image.colorIndex}
+            size={imageSize}
+            border={imageBorder}
+          />
+        </Overlap>
+      ))}
+    </RoundChildImagesContainer>
+  )
+})
+
+const RoundChildImagesContainer = styled.div`
+  display: flex;
+`
+
+const Overlap = styled.div<{ overlap: number; index: number }>`
+  flex: 0 0 auto;
+  margin-left: ${(p) => (p.index > 0 ? -p.overlap : 0)}px;
+`
+
+export interface RoundChildImageProps {
+  imageId: UUID | null
+  initialLetter: string
+  colorIndex: number
+  size: number
+  border?: number
+}
+
+export const RoundChildImage = React.memo(function RoundChildImage({
+  imageId,
+  initialLetter,
+  colorIndex,
+  size,
+  border = 0
+}: RoundChildImageProps) {
+  return imageId !== null ? (
+    <ChildImage
+      src={`/api/application/citizen/child-images/${imageId}`}
+      size={size}
+      border={border}
+    />
+  ) : (
+    <ChildInitialLetter colorIndex={colorIndex} size={size} border={border}>
+      {initialLetter}
+    </ChildInitialLetter>
+  )
+})
+
+const roundMixin = css<{ size: number; border: number }>`
+  width: ${(p) => p.size}px;
+  height: ${(p) => p.size}px;
+  ${(p) => (p.border > 0 ? `border: ${p.border}px solid #fff;` : undefined)};
+  border-radius: 50%;
+`
+
+const ChildImage = styled.img<{ size: number; border: number }>`
+  ${roundMixin};
+`
+
+const accentColors = [
+  theme.colors.accents.a6turquoise,
+  theme.colors.accents.a9pink,
+  theme.colors.accents.a7mint,
+  theme.colors.accents.a5orangeLight
+]
+
+const ChildInitialLetter = styled.div<{
+  size: number
+  border: number
+  colorIndex: number
+}>`
+  ${roundMixin};
+  background-color: ${(p) => accentColors[p.colorIndex % accentColors.length]};
+  font-weight: ${fontWeights.semibold};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+export function getPresentChildImages(
+  childData: ReservationChild[],
+  day: DailyReservationData
+): ChildImageData[] {
+  return childData
+    .map((child, index) => [child, index] as const)
+    .filter(([child, _]) =>
+      day.children.some(
+        (dc) =>
+          dc.childId === child.id &&
+          dc.absence === null &&
+          (dc.reservations.length > 0 || dc.attendances.length > 0)
+      )
+    )
+    .map(([child, index]) => ({
+      childId: child.id,
+      imageId: child.imageId,
+      initialLetter: (child.preferredName || child.firstName || '?')[0],
+      colorIndex: index
+    }))
+}

--- a/frontend/src/citizen-frontend/calendar/WeekElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/WeekElem.tsx
@@ -17,6 +17,7 @@ import { useLang, useTranslation } from '../localization'
 import { scrollMainToPos } from '../utils'
 
 import { WeeklyData } from './CalendarListView'
+import { HistoryOverlay } from './HistoryOverlay'
 import { Reservations } from './calendar-elements'
 
 interface Props extends WeeklyData {
@@ -196,14 +197,4 @@ const DayColumn = styled(FixedSpaceColumn)<{ inactive: boolean }>`
   width: 3rem;
   color: ${(p) => (p.inactive ? colors.grayscale.g70 : colors.main.m1)};
   font-weight: ${fontWeights.semibold};
-`
-
-const HistoryOverlay = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0.6;
-  background-color: ${(p) => p.theme.colors.grayscale.g0};
 `

--- a/frontend/src/citizen-frontend/calendar/WeekElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/WeekElem.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { Fragment, useEffect, useRef } from 'react'
+import React, { Fragment, useCallback, useEffect, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { DailyReservationData } from 'lib-common/generated/api-types/reservations'
@@ -99,6 +99,20 @@ const DayElem = React.memo(function DayElem({
   const [lang] = useLang()
   const ref = useRef<HTMLButtonElement>()
 
+  const isToday = dailyReservations.date.isToday()
+  const setRef = useCallback(
+    (e: HTMLDivElement) => {
+      if (isToday) {
+        ref.current = e ?? undefined
+      }
+    },
+    [isToday]
+  )
+
+  const handleClick = useCallback(() => {
+    selectDate(dailyReservations.date)
+  }, [selectDate, dailyReservations.date])
+
   useEffect(() => {
     if (ref.current) {
       const pos = ref.current?.getBoundingClientRect().top
@@ -115,14 +129,10 @@ const DayElem = React.memo(function DayElem({
 
   return (
     <Day
-      ref={(e) => {
-        if (dailyReservations.date.isToday()) {
-          ref.current = e ?? undefined
-        }
-      }}
+      ref={setRef}
       today={dailyReservations.date.isToday()}
       holidayPeriod={isHolidayPeriod}
-      onClick={() => selectDate(dailyReservations.date)}
+      onClick={handleClick}
       data-qa={`mobile-calendar-day-${dailyReservations.date.formatIso()}`}
     >
       <DayColumn spacing="xxs" inactive={!isReservable}>

--- a/frontend/src/citizen-frontend/calendar/WeekElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/WeekElem.tsx
@@ -5,8 +5,12 @@
 import React, { Fragment, useCallback, useEffect, useMemo, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
-import { DailyReservationData } from 'lib-common/generated/api-types/reservations'
+import {
+  DailyReservationData,
+  ReservationChild
+} from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
+import { capitalizeFirstLetter } from 'lib-common/string'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { fontWeights, H2, H3 } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -18,9 +22,11 @@ import { scrollMainToPos } from '../utils'
 
 import { WeeklyData } from './CalendarListView'
 import { HistoryOverlay } from './HistoryOverlay'
+import RoundChildImages, { getPresentChildImages } from './RoundChildImages'
 import { Reservations } from './calendar-elements'
 
 interface Props extends WeeklyData {
+  childData: ReservationChild[]
   selectDate: (date: LocalDate) => void
   dayIsReservable: (dailyData: DailyReservationData) => boolean
   dayIsHolidayPeriod: (date: LocalDate) => boolean
@@ -28,6 +34,7 @@ interface Props extends WeeklyData {
 
 export default React.memo(function WeekElem({
   weekNumber,
+  childData,
   dailyReservations,
   dayIsHolidayPeriod,
   selectDate,
@@ -48,6 +55,7 @@ export default React.memo(function WeekElem({
               </MonthTitle>
             )}
             <DayElem
+              childData={childData}
               dailyReservations={d}
               key={d.date.formatIso()}
               selectDate={selectDate}
@@ -85,6 +93,7 @@ const MonthTitle = styled(H2)`
 `
 
 interface DayProps {
+  childData: ReservationChild[]
   dailyReservations: DailyReservationData
   selectDate: (date: LocalDate) => void
   isReservable: boolean
@@ -92,6 +101,7 @@ interface DayProps {
 }
 
 const DayElem = React.memo(function DayElem({
+  childData,
   dailyReservations,
   selectDate,
   isReservable,
@@ -121,6 +131,11 @@ const DayElem = React.memo(function DayElem({
     selectDate(dailyReservations.date)
   }, [selectDate, dailyReservations.date])
 
+  const presentChildImages = useMemo(
+    () => getPresentChildImages(childData, dailyReservations),
+    [childData, dailyReservations]
+  )
+
   useEffect(() => {
     if (ref.current) {
       const pos = ref.current?.getBoundingClientRect().top
@@ -146,21 +161,37 @@ const DayElem = React.memo(function DayElem({
     >
       <DayColumn spacing="xxs" inactive={!isReservable}>
         <div aria-label={dailyReservations.date.formatExotic('EEEE', lang)}>
-          {dailyReservations.date.format('EEEEEE', lang)}
+          {capitalizeFirstLetter(dailyReservations.date.format('EEEEEE', lang))}
         </div>
         <div aria-label={dailyReservations.date.formatExotic('do MMMM', lang)}>
           {dailyReservations.date.format('d.M.')}
         </div>
       </DayColumn>
       <Gap size="s" horizontal />
-      <div data-qa="reservations">
+      <ReservationsContainer data-qa="reservations">
         <Reservations data={dailyReservations} />
-      </div>
+      </ReservationsContainer>
       <Gap size="s" horizontal />
+      <ChildImagesContainer>
+        <RoundChildImages
+          images={presentChildImages}
+          imageSize={34}
+          imageBorder={2}
+          imageOverlap={9}
+        />
+      </ChildImagesContainer>
       {dailyReservations.date.isBefore(LocalDate.today()) && <HistoryOverlay />}
     </Day>
   )
 })
+
+const ReservationsContainer = styled.div`
+  flex: 1 0 0;
+`
+
+const ChildImagesContainer = styled.div`
+  flex: 0 0 auto;
+`
 
 const Day = styled.button<{
   today: boolean
@@ -169,7 +200,6 @@ const Day = styled.button<{
 }>`
   display: flex;
   flex-direction: row;
-  align-items: center;
   width: 100%;
   position: relative;
   padding: ${defaultMargins.s} ${defaultMargins.s};
@@ -180,6 +210,7 @@ const Day = styled.button<{
   border-left: 6px solid
     ${(p) => (p.today ? colors.status.success : 'transparent')};
   cursor: pointer;
+  text-align: left;
 
   ${(p) =>
     p.markedByEmployee

--- a/frontend/src/citizen-frontend/calendar/WeekElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/WeekElem.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { Fragment, useCallback, useEffect, useRef } from 'react'
+import React, { Fragment, useCallback, useEffect, useMemo, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { DailyReservationData } from 'lib-common/generated/api-types/reservations'
@@ -99,9 +99,16 @@ const DayElem = React.memo(function DayElem({
   const [lang] = useLang()
   const ref = useRef<HTMLButtonElement>()
 
+  const markedByEmployee = useMemo(
+    () =>
+      dailyReservations.children.length > 0 &&
+      dailyReservations.children.every((c) => c.markedByEmployee),
+    [dailyReservations]
+  )
+
   const isToday = dailyReservations.date.isToday()
   const setRef = useCallback(
-    (e: HTMLDivElement) => {
+    (e: HTMLButtonElement) => {
       if (isToday) {
         ref.current = e ?? undefined
       }
@@ -131,6 +138,7 @@ const DayElem = React.memo(function DayElem({
     <Day
       ref={setRef}
       today={dailyReservations.date.isToday()}
+      markedByEmployee={markedByEmployee}
       holidayPeriod={isHolidayPeriod}
       onClick={handleClick}
       data-qa={`mobile-calendar-day-${dailyReservations.date.formatIso()}`}
@@ -155,6 +163,7 @@ const DayElem = React.memo(function DayElem({
 
 const Day = styled.button<{
   today: boolean
+  markedByEmployee: boolean
   holidayPeriod: boolean
 }>`
   display: flex;
@@ -170,11 +179,13 @@ const Day = styled.button<{
   border-left: 6px solid
     ${(p) => (p.today ? colors.status.success : 'transparent')};
   cursor: pointer;
+
   ${(p) =>
-    p.holidayPeriod &&
-    css`
-      background-color: ${colors.accents.a10powder};
-    `}
+    p.markedByEmployee
+      ? `background-color: ${colors.grayscale.g15}`
+      : p.holidayPeriod
+      ? `background-color: ${colors.accents.a10powder}`
+      : undefined};
 
   :focus {
     outline: 2px solid ${(p) => p.theme.colors.main.m2Focus};

--- a/frontend/src/citizen-frontend/map/UnitDetailsPanel.tsx
+++ b/frontend/src/citizen-frontend/map/UnitDetailsPanel.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components'
 import { Result, Success } from 'lib-common/api'
 import { CareType, PublicUnit } from 'lib-common/generated/api-types/daycare'
 import { Coordinate } from 'lib-common/generated/api-types/shared'
+import { capitalizeFirstLetter } from 'lib-common/string'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
@@ -75,8 +76,6 @@ export default React.memo(function UnitDetailsPanel({
     .map(formatCareType)
     .join(', ')
 
-  const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.substr(1)
-
   const getRouteLink = useCallback(() => {
     if (!unit.location || !selectedAddress) return null
 
@@ -142,7 +141,9 @@ export default React.memo(function UnitDetailsPanel({
             <Label>{t.map.language}</Label>
             <Gap size="xs" />
             {/* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */}
-            <div>{capitalize(t.common.unit.languages[unit.language])}</div>
+            <div>
+              {capitalizeFirstLetter(t.common.unit.languages[unit.language])}
+            </div>
             <Gap size="s" />
             <Label>{t.map.providerType}</Label>
             <Gap size="xs" />

--- a/frontend/src/employee-frontend/components/GroupCaretakers.tsx
+++ b/frontend/src/employee-frontend/components/GroupCaretakers.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { Loading, Result } from 'lib-common/api'
+import { capitalizeFirstLetter } from 'lib-common/string'
 import { UUID } from 'lib-common/types'
 import Loader from 'lib-components/atoms/Loader'
 import Title from 'lib-components/atoms/Title'
@@ -25,7 +26,6 @@ import GroupCaretakersModal from '../components/group-caretakers/GroupCaretakers
 import { useTranslation } from '../state/i18n'
 import { TitleContext, TitleState } from '../state/title'
 import { CaretakerAmount, CaretakersResponse } from '../types/caretakers'
-import { capitalizeFirstLetter } from '../utils'
 import { getStatusLabelByDateRange } from '../utils/date'
 
 const NarrowContainer = styled.div`

--- a/frontend/src/employee-frontend/components/SettingsPage.tsx
+++ b/frontend/src/employee-frontend/components/SettingsPage.tsx
@@ -133,7 +133,7 @@ const SettingRow = React.memo(function SettingRow({
         <ExpandingInfo
           info={i18n.settings.options[option].description}
           ariaLabel={i18n.common.openExpandingInfo}
-          fullWidth={true}
+          width="full"
         >
           {i18n.settings.options[option].title}
         </ExpandingInfo>

--- a/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
@@ -261,7 +261,7 @@ export default React.memo(function AssistanceActionForm(props: Props) {
                       key={option.value}
                       info={option.descriptionFi}
                       ariaLabel=""
-                      fullWidth={true}
+                      width="full"
                     >
                       <CheckboxRow>
                         <Checkbox
@@ -341,7 +341,7 @@ export default React.memo(function AssistanceActionForm(props: Props) {
                           .measureTypes[`${measure}_INFO`]
                       )}
                       ariaLabel=""
-                      fullWidth={true}
+                      width="full"
                     >
                       <CheckboxRow key={measure}>
                         <Checkbox

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
@@ -268,7 +268,7 @@ export default React.memo(function AssistanceNeedForm(props: Props) {
                   ariaLabel={
                     i18n.childInformation.assistanceNeed.fields.capacityFactor
                   }
-                  fullWidth={true}
+                  width="full"
                 >
                   <CoefficientInputContainer>
                     <InputField
@@ -308,7 +308,7 @@ export default React.memo(function AssistanceNeedForm(props: Props) {
                       key={basis.value}
                       info={basis.descriptionFi}
                       ariaLabel=""
-                      fullWidth={true}
+                      width="full"
                     >
                       <CheckboxRow key={basis.value}>
                         <Checkbox

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
@@ -128,7 +128,7 @@ export default React.memo(function AssistanceNeedRow({
                         .capacityFactorInfo
                     }
                     ariaLabel=""
-                    fullWidth={true}
+                    width="full"
                   >
                     <span data-qa="assistance-need-multiplier">
                       {formatDecimal(assistanceNeed.capacityFactor)}

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
@@ -18,6 +18,7 @@ import {
   NotesByGroupResponse
 } from 'lib-common/generated/api-types/note'
 import LocalDate from 'lib-common/local-date'
+import { capitalizeFirstLetter } from 'lib-common/string'
 import { UUID } from 'lib-common/types'
 import { formatPercentage } from 'lib-common/utils/number'
 import { useApiState } from 'lib-common/utils/useRestApi'
@@ -63,7 +64,7 @@ import {
   Unit,
   UnitChildrenCapacityFactors
 } from '../../../../types/unit'
-import { capitalizeFirstLetter, formatPersonName } from '../../../../utils'
+import { formatPersonName } from '../../../../utils'
 import { UnitFilters } from '../../../../utils/UnitFilters'
 import { rangesOverlap } from '../../../../utils/date'
 import { isPartDayPlacement } from '../../../../utils/placements'

--- a/frontend/src/employee-frontend/utils/index.ts
+++ b/frontend/src/employee-frontend/utils/index.ts
@@ -27,12 +27,6 @@ export const formatPersonName = (
   lastNameFirst = false
 ): string => formatName(person.firstName, person.lastName, i18n, lastNameFirst)
 
-export const capitalizeFirstLetter = (str: string | null): string => {
-  if (!str || str.length === 0) return ''
-  if (str.length === 1) return str.toUpperCase()
-  return str[0].toUpperCase() + str.slice(1)
-}
-
 export function distinct<E>(array: E[]): E[] {
   return [...new Set(array)]
 }

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -26,6 +26,7 @@ export interface ChildDailyData {
   absence: AbsenceType | null
   attendances: OpenTimeRange[]
   childId: UUID
+  markedByEmployee: boolean
   reservations: TimeRange[]
 }
 

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -62,6 +62,7 @@ export interface OpenTimeRange {
 export interface ReservationChild {
   firstName: string
   id: UUID
+  imageId: UUID | null
   inShiftCareUnit: boolean
   maxOperationalDays: number[]
   placementMaxEnd: LocalDate

--- a/frontend/src/lib-common/string.ts
+++ b/frontend/src/lib-common/string.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+export const capitalizeFirstLetter = (
+  str: string | null | undefined
+): string => {
+  if (!str) return ''
+  if (str.length === 1) return str.toUpperCase()
+  return str[0].toUpperCase() + str.slice(1)
+}

--- a/frontend/src/lib-components/layout/flex-helpers.ts
+++ b/frontend/src/lib-components/layout/flex-helpers.ts
@@ -49,6 +49,7 @@ export const FixedSpaceRow = styled.div<FixedSpaceRowProps>`
 
 interface FixedSpaceColumnProps {
   spacing?: SpacingSize | string
+  justifyContent?: Property.JustifyContent
   alignItems?: Property.AlignItems
   marginRight?: SpacingSize | string
   fullWidth?: boolean
@@ -57,6 +58,7 @@ interface FixedSpaceColumnProps {
 export const FixedSpaceColumn = styled.div<FixedSpaceColumnProps>`
   display: flex;
   flex-direction: column;
+  ${(p) => (p.justifyContent ? `justify-content: ${p.justifyContent};` : '')}
   ${(p) => (p.alignItems ? `align-items: ${p.alignItems};` : '')}
   ${(p) => (p.fullWidth ? `width: 100%;` : '')}
 

--- a/frontend/src/lib-components/molecules/ExpandingInfo.tsx
+++ b/frontend/src/lib-components/molecules/ExpandingInfo.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode, useCallback, useState } from 'react'
 import styled, { useTheme } from 'styled-components'
 
 import Container, { ContentArea } from 'lib-components/layout/Container'
@@ -15,8 +15,15 @@ import IconButton from '../atoms/buttons/IconButton'
 import { desktopMin } from '../breakpoints'
 import { defaultMargins, SpacingSize } from '../white-space'
 
-const InfoBoxContainer = styled(Container)<{ fullWidth?: boolean }>`
-  ${({ fullWidth }) => fullWidth && `width: 100%;`}
+const InfoBoxContainer = styled(Container)<{
+  width?: 'fixed' | 'full' | 'auto'
+}>`
+  ${({ width }) =>
+    width === 'auto'
+      ? 'width: auto'
+      : width === 'full'
+      ? 'width: 100%'
+      : undefined};
 
   @keyframes open {
     from {
@@ -29,17 +36,17 @@ const InfoBoxContainer = styled(Container)<{ fullWidth?: boolean }>`
 
   background-color: ${(p) => p.theme.colors.main.m4};
   overflow: hidden;
-  ${({ fullWidth }) =>
-    fullWidth
+  ${({ width }) =>
+    width === 'full'
       ? `margin: ${defaultMargins.s} 0px;`
-      : `margin: ${defaultMargins.s} -${defaultMargins.s} ${defaultMargins.xs};`}
+      : `margin: ${defaultMargins.s} -${defaultMargins.s} ${defaultMargins.xs};`};
 
   @media (min-width: ${desktopMin}) {
     animation-name: open;
     animation-duration: 0.2s;
     animation-timing-function: ease-out;
-    ${({ fullWidth }) =>
-      fullWidth
+    ${({ width }) =>
+      width === 'full'
         ? `margin: ${defaultMargins.s} 0px;`
         : `margin: ${defaultMargins.s} -${defaultMargins.L} ${defaultMargins.xs};`}
   }
@@ -92,8 +99,8 @@ type ExpandingInfoProps = {
   children: React.ReactNode
   info: ReactNode
   ariaLabel: string
+  width?: 'fixed' | 'full' | 'auto'
   margin?: SpacingSize
-  fullWidth?: boolean
   'data-qa'?: string
 }
 
@@ -101,18 +108,20 @@ export default React.memo(function ExpandingInfo({
   children,
   info,
   ariaLabel,
+  width = 'fixed',
   margin,
-  fullWidth,
   'data-qa': dataQa
 }: ExpandingInfoProps) {
   const [expanded, setExpanded] = useState<boolean>(false)
+  const toggleExpanded = useCallback(() => setExpanded((prev) => !prev), [])
+  const close = useCallback(() => setExpanded(false), [])
 
   return (
     <span aria-live="polite">
       <FixedSpaceRow spacing="xs" alignItems="center">
         <div>{children}</div>
         <InfoButton
-          onClick={() => setExpanded(!expanded)}
+          onClick={toggleExpanded}
           aria-label={ariaLabel}
           margin={margin ?? 'zero'}
           data-qa={dataQa}
@@ -121,8 +130,8 @@ export default React.memo(function ExpandingInfo({
       {expanded && (
         <ExpandingInfoBox
           info={info}
-          close={() => setExpanded(false)}
-          fullWidth={fullWidth}
+          width={width}
+          close={close}
           data-qa={dataQa}
         />
       )}
@@ -152,6 +161,7 @@ export const InfoButton = React.memo(function InfoButton({
       margin={margin ?? 'zero'}
       color={colors.status.info}
       onClick={onClick}
+      type="button"
       role="button"
       aria-label={ariaLabel}
     >
@@ -163,20 +173,20 @@ export const InfoButton = React.memo(function InfoButton({
 export const ExpandingInfoBox = React.memo(function ExpandingInfoBox({
   info,
   close,
-  fullWidth,
+  width = 'fixed',
   className,
   'data-qa': dataQa
 }: {
   info: ReactNode
   close: () => void
-  fullWidth?: boolean
+  width?: 'fixed' | 'full' | 'auto'
   className?: string
   'data-qa'?: string
 }) {
   const { colors } = useTheme()
 
   return (
-    <InfoBoxContainer className={className} fullWidth={fullWidth}>
+    <InfoBoxContainer className={className} width={width}>
       <InfoBoxContentArea opaque={false}>
         <RoundIcon content={fasInfo} color={colors.status.info} size="s" />
 

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
@@ -7,6 +7,8 @@ import React from 'react'
 import DayPicker, { DayModifiers } from 'react-day-picker'
 
 import LocalDate from 'lib-common/local-date'
+import { capitalizeFirstLetter } from 'lib-common/string'
+
 import 'react-day-picker/lib/style.css'
 
 const monthNumbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
@@ -38,17 +40,15 @@ export default React.memo(function DatePickerDay({
     }
   }
 
-  const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-
   const months = monthNumbers
     .map((m) => dateI18n.localize?.month(m) ?? '') // eslint-disable-line @typescript-eslint/no-unsafe-return
-    .map(capitalize)
+    .map(capitalizeFirstLetter)
   const weekdaysLong = weekdayNumbers
     .map((d) => dateI18n.localize?.day(d) ?? '') // eslint-disable-line @typescript-eslint/no-unsafe-return
-    .map(capitalize)
+    .map(capitalizeFirstLetter)
   const weekdaysShort = weekdayNumbers
     .map((d) => dateI18n.localize?.day(d, { width: 'short' }) ?? '') // eslint-disable-line @typescript-eslint/no-unsafe-return
-    .map(capitalize)
+    .map(capitalizeFirstLetter)
 
   return (
     <DayPicker

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -51,12 +51,14 @@ const en: Translations = {
         PREPARATORY_EDUCATION: 'Preparatory education'
       },
       languages: {
-        fi: 'finnish',
-        sv: 'swedish'
+        fi: 'Finnish',
+        sv: 'Swedish',
+        en: 'English'
       },
       languagesShort: {
-        fi: 'finnish',
-        sv: 'swedish'
+        fi: 'Finnish',
+        sv: 'Swedish',
+        en: 'English'
       }
     },
     openExpandingInfo: 'Open the details',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -237,6 +237,9 @@ const en: Translations = {
     absences: {
       SICKLEAVE: 'Sickness absence'
     },
+    absenceMarkedByEmployee: 'Absence marked by staff',
+    contactStaffToEditAbsence:
+      'Contact staff if you want to change the absence',
     newReservationOrAbsence: 'Reservation / Absence',
     newHoliday: 'Report holiday',
     newAbsence: 'Report absence',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -51,11 +51,13 @@ export default {
       },
       languages: {
         fi: 'suomenkielinen',
-        sv: 'ruotsinkielinen'
+        sv: 'ruotsinkielinen',
+        en: 'englanninkielinen'
       },
       languagesShort: {
         fi: 'suomi',
-        sv: 'ruotsi'
+        sv: 'ruotsi',
+        en: 'englanti'
       }
     },
     openExpandingInfo: 'Avaa lisätietokenttä',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -236,6 +236,9 @@ export default {
     absences: {
       SICKLEAVE: 'Sairauspoissaolo'
     },
+    absenceMarkedByEmployee: 'Henkilökunnan merkitsemä poissaolo',
+    contactStaffToEditAbsence:
+      'Jos haluat muuttaa poissaoloa, ota yhteyttä henkilökuntaan.',
     newReservationOrAbsence: 'Varaus / Poissaolo',
     newHoliday: 'Ilmoita loma',
     newAbsence: 'Ilmoita poissaolo',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -52,11 +52,13 @@ const sv: Translations = {
       },
       languages: {
         fi: 'finskspråkig',
-        sv: 'svenskaspråkig'
+        sv: 'svenskspråkig',
+        en: 'engelskspråkig'
       },
       languagesShort: {
         fi: 'suomi',
-        sv: 'svenska'
+        sv: 'svenska',
+        en: 'engelska'
       }
     },
     openExpandingInfo: 'Öppna detaljer',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -237,6 +237,8 @@ const sv: Translations = {
     absences: {
       SICKLEAVE: 'Sjukskriven'
     },
+    absenceMarkedByEmployee: 'Frånvaro markerad av personal',
+    contactStaffToEditAbsence: 'Kontakta personalen om du vill ändra frånvaron',
     newReservationOrAbsence: 'Reservation / Frånvaro',
     newHoliday: 'Meddela semester',
     newAbsence: 'Anmäl frånvaro',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
@@ -119,8 +119,8 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
         assertEquals(testDate, dailyData[0].date)
         assertEquals(
             setOf(
-                ChildDailyData(testChild_1.id, null, listOf(TimeRange(startTime, endTime)), listOf()),
-                ChildDailyData(testChild_2.id, null, listOf(TimeRange(startTime, endTime)), listOf())
+                ChildDailyData(testChild_1.id, false, null, listOf(TimeRange(startTime, endTime)), listOf()),
+                ChildDailyData(testChild_2.id, false, null, listOf(TimeRange(startTime, endTime)), listOf())
             ),
             dailyData[0].children.toSet()
         )
@@ -128,8 +128,8 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
         assertEquals(testDate.plusDays(1), dailyData[1].date)
         assertEquals(
             setOf(
-                ChildDailyData(testChild_1.id, null, listOf(TimeRange(startTime, endTime)), listOf()),
-                ChildDailyData(testChild_2.id, null, listOf(TimeRange(startTime, endTime)), listOf()),
+                ChildDailyData(testChild_1.id, false, null, listOf(TimeRange(startTime, endTime)), listOf()),
+                ChildDailyData(testChild_2.id, false, null, listOf(TimeRange(startTime, endTime)), listOf()),
             ),
             dailyData[1].children.toSet()
         )
@@ -166,12 +166,14 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
             setOf(
                 ChildDailyData(
                     childId = testChild_1.id,
+                    markedByEmployee = false,
                     absence = AbsenceType.OTHER_ABSENCE,
                     reservations = listOf(),
                     attendances = listOf()
                 ),
                 ChildDailyData(
                     childId = testChild_2.id,
+                    markedByEmployee = false,
                     absence = AbsenceType.OTHER_ABSENCE,
                     reservations = listOf(),
                     attendances = listOf()
@@ -185,12 +187,14 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
             setOf(
                 ChildDailyData(
                     childId = testChild_1.id,
+                    markedByEmployee = false,
                     absence = AbsenceType.OTHER_ABSENCE,
                     reservations = listOf(),
                     attendances = listOf()
                 ),
                 ChildDailyData(
                     childId = testChild_2.id,
+                    markedByEmployee = false,
                     absence = AbsenceType.OTHER_ABSENCE,
                     reservations = listOf(),
                     attendances = listOf()
@@ -248,6 +252,7 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
             setOf(
                 ChildDailyData(
                     childId = testChild_2.id,
+                    markedByEmployee = true,
                     absence = AbsenceType.PLANNED_ABSENCE,
                     reservations = listOf(),
                     attendances = listOf()
@@ -261,6 +266,7 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
             setOf(
                 ChildDailyData(
                     childId = testChild_2.id,
+                    markedByEmployee = false,
                     absence = AbsenceType.OTHER_ABSENCE,
                     reservations = listOf(),
                     attendances = listOf()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
@@ -91,25 +91,28 @@ class ReservationCitizenControllerTest : FullApplicationTest() {
 
         assertEquals(
             listOf(
+                // Sorted by date of birth, oldest child first
                 ReservationChild(
-                    testChild_1.id,
-                    testChild_1.firstName,
+                    testChild_2.id,
+                    testChild_2.firstName,
                     "",
+                    null,
                     testDate,
                     testDate.plusDays(1),
                     setOf(1, 2, 3, 4, 5),
                     false
                 ),
                 ReservationChild(
-                    testChild_2.id,
-                    testChild_2.firstName,
+                    testChild_1.id,
+                    testChild_1.firstName,
                     "",
+                    null,
                     testDate,
                     testDate.plusDays(1),
                     setOf(1, 2, 3, 4, 5),
                     false
-                )
-            ).sortedBy { it.firstName },
+                ),
+            ),
             res.children
         )
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenQueriesTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.daycare.service.getAbsencesByChildByRange
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.pis.service.insertGuardian
+import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.dev.insertTestAbsence
 import fi.espoo.evaka.shared.dev.insertTestHoliday
 import fi.espoo.evaka.shared.dev.insertTestPlacement
@@ -215,8 +216,8 @@ class ReservationCitizenQueriesTest : PureJdbiTest() {
         db.transaction {
             it.insertTestPlacement(childId = testChild_1.id, unitId = testDaycare.id, startDate = monday, endDate = monday.plusDays(1))
             it.insertGuardian(guardianId = testAdult_1.id, childId = testChild_1.id)
-            it.insertTestAbsence(childId = testChild_1.id, date = monday, category = AbsenceCategory.BILLABLE)
-            it.insertTestAbsence(childId = testChild_1.id, date = monday.plusDays(1), category = AbsenceCategory.BILLABLE)
+            it.insertTestAbsence(childId = testChild_1.id, date = monday, category = AbsenceCategory.BILLABLE, modifiedBy = EvakaUserId(testAdult_1.id.raw))
+            it.insertTestAbsence(childId = testChild_1.id, date = monday.plusDays(1), category = AbsenceCategory.BILLABLE, modifiedBy = EvakaUserId(testAdult_1.id.raw))
         }
 
         // when
@@ -258,9 +259,9 @@ class ReservationCitizenQueriesTest : PureJdbiTest() {
         db.transaction {
             it.insertTestPlacement(childId = testChild_1.id, unitId = testDaycare.id, startDate = monday, endDate = tuesday)
             it.insertGuardian(guardianId = testAdult_1.id, childId = testChild_1.id)
-            it.insertTestAbsence(childId = testChild_1.id, date = monday, category = AbsenceCategory.BILLABLE)
-            it.insertTestAbsence(childId = testChild_1.id, date = tuesday, category = AbsenceCategory.BILLABLE, absenceType = AbsenceType.FREE_ABSENCE)
-            it.insertTestAbsence(childId = testChild_1.id, date = wednesday, category = AbsenceCategory.BILLABLE, absenceType = AbsenceType.FREE_ABSENCE)
+            it.insertTestAbsence(childId = testChild_1.id, date = monday, category = AbsenceCategory.BILLABLE, modifiedBy = EvakaUserId(testAdult_1.id.raw))
+            it.insertTestAbsence(childId = testChild_1.id, date = tuesday, category = AbsenceCategory.BILLABLE, absenceType = AbsenceType.FREE_ABSENCE, modifiedBy = EvakaUserId(testAdult_1.id.raw))
+            it.insertTestAbsence(childId = testChild_1.id, date = wednesday, category = AbsenceCategory.BILLABLE, absenceType = AbsenceType.FREE_ABSENCE, modifiedBy = EvakaUserId(testAdult_1.id.raw))
         }
 
         // when

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.holidayperiod
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.pis.service.getGuardianChildIds
 import fi.espoo.evaka.reservations.AbsenceInsert
-import fi.espoo.evaka.reservations.clearOldAbsencesExcludingFreeAbsences
+import fi.espoo.evaka.reservations.clearOldCitizenEditableAbsences
 import fi.espoo.evaka.reservations.clearOldReservations
 import fi.espoo.evaka.reservations.deleteAbsencesCreatedFromQuestionnaire
 import fi.espoo.evaka.reservations.insertAbsences
@@ -126,7 +126,7 @@ class HolidayPeriodControllerCitizen(private val accessControl: AccessControl) {
 
                 absences.flatMap { absence -> absence.dateRange.dates().map { absence.childId to it } }.let {
                     tx.clearOldReservations(it)
-                    tx.clearOldAbsencesExcludingFreeAbsences(it)
+                    tx.clearOldCitizenEditableAbsences(it)
                 }
                 tx.deleteAbsencesCreatedFromQuestionnaire(questionnaire.id, childIds)
                 tx.insertAbsences(PersonId(user.id), absences)

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -186,7 +186,7 @@ SELECT
                 'reservations', coalesce(ar.reservations, '[]'),
                 'attendances', coalesce(ca.attendances, '[]')
             )
-        ) FILTER (WHERE a.absence_type IS NOT NULL OR ar.reservations IS NOT NULL),
+        ) FILTER (WHERE a.absence_type IS NOT NULL OR ar.reservations IS NOT NULL OR ca.attendances IS NOT NULL),
         '[]'
     ) AS children
 FROM generate_series(:start, :end, '1 day') t

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -112,7 +112,7 @@ class ReservationControllerCitizen(
 
         db.connect { dbc ->
             dbc.transaction { tx ->
-                tx.clearOldAbsencesExcludingFreeAbsences(
+                tx.clearOldCitizenEditableAbsences(
                     body.childIds.flatMap { childId ->
                         body.dateRange.dates().map { childId to it }
                     }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -76,7 +76,7 @@ class OpenTimeRangeSerializer : JsonSerializer<OpenTimeRange>() {
 }
 
 fun createReservations(tx: Database.Transaction, userId: UUID, reservations: List<DailyReservationRequest>) {
-    tx.clearOldAbsencesExcludingFreeAbsences(reservations.filter { it.reservations != null }.map { it.childId to it.date })
+    tx.clearOldCitizenEditableAbsences(reservations.filter { it.reservations != null }.map { it.childId to it.date })
     tx.clearOldReservations(reservations.map { it.childId to it.date })
     tx.insertValidReservations(userId, reservations)
 }


### PR DESCRIPTION
#### Summary

* Don't allow citizen to add reservations or absences if staff has marked absences.
* Make some frontend optimizations while at it.
* Add child pictures to the calendar and the day modal

Desktop calendar:

<img width="548" alt="Screenshot 2022-03-28 at 7 51 22" src="https://user-images.githubusercontent.com/70927/160328639-e3527ce0-eb90-4fa3-a41e-999f83a589ca.png">

Mobile calendar:

<img width="394" alt="Screenshot 2022-03-28 at 7 51 52" src="https://user-images.githubusercontent.com/70927/160328692-9e7e05f6-55d7-4cb6-9a83-0a2c9e868848.png">

Day modal:

<img width="393" alt="Screenshot 2022-03-28 at 7 52 21" src="https://user-images.githubusercontent.com/70927/160328736-24fde680-69ef-4353-8a01-8c5b65a5cc85.png">

