### PR TITLE
Show tooltip at nearest point in realtime staff attendance graph

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -96,6 +96,7 @@ export default React.memo(function OccupancyDayGraph({ occupancy }: Props) {
       tooltip: {
         mode: 'index',
         intersect: false,
+        position: 'nearest',
         callbacks: {
           title: (items) => formatTime(new Date(items[0].parsed.x)),
           footer: (items) => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4218,9 +4218,9 @@ __metadata:
   linkType: hard
 
 "chart.js@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "chart.js@npm:3.7.0"
-  checksum: 050d675d15742e873ec10aa3c77fecd43d16062a5f188615795a08158b8aed591f98f2f067adf5d3f6b710093ea3a754977b2418fb30ff0babdeabbcf6898e5e
+  version: 3.7.1
+  resolution: "chart.js@npm:3.7.1"
+  checksum: f9d118d3b7dd3c36b6da7a8d71ac9e5d9673b81095cc66c3f61ff91674e20020c6700f8c9c6f93713fa8474eb471ded106114346ccc6afa88b4a7d0eb73dcea4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Summary

Show tooltip at nearest point in realtime staff attendance graph, which makes the tooltip less jumpy by following the cursor.
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Also upgrade chart.js