### PR TITLE
EVAKA-4455 Row-level occupancy coefficient calculation

### DIFF
--- a/frontend/src/employee-frontend/api/unit.ts
+++ b/frontend/src/employee-frontend/api/unit.ts
@@ -395,10 +395,12 @@ function mapUnitOccupancyJson(data: JsonOf<UnitOccupancies>): UnitOccupancies {
               time: new Date(dataPoint.time)
             })
           ),
-          staffCountSeries: data.realtime.staffCountSeries.map((dataPoint) => ({
-            ...dataPoint,
-            time: new Date(dataPoint.time)
-          })),
+          staffCapacitySumSeries: data.realtime.staffCapacitySumSeries.map(
+            (dataPoint) => ({
+              ...dataPoint,
+              time: new Date(dataPoint.time)
+            })
+          ),
           occupancySeries: data.realtime.occupancySeries.map((dataPoint) => ({
             ...dataPoint,
             time: new Date(dataPoint.time)

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -32,7 +32,7 @@ export default React.memo(function OccupancyDayGraph({ occupancy }: Props) {
   }))
   const staffData: DatePoint[] = occupancy.occupancySeries.map((p) => ({
     x: p.time,
-    y: p.staffCount * 7
+    y: p.staffCapacity
   }))
 
   const data: ChartData<'line', DatePoint[]> = {

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -48,6 +48,7 @@ export interface Attendance {
   departed: Date | null
   groupId: UUID
   id: UUID
+  occupancyCoefficient: number
 }
 
 /**
@@ -175,6 +176,7 @@ export interface ExternalAttendance {
   groupId: UUID
   id: UUID
   name: string
+  occupancyCoefficient: number
 }
 
 /**

--- a/frontend/src/lib-common/generated/api-types/occupancy.ts
+++ b/frontend/src/lib-common/generated/api-types/occupancy.ts
@@ -42,7 +42,7 @@ export interface OccupancyPeriod {
 export interface OccupancyPoint {
   childCapacity: number
   occupancyRatio: number | null
-  staffCount: number
+  staffCapacity: number
   time: Date
 }
 
@@ -91,14 +91,14 @@ export interface RealtimeOccupancy {
   childCapacitySumSeries: ChildCapacityPoint[]
   occupancySeries: OccupancyPoint[]
   staffAttendances: StaffOccupancyAttendance[]
-  staffCountSeries: StaffCountPoint[]
+  staffCapacitySumSeries: StaffCapacityPoint[]
 }
 
 /**
-* Generated from fi.espoo.evaka.occupancy.StaffCountPoint
+* Generated from fi.espoo.evaka.occupancy.StaffCapacityPoint
 */
-export interface StaffCountPoint {
-  count: number
+export interface StaffCapacityPoint {
+  capacity: number
   time: Date
 }
 
@@ -107,5 +107,6 @@ export interface StaffCountPoint {
 */
 export interface StaffOccupancyAttendance {
   arrived: Date
+  capacity: number
   departed: Date | null
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancyTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2021 City of Espoo
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -9,6 +9,7 @@ import fi.espoo.evaka.FixtureBuilder
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.attendance.ExternalStaffArrival
 import fi.espoo.evaka.attendance.ExternalStaffDeparture
+import fi.espoo.evaka.attendance.defaultOccupancyCoefficient
 import fi.espoo.evaka.attendance.markExternalStaffArrival
 import fi.espoo.evaka.attendance.markExternalStaffDeparture
 import fi.espoo.evaka.insertGeneralTestFixtures
@@ -26,6 +27,7 @@ import fi.espoo.evaka.testDecisionMaker_1
 import fi.espoo.evaka.unitSupervisorOfTestDaycare
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -73,22 +75,42 @@ class RealtimeOccupancyTest : FullApplicationTest() {
                 .withScopedRole(UserRole.STAFF, testDaycare.id)
                 .withGroupAccess(testDaycare.id, groupId)
                 .saveAnd {
-                    addRealtimeAttendance().inGroup(groupId).arriving(LocalTime.of(7, 0)).departing(LocalTime.of(16, 45)).save()
+                    addRealtimeAttendance().inGroup(groupId).arriving(LocalTime.of(7, 0))
+                        .departing(LocalTime.of(16, 45)).withCoefficient(defaultOccupancyCoefficient).save()
                 }
 
-            val extAttendanceId = tx.markExternalStaffArrival(
+            tx.markExternalStaffArrival(
                 ExternalStaffArrival(
                     "Matti",
                     groupId,
-                    HelsinkiDateTime.of(date, LocalTime.of(10, 0))
+                    HelsinkiDateTime.of(date, LocalTime.of(10, 0)),
+                    BigDecimal("3.5")
                 )
-            )
-            tx.markExternalStaffDeparture(
-                ExternalStaffDeparture(
-                    extAttendanceId,
-                    HelsinkiDateTime.of(date, LocalTime.of(18, 0))
+            ).let { extAttendanceId ->
+                tx.markExternalStaffDeparture(
+                    ExternalStaffDeparture(
+                        extAttendanceId,
+                        HelsinkiDateTime.of(date, LocalTime.of(18, 0))
+                    )
                 )
-            )
+            }
+
+            // staff with coefficient of zero does not affect occupancy rates
+            tx.markExternalStaffArrival(
+                ExternalStaffArrival(
+                    "Nolla Sijainen",
+                    groupId,
+                    HelsinkiDateTime.of(date, LocalTime.of(11, 0)),
+                    BigDecimal.ZERO
+                )
+            ).let { extAttendanceId ->
+                tx.markExternalStaffDeparture(
+                    ExternalStaffDeparture(
+                        extAttendanceId,
+                        HelsinkiDateTime.of(date, LocalTime.of(15, 0))
+                    )
+                )
+            }
         }
 
         val child1Capacity = 1.75
@@ -97,54 +119,68 @@ class RealtimeOccupancyTest : FullApplicationTest() {
 
         val result = getRealtimeOccupancy()
         val occupancies = result.occupancySeries
-        assertEquals(7, occupancies.size)
+        assertEquals(9, occupancies.size)
 
         // 7:00, staff 1 arrives
         occupancies.find { it.time == HelsinkiDateTime.Companion.of(date, LocalTime.of(7, 0)) }
             ?.also { assertEquals(0.0, it.childCapacity) }
-            ?.also { assertEquals(1, it.staffCount) }
+            ?.also { assertEquals(7.0, it.staffCapacity) }
             ?.also { assertEquals(0.0, it.occupancyRatio) }
             ?: error("data point missing")
 
         // 7:45, child 1 arrives
         occupancies.find { it.time == HelsinkiDateTime.Companion.of(date, LocalTime.of(7, 45)) }
             ?.also { assertEquals(child1Capacity, it.childCapacity) }
-            ?.also { assertEquals(1, it.staffCount) }
+            ?.also { assertEquals(7.0, it.staffCapacity) }
             ?.also { assertEquals(child1Capacity / (7 * 1), it.occupancyRatio) }
             ?: error("data point missing")
 
         // 8:15, children 2 and 3 arrive
         occupancies.find { it.time == HelsinkiDateTime.Companion.of(date, LocalTime.of(8, 15)) }
             ?.also { assertEquals(child1Capacity + child2Capacity + child3Capacity, it.childCapacity) }
-            ?.also { assertEquals(1, it.staffCount) }
+            ?.also { assertEquals(7.0, it.staffCapacity) }
             ?.also { assertEquals((child1Capacity + child2Capacity + child3Capacity) / (7 * 1), it.occupancyRatio) }
             ?: error("data point missing")
 
         // 10:00, staff 2 arrives
         occupancies.find { it.time == HelsinkiDateTime.Companion.of(date, LocalTime.of(10, 0)) }
             ?.also { assertEquals(child1Capacity + child2Capacity + child3Capacity, it.childCapacity) }
-            ?.also { assertEquals(2, it.staffCount) }
-            ?.also { assertEquals((child1Capacity + child2Capacity + child3Capacity) / (7 * 2), it.occupancyRatio) }
+            ?.also { assertEquals(10.5, it.staffCapacity) }
+            ?.also { assertEquals((child1Capacity + child2Capacity + child3Capacity) / 10.5, it.occupancyRatio) }
+            ?: error("data point missing")
+
+        // 11:00, staff 3 with zero coefficient arrives, does not affect capacities
+        occupancies.find { it.time == HelsinkiDateTime.Companion.of(date, LocalTime.of(11, 0)) }
+            ?.also { assertEquals(child1Capacity + child2Capacity + child3Capacity, it.childCapacity) }
+            ?.also { assertEquals(10.5, it.staffCapacity) }
+            ?.also { assertEquals((child1Capacity + child2Capacity + child3Capacity) / 10.5, it.occupancyRatio) }
+            ?: error("data point missing")
+
+        // 15:00, staff 3 with zero coefficient departs, does not affect capacities
+        occupancies.find { it.time == HelsinkiDateTime.Companion.of(date, LocalTime.of(15, 0)) }
+            ?.also { assertEquals(child1Capacity + child2Capacity + child3Capacity, it.childCapacity) }
+            ?.also { assertEquals(10.5, it.staffCapacity) }
+            ?.also { assertEquals((child1Capacity + child2Capacity + child3Capacity) / 10.5, it.occupancyRatio) }
             ?: error("data point missing")
 
         // 16:30, children 1 and 2 depart
         occupancies.find { it.time == HelsinkiDateTime.Companion.of(date, LocalTime.of(16, 30)) }
             ?.also { assertEquals(child3Capacity, it.childCapacity) }
-            ?.also { assertEquals(2, it.staffCount) }
-            ?.also { assertEquals(child3Capacity / (7 * 2), it.occupancyRatio) }
+            ?.also { assertEquals(10.5, it.staffCapacity) }
+            ?.also { assertEquals(child3Capacity / 10.5, it.occupancyRatio) }
             ?: error("data point missing")
 
         // 16:45, staff 1 departs
         occupancies.find { it.time == HelsinkiDateTime.Companion.of(date, LocalTime.of(16, 45)) }
             ?.also { assertEquals(child3Capacity, it.childCapacity) }
-            ?.also { assertEquals(1, it.staffCount) }
-            ?.also { assertEquals(child3Capacity / (7 * 1), it.occupancyRatio) }
+            ?.also { assertEquals(3.5, it.staffCapacity) }
+            ?.also { assertEquals(child3Capacity / 3.5, it.occupancyRatio) }
             ?: error("data point missing")
 
         // 18:00, staff 2 departs, forgets to mark child 3 departed
         occupancies.find { it.time == HelsinkiDateTime.Companion.of(date, LocalTime.of(18, 0)) }
             ?.also { assertEquals(child3Capacity, it.childCapacity) }
-            ?.also { assertEquals(0, it.staffCount) }
+            ?.also { assertEquals(0.0, it.staffCapacity) }
             ?.also { assertNull(it.occupancyRatio) }
             ?: error("data point missing")
     }
@@ -164,6 +200,6 @@ private data class RealtimeOccupancyResponse(
     val childAttendances: List<ChildOccupancyAttendance>,
     val staffAttendances: List<StaffOccupancyAttendance>,
     val childCapacitySumSeries: List<ChildCapacityPoint>,
-    val staffCountSeries: List<StaffCountPoint>,
+    val staffCapacitySumSeries: List<StaffCapacityPoint>,
     val occupancySeries: List<OccupancyPoint>
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
@@ -82,10 +82,12 @@ class MobileRealtimeStaffAttendanceController(
         try {
             db.connect { dbc ->
                 dbc.transaction {
+                    val occupancyCoefficient = it.getOccupancyCoefficientForEmployee(body.employeeId, body.groupId) ?: defaultOccupancyCoefficient
                     it.markStaffArrival(
                         employeeId = body.employeeId,
                         groupId = body.groupId,
-                        arrivalTime = arrivedTimeOrDefault
+                        arrivalTime = arrivedTimeOrDefault,
+                        occupancyCoefficient = occupancyCoefficient,
                     )
                 }
             }
@@ -149,7 +151,9 @@ class MobileRealtimeStaffAttendanceController(
                 it.markExternalStaffArrival(
                     ExternalStaffArrival(
                         name = body.name,
-                        groupId = body.groupId, arrived = arrivedTimeOrDefault
+                        groupId = body.groupId,
+                        arrived = arrivedTimeOrDefault,
+                        occupancyCoefficient = defaultOccupancyCoefficient
                     )
                 )
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -50,7 +50,7 @@ class RealtimeStaffAttendanceController(
                         employeeId = employeeId,
                         firstName = data[0].firstName,
                         lastName = data[0].lastName,
-                        attendances = data.map { att -> Attendance(att.id, att.groupId, att.arrived, att.departed) }
+                        attendances = data.map { att -> Attendance(att.id, att.groupId, att.arrived, att.departed, att.occupancyCoefficient) }
                     )
                 }
                 val staffWithoutAttendance = it.getCurrentStaffForAttendanceCalendar(unitId)

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.StaffAttendanceId
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.jdbi.v3.core.mapper.Nested
 import org.jdbi.v3.core.mapper.PropagateNull
+import java.math.BigDecimal
 import java.util.UUID
 
 data class CurrentDayStaffAttendanceResponse(
@@ -52,6 +53,7 @@ data class ExternalAttendance(
     val groupId: GroupId,
     val arrived: HelsinkiDateTime,
     val departed: HelsinkiDateTime?,
+    val occupancyCoefficient: BigDecimal
 )
 
 data class Attendance(
@@ -59,6 +61,7 @@ data class Attendance(
     val groupId: GroupId,
     val arrived: HelsinkiDateTime,
     val departed: HelsinkiDateTime?,
+    val occupancyCoefficient: BigDecimal
 )
 
 data class EmployeeAttendance(

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficient.kt
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.attendance
+
+import java.math.BigDecimal
+
+val defaultOccupancyCoefficient = BigDecimal("7.0")

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficientQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficientQueries.kt
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.attendance
+
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.db.Database
+import org.jdbi.v3.core.kotlin.mapTo
+import java.math.BigDecimal
+
+fun Database.Read.getOccupancyCoefficientForEmployee(employeeId: EmployeeId, groupId: GroupId): BigDecimal? =
+    createQuery(
+        """
+SELECT soc.coefficient
+FROM staff_occupancy_coefficient soc
+JOIN daycare_group grp ON soc.daycare_id = grp.daycare_id AND grp.id = :groupId
+WHERE soc.employee_id = :employeeId
+        """.trimIndent()
+    )
+        .bind("employeeId", employeeId)
+        .bind("groupId", groupId)
+        .mapTo<BigDecimal>()
+        .firstOrNull()

--- a/service/src/main/resources/db/migration/V220__staff_occupancy_coefficient.sql
+++ b/service/src/main/resources/db/migration/V220__staff_occupancy_coefficient.sql
@@ -1,0 +1,24 @@
+CREATE TABLE staff_occupancy_coefficient (
+    id          uuid PRIMARY KEY                  DEFAULT ext.uuid_generate_v1mc(),
+    created     timestamp with time zone NOT NULL DEFAULT now(),
+    updated     timestamp with time zone          DEFAULT now(),
+    employee_id uuid                     NOT NULL CONSTRAINT fk$employee REFERENCES employee ON DELETE CASCADE,
+    daycare_id  uuid                     NOT NULL CONSTRAINT fk$daycare REFERENCES daycare ON DELETE CASCADE,
+    coefficient numeric(4, 2)            NOT NULL
+);
+
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON staff_occupancy_coefficient FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();
+
+CREATE UNIQUE INDEX uniq$staff_occupancy_coefficient_daycare_employee ON staff_occupancy_coefficient (daycare_id, employee_id);
+
+ALTER TABLE staff_attendance_realtime
+    ADD COLUMN occupancy_coefficient numeric(4, 2);
+UPDATE staff_attendance_realtime SET occupancy_coefficient = 7.0;
+ALTER TABLE staff_attendance_realtime
+    ALTER COLUMN occupancy_coefficient SET NOT NULL;
+
+ALTER TABLE staff_attendance_external
+    ADD COLUMN occupancy_coefficient numeric(4, 2);
+UPDATE staff_attendance_external SET occupancy_coefficient = 7.0;
+ALTER TABLE staff_attendance_external
+    ALTER COLUMN occupancy_coefficient SET NOT NULL;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -217,3 +217,4 @@ V216__mobile_device_hard_delete.sql
 V217__guardian_blocklist.sql
 V218__invoice_correction.sql
 V219__add_occupancy_coefficient_under_3y.sql
+V220__staff_occupancy_coefficient.sql


### PR DESCRIPTION
#### Summary

- Save occupancy coefficient to staff attendance rows
- Use row-level coefficient in calculations and occupancy graph
- Add table for saving employee specific coefficient per unit
- Saving employee coefficient will be implemented later, use default coefficient as a fallback for now

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

