### PR TITLE
Optimize the query for getting threads/messages by account

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -275,7 +275,7 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         }
         assertEquals(
             listOf(0, 1),
-            receivedMessageCounts(listOf(receiverAccount, receiverDuplicateAccount), false)
+            receivedMessageCounts(listOf(receiverAccount, receiverDuplicateAccount))
         )
 
         db.transaction {
@@ -285,13 +285,14 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         assertEquals(
             listOf(1, 0),
-            receivedMessageCounts(listOf(receiverAccount, receiverDuplicateAccount), false)
+            receivedMessageCounts(listOf(receiverAccount, receiverDuplicateAccount))
         )
     }
 
-    private fun receivedMessageCounts(accountIds: List<MessageAccountId>, isEmployee: Boolean): List<Int> = db.read { tx ->
-        accountIds.map { tx.getMessagesReceivedByAccount(it, 10, 1, isEmployee).total }
-    }
+    private fun receivedMessageCounts(accountIds: List<MessageAccountId>): List<Int> =
+        db.read { tx ->
+            accountIds.map { tx.getMessagesReceivedByAccount(it, false, 10, 1).total }
+        }
 
     @Test
     fun `merging child sends update event to head of child`() {

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
@@ -21,7 +21,7 @@ import java.time.LocalDate
 data class Message(
     val id: MessageId,
     val sender: MessageAccount,
-    val recipients: Set<MessageAccount>,
+    val recipients: List<MessageAccount>,
     val sentAt: HelsinkiDateTime,
     val content: String,
     val readAt: HelsinkiDateTime? = null,

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -80,7 +80,7 @@ class MessageController(
         Audit.MessagingReceivedMessagesRead.log(accountId)
         return db.connect { dbc ->
             requireMessageAccountAccess(dbc, user, accountId)
-            dbc.read { it.getMessagesReceivedByAccount(accountId, pageSize, page) }
+            dbc.read { it.getMessagesReceivedByAccount(accountId, false, pageSize, page) }
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -80,7 +80,7 @@ class MessageControllerCitizen(
         Audit.MessagingReceivedMessagesRead.log()
         return db.connect { dbc ->
             val accountId = requireMessageAccountAccess(dbc, user)
-            dbc.read { it.getMessagesReceivedByAccount(accountId, pageSize, page, true) }
+            dbc.read { it.getMessagesReceivedByAccount(accountId, true, pageSize, page) }
         }
     }
 
@@ -141,7 +141,8 @@ class MessageControllerCitizen(
         return db.connect { dbc ->
             val accountId = requireMessageAccountAccess(dbc, user)
             val validReceivers = dbc.read { it.getCitizenReceivers(accountId) }
-            val allReceiversValid = body.recipients.all { validReceivers.map { receiver -> receiver.id }.contains(it.id) }
+            val allReceiversValid =
+                body.recipients.all { validReceivers.map { receiver -> receiver.id }.contains(it.id) }
             if (allReceiversValid) {
                 dbc.transaction { tx ->
                     val contentId = tx.insertMessageContent(body.content, accountId)


### PR DESCRIPTION
#### Summary

Try to clean up and speed up the 3rd most time consuming SQL query in eVaka. The query itself doesn't take _too long_ to perform (avg ~330 ms in Espoo production), but it's used a lot.

After the changes in this PR, the query is now simpler and more readable (at least to me), but it seems to be even slower than it was.

Let's have a mob review/discussion about the messaging data model at some point.