### PR TITLE
Try to fix message textarea min height bug on android

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -200,6 +200,7 @@ const StyledTextArea = styled.textarea`
   width: 100%;
   resize: none;
   flex-grow: 1;
+  min-height: 100px;
 `
 
 const BottomRow = styled.div`


### PR DESCRIPTION
#### Summary
On Samsum A32 the mobile message editor text area does not respect min-height. Try to fix that according to the internet. Works still on iphone after the change:
![IMG_7764](https://user-images.githubusercontent.com/158767/161210297-be6c7b2f-f511-4ac1-853c-0d4f34963f89.PNG)

