### PR TITLE
Front page text fix

### DIFF
--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -153,7 +153,7 @@ export default {
         'hakea lapsellesi varhaiskasvatus-, esiopetus- tai kerhopaikkaa tai tarkastella aiemmin tekemääsi hakemusta',
         'tarkastella lapsesi varhaiskasvatukseen tai esiopetukseen liittyviä kuvia ja muita dokumentteja',
         'ilmoittaa omat tai lapsesi tulotiedot',
-        'hyväksyä tai hylätä varhaiskasvatuspäätöksen, jos olet hakemuksen tekijä'
+        'hyväksyä tai hylätä päätöksen, jos olet hakemuksen tekijä'
       ],
       link: 'Tunnistaudu',
       mapText: 'Katso kartalta yksiköt, joihin voit hakea eVakassa.',


### PR DESCRIPTION
#### Summary

`sv` and `en` were already ok, that's why they don't change.

