### PR TITLE
EVAKA-HOTFIX use relative age in age calculation

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
@@ -25,7 +25,7 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
 
-const val youngChildOccupancyCoefficient = "1.75"
+const val familyUnitPlacementCoefficient = "1.75"
 
 enum class OccupancyType {
     PLANNED,
@@ -387,11 +387,11 @@ private fun <K : OccupancyGroupingKey> Database.Read.calculateDailyOccupancies(
 SELECT
     sn.placement_id,
     CASE
-        WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN 1.75
+        WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN $familyUnitPlacementCoefficient
         ELSE sno.occupancy_coefficient
     END AS occupancy_coefficient,
     CASE
-        WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN 1.75
+        WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN $familyUnitPlacementCoefficient
         ELSE sno.occupancy_coefficient_under_3y
     END AS occupancy_coefficient_under_3y,
     daterange(sn.start_date, sn.end_date, '[]') AS period

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancy.kt
@@ -102,7 +102,7 @@ fun Database.Read.getChildOccupancyAttendances(unitId: DaycareId, date: LocalDat
         (ca.date + ca.start_time) AT TIME ZONE 'Europe/Helsinki' AS arrived,
         (ca.date + ca.end_time) AT TIME ZONE 'Europe/Helsinki' AS departed,
         COALESCE(an.capacity_factor, 1) * CASE 
-            WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN 1.75
+            WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN $familyUnitPlacementCoefficient
             WHEN extract(YEARS FROM age(ca.date, ch.date_of_birth)) < 3 THEN coalesce(sno.occupancy_coefficient_under_3y, default_sno.occupancy_coefficient_under_3y)
             ELSE 1.0
         END AS capacity

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancy.kt
@@ -103,7 +103,7 @@ fun Database.Read.getChildOccupancyAttendances(unitId: DaycareId, date: LocalDat
         (ca.date + ca.end_time) AT TIME ZONE 'Europe/Helsinki' AS departed,
         COALESCE(an.capacity_factor, 1) * CASE 
             WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN 1.75
-            WHEN extract(YEARS FROM age(ch.date_of_birth)) < 3 THEN coalesce(sno.occupancy_coefficient_under_3y, default_sno.occupancy_coefficient_under_3y)
+            WHEN extract(YEARS FROM age(ca.date, ch.date_of_birth)) < 3 THEN coalesce(sno.occupancy_coefficient_under_3y, default_sno.occupancy_coefficient_under_3y)
             ELSE 1.0
         END AS capacity
     FROM child_attendance ca

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancy.kt
@@ -104,7 +104,7 @@ fun Database.Read.getChildOccupancyAttendances(unitId: DaycareId, date: LocalDat
         COALESCE(an.capacity_factor, 1) * CASE 
             WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN $familyUnitPlacementCoefficient
             WHEN extract(YEARS FROM age(ca.date, ch.date_of_birth)) < 3 THEN coalesce(sno.occupancy_coefficient_under_3y, default_sno.occupancy_coefficient_under_3y)
-            ELSE 1.0
+            ELSE coalesce(sno.occupancy_coefficient, default_sno.occupancy_coefficient)
         END AS capacity
     FROM child_attendance ca
     JOIN daycare u ON u.id = ca.unit_id

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -318,7 +318,7 @@ fun Database.Read.getUnitChildrenCapacities(
             MAX(COALESCE(an.capacity_factor, 1)) assistance_need_factor,
             MAX(CASE
                 WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN 1.75
-                WHEN extract(YEARS FROM age(ch.date_of_birth)) < 3 THEN coalesce(sno.occupancy_coefficient_under_3y, default_sno.occupancy_coefficient_under_3y)
+                WHEN extract(YEARS FROM age(:date, ch.date_of_birth)) < 3 THEN coalesce(sno.occupancy_coefficient_under_3y, default_sno.occupancy_coefficient_under_3y)
                 ELSE coalesce(sno.occupancy_coefficient, default_sno.occupancy_coefficient, 1)
             END) AS service_need_factor
         FROM placement pl

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.placement
 import fi.espoo.evaka.application.utils.exhaust
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.getDaycareGroup
+import fi.espoo.evaka.occupancy.familyUnitPlacementCoefficient
 import fi.espoo.evaka.serviceneed.ServiceNeed
 import fi.espoo.evaka.serviceneed.clearServiceNeedsFromPeriod
 import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
@@ -317,7 +318,7 @@ fun Database.Read.getUnitChildrenCapacities(
             ch.id child_id,
             MAX(COALESCE(an.capacity_factor, 1)) assistance_need_factor,
             MAX(CASE
-                WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN 1.75
+                WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN $familyUnitPlacementCoefficient
                 WHEN extract(YEARS FROM age(:date, ch.date_of_birth)) < 3 THEN coalesce(sno.occupancy_coefficient_under_3y, default_sno.occupancy_coefficient_under_3y)
                 ELSE coalesce(sno.occupancy_coefficient, default_sno.occupancy_coefficient, 1)
             END) AS service_need_factor

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
@@ -45,7 +45,7 @@ private fun Database.Read.getChildAgeLanguageRows(date: LocalDate, authorizedUni
     val sql =
         """
         WITH children AS (
-            SELECT id, extract(year from age(date_of_birth)) age, language
+            SELECT id, extract(year from age(:target_date, date_of_birth)) age, language
             FROM person
         )
         SELECT

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.service.AbsenceType
-import fi.espoo.evaka.occupancy.youngChildOccupancyCoefficient
+import fi.espoo.evaka.occupancy.familyUnitPlacementCoefficient
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
@@ -88,7 +88,7 @@ SELECT
     an IS NOT NULL as has_assistance_need,
     coalesce(an.capacity_factor, 1.0) as capacity_factor,
     coalesce(capacity_factor, 1.0) * (CASE
-        WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN $youngChildOccupancyCoefficient
+        WHEN u.type && array['FAMILY', 'GROUP_FAMILY']::care_types[] THEN $familyUnitPlacementCoefficient
         WHEN date_part('year', age(t::date, p.date_of_birth)) < 3 THEN coalesce(sno.occupancy_coefficient_under_3y, default_sno.occupancy_coefficient_under_3y)
         ELSE coalesce(sno.occupancy_coefficient, default_sno.occupancy_coefficient)
     END) AS capacity,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
@@ -59,7 +59,7 @@ private fun Database.Read.getServiceNeedRows(date: LocalDate, authorizedUnits: A
         JOIN ages ON true
         JOIN care_area ON d.care_area_id = care_area.id
         LEFT JOIN placement pl ON d.id = pl.unit_id AND daterange(pl.start_date, pl.end_date, '[]') @> :target_date AND pl.type != 'CLUB'::placement_type
-        LEFT JOIN person p ON pl.child_id = p.id AND date_part('year', age(p.date_of_birth)) = ages.age
+        LEFT JOIN person p ON pl.child_id = p.id AND date_part('year', age(:target_date, p.date_of_birth)) = ages.age
         LEFT JOIN service_need sn ON sn.placement_id = pl.id AND daterange(sn.start_date, sn.end_date, '[]') @> :target_date
         LEFT JOIN service_need_option sno ON sno.id = sn.option_id
         ${if (authorizedUnits != AclAuthorization.All) "WHERE d.id = ANY(:units :: uuid[])" else ""}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
- Always use relative age when determining child age
- Use constant variable for family unit placement coefficient value
- Use service need occupancy coefficients with realtime occupancy


