### PR TITLE
EVAKA-4455 Quickfix to show child reservations

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -123,8 +123,8 @@ export default React.memo(function UnitAttendanceReservationsView({
   const { daycareAclRows } = useContext(UnitContext)
 
   return renderResult(
-    combine(childReservations, staffAttendances, daycareAclRows),
-    ([childData, staffData, daycareAclRows]) => (
+    combine(childReservations, staffAttendances),
+    ([childData, staffData]) => (
       <>
         {creatingReservationChild && (
           <ReservationModalSingleChild
@@ -163,21 +163,22 @@ export default React.memo(function UnitAttendanceReservationsView({
             />
           ) : (
             <>
-              {featureFlags.experimental?.realtimeStaffAttendance && (
-                <StaffAttendanceTable
-                  operationalDays={childData.operationalDays}
-                  staffAttendances={staffData.staff.filter((s) =>
-                    daycareAclRows
-                      .find((r) => r.employee.id === s.employeeId)
-                      ?.groupIds.includes(groupId)
-                  )}
-                  extraAttendances={staffData.extraAttendances.filter(
-                    (ea) => ea.groupId === groupId
-                  )}
-                  saveAttendance={saveAttendance}
-                  saveExternalAttendance={saveExternalAttendance}
-                />
-              )}
+              {featureFlags.experimental?.realtimeStaffAttendance &&
+                renderResult(daycareAclRows, (daycareAclRows) => (
+                  <StaffAttendanceTable
+                    operationalDays={childData.operationalDays}
+                    staffAttendances={staffData.staff.filter((s) =>
+                      daycareAclRows
+                        .find((r) => r.employee.id === s.employeeId)
+                        ?.groupIds.includes(groupId)
+                    )}
+                    extraAttendances={staffData.extraAttendances.filter(
+                      (ea) => ea.groupId === groupId
+                    )}
+                    saveAttendance={saveAttendance}
+                    saveExternalAttendance={saveExternalAttendance}
+                  />
+                ))}
               <ChildReservationsTable
                 unitId={unitId}
                 operationalDays={childData.operationalDays}


### PR DESCRIPTION
The child reservation table was not shown if the user has no access to
the daycare acl endpoint. This quickfix removes that issue, but the
employee attendance list is only visible to unit supervisors at this
point.