### PR TITLE
EVAKA-4322 income attachments for finance admin

### DIFF
--- a/apigw/src/internal/app.ts
+++ b/apigw/src/internal/app.ts
@@ -157,6 +157,12 @@ function internalApiRouter() {
     createProxy({ multipart: true })
   )
   router.put('/children/:childId/image', createProxy({ multipart: true }))
+
+  router.post(
+    '/attachments/income/:incomeId?',
+    createProxy({ multipart: true })
+  )
+
   router.use(createProxy())
   return router
 }

--- a/frontend/src/e2e-test/pages/employee/guardian-information.ts
+++ b/frontend/src/e2e-test/pages/employee/guardian-information.ts
@@ -14,6 +14,7 @@ import {
   DatePicker,
   DatePickerDeprecated,
   Element,
+  FileInput,
   Modal,
   Page,
   Select,
@@ -347,6 +348,30 @@ export class IncomeSection extends Section {
 
   async edit() {
     await this.#editIncomeItemButton.click()
+  }
+
+  #incomeFileUpload = this.find('[data-qa="income-attachment-upload"]')
+
+  async uploadedCount() {
+    return this.#incomeFileUpload
+      .findAll('[data-qa="file-download-button"]')
+      .count()
+  }
+
+  async addAttachment() {
+    const testFileName = 'test_file.png'
+    const initiallyUploadedCount = await this.uploadedCount()
+
+    const testFilePath = `src/e2e-test/assets/${testFileName}`
+    await new FileInput(
+      this.#incomeFileUpload.find('[data-qa="btn-upload-file"]')
+    ).setInputFiles(testFilePath)
+
+    await waitUntilEqual(() => this.uploadedCount(), initiallyUploadedCount + 1)
+  }
+
+  async getAttachmentCount() {
+    return this.findAll('[data-qa="attachment"]').count()
   }
 }
 

--- a/frontend/src/e2e-test/specs/5_employee/income.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/income.spec.ts
@@ -187,4 +187,18 @@ describe('Income', () => {
       'Ajanjaksolle on jo tallennettu tulotietoja! Tarkista tulotietojen voimassaoloajat.'
     )
   })
+
+  it('Attachments can be added.', async () => {
+    await incomesSection.openNewIncomeForm()
+
+    await incomesSection.addAttachment()
+    await incomesSection.save()
+    await waitUntilEqual(() => incomesSection.getAttachmentCount(), 1)
+
+    await incomesSection.edit()
+
+    await incomesSection.addAttachment()
+    await incomesSection.save()
+    await waitUntilEqual(() => incomesSection.getAttachmentCount(), 2)
+  })
 })

--- a/frontend/src/employee-frontend/api/attachments.ts
+++ b/frontend/src/employee-frontend/api/attachments.ts
@@ -53,6 +53,20 @@ export async function saveIncomeStatementAttachment(
   )
 }
 
+export async function saveIncomeAttachment(
+  incomeId: UUID | null,
+  file: File,
+  onUploadProgress: (progressEvent: ProgressEvent) => void
+): Promise<Result<UUID>> {
+  return await doSaveAttachment(
+    {
+      path: incomeId ? `/attachments/income/${incomeId}` : `/attachments/income`
+    },
+    file,
+    onUploadProgress
+  )
+}
+
 export const saveMessageAttachment = (
   draftId: UUID,
   file: File,

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemBody.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemBody.tsx
@@ -2,14 +2,22 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useContext, useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import styled from 'styled-components'
 
+import { Attachment } from 'lib-common/api-types/attachment'
 import { formatDate } from 'lib-common/date'
 import Title from 'lib-components/atoms/Title'
 import ListGrid from 'lib-components/layout/ListGrid'
+import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import FileDownloadButton from 'lib-components/molecules/FileDownloadButton'
+import { fileIcon } from 'lib-components/molecules/FileUpload'
 import { Label } from 'lib-components/typography'
+import { defaultMargins } from 'lib-components/white-space'
 
+import { getAttachmentBlob } from '../../../api/attachments'
 import { IncomeTypeOptions } from '../../../api/income'
 import { useTranslation } from '../../../state/i18n'
 import { UserContext } from '../../../state/user'
@@ -101,8 +109,41 @@ const IncomeItemBody = React.memo(function IncomeItemBody({
           />
         </>
       ) : null}
+      <IncomeAttachments attachments={income.attachments} />
     </>
   )
 })
+
+function IncomeAttachments({ attachments }: { attachments: Attachment[] }) {
+  const { i18n } = useTranslation()
+  return (
+    <>
+      <Title size={4}>{i18n.personProfile.income.details.attachments}</Title>
+      {attachments.length === 0 ? (
+        <p data-qa="no-attachments">
+          {i18n.incomeStatement.citizenAttachments.noAttachments}
+        </p>
+      ) : (
+        <FixedSpaceColumn>
+          {attachments.map((file) => (
+            <div key={file.id} data-qa="attachment">
+              <FileIcon icon={fileIcon(file)} />
+              <FileDownloadButton
+                file={file}
+                fileFetchFn={getAttachmentBlob}
+                onFileUnavailable={() => undefined}
+              />
+            </div>
+          ))}
+        </FixedSpaceColumn>
+      )}
+    </>
+  )
+}
+
+const FileIcon = styled(FontAwesomeIcon)`
+  color: ${(p) => p.theme.colors.main.m2};
+  margin-right: ${defaultMargins.s};
+`
 
 export default IncomeItemBody

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
@@ -363,6 +363,7 @@ function IncomeAttachments({
       <H1>{i18n.incomeStatement.employeeAttachments.title}</H1>
       <P>{i18n.incomeStatement.employeeAttachments.description}</P>
       <FileUpload
+        data-qa="income-attachment-upload"
         files={attachments}
         onUpload={handleUpload}
         onDelete={handleDelete}

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
+import { Attachment } from 'lib-common/api-types/attachment'
 import {
   IncomeCoefficient,
   IncomeEffect,
@@ -14,6 +15,7 @@ import {
 import { formatDate } from 'lib-common/date'
 import LocalDate from 'lib-common/local-date'
 import { parseCents } from 'lib-common/money'
+import { UUID } from 'lib-common/types'
 import Title from 'lib-components/atoms/Title'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
@@ -25,9 +27,15 @@ import {
   FixedSpaceColumn,
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
-import { Label } from 'lib-components/typography'
+import FileUpload from 'lib-components/molecules/FileUpload'
+import { H1, Label, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
+import {
+  deleteAttachment,
+  getAttachmentBlob,
+  saveIncomeAttachment
+} from '../../../api/attachments'
 import { IncomeTypeOptions } from '../../../api/income'
 import { useTranslation } from '../../../state/i18n'
 import { Income, IncomeBody, IncomeFields } from '../../../types/income'
@@ -50,6 +58,7 @@ export interface IncomeForm {
   validFrom: LocalDate
   validTo?: LocalDate
   notes: string
+  attachments: Attachment[]
 }
 
 function incomeFormFromIncome(value: IncomeBody): IncomeForm {
@@ -63,7 +72,8 @@ const emptyIncome: IncomeForm = {
   worksAtECHA: false,
   notes: '',
   validFrom: LocalDate.today(),
-  validTo: undefined
+  validTo: undefined,
+  attachments: []
 }
 
 export const coefficientMultipliers: Record<IncomeCoefficient, number> = {
@@ -273,6 +283,22 @@ const IncomeItemEditor = React.memo(function IncomeItemEditor({
           />
         </>
       ) : null}
+      <IncomeAttachments
+        incomeId={baseIncome?.id ?? null}
+        attachments={baseIncome?.attachments ?? []}
+        onUploaded={(attachment) => {
+          setEditedIncome((prev) => ({
+            ...prev,
+            attachments: prev.attachments.concat(attachment)
+          }))
+        }}
+        onDeleted={(deletedId) => {
+          setEditedIncome((prev) => ({
+            ...prev,
+            attachments: prev.attachments.filter(({ id }) => id !== deletedId)
+          }))
+        }}
+      />
       <ButtonsContainer>
         <Button onClick={cancel} text={i18n.common.cancel} />
         <AsyncButton
@@ -295,5 +321,56 @@ const IncomeItemEditor = React.memo(function IncomeItemEditor({
     </>
   )
 })
+
+function IncomeAttachments({
+  incomeId,
+  attachments,
+  onUploaded,
+  onDeleted
+}: {
+  incomeId: UUID | null
+  attachments: Attachment[]
+  onUploaded: (attachment: Attachment) => void
+  onDeleted: (id: UUID) => void
+}) {
+  const { i18n } = useTranslation()
+
+  const handleUpload = useCallback(
+    async (
+      file: File,
+      onUploadProgress: (progressEvent: ProgressEvent) => void
+    ) =>
+      (await saveIncomeAttachment(incomeId, file, onUploadProgress)).map(
+        (id) => {
+          onUploaded({ id, name: file.name, contentType: file.type })
+          return id
+        }
+      ),
+    [incomeId, onUploaded]
+  )
+
+  const handleDelete = useCallback(
+    async (id: UUID) => {
+      return (await deleteAttachment(id)).map(() => {
+        onDeleted(id)
+      })
+    },
+    [onDeleted]
+  )
+
+  return (
+    <>
+      <H1>{i18n.incomeStatement.employeeAttachments.title}</H1>
+      <P>{i18n.incomeStatement.employeeAttachments.description}</P>
+      <FileUpload
+        files={attachments}
+        onUpload={handleUpload}
+        onDelete={handleDelete}
+        onDownloadFile={getAttachmentBlob}
+        i18n={i18n.fileUpload}
+      />
+    </>
+  )
+}
 
 export default IncomeItemEditor

--- a/frontend/src/employee-frontend/types/income.ts
+++ b/frontend/src/employee-frontend/types/income.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { Attachment } from 'lib-common/api-types/attachment'
 import { IncomeEffect, IncomeValue } from 'lib-common/api-types/income'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
@@ -18,6 +19,7 @@ export interface IncomeBody {
   validFrom: LocalDate
   validTo?: LocalDate
   notes: string
+  attachments: Attachment[]
 }
 
 export interface Income extends IncomeBody {

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -1176,6 +1176,7 @@ export const fi = {
       itemHeader: 'Tulotiedot ajalle',
       itemHeaderNew: 'Uusi tulotieto',
       details: {
+        attachments: 'Liitteet',
         name: 'Nimi',
         updated: 'Tulotiedot päivitetty',
         handler: 'Käsittelijä',

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/Attachment.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/Attachment.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.attachment
 import fi.espoo.evaka.ExcludeCodeGen
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AttachmentId
+import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.IncomeStatementId
 import fi.espoo.evaka.shared.MessageContentId
 import fi.espoo.evaka.shared.MessageDraftId
@@ -15,6 +16,7 @@ import fi.espoo.evaka.shared.PedagogicalDocumentId
 sealed class AttachmentParent {
     data class Application(val applicationId: ApplicationId) : AttachmentParent()
     data class IncomeStatement(val incomeStatementId: IncomeStatementId) : AttachmentParent()
+    data class Income(val incomeId: IncomeId) : AttachmentParent()
     data class MessageDraft(val draftId: MessageDraftId) : AttachmentParent()
     data class MessageContent(val messageContentId: MessageContentId) : AttachmentParent()
     data class PedagogicalDocument(val pedagogicalDocumentId: PedagogicalDocumentId) : AttachmentParent()
@@ -27,6 +29,12 @@ data class Attachment(
     val name: String,
     val contentType: String,
     val attachedTo: AttachmentParent
+)
+
+data class IncomeAttachment(
+    val id: AttachmentId,
+    val name: String,
+    val contentType: String,
 )
 
 data class MessageAttachment(

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
@@ -20,7 +20,6 @@ import fi.espoo.evaka.shared.domain.BadRequest
 import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.kotlin.mapTo
 import java.lang.IllegalArgumentException
-import java.util.UUID
 
 fun Database.Transaction.insertAttachment(
     user: AuthenticatedUser,
@@ -148,7 +147,7 @@ fun Database.Transaction.associateAttachments(
 }
 
 fun Database.Transaction.associateIncomeAttachments(
-    personId: UUID,
+    personId: EvakaUserId,
     incomeId: IncomeId,
     attachmentIds: List<AttachmentId>
 ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -76,7 +76,7 @@ class IncomeController(
                 val validIncome = validateIncome(income.copy(id = id), incomeTypes)
                 tx.splitEarlierIncome(validIncome.personId, period)
                 tx.upsertIncome(mapper, validIncome, user.evakaUserId)
-                tx.associateIncomeAttachments(user.id, id, income.attachments.map { it.id })
+                tx.associateIncomeAttachments(user.evakaUserId, id, income.attachments.map { it.id })
                 asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forAdult(validIncome.personId, period)))
                 asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forChild(validIncome.personId, period)))
                 id

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.invoicing.controller
 
 import com.fasterxml.jackson.databind.json.JsonMapper
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.attachment.associateIncomeAttachments
 import fi.espoo.evaka.invoicing.data.deleteIncome
 import fi.espoo.evaka.invoicing.data.getIncome
 import fi.espoo.evaka.invoicing.data.getIncomesForPerson
@@ -75,6 +76,7 @@ class IncomeController(
                 val validIncome = validateIncome(income.copy(id = id), incomeTypes)
                 tx.splitEarlierIncome(validIncome.personId, period)
                 tx.upsertIncome(mapper, validIncome, user.evakaUserId)
+                tx.associateIncomeAttachments(user.id, id, income.attachments.map { it.id })
                 asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forAdult(validIncome.personId, period)))
                 asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forChild(validIncome.personId, period)))
                 id

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.attachment.IncomeAttachment
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.PersonId
+import org.jdbi.v3.json.Json
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Instant
@@ -31,6 +32,7 @@ data class Income(
     val updatedAt: Instant? = null,
     val updatedBy: String? = null,
     val applicationId: ApplicationId? = null,
+    @Json
     val attachments: List<IncomeAttachment> = listOf()
 ) {
     @JsonProperty("totalIncome")

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.invoicing.domain
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.espoo.evaka.ExcludeCodeGen
+import fi.espoo.evaka.attachment.IncomeAttachment
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.PersonId
@@ -29,7 +30,8 @@ data class Income(
     val notes: String,
     val updatedAt: Instant? = null,
     val updatedBy: String? = null,
-    val applicationId: ApplicationId? = null
+    val applicationId: ApplicationId? = null,
+    val attachments: List<IncomeAttachment> = listOf()
 ) {
     @JsonProperty("totalIncome")
     fun totalIncome(): Int =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -261,6 +261,7 @@ sealed interface Action {
     enum class Attachment(override vararg val defaultRules: ScopedActionRule<in AttachmentId>) : ScopedAction<AttachmentId> {
         READ_APPLICATION_ATTACHMENT(HasGlobalRole(SERVICE_WORKER), HasUnitRole(UNIT_SUPERVISOR).inUnitOfApplicationAttachment(), IsCitizen(allowWeakLogin = false).uploaderOfAttachment()),
         READ_INCOME_STATEMENT_ATTACHMENT(HasGlobalRole(FINANCE_ADMIN), IsCitizen(allowWeakLogin = false).uploaderOfAttachment()),
+        READ_INCOME_ATTACHMENT(HasGlobalRole(FINANCE_ADMIN)),
         READ_MESSAGE_CONTENT_ATTACHMENT(
             IsEmployee.hasPermissionForAttachmentThroughMessageContent(),
             IsCitizen(allowWeakLogin = true).hasPermissionForAttachmentThroughMessageContent(),
@@ -273,6 +274,7 @@ sealed interface Action {
         ),
         DELETE_APPLICATION_ATTACHMENT(HasGlobalRole(SERVICE_WORKER).andAttachmentWasUploadedByAnyEmployee(), IsCitizen(allowWeakLogin = false).uploaderOfAttachment()),
         DELETE_INCOME_STATEMENT_ATTACHMENT(HasGlobalRole(FINANCE_ADMIN).andAttachmentWasUploadedByAnyEmployee(), IsCitizen(allowWeakLogin = false).uploaderOfAttachment()),
+        DELETE_INCOME_ATTACHMENT(HasGlobalRole(FINANCE_ADMIN)),
         DELETE_MESSAGE_CONTENT_ATTACHMENT,
         DELETE_MESSAGE_DRAFT_ATTACHMENT(IsEmployee.hasPermissionForAttachmentThroughMessageDraft()),
         DELETE_PEDAGOGICAL_DOCUMENT_ATTACHMENT(
@@ -440,7 +442,8 @@ sealed interface Action {
     }
     enum class Income(override vararg val defaultRules: ScopedActionRule<in IncomeId>) : ScopedAction<IncomeId> {
         UPDATE(HasGlobalRole(FINANCE_ADMIN)),
-        DELETE(HasGlobalRole(FINANCE_ADMIN));
+        DELETE(HasGlobalRole(FINANCE_ADMIN)),
+        UPLOAD_ATTACHMENT(HasGlobalRole(FINANCE_ADMIN));
 
         override fun toString(): String = "${javaClass.name}.$name"
     }

--- a/service/src/main/resources/db/migration/V227__income_attachments.sql
+++ b/service/src/main/resources/db/migration/V227__income_attachments.sql
@@ -1,0 +1,7 @@
+ALTER TABLE attachment
+    ADD COLUMN income_id UUID,
+    ADD CONSTRAINT attachment_income_id_fkey FOREIGN KEY (income_id) REFERENCES income (id) ON DELETE RESTRICT,
+    DROP CONSTRAINT created_for_fk,
+    ADD CONSTRAINT created_for_fk CHECK (num_nonnulls(application_id, income_statement_id, income_id, message_content_id, message_draft_id) <= 1);
+
+CREATE INDEX idx$attachment_income ON attachment (income_id);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -224,3 +224,4 @@ V223__invoice_row_correction_reference.sql
 V224__track_invoice_correction_status.sql
 V225__remove_holiday_questionnaire_linking.sql
 V226__application_type.sql
+V227__income_attachments.sql

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
@@ -164,8 +164,7 @@ val testIncome = Income(
     validTo = null,
     effect = IncomeEffect.INCOME,
     data = mapOf(),
-    notes = "",
-    attachments = listOf()
+    notes = ""
 )
 
 val testDecisionIncome = DecisionIncome(

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
@@ -164,7 +164,8 @@ val testIncome = Income(
     validTo = null,
     effect = IncomeEffect.INCOME,
     data = mapOf(),
-    notes = ""
+    notes = "",
+    attachments = listOf()
 )
 
 val testDecisionIncome = DecisionIncome(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Provide FinanceAdmins with possibility to include attachments to manually inserted income data.

- [x] Migration
- [x] Backend support
- [x] Frontend support
- [x] E2E-test
