### PR TITLE
Disallow saving a highest-fee income statement for a child

### DIFF
--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
@@ -50,11 +50,7 @@ async function initializeEditorState(
       startDates,
       formData:
         incomeStatement === undefined
-          ? {
-              ...initialFormData(startDates),
-              childIncome: true,
-              highestFee: true
-            }
+          ? { ...initialFormData(startDates), childIncome: true }
           : Form.fromIncomeStatement(incomeStatement)
     })
   )
@@ -94,7 +90,7 @@ export default React.memo(function ChildIncomeStatementEditor() {
     const { id, formData, startDates } = state
 
     const save = (cancel: () => Promise<void>) => {
-      const validatedData = formData ? fromBody(formData) : undefined
+      const validatedData = formData ? fromBody('child', formData) : undefined
       if (validatedData) {
         if (id) {
           return updateChildIncomeStatement(childId, id, validatedData)

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
@@ -15,7 +15,6 @@ import AsyncButton, {
 } from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
-import Radio from 'lib-components/atoms/form/Radio'
 import TextArea from 'lib-components/atoms/form/TextArea'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import {
@@ -108,10 +107,10 @@ const ChildIncome = React.memo(function ChildIncome({
 
       <OtherInfoContainer>
         <TextArea
-          id="more-info"
           placeholder={t.income.childIncome.write}
           value={formData.otherInfo}
           onChange={useFieldDispatch(onChange, 'otherInfo')}
+          data-qa="other-info"
         />
       </OtherInfoContainer>
     </>
@@ -127,23 +126,18 @@ interface ChildIncomeTypeSelectionData {
 }
 
 // eslint-disable-next-line react/display-name
-const ChildIncomeTypeSelection = React.memo(
+const ChildIncomeTimeRangeSelection = React.memo(
   React.forwardRef(function ChildIncomeTypeSelection(
     {
       formData,
       isValidStartDate,
       showFormErrors,
-      onChange,
-      onSelect
+      onChange
     }: {
       formData: ChildIncomeTypeSelectionData
       isValidStartDate: (date: LocalDate) => boolean
       showFormErrors: boolean
       onChange: SetStateCallback<Form.IncomeStatementForm>
-      onSelect: (
-        incomeType: 'highestFee' | 'childIncome',
-        value: boolean
-      ) => void
     },
     ref: React.ForwardedRef<HTMLDivElement>
   ) {
@@ -214,25 +208,6 @@ const ChildIncomeTypeSelection = React.memo(
             />
           </div>
         </FixedSpaceRow>
-        <Gap size="L" />
-        <Label>{t.income.childIncome.subtitle}</Label>
-        <Gap size="s" />
-
-        <Radio
-          label={t.income.childIncome.noIncome}
-          data-qa="child-income-no-income"
-          checked={formData.highestFeeSelected}
-          onChange={() => onSelect('highestFee', true)}
-        />
-
-        <Gap size="s" />
-
-        <Radio
-          label={t.income.childIncome.hasIncome}
-          data-qa="child-income-has-income"
-          checked={!formData.highestFeeSelected}
-          onChange={() => onSelect('childIncome', true)}
-        />
       </FixedSpaceColumn>
     )
   })
@@ -271,16 +246,6 @@ export default React.memo(
       [otherStartDates]
     )
 
-    const onSelectIncomeType = useCallback(
-      (incomeType: 'highestFee' | 'childIncome') =>
-        onChange((prev) => ({
-          ...prev,
-          highestFee: incomeType === 'highestFee',
-          childIncome: incomeType === 'childIncome'
-        })),
-      [onChange]
-    )
-
     const incomeTypeSelectionFormData = useMemo(
       () => ({
         startDate: formData.startDate,
@@ -304,9 +269,7 @@ export default React.memo(
       }
     }))
 
-    const saveButtonEnabled =
-      (formData.highestFee || formData.attachments.length > 0) &&
-      formData.assure
+    const saveButtonEnabled = formData.attachments.length > 0 && formData.assure
 
     return (
       <>
@@ -325,25 +288,19 @@ export default React.memo(
           <Gap size="s" />
 
           <ContentArea opaque>
-            <ChildIncomeTypeSelection
+            <ChildIncomeTimeRangeSelection
               formData={incomeTypeSelectionFormData}
               isValidStartDate={isValidStartDate}
               showFormErrors={showFormErrors}
-              onSelect={onSelectIncomeType}
               onChange={onChange}
               ref={scrollTarget}
             />
-            {!formData.highestFee && (
-              <>
-                <Gap size="L" />
-
-                <ChildIncome
-                  incomeStatementId={incomeStatementId}
-                  formData={formData}
-                  onChange={onChange}
-                />
-              </>
-            )}
+            <Gap size="L" />
+            <ChildIncome
+              incomeStatementId={incomeStatementId}
+              formData={formData}
+              onChange={onChange}
+            />
           </ContentArea>
           <ActionContainer>
             <AssureCheckbox>

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementView.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementView.tsx
@@ -67,7 +67,7 @@ export default React.memo(function ChildIncomeStatementView() {
         <Row
           label={t.income.view.startDate}
           value={incomeStatement.startDate.format()}
-          dataQa="start-date"
+          data-qa="start-date"
         />
         <Row
           label={t.income.view.feeBasis}
@@ -93,6 +93,7 @@ const ChildIncomeInfo = React.memo(function IncomeInfo({
       <Row
         label={t.income.view.otherInfo}
         value={incomeStatement.otherInfo || '-'}
+        data-qa="other-info"
       />
       <HorizontalLine />
       <CitizenAttachments attachments={incomeStatement.attachments} />
@@ -167,12 +168,12 @@ const Row = React.memo(function Row({
   label,
   light,
   value,
-  dataQa
+  'data-qa': dataQa
 }: {
   label: string
   light?: boolean
   value: React.ReactNode
-  dataQa?: string
+  'data-qa'?: string
 }) {
   return (
     <>

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
@@ -83,7 +83,7 @@ export default React.memo(function IncomeStatementEditor() {
     const { id, formData, startDates } = state
 
     const save = (cancel: () => Promise<void>) => {
-      const validatedData = formData ? fromBody(formData) : undefined
+      const validatedData = formData ? fromBody('adult', formData) : undefined
       if (validatedData) {
         if (id) {
           return updateIncomeStatement(id, validatedData)

--- a/frontend/src/citizen-frontend/income-statements/types/body.ts
+++ b/frontend/src/citizen-frontend/income-statements/types/body.ts
@@ -30,6 +30,7 @@ export interface IncomeBody
 export type IncomeStatementBody = HighestFeeBody | IncomeBody | ChildIncomeBody
 
 export function fromBody(
+  personType: 'adult' | 'child',
   formData: Form.IncomeStatementForm
 ): IncomeStatementBody | null {
   if (!formData.assure) return null
@@ -43,6 +44,9 @@ export function fromBody(
   if (endDate && startDate > endDate) return null
 
   if (formData.highestFee) {
+    if (personType === 'child') {
+      return null
+    }
     return { type: 'HIGHEST_FEE', startDate, endDate }
   }
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
@@ -3,27 +3,34 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { waitUntilEqual, waitUntilTrue } from '../../utils'
-import { FileInput, Page } from '../../utils/page'
+import { FileInput, Page, TextInput } from '../../utils/page'
 
 export class CitizenChildIncomeStatementViewPage {
   constructor(private readonly page: Page) {}
 
-  private startDate = this.page.find('[data-qa="start-date"]')
+  private startDate = this.page.findByDataQa('start-date')
+  private otherInfo = this.page.findByDataQa('other-info')
 
   async waitUntilReady() {
     await this.startDate.waitUntilVisible()
   }
 
+  async assertOtherInfo(expected: string) {
+    await waitUntilEqual(() => this.otherInfo.innerText, expected)
+  }
+
   async assertAttachmentExists(name: string) {
     await waitUntilTrue(async () =>
       (
-        await this.page.find('[data-qa="attachment-download-button"]').innerText
+        await this.page
+          .findAllByDataQa('attachment-download-button')
+          .allInnerTexts()
       ).includes(name)
     )
   }
 
   async clickEdit() {
-    await this.page.find('[data-qa="edit-button"]').click()
+    await this.page.findByDataQa('edit-button').click()
   }
 
   async clickGoBack() {
@@ -34,24 +41,17 @@ export class CitizenChildIncomeStatementViewPage {
 export class CitizenChildIncomeStatementEditPage {
   constructor(private readonly page: Page) {}
 
-  private startDateInput = this.page.find('[data-qa="start-date"]')
-  private noIncomeSelect = this.page.find('[data-qa="child-income-no-income"]')
-  private hasIncomeSelect = this.page.find(
-    '[data-qa="child-income-has-income"]'
-  )
-  private assure = this.page.find('[data-qa="assure-checkbox"]')
-  private saveButton = this.page.find('[data-qa="save-btn"]')
+  private startDateInput = this.page.findByDataQa('start-date')
+  private otherInfoInput = new TextInput(this.page.findByDataQa('other-info'))
+  private assure = this.page.findByDataQa('assure-checkbox')
+  private saveButton = this.page.findByDataQa('save-btn')
 
   async waitUntilReady() {
     await this.startDateInput.waitUntilVisible()
   }
 
-  async selectNoIncome() {
-    await this.noIncomeSelect.click()
-  }
-
-  async selectHasIncome() {
-    await this.hasIncomeSelect.click()
+  async typeOtherInfo(text: string) {
+    await this.otherInfoInput.type(text)
   }
 
   async selectAssure() {
@@ -64,7 +64,7 @@ export class CitizenChildIncomeStatementEditPage {
 
   async uploadAttachment(filePath: string) {
     await new FileInput(
-      this.page.find('[data-qa="btn-upload-file"]')
+      this.page.findByDataQa('btn-upload-file')
     ).setInputFiles(filePath)
   }
 }

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-income-statement.spec.ts
@@ -19,8 +19,10 @@ let page: Page
 let header: CitizenHeader
 let child1ISList: CitizenChildIncomeStatementListPage
 
-const testFileName = 'test_file.png'
-const testFilePath = `src/e2e-test/assets/${testFileName}`
+const testFileName1 = 'test_file.png'
+const testFilePath1 = `src/e2e-test/assets/${testFileName1}`
+const testFileName2 = 'test_file.jpg'
+const testFilePath2 = `src/e2e-test/assets/${testFileName2}`
 let fixtures: AreaAndPersonFixtures
 
 beforeEach(async () => {
@@ -66,15 +68,15 @@ describe('Child Income statements', () => {
     await child1ISList.assertChildCount(1)
 
     const editPage = await child1ISList.createIncomeStatement()
-    await editPage.selectNoIncome()
+    await editPage.uploadAttachment(testFilePath1)
     await editPage.selectAssure()
     await editPage.save()
     await child1ISList.assertChildIncomeStatementRowCount(1)
 
     // Edit
     await child1ISList.clickEditChildIncomeStatement(0)
-    await editPage.selectHasIncome()
-    await editPage.uploadAttachment(testFilePath)
+    await editPage.uploadAttachment(testFilePath2)
+    await editPage.typeOtherInfo('foo bar baz')
     await editPage.selectAssure()
     await editPage.save()
     await child1ISList.assertChildIncomeStatementRowCount(1)
@@ -82,7 +84,9 @@ describe('Child Income statements', () => {
     // View
     const viewPage = await child1ISList.clickViewChildIncomeStatement(0)
     await viewPage.waitUntilReady()
-    await viewPage.assertAttachmentExists(testFileName)
+    await viewPage.assertOtherInfo('foo bar baz')
+    await viewPage.assertAttachmentExists(testFileName1)
+    await viewPage.assertAttachmentExists(testFileName2)
     await viewPage.clickGoBack()
 
     // Delete

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1481,8 +1481,7 @@ const en: Translations = {
 
         <P>
           If your child has no income, or your family has agreed to the highest
-          early childhood fee, select &apos;Child has no income, or I have
-          agreed to the highest early childhood education fee&apos;.
+          early childhood fee, you should not fill this form.
         </P>
 
         <P>* Information marked with an asterisk is required.</P>
@@ -1520,12 +1519,6 @@ const en: Translations = {
       entrepreneurIncome: "Entrepreneur's income information"
     },
     childIncome: {
-      subtitle:
-        'Does the child have income that affects the early childhood education fee? *',
-      noIncome:
-        'The child has no income, or I have agreed to the highest early childhood education fee\n',
-      hasIncome:
-        'The child has income and I will provide information about it as attachments below',
       childAttachments: 'Child income information attached *',
       additionalInfo: "Learn more about your child's income information",
       write: 'Write'
@@ -1820,9 +1813,7 @@ const en: Translations = {
         <>
           The income of children in early childhood education should be
           clarified. The most common income of a child is maintenance or
-          support, interest and dividend income and pension. You should also
-          report if the child has no income or your family has agreed to the
-          highest early childhood education fee.
+          support, interest and dividend income and pension.
         </>
       ),
       noChildIncomeStatementsNeeded: (

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1421,8 +1421,7 @@ export default {
 
         <P>
           Jos lapsella ei ole tuloja, tai perheenne on suostunut korkeimpaan
-          varhaiskasvatusmaksuun, valitse alta &apos;Lapsella ei ole tuloja, tai
-          olen suostunut korkeimpaan varhaiskasvatusmaksuun&apos;.
+          varhaiskasvatusmaksuun, ei tätä lomaketta tule täyttää.
         </P>
 
         <P>* Tähdellä merkityt tiedot ovat pakollisia.</P>
@@ -1460,10 +1459,6 @@ export default {
       entrepreneurIncome: 'Yrittäjän tulotiedot'
     },
     childIncome: {
-      subtitle: 'Onko lapsella varhaiskasvatusmaksuun vaikuttavia tuloja? *',
-      noIncome:
-        'Lapsella ei ole tuloja, tai olen suostunut korkeimpaan varhaiskasvatusmaksuun',
-      hasIncome: 'Lapsella on tuloja ja toimitan tiedot niistä liitteinä alla',
       childAttachments: 'Lapsen tulotiedot liitteinä *',
       additionalInfo: 'Lisätietoja lapsen tulotietoihin liittyen',
       write: 'Kirjoita'
@@ -1749,9 +1744,7 @@ export default {
         <>
           Varhaiskasvatuksessa olevien lasten tuloista tulee tehdä selvistys.
           Yleisimpiä lapsen tuloja ovat elatusapu tai -tuki, korko- ja
-          osinkotulot sekä eläke. Sinun tulee ilmoittaa myös, mikäli lapsella ei
-          ole tuloja, tai perheenne on suostunut korkeimpaan
-          varhaiskasvatusmaksuun.
+          osinkotulot sekä eläke.
         </>
       ),
       noChildIncomeStatementsNeeded: (

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1434,9 +1434,9 @@ const sv: Translations = {
         </P>
 
         <P>
-          Välj &apos;Barnet har inga inkomster, eller så har jag gått med på
-          högsta avgiften&apos; om barnet inte har några inkomster, eller er
-          familj har godkännt en högre avgift för småbarnspedagogiken.
+          Om barnet inte har några inkomster, eller er familj har godkännt den
+          högsta avgiften för småbarnspedagogiken, ska du inte fylla i detta
+          formulär.
         </P>
 
         <P>* Uppgifter markerade med en stjärna är obligatoriska.</P>
@@ -1478,11 +1478,6 @@ const sv: Translations = {
       entrepreneurIncome: 'Uppgifter om företagarens inkomster'
     },
     childIncome: {
-      subtitle:
-        'Har barnet inkomster som inverkar på avgiften för småbarnspedagogiken? *',
-      noIncome:
-        'Barnet har inga inkomster, eller så har jag gått med på högsta avgiften',
-      hasIncome: 'Barnet har inkomster och jag bifogar dem nedan',
       childAttachments: 'Information om barnets inkomster bifogas *',
       additionalInfo: 'Övrig information angående barnets inkomster',
       write: 'Fyll i'
@@ -1775,9 +1770,7 @@ const sv: Translations = {
         <>
           En utredning av barnens inkomster bör göras för småbarnspedagogiken.
           De vanligaste inkomsterna barn har är underhållsbidrag eller -stöd,
-          ränte- och aktieinkomster samt pension. Även om barnet inte har några
-          inkomster, eller om familjen har godkännt den högsta avgiften, bör du
-          göra utredningen.
+          ränte- och aktieinkomster samt pension.
         </>
       ),
       noChildIncomeStatementsNeeded: (


### PR DESCRIPTION
#### Summary

Remove the radio selection about whether the child has income. The form can only be saved by adding info about the child's income.