### PR TITLE
Speed up Gradle CI build

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -1051,7 +1051,7 @@ jobs:
       - restore_service_gradle
       - run:
           working_directory: *workspace_service
-          command: ./gradlew assemble compileIntegrationTestKotlin
+          command: ./gradlew assemble testClasses integrationTestClasses
       - store_service_artifacts
       - run:
           working_directory: *workspace_service

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -324,9 +324,6 @@ commands:
           name: Store Gradle cache
           key: gradle-home-service-v5-{{ checksum ".circleci/template.yml" }}-{{ checksum "service/build.gradle.kts" }}-{{ checksum "service/gradle.properties" }}-{{ checksum "service/settings.gradle.kts" }}-{{ checksum "service/buildSrc/build.gradle.kts" }}-{{ checksum "service/buildSrc/src/main/kotlin/Version.kt" }}
           paths:
-            - service/buildSrc/.gradle
-            - service/.gradle
-            - service/custom-ktlint-rules/.gradle
             - .gradle-user-home/wrapper
             - .gradle-user-home/caches
             - .gradle-user-home/notifications
@@ -350,6 +347,9 @@ commands:
             - service/sficlient/build
             - service/vtjclient/build
             - service-lib/build
+            - service/.gradle
+            - service/buildSrc/.gradle
+            - service/custom-ktlint-rules/.gradle
   restore_service_build_cache:
     steps:
       - restore_cache:


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Fixing broken caching reduces integration test job times by ~2 minutes since we no longer recompile all code in the test / integration test jobs.