### PR TITLE
EVAKA-FIX: open message attachments in browser

### DIFF
--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -69,7 +69,7 @@ export default React.memo(function ThreadListItem({
                 onFileUnavailable={onAttachmentUnavailable}
                 icon
                 data-qa="thread-list-attachment"
-                openInBrowser={true}
+                openInBrowser
               />
             ))}
           </FixedSpaceColumn>

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -125,6 +125,7 @@ const SingleMessage = React.memo(function SingleMessage({
                 }
                 icon
                 data-qa="attachment"
+                openInBrowser
               />
             ))}
           </FixedSpaceColumn>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add missing parameter to citizen's message attachment button.