### PR TITLE
Add a "units on map" button to application read view

### DIFF
--- a/frontend/src/employee-frontend/components/application-page/ApplicationReadView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationReadView.tsx
@@ -11,14 +11,16 @@ import {
   ApplicationAttachment,
   ApplicationPersonBasics
 } from 'lib-common/api-types/application/ApplicationDetails'
+import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import ListGrid from 'lib-components/layout/ListGrid'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import CollapsibleSection from 'lib-components/molecules/CollapsibleSection'
-import { H4, Label, Dimmed } from 'lib-components/typography'
+import { Dimmed, H4, Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/employee'
 import {
   faChild,
+  faExternalLink,
   faFileAlt,
   faInfo,
   faMapMarkerAlt,
@@ -325,6 +327,12 @@ export default React.memo(function ApplicationReadView({
               <Link to={`/units/${unit.id}`}>{`${i + 1}. ${unit.name}`}</Link>
             </React.Fragment>
           ))}
+          <Label />
+          <InlineButton
+            icon={faExternalLink}
+            text={i18n.application.preferences.unitsOnMap}
+            onClick={() => window.open('/map', '_blank')}
+          />
         </ListGrid>
         <Gap size="s" />
         <ListGrid>

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -415,6 +415,7 @@ export const fi = {
       preferredUnits: 'Hakutoiveet',
       missingPreferredUnits: 'Valitse vähintään yksi hakutoive',
       unitMismatch: 'Hakutoiveet eivät vastaa haettavia yksiköitä',
+      unitsOnMap: 'Yksiköt kartalla',
       siblingBasisLabel: 'Sisarusperuste',
       siblingBasisValue: 'Haen paikkaa sisarusperusteella',
       siblingName: 'Sisaruksen nimi',


### PR DESCRIPTION
#### Summary

The same window.open method is used for opening the application read view itself, so use it here too.
[Figma](https://www.figma.com/file/UyFTAPt5kFhErtP56e7Ze8/eVaka-employee?node-id=894%3A1992)
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

