### PR TITLE
Realtime occupancy graph enhancements

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { ChartData, ChartOptions } from 'chart.js'
+import { ChartData, ChartDataset, ChartOptions } from 'chart.js'
 import {
   isBefore,
   max,
@@ -85,24 +85,16 @@ function graphData(
 
   const data: ChartData<'line', DatePoint[]> = {
     datasets: [
-      {
-        label: i18n.unit.occupancy.realtime.children,
-        data: childData,
-        spanGaps: true,
-        stepped: 'before',
-        fill: false,
-        pointBackgroundColor: colors.grayscale.g100,
-        borderColor: colors.grayscale.g100
-      },
-      {
-        label: i18n.unit.occupancy.realtime.childrenMax,
-        data: staffData,
-        spanGaps: true,
-        stepped: 'before',
-        fill: false,
-        pointBackgroundColor: colors.status.danger,
-        borderColor: colors.status.danger
-      }
+      line(
+        i18n.unit.occupancy.realtime.children,
+        childData,
+        colors.grayscale.g100
+      ),
+      line(
+        i18n.unit.occupancy.realtime.childrenMax,
+        staffData,
+        colors.status.danger
+      )
     ]
   }
 
@@ -166,6 +158,25 @@ function graphData(
   }
 
   return { data, graphOptions }
+}
+
+function line(
+  label: string,
+  data: DatePoint[],
+  color: string
+): ChartDataset<'line', DatePoint[]> {
+  return {
+    label,
+    data,
+    spanGaps: true,
+    stepped: 'before',
+    fill: false,
+    pointRadius: 0,
+    pointBackgroundColor: color,
+    borderWidth: 2,
+    borderColor: color,
+    borderJoinStyle: 'miter'
+  }
 }
 
 function getCurrentMinute(): Date {

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancySingleDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancySingleDay.tsx
@@ -32,7 +32,7 @@ interface Props {
   realtimeOccupancies: RealtimeOccupancy | null
 }
 
-function OccupancySingleDay({
+const OccupancySingleDay = React.memo(function OccupancySingleDay({
   occupancies,
   plannedOccupancies,
   realizedOccupancies,
@@ -82,6 +82,6 @@ function OccupancySingleDay({
       )}
     </Container>
   )
-}
+})
 
 export default OccupancySingleDay


### PR DESCRIPTION
#### Summary

- Extend the graph lines up to current time if there are employees still present
- Make the graph look more like the designs

<img width="987" alt="Screenshot 2022-04-12 at 12 32 19" src="https://user-images.githubusercontent.com/70927/162929297-8c20b5e0-773a-4b89-9323-9a4b67fcb477.png">

