### PR TITLE
Fix missing sender after accounts refresh

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -135,7 +135,21 @@ export const MessageContextProvider = React.memo(
 
     usePeriodicRefresh(client, refreshUnreadCounts, { thresholdInMinutes: 1 })
 
-    const [selectedAccount, setSelectedAccount] = useState<AccountView>()
+    const [unverifiedSelectedAccount, setSelectedAccount] =
+      useState<AccountView>()
+
+    const selectedAccount = useMemo(
+      () =>
+        unverifiedSelectedAccount &&
+        accounts.isSuccess &&
+        accounts.value.find(
+          (a) => a.account.id === unverifiedSelectedAccount.account.id
+        )
+          ? unverifiedSelectedAccount
+          : undefined,
+      [accounts, unverifiedSelectedAccount]
+    )
+
     const [selectedDraft, setSelectedDraft] = useState(
       defaultState.selectedDraft
     )

--- a/frontend/src/lib-components/employee/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/employee/messages/MessageEditor.tsx
@@ -59,11 +59,14 @@ type Message = UpsertableDraftContent & {
   attachments: Attachment[]
 }
 
-const messageToUpsertableDraftWithAccount = ({
-  sender: { value: accountId },
-  recipientAccountIds: _,
-  ...rest
-}: Message): Draft => ({ ...rest, accountId })
+const messageToUpsertableDraftWithAccount = (m: Message): Draft => ({
+  content: m.content,
+  recipientIds: m.recipientIds,
+  recipientNames: m.recipientNames,
+  title: m.title,
+  type: m.type,
+  accountId: m.sender.value
+})
 
 const emptyMessage = {
   content: '',
@@ -161,7 +164,7 @@ export default React.memo(function MessageEditor({
   selectedUnit,
   sending
 }: Props) {
-  const [receiverTree, setReceiverTree] = useState<SelectorNode>(
+  const [receiverTree, setReceiverTree] = useState<SelectorNode>(() =>
     draftContent
       ? createReceiverTree(availableReceivers, draftContent.recipientIds)
       : availableReceivers
@@ -175,7 +178,7 @@ export default React.memo(function MessageEditor({
     [receiverTree]
   )
 
-  const [message, setMessage] = useState<Message>(
+  const [message, setMessage] = useState<Message>(() =>
     getInitialMessage(draftContent, defaultSender)
   )
   const [contentTouched, setContentTouched] = useState(false)


### PR DESCRIPTION

#### Summary

User's authorized accounts can change during the lifetime of a session. If access to an account is revoked, the `selectedAccount` contains a value which cannot be found from the `accounts` list.
Expose the selected account only if it can be found from user's authorized accounts.

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

