### PR TITLE
Always redirect to login page on session expiry

### DIFF
--- a/frontend/src/citizen-frontend/RequireAuth.tsx
+++ b/frontend/src/citizen-frontend/RequireAuth.tsx
@@ -6,7 +6,7 @@ import React, { useContext } from 'react'
 import { Redirect, useLocation } from 'react-router-dom'
 
 import { AuthContext } from './auth/state'
-import { getStrongLoginUri, getWeakLoginUri } from './header/const'
+import { getStrongLoginUri } from './header/const'
 
 interface Props {
   strength?: 'STRONG' | 'WEAK' | undefined
@@ -34,10 +34,8 @@ export default React.memo(function RequireAuth({
     ) : (
       <>{children}</>
     )
-  ) : strength === 'STRONG' ? (
-    <Redirect to="/" />
   ) : (
-    refreshRedirect(getWeakLoginUri(location.pathname))
+    <Redirect to="/login" />
   )
 })
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Previously this was only done if the current page required strong authentication. If it required weak authentication, the browser was redirected directly to the weak authentication login, even if you previously had a strongly authenticated session.