### PR TITLE
EVAKA-FIX: Avoid placement plans to history

### DIFF
--- a/frontend/src/employee-frontend/components/placement-draft/PlacementDraftRow.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/PlacementDraftRow.tsx
@@ -138,6 +138,7 @@ export default React.memo(function PlacementDraftSection({
             date={placement.period.start}
             type="full-width"
             onChange={updateStart}
+            minDate={LocalDate.today()}
           />
           <DateRowSpacer>-</DateRowSpacer>
           <DatePickerDeprecated


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add minDate to placement plan date picker to softly block making placement plans to history.
