### PR TITLE
Fix two E2E flakiness problems

### DIFF
--- a/frontend/src/e2e-test/dev-api/index.ts
+++ b/frontend/src/e2e-test/dev-api/index.ts
@@ -151,6 +151,9 @@ export async function execSimpleApplicationActions(
 ): Promise<void> {
   for (const action of actions) {
     await execSimpleApplicationAction(applicationId, action)
+    if (action === 'move-to-waiting-placement') {
+      await runPendingAsyncJobs()
+    }
   }
 }
 

--- a/frontend/src/e2e-test/pages/employee/units/unit.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit.ts
@@ -495,12 +495,6 @@ class StaffAclRowEditor extends Element {
 export class ApplicationProcessPage {
   constructor(private readonly page: Page) {}
 
-  async assertIsLoading() {
-    await this.page
-      .find('[data-qa="application-process-page"][data-isloading="true"]')
-      .waitUntilVisible()
-  }
-
   async waitUntilLoaded() {
     await this.page
       .find('[data-qa="application-process-page"][data-isloading="false"]')

--- a/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
@@ -359,7 +359,6 @@ describe('Application transitions', () => {
     placementProposals = applicationProcessPage.placementProposals
     await placementProposals.assertAcceptButtonEnabled()
     await placementProposals.clickAcceptButton()
-    await applicationProcessPage.assertIsLoading()
     await applicationProcessPage.waitUntilLoaded()
 
     await execSimpleApplicationActions(applicationId, [


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- `move-to-waiting-placement` starts an async job, which might deadlock with the next request(s). Fixing the deadlock is complicated, so wait for the async job to finish as a workaround. Note: there are other application-related tests that may still deadlock (e.g. when sending an application) so this is not a universal solution
- don't wait for a loading indicator to be visible...this only works when the test is slow