### PR TITLE
Allow weak logins to save answers to holiday questionnaires

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -164,7 +164,7 @@ sealed interface Action {
             READ(IsCitizen(allowWeakLogin = false).guardianOfChild()),
             CREATE_ABSENCE(IsCitizen(allowWeakLogin = true).guardianOfChild()),
 
-            CREATE_HOLIDAY_ABSENCE(IsCitizen(allowWeakLogin = false).guardianOfChild()),
+            CREATE_HOLIDAY_ABSENCE(IsCitizen(allowWeakLogin = true).guardianOfChild()),
             CREATE_RESERVATION(IsCitizen(allowWeakLogin = true).guardianOfChild()),
 
             READ_PLACEMENT(IsCitizen(allowWeakLogin = false).guardianOfChild()),


### PR DESCRIPTION
Weakly authenticated citizens were not able to POST answers to the holiday questionnaire, even when the 'require strong auth' setting was off.
