### PR TITLE
Include all staff attendances in realtime occupancy numbers

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancy.kt
@@ -129,7 +129,7 @@ fun Database.Read.getStaffOccupancyAttendances(unitId: DaycareId, date: LocalDat
     JOIN daycare_group dg ON dg.id = sa.group_id
     WHERE dg.daycare_id = :unitId AND tstzrange(sa.arrived, sa.departed) && tstzrange(:dayStart, :dayEnd)
     
-    UNION 
+    UNION ALL
     
     SELECT sae.arrived, sae.departed, sae.occupancy_coefficient AS capacity
     FROM staff_attendance_external sae


### PR DESCRIPTION
#### Summary

Using UNION doesn't return any duplicate rows, so staff members who arrived and departed in the same minute only counted as one in the occupancy graphs.

