### PR TITLE
Save and use generated invoice row order

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -546,7 +546,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
             it.createQuery("SELECT * FROM voucher_value_decision")
                 .mapTo<VoucherValueDecision>()
                 .toList()
-        }
+        }.shuffled() // randomize order to expose assumptions
     }
 
     private fun endDecisions(now: LocalDate) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -220,7 +220,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
 
-        val result = getAllFeeDecisions()
+        val result = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, result.size)
         result.first().let {
             assertEquals(periodInPast.start, it.validFrom)
@@ -376,7 +376,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertServiceNeed(placementId, serviceNeedPeriod, serviceNeed.id)
         db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
 
-        val updated = getAllFeeDecisions()
+        val updated = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, updated.size)
         updated[0].let { decision ->
             assertEquals(placementPeriod.copy(end = serviceNeedPeriod.start.minusDays(1)), decision.validDuring)
@@ -399,7 +399,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
 
-        val original = getAllFeeDecisions()
+        val original = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, original.size)
         original[0].let { decision ->
             assertEquals(placementPeriod.copy(end = serviceNeedPeriod.start.minusDays(1)), decision.validDuring)
@@ -814,7 +814,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         decisions.first().let { decision ->
             assertEquals(3, decision.familySize)
@@ -959,7 +959,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
             generator.generateNewDecisionsForAdult(tx, testAdult_1.id, period.start)
         }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(3, decisions.size)
 
         val drafts = decisions.filter { it.status == FeeDecisionStatus.DRAFT }
@@ -1057,7 +1057,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
             generator.generateNewDecisionsForAdult(tx, testAdult_1.id, newerPeriod.start)
         }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(3, decisions.size)
 
         val drafts = decisions.filter { it.status == FeeDecisionStatus.DRAFT }
@@ -1092,7 +1092,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(3, decisions.size)
         decisions[0].let { decision ->
             assertEquals(4, decision.familySize)
@@ -1187,7 +1187,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period_1.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(3, decisions.size)
         decisions[0].let { decision ->
             assertEquals(4, decision.familySize)
@@ -1251,7 +1251,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         decisions[0].let { decision ->
             assertEquals(subPeriod_1.start, decision.validFrom)
@@ -1298,7 +1298,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         decisions[0].let { decision ->
             assertEquals(2, decision.familySize)
@@ -1344,7 +1344,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(1, decisions.size)
         decisions[0].let { decision ->
             assertEquals(2, decision.familySize)
@@ -1397,7 +1397,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         decisions[0].let { decision ->
             assertEquals(2, decision.familySize)
@@ -1537,7 +1537,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
             generator.generateNewDecisionsForAdult(it, testAdult_2.id, period.start)
         }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         assertEquals(setOf(5), decisions.map { it.familySize }.toSet())
         assertEquals(setOf(testAdult_1.id, testAdult_2.id), decisions.map { it.headOfFamilyId }.toSet())
@@ -1576,7 +1576,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
             generator.generateNewDecisionsForAdult(it, testAdult_2.id, period.start)
         }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         assertEquals(setOf(testAdult_1.id, testAdult_2.id), decisions.map { it.headOfFamilyId }.toSet())
         assertEquals(setOf(6), decisions.map { it.familySize }.toSet())
@@ -1614,7 +1614,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
             generator.generateNewDecisionsForAdult(it, testAdult_2.id, period.start)
         }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         assertEquals(setOf(3, 2), decisions.map { it.familySize }.toSet())
         assertEquals(setOf(testAdult_1.id, testAdult_2.id), decisions.map { it.headOfFamilyId }.toSet())
@@ -1644,7 +1644,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         decisions[0].let { decision ->
             assertEquals(2, decision.familySize)
@@ -1692,7 +1692,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         decisions[0].let { decision ->
             assertEquals(2, decision.familySize)
@@ -1769,7 +1769,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, combinedPeriod.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         decisions[0].let { decision ->
             assertEquals(2, decision.familySize)
@@ -1864,7 +1864,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, newPeriod.start) }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
         assertEqualEnoughDecisions(sentDecision, decisions.first())
         decisions.last().let { decision ->
@@ -1926,7 +1926,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
             generator.generateNewDecisionsForAdult(tx, testAdult_1.id, familyPeriod.start)
         }
 
-        val decisions = getAllFeeDecisions()
+        val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(3, decisions.size)
         val sent = decisions.find { it.status == FeeDecisionStatus.SENT }!!
         val (firstDraft, secondDraft) = decisions.filter { it.status == FeeDecisionStatus.DRAFT }
@@ -2178,6 +2178,6 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
             tx.createQuery(feeDecisionQueryBase)
                 .mapTo<FeeDecision>()
                 .merge()
-        }
+        }.shuffled() // randomize order to expose assumptions
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
@@ -144,7 +144,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBefor
             tx.createQuery(feeDecisionQueryBase)
                 .mapTo<FeeDecision>()
                 .let { it.merge() }
-        }
+        }.shuffled() // randomize order to expose assumptions
     }
 
     private fun getAllVoucherValueDecisions(): List<VoucherValueDecision> {
@@ -152,6 +152,6 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBefor
             tx.createQuery("SELECT * FROM voucher_value_decision")
                 .mapTo<VoucherValueDecision>()
                 .toList()
-        }
+        }.shuffled() // randomize order to expose assumptions
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
@@ -355,6 +355,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
         period: FiniteDateRange = FiniteDateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 31))
     ): List<Invoice> {
         return generator.applyCorrections(this, invoices, period.asDateRange(), mapOf(testDaycare.id to testArea.id))
+            .shuffled() // randomize order to expose assumptions
     }
 
     private fun createTestInvoice(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
@@ -252,7 +252,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
         assertEquals(correctionId, firstInvoice.rows.last().correctionId)
         db.transaction { it.upsertInvoices(listOf(firstInvoice.copy(status = InvoiceStatus.SENT))) }
 
-        val secondMonth = Month.JANUARY
+        val secondMonth = Month.FEBRUARY
         val secondInvoice = db.read { it.applyCorrections(listOf(createTestInvoice(30_00, secondMonth)), secondMonth) }.first()
         assertEquals(2, secondInvoice.rows.size)
         assertEquals(0, secondInvoice.totalPrice)
@@ -263,7 +263,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
         assertEquals(correctionId, secondInvoice.rows.last().correctionId)
         db.transaction { it.upsertInvoices(listOf(secondInvoice.copy(status = InvoiceStatus.SENT))) }
 
-        val thirdMonth = Month.JANUARY
+        val thirdMonth = Month.MARCH
         val thirdInvoice = db.read { it.applyCorrections(listOf(createTestInvoice(100_00, thirdMonth)), thirdMonth) }.first()
         assertEquals(2, thirdInvoice.rows.size)
         assertEquals(20_00, thirdInvoice.totalPrice)
@@ -274,7 +274,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
         assertEquals(correctionId, thirdInvoice.rows.last().correctionId)
         db.transaction { it.upsertInvoices(listOf(thirdInvoice.copy(status = InvoiceStatus.SENT))) }
 
-        val fourthMonth = Month.JANUARY
+        val fourthMonth = Month.APRIL
         val fourthInvoice = db.read { it.applyCorrections(listOf(createTestInvoice(100_00, fourthMonth)), fourthMonth) }.first()
         assertEquals(2, fourthInvoice.rows.size)
         assertEquals(60_00, fourthInvoice.totalPrice)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -311,7 +311,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         db.transaction { generator.createAndStoreAllDraftInvoices(it, period) }
 
-        val result = db.read(getAllInvoices)
+        val result = db.read(getAllInvoices).sortedBy { it.headOfFamily == testAdult_2.id }
 
         assertEquals(2, result.size)
         result.first().let { invoice ->
@@ -3982,6 +3982,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             .map(toInvoice)
             .list()
             .let(::flatten)
+            .shuffled() // randomize order to expose assumptions
     }
 
     private fun datesBetween(start: LocalDate, endInclusive: LocalDate?): List<LocalDate> {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
@@ -71,7 +71,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
 
-        val voucherValueDecisions = getAllVoucherValueDecisions()
+        val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
         voucherValueDecisions.first().let { decision ->
             assertEquals(VoucherValueDecisionStatus.DRAFT, decision.status)
@@ -106,7 +106,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
 
-        val voucherValueDecisions = getAllVoucherValueDecisions()
+        val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
         val assumedPeriodStart = testChild.dateOfBirth.plusYears(3).plusMonths(1).withDayOfMonth(1)
         voucherValueDecisions.first().let { decision ->
@@ -139,7 +139,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
 
-        val voucherValueDecisions = getAllVoucherValueDecisions()
+        val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
         voucherValueDecisions.first().let { decision ->
             assertEquals(VoucherValueDecisionStatus.DRAFT, decision.status)
@@ -330,7 +330,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
 
         db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_2.id, firstPeriod.start) }
 
-        val voucherValueDecisions = getAllVoucherValueDecisions()
+        val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
         voucherValueDecisions.first().let { decision ->
             assertEquals(VoucherValueDecisionStatus.DRAFT, decision.status)
@@ -476,7 +476,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
             tx.createQuery("SELECT * FROM voucher_value_decision")
                 .mapTo<VoucherValueDecision>()
                 .toList()
-        }
+        }.shuffled() // randomize order to expose assumptions
     }
 
     private fun insertIncome(adultId: PersonId, amount: Int, period: DateRange) {

--- a/service/src/main/resources/db/migration/V230__invoice_row_idx.sql
+++ b/service/src/main/resources/db/migration/V230__invoice_row_idx.sql
@@ -1,0 +1,28 @@
+LOCK TABLE invoice_row;
+
+ALTER TABLE invoice_row ADD COLUMN idx smallint;
+
+-- Loop invoices with seqscan disabled to try to make sure we use the (invoice_id) index, which contains
+-- the row order we want
+DO $$
+DECLARE
+    current_invoice uuid;
+BEGIN
+    SET enable_seqscan = FALSE;
+    FOR current_invoice IN SELECT id FROM invoice LOOP
+        UPDATE invoice_row
+        SET idx = f.idx
+        FROM (
+          SELECT id, (row_number() OVER () - 1) AS idx
+          FROM invoice_row
+          WHERE invoice_id = current_invoice
+        ) f
+        WHERE invoice_row.id = f.id;
+    END LOOP;
+END $$ LANGUAGE plpgsql;
+
+ALTER TABLE invoice_row ALTER COLUMN idx SET NOT NULL;
+ALTER TABLE invoice_row ADD CONSTRAINT uniq$invoice_row_invoice_idx UNIQUE (invoice_id, idx);
+
+DROP INDEX invoice_row_invoice_id_idx;
+

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -227,3 +227,4 @@ V226__application_type.sql
 V227__income_attachments.sql
 V228__evaka_user_lastname_firstname.sql
 V229__voucher_value_base_value_age_under_three.sql
+V230__invoice_row_idx.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- save row indexes and use them to sort invoice rows in queries
- row index is mostly a transparent low-level detail, and is not exposed in the `InvoiceRow` / `InvoiceRowDetailed` types
- gaps are allowed and are created if an invoice correction is deleted. This is not a problem, because the sort order is retained, and we never insert rows without first deleting all old ones
- currently the order comes in practice from the invoice_id index in `invoice_row`. In the migration, updating the entire `invoice_row` table in a single SQL statement didn't always result in the correct order, so loop each invoice individually and disable seq scan to try to use this index. This seemed to give correct results, at least based on tests in staging.
- add random shuffling to result lists in various tests to expose invalid assumptions about order
- refactor invoice correction tests to explicitly use months instead of dateranges
- fix broken invoice correction test, which was generating multiple invoices for the same month