### PR TITLE
Flaky E2E fix: make sure service need defaults exist in application tests

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
@@ -47,6 +47,7 @@ beforeEach(async () => {
   fixtures = await initializeAreaAndPersonData()
   serviceWorker = (await Fixture.employeeServiceWorker().save()).data
   await insertDefaultServiceNeedOptions()
+  await Fixture.feeThresholds().save()
 
   page = await Page.open()
   applicationWorkbench = new ApplicationWorkbenchPage(page)

--- a/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
@@ -46,6 +46,7 @@ beforeEach(async () => {
   await cleanUpMessages()
   fixtures = await initializeAreaAndPersonData()
   serviceWorker = (await Fixture.employeeServiceWorker().save()).data
+  await insertDefaultServiceNeedOptions()
 
   page = await Page.open()
   applicationWorkbench = new ApplicationWorkbenchPage(page)
@@ -167,7 +168,6 @@ describe('Application transitions', () => {
 
   test('Placement dialog works', async () => {
     const preferredStartDate = LocalDate.of(2021, 8, 16)
-    await insertDefaultServiceNeedOptions()
 
     const group = await Fixture.daycareGroup()
       .with({ daycareId: fixtures.daycareFixture.id })


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Some application state transitions trigger async jobs that require this data. Even if we don't really care about the jobs, their failures can get propagated to the test, so it's better to make sure the jobs work.