### PR TITLE
Add user type to apigw auth status response

### DIFF
--- a/apigw/src/internal/routes/auth-status.ts
+++ b/apigw/src/internal/routes/auth-status.ts
@@ -33,6 +33,7 @@ export default toRequestHandler(async (req, res) => {
           user: {
             id,
             name,
+            userType: user.userType,
             unitIds,
             employeeId,
             pinLoginActive,
@@ -72,6 +73,7 @@ export default toRequestHandler(async (req, res) => {
         user: {
           id,
           name,
+          userType: user.userType,
           accessibleFeatures: accessibleFeatures ?? {},
           permittedGlobalActions: permittedGlobalActions ?? []
         },

--- a/frontend/src/lib-common/api-types/employee-auth.ts
+++ b/frontend/src/lib-common/api-types/employee-auth.ts
@@ -11,11 +11,13 @@ import { UUID } from '../types'
 export interface User {
   id: UUID
   name: string
+  userType: 'EMPLOYEE'
   accessibleFeatures: EmployeeFeatures
   permittedGlobalActions: Set<Action.Global>
 }
 
 export interface MobileUser extends MobileDeviceDetails {
+  userType: 'MOBILE'
   pinLoginActive: boolean
 }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This information will be later in a separate pull request to prevent using the wrong internal-gw session (mobile session in employee, or employee session in mobile)