### PR TITLE
EVAKA-FIX Reload incomes after cancelling edit

### DIFF
--- a/frontend/src/e2e-test/pages/employee/guardian-information.ts
+++ b/frontend/src/e2e-test/pages/employee/guardian-information.ts
@@ -306,6 +306,7 @@ export class IncomeSection extends Section {
   }
 
   #saveIncomeButton = this.page.find('[data-qa="save-income"]')
+  #cancelIncomeButton = this.page.find('[data-qa="cancel-income-edit"]')
 
   async save() {
     await this.#saveIncomeButton.click()
@@ -318,6 +319,10 @@ export class IncomeSection extends Section {
 
   async saveIsDisabled() {
     return await this.#saveIncomeButton.disabled
+  }
+
+  async cancelEdit() {
+    await this.#cancelIncomeButton.click()
   }
 
   #incomeListItems = this.page.findAll('[data-qa="income-list-item"]')
@@ -376,6 +381,10 @@ export class IncomeSection extends Section {
     ).setInputFiles(testFilePath)
 
     await waitUntilEqual(() => this.uploadedCount(), initiallyUploadedCount + 1)
+  }
+
+  async deleteIncomeAttachment(n: number) {
+    return this.findAll('[data-qa^="file-delete-button"]').nth(n).click()
   }
 
   async getAttachmentCount() {

--- a/frontend/src/e2e-test/specs/5_employee/income.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/income.spec.ts
@@ -213,4 +213,19 @@ describe('Income', () => {
 
     await waitUntilEqual(() => incomesSection.incomeListItemCount(), 0)
   })
+
+  it('Attachment can be deleted while editing income without dead links', async () => {
+    await incomesSection.openNewIncomeForm()
+
+    await incomesSection.addAttachment()
+    await incomesSection.save()
+    await waitUntilEqual(() => incomesSection.getAttachmentCount(), 1)
+
+    await incomesSection.edit()
+
+    await incomesSection.deleteIncomeAttachment(0)
+    await incomesSection.cancelEdit()
+
+    await waitUntilEqual(() => incomesSection.getAttachmentCount(), 0)
+  })
 })

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
@@ -300,7 +300,11 @@ const IncomeItemEditor = React.memo(function IncomeItemEditor({
         }}
       />
       <ButtonsContainer>
-        <Button onClick={cancel} text={i18n.common.cancel} />
+        <Button
+          onClick={cancel}
+          text={i18n.common.cancel}
+          data-qa="cancel-income-edit"
+        />
         <AsyncButton
           primary
           text={i18n.common.save}

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeList.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeList.tsx
@@ -117,7 +117,7 @@ const IncomeList = React.memo(function IncomeList({
                 <IncomeItemEditor
                   baseIncome={item}
                   incomeTypeOptions={incomeTypeOptions}
-                  cancel={() => setEditing(undefined)}
+                  cancel={onSuccessfulUpdate}
                   create={createIncome}
                   update={(income) => updateIncome(item.id, income)}
                   onSuccess={onSuccessfulUpdate}


### PR DESCRIPTION
Attachments can be deleted directly while editing income so we should refresh data if editing itself is canceled

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

