### PR TITLE
Do not fail whole fee decision batch if there are manual deps

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -1172,6 +1172,33 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
     }
 
     @Test
+    fun `confirmDrafts ignores decisions that have related manual sending decisions`() {
+        val toBeCreatedDecisions = testDecisions.filter { it.status == FeeDecisionStatus.DRAFT && it.decisionType == FeeDecisionType.NORMAL }
+        db.transaction { tx -> tx.upsertFeeDecisions(toBeCreatedDecisions) }
+        val notToBeCreated = toBeCreatedDecisions.first()
+        val requiresManualSending = notToBeCreated.copy(
+            id = FeeDecisionId(UUID.randomUUID()),
+            status = FeeDecisionStatus.WAITING_FOR_MANUAL_SENDING,
+        )
+        db.transaction { tx -> tx.upsertFeeDecisions(listOf(requiresManualSending)) }
+
+        http.post("/decisions/confirm")
+            .asUser(user)
+            .jsonBody(jsonMapper.writeValueAsString(toBeCreatedDecisions.map { it.id }))
+            .response()
+
+        val (_, _, result) = http.post("/decisions/search")
+            .jsonBody("""{"page": "0", "pageSize": "50", "status": "DRAFT"}""")
+            .asUser(user)
+            .responseString()
+
+        val draftDecisions = deserializeListResult(result.get()).data
+
+        assertEquals(1, draftDecisions.size)
+        assertEquals(notToBeCreated.id, draftDecisions.first().id)
+    }
+
+    @Test
     fun `date range picker does not return anything with range before first decision`() {
         val now = LocalDate.now()
         val oldDecision = testDecisions[0].copy(validDuring = DateRange(now.minusMonths(2), now.minusMonths(1)))


### PR DESCRIPTION
- When creating fee decisions from drafts, do not fail the whole batch if some have related fee decisions waiting for sending. Instead skip those.
- From the UI point of view this means that the skipped drafts will remain in the search results after the create fee decisions operation is done
