### PR TITLE
EVAKA-4406 Only show attendances for the selected group

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -165,9 +165,14 @@ export default React.memo(function UnitAttendanceReservationsView({
               {featureFlags.experimental?.realtimeStaffAttendance && (
                 <StaffAttendanceTable
                   operationalDays={childData.operationalDays}
-                  staffAttendances={staffData.staff.filter((s) =>
-                    s.groups.includes(groupId)
-                  )}
+                  staffAttendances={staffData.staff
+                    .filter((s) => s.groups.includes(groupId))
+                    .map((employeeAttendance) => ({
+                      ...employeeAttendance,
+                      attendances: employeeAttendance.attendances.filter(
+                        (a) => a.groupId === groupId
+                      )
+                    }))}
                   extraAttendances={staffData.extraAttendances.filter(
                     (ea) => ea.groupId === groupId
                   )}


### PR DESCRIPTION
Staff attendances for one group would be shown in all groups where a
member of the staff had access. Now only show attendances in the
currently selected group on the group view.
