### PR TITLE
EVAKA-4406 Fix issue where the tooltip positioning was slightly off

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/ChartTooltip.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/ChartTooltip.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { TooltipModel } from 'chart.js'
-import React, { useRef } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import colors from 'lib-customizations/common'
@@ -25,14 +25,9 @@ export const ChartTooltip = React.memo(function ChartTooltip({
   data: ChartTooltipData
   visible: boolean
 }) {
-  const bodyRef = useRef<HTMLDivElement>(null)
   if (tooltip === undefined) {
     return null
   }
-
-  const bodyRect = bodyRef.current?.getBoundingClientRect()
-  const tooltipWidth = bodyRect ? bodyRect.width : 265
-  const tooltipHeight = bodyRect ? bodyRect.height : 150
 
   const align =
     tooltip.xAlign !== 'center'
@@ -79,17 +74,20 @@ export const ChartTooltip = React.memo(function ChartTooltip({
     <>
       <Caret pos={caretPos} className={align} opacity={visible ? 1 : 0} />
       <PositionedDiv pos={pos} opacity={visible ? 1 : 0} className={align}>
-        <TooltipBody ref={bodyRef}>{children}</TooltipBody>
+        <TooltipBody>{children}</TooltipBody>
       </PositionedDiv>
     </>
   )
 })
 
+const tooltipWidth = 275
+const tooltipHeight = 150
 const PositionedDiv = styled.div<{ pos: Position; opacity: number }>`
   position: absolute;
   opacity: ${(p) => p.opacity};
   z-index: 9999;
-  min-width: 265px;
+  width: ${tooltipWidth}px;
+  height: ${tooltipHeight}px;
 
   &.top {
     left: ${({ pos }) => pos.x}px;


### PR DESCRIPTION
The measurements of width and height of the tooltip body always used the
previous tooltip's content and applied it to the next render. So for
cases where the utilization went from e.g. 15% to 0%, causing the
tooltip body to be slightly smaller, the caret was rendered as detached
from the tooltip itself.

The above issue is fixed by specifying a fixed width/height for the
tooltip, which works when we know the contents, but is not ideal if the
content would be radically different.
