### PR TITLE
Improve message_account table indexes

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageAccountQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageAccountQueries.kt
@@ -121,7 +121,7 @@ fun Database.Transaction.upsertEmployeeMessageAccount(employeeId: EmployeeId): M
     // language=SQL
     val sql = """
         INSERT INTO message_account (employee_id) VALUES (:employeeId)
-        ON CONFLICT (employee_id) DO UPDATE SET active = true
+        ON CONFLICT (employee_id) WHERE employee_id IS NOT NULL DO UPDATE SET active = true
         RETURNING id
     """.trimIndent()
     return createQuery(sql)

--- a/service/src/main/resources/db/migration/V231__message_account_indexes.sql
+++ b/service/src/main/resources/db/migration/V231__message_account_indexes.sql
@@ -1,0 +1,17 @@
+CREATE UNIQUE INDEX uniq$message_account_daycare_group ON message_account (daycare_group_id)
+    INCLUDE (active)
+    WHERE daycare_group_id IS NOT NULL;
+ALTER TABLE message_account DROP CONSTRAINT message_account_daycare_group_uniq;
+DROP INDEX idx$message_account_daycare_group_id;
+
+CREATE UNIQUE INDEX uniq$message_account_employee ON message_account (employee_id)
+    INCLUDE (active)
+    WHERE employee_id IS NOT NULL;
+ALTER TABLE message_account DROP CONSTRAINT message_account_employee_uniq;
+DROP INDEX idx$message_account_employee_id;
+
+CREATE UNIQUE INDEX uniq$message_account_person ON message_account (person_id)
+    INCLUDE (active)
+    WHERE person_id IS NOT NULL;
+ALTER TABLE message_account DROP CONSTRAINT message_account_person_uniq;
+DROP INDEX idx$message_account_person_id;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -228,3 +228,4 @@ V227__income_attachments.sql
 V228__evaka_user_lastname_firstname.sql
 V229__voucher_value_base_value_age_under_three.sql
 V230__invoice_row_idx.sql
+V231__message_account_indexes.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Currently we use a unique constraint per foreign key, but these indexes
are not partial indexes so they include nulls. Also, we have
separate (some_id, active) indexes, and they seem to only exist to allow
the database to do index-only scans based on (id, active) pairs without
needing to read the actual row data.

Replace both with partial indexes that include the active column, but
just include the column instead of using it as a key. Benefits:

- partial index -> no wasted space on NULLs
- active column included -> we can have the unique constraint *and*
  index-only scans based on (id, active) pairs with just one index
  
**In staging this reduced the total size of these indexes in message_account by 84%**