### PR TITLE
Increase timeout when taking screenshots

### DIFF
--- a/frontend/src/e2e-test/browser.ts
+++ b/frontend/src/e2e-test/browser.ts
@@ -115,12 +115,14 @@ async function captureScreenshots(namePrefix: string): Promise<void> {
   await forEachPage(async ({ ctxIndex, pageIndex, page }) => {
     await page.screenshot({
       type: 'png',
-      path: `screenshots/${namePrefix}.${ctxIndex}.${pageIndex}.png`
+      path: `screenshots/${namePrefix}.${ctxIndex}.${pageIndex}.png`,
+      timeout: 30_000
     })
     await page.screenshot({
       type: 'png',
       path: `screenshots/${namePrefix}.${ctxIndex}.full.${pageIndex}.png`,
-      fullPage: true
+      fullPage: true,
+      timeout: 30_000
     })
   })
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Some of our pages have a slightly broken layout that confuses Playwright, and it might take a massive screenshot (e.g. 160 000 pixels wide!) that won't happen in less than 5 seconds.