### PR TITLE
Improve error handling and type safety in internal-gw auth status endpoint

### DIFF
--- a/apigw/src/internal/routes/auth-status.ts
+++ b/apigw/src/internal/routes/auth-status.ts
@@ -2,56 +2,83 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import express from 'express'
 import { eq } from 'lodash'
 import { toRequestHandler } from '../../shared/express'
 import {
   getEmployeeDetails,
-  getMobileDevice
+  getMobileDevice,
+  UUID
 } from '../../shared/service-client'
 import { logoutExpress, saveSession } from '../../shared/session'
 import { fromCallback } from '../../shared/promise-utils'
 import { appCommit } from '../../shared/config'
 
-export default toRequestHandler(async (req, res) => {
+interface AuthStatus {
+  loggedIn: boolean
+  user?: EmployeeUser | MobileUser
+  roles?: string[]
+  globalRoles?: string[]
+  allScopedRoles?: string[]
+  apiVersion: string
+}
+
+interface EmployeeUser {
+  userType: 'EMPLOYEE'
+  id: UUID
+  name: string
+  accessibleFeatures: object
+  permittedGlobalActions: string[]
+}
+
+interface MobileUser {
+  userType: 'MOBILE'
+  employeeId: UUID | null
+  id: UUID
+  name: string
+  personalDevice: boolean
+  unitIds: UUID[]
+  pinLoginActive: boolean
+}
+
+interface ValidatedUser {
+  user: EmployeeUser | MobileUser
+  globalRoles: string[]
+  allScopedRoles: string[]
+}
+
+async function validateUser(
+  req: express.Request
+): Promise<ValidatedUser | undefined> {
   const user = req.user
-  if (user && user.id) {
-    if (user.userType === 'MOBILE') {
+  if (!user || !user.id) return undefined
+  switch (user.userType) {
+    case 'MOBILE': {
       const device = await getMobileDevice(req, user.id)
       if (!device) {
-        // device has been removed
-        await logoutExpress(req, res, 'employee')
-        res.status(200).json({ loggedIn: false, apiVersion: appCommit })
-      } else {
-        const globalRoles = user.globalRoles ?? []
-        const allScopedRoles = user.allScopedRoles ?? ['MOBILE']
-        const employeeId = device.employeeId ?? user.mobileEmployeeId
-        const pinLoginActive = user.mobileEmployeeId
-        const { id, name, unitIds, personalDevice } = device
-        await saveSession(req)
-        res.status(200).json({
-          loggedIn: true,
-          user: {
-            id,
-            name,
-            userType: user.userType,
-            unitIds,
-            employeeId,
-            pinLoginActive,
-            personalDevice
-          },
-          globalRoles,
-          allScopedRoles,
-          roles: [...globalRoles, ...allScopedRoles],
-          apiVersion: appCommit
-        })
+        return undefined
       }
-    } else {
+      const employeeId = device.employeeId ?? user.mobileEmployeeId ?? null
+      const pinLoginActive = !!user.mobileEmployeeId
+      const { id, name, unitIds, personalDevice } = device
+      return {
+        user: {
+          id,
+          name,
+          userType: 'MOBILE',
+          unitIds,
+          employeeId,
+          pinLoginActive,
+          personalDevice
+        },
+        globalRoles: [],
+        allScopedRoles: ['MOBILE']
+      }
+    }
+    case 'EMPLOYEE': {
       const employee = await getEmployeeDetails(req, user.id)
       if (!employee) {
-        // user id is invalid (e.g. employee has been removed)
-        await logoutExpress(req, res, 'employee')
-        res.status(200).json({ loggedIn: false, apiVersion: appCommit })
-        return
+        return undefined
       }
       const {
         id,
@@ -63,34 +90,55 @@ export default toRequestHandler(async (req, res) => {
         permittedGlobalActions
       } = employee
       const name = [firstName, lastName].filter((x) => !!x).join(' ')
-
-      // Refresh roles if necessary
-      if (
-        !eq(user.globalRoles, globalRoles) ||
-        !eq(user.allScopedRoles, allScopedRoles)
-      ) {
-        await fromCallback((cb) =>
-          req.logIn({ ...user, globalRoles, allScopedRoles }, cb)
-        )
-      }
-
-      await saveSession(req)
-      res.status(200).json({
-        loggedIn: true,
+      return {
         user: {
+          userType: 'EMPLOYEE',
           id,
           name,
-          userType: user.userType,
           accessibleFeatures: accessibleFeatures ?? {},
           permittedGlobalActions: permittedGlobalActions ?? []
         },
         globalRoles,
-        allScopedRoles,
-        roles: [...globalRoles, ...allScopedRoles],
-        apiVersion: appCommit
-      })
+        allScopedRoles
+      }
+    }
+    default:
+      return undefined
+  }
+}
+
+export default toRequestHandler(async (req, res) => {
+  const sessionUser = req.user
+  const validUser = sessionUser && (await validateUser(req))
+  let status: AuthStatus
+  if (validUser) {
+    const { user, globalRoles, allScopedRoles } = validUser
+    // Refresh roles if necessary
+    if (
+      !eq(sessionUser.globalRoles, globalRoles) ||
+      !eq(sessionUser.allScopedRoles, allScopedRoles)
+    ) {
+      await fromCallback((cb) =>
+        req.logIn({ ...sessionUser, globalRoles, allScopedRoles }, cb)
+      )
+    }
+    await saveSession(req)
+    status = {
+      loggedIn: true,
+      user,
+      globalRoles,
+      allScopedRoles,
+      roles: [...globalRoles, ...allScopedRoles],
+      apiVersion: appCommit
     }
   } else {
-    res.status(200).json({ loggedIn: false, apiVersion: appCommit })
+    if (sessionUser) {
+      await logoutExpress(req, res, 'employee')
+    }
+    status = {
+      loggedIn: false,
+      apiVersion: appCommit
+    }
   }
+  res.status(200).json(status)
 })

--- a/apigw/src/internal/routes/auth-status.ts
+++ b/apigw/src/internal/routes/auth-status.ts
@@ -46,6 +46,13 @@ export default toRequestHandler(async (req, res) => {
         })
       }
     } else {
+      const employee = await getEmployeeDetails(req, user.id)
+      if (!employee) {
+        // user id is invalid (e.g. employee has been removed)
+        await logoutExpress(req, res, 'employee')
+        res.status(200).json({ loggedIn: false, apiVersion: appCommit })
+        return
+      }
       const {
         id,
         firstName,
@@ -54,7 +61,7 @@ export default toRequestHandler(async (req, res) => {
         allScopedRoles,
         accessibleFeatures,
         permittedGlobalActions
-      } = await getEmployeeDetails(req, user.id)
+      } = employee
       const name = [firstName, lastName].filter((x) => !!x).join(' ')
 
       // Refresh roles if necessary

--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -104,7 +104,7 @@ export async function getEmployeeDetails(
   req: express.Request,
   employeeId: string
 ) {
-  const { data } = await client.get<EmployeeUserResponse>(
+  const { data } = await client.get<EmployeeUserResponse | undefined>(
     `/system/employee/${employeeId}`,
     {
       headers: createServiceRequestHeaders(req, machineUser)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- if `/auth/status` can't find the employee based on the id in an active session, the user is logged out. This fixes a problem in local environment where you might end up with HTTP status 500 and broken app if you have a session and the employee is deleted in the backend (e.g. you run a test that resets the db)
- as a side effect, removes a potential security hole where old sessions belonging to an employee that is deleted could still be used
- refactoring to improve error handling and type safety