### PR TITLE
Make `AsyncButton` better and use it more

### DIFF
--- a/frontend/src/citizen-frontend/applications/ApplicationCreation.tsx
+++ b/frontend/src/citizen-frontend/applications/ApplicationCreation.tsx
@@ -168,14 +168,10 @@ export default React.memo(function ApplicationCreation() {
               disabled={selectedType === undefined || duplicateExists}
               onClick={() =>
                 selectedType !== undefined
-                  ? createApplication(childId, selectedType).then((result) => {
-                      if (result.isSuccess) {
-                        navigate(`/applications/${result.value}/edit`)
-                      }
-                    })
-                  : Promise.resolve()
+                  ? createApplication(childId, selectedType)
+                  : undefined
               }
-              onSuccess={() => undefined}
+              onSuccess={(id) => navigate(`/applications/${id}/edit`)}
               data-qa="submit"
             />
             <Button

--- a/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
@@ -94,10 +94,10 @@ export default React.memo(function AbsenceModal({
       <AsyncFormModal
         mobileFullScreen
         title={i18n.calendar.absenceModal.title}
-        resolveAction={(cancel) => {
+        resolveAction={() => {
           if (!request) {
             setShowAllErrors(true)
-            return cancel()
+            return
           }
           return postAbsences(request)
         }}

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -136,10 +136,10 @@ export default React.memo(function ReservationModal({
       <AsyncFormModal
         mobileFullScreen
         title={i18n.calendar.reservationModal.title}
-        resolveAction={(cancel) => {
+        resolveAction={() => {
           if (validationResult.errors) {
             setShowAllErrors(true)
-            return cancel()
+            return
           } else {
             return postReservations(validationResult.requestPayload)
           }

--- a/frontend/src/citizen-frontend/calendar/api.ts
+++ b/frontend/src/citizen-frontend/calendar/api.ts
@@ -47,10 +47,10 @@ export async function getReservations(
 
 export async function postReservations(
   reservations: DailyReservationRequest[]
-): Promise<Result<null>> {
+): Promise<Result<void>> {
   return client
     .post('/citizen/reservations', reservations)
-    .then(() => Success.of(null))
+    .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 }
 

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
@@ -93,7 +93,7 @@ export default React.memo(function ChildIncomeStatementEditor() {
   return renderResult(state, (state) => {
     const { id, formData, startDates } = state
 
-    const save = (cancel: () => Promise<void>) => {
+    const save = () => {
       const validatedData = formData ? fromBody('child', formData) : undefined
       if (validatedData) {
         if (id) {
@@ -104,7 +104,7 @@ export default React.memo(function ChildIncomeStatementEditor() {
       } else {
         setShowFormErrors(true)
         if (form.current) form.current.scrollToErrors()
-        return cancel()
+        return
       }
     }
 

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
@@ -5,14 +5,13 @@
 import React, { useCallback, useImperativeHandle, useMemo, useRef } from 'react'
 import styled from 'styled-components'
 
+import { Result } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
 import { validateIf, validDate } from 'lib-common/form-validation'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { scrollToRef } from 'lib-common/utils/scrolling'
-import AsyncButton, {
-  AsyncClickCallback
-} from 'lib-components/atoms/buttons/AsyncButton'
+import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import TextArea from 'lib-components/atoms/form/TextArea'
@@ -46,7 +45,7 @@ interface Props {
   showFormErrors: boolean
   otherStartDates: LocalDate[]
   onChange: SetStateCallback<Form.IncomeStatementForm>
-  onSave: AsyncClickCallback
+  onSave: () => Promise<Result<unknown>> | undefined
   onSuccess: () => void
   onCancel: () => void
 }

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
@@ -83,7 +83,7 @@ export default React.memo(function IncomeStatementEditor() {
   return renderResult(state, (state) => {
     const { id, formData, startDates } = state
 
-    const save = (cancel: () => Promise<void>) => {
+    const save = () => {
       const validatedData = formData ? fromBody('adult', formData) : undefined
       if (validatedData) {
         if (id) {
@@ -94,7 +94,7 @@ export default React.memo(function IncomeStatementEditor() {
       } else {
         setShowFormErrors(true)
         if (form.current) form.current.scrollToErrors()
-        return cancel()
+        return
       }
     }
 

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useImperativeHandle, useMemo, useRef } from 'react'
 import styled from 'styled-components'
 
+import { Result } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
 import { otherIncome } from 'lib-common/api-types/incomeStatement'
 import {
@@ -18,9 +19,7 @@ import { OtherIncome } from 'lib-common/generated/enums'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { scrollToRef } from 'lib-common/utils/scrolling'
-import AsyncButton, {
-  AsyncClickCallback
-} from 'lib-components/atoms/buttons/AsyncButton'
+import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import InputField from 'lib-components/atoms/form/InputField'
@@ -65,7 +64,7 @@ interface Props {
   showFormErrors: boolean
   otherStartDates: LocalDate[]
   onChange: SetStateCallback<Form.IncomeStatementForm>
-  onSave: AsyncClickCallback
+  onSave: () => Promise<Result<unknown>> | undefined
   onSuccess: () => void
   onCancel: () => void
 }

--- a/frontend/src/citizen-frontend/income-statements/api.ts
+++ b/frontend/src/citizen-frontend/income-statements/api.ts
@@ -95,30 +95,42 @@ export const getChildIncomeStatementStartDates = (
 
 export async function createIncomeStatement(
   body: IncomeStatementBody
-): Promise<void> {
-  return client.post('/citizen/income-statements', body)
+): Promise<Result<void>> {
+  return client
+    .post('/citizen/income-statements', body)
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
 }
 
 export async function createChildIncomeStatement(
   childId: string,
   body: IncomeStatementBody
-): Promise<void> {
-  return client.post(`/citizen/income-statements/child/${childId}`, body)
+): Promise<Result<void>> {
+  return client
+    .post(`/citizen/income-statements/child/${childId}`, body)
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
 }
 
 export async function updateIncomeStatement(
   id: UUID,
   body: IncomeStatementBody
-): Promise<void> {
-  return client.put(`/citizen/income-statements/${id}`, body)
+): Promise<Result<void>> {
+  return client
+    .put(`/citizen/income-statements/${id}`, body)
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
 }
 
 export async function updateChildIncomeStatement(
   childId: UUID,
   id: UUID,
   body: IncomeStatementBody
-): Promise<void> {
-  return client.put(`/citizen/income-statements/child/${childId}/${id}`, body)
+): Promise<Result<void>> {
+  return client
+    .put(`/citizen/income-statements/child/${childId}/${id}`, body)
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
 }
 
 export async function deleteIncomeStatement(id: UUID): Promise<Result<void>> {

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
 import { Result } from 'lib-common/api'
@@ -57,6 +57,7 @@ export default React.memo(function MessageEditor({
 
   const title = message.title || i18n.messages.messageEditor.newMessage
 
+  const send = useCallback(() => onSend(message), [message, onSend])
   const sendEnabled = areRequiredFieldsFilledForMessage(message)
 
   return (
@@ -136,7 +137,7 @@ export default React.memo(function MessageEditor({
             primary
             text={i18n.messages.messageEditor.send}
             disabled={!sendEnabled}
-            onClick={() => onSend(message)}
+            onClick={send}
             onSuccess={onSuccess}
             onFailure={onFailure}
             data-qa="send-message-btn"

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
+import { Result } from 'lib-common/api'
 import {
   CitizenMessageBody,
   MessageAccount
@@ -34,7 +35,9 @@ const areRequiredFieldsFilledForMessage = (msg: CitizenMessageBody): boolean =>
 
 interface Props {
   receiverOptions: MessageAccount[]
-  onSend: (messageBody: CitizenMessageBody) => Promise<void>
+  onSend: (messageBody: CitizenMessageBody) => Promise<Result<unknown>>
+  onSuccess: () => void
+  onFailure: () => void
   onClose: () => void
   displaySendError: boolean
 }
@@ -42,6 +45,8 @@ interface Props {
 export default React.memo(function MessageEditor({
   receiverOptions,
   onSend,
+  onSuccess,
+  onFailure,
   onClose,
   displaySendError
 }: Props) {
@@ -132,7 +137,8 @@ export default React.memo(function MessageEditor({
             text={i18n.messages.messageEditor.send}
             disabled={!sendEnabled}
             onClick={() => onSend(message)}
-            onSuccess={() => onClose()}
+            onSuccess={onSuccess}
+            onFailure={onFailure}
             data-qa="send-message-btn"
           />
         </BottomRow>

--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -77,15 +77,12 @@ export default React.memo(function MessagesPage() {
             {editorVisible && (
               <MessageEditor
                 receiverOptions={receivers}
-                onSend={(message) =>
-                  sendMessage(message).then((result) => {
-                    if (result.isSuccess) {
-                      refreshThreads()
-                    } else {
-                      setDisplaySendError(true)
-                    }
-                  })
-                }
+                onSend={(message) => sendMessage(message)}
+                onSuccess={() => {
+                  refreshThreads()
+                  setEditorVisible(false)
+                }}
+                onFailure={() => setDisplaySendError(true)}
                 onClose={() => setEditorVisible(false)}
                 displaySendError={displaySendError}
               />

--- a/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
+++ b/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
@@ -67,7 +67,7 @@ export default React.memo(function PersonalDetails() {
 
   const formWrapper = (children: React.ReactNode) =>
     editing ? (
-      <form onSubmit={(e) => e.preventDefault()}>
+      <form>
         {children}
         <FixedSpaceRow justifyContent="flex-end">
           <Button

--- a/frontend/src/e2e-test/specs/5_employee/absence.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/absence.spec.ts
@@ -21,7 +21,6 @@ import {
   uuidv4
 } from '../../dev-api/fixtures'
 import { DaycarePlacement } from '../../dev-api/types'
-// import AbsencesPage from '../../pages/employee/absences/absences-page'
 import { UnitPage } from '../../pages/employee/units/unit'
 import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'

--- a/frontend/src/employee-frontend/api/applications.ts
+++ b/frontend/src/employee-frontend/api/applications.ts
@@ -135,10 +135,13 @@ export interface PaperApplicationRequest {
   guardianToBeCreated?: CreatePersonBody
 }
 
-export async function sendApplication(applicationId: UUID): Promise<void> {
-  return client.post(
-    `/v2/applications/${applicationId}/actions/send-application`
-  )
+export async function sendApplication(
+  applicationId: UUID
+): Promise<Result<void>> {
+  return client
+    .post(`/v2/applications/${applicationId}/actions/send-application`)
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
 }
 
 export async function moveToWaitingPlacement(
@@ -254,36 +257,49 @@ export function getPlacementDraft(id: UUID): Promise<Result<PlacementDraft>> {
 export async function createPlacementPlan(
   applicationId: UUID,
   placementPlan: DaycarePlacementPlan
-): Promise<void> {
-  return client.post(
-    `/v2/applications/${applicationId}/actions/create-placement-plan`,
-    placementPlan
-  )
+): Promise<Result<void>> {
+  return client
+    .post(
+      `/v2/applications/${applicationId}/actions/create-placement-plan`,
+      placementPlan
+    )
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
 }
 
-export async function acceptPlacementProposal(unitId: UUID): Promise<void> {
-  return client.post(`/v2/applications/placement-proposals/${unitId}/accept`)
+export async function acceptPlacementProposal(
+  unitId: UUID
+): Promise<Result<void>> {
+  return client
+    .post(`/v2/applications/placement-proposals/${unitId}/accept`)
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
 }
 
 export async function acceptDecision(
   applicationId: UUID,
   decisionId: UUID,
   requestedStartDate: LocalDate
-): Promise<void> {
-  return client.post(
-    `/v2/applications/${applicationId}/actions/accept-decision`,
-    { decisionId, requestedStartDate }
-  )
+): Promise<Result<void>> {
+  return client
+    .post(`/v2/applications/${applicationId}/actions/accept-decision`, {
+      decisionId,
+      requestedStartDate
+    })
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
 }
 
 export async function rejectDecision(
   applicationId: UUID,
   decisionId: UUID
-): Promise<void> {
-  return client.post(
-    `/v2/applications/${applicationId}/actions/reject-decision`,
-    { decisionId }
-  )
+): Promise<Result<void>> {
+  return client
+    .post(`/v2/applications/${applicationId}/actions/reject-decision`, {
+      decisionId
+    })
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
 }
 
 export async function batchMoveToWaitingPlacement(
@@ -382,7 +398,7 @@ export async function deleteNote(id: UUID): Promise<void> {
 export async function updateServiceWorkerNote(
   applicationId: UUID,
   text: string
-): Promise<void> {
+): Promise<Result<void>> {
   return client.put(`/note/service-worker/application/${applicationId}`, {
     text
   })

--- a/frontend/src/employee-frontend/api/child/additional-information.ts
+++ b/frontend/src/employee-frontend/api/child/additional-information.ts
@@ -23,9 +23,9 @@ export async function getAdditionalInformation(
 export async function updateAdditionalInformation(
   id: UUID,
   data: AdditionalInformation
-): Promise<Result<null>> {
+): Promise<Result<void>> {
   return client
     .put(`/children/${id}/additional-information`, data)
-    .then(() => Success.of(null))
+    .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-frontend/api/child/daily-service-times.ts
+++ b/frontend/src/employee-frontend/api/child/daily-service-times.ts
@@ -27,18 +27,18 @@ export async function getChildDailyServiceTimes(
 export async function putChildDailyServiceTimes(
   childId: UUID,
   data: DailyServiceTimes
-): Promise<Result<null>> {
+): Promise<Result<void>> {
   return client
     .put(`/children/${childId}/daily-service-times`, data)
-    .then(() => Success.of(null))
+    .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 }
 
 export async function deleteChildDailyServiceTimes(
   childId: UUID
-): Promise<Result<null>> {
+): Promise<Result<void>> {
   return client
     .delete(`/children/${childId}/daily-service-times`)
-    .then(() => Success.of(null))
+    .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-frontend/api/child/placements.ts
+++ b/frontend/src/employee-frontend/api/child/placements.ts
@@ -94,14 +94,14 @@ export async function getPlacements(
 export async function updatePlacement(
   placementId: UUID,
   body: PlacementUpdate
-): Promise<Result<null>> {
+): Promise<Result<void>> {
   return client
     .put(`/placements/${placementId}`, {
       ...body,
       startDate: body.startDate,
       endDate: body.endDate
     })
-    .then(() => Success.of(null))
+    .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 }
 

--- a/frontend/src/employee-frontend/api/decision-draft.ts
+++ b/frontend/src/employee-frontend/api/decision-draft.ts
@@ -40,8 +40,11 @@ export async function getDecisionDrafts(
 export async function updateDecisionDrafts(
   id: UUID,
   updatedDrafts: DecisionDraftUpdate[]
-): Promise<void> {
-  return client.put(`/v2/applications/${id}/decision-drafts`, updatedDrafts)
+): Promise<Result<void>> {
+  return client
+    .put(`/v2/applications/${id}/decision-drafts`, updatedDrafts)
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
 }
 
 export function getDecisionUnits(): Promise<Result<DecisionUnit[]>> {

--- a/frontend/src/employee-frontend/api/employees.ts
+++ b/frontend/src/employee-frontend/api/employees.ts
@@ -81,12 +81,12 @@ export function getEmployeeDetails(id: UUID): Promise<Result<EmployeeUser>> {
 export function updateEmployee(
   id: UUID,
   globalRoles: GlobalRole[]
-): Promise<Result<null>> {
+): Promise<Result<void>> {
   return client
     .put(`/employee/${id}`, {
       globalRoles
     })
-    .then(() => Success.of(null))
+    .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 }
 

--- a/frontend/src/employee-frontend/components/SettingsPage.tsx
+++ b/frontend/src/employee-frontend/components/SettingsPage.tsx
@@ -52,10 +52,10 @@ export default React.memo(function SettingsPage() {
   const loadSettings = useRestApi(getSettings, setSettings)
   useEffect(loadSettings, [loadSettings])
 
-  const submit = useCallback(async () => {
+  const submit = useCallback(() => {
     if (!settings.isSuccess) return
 
-    return await putSettings(
+    return putSettings(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       Object.fromEntries(
         Object.entries(settings.value)

--- a/frontend/src/employee-frontend/components/application-page/ApplicationActionsBar.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationActionsBar.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
+import { Success } from 'lib-common/api'
 import { ApplicationDetails } from 'lib-common/api-types/application/ApplicationDetails'
 import { ApplicationStatus } from 'lib-common/generated/api-types/application'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
@@ -75,10 +76,10 @@ export default React.memo(function ApplicationActionsBar({
           textDone={i18n.common.saved}
           disabled={!editedApplication || errors}
           onClick={() =>
-            updateApplication(editedApplication).then((res) =>
+            updateApplication(editedApplication).then(() =>
               editedApplication.status === 'CREATED'
                 ? sendApplication(editedApplication.id)
-                : res
+                : Success.of()
             )
           }
           onSuccess={() => {

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -535,7 +535,7 @@ const ApplicationsList = React.memo(function Applications({
       {editedNote && (
         <AsyncFormModal
           title={i18n.applications.list.serviceWorkerNote}
-          resolveAction={async () =>
+          resolveAction={() =>
             updateServiceWorkerNote(editedNote, editedNoteText)
           }
           resolveLabel={i18n.common.save}

--- a/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
@@ -6,10 +6,9 @@ import React, { useCallback, useContext, useMemo, useState } from 'react'
 import { useEffect } from 'react'
 import styled from 'styled-components'
 
-import { Loading, Result } from 'lib-common/api'
+import { Result } from 'lib-common/api'
 import {
   isRegular,
-  DailyServiceTimes,
   isIrregular,
   RegularDailyServiceTimes,
   IrregularDailyServiceTimes,
@@ -19,7 +18,8 @@ import {
 } from 'lib-common/api-types/child/common'
 import { DailyServiceTimesType } from 'lib-common/generated/enums'
 import { UUID } from 'lib-common/types'
-import { useRestApi } from 'lib-common/utils/useRestApi'
+import { useApiState } from 'lib-common/utils/useRestApi'
+import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
@@ -162,7 +162,7 @@ function validate(
   }
 }
 
-function saveFormData(id: UUID, formData: FormData) {
+function saveFormData(id: UUID, formData: FormData): Promise<Result<void>> {
   switch (formData.type) {
     case 'NOT_SET':
       return deleteChildDailyServiceTimes(id)
@@ -248,18 +248,16 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
 
   const [open, setOpen] = useState(startOpen)
 
-  const [apiData, setApiData] = useState<Result<DailyServiceTimes | null>>(
-    Loading.of()
+  const [apiData, loadData] = useApiState(
+    () => getChildDailyServiceTimes(id),
+    [id]
   )
   const [formData, setFormData] = useState<FormData | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [validationResult, setValidationResult] =
     useState<ValidationResult | null>(null)
 
-  const loadData = useRestApi(getChildDailyServiceTimes, setApiData)
-  useEffect(() => loadData(id), [id, loadData])
-
-  const startEditing = () => {
+  const startEditing = useCallback(() => {
     if (apiData.isSuccess) {
       if (apiData.value === null) {
         setFormData(emptyForm)
@@ -321,7 +319,7 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
     } else {
       setFormData(null)
     }
-  }
+  }, [apiData])
 
   const formIsValid = useMemo(
     () =>
@@ -349,23 +347,24 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
   const onSubmit = useCallback(() => {
     if (!formIsValid || !formData) return
     setSubmitting(true)
+    return saveFormData(id, formData)
+  }, [formData, formIsValid, id])
 
-    saveFormData(id, formData)
-      .then((res) => {
-        if (res.isSuccess) {
-          setFormData(null)
-          loadData(id)
-        } else {
-          setErrorMessage({
-            type: 'error',
-            title: i18n.common.error.unknown,
-            text: i18n.common.error.saveFailed,
-            resolveLabel: i18n.common.ok
-          })
-        }
-      })
-      .finally(() => setSubmitting(false))
-  }, [formData, formIsValid, i18n, id, loadData, setErrorMessage])
+  const onSuccess = useCallback(() => {
+    setSubmitting(false)
+    setFormData(null)
+    loadData()
+  }, [loadData])
+
+  const onFailure = useCallback(() => {
+    setSubmitting(false)
+    setErrorMessage({
+      type: 'error',
+      title: i18n.common.error.unknown,
+      text: i18n.common.error.saveFailed,
+      resolveLabel: i18n.common.ok
+    })
+  }, [i18n, setErrorMessage])
 
   const setType = (type: 'NOT_SET' | DailyServiceTimesType) => () =>
     setFormData((old) => (old !== null ? { ...old, type } : null))
@@ -572,10 +571,12 @@ const DailyServiceTimesSection = React.memo(function DailyServiceTimesSection({
                     onClick={() => setFormData(null)}
                     disabled={submitting}
                   />
-                  <Button
+                  <AsyncButton
                     text={i18n.common.confirm}
                     onClick={onSubmit}
-                    disabled={submitting || !formIsValid}
+                    onSuccess={onSuccess}
+                    onFailure={onFailure}
+                    disabled={!formIsValid}
                     primary
                     data-qa="submit-button"
                   />

--- a/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationList.tsx
+++ b/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationList.tsx
@@ -5,6 +5,7 @@
 import React, { Fragment } from 'react'
 import styled from 'styled-components'
 
+import { Result } from 'lib-common/api'
 import { UUID } from 'lib-common/types'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import ListGrid from 'lib-components/layout/ListGrid'
@@ -22,7 +23,9 @@ interface Props {
   toggleEditing: (id: UUID) => void
   isEdited: (id: UUID) => boolean
   cancel: () => void
-  update: (v: FeeAlteration) => void
+  update: (v: FeeAlteration) => Promise<Result<unknown>>
+  onSuccess: () => void
+  onFailure?: () => void
   toggleDeleteModal: (v: FeeAlteration) => void
 }
 
@@ -32,6 +35,8 @@ export default React.memo(function FeeAlterationList({
   isEdited,
   cancel,
   update,
+  onSuccess,
+  onFailure,
   toggleDeleteModal
 }: Props) {
   const { i18n } = useTranslation()
@@ -50,8 +55,9 @@ export default React.memo(function FeeAlterationList({
               personId={feeAlteration.personId}
               baseFeeAlteration={feeAlteration}
               cancel={cancel}
-              create={() => undefined}
               update={update}
+              onSuccess={onSuccess}
+              onFailure={onFailure}
             />
           </EditorWrapper>
         ) : (

--- a/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
@@ -125,9 +125,9 @@ export default React.memo(function PlacementRow({
   }, [onRefreshNeeded])
 
   const onFailure = useCallback(
-    (res: Failure<unknown> | undefined) => {
+    (res: Failure<unknown>) => {
       const message =
-        res?.statusCode === 403
+        res.statusCode === 403
           ? i18n.common.error.forbidden
           : res?.statusCode === 409
           ? i18n.childInformation.placements.error.conflict.title

--- a/frontend/src/employee-frontend/components/employee/EmployeePinCodePage.tsx
+++ b/frontend/src/employee-frontend/components/employee/EmployeePinCodePage.tsx
@@ -5,7 +5,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useEffect, useState } from 'react'
 
-import { Result } from 'lib-common/api'
 import usePrompt from 'lib-common/utils/usePrompt'
 import Title from 'lib-components/atoms/Title'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
@@ -26,11 +25,11 @@ export default React.memo(function EmployeePinCodePage() {
   const { i18n } = useTranslation()
   const [pin, setPin] = useState<string>('')
   const [error, setError] = useState<boolean>(false)
-  const [pinLocked, setPinLocked] = useState<Result<boolean>>()
+  const [pinLocked, setPinLocked] = useState<boolean>(false)
   const [dirty, setDirty] = useState<boolean>(false)
 
   useEffect(() => {
-    void isPinCodeLocked().then(setPinLocked)
+    void isPinCodeLocked().then((res) => res.map(setPinLocked))
   }, [setPinLocked])
 
   function isValidNumber(pin: string) {
@@ -64,7 +63,6 @@ export default React.memo(function EmployeePinCodePage() {
     return updatePinCode(pin)
       .then(() => setDirty(false))
       .then(isPinCodeLocked)
-      .then(setPinLocked)
   }
 
   function getInputInfo(): InputInfo | undefined {
@@ -73,7 +71,7 @@ export default React.memo(function EmployeePinCodePage() {
           text: i18n.pinCode.error,
           status: 'warning'
         }
-      : pinLocked && pinLocked.isSuccess && pinLocked.value && !pin
+      : pinLocked && !pin
       ? {
           text: i18n.pinCode.locked,
           status: 'warning'
@@ -98,7 +96,7 @@ export default React.memo(function EmployeePinCodePage() {
         <Title size={2}>{i18n.pinCode.title2}</Title>
         <P>{i18n.pinCode.text5}</P>
 
-        {pinLocked && pinLocked.isSuccess && pinLocked.value && (
+        {pinLocked && (
           <AlertBox
             data-qa="pin-locked-alert-box"
             message={i18n.pinCode.lockedLong}
@@ -124,7 +122,8 @@ export default React.memo(function EmployeePinCodePage() {
             primary
             text={i18n.pinCode.button}
             onClick={savePinCode}
-            onSuccess={() => {
+            onSuccess={(isLocked) => {
+              setPinLocked(isLocked)
               setError(false)
             }}
             data-qa="send-pin-button"

--- a/frontend/src/employee-frontend/components/fee-decisions/Actions.tsx
+++ b/frontend/src/employee-frontend/components/fee-decisions/Actions.tsx
@@ -46,26 +46,18 @@ const Actions = React.memo(function Actions({
         primary
         text={i18n.feeDecisions.buttons.createDecision(checkedIds.length)}
         disabled={checkedIds.length === 0}
-        onClick={() =>
-          confirmFeeDecisions(checkedIds).then((result) => {
-            if (result.isSuccess) {
-              setError(undefined)
-            }
-
-            if (result.isFailure) {
-              setError(
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                i18n.feeDecisions.buttons.errors[result.errorCode ?? ''] ??
-                  i18n.common.error.unknown
-              )
-            }
-
-            return result
-          })
-        }
+        onClick={() => confirmFeeDecisions(checkedIds)}
         onSuccess={() => {
+          setError(undefined)
           clearChecked()
           loadDecisions()
+        }}
+        onFailure={(result) => {
+          setError(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            i18n.feeDecisions.buttons.errors[result.errorCode ?? ''] ??
+              i18n.common.error.unknown
+          )
         }}
         data-qa="confirm-decisions"
       />

--- a/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsItem.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsItem.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import { FeeThresholds } from 'lib-common/api-types/finance'
@@ -15,10 +15,11 @@ import {
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
+import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { H3, H4, Label } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import { Translations } from 'lib-customizations/employee'
-import { faCopy, faPen } from 'lib-icons'
+import { faCopy, faPen, faQuestion } from 'lib-icons'
 
 import { familySizes } from '../../types/finance-basics'
 import StatusLabel from '../common/StatusLabel'
@@ -30,8 +31,7 @@ export const FeeThresholdsItem = React.memo(function FeeThresholdsItem({
   copyThresholds,
   editThresholds,
   editing,
-  toggleEditRetroactiveWarning,
-  ...props
+  'data-qa': dataQa
 }: {
   i18n: Translations
   id: string
@@ -39,13 +39,13 @@ export const FeeThresholdsItem = React.memo(function FeeThresholdsItem({
   copyThresholds: (feeThresholds: FeeThresholds) => void
   editThresholds: (id: string, feeThresholds: FeeThresholds) => void
   editing: boolean
-  toggleEditRetroactiveWarning: (resolve: () => void) => void
-  ['data-qa']: string
+  'data-qa': string
 }) {
+  const [showModal, setShowModal] = useState(false)
   return (
     <>
       <div className="separator large" />
-      <div data-qa={props['data-qa']}>
+      <div data-qa={dataQa}>
         <TitleContainer>
           <H3>
             {i18n.financeBasics.fees.validDuring}{' '}
@@ -68,9 +68,7 @@ export const FeeThresholdsItem = React.memo(function FeeThresholdsItem({
                 ) {
                   editThresholds(id, feeThresholds)
                 } else {
-                  toggleEditRetroactiveWarning(() =>
-                    editThresholds(id, feeThresholds)
-                  )
+                  setShowModal(true)
                 }
               }}
               disabled={editing}
@@ -177,6 +175,25 @@ export const FeeThresholdsItem = React.memo(function FeeThresholdsItem({
           </FixedSpaceColumn>
         </RowWithMargin>
       </div>
+      {showModal ? (
+        <InfoModal
+          icon={faQuestion}
+          type="danger"
+          title={i18n.financeBasics.fees.modals.editRetroactive.title}
+          text={i18n.financeBasics.fees.modals.editRetroactive.text}
+          reject={{
+            action: () => setShowModal(false),
+            label: i18n.financeBasics.fees.modals.editRetroactive.reject
+          }}
+          resolve={{
+            action: () => {
+              setShowModal(false)
+              editThresholds(id, feeThresholds)
+            },
+            label: i18n.financeBasics.fees.modals.editRetroactive.resolve
+          }}
+        />
+      ) : null}
     </>
   )
 })

--- a/frontend/src/employee-frontend/components/finance-basics/FeesSection.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeesSection.tsx
@@ -10,9 +10,7 @@ import { formatCents } from 'lib-common/money'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
-import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { H2 } from 'lib-components/typography'
-import { faQuestion } from 'lib-icons'
 
 import { getFeeThresholds } from '../../api/finance-basics'
 import { useTranslation } from '../../state/i18n'
@@ -29,33 +27,6 @@ export default React.memo(function FeesSection() {
   const toggleOpen = useCallback(() => setOpen((isOpen) => !isOpen), [setOpen])
 
   const [data, loadData] = useApiState(() => getFeeThresholds(), [])
-
-  const [modal, setModal] = useState<{
-    type: 'editRetroactive' | 'saveRetroactive'
-    resolve: () => void
-    reject?: () => void
-  }>()
-
-  const toggleEditRetroactiveWarning = useCallback(
-    (resolve: () => void) => {
-      setModal({
-        type: 'editRetroactive',
-        resolve
-      })
-    },
-    [setModal]
-  )
-
-  const toggleSaveRetroactiveWarning = useCallback(
-    ({ resolve, reject }: { resolve: () => void; reject: () => void }) => {
-      setModal({
-        type: 'saveRetroactive',
-        resolve,
-        reject
-      })
-    },
-    [setModal]
-  )
 
   const [editorState, setEditorState] = useState<EditorState>({})
   const closeEditor = useCallback(() => setEditorState({}), [setEditorState])
@@ -118,7 +89,6 @@ export default React.memo(function FeesSection() {
           initialState={editorState.form}
           close={closeEditor}
           reloadData={loadData}
-          toggleSaveRetroactiveWarning={toggleSaveRetroactiveWarning}
           existingThresholds={data}
         />
       ) : null}
@@ -133,7 +103,6 @@ export default React.memo(function FeesSection() {
                 initialState={editorState.form}
                 close={closeEditor}
                 reloadData={loadData}
-                toggleSaveRetroactiveWarning={toggleSaveRetroactiveWarning}
                 existingThresholds={data}
               />
             ) : (
@@ -145,35 +114,12 @@ export default React.memo(function FeesSection() {
                 copyThresholds={copyThresholds}
                 editThresholds={editThresholds}
                 editing={!!editorState.editing}
-                toggleEditRetroactiveWarning={toggleEditRetroactiveWarning}
                 data-qa={`fee-thresholds-item-${index}`}
               />
             )
           )}
         </>
       ))}
-      {modal ? (
-        <InfoModal
-          icon={faQuestion}
-          type="danger"
-          title={i18n.financeBasics.fees.modals[modal.type].title}
-          text={i18n.financeBasics.fees.modals[modal.type].text}
-          reject={{
-            action: () => {
-              setModal(undefined)
-              modal.reject?.()
-            },
-            label: i18n.financeBasics.fees.modals[modal.type].reject
-          }}
-          resolve={{
-            action: () => {
-              setModal(undefined)
-              modal.resolve()
-            },
-            label: i18n.financeBasics.fees.modals[modal.type].resolve
-          }}
-        />
-      ) : null}
     </CollapsibleContentArea>
   )
 })

--- a/frontend/src/employee-frontend/components/holiday-periods/FixedPeriodQuestionnaireForm.tsx
+++ b/frontend/src/employee-frontend/components/holiday-periods/FixedPeriodQuestionnaireForm.tsx
@@ -286,9 +286,8 @@ export default React.memo(function FixedPeriodQuestionnaireForm({
 
   const onSubmit = useCallback(() => {
     const body = isValid && formToQuestionnaireBody(form)
-    if (!body) {
-      return Promise.reject()
-    }
+    if (!body) return
+
     return questionnaire
       ? updateFixedPeriodQuestionnaire(questionnaire.id, body)
       : createFixedPeriodQuestionnaire(body)
@@ -607,8 +606,8 @@ export default React.memo(function FixedPeriodQuestionnaireForm({
           primary
           disabled={!isValid}
           text={i18n.common.save}
-          onSuccess={onSuccess}
           onClick={onSubmit}
+          onSuccess={onSuccess}
           data-qa="save-btn"
         />
         <Button onClick={onCancel} text={i18n.common.goBack} />

--- a/frontend/src/employee-frontend/components/holiday-periods/HolidayPeriodForm.tsx
+++ b/frontend/src/employee-frontend/components/holiday-periods/HolidayPeriodForm.tsx
@@ -108,9 +108,8 @@ export default React.memo(function HolidayPeriodForm({
 
   const onSubmit = useCallback(() => {
     const validForm = isValid && formToHolidayPeriodBody(form)
-    if (!validForm) {
-      return Promise.reject()
-    }
+    if (!validForm) return
+
     const apiCall = holidayPeriod
       ? (params: HolidayPeriodBody) =>
           updateHolidayPeriod(holidayPeriod.id, params)

--- a/frontend/src/employee-frontend/components/invoices/Actions.tsx
+++ b/frontend/src/employee-frontend/components/invoices/Actions.tsx
@@ -68,23 +68,13 @@ const Actions = React.memo(function Actions({
       <AsyncButton
         text={i18n.invoices.buttons.deleteInvoice(checkedIds.length)}
         disabled={checkedIds.length === 0}
-        onClick={() =>
-          deleteInvoices(checkedIds).then((result) => {
-            if (result.isSuccess) {
-              setError(undefined)
-            }
-
-            if (result.isFailure) {
-              setError(i18n.common.error.unknown)
-            }
-
-            return result
-          })
-        }
+        onClick={() => deleteInvoices(checkedIds)}
         onSuccess={() => {
+          setError(undefined)
           actions.clearChecked()
           reloadInvoices()
         }}
+        onFailure={() => setError(i18n.common.error.unknown)}
         data-qa="delete-invoices"
       />
       <Gap size="s" horizontal />

--- a/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
@@ -134,7 +134,7 @@ const Modal = React.memo(function Modal({
         LocalDate.parseFiOrThrow(date)
       )
     }
-    return Promise.resolve()
+    return
   }, [headOfFamily, date, dateIsValid])
 
   const onSuccess = useCallback(() => {

--- a/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
-import { combine, Result } from 'lib-common/api'
+import { combine, Failure, Result } from 'lib-common/api'
 import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Pagination from 'lib-components/Pagination'
@@ -178,22 +178,18 @@ export const Incomes = React.memo(function Incomes({
     return res
   }
 
-  const handleErrors = (res: Result<unknown>) => {
-    if (res.isFailure) {
-      const text =
-        res.statusCode === 409
-          ? i18n.personProfile.income.details.conflictErrorText
-          : undefined
+  const handleErrors = (res: Failure<unknown>) => {
+    const text =
+      res.statusCode === 409
+        ? i18n.personProfile.income.details.conflictErrorText
+        : undefined
 
-      setErrorMessage({
-        type: 'error',
-        title: i18n.personProfile.income.details.updateError,
-        text,
-        resolveLabel: i18n.common.ok
-      })
-
-      throw res.message
-    }
+    setErrorMessage({
+      type: 'error',
+      title: i18n.personProfile.income.details.updateError,
+      text,
+      resolveLabel: i18n.common.ok
+    })
   }
 
   return (
@@ -222,20 +218,17 @@ export const Incomes = React.memo(function Incomes({
               deleting={deleting}
               setDeleting={setDeleting}
               createIncome={(income: IncomeBody) =>
-                createIncome(personId, income)
-                  .then(toggleCreated)
-                  .then(handleErrors)
+                createIncome(personId, income).then(toggleCreated)
               }
               updateIncome={(incomeId: UUID, income: Income) =>
-                updateIncome(incomeId, income).then(handleErrors)
+                updateIncome(incomeId, income)
               }
-              deleteIncome={(incomeId: UUID) =>
-                deleteIncome(incomeId).then(handleErrors)
-              }
+              deleteIncome={(incomeId: UUID) => deleteIncome(incomeId)}
               onSuccessfulUpdate={() => {
                 setEditing(undefined)
                 reloadIncomes()
               }}
+              onFailedUpdate={handleErrors}
             />
           </>
         )

--- a/frontend/src/employee-frontend/components/person-profile/PersonInvoiceCorrections.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonInvoiceCorrections.tsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { formatPersonName } from 'employee-frontend/utils'
-import { combine, Result } from 'lib-common/api'
+import { combine, Result, Success } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { UpdateStateFn } from 'lib-common/form-state'
 import {
@@ -139,10 +139,10 @@ export default React.memo(function PersonInvoiceCorrections({
   )
 
   const saveNote = useCallback(() => {
-    if (!noteModalState) return Promise.resolve()
+    if (!noteModalState) return
     if (noteModalState.id === 'new') {
       updateState({ note: noteModalState.note })
-      return Promise.resolve()
+      return
     } else {
       return updateInvoiceCorrectionNote(noteModalState.id, noteModalState.note)
     }
@@ -330,7 +330,7 @@ const ChildSection = React.memo(function ChildSection({
             <InlineButton text={i18n.common.cancel} onClick={cancelEditing} />
             <InlineAsyncButton
               text={i18n.common.save}
-              onClick={save ?? (() => Promise.resolve())}
+              onClick={save ?? (() => Promise.resolve(Success.of()))}
               onSuccess={onSaveSuccess}
               disabled={!save}
             />

--- a/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
@@ -136,13 +136,13 @@ const Modal = React.memo(function Modal({
   const dateIsValid = LocalDate.parseFiOrNull(date)
 
   const resolve = useCallback(() => {
-    if (dateIsValid) {
+    if (!dateIsValid) {
       return createRetroactiveValueDecisions(
         headOfFamily,
         LocalDate.parseFiOrThrow(date)
       )
     }
-    return Promise.resolve()
+    return
   }, [headOfFamily, date, dateIsValid])
 
   const onSuccess = useCallback(() => {

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
+import { Failure, Result } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
 import {
   IncomeCoefficient,
@@ -146,9 +147,10 @@ interface Props {
   baseIncome?: Income
   incomeTypeOptions: IncomeTypeOptions
   cancel: () => void
-  update: (income: Income) => Promise<void>
-  create: (income: IncomeBody) => Promise<void>
+  update: (income: Income) => Promise<Result<unknown>> | void
+  create: (income: IncomeBody) => Promise<Result<unknown>>
   onSuccess: () => void
+  onFailure: (value: Failure<unknown>) => void
 }
 
 const IncomeItemEditor = React.memo(function IncomeItemEditor({
@@ -157,7 +159,8 @@ const IncomeItemEditor = React.memo(function IncomeItemEditor({
   cancel,
   update,
   create,
-  onSuccess
+  onSuccess,
+  onFailure
 }: Props) {
   const { i18n } = useTranslation()
 
@@ -311,14 +314,15 @@ const IncomeItemEditor = React.memo(function IncomeItemEditor({
           textInProgress={i18n.common.saving}
           textDone={i18n.common.saved}
           disabled={Object.values(validationErrors).some(Boolean)}
-          onClick={() => {
+          onClick={(): Promise<Result<unknown>> | void => {
             const body = formToIncomeBody(editedIncome)
-            if (!body) return Promise.reject()
+            if (!body) return
             return !baseIncome
               ? create(body)
               : update({ ...baseIncome, ...body })
           }}
           onSuccess={onSuccess}
+          onFailure={onFailure}
           data-qa="save-income"
         />
       </ButtonsContainer>

--- a/frontend/src/employee-frontend/components/reports/VardaErrors.tsx
+++ b/frontend/src/employee-frontend/components/reports/VardaErrors.tsx
@@ -57,12 +57,8 @@ export default React.memo(function VardaErrors() {
   }
 
   const markChildForResetAndReload = async (childId: string) => {
-    await markChildForVardaReset(childId)
     setDirty(true)
-  }
-
-  const startResetVardaChildren = async () => {
-    await runResetVardaChildren()
+    return markChildForVardaReset(childId)
   }
 
   return (
@@ -72,7 +68,7 @@ export default React.memo(function VardaErrors() {
         <Title size={1}>{i18n.reports.vardaErrors.title}</Title>
         <AsyncButton
           text={i18n.reports.vardaErrors.vardaResetButton}
-          onClick={startResetVardaChildren}
+          onClick={runResetVardaChildren}
           onSuccess={() => null}
         />
         {rows.isLoading && <Loader />}

--- a/frontend/src/employee-frontend/components/unit/tab-groups/notes/ChildDailyNoteForm.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/notes/ChildDailyNoteForm.tsx
@@ -119,16 +119,17 @@ export default React.memo(function ChildDailyNoteForm({
   const submit = useCallback(() => {
     setSubmitting(true)
     const body = formDataToRequestBody(form)
-    const promise = note
+    return note
       ? putChildDailyNote(note.id, body)
       : postChildDailyNote(childId, body)
-    return promise.then((res) => {
-      setSubmitting(false)
-      if (res.isSuccess) {
-        onSuccess()
-      }
-    })
-  }, [childId, form, note, onSuccess])
+  }, [childId, form, note])
+  const submitSuccess = useCallback(() => {
+    setSubmitting(false)
+    onSuccess()
+  }, [onSuccess])
+  const submitFailure = useCallback(() => {
+    setSubmitting(false)
+  }, [])
 
   const [deleting, setDeleting] = useState(false)
   const clearNote = useCallback(() => {
@@ -288,7 +289,8 @@ export default React.memo(function ChildDailyNoteForm({
             primary
             onClick={submit}
             text={i18n.common.save}
-            onSuccess={onSuccess}
+            onSuccess={submitSuccess}
+            onFailure={submitFailure}
             data-qa="btn-submit"
           />
         </FixedSpaceRow>

--- a/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposals.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposals.tsx
@@ -3,7 +3,14 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import _ from 'lodash'
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import styled from 'styled-components'
 
 import {
@@ -11,10 +18,10 @@ import {
   PlacementPlanRejectReason
 } from 'lib-common/generated/api-types/placement'
 import { UUID } from 'lib-common/types'
-import Button from 'lib-components/atoms/buttons/Button'
+import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import InputField from 'lib-components/atoms/form/InputField'
 import Radio from 'lib-components/atoms/form/Radio'
-import { Table, Th, Tr, Thead, Tbody } from 'lib-components/layout/Table'
+import { Table, Tbody, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import FormModal from 'lib-components/molecules/modals/FormModal'
 import { Label, P } from 'lib-components/typography'
@@ -131,6 +138,27 @@ export default React.memo(function PlacementProposals({
     }
   }
 
+  const onAccept = useCallback(() => acceptPlacementProposal(unitId), [unitId])
+
+  const onAcceptFailure = useCallback(() => {
+    setErrorMessage({
+      type: 'error',
+      title: i18n.common.error.unknown,
+      resolveLabel: i18n.common.ok
+    })
+  }, [i18n, setErrorMessage])
+
+  const acceptDisabled = useMemo(
+    () =>
+      Object.values(confirmationStates).some((state) => state.submitting) ||
+      !Object.values(confirmationStates).some(
+        (state) =>
+          state.confirmation === 'ACCEPTED' ||
+          state.confirmation === 'REJECTED_NOT_CONFIRMED'
+      ),
+    [confirmationStates]
+  )
+
   const sortedRows = _.sortBy(placementPlans, [
     (p: DaycarePlacementPlan) => p.child.lastName,
     (p: DaycarePlacementPlan) => p.child.firstName,
@@ -240,31 +268,14 @@ export default React.memo(function PlacementProposals({
 
       {placementPlans.length > 0 && (
         <ButtonRow>
-          <Button
+          <AsyncButton
             data-qa="placement-proposals-accept-button"
-            onClick={() => {
-              acceptPlacementProposal(unitId)
-                .then(loadUnitData)
-                .catch(() =>
-                  setErrorMessage({
-                    type: 'error',
-                    title: i18n.common.error.unknown,
-                    resolveLabel: i18n.common.ok
-                  })
-                )
-            }}
+            onClick={onAccept}
+            onSuccess={loadUnitData}
+            onFailure={onAcceptFailure}
+            disabled={acceptDisabled}
             text={i18n.unit.placementProposals.acceptAllButton}
             primary
-            disabled={
-              Object.values(confirmationStates).some(
-                (state) => state.submitting
-              ) ||
-              !Object.values(confirmationStates).some(
-                (state) =>
-                  state.confirmation === 'ACCEPTED' ||
-                  state.confirmation === 'REJECTED_NOT_CONFIRMED'
-              )
-            }
           />
         </ButtonRow>
       )}

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
@@ -112,10 +112,10 @@ export default React.memo(function ReservationModalSingleChild({
     <AsyncFormModal
       mobileFullScreen
       title={i18n.unit.attendanceReservations.reservationModal.title}
-      resolveAction={(cancel) => {
+      resolveAction={() => {
         if (validationResult.errors) {
           setShowAllErrors(true)
-          return cancel()
+          return
         } else {
           return postReservations(validationResult.requestPayload)
         }

--- a/frontend/src/employee-frontend/components/vasu/templates/api.ts
+++ b/frontend/src/employee-frontend/components/vasu/templates/api.ts
@@ -83,16 +83,16 @@ export async function getVasuTemplate(id: UUID): Promise<Result<VasuTemplate>> {
 export async function updateVasuTemplateContents(
   id: UUID,
   content: VasuContent
-): Promise<Result<null>> {
+): Promise<Result<void>> {
   return client
     .put(`/vasu/templates/${id}/content`, content)
-    .then(() => Success.of(null))
+    .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 }
 
-export async function deleteVasuTemplate(id: UUID): Promise<Result<null>> {
+export async function deleteVasuTemplate(id: UUID): Promise<Result<void>> {
   return client
     .delete(`/vasu/templates/${id}`)
-    .then(() => Success.of(null))
+    .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-frontend/components/voucher-value-decision/VoucherValueDecisionActionBar.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decision/VoucherValueDecisionActionBar.tsx
@@ -35,45 +35,16 @@ export default React.memo(function VoucherValueDecisionActionBar({
   const { i18n } = useTranslation()
   const { setErrorMessage, clearErrorMessage } = useContext(UIContext)
   const updateType = useCallback(
-    () =>
-      setVoucherDecisionType(decision.id, newDecisionType).then((result) => {
-        if (result.isSuccess) {
-          clearErrorMessage()
-        } else if (result.isFailure) {
-          setErrorMessage({
-            title: i18n.common.error.unknown,
-            text: i18n.common.error.saveFailed,
-            type: 'error',
-            resolveLabel: i18n.common.ok
-          })
-        }
-        return result
-      }),
-    [i18n, decision.id, newDecisionType, setErrorMessage, clearErrorMessage]
+    () => setVoucherDecisionType(decision.id, newDecisionType),
+    [decision.id, newDecisionType]
   )
   const reloadDecision = useCallback(
     () => loadDecision().then(() => setModified(false)),
     [loadDecision, setModified]
   )
   const sendDecision = useCallback(
-    () =>
-      sendVoucherValueDecisions([decision.id]).then((result) => {
-        if (result.isSuccess) {
-          clearErrorMessage()
-        } else if (result.isFailure) {
-          setErrorMessage({
-            title: i18n.common.error.unknown,
-            text:
-              result.errorCode === 'WAITING_FOR_MANUAL_SENDING'
-                ? i18n.valueDecisions.buttons.errors.WAITING_FOR_MANUAL_SENDING
-                : i18n.common.error.saveFailed,
-            type: 'error',
-            resolveLabel: i18n.common.ok
-          })
-        }
-        return result
-      }),
-    [i18n, decision.id, setErrorMessage, clearErrorMessage]
+    () => sendVoucherValueDecisions([decision.id]),
+    [decision.id]
   )
 
   const isDraft = decision.status === 'DRAFT'
@@ -88,7 +59,18 @@ export default React.memo(function VoucherValueDecisionActionBar({
             textInProgress={i18n.common.saving}
             textDone={i18n.common.saved}
             onClick={updateType}
-            onSuccess={reloadDecision}
+            onSuccess={() => {
+              clearErrorMessage()
+              void reloadDecision()
+            }}
+            onFailure={() => {
+              setErrorMessage({
+                title: i18n.common.error.unknown,
+                text: i18n.common.error.saveFailed,
+                type: 'error',
+                resolveLabel: i18n.common.ok
+              })
+            }}
             disabled={!modified}
             data-qa="button-save-decision"
           />
@@ -98,7 +80,22 @@ export default React.memo(function VoucherValueDecisionActionBar({
             disabled={modified}
             text={i18n.common.send}
             onClick={sendDecision}
-            onSuccess={loadDecision}
+            onSuccess={() => {
+              clearErrorMessage()
+              void loadDecision()
+            }}
+            onFailure={(result) => {
+              setErrorMessage({
+                title: i18n.common.error.unknown,
+                text:
+                  result.errorCode === 'WAITING_FOR_MANUAL_SENDING'
+                    ? i18n.valueDecisions.buttons.errors
+                        .WAITING_FOR_MANUAL_SENDING
+                    : i18n.common.error.saveFailed,
+                type: 'error',
+                resolveLabel: i18n.common.ok
+              })
+            }}
           />
         </>
       )}

--- a/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionActions.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionActions.tsx
@@ -46,26 +46,18 @@ const Actions = React.memo(function Actions({
         primary
         text={i18n.valueDecisions.buttons.createDecision(checkedIds.length)}
         disabled={checkedIds.length === 0}
-        onClick={() =>
-          sendVoucherValueDecisions(checkedIds).then((result) => {
-            if (result.isSuccess) {
-              setError(undefined)
-            }
-
-            if (result.isFailure) {
-              setError(
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                i18n.valueDecisions.buttons.errors[result.errorCode ?? ''] ??
-                  i18n.common.error.unknown
-              )
-            }
-
-            return result
-          })
-        }
+        onClick={() => sendVoucherValueDecisions(checkedIds)}
         onSuccess={() => {
+          setError(undefined)
           clearChecked()
           loadDecisions()
+        }}
+        onFailure={(result) => {
+          setError(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            i18n.valueDecisions.buttons.errors[result.errorCode ?? ''] ??
+              i18n.common.error.unknown
+          )
         }}
         data-qa="send-decisions"
       />

--- a/frontend/src/employee-mobile-frontend/api/childImages.ts
+++ b/frontend/src/employee-mobile-frontend/api/childImages.ts
@@ -9,7 +9,7 @@ import { client } from './client'
 export async function uploadChildImage(
   childId: string,
   file: File
-): Promise<Result<null>> {
+): Promise<Result<void>> {
   const formData = new FormData()
   formData.append('file', file)
 
@@ -19,7 +19,7 @@ export async function uploadChildImage(
         'Content-Type': 'multipart/form-data'
       }
     })
-    .then(() => Success.of(null))
+    .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 }
 

--- a/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkPresent.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkPresent.tsx
@@ -105,7 +105,7 @@ export default React.memo(function MarkPresent() {
                   primary
                   text={i18n.common.confirm}
                   disabled={!isValidTime(time)}
-                  onClick={() => childArrives()}
+                  onClick={childArrives}
                   onSuccess={() => {
                     reloadAttendances()
                     navigate(-2)

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/MarkExternalStaffMemberArrivalPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/MarkExternalStaffMemberArrivalPage.tsx
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useContext, useState } from 'react'
+import React, { useCallback, useContext, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { Result } from 'lib-common/api'
 import { formatTime, isValidTime } from 'lib-common/date'
 import { GroupInfo } from 'lib-common/generated/api-types/attendance'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
@@ -51,14 +50,17 @@ export default function MarkExternalStaffMemberArrivalPage() {
     name: ''
   })
 
-  const onSubmit = (): Promise<Result<void>> =>
-    form.group
-      ? postExternalStaffArrival({
-          arrived: form.arrived,
-          groupId: form.group.id,
-          name: form.name
-        })
-      : Promise.reject()
+  const onSubmit = useCallback(
+    () =>
+      form.group
+        ? postExternalStaffArrival({
+            arrived: form.arrived,
+            groupId: form.group.id,
+            name: form.name
+          })
+        : undefined,
+    [form.arrived, form.group, form.name]
+  )
 
   const formIsValid = () =>
     !!(isValidTime(form.arrived) && form.name.trim() && form.group)

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkArrivedPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkArrivedPage.tsx
@@ -227,7 +227,7 @@ export default React.memo(function StaffMarkArrivedPage() {
                               }
                               return res
                             })
-                          : Promise.reject()
+                          : undefined
                       }
                       onSuccess={() => {
                         reloadStaffAttendance()

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkDepartedPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkDepartedPage.tsx
@@ -26,10 +26,9 @@ import { StaffAttendanceContext } from '../../state/staff-attendance'
 import { UnitContext } from '../../state/unit'
 import { renderResult } from '../async-rendering'
 import { Actions } from '../attendances/components'
+import { TimeWrapper } from '../attendances/components'
 import TopBar from '../common/TopBar'
 import { TallContentArea } from '../mobile/components'
-
-import { TimeWrapper } from './components/staff-components'
 
 export default React.memo(function StaffMarkDepartedPage() {
   const { i18n } = useTranslation()
@@ -186,19 +185,17 @@ export default React.memo(function StaffMarkDepartedPage() {
                         postStaffDeparture(attendanceId, {
                           time,
                           pinCode: pinCode.join('')
-                        }).then((res) => {
-                          if (res.isFailure) {
-                            setErrorCode(res.errorCode)
-                            if (res.errorCode === 'WRONG_PIN') {
-                              setPinCode(EMPTY_PIN)
-                            }
-                          }
-                          return res
                         })
                       }
                       onSuccess={() => {
                         reloadStaffAttendance()
                         history.go(-1)
+                      }}
+                      onFailure={(res) => {
+                        setErrorCode(res.errorCode)
+                        if (res.errorCode === 'WRONG_PIN') {
+                          setPinCode(EMPTY_PIN)
+                        }
                       }}
                       data-qa="mark-departed-btn"
                     />

--- a/frontend/src/lib-common/api.ts
+++ b/frontend/src/lib-common/api.ts
@@ -43,7 +43,7 @@ export class Loading<T> {
 
   mapAll<A>(fs: {
     loading: () => A
-    failure: () => A
+    failure: (v: Failure<T>) => A
     success: (v: T, isReloading: boolean) => A
   }): A {
     return fs.loading()
@@ -108,10 +108,10 @@ export class Failure<T> {
 
   mapAll<A>(fs: {
     loading: () => A
-    failure: () => A
+    failure: (v: Failure<T>) => A
     success: (v: T, isReloading: boolean) => A
   }): A {
-    return fs.failure()
+    return fs.failure(this)
   }
 
   getOrElse<A>(other: A): A | T {
@@ -155,7 +155,7 @@ export class Success<T> {
 
   mapAll<A>(fs: {
     loading: () => A
-    failure: () => A
+    failure: (v: Failure<T>) => A
     success: (v: T, isReloading: boolean) => A
   }): A {
     return fs.success(this.value, this.isReloading)

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -40,8 +40,11 @@ export interface Props<T> {
   text: string
   textInProgress?: string
   textDone?: string
+  /** Return a promise to start an async action, or `undefined` to do a sync action (or nothing at all) */
   onClick: () => Promise<Result<T>> | void
+  /** Called when the promise has resolved with a Success value and the success animation has finished */
   onSuccess: (value: T) => void
+  /** Called immediately when the promis has resolved with a Failure value */
   onFailure?: (failure: Failure<T>) => void
   type?: 'button' | 'submit'
   preventDefault?: boolean

--- a/frontend/src/lib-components/molecules/modals/FormModal.tsx
+++ b/frontend/src/lib-components/molecules/modals/FormModal.tsx
@@ -4,7 +4,7 @@
 
 import React, { FormEvent, useCallback } from 'react'
 
-import { Result } from 'lib-common/api'
+import { Failure, Result } from 'lib-common/api'
 
 import AsyncButton from '../../atoms/buttons/AsyncButton'
 import Button from '../../atoms/buttons/Button'
@@ -60,27 +60,27 @@ export default React.memo(function FormModal({
   )
 })
 
-type AsyncModalProps = ModalBaseProps & {
-  resolveAction: (
-    cancel: () => Promise<void>
-  ) => Promise<void | Result<unknown>>
+type AsyncModalProps<T> = ModalBaseProps & {
+  resolveAction: () => Promise<Result<T>> | void
   resolveLabel: string
   resolveDisabled?: boolean
-  onSuccess: () => void
+  onSuccess: (value: T) => void
+  onFailure?: (value: Failure<T>) => void
   rejectAction: () => void
   rejectLabel: string
 }
 
-export const AsyncFormModal = React.memo(function AsyncFormModal({
+function AsyncFormModal_<T>({
   children,
   resolveAction,
   resolveLabel,
   resolveDisabled,
   onSuccess,
+  onFailure,
   rejectAction,
   rejectLabel,
   ...props
-}: AsyncModalProps) {
+}: AsyncModalProps<T>) {
   return (
     <BaseModal {...props} close={rejectAction} closeLabel={rejectLabel}>
       {children}
@@ -91,6 +91,7 @@ export const AsyncFormModal = React.memo(function AsyncFormModal({
           disabled={resolveDisabled}
           onClick={resolveAction}
           onSuccess={onSuccess}
+          onFailure={onFailure}
           data-qa="modal-okBtn"
         />
         <Gap horizontal size="xs" />
@@ -102,4 +103,8 @@ export const AsyncFormModal = React.memo(function AsyncFormModal({
       </ModalButtons>
     </BaseModal>
   )
-})
+}
+
+export const AsyncFormModal = React.memo(
+  AsyncFormModal_
+) as typeof AsyncFormModal_


### PR DESCRIPTION
#### Summary

Fix design problems in the `AsyncButton` API:
- Allow making a synchronous action (or nothing at all) in the `onClick` handler. In this case, the `onClick` handler should return `undefined`.
- It the `onClick` callback returns `undefined`, the button never starts spinning. It just acts like a normal button.
- Remove the old cancel mechanism in favor of this simpler way of controlling whether to start an async call or not.
- `onSuccess` and `onFailure` will only be called if an async action was started.
- If the async action returns a `Success`, `onSuccess` gets the payload as a parameter
- If the async action returns a `Failure`, `onFailure` will get that as a parameter
- The async action (promise) must not reject, as is customary with our API functions.

This required many small changes in the usage sites, and a few bigger refactorings too.

Smaller enhancements to `AsyncButton` in this PR:
- Fix a state update after unmount bug
- Call `e.preventDefault()` if `type` is `"submit"`. This way `AsyncButton` is much more useful as the submit button inside a `<form>` element.

Use  `AsyncButton` in many places where a `Button` was used to start an async action

Fix many usage sites of `AsyncButton` to use the enhanced `onSuccess` and `onFailure` callbacks instead of promise chaining.

