### PR TITLE
EVAKA-4406 Show correct child count also before they leave

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -70,7 +70,7 @@ const Graph = React.memo(function Graph({ occupancy }: Props) {
       occupancy.childAttendances.filter(
         (a) =>
           compareAsc(a.arrived, time) <= 0 &&
-          compareAsc(time, a.departed || time) < 0
+          (a.departed === null || compareAsc(time, a.departed) < 0)
       ).length,
     [occupancy]
   )


### PR DESCRIPTION
A bug caused the child count to be 0 if they still had not left the daycare.
