### PR TITLE
Fix ambiguous route in staff attendance router

### DIFF
--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -162,7 +162,11 @@ function StaffAttendanceRouter() {
   return (
     <StaffAttendanceContextProvider>
       <Routes>
-        <Route path=":tab" element={<StaffAttendancesPage />} />
+        <Route path="absent" element={<StaffAttendancesPage tab="absent" />} />
+        <Route
+          path="present"
+          element={<StaffAttendancesPage tab="present" />}
+        />
         <Route
           path="external"
           element={<MarkExternalStaffMemberArrivalPage />}

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffAttendancesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffAttendancesPage.tsx
@@ -31,12 +31,15 @@ const StaticIconContainer = styled.div`
 
 type StatusTab = 'present' | 'absent'
 
-export default React.memo(function StaffAttendancesPage() {
+interface Props {
+  tab: StatusTab
+}
+
+export default React.memo(function StaffAttendancesPage({ tab }: Props) {
   const navigate = useNavigate()
-  const { unitId, groupId, tab } = useNonNullableParams<{
+  const { unitId, groupId } = useNonNullableParams<{
     unitId: string
     groupId: string
-    tab: StatusTab
   }>()
   const { i18n } = useTranslation()
   const { unitInfoResponse } = useContext(UnitContext)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Regression: `:tab` and `:employeeId` both match a path with an employee ID,
and the first route wins.

Previously React Router accepted `:tab(absent|present)`, which was enough
to distinguish it from `:employeeId`. This is no longer supported, so use
two hard-coded routes and pass the information via props instead.