### PR TITLE
Add feature flags to employee mobile customizations

### DIFF
--- a/frontend/src/employee-mobile-frontend/api/unit.ts
+++ b/frontend/src/employee-mobile-frontend/api/unit.ts
@@ -5,7 +5,7 @@
 import { Failure, Result, Success } from 'lib-common/api'
 import { UnitInfo, UnitStats } from 'lib-common/generated/api-types/attendance'
 import { JsonOf } from 'lib-common/json'
-import { featureFlags } from 'lib-customizations/employee'
+import { featureFlags } from 'lib-customizations/employeeMobile'
 
 import { client } from '../api/client'
 

--- a/frontend/src/employee-mobile-frontend/components/common/BottomNavbar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/BottomNavbar.tsx
@@ -17,7 +17,7 @@ import {
 import { fontWeights } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
-import { featureFlags } from 'lib-customizations/employee'
+import { featureFlags } from 'lib-customizations/employeeMobile'
 import {
   faChild,
   fasChild,

--- a/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessageEditorPage.tsx
@@ -20,7 +20,7 @@ import {
 } from 'lib-components/employee/messages/SelectorNode'
 import { ContentArea } from 'lib-components/layout/Container'
 import { defaultMargins } from 'lib-components/white-space'
-import { featureFlags } from 'lib-customizations/employee'
+import { featureFlags } from 'lib-customizations/employeeMobile'
 import { faArrowLeft } from 'lib-icons'
 
 import {

--- a/frontend/src/lib-customizations/employeeMobile.tsx
+++ b/frontend/src/lib-customizations/employeeMobile.tsx
@@ -32,8 +32,8 @@ const customizations: EmployeeMobileCustomizations = overrides
   : defaults
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const { appConfig }: EmployeeMobileCustomizations = customizations
-export { appConfig }
+const { appConfig, featureFlags }: EmployeeMobileCustomizations = customizations
+export { appConfig, featureFlags }
 
 export type Lang = 'fi'
 export type Translations = typeof fi

--- a/frontend/src/lib-customizations/espoo/employeeMobile.tsx
+++ b/frontend/src/lib-customizations/espoo/employeeMobile.tsx
@@ -5,9 +5,11 @@
 import type { EmployeeMobileCustomizations } from 'lib-customizations/types'
 
 import { employeeMobileConfig } from './appConfigs'
+import featureFlags from './featureFlags'
 
 const customizations: EmployeeMobileCustomizations = {
   appConfig: employeeMobileConfig,
+  featureFlags,
   translations: {
     fi: {}
   }

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -152,6 +152,7 @@ export interface EmployeeCustomizations {
 
 export interface EmployeeMobileCustomizations {
   appConfig: BaseAppConfig
+  featureFlags: FeatureFlags
   translations: Record<
     LangEmployeeMobile,
     DeepPartial<TranslationsEmployeeMobile>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

employee-mobile-frontend code imported these previously from employee customizations and by doing so pulled all the employee-frontend translations into the mobile bundle.

This fix reduces the main mobile bundle (main.js) size by ~20%