### PR TITLE
Fix voucher value decision ending

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -199,7 +199,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
             assertEquals(endDate, decisions.first().validTo)
         }
 
-        endDecisions(now = newEndDate.plusDays(1))
+        endOutdatedDecisions(now = newEndDate.plusDays(1))
         getAllValueDecisions().let { decisions ->
             assertEquals(1, decisions.size)
             assertEquals(VoucherValueDecisionStatus.SENT, decisions.first().status)
@@ -270,7 +270,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         val newStartDate = now.toLocalDate().minusDays(1)
         createPlacement(newStartDate, endDate, testVoucherDaycare2.id)
-        endDecisions(now = newStartDate.plusDays(1))
+        endOutdatedDecisions(now = newStartDate.plusDays(1))
 
         getAllValueDecisions().let { decisions ->
             assertEquals(2, decisions.size)
@@ -309,7 +309,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         val newStartDate = now.toLocalDate().minusDays(1)
         createPlacement(newStartDate, endDate, testDaycare.id)
-        endDecisions(now = newStartDate.plusDays(1))
+        endOutdatedDecisions(now = newStartDate.plusDays(1))
 
         getAllValueDecisions().let { decisions ->
             assertEquals(1, decisions.size)
@@ -330,7 +330,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
         }
 
         deletePlacement(placementId)
-        endDecisions(now = startDate)
+        endOutdatedDecisions(now = startDate)
 
         getAllValueDecisions().let { decisions ->
             assertEquals(1, decisions.size)
@@ -352,7 +352,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         val newStartDate = now.toLocalDate().minusDays(1)
         createPlacement(newStartDate, endDate, type = PlacementType.PRESCHOOL)
-        endDecisions(now = newStartDate.plusDays(1))
+        endOutdatedDecisions(now = newStartDate.plusDays(1))
 
         getAllValueDecisions().let { decisions ->
             assertEquals(1, decisions.size)
@@ -377,7 +377,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
             assertEquals(endDate, decisions.last().validTo)
         }
 
-        endDecisions(now = endDate)
+        endOutdatedDecisions(now = endDate)
 
         getAllValueDecisions().sortedBy { it.validFrom }.let { decisions ->
             assertEquals(2, decisions.size)
@@ -668,9 +668,9 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
         }.shuffled() // randomize order to expose assumptions
     }
 
-    private fun endDecisions(now: LocalDate) {
+    private fun endOutdatedDecisions(now: LocalDate) {
         db.transaction {
-            voucherValueDecisionService.endDecisionsWithEndedPlacements(
+            voucherValueDecisionService.endOutdatedDecisions(
                 it,
                 HelsinkiDateTime.of(now, LocalTime.of(12, 0))
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -11,7 +11,7 @@ import fi.espoo.evaka.invoicing.controller.sendVoucherValueDecisions
 import fi.espoo.evaka.invoicing.createVoucherValueDecisionFixture
 import fi.espoo.evaka.invoicing.data.annulVoucherValueDecisions
 import fi.espoo.evaka.invoicing.data.getValueDecisionsByIds
-import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionEndDates
+import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionEndDatesIfNeeded
 import fi.espoo.evaka.invoicing.data.upsertValueDecisions
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionServiceNeed
@@ -351,7 +351,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest(resetDbBeforeEach 
         val decision = createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 0)
         db.transaction { freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue, janFreeze) }
         val endedDecision = decision.copy(validTo = janFirst.plusDays(13))
-        db.transaction { it.updateVoucherValueDecisionEndDates(listOf(endedDecision), janFreeze.plusSeconds(3600)) }
+        db.transaction { it.updateVoucherValueDecisionEndDatesIfNeeded(listOf(endedDecision), janFreeze.plusSeconds(3600)) }
 
         val febReport = getUnitReport(testDaycare.id, febFirst.year, febFirst.monthValue)
         assertEquals(2, febReport.size)
@@ -368,7 +368,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest(resetDbBeforeEach 
     fun `continued value decisions are corrected after original end`() {
         val decision = createVoucherDecision(janFirst, unitId = testDaycare.id, value = 87000, coPayment = 0)
         db.transaction {
-            it.updateVoucherValueDecisionEndDates(
+            it.updateVoucherValueDecisionEndDatesIfNeeded(
                 listOf(decision.copy(validTo = janFirst.plusDays(13))),
                 janFreeze.plusSeconds(3600)
             )
@@ -381,7 +381,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest(resetDbBeforeEach 
 
         // move decision end date to end of february
         db.transaction {
-            it.updateVoucherValueDecisionEndDates(
+            it.updateVoucherValueDecisionEndDatesIfNeeded(
                 listOf(decision.copy(validTo = marFirst.toEndOfMonth())),
                 janFreeze.plusSeconds(3600)
             )
@@ -427,7 +427,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest(resetDbBeforeEach 
         db.transaction { freezeVoucherValueReportRows(it, febFirst.year, febFirst.monthValue, febFreeze) }
 
         val endedDecision = decision.copy(validTo = janFirst.toEndOfMonth())
-        db.transaction { it.updateVoucherValueDecisionEndDates(listOf(endedDecision), febFreeze.plusDays(1)) }
+        db.transaction { it.updateVoucherValueDecisionEndDatesIfNeeded(listOf(endedDecision), febFreeze.plusDays(1)) }
 
         createVoucherDecision(febFirst, unitId = testDaycare.id, value = 87000, coPayment = 28800)
         db.transaction { freezeVoucherValueReportRows(it, marFirst.year, marFirst.monthValue, marFreeze) }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -16,7 +16,7 @@ import fi.espoo.evaka.invoicing.data.lockValueDecisions
 import fi.espoo.evaka.invoicing.data.lockValueDecisionsForChild
 import fi.espoo.evaka.invoicing.data.markVoucherValueDecisionsSent
 import fi.espoo.evaka.invoicing.data.searchValueDecisions
-import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionEndDates
+import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionEndDatesIfNeeded
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionDetailed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus.ANNULLED
@@ -274,7 +274,7 @@ fun sendVoucherValueDecisions(
     val (annulled, updatedDates) = updateEndDatesOrAnnulConflictingDecisions(decisions, conflicts)
         .partition { it.status == ANNULLED }
     tx.annulVoucherValueDecisions(annulled.map { it.id }, now)
-    tx.updateVoucherValueDecisionEndDates(updatedDates, now)
+    tx.updateVoucherValueDecisionEndDatesIfNeeded(updatedDates, now)
 
     val validIds = decisions.map { it.id }
     tx.approveValueDecisionDraftsForSending(validIds, EmployeeId(user.id), now, alwaysUseDaycareFinanceDecisionHandler)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
@@ -540,11 +540,17 @@ fun Database.Transaction.markVoucherValueDecisionsSent(ids: List<VoucherValueDec
         .execute()
 }
 
-fun Database.Transaction.updateVoucherValueDecisionEndDates(
+fun Database.Transaction.updateVoucherValueDecisionEndDatesIfNeeded(
     updatedDecisions: List<VoucherValueDecision>,
     now: HelsinkiDateTime
 ) {
-    prepareBatch("UPDATE voucher_value_decision SET valid_to = :validTo, validity_updated_at = :now WHERE id = :id")
+    prepareBatch(
+        """
+UPDATE voucher_value_decision
+SET valid_to = :validTo, validity_updated_at = :now
+WHERE id = :id AND (valid_to IS NULL OR valid_to <> :validTo)
+"""
+    )
         .also { batch ->
             updatedDecisions.forEach { decision ->
                 batch

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.invoicing.data.getFeeAlterationsFrom
 import fi.espoo.evaka.invoicing.data.getFeeThresholds
 import fi.espoo.evaka.invoicing.data.getIncomesFrom
 import fi.espoo.evaka.invoicing.data.lockValueDecisionsForChild
-import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionEndDates
+import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionEndDatesIfNeeded
 import fi.espoo.evaka.invoicing.data.upsertValueDecisions
 import fi.espoo.evaka.invoicing.domain.ChildWithDateOfBirth
 import fi.espoo.evaka.invoicing.domain.FeeAlteration
@@ -100,7 +100,7 @@ internal fun Database.Transaction.handleValueDecisionChanges(
     val updatedDecisions = updateExistingDecisions(from, newDrafts, existingDrafts, activeDecisions)
     deleteValueDecisions(existingDrafts.map { it.id })
     upsertValueDecisions(updatedDecisions.updatedDrafts)
-    updateVoucherValueDecisionEndDates(updatedDecisions.updatedActiveDecisions, HelsinkiDateTime.now())
+    updateVoucherValueDecisionEndDatesIfNeeded(updatedDecisions.updatedActiveDecisions, HelsinkiDateTime.now())
 }
 
 private fun generateNewValueDecisions(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
@@ -15,7 +15,7 @@ import fi.espoo.evaka.invoicing.data.lockValueDecisions
 import fi.espoo.evaka.invoicing.data.markVoucherValueDecisionsSent
 import fi.espoo.evaka.invoicing.data.setVoucherValueDecisionType
 import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionDocumentKey
-import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionEndDates
+import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionEndDatesIfNeeded
 import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionStatus
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionDetailed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
@@ -196,7 +196,7 @@ AND coalesce(sno.voucher_value_coefficient, default_sno.voucher_value_coefficien
                     mergedPlacementPeriods.isEmpty() -> tx.annulVoucherValueDecisions(listOf(decision.id), now)
                     mergedPlacementPeriods.first().end < decision.validTo -> {
                         val withUpdatedEndDate = decision.copy(validTo = mergedPlacementPeriods.first().end)
-                        tx.updateVoucherValueDecisionEndDates(listOf(withUpdatedEndDate), now)
+                        tx.updateVoucherValueDecisionEndDatesIfNeeded(listOf(withUpdatedEndDate), now)
                     }
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -185,7 +185,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun endOutdatedVoucherValueDecisions(db: Database.Connection) {
-        db.transaction { voucherValueDecisionService.endDecisionsWithEndedPlacements(it, HelsinkiDateTime.now()) }
+        db.transaction { voucherValueDecisionService.endOutdatedDecisions(it, HelsinkiDateTime.now()) }
     }
 
     fun removeExpiredNotes(db: Database.Connection) {


### PR DESCRIPTION
#### Summary

Fix a bug that ends voucher value decisions prematurely if there's no service need in effect. Also rename the function that ends decisions, because an ended placement is not the only reason.

I tried to bundle finding the end date to the same SQL query too, but that seemed too hard, so this PR keeps the old logic for that part.