### PR TITLE
Sort by row.idx in test

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -4022,7 +4022,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         }
 
     private val getAllInvoices: (Database.Read) -> List<Invoice> = { r ->
-        r.createQuery(invoiceQueryBase)
+        r.createQuery(
+            """
+            $invoiceQueryBase
+            ORDER BY invoice.id, row.idx
+            """.trimIndent()
+        )
             .map(toInvoice)
             .list()
             .let(::flatten)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

All "real" queries already sort by row.idx, but the test didn't. It reused the base query, but the base query can't have ORDER BY because of the position it's used in.

**Fixes integration test flakiness**