### PR TITLE
EVAKA-FIX Use correct boolean when creating retroactive value decisions

### DIFF
--- a/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
@@ -136,7 +136,7 @@ const Modal = React.memo(function Modal({
   const dateIsValid = LocalDate.parseFiOrNull(date)
 
   const resolve = useCallback(() => {
-    if (!dateIsValid) {
+    if (dateIsValid) {
       return createRetroactiveValueDecisions(
         headOfFamily,
         LocalDate.parseFiOrThrow(date)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Previous change seems to be accidentally introduced here: https://github.com/espoon-voltti/evaka/blame/2c9943c60608da06bb1687f60b1ae7e2bb4db994/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx#L139-L140