### PR TITLE
Evaka fix allow assistance need showing for future preshooling

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionIntegrationTest.kt
@@ -273,28 +273,43 @@ class AssistanceActionIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
 
     @Test
     fun `if child is in preschool, only show preschool assistance actions if employee is not an admin`() {
-        val today = LocalDate.now().withMonth(8).withDayOfMonth(1)
-        givenAssistanceAction(today.withMonth(1), today.withMonth(7), testChild_1.id)
-        val assistanceActionDuringPreschool = givenAssistanceAction(today.withMonth(8), today.withMonth(12), testChild_1.id)
+        val today = LocalDate.now()
+        givenAssistanceAction(today.minusDays(1), today.minusDays(1), testChild_1.id)
+        val assistanceActionNow = givenAssistanceAction(today, today, testChild_1.id)
 
         // No preschool placement, so expect both
         assertEquals(2, whenGetAssistanceActionsThenExpectSuccess(testChild_1.id).size)
 
         // With a non preschool placement expect seeing both
-        givenPlacement(today.withMonth(1), today.withMonth(7), PlacementType.DAYCARE)
+        val placement = givenPlacement(today, today, PlacementType.DAYCARE)
         assertEquals(2, whenGetAssistanceActionsThenExpectSuccess(testChild_1.id).size)
+        db.transaction {
+            it.createUpdate("delete from placement where id = :id")
+                .bind("id", placement.raw)
+                .execute()
+        }
 
         // With a preschool placement, expect only seeing the assistance need starting after the placement
-        givenPlacement(today.withMonth(8), today.withMonth(12), PlacementType.PRESCHOOL)
+        givenPlacement(today, today, PlacementType.PRESCHOOL)
         val assistanceActions = whenGetAssistanceActionsThenExpectSuccess(testChild_1.id)
         assertEquals(1, assistanceActions.size)
 
         with(assistanceActions[0]) {
-            assertEquals(assistanceActionDuringPreschool, id)
+            assertEquals(assistanceActionNow, id)
         }
 
         // Admin sees all
         assertEquals(2, whenGetAssistanceActionsThenExpectSuccess(testChild_1.id, admin).size)
+    }
+
+    @Test
+    fun `if child will be in preschool, show pre preschool assistance actions if employee is not an admin`() {
+        val today = LocalDate.now()
+        givenAssistanceAction(today, today, testChild_1.id)
+
+        givenPlacement(today.plusDays(1), today.plusDays(1), PlacementType.PRESCHOOL)
+        val assistanceActions = whenGetAssistanceActionsThenExpectSuccess(testChild_1.id)
+        assertEquals(1, assistanceActions.size)
     }
 
     private fun testDate(day: Int) = LocalDate.now().withMonth(1).withDayOfMonth(day)

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.AssistanceNeedId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -49,19 +50,21 @@ class AssistanceNeedController(
     fun getAssistanceNeeds(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<AssistanceNeedResponse> {
         Audit.ChildAssistanceNeedRead.log(targetId = childId)
         accessControl.requirePermissionFor(user, Action.Child.READ_ASSISTANCE_NEED, childId)
         return db.connect { dbc ->
-            val preschoolPlacements = dbc.read { tx ->
+            val relevantPreschoolPlacements = dbc.read { tx ->
                 tx.getPlacementsForChild(childId).filter {
-                    (it.type == PlacementType.PRESCHOOL || it.type == PlacementType.PRESCHOOL_DAYCARE)
+                    (it.type == PlacementType.PRESCHOOL || it.type == PlacementType.PRESCHOOL_DAYCARE) &&
+                        it.startDate <= clock.today()
                 }
             }
             val assistanceNeeds = assistanceNeedService.getAssistanceNeedsByChildId(dbc, childId).let { allAssistanceNeeds ->
                 val prePreschool = allAssistanceNeeds.filterNot {
-                    preschoolPlacements.isEmpty() || preschoolPlacements.any { placement ->
+                    relevantPreschoolPlacements.isEmpty() || relevantPreschoolPlacements.any { placement ->
                         placement.startDate.isBefore(it.startDate) || placement.startDate == it.startDate
                     }
                 }


### PR DESCRIPTION
#### Summary
- For a child in preschool (or after), assistance needs and actions from pre preschool are not shown to non admin. This fixes a bug that caused the filtering to happen to children not YET in preschool, but with a preschool placement


