### PR TITLE
Avoid flaky test by using better selector

### DIFF
--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -92,7 +92,7 @@ export default class MessagesPage {
     content: string
     urgent?: boolean
     attachmentCount?: number
-    receiver?: number
+    receiver?: string
   }) {
     const attachmentCount = message.attachmentCount ?? 0
 
@@ -103,10 +103,7 @@ export default class MessagesPage {
     await this.#receiverSelection.click()
 
     if (message.receiver) {
-      await this.#receiverSelection
-        .findAll('[data-qa="option"]')
-        .nth(message.receiver)
-        .click()
+      await this.page.findText(message.receiver).click()
     } else {
       await this.page.keyboard.press('Enter')
     }

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -145,7 +145,7 @@ describe('Sending and receiving messages', () => {
 
         await messagesPage.sendNewMessage({
           ...defaultMessage,
-          receiver: 3
+          receiver: `${enduserChildFixtureKaarina.firstName} ${enduserChildFixtureKaarina.lastName}`
         })
 
         await messagesPage.assertMessageIsSentForParticipants(


### PR DESCRIPTION
#### Summary
- For unknown reason a flaky test picked the wrong recipient from the list when using index, so use the selection text as selector instead

