### PR TITLE
Remove async jobs after six months instead of just one

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueriesTest.kt
@@ -105,7 +105,7 @@ class AsyncJobQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
     fun testRemoveOldAsyncJobs() {
         val now = HelsinkiDateTime.of(LocalDate.of(2020, 9, 1), LocalTime.of(12, 0))
         val ancient = LocalDate.of(2019, 1, 1)
-        val recent = LocalDate.of(2020, 7, 1)
+        val recent = LocalDate.of(2020, 3, 1)
         val future = LocalDate.of(2020, 9, 2)
         db.transaction { tx ->
             listOf(ancient, recent)
@@ -126,6 +126,7 @@ class AsyncJobQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(
             listOf(
                 TestJobParams(recent, completed = false),
+                TestJobParams(recent, completed = true),
                 TestJobParams(future, completed = false),
             ),
             remainingJobs

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueries.kt
@@ -133,7 +133,7 @@ WHERE run_at < :runBefore
     .execute()
 
 fun Database.Connection.removeOldAsyncJobs(now: HelsinkiDateTime) {
-    val completedBefore = now.minusMonths(1)
+    val completedBefore = now.minusMonths(6)
     val completedCount = transaction { it.removeCompletedJobs(completedBefore) }
     logger.info { "Removed $completedCount async jobs completed before $completedBefore" }
 


### PR DESCRIPTION
On 11.5.2022 there was a case where older than one month of history
data would have been useful.
