### PR TITLE
Fix parameter name

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -610,7 +610,7 @@ fun Database.Read.getReceiversForNewMessage(
             JOIN daycare d ON bc.unit_id = d.id
             WHERE d.id = :unitId AND EXISTS (
                 SELECT 1 FROM child_acl_view a
-                WHERE a.employee_id = :employeeId AND a.child_id = bc.child_id
+                WHERE a.employee_id = :employeeOrMobileId AND a.child_id = bc.child_id
             )
             AND 'MESSAGING' = ANY(d.enabled_pilot_features)
         ), receivers AS (


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

One PR renamed the parameter and all uses, another PR added a new use site -> no merge conflict but the query doesn't work