### PR TITLE
Add inline "load-failed" script to CSP config

### DIFF
--- a/compose/proxy/nginx.conf
+++ b/compose/proxy/nginx.conf
@@ -45,8 +45,9 @@ server {
   # connect to it using its Docker network name and anything else than localhost
   # will cause browsers to obey upgrade-insecure-requests and try to use HTTPS
   # which obviously won't work here.
+  set $loadFailedInlineScript "'sha256-z1vaAvxob9VDuw7klCB049Y2Xr6lf7KjhDrsLvsvcPU='"; # SHA256 calculated from the script contents
   set $contentSecurityPolicyBase "block-all-mixed-content; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
-  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self'; frame-ancestors 'none'; form-action 'self';";
+  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' ${loadFailedInlineScript}; frame-ancestors 'none'; form-action 'self';";
 
   # Tracing
   add_header X-Request-ID $request_id always;

--- a/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -148,8 +148,9 @@ server {
   add_header X-DNS-Prefetch-Control off;
   add_header Report-To '{"group","csp-endpoint","max_age":31536000,"endpoints":[{"url":"https://$host/api/csp"}]}';
 
+  set $loadFailedInlineScript "'sha256-z1vaAvxob9VDuw7klCB049Y2Xr6lf7KjhDrsLvsvcPU='"; # SHA256 calculated from the script contents
   set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
-  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self'; frame-ancestors 'none'; form-action 'self';";
+  add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' ${loadFailedInlineScript}; frame-ancestors 'none'; form-action 'self';";
 
   # Tracing
   # Return the request ID to the client to make tracing of test requests very easy


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Our CSP config blocks inline scripts, so we need to explicitly whitelist this one
