### PR TITLE
Fix chart tooltip positioning bug

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/ChartTooltip.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/ChartTooltip.tsx
@@ -62,9 +62,6 @@ export const ChartTooltip = React.memo(function ChartTooltip({
   if (pos.x + tooltipWidth > rect.right) {
     pos.x = pos.x - (tooltipWidth - (rect.right - pos.x)) - 16
   }
-  if (pos.x < rect.left) {
-    pos.x = rect.left + 16
-  }
 
   const caretPos = {
     x: tooltip.caretX - caretSize,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/417206/168545867-c3f2152f-bbd3-4871-931f-aa484af9a2d7.png)

After:
<img width="510" alt="image" src="https://user-images.githubusercontent.com/417206/168545986-4038e511-f2e1-41d9-8793-e6b348e7f85b.png">
