### PR TITLE
Fix unnecessary value decision draft generation

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
@@ -140,9 +140,9 @@ INSERT INTO voucher_value_decision (
             .bind("serviceNeedFeeCoefficient", decision.serviceNeed.feeCoefficient)
             .bind("serviceNeedVoucherValueCoefficient", decision.serviceNeed.voucherValueCoefficient)
             .bind("serviceNeedFeeDescriptionFi", decision.serviceNeed.feeDescriptionFi)
-            .bind("serviceNeedFeeDescriptionSv", decision.serviceNeed.feeDescriptionFi)
+            .bind("serviceNeedFeeDescriptionSv", decision.serviceNeed.feeDescriptionSv)
             .bind("serviceNeedVoucherValueDescriptionFi", decision.serviceNeed.voucherValueDescriptionFi)
-            .bind("serviceNeedVoucherValueDescriptionSv", decision.serviceNeed.voucherValueDescriptionFi)
+            .bind("serviceNeedVoucherValueDescriptionSv", decision.serviceNeed.voucherValueDescriptionSv)
             .bind("sentAt", decision.sentAt)
             .execute()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/VoucherValueDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/VoucherValueDecisions.kt
@@ -77,8 +77,7 @@ data class VoucherValueDecision(
             this.finalCoPayment == decision.finalCoPayment &&
             this.baseValue == decision.baseValue &&
             this.voucherValue == decision.voucherValue &&
-            this.childIncome == decision.childIncome &&
-            this.decisionHandler == decision.decisionHandler
+            this.childIncome == decision.childIncome
     }
 
     override fun overlapsWith(other: VoucherValueDecision): Boolean {

--- a/service/src/main/resources/db/migration/V233__fix_voucher_value_decision_swedish_service_need_descriptions.sql
+++ b/service/src/main/resources/db/migration/V233__fix_voucher_value_decision_swedish_service_need_descriptions.sql
@@ -1,0 +1,5 @@
+UPDATE voucher_value_decision d SET
+    service_need_fee_description_sv = coalesce(opt.fee_description_sv, d.service_need_fee_description_sv),
+    service_need_voucher_value_description_sv = coalesce(opt.voucher_value_description_sv, d.service_need_voucher_value_description_sv)
+FROM service_need_option opt
+WHERE opt.fee_description_fi = d.service_need_fee_description_fi AND opt.voucher_value_description_fi = service_need_voucher_value_description_fi;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -230,3 +230,4 @@ V229__voucher_value_base_value_age_under_three.sql
 V230__invoice_row_idx.sql
 V231__message_account_indexes.sql
 V232__urgent_message_thread.sql
+V233__fix_voucher_value_decision_swedish_service_need_descriptions.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
When voucher value decisions were inserted into the database the Swedish service need descriptions were incorrectly saved, which meant that drafts and sent decisions were never considered equal.