### PR TITLE
Fix unnecessary drafts being generated when income dates change

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -963,18 +963,12 @@ export function createBackupCareFixture(
   }
 }
 
-export const DecisionIncomeFixture = (
-  total: number,
-  validFrom: LocalDate = LocalDate.today(),
-  validTo: LocalDate = LocalDate.today()
-): DecisionIncome => ({
+export const DecisionIncomeFixture = (total: number): DecisionIncome => ({
   data: { MAIN_INCOME: total },
   effect: 'INCOME',
   total: total,
   totalExpenses: 0,
   totalIncome: total,
-  validFrom,
-  validTo,
   worksAtECHA: false
 })
 

--- a/frontend/src/employee-frontend/api/invoicing.ts
+++ b/frontend/src/employee-frontend/api/invoicing.ts
@@ -4,7 +4,6 @@
 
 import { SearchOrder } from 'employee-frontend/types'
 import { Failure, Paged, Response, Result, Success } from 'lib-common/api'
-import { DecisionIncome } from 'lib-common/api-types/income'
 import DateRange from 'lib-common/date-range'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { Absence } from 'lib-common/generated/api-types/daycare'
@@ -152,18 +151,9 @@ export async function getFeeDecision(
         validDuring: DateRange.parseJson(json.validDuring),
         headOfFamily: deserializePersonDetailed(json.headOfFamily),
         partner: json.partner ? deserializePersonDetailed(json.partner) : null,
-        headOfFamilyIncome: json.headOfFamilyIncome
-          ? deserializeIncome(json.headOfFamilyIncome)
-          : null,
-        partnerIncome: json.partnerIncome
-          ? deserializeIncome(json.partnerIncome)
-          : null,
         children: json.children.map((childJson) => ({
           ...childJson,
-          child: deserializePersonDetailed(childJson.child),
-          childIncome: childJson.childIncome
-            ? deserializeIncome(childJson.childIncome)
-            : null
+          child: deserializePersonDetailed(childJson.child)
         })),
         sentAt: json.sentAt ? new Date(json.sentAt) : null,
         financeDecisionHandlerFirstName: json.financeDecisionHandlerFirstName
@@ -193,15 +183,6 @@ export async function getVoucherValueDecision(
         validTo: LocalDate.parseNullableIso(json.validTo),
         headOfFamily: deserializePersonDetailed(json.headOfFamily),
         partner: json.partner ? deserializePersonDetailed(json.partner) : null,
-        headOfFamilyIncome: json.headOfFamilyIncome
-          ? deserializeIncome(json.headOfFamilyIncome)
-          : null,
-        partnerIncome: json.partnerIncome
-          ? deserializeIncome(json.partnerIncome)
-          : null,
-        childIncome: json.childIncome
-          ? deserializeIncome(json.childIncome)
-          : null,
         child: deserializePersonDetailed(json.child),
         sentAt: json.sentAt ? new Date(json.sentAt) : null,
         approvedAt: json.approvedAt ? new Date(json.approvedAt) : null,
@@ -289,21 +270,12 @@ export async function getPersonFeeDecisions(
           sentAt: json.sentAt ? new Date(json.sentAt) : null,
           approvedAt: json.approvedAt ? new Date(json.approvedAt) : null,
           created: new Date(json.created),
-          headOfFamilyIncome: json.headOfFamilyIncome
-            ? deserializeIncome(json.headOfFamilyIncome)
-            : null,
-          partnerIncome: json.partnerIncome
-            ? deserializeIncome(json.partnerIncome)
-            : null,
           children: json.children.map((childJson) => ({
             ...childJson,
             child: {
               ...childJson.child,
               dateOfBirth: LocalDate.parseIso(childJson.child.dateOfBirth)
-            },
-            childIncome: childJson.childIncome
-              ? deserializeIncome(childJson.childIncome)
-              : null
+            }
           }))
         }))
       )
@@ -634,10 +606,4 @@ const deserializePersonDetailed = (
   ...json,
   dateOfBirth: LocalDate.parseIso(json.dateOfBirth),
   dateOfDeath: LocalDate.parseNullableIso(json.dateOfDeath)
-})
-
-const deserializeIncome = (json: JsonOf<DecisionIncome>): DecisionIncome => ({
-  ...json,
-  validFrom: LocalDate.parseNullableIso(json.validFrom),
-  validTo: LocalDate.parseNullableIso(json.validTo)
 })

--- a/frontend/src/lib-common/api-types/income.ts
+++ b/frontend/src/lib-common/api-types/income.ts
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import LocalDate from 'lib-common/local-date'
-
 export const incomeCoefficients = [
   'MONTHLY_WITH_HOLIDAY_BONUS',
   'MONTHLY_NO_HOLIDAY_BONUS',
@@ -37,6 +35,4 @@ export interface DecisionIncome {
   totalExpenses: number
   total: number
   worksAtECHA: boolean
-  validFrom: LocalDate | null
-  validTo: LocalDate | null
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -1959,8 +1959,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 totalIncome = 0,
                 totalExpenses = 0,
                 total = 0,
-                validFrom = period.start,
-                validTo = period.end
+                worksAtECHA = false
             ),
             children = listOf(
                 createFeeDecisionChildFixture(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
@@ -56,9 +56,7 @@ data class Income(
         totalIncome = totalIncome(),
         totalExpenses = totalExpenses(),
         total = total(),
-        worksAtECHA = worksAtECHA,
-        validFrom = validFrom,
-        validTo = validTo
+        worksAtECHA = worksAtECHA
     )
 }
 
@@ -70,9 +68,7 @@ data class DecisionIncome(
     val totalIncome: Int,
     val totalExpenses: Int,
     val total: Int,
-    val worksAtECHA: Boolean = false,
-    val validFrom: LocalDate?,
-    val validTo: LocalDate?
+    val worksAtECHA: Boolean
 )
 
 fun incomeTotal(data: Map<String, IncomeValue>) = data.entries

--- a/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/invoicing/TestFixtures.kt
@@ -173,8 +173,7 @@ val testDecisionIncome = DecisionIncome(
     totalIncome = 314100,
     totalExpenses = 0,
     total = 314100,
-    validFrom = LocalDate.of(2000, 1, 1),
-    validTo = null
+    worksAtECHA = false
 )
 
 fun createFeeDecisionAlterationFixture(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The income dates were not even used anywhere so there is no reason to generate new finance decisions when income validity dates change.

