### PR TITLE
Override default HTML button text color in ThreadListItem

### DIFF
--- a/frontend/src/lib-components/molecules/ThreadListItem.tsx
+++ b/frontend/src/lib-components/molecules/ThreadListItem.tsx
@@ -36,9 +36,9 @@ export const Container = styled.button<{ isRead: boolean; active: boolean }>`
   width: 100%;
 
   background-color: ${(p) => p.theme.colors.grayscale.g0};
+  color: ${(p) => p.theme.colors.grayscale.g100};
   padding: ${defaultMargins.s} ${defaultMargins.m};
   cursor: pointer;
-
   border: 1px solid ${(p) => p.theme.colors.grayscale.g15};
 
   &:focus {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

At least on some iOS devices the default color for HTML button text is *blue*