### PR TITLE
EVAKA-4406 Show utilization in group selector for realtime attendances

### DIFF
--- a/frontend/src/employee-mobile-frontend/api/unit.ts
+++ b/frontend/src/employee-mobile-frontend/api/unit.ts
@@ -74,7 +74,12 @@ export function authMobile(
 
 export function getMobileUnitInfo(unitId: string): Promise<Result<UnitInfo>> {
   return client
-    .get<JsonOf<UnitInfo>>(`/mobile/units/${unitId}`)
+    .get<JsonOf<UnitInfo>>(`/mobile/units/${unitId}`, {
+      params: {
+        useRealtimeStaffAttendance:
+          featureFlags.experimental?.realtimeStaffAttendance ?? false
+      }
+    })
     .then((res) => Success.of(res.data))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-mobile-frontend/components/common/GroupSelectorBar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/GroupSelectorBar.tsx
@@ -11,7 +11,7 @@ import IconButton from 'lib-components/atoms/buttons/IconButton'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
-import { faAngleDown, faAngleUp, faSearch } from 'lib-icons'
+import { faAngleDown, faAngleUp, faChevronUp, faSearch } from 'lib-icons'
 
 import { useTranslation } from '../../state/i18n'
 import { zIndex } from '../constants'
@@ -84,24 +84,24 @@ export const GroupSelectorBar = React.memo(function GroupSelectorBar({
           maxHeight: groupSelectorSpring.x.to((x) => `${100 * x}%`)
         }}
       >
-        <GroupSelectorButtonRow>
-          <GroupSelectorButton
-            text={selectedGroup ? selectedGroup.name : i18n.common.all}
-            onClick={() => {
-              setShowGroupSelector(!showGroupSelector)
-            }}
-            icon={
-              hasMultipleGroups
-                ? showGroupSelector
-                  ? faAngleUp
-                  : faAngleDown
-                : undefined
-            }
-            iconRight
-            data-qa="group-selector-button"
-          />
-          {onSearch && <IconButton onClick={onSearch} icon={faSearch} />}
-        </GroupSelectorButtonRow>
+        {!showGroupSelector && (
+          <GroupSelectorButtonRow>
+            <GroupSelectorButton
+              text={selectedGroup ? selectedGroup.name : i18n.common.all}
+              onClick={() => setShowGroupSelector(true)}
+              icon={
+                hasMultipleGroups
+                  ? showGroupSelector
+                    ? faAngleUp
+                    : faAngleDown
+                  : undefined
+              }
+              iconRight
+              data-qa="group-selector-button"
+            />
+            {onSearch && <IconButton onClick={onSearch} icon={faSearch} />}
+          </GroupSelectorButtonRow>
+        )}
         <GroupSelector
           selectedGroup={selectedGroup}
           onChangeGroup={(group) => {
@@ -113,8 +113,20 @@ export const GroupSelectorBar = React.memo(function GroupSelectorBar({
           includeSelectAll={includeSelectAll}
           data-qa="group-selector"
         />
+        <CloseButtonWrapper>
+          <InlineButton
+            text={i18n.common.close}
+            icon={faChevronUp}
+            onClick={() => setShowGroupSelector(false)}
+          />
+        </CloseButtonWrapper>
       </GroupSelectorWrapper>
       <Gap size="s" />
     </GroupContainer>
   )
 })
+
+const CloseButtonWrapper = styled.span`
+  text-align: center;
+  padding: 19px;
+`

--- a/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/MessagesPage.tsx
@@ -70,7 +70,8 @@ export default function MessagesPage() {
         selectedAccount?.daycareGroup
           ? {
               id: selectedAccount.daycareGroup.id,
-              name: selectedAccount.daycareGroup.name
+              name: selectedAccount.daycareGroup.name,
+              utilization: 0
             }
           : undefined
       }

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -221,6 +221,7 @@ export interface FullDayAbsenceRequest {
 export interface GroupInfo {
   id: UUID
   name: string
+  utilization: number
 }
 
 /**
@@ -313,6 +314,7 @@ export interface UnitInfo {
   id: UUID
   name: string
   staff: Staff[]
+  utilization: number
 }
 
 /**


### PR DESCRIPTION
Implements the new design for the group selector in the employee mobile.

If the realtime staff attendances feature flag is on, the current
utilization will be shown next to the name of each group in the group
selector. In other cases a `present children / total children` count
will be shown.

