### PR TITLE
Make Koski VOID operation consider status 404 a success

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/MockKoskiServer.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/MockKoskiServer.kt
@@ -15,6 +15,7 @@ import io.javalin.http.Context
 import mu.KotlinLogging
 import java.util.concurrent.locks.ReentrantLock
 import javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
+import javax.servlet.http.HttpServletResponse.SC_NOT_FOUND
 import kotlin.concurrent.withLock
 import kotlin.random.Random
 
@@ -64,8 +65,17 @@ class MockKoskiServer(private val jsonMapper: JsonMapper, port: Int) : AutoClose
                 return
             }
             "PUT" -> if (oppija.opiskeluoikeudet.mapNotNull { it.oid }.any { !studyRights.containsKey(it) }) {
-                ctx.contentType("text/plain").status(SC_BAD_REQUEST)
-                    .result("Can't update a study right that doesn't exist")
+                ctx.contentType("application/json").status(SC_NOT_FOUND)
+                    .result(
+                        jsonMapper.writeValueAsString(
+                            listOf(
+                                KoskiClient.Error(
+                                    key = "notFound.opiskeluoikeuttaEiLöydyTaiEiOikeuksia",
+                                    message = "Not found"
+                                )
+                            )
+                        )
+                    )
                 return
             }
         }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This effectively makes it an idempotent operation, so if a study right has been manually voided and the endpoint returns 404, no error is generated.