### PR TITLE
Upgrade to Spring Boot 2.7.0

### DIFF
--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -67,6 +67,6 @@ dependencies {
     api(platform("org.jdbi:jdbi3-bom:3.28.0"))
     api(platform("org.jetbrains.kotlin:kotlin-bom:1.6.20"))
     api(platform("org.junit:junit-bom:5.8.2"))
-    api(platform("org.springframework.boot:spring-boot-dependencies:2.6.7"))
+    api(platform("org.springframework.boot:spring-boot-dependencies:2.7.0"))
     api(platform("software.amazon.awssdk:bom:2.17.164"))
 }

--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
     api(platform("com.fasterxml.jackson:jackson-bom:2.13.3"))
     api(platform("org.apache.cxf:cxf-bom:${Version.cxf}"))
     api(platform("org.jdbi:jdbi3-bom:3.28.0"))
-    api(platform("org.jetbrains.kotlin:kotlin-bom:1.6.20"))
+    api(platform("org.jetbrains.kotlin:kotlin-bom:1.6.21"))
     api(platform("org.junit:junit-bom:5.8.2"))
     api(platform("org.springframework.boot:spring-boot-dependencies:2.7.0"))
     api(platform("software.amazon.awssdk:bom:2.17.164"))

--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -62,7 +62,6 @@ dependencies {
     }
 
     api(platform("com.fasterxml.jackson:jackson-bom:2.13.2.20220328"))
-    api(platform("io.netty:netty-bom:4.1.77.Final"))
     api(platform("org.apache.cxf:cxf-bom:${Version.cxf}"))
     api(platform("org.jdbi:jdbi3-bom:3.28.0"))
     api(platform("org.jetbrains.kotlin:kotlin-bom:1.6.20"))

--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
         api("redis.clients:jedis:4.2.1")
     }
 
-    api(platform("com.fasterxml.jackson:jackson-bom:2.13.2.20220328"))
+    api(platform("com.fasterxml.jackson:jackson-bom:2.13.3"))
     api(platform("org.apache.cxf:cxf-bom:${Version.cxf}"))
     api(platform("org.jdbi:jdbi3-bom:3.28.0"))
     api(platform("org.jetbrains.kotlin:kotlin-bom:1.6.20"))

--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
         api("org.apache.wss4j:wss4j-ws-security-dom:2.3.0")
         api("org.bouncycastle:bcpkix-jdk15on:${Version.bouncyCastle}")
         api("org.bouncycastle:bcprov-jdk15on:${Version.bouncyCastle}")
-        api("org.flywaydb:flyway-core:8.5.5")
+        api("org.flywaydb:flyway-core:8.5.11")
         api("org.glassfish.jaxb:jaxb-runtime:2.3.2")
         api("org.jetbrains:annotations:23.0.0")
         api("org.mockito:mockito-core:${Version.mockito}")

--- a/service/buildSrc/build.gradle.kts
+++ b/service/buildSrc/build.gradle.kts
@@ -11,5 +11,5 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.6.20"))
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.6.21"))
 }

--- a/service/buildSrc/src/main/kotlin/Version.kt
+++ b/service/buildSrc/src/main/kotlin/Version.kt
@@ -8,7 +8,7 @@ object Version {
 
     object GradlePlugin {
         const val flyway = "8.5.5"
-        const val kotlin = "1.6.20"
+        const val kotlin = "1.6.21"
         const val kotlinter = "3.9.0"
         const val owasp = "7.0.4.1"
         const val springBoot = "2.7.0"

--- a/service/buildSrc/src/main/kotlin/Version.kt
+++ b/service/buildSrc/src/main/kotlin/Version.kt
@@ -11,7 +11,7 @@ object Version {
         const val kotlin = "1.6.20"
         const val kotlinter = "3.9.0"
         const val owasp = "7.0.4.1"
-        const val springBoot = "2.6.7"
+        const val springBoot = "2.7.0"
         const val versions = "0.42.0"
     }
 }

--- a/service/buildSrc/src/main/kotlin/Version.kt
+++ b/service/buildSrc/src/main/kotlin/Version.kt
@@ -7,7 +7,7 @@ object Version {
     const val ktlint = "0.45.1"
 
     object GradlePlugin {
-        const val flyway = "8.5.5"
+        const val flyway = "8.5.11"
         const val kotlin = "1.6.21"
         const val kotlinter = "3.9.0"
         const val owasp = "7.0.4.1"

--- a/service/custom-ktlint-rules/build.gradle
+++ b/service/custom-ktlint-rules/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.6.20'
+    id 'org.jetbrains.kotlin.jvm' version '1.6.21'
 }
 
 repositories {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Spring Boot 2.7.0 uses a newer version of Tomcat, which fixes a CVE
