### PR TITLE
Only cancel sent transfer applications when terminating

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizenIntegrationTest.kt
@@ -577,7 +577,8 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
                 child = child,
                 applicationId = ApplicationId(UUID.randomUUID()),
                 preferredStartDate = placementTerminationDate.plusDays(1),
-                transferApplication = true
+                transferApplication = true,
+                status = ApplicationStatus.SENT
             )
         }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -279,36 +279,6 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `transfer application cancelling cleans up placement plans and decision drafts`() {
-        val preferredStartDate = LocalDate.now()
-        val applicationId = createTransferApplication(
-            ApplicationType.PRESCHOOL,
-            preferredStartDate,
-            status = ApplicationStatus.WAITING_PLACEMENT
-        )
-        db.transaction {
-            applicationStateService.createPlacementPlan(
-                it,
-                serviceWorker,
-                applicationId,
-                DaycarePlacementPlan(
-                    testDaycare.id,
-                    FiniteDateRange(preferredStartDate, preferredStartDate.plusMonths(1))
-                )
-            )
-        }
-
-        scheduledJobs.cancelOutdatedTransferApplications(db)
-
-        val applicationStatus = getApplicationStatus(applicationId)
-        assertEquals(ApplicationStatus.CANCELLED, applicationStatus)
-        val placementPlans = db.read { it.createQuery("SELECT COUNT(*) FROM placement_plan").mapTo<Int>().first() }
-        assertEquals(0, placementPlans)
-        val decisions = db.read { it.createQuery("SELECT COUNT(*) FROM decision").mapTo<Int>().first() }
-        assertEquals(0, decisions)
-    }
-
-    @Test
     fun `a transfer application with a decision does not get canceled`() {
         val preferredStartDate = LocalDate.now()
         val applicationId = createTransferApplication(

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -926,14 +926,14 @@ fun Database.Transaction.removeOldDrafts(deleteAttachment: (db: Database.Transac
     }
 }
 
-fun Database.Transaction.cancelOutdatedTransferApplications(): List<ApplicationId> = createUpdate(
+fun Database.Transaction.cancelOutdatedSentTransferApplications(): List<ApplicationId> = createUpdate(
     // only include applications that don't have decisions
     // placement type checks are doing in inverse so that the addition and accidental omission of new placement types
     // does not cause the cancellation of applications that shouldn't be cancelled
     """
 UPDATE application SET status = :cancelled
 WHERE transferapplication
-AND status = ANY('{CREATED, SENT, WAITING_PLACEMENT, WAITING_UNIT_CONFIRMATION, WAITING_DECISION}')
+AND status = ANY('{SENT}')
 AND NOT EXISTS (
     SELECT 1
     FROM placement p
@@ -1038,7 +1038,6 @@ RETURNING id
     .bind(
         "activeApplicationStatus",
         arrayOf(
-            ApplicationStatus.CREATED,
             ApplicationStatus.SENT
         )
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -1039,12 +1039,7 @@ RETURNING id
         "activeApplicationStatus",
         arrayOf(
             ApplicationStatus.CREATED,
-            ApplicationStatus.SENT,
-            ApplicationStatus.WAITING_PLACEMENT,
-            ApplicationStatus.WAITING_CONFIRMATION,
-            ApplicationStatus.WAITING_UNIT_CONFIRMATION,
-            ApplicationStatus.WAITING_DECISION,
-            ApplicationStatus.WAITING_MAILING
+            ApplicationStatus.SENT
         )
     )
     .bind("preferredStartDateMinDate", preferredStartDateMinDate)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -5,10 +5,9 @@
 package fi.espoo.evaka.shared.job
 
 import fi.espoo.evaka.application.PendingDecisionEmailService
-import fi.espoo.evaka.application.cancelOutdatedTransferApplications
+import fi.espoo.evaka.application.cancelOutdatedSentTransferApplications
 import fi.espoo.evaka.application.removeOldDrafts
 import fi.espoo.evaka.attachment.AttachmentsController
-import fi.espoo.evaka.decision.clearDecisionDrafts
 import fi.espoo.evaka.dvv.DvvModificationsBatchRefreshService
 import fi.espoo.evaka.invoicing.service.VoucherValueDecisionService
 import fi.espoo.evaka.koski.KoskiSearchParams
@@ -16,7 +15,6 @@ import fi.espoo.evaka.koski.KoskiUpdateService
 import fi.espoo.evaka.note.child.daily.deleteExpiredNotes
 import fi.espoo.evaka.pis.cleanUpInactivePeople
 import fi.espoo.evaka.pis.clearRolesForInactiveEmployees
-import fi.espoo.evaka.placement.deletePlacementPlans
 import fi.espoo.evaka.reports.freezeVoucherValueReportRows
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -158,9 +156,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
 
     fun cancelOutdatedTransferApplications(db: Database.Connection) {
         val canceledApplications = db.transaction {
-            val applicationIds = it.cancelOutdatedTransferApplications()
-            it.deletePlacementPlans(applicationIds)
-            it.clearDecisionDrafts(applicationIds)
+            val applicationIds = it.cancelOutdatedSentTransferApplications()
             applicationIds
         }
         logger.info {


### PR DESCRIPTION
- Only cancel sent transfer applications when terminating
- Only clean up sent transfer applications during nightly cleanup. And because sent application cannot have placements nor decisions, no need to try to clean up those