### PR TITLE
Make realtime staff attendance feature flag unit-specific - part 2

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -38,9 +38,15 @@ beforeEach(async () => {
 
   const fixtures = await initializeAreaAndPersonData()
   const careArea = await Fixture.careArea().with(careArea2Fixture).save()
-  await Fixture.daycare().with(daycare2Fixture).careArea(careArea).save()
-
-  daycare = daycare2Fixture
+  daycare = (
+    await Fixture.daycare()
+      .with({
+        ...daycare2Fixture,
+        enabledPilotFeatures: ['REALTIME_STAFF_ATTENDANCE']
+      })
+      .careArea(careArea)
+      .save()
+  ).data
 
   unitSupervisor = (await Fixture.employeeUnitSupervisor(daycare.id).save())
     .data
@@ -93,14 +99,7 @@ beforeEach(async () => {
   await Fixture.staffOccupancyCoefficient(daycare.id, staff[1].id).save()
 
   page = await Page.open({
-    mockedTime: mockedToday.toSystemTzDate(),
-    employeeCustomizations: {
-      featureFlags: {
-        experimental: {
-          realtimeStaffAttendance: true
-        }
-      }
-    }
+    mockedTime: mockedToday.toSystemTzDate()
   })
   await employeeLogin(page, unitSupervisor)
 })

--- a/frontend/src/employee-frontend/components/absences/AbsenceTable.tsx
+++ b/frontend/src/employee-frontend/components/absences/AbsenceTable.tsx
@@ -15,7 +15,6 @@ import Tooltip from 'lib-components/atoms/Tooltip'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { fontWeights } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
-import { featureFlags } from 'lib-customizations/employee'
 import { fasExclamationTriangle } from 'lib-icons'
 
 import { Translations, useTranslation } from '../../state/i18n'
@@ -240,6 +239,7 @@ interface AbsenceTableProps {
   childList: AbsenceChild[]
   operationDays: LocalDate[]
   reservationEnabled: boolean
+  staffAttendanceEnabled: boolean
 }
 
 export default React.memo(function AbsenceTable({
@@ -249,7 +249,8 @@ export default React.memo(function AbsenceTable({
   selectedDate,
   childList,
   operationDays,
-  reservationEnabled
+  reservationEnabled,
+  staffAttendanceEnabled
 }: AbsenceTableProps) {
   const { i18n } = useTranslation()
 
@@ -286,7 +287,7 @@ export default React.memo(function AbsenceTable({
           />
         ))}
         {renderEmptyRow()}
-        {!featureFlags.experimental?.realtimeStaffAttendance && (
+        {staffAttendanceEnabled && (
           <StaffAttendance
             groupId={groupId}
             selectedDate={selectedDate}

--- a/frontend/src/employee-frontend/components/absences/Absences.tsx
+++ b/frontend/src/employee-frontend/components/absences/Absences.tsx
@@ -48,13 +48,15 @@ interface Props {
   selectedDate: LocalDate
   setSelectedDate: (date: LocalDate) => void
   reservationEnabled: boolean
+  staffAttendanceEnabled: boolean
 }
 
 export default React.memo(function Absences({
   groupId,
   selectedDate,
   setSelectedDate,
-  reservationEnabled
+  reservationEnabled,
+  staffAttendanceEnabled
 }: Props) {
   const { i18n } = useTranslation()
   const { setTitle } = useContext<TitleState>(TitleContext)
@@ -188,6 +190,7 @@ export default React.memo(function Absences({
             childList={absences.children}
             operationDays={absences.operationDays}
             reservationEnabled={reservationEnabled}
+            staffAttendanceEnabled={staffAttendanceEnabled}
           />
           <Gap />
           <AddAbsencesButton

--- a/frontend/src/employee-frontend/components/unit/TabAttendances.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabAttendances.tsx
@@ -77,6 +77,12 @@ export default React.memo(function TabAttendances() {
     .map((u) => u.daycare.enabledPilotFeatures.includes('RESERVATIONS'))
     .getOrElse(false)
 
+  const realtimeStaffAttendanceEnabled = unitInformation
+    .map((u) =>
+      u.daycare.enabledPilotFeatures.includes('REALTIME_STAFF_ATTENDANCE')
+    )
+    .getOrElse(false)
+
   const staffOrNoGroupSelected = groupId === 'staff' || groupId === 'no-group'
   return (
     <>
@@ -119,6 +125,7 @@ export default React.memo(function TabAttendances() {
             <Occupancy
               filters={filters}
               occupancies={unitData.unitOccupancies}
+              realtimeStaffAttendanceEnabled={realtimeStaffAttendanceEnabled}
             />
           ) : null
         )}
@@ -148,6 +155,7 @@ export default React.memo(function TabAttendances() {
             selected={groupId}
             onSelect={setGroupId}
             data-qa="attendances-group-select"
+            realtimeStaffAttendanceEnabled={realtimeStaffAttendanceEnabled}
           />
         </GroupSelectorWrapper>
 
@@ -157,6 +165,7 @@ export default React.memo(function TabAttendances() {
             selectedDate={selectedDate}
             setSelectedDate={setSelectedDate}
             reservationEnabled={reservationEnabled}
+            staffAttendanceEnabled={!realtimeStaffAttendanceEnabled}
           />
         )}
 
@@ -174,6 +183,7 @@ export default React.memo(function TabAttendances() {
                 .map(({ daycare }) => daycare.operationDays)
                 .getOrElse(null) ?? [1, 2, 3, 4, 5]
             }
+            realtimeStaffAttendanceEnabled={realtimeStaffAttendanceEnabled}
           />
         )}
         <Gap size="L" />

--- a/frontend/src/employee-frontend/components/unit/TabUnitInformation.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabUnitInformation.tsx
@@ -9,7 +9,6 @@ import { ContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { H2 } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
-import { featureFlags } from 'lib-customizations/employee'
 
 import UnitAccessControl from '../../components/unit/tab-unit-information/UnitAccessControl'
 import UnitInformation from '../../components/unit/tab-unit-information/UnitInformation'
@@ -53,7 +52,7 @@ export default React.memo(function TabUnitInformation() {
         />
       )}
 
-      {featureFlags.experimental?.realtimeStaffAttendance &&
+      {daycare.enabledPilotFeatures.includes('REALTIME_STAFF_ATTENDANCE') &&
         permittedActions.has('READ_STAFF_OCCUPANCY_COEFFICIENTS') && (
           <StaffOccupancyCoefficients
             allowEditing={permittedActions.has(

--- a/frontend/src/employee-frontend/components/unit/tab-attendances/GroupSelector.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-attendances/GroupSelector.tsx
@@ -10,7 +10,6 @@ import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Select from 'lib-components/atoms/dropdowns/Select'
-import { featureFlags } from 'lib-customizations/employee'
 
 import { getDaycareGroups } from '../../../api/unit'
 import { useTranslation } from '../../../state/i18n'
@@ -20,13 +19,15 @@ interface Props {
   selected: UUID | 'no-group' | 'staff' | null
   onSelect: (val: UUID | 'no-group' | 'staff') => void
   'data-qa'?: string
+  realtimeStaffAttendanceEnabled: boolean
 }
 
 export default React.memo(function GroupSelector({
   unitId,
   selected,
   onSelect,
-  'data-qa': dataQa
+  'data-qa': dataQa,
+  realtimeStaffAttendanceEnabled
 }: Props) {
   const { i18n } = useTranslation()
   const [groups] = useApiState(() => getDaycareGroups(unitId), [unitId])
@@ -47,9 +48,9 @@ export default React.memo(function GroupSelector({
         )
         .getOrElse([]),
       'no-group',
-      ...(featureFlags.experimental?.realtimeStaffAttendance ? ['staff'] : [])
+      ...(realtimeStaffAttendanceEnabled ? ['staff'] : [])
     ],
-    [groups, selected]
+    [groups, selected, realtimeStaffAttendanceEnabled]
   )
 
   const getItemLabel = useCallback(

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
@@ -48,11 +48,13 @@ interface SelectionsState {
 type Props = {
   filters: UnitFilters
   occupancies: UnitOccupancies
+  realtimeStaffAttendanceEnabled: boolean
 }
 
 export default React.memo(function OccupancyContainer({
   filters,
-  occupancies
+  occupancies,
+  realtimeStaffAttendanceEnabled
 }: Props) {
   const { startDate, endDate } = filters
 
@@ -69,7 +71,9 @@ export default React.memo(function OccupancyContainer({
           occupancies={occupancies.confirmed}
           plannedOccupancies={occupancies.planned}
           realizedOccupancies={occupancies.realized}
-          realtimeOccupancies={occupancies.realtime}
+          realtimeOccupancies={
+            realtimeStaffAttendanceEnabled ? occupancies.realtime : null
+          }
         />
       ) : (
         <WrapBox>

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancySingleDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancySingleDay.tsx
@@ -8,7 +8,6 @@ import styled from 'styled-components'
 import { RealtimeOccupancy } from 'lib-common/generated/api-types/occupancy'
 import Title from 'lib-components/atoms/Title'
 import { fontWeights } from 'lib-components/typography'
-import { featureFlags } from 'lib-customizations/employee'
 
 import { OccupancyResponse } from '../../../../api/unit'
 import { useTranslation } from '../../../../state/i18n'
@@ -40,10 +39,7 @@ const OccupancySingleDay = React.memo(function OccupancySingleDay({
 }: Props) {
   const { i18n } = useTranslation()
 
-  if (
-    featureFlags.experimental?.realtimeStaffAttendance &&
-    realtimeOccupancies
-  ) {
+  if (realtimeOccupancies) {
     return (
       <Container>
         <OccupancyDayGraph occupancy={realtimeOccupancies} />

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useMemo, useState, useCallback } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { renderResult } from 'employee-frontend/components/async-rendering'
@@ -23,7 +23,6 @@ import {
 import { fontWeights, H3, Title } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
-import { featureFlags } from 'lib-customizations/employee'
 import { faChevronLeft, faChevronRight } from 'lib-icons'
 
 import {
@@ -62,6 +61,7 @@ interface Props {
   selectedDate: LocalDate
   setSelectedDate: (date: LocalDate) => void
   isShiftCareUnit: boolean
+  realtimeStaffAttendanceEnabled: boolean
   operationalDays: number[]
 }
 
@@ -71,6 +71,7 @@ export default React.memo(function UnitAttendanceReservationsView({
   selectedDate,
   setSelectedDate,
   isShiftCareUnit,
+  realtimeStaffAttendanceEnabled,
   operationalDays
 }: Props) {
   const { i18n } = useTranslation()
@@ -181,7 +182,7 @@ export default React.memo(function UnitAttendanceReservationsView({
             />
           ) : (
             <>
-              {featureFlags.experimental?.realtimeStaffAttendance && (
+              {realtimeStaffAttendanceEnabled && (
                 <StaffAttendanceTable
                   operationalDays={childData.operationalDays}
                   staffAttendances={staffData.staff

--- a/frontend/src/employee-mobile-frontend/api/unit.ts
+++ b/frontend/src/employee-mobile-frontend/api/unit.ts
@@ -5,9 +5,8 @@
 import { Failure, Result, Success } from 'lib-common/api'
 import { UnitInfo, UnitStats } from 'lib-common/generated/api-types/attendance'
 import { JsonOf } from 'lib-common/json'
-import { featureFlags } from 'lib-customizations/employeeMobile'
 
-import { client } from '../api/client'
+import { client } from './client'
 
 type PairingStatus =
   | 'WAITING_CHALLENGE'
@@ -74,12 +73,7 @@ export function authMobile(
 
 export function getMobileUnitInfo(unitId: string): Promise<Result<UnitInfo>> {
   return client
-    .get<JsonOf<UnitInfo>>(`/mobile/units/${unitId}`, {
-      params: {
-        useRealtimeStaffAttendance:
-          featureFlags.experimental?.realtimeStaffAttendance ?? false
-      }
-    })
+    .get<JsonOf<UnitInfo>>(`/mobile/units/${unitId}`)
     .then((res) => Success.of(res.data))
     .catch((e) => Failure.fromError(e))
 }
@@ -90,9 +84,7 @@ export function getMobileUnitStats(
   return client
     .get<JsonOf<UnitStats[]>>('/mobile/units/stats', {
       params: {
-        unitIds: unitIds.join(','),
-        useRealtimeStaffAttendance:
-          featureFlags.experimental?.realtimeStaffAttendance ?? false
+        unitIds: unitIds.join(',')
       }
     })
     .then((res) => Success.of(res.data))

--- a/frontend/src/employee-mobile-frontend/components/common/BottomNavbar.tsx
+++ b/frontend/src/employee-mobile-frontend/components/common/BottomNavbar.tsx
@@ -17,7 +17,6 @@ import {
 import { fontWeights } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
-import { featureFlags } from 'lib-customizations/employeeMobile'
 import {
   faChild,
   fasChild,
@@ -140,7 +139,7 @@ export default function BottomNavbar({ selected }: BottomNavbarProps) {
               onClick={() =>
                 selected !== 'staff' &&
                 navigate(
-                  featureFlags.experimental?.realtimeStaffAttendance
+                  unit.features.includes('REALTIME_STAFF_ATTENDANCE')
                     ? `/units/${unitId}/groups/${groupId}/staff-attendance`
                     : `/units/${unitId}/groups/${groupId}/staff`
                 )

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -28,7 +28,6 @@ const features: Features = {
     experimental: {
       ai: true,
       messageAttachments: true,
-      realtimeStaffAttendance: false,
       personalDetailsPage: true,
       mobileMessages: true,
       leops: true
@@ -49,7 +48,6 @@ const features: Features = {
     experimental: {
       ai: true,
       messageAttachments: true,
-      realtimeStaffAttendance: true,
       personalDetailsPage: true,
       mobileMessages: true,
       leops: true
@@ -70,7 +68,6 @@ const features: Features = {
     experimental: {
       ai: false,
       messageAttachments: true,
-      realtimeStaffAttendance: false,
       personalDetailsPage: false,
       mobileMessages: false,
       leops: false

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -122,7 +122,6 @@ interface BaseFeatureFlags {
   experimental?: {
     ai?: boolean
     messageAttachments?: boolean
-    realtimeStaffAttendance?: boolean
     personalDetailsPage?: boolean
     mobileMessages?: boolean
     leops?: boolean


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- pass feature flag in frontend instead of accessing global variable
- handle unit-specific flags in queries where a global parameter was previously used
- set unit features in E2E test fixtures instead of overriding frontend feature flags

**Depends on [part 1](https://github.com/espoon-voltti/evaka/pull/2502), and must not be merged until part 1 is in production and feature flags have been added to relevant units**