### PR TITLE
Scroll the map page to top on mount

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -98,8 +98,14 @@ const Content = React.memo(function Content() {
       <Main ariaHidden={modalOpen} ref={mainRef}>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/map" element={<MapView />} />
-          <Route path="/applying/*" element={<ApplyingRouter />} />
+          <Route
+            path="/map"
+            element={<MapView scrollToTop={scrollMainToTop} />}
+          />
+          <Route
+            path="/applying/*"
+            element={<ApplyingRouter scrollToTop={scrollMainToTop} />}
+          />
           <Route
             path="/accessibility"
             element={<AccessibilityStatement scrollToTop={scrollMainToTop} />}

--- a/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
+++ b/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
@@ -23,7 +23,11 @@ const WhiteBg = styled.div`
   background-color: ${colors.grayscale.g0};
 `
 
-export default React.memo(function ApplyingRouter() {
+export interface Props {
+  scrollToTop: () => void
+}
+
+export default React.memo(function ApplyingRouter({ scrollToTop }: Props) {
   const t = useTranslation()
   const user = useUser()
   const isEndUser = user?.userType === 'ENDUSER'
@@ -73,7 +77,7 @@ export default React.memo(function ApplyingRouter() {
             </RequireAuth>
           }
         />
-        <Route path="map" element={<MapView />} />
+        <Route path="map" element={<MapView scrollToTop={scrollToTop} />} />
         <Route
           path="decisions"
           element={

--- a/frontend/src/citizen-frontend/map/MapView.tsx
+++ b/frontend/src/citizen-frontend/map/MapView.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import _ from 'lodash'
-import React, { ReactNode, useMemo, useState } from 'react'
+import React, { ReactNode, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -88,7 +88,11 @@ async function fetchUnitsWithDistances(
   }
 }
 
-export default React.memo(function MapView() {
+export interface Props {
+  scrollToTop: () => void
+}
+
+export default React.memo(function MapView({ scrollToTop }: Props) {
   const navigate = useNavigate()
   const t = useTranslation()
   const [mobileMode, setMobileMode] = useState<MobileMode>('map')
@@ -103,6 +107,10 @@ export default React.memo(function MapView() {
   const [languages, setLanguages] = useState<Language[]>([])
   const [providerTypes, setProviderTypes] = useState<ProviderTypeOption[]>([])
   const [shiftCare, setShiftCare] = useState<boolean>(false)
+
+  // Scroll the main content area to top on first mount
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => scrollToTop(), [])
 
   const [allUnits] = useApiState(() => fetchUnits(careType), [careType])
 


### PR DESCRIPTION
#### Summary

The page may be scrolled e.g. if the user is viewing the calendar and then navigating to the applying tab. This is bad because the second level menu is not shown in that case.

