### PR TITLE
Evaka 4406 more utilization fixes

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/UnitList.tsx
+++ b/frontend/src/employee-mobile-frontend/components/UnitList.tsx
@@ -75,7 +75,7 @@ export default React.memo(function UnitList() {
                             <StatDesc>{i18n.units.staff}</StatDesc>
                           </div>
                           <div>
-                            <Stat>{utilization} %</Stat>
+                            <Stat>{utilization.toFixed(1)} %</Stat>
                             <StatDesc>{i18n.units.utilization}</StatDesc>
                           </div>
                         </UnitRow>

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
@@ -133,7 +133,7 @@ fun Database.Read.fetchUnitInfo(unitId: DaycareId, date: LocalDate, useRealtimeS
                 LEFT JOIN service_need_option sno on sn.option_id = sno.id
                 LEFT JOIN service_need_option default_sno on pl.type = default_sno.valid_placement_type AND default_sno.default_option
                 LEFT JOIN assistance_need an on an.child_id = ca.child_id AND daterange(an.start_date, an.end_date, '[]') @> :date
-                JOIN daycare_group_placement dgp ON dgp.daycare_placement_id = pl.id
+                JOIN daycare_group_placement dgp ON dgp.daycare_placement_id = pl.id AND daterange(dgp.start_date, dgp.end_date, '[]') @> :date
             WHERE ca.unit_id = :unitId AND ca.end_time IS NULL
             GROUP BY dgp.daycare_group_id
         ), staff AS (


### PR DESCRIPTION
- Fix bug where utilization was calculated incorrectly if a child was placed in more than one group during their daycare unit placement
- Ensure that the utilization % always is formatted correctly on the supervisor's unit list view.
