### PR TITLE
EVAKA-4406 Fix bug where we sometimes called 'toFixed' on a string

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/UnitList.tsx
+++ b/frontend/src/employee-mobile-frontend/components/UnitList.tsx
@@ -75,7 +75,12 @@ export default React.memo(function UnitList() {
                             <StatDesc>{i18n.units.staff}</StatDesc>
                           </div>
                           <div>
-                            <Stat>{utilization.toFixed(1)} %</Stat>
+                            <Stat>
+                              {utilization.toFixed
+                                ? utilization.toFixed(1)
+                                : utilization}{' '}
+                              %
+                            </Stat>
                             <StatDesc>{i18n.units.utilization}</StatDesc>
                           </div>
                         </UnitRow>


### PR DESCRIPTION
The utilization can sometimes be the string 'Infinity', which does not have `toFixed` defined.