### PR TITLE
Fix invoice corrections being applied multiple times

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -209,8 +209,9 @@ SELECT
         '[]'::jsonb
     ) AS invoiced_corrections
 FROM invoice_correction c
-LEFT JOIN invoice_row r ON c.id = r.correction_id AND NOT c.applied_completely
+LEFT JOIN invoice_row r ON c.id = r.correction_id
 LEFT JOIN invoice i ON r.invoice_id = i.id AND i.status != 'DRAFT'
+WHERE NOT c.applied_completely
 GROUP BY c.id
 HAVING c.amount * c.unit_price != coalesce(sum(r.amount * r.unit_price) FILTER (WHERE i.id IS NOT NULL), 0)
 """


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Faulty database query caused invoice corrections being invoiced multiple times.

