### PR TITLE
Oulu-412 Hide some service needs from the citizen

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueriesTest.kt
@@ -5,7 +5,11 @@
 package fi.espoo.evaka.serviceneed
 
 import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.insertServiceNeedOptions
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.snPreparatoryDaycare50
+import fi.espoo.evaka.snPreschoolDaycare45
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -13,5 +17,21 @@ class ServiceNeedQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
     @Test
     fun getServiceNeedOptionPublicInfos() {
         assertThat(db.read { tx -> tx.getServiceNeedOptionPublicInfos(PlacementType.values().toList()) }).isEmpty()
+    }
+
+    @Test
+    fun getOnlyShownServiceNeedOptionPublicInfos() {
+        db.transaction { tx -> tx.insertServiceNeedOptions() }
+        db.transaction { tx -> tx.updateShowForCitizen() }
+        val queriedOptions = db.read { tx -> tx.getServiceNeedOptionPublicInfos(PlacementType.values().toList()) }
+        // I couln't get any of the fancy asssertj list assertions to work in Kotlin, so test the stupid way
+        queriedOptions.forEach {
+            assertThat(it.id).isNotEqualTo(snPreschoolDaycare45.id)
+            assertThat(it.id).isNotEqualTo(snPreparatoryDaycare50.id)
+        }
+    }
+
+    fun Database.Transaction.updateShowForCitizen() {
+        execute("UPDATE service_need_option SET show_for_citizen=FALSE WHERE id=? OR id=?", snPreschoolDaycare45.id, snPreparatoryDaycare50.id)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedQueries.kt
@@ -260,7 +260,7 @@ fun Database.Read.getServiceNeedOptionPublicInfos(placementTypes: List<Placement
             name_fi, name_sv, name_en,
             valid_placement_type
         FROM service_need_option
-        WHERE default_option IS FALSE AND valid_placement_type = ANY(:placementTypes::placement_type[])
+        WHERE default_option IS FALSE AND show_for_citizen IS TRUE AND valid_placement_type = ANY(:placementTypes::placement_type[])
         ORDER BY display_order
     """.trimIndent()
     return createQuery(sql)

--- a/service/src/main/resources/db/migration/V240__service_need_hiding.sql
+++ b/service/src/main/resources/db/migration/V240__service_need_hiding.sql
@@ -1,0 +1,1 @@
+ALTER TABLE service_need_option ADD COLUMN show_for_citizen boolean NOT NULL DEFAULT TRUE;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -237,3 +237,4 @@ V236__realtime_staff_attendance_unit_feature.sql
 V237__service_need_option_voucher_value.sql
 V238__employee_number.sql
 V239__daycare_extra_fields.sql
+V240__service_need_hiding.sql


### PR DESCRIPTION
Add the show_for_citizen field to service_need_option table and use it to
filter the service need options visible in the citizen UI

The show_for_citizen field defaults to true, so the functionality will remain the same for anyone who does not actively choose to set some rows to false to hide them from the citizen

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

