### PR TITLE
Occupancy report improvements part2

### DIFF
--- a/frontend/src/employee-frontend/components/reports/Occupancies.tsx
+++ b/frontend/src/employee-frontend/components/reports/Occupancies.tsx
@@ -6,7 +6,7 @@ import { addDays, isAfter, isWeekend, lastDayOfMonth } from 'date-fns'
 import { range } from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { Loading, Result, Success } from 'lib-common/api'
 import { formatDate } from 'lib-common/date'
@@ -35,8 +35,19 @@ import { FlexRow } from '../common/styled/containers'
 
 import { FilterLabel, FilterRow, TableScrollable } from './common'
 
-const StyledTd = styled(Td)`
+const StyledTd = styled(Td)<{ borderEdge?: 'left' | 'right' }>`
   white-space: nowrap;
+
+  ${(props) =>
+    props.borderEdge === 'left' &&
+    css`
+      border-left: 1px solid ${(props) => props.theme.colors.grayscale.g15};
+    `}
+  ${(props) =>
+    props.borderEdge === 'right' &&
+    css`
+      border-right: 1px solid ${(props) => props.theme.colors.grayscale.g15};
+    `}
 `
 
 const Wrapper = styled.div`
@@ -420,8 +431,12 @@ export default React.memo(function Occupancies() {
                   {usedValues !== 'raw' && (
                     <Th>{i18n.reports.occupancies.average}</Th>
                   )}
-                  {dateCols.map((date, i) => (
-                    <Th key={`${date.toDateString()}:${i}`}>
+                  {dates.map((date) => (
+                    <Th
+                      align="center"
+                      key={date.toDateString()}
+                      colSpan={usedValues === 'raw' ? 2 : undefined}
+                    >
                       {formatDate(date, 'dd.MM.')}
                     </Th>
                   ))}
@@ -435,7 +450,18 @@ export default React.memo(function Occupancies() {
                       <Link to={`/units/${row.unitId}`}>{row.unitName}</Link>
                     </StyledTd>
                     {displayCells[rowNum].slice(2).map((cell, colNum) => (
-                      <StyledTd key={colNum}>{cell}</StyledTd>
+                      <StyledTd
+                        key={colNum}
+                        borderEdge={
+                          usedValues === 'raw'
+                            ? colNum % 2 === (includeGroups ? 1 : 0)
+                              ? 'left'
+                              : 'right'
+                            : undefined
+                        }
+                      >
+                        {cell}
+                      </StyledTd>
                     ))}
                   </Tr>
                 ))}

--- a/frontend/src/employee-frontend/components/reports/Occupancies.tsx
+++ b/frontend/src/employee-frontend/components/reports/Occupancies.tsx
@@ -15,6 +15,7 @@ import LocalDate from 'lib-common/local-date'
 import { formatPercentage, formatDecimal } from 'lib-common/utils/number'
 import Loader from 'lib-components/atoms/Loader'
 import Title from 'lib-components/atoms/Title'
+import Tooltip from 'lib-components/atoms/Tooltip'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import { Container, ContentArea } from 'lib-components/layout/Container'
@@ -460,7 +461,20 @@ export default React.memo(function Occupancies() {
                             : undefined
                         }
                       >
-                        {cell}
+                        {usedValues === 'raw' &&
+                        (!includeGroups || colNum > 0) ? (
+                          <Tooltip
+                            tooltip={
+                              colNum % 2 === (includeGroups ? 1 : 0)
+                                ? i18n.reports.occupancies.sum
+                                : i18n.reports.occupancies.caretakers
+                            }
+                          >
+                            {cell}
+                          </Tooltip>
+                        ) : (
+                          <>{cell}</>
+                        )}
                       </StyledTd>
                     ))}
                   </Tr>

--- a/frontend/src/lib-components/layout/Table.tsx
+++ b/frontend/src/lib-components/layout/Table.tsx
@@ -27,7 +27,7 @@ interface ThProps {
   sticky?: boolean
   top?: string
   hidden?: boolean
-  align?: 'left' | 'right'
+  align?: 'left' | 'right' | 'center'
 }
 
 export const Th = styled.th<ThProps>`

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -2558,6 +2558,8 @@ export const fi = {
         }
       },
       average: 'Keskiarvo',
+      sum: 'Summa',
+      caretakers: 'Kasvattajia',
       missingCaretakersLegend: 'kasvattajien lukumäärä puuttuu'
     },
     invoices: {


### PR DESCRIPTION
#### Summary

Some small visual improvements to occupancy report's raw-format:
- dates are shown only once in the header
- borders and tooltips to data cells

![Screenshot_20220609_075227](https://user-images.githubusercontent.com/8450552/172767784-8abde757-f93f-4357-862a-1c54ebbea9ad.png)

