### PR TITLE
Remove "No applications" placeholder in citizen applications list

### DIFF
--- a/frontend/src/citizen-frontend/applications/ChildApplicationsBlock.tsx
+++ b/frontend/src/citizen-frontend/applications/ChildApplicationsBlock.tsx
@@ -77,10 +77,6 @@ const Icon = styled(FontAwesomeIcon)`
   margin-right: 10px;
 `
 
-const NoApplications = styled.p`
-  color: ${colors.grayscale.g70};
-`
-
 interface ChildApplicationsBlockProps {
   childId: string
   childName: string
@@ -178,7 +174,7 @@ export default React.memo(function ChildApplicationsBlock({
         />
       </TitleContainer>
 
-      {applicationSummaries.length ? (
+      {applicationSummaries.length > 0 &&
         applicationSummaries.map(
           (
             {
@@ -315,10 +311,7 @@ export default React.memo(function ChildApplicationsBlock({
               {index != applicationSummaries.length - 1 && <LineBreak />}
             </React.Fragment>
           )
-        )
-      ) : (
-        <NoApplications>{t.applicationsList.noApplications}</NoApplications>
-      )}
+        )}
     </ContentArea>
   )
 })

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1305,7 +1305,6 @@ const en: Translations = {
       </P>
     ),
     pageLoadError: 'Failed to load guardian applications',
-    noApplications: 'No applications',
     type: {
       DAYCARE: 'Application for early childhood education',
       PRESCHOOL: 'Pre-primary education application',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1245,7 +1245,6 @@ export default {
       </P>
     ),
     pageLoadError: 'Tietojen hakeminen ei onnistunut',
-    noApplications: 'Ei hakemuksia',
     type: {
       DAYCARE: 'Varhaiskasvatushakemus',
       PRESCHOOL: 'Esiopetushakemus',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1256,7 +1256,6 @@ const sv: Translations = {
       </P>
     ),
     pageLoadError: 'Tietojen hakeminen ei onnistunut',
-    noApplications: 'Inga ansökningar',
     type: {
       DAYCARE: 'Ansökan till småbarnspedagogik',
       PRESCHOOL: 'Ansökan till förskolan',


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

EVAKA-4550: a guardian cannot see another's applications, so the inaccurate placeholder is removed.
