### PR TITLE
Mobile pairing improvements

### DIFF
--- a/frontend/src/employee-frontend/components/MobilePairingModal.tsx
+++ b/frontend/src/employee-frontend/components/MobilePairingModal.tsx
@@ -157,7 +157,7 @@ export default React.memo(function MobilePairingModal({
             <Flex>
               <InputField
                 value={responseKey}
-                onChange={setResponseKey}
+                onChange={(v) => setResponseKey(v.toLowerCase())}
                 placeholder={i18n.common.code}
                 width="m"
                 data-qa="response-key-input"

--- a/frontend/src/employee-frontend/components/MobilePairingModal.tsx
+++ b/frontend/src/employee-frontend/components/MobilePairingModal.tsx
@@ -65,7 +65,7 @@ export default React.memo(function MobilePairingModal({
   }, [phase]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (responseKey.length === 10) {
+    if (responseKey.length === 12) {
       if (pairingResponse.isSuccess) {
         void postPairingResponse(
           pairingResponse.value.id,

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitAccessControl.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitAccessControl.tsx
@@ -323,7 +323,7 @@ const DevicesTable = React.memo(function DevicesTable({
         </Tr>
       </Thead>
       <Tbody>
-        {sortBy(rows, ['name']).map((row) => (
+        {sortBy(rows, (row) => row.name).map((row) => (
           <DeviceRow
             key={row.id}
             row={row}

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitAccessControl.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitAccessControl.tsx
@@ -323,7 +323,7 @@ const DevicesTable = React.memo(function DevicesTable({
         </Tr>
       </Thead>
       <Tbody>
-        {rows.map((row) => (
+        {sortBy(rows, ['name']).map((row) => (
           <DeviceRow
             key={row.id}
             row={row}

--- a/frontend/src/employee-mobile-frontend/components/mobile/PairingWizard.tsx
+++ b/frontend/src/employee-mobile-frontend/components/mobile/PairingWizard.tsx
@@ -119,7 +119,7 @@ export default React.memo(function ParingWizard() {
               <Flex>
                 <InputField
                   value={challengeKey}
-                  onChange={setChallengeKey}
+                  onChange={(v) => setChallengeKey(v.toLowerCase())}
                   placeholder={i18n.common.code}
                   data-qa="challenge-key-input"
                 />

--- a/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
@@ -341,7 +341,7 @@ export const fi = {
       START: 'Aloitetaan'
     },
     wizard: {
-      text1: 'Syötä eVakasta saatava 10-merkkinen koodi kenttään alla.',
+      text1: 'Syötä eVakasta saatava 12-merkkinen koodi kenttään alla.',
       text2: 'Syötä alla oleva vahvistuskoodi eVakaan.',
       title1: 'eVaka-mobiilin käyttöönotto, vaihe 1/3',
       title2: 'eVaka-mobiilin käyttöönotto, vaihe 2/3',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -49,7 +49,7 @@ class PairingIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         val id = res1.id
         val challengeKey = res1.challengeKey
         assertEquals(testUnitId, res1.unitId)
-        assertEquals(10, challengeKey.length)
+        assertEquals(12, challengeKey.length)
         assertNull(res1.responseKey)
         assertNull(res1.mobileDeviceId)
         assertEquals(PairingStatus.WAITING_CHALLENGE, res1.status)
@@ -63,7 +63,7 @@ class PairingIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         assertEquals(id, res2.id)
         assertEquals(testUnitId, res2.unitId)
         assertEquals(challengeKey, res2.challengeKey)
-        assertEquals(10, responseKey!!.length)
+        assertEquals(12, responseKey!!.length)
         assertNull(res1.mobileDeviceId)
         assertEquals(PairingStatus.WAITING_RESPONSE, res2.status)
 
@@ -368,15 +368,16 @@ class PairingIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `generatePairingKey - values are unique and chars are easy to distinguish`() {
+    fun `generatePairingKey - values are unique, chars are easy to distinguish and no uppercase chars`() {
         val count = 100
         val values = (1..count).map { generatePairingKey() }.toSet()
         assertEquals(count, values.size)
-        assertTrue(values.all { key -> key.length == 10 })
+        assertTrue(values.all { key -> key.length == 12 })
 
         val concatenated = values.joinToString(separator = "")
         val badChars = listOf('i', 'l', 'I', '1', 'o', 'O', '0', ' ')
         badChars.forEach { c -> assertFalse(concatenated.contains(c, ignoreCase = false)) }
+        concatenated.forEach { c -> assertFalse(c.isUpperCase()) }
     }
 
     private fun givenPairing(pairing: Pairing, attempts: Int = 0) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
@@ -154,8 +154,8 @@ fun Database.Transaction.incrementAttempts(id: PairingId, challengeKey: String) 
         .execute()
 }
 
-const val distinguishableChars = "abcdefghkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789"
-const val keyLength = 10
+const val distinguishableChars = "abcdefghkmnpqrstuvwxyz23456789"
+const val keyLength = 12
 val random: SecureRandom = SecureRandom()
 fun generatePairingKey(): String = (1..keyLength)
     .map { random.nextInt(distinguishableChars.length) }


### PR DESCRIPTION
#### Summary
- Removed lowercase characters from the available character pool for generating pairing codes
  - Increased the code length to 12 (from 10) in order to keep the amount of possible combinations ≥ as before
- Device names in the unit view are sorted alphabetically
