### PR TITLE
Add child additional info field to employee mobile

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/attendances/child-info/ChildSensitiveInfo.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/child-info/ChildSensitiveInfo.tsx
@@ -120,6 +120,12 @@ export default React.memo(function ChildSensitiveInfo({ child }: Props) {
           <Gap size="s" />
           <FixedSpaceColumn>
             {renderKeyValue(
+              i18n.childInfo.additionalInfo,
+              child.additionalInfo,
+              'child-info-additional-info'
+            )}
+
+            {renderKeyValue(
               i18n.childInfo.allergies,
               child.allergies,
               'child-info-allergies'

--- a/frontend/src/lib-common/generated/api-types/sensitive.ts
+++ b/frontend/src/lib-common/generated/api-types/sensitive.ts
@@ -14,6 +14,7 @@ import { UUID } from '../../types'
 * Generated from fi.espoo.evaka.sensitive.ChildSensitiveInformation
 */
 export interface ChildSensitiveInformation {
+  additionalInfo: string
   allergies: string
   backupPickups: ContactInfo[]
   childAddress: string

--- a/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
@@ -240,6 +240,7 @@ export const fi = {
     allergies: 'Allergiat',
     diet: 'Ruokavalio',
     medication: 'Lääkitys',
+    additionalInfo: 'Lisätiedot',
     contactInfoHeader: 'Yhteystiedot',
     contact: 'Yhteyshenkilö',
     name: 'Nimi',

--- a/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInformation.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInformation.kt
@@ -22,6 +22,7 @@ data class ChildSensitiveInformation(
     val allergies: String,
     val diet: String,
     val medication: String,
+    val additionalInfo: String,
     val contacts: List<ContactInfo>,
     val backupPickups: List<ContactInfo>
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/sensitive/GetChildSensitiveInfoQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sensitive/GetChildSensitiveInfoQueries.kt
@@ -34,6 +34,7 @@ fun Database.Read.getChildSensitiveInfo(childId: ChildId): ChildSensitiveInforma
         allergies = child?.additionalInformation?.allergies ?: "",
         diet = child?.additionalInformation?.diet ?: "",
         medication = child?.additionalInformation?.medication ?: "",
+        additionalInfo = child?.additionalInformation?.additionalInfo ?: "",
         contacts = familyContacts.filter { it.priority != null }.sortedBy { it.priority }.map {
             ContactInfo(
                 id = it.id.toString(),


### PR DESCRIPTION
#### Summary

Adds the additional info field to the sensitive information view in the employee mobile, mirroring the information visible in the regular employee child information view.

<img width="424" alt="Screenshot 2022-06-10 at 10 06 28" src="https://user-images.githubusercontent.com/5909886/173009817-7d5825f5-949b-41cc-8d08-24d40924672c.png">

