### PR TITLE
Fix spelling of save in Swedish translation

### DIFF
--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -22,7 +22,7 @@ const sv: Translations = {
     cancel: 'Gå tillbaka',
     return: 'Tillbaka',
     ok: 'Ok',
-    save: 'Spar',
+    save: 'Spara',
     discard: 'Spar inte',
     saveConfirmation: 'Vill du spara ändringar?',
     confirm: 'Bekräfta',


### PR DESCRIPTION
#### Summary
Spar → Spara
