### PR TITLE
Vasu document read -support

### DIFF
--- a/frontend/src/citizen-frontend/child-documents/CitizenVasuAndLeops.tsx
+++ b/frontend/src/citizen-frontend/child-documents/CitizenVasuAndLeops.tsx
@@ -39,15 +39,11 @@ const VasuTableContainer = styled.table`
 const VasuTr = styled.tr`
   & td {
     vertical-align: top;
+    padding-bottom: 16px;
+    padding-right: 16px;
   }
 `
 
-const VasuTd = styled.td`
-  padding-bottom: 16px;
-  padding-right: 16px;
-`
-
-const StateTd = styled(VasuTd)``
 const PermissionToShareText = styled.span`
   padding-left: 6px;
 `
@@ -71,6 +67,22 @@ const PermissionToShare = React.memo(function PermissionToShare() {
   )
 })
 
+const LinkTd = styled.td`
+  width: 40%;
+`
+
+const StateTd = styled.td`
+  width: 10%;
+`
+
+const DateTd = styled.td`
+  width: 10%;
+`
+
+const PermissionTd = styled.td`
+  width: 45%;
+`
+
 const VasuTable = React.memo(function VasuTable({
   summary
 }: {
@@ -85,27 +97,27 @@ const VasuTable = React.memo(function VasuTable({
         <tbody>
           {summary.vasuDocumentsSummary.map((vasu) => (
             <VasuTr key={vasu.id} data-qa={`vasu-${vasu.id}`}>
-              <VasuTd>
+              <LinkTd>
                 <Link to={`/vasu/${vasu.id}`} data-qa="vasu-link">
                   {`${vasu.name}`}
                 </Link>
-              </VasuTd>
+              </LinkTd>
               <StateTd data-qa={`state-chip-${vasu.id}`}>
                 <VasuStateChip
                   state={vasu.documentState}
                   labels={i18n.vasu.states}
                 />
               </StateTd>
-              <VasuTd data-qa={`published-at-${vasu.id}`}>
+              <DateTd data-qa={`published-at-${vasu.id}`}>
                 {vasu.publishedAt
                   ? LocalDate.fromSystemTzDate(vasu.publishedAt).format()
                   : ''}
-              </VasuTd>
-              <VasuTd data-qa={`permission-to-share-needed-${vasu.id}`}>
+              </DateTd>
+              <PermissionTd data-qa={`permission-to-share-needed-${vasu.id}`}>
                 {!vasu.guardiansThatHaveGivenPermissionToShare.some(
                   (guardianId) => guardianId === user?.id
                 ) && <PermissionToShare />}
-              </VasuTd>
+              </PermissionTd>
             </VasuTr>
           ))}
         </tbody>

--- a/frontend/src/citizen-frontend/child-documents/CitizenVasuAndLeops.tsx
+++ b/frontend/src/citizen-frontend/child-documents/CitizenVasuAndLeops.tsx
@@ -82,7 +82,7 @@ const DateTd = styled.td`
 `
 
 const PermissionTd = styled.td`
-  width: 45%;
+  width: 40%;
 `
 
 const VasuTable = React.memo(function VasuTable({

--- a/frontend/src/citizen-frontend/child-documents/CitizenVasuAndLeops.tsx
+++ b/frontend/src/citizen-frontend/child-documents/CitizenVasuAndLeops.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled, { useTheme } from 'styled-components'
 
@@ -28,6 +28,7 @@ import { useUser } from '../auth/state'
 import { useTranslation } from '../localization'
 
 import { Desktop, Mobile, PaddedDiv } from './components'
+import { ChildDocumentsContext, ChildDocumentsState } from './state'
 import { getGuardianChildVasuSummaries } from './vasu/api'
 import { VasuStateChip } from './vasu/components/VasuStateChip'
 
@@ -56,6 +57,7 @@ const PermissionToShare = React.memo(function PermissionToShare() {
     <>
       <RoundIcon
         content={faExclamation}
+        iconColor={theme.colors.grayscale.g0}
         color={theme.colors.status.warning}
         size="s"
         data-qa="attention-indicator"
@@ -236,6 +238,9 @@ const VasuDisplay = React.memo(function VasuDisplay({
 }) {
   const i18n = useTranslation()
   const [open, setOpen] = useState(true)
+  const { unreadVasuDocumentsCount } = useContext<ChildDocumentsState>(
+    ChildDocumentsContext
+  )
 
   return (
     <>
@@ -251,6 +256,7 @@ const VasuDisplay = React.memo(function VasuDisplay({
           opaque
           paddingVertical="16px 0px 0px 0px;"
           paddingHorizontal="zero"
+          countIndicator={unreadVasuDocumentsCount}
           data-qa="vasu-and-leops-collapsible"
         >
           <ContentArea opaque paddingVertical="s" paddingHorizontal="zero">
@@ -266,6 +272,7 @@ const VasuDisplay = React.memo(function VasuDisplay({
           toggleOpen={() => setOpen(!open)}
           opaque
           paddingVertical="L"
+          countIndicator={unreadVasuDocumentsCount}
           data-qa="vasu-and-leops-collapsible"
         >
           <ContentArea opaque paddingVertical="s" paddingHorizontal="zero">

--- a/frontend/src/citizen-frontend/child-documents/CitizenVasuAndLeops.tsx
+++ b/frontend/src/citizen-frontend/child-documents/CitizenVasuAndLeops.tsx
@@ -57,7 +57,6 @@ const PermissionToShare = React.memo(function PermissionToShare() {
     <>
       <RoundIcon
         content={faExclamation}
-        iconColor={theme.colors.grayscale.g0}
         color={theme.colors.status.warning}
         size="s"
         data-qa="attention-indicator"

--- a/frontend/src/citizen-frontend/child-documents/PedagogicalDocuments.tsx
+++ b/frontend/src/citizen-frontend/child-documents/PedagogicalDocuments.tsx
@@ -40,7 +40,7 @@ import { useTranslation } from '../localization'
 
 import { getPedagogicalDocuments, markPedagogicalDocumentRead } from './api'
 import { Desktop, Mobile, PaddedDiv } from './components'
-import { PedagogicalDocumentsContext, PedagogicalDocumentsState } from './state'
+import { ChildDocumentsContext, ChildDocumentsState } from './state'
 
 const AttachmentLink = React.memo(function AttachmentLink({
   pedagogicalDocument,
@@ -330,8 +330,9 @@ export default React.memo(function PedagogicalDocuments() {
   )
 
   const { refreshUnreadPedagogicalDocumentsCount } =
-    useContext<PedagogicalDocumentsState>(PedagogicalDocumentsContext)
+    useContext<ChildDocumentsState>(ChildDocumentsContext)
 
+  // TODO is this needed?
   useEffect(refreshUnreadPedagogicalDocumentsCount, [
     refreshUnreadPedagogicalDocumentsCount,
     pedagogicalDocuments

--- a/frontend/src/citizen-frontend/child-documents/PedagogicalDocuments.tsx
+++ b/frontend/src/citizen-frontend/child-documents/PedagogicalDocuments.tsx
@@ -178,6 +178,10 @@ const PedagogicalDocumentsDisplay = React.memo(
     const t = useTranslation()
     const [open, setOpen] = useState(true)
 
+    const { unreadPedagogicalDocumentsCount } = useContext<ChildDocumentsState>(
+      ChildDocumentsContext
+    )
+
     const moreThanOneChild = useMemo(
       () => uniq(items.map((doc) => doc.childId)).length > 1,
       [items]
@@ -207,6 +211,7 @@ const PedagogicalDocumentsDisplay = React.memo(
             opaque
             paddingVertical="L"
             data-qa="pedagogical-documents-collapsible"
+            countIndicator={unreadPedagogicalDocumentsCount}
           >
             {items.length > 0 && (
               <PedagogicalDocumentsTable
@@ -332,7 +337,6 @@ export default React.memo(function PedagogicalDocuments() {
   const { refreshUnreadPedagogicalDocumentsCount } =
     useContext<ChildDocumentsState>(ChildDocumentsContext)
 
-  // TODO is this needed?
   useEffect(refreshUnreadPedagogicalDocumentsCount, [
     refreshUnreadPedagogicalDocumentsCount,
     pedagogicalDocuments

--- a/frontend/src/citizen-frontend/child-documents/api.ts
+++ b/frontend/src/citizen-frontend/child-documents/api.ts
@@ -54,3 +54,14 @@ export async function getUnreadPedagogicalDocumentsCount(): Promise<
     return Failure.fromError(e)
   }
 }
+
+export async function getUnreadVasuDocumentsCount(): Promise<Result<number>> {
+  try {
+    const count = await client
+      .get<number>(`/citizen/vasu/children/unread-count`)
+      .then((res) => res.data)
+    return Success.of(count)
+  } catch (e) {
+    return Failure.fromError(e)
+  }
+}

--- a/frontend/src/citizen-frontend/child-documents/state.tsx
+++ b/frontend/src/citizen-frontend/child-documents/state.tsx
@@ -7,20 +7,27 @@ import React, { createContext, useCallback, useMemo, useState } from 'react'
 import { Result } from 'lib-common/api'
 import { useRestApi } from 'lib-common/utils/useRestApi'
 
-import { getUnreadPedagogicalDocumentsCount } from './api'
+import {
+  getUnreadPedagogicalDocumentsCount,
+  getUnreadVasuDocumentsCount
+} from './api'
 
-export interface PedagogicalDocumentsState {
+export interface ChildDocumentsState {
   unreadPedagogicalDocumentsCount: number | undefined
+  unreadVasuDocumentsCount: number | undefined
   refreshUnreadPedagogicalDocumentsCount: () => void
+  refreshUnreadVasuDocumentsCount: () => void
 }
 
-const defaultState: PedagogicalDocumentsState = {
+const defaultState: ChildDocumentsState = {
   unreadPedagogicalDocumentsCount: undefined,
-  refreshUnreadPedagogicalDocumentsCount: () => undefined
+  unreadVasuDocumentsCount: undefined,
+  refreshUnreadPedagogicalDocumentsCount: () => undefined,
+  refreshUnreadVasuDocumentsCount: () => undefined
 }
 
-export const PedagogicalDocumentsContext =
-  createContext<PedagogicalDocumentsState>(defaultState)
+export const ChildDocumentsContext =
+  createContext<ChildDocumentsState>(defaultState)
 
 export const PedagogicalDocumentsContextProvider = React.memo(
   function PedagogicalDocumentsContextProvider({
@@ -33,29 +40,56 @@ export const PedagogicalDocumentsContextProvider = React.memo(
       setUnreadPedagogicalDocumentsCount
     ] = useState<number>()
 
-    const setUnreadResult = useCallback((res: Result<number>) => {
-      if (res.isSuccess) {
-        setUnreadPedagogicalDocumentsCount(res.value)
-      }
-    }, [])
+    const [unreadVasuDocumentsCount, setUnreadVasuDocumentsCount] =
+      useState<number>()
+
+    const setUnreadPedagogicalDocumentCountResult = useCallback(
+      (res: Result<number>) => {
+        if (res.isSuccess) {
+          setUnreadPedagogicalDocumentsCount(res.value)
+        }
+      },
+      []
+    )
 
     const refreshUnreadPedagogicalDocumentsCount = useRestApi(
       getUnreadPedagogicalDocumentsCount,
-      setUnreadResult
+      setUnreadPedagogicalDocumentCountResult
+    )
+
+    const setUnreadVasuDocumentCountResult = useCallback(
+      (res: Result<number>) => {
+        if (res.isSuccess) {
+          setUnreadVasuDocumentsCount(res.value)
+        }
+      },
+      []
+    )
+
+    const refreshUnreadVasuDocumentsCount = useRestApi(
+      getUnreadVasuDocumentsCount,
+      setUnreadVasuDocumentCountResult
     )
 
     const value = useMemo(
       () => ({
         unreadPedagogicalDocumentsCount,
-        refreshUnreadPedagogicalDocumentsCount
+        unreadVasuDocumentsCount,
+        refreshUnreadPedagogicalDocumentsCount,
+        refreshUnreadVasuDocumentsCount
       }),
-      [unreadPedagogicalDocumentsCount, refreshUnreadPedagogicalDocumentsCount]
+      [
+        unreadPedagogicalDocumentsCount,
+        refreshUnreadPedagogicalDocumentsCount,
+        unreadVasuDocumentsCount,
+        refreshUnreadVasuDocumentsCount
+      ]
     )
 
     return (
-      <PedagogicalDocumentsContext.Provider value={value}>
+      <ChildDocumentsContext.Provider value={value}>
         {children}
-      </PedagogicalDocumentsContext.Provider>
+      </ChildDocumentsContext.Provider>
     )
   }
 )

--- a/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
@@ -138,7 +138,6 @@ export default React.memo(function VasuPage() {
                   })
                 }}
                 onSuccess={() => {
-                  console.log('DDEBUG')
                   setGuardianHasGivenPermissionToShare(true)
                 }}
                 data-qa="confirm-button"

--- a/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 
 import { UUID } from 'lib-common/types'
@@ -19,6 +19,7 @@ import { Label } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 
 import { useTranslation } from '../../localization'
+import { ChildDocumentsContext, ChildDocumentsState } from '../state'
 
 import { givePermissionToShareVasu } from './api'
 import { VasuContainer } from './components/VasuContainer'
@@ -52,6 +53,10 @@ export default React.memo(function VasuPage() {
 
   const [givePermissionToShareSelected, setGivePermissionToShareSelected] =
     useState<boolean>(false)
+
+  const { refreshUnreadVasuDocumentsCount } = useContext<ChildDocumentsState>(
+    ChildDocumentsContext
+  )
 
   const {
     vasu,
@@ -126,8 +131,16 @@ export default React.memo(function VasuPage() {
                 primary
                 text={t.common.confirm}
                 disabled={!givePermissionToShareSelected}
-                onClick={() => givePermissionToShareVasu(id)}
-                onSuccess={() => setGuardianHasGivenPermissionToShare(true)}
+                onClick={() => {
+                  return givePermissionToShareVasu(id).then((res) => {
+                    refreshUnreadVasuDocumentsCount()
+                    return res
+                  })
+                }}
+                onSuccess={() => {
+                  console.log('DDEBUG')
+                  setGuardianHasGivenPermissionToShare(true)
+                }}
                 data-qa="confirm-button"
               />
             </ContentArea>

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -33,13 +33,13 @@ import { getLogoutUri } from './const'
 
 interface Props {
   unreadMessagesCount: number
-  unreadPedagogicalDocuments: number
+  unreadChildDocuments: number
   hideLoginButton: boolean
 }
 
 export default React.memo(function DesktopNav({
   unreadMessagesCount,
-  unreadPedagogicalDocuments,
+  unreadChildDocuments,
   hideLoginButton
 }: Props) {
   const { user } = useContext(AuthContext)
@@ -78,16 +78,16 @@ export default React.memo(function DesktopNav({
                       )}
                     </StyledNavLink>
                   )}
-                  {user.accessibleFeatures.pedagogicalDocumentation && (
+                  {user.accessibleFeatures.childDocumentation && (
                     <StyledNavLink
                       to="/child-documents"
                       data-qa="nav-child-documents"
                     >
                       {t.header.nav.pedagogicalDocuments}
                       {maybeLockElem}
-                      {isEnduser && unreadPedagogicalDocuments > 0 && (
-                        <CircledChar data-qa="unread-pedagogical-documents-count">
-                          {unreadPedagogicalDocuments}
+                      {isEnduser && unreadChildDocuments > 0 && (
+                        <CircledChar data-qa="unread-child-documents-count">
+                          {unreadChildDocuments}
                         </CircledChar>
                       )}
                     </StyledNavLink>

--- a/frontend/src/citizen-frontend/header/Header.tsx
+++ b/frontend/src/citizen-frontend/header/Header.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback, useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -50,11 +50,8 @@ export default React.memo(function Header(props: { ariaHidden: boolean }) {
   const location = useLocation()
   const hideLoginButton = location.pathname === '/login'
 
-  const unreadDocumentCount = useCallback(() => {
-    return (
-      (unreadPedagogicalDocumentsCount || 0) + (unreadVasuDocumentsCount || 0)
-    )
-  }, [unreadPedagogicalDocumentsCount, unreadVasuDocumentsCount])
+  const unreadDocumentCount =
+    (unreadPedagogicalDocumentsCount || 0) + (unreadVasuDocumentsCount || 0)
 
   return (
     <HeaderContainer showMenu={showMenu} aria-hidden={props.ariaHidden}>
@@ -62,14 +59,14 @@ export default React.memo(function Header(props: { ariaHidden: boolean }) {
       <EvakaLogo />
       <DesktopNav
         unreadMessagesCount={unreadMessagesCount ?? 0}
-        unreadChildDocuments={unreadDocumentCount()}
+        unreadChildDocuments={unreadDocumentCount}
         hideLoginButton={hideLoginButton}
       />
       <MobileNav
         showMenu={showMenu}
         setShowMenu={setShowMenu}
         unreadMessagesCount={unreadMessagesCount ?? 0}
-        unreadChildDocumentsCount={unreadDocumentCount()}
+        unreadChildDocumentsCount={unreadDocumentCount}
         hideLoginButton={hideLoginButton}
       />
     </HeaderContainer>

--- a/frontend/src/citizen-frontend/header/Header.tsx
+++ b/frontend/src/citizen-frontend/header/Header.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -11,8 +11,8 @@ import colors from 'lib-customizations/common'
 
 import { useUser } from '../auth/state'
 import {
-  PedagogicalDocumentsContext,
-  PedagogicalDocumentsState
+  ChildDocumentsContext,
+  ChildDocumentsState
 } from '../child-documents/state'
 import { MessageContext, MessagePageState } from '../messages/state'
 
@@ -35,15 +35,26 @@ export default React.memo(function Header(props: { ariaHidden: boolean }) {
 
   const {
     unreadPedagogicalDocumentsCount,
-    refreshUnreadPedagogicalDocumentsCount
-  } = useContext<PedagogicalDocumentsState>(PedagogicalDocumentsContext)
+    unreadVasuDocumentsCount,
+    refreshUnreadPedagogicalDocumentsCount,
+    refreshUnreadVasuDocumentsCount
+  } = useContext<ChildDocumentsState>(ChildDocumentsContext)
 
   useEffect(() => {
-    if (user) refreshUnreadPedagogicalDocumentsCount()
-  }, [refreshUnreadPedagogicalDocumentsCount, user])
+    if (user) {
+      refreshUnreadPedagogicalDocumentsCount()
+      refreshUnreadVasuDocumentsCount()
+    }
+  }, [refreshUnreadVasuDocumentsCount, refreshUnreadPedagogicalDocumentsCount, user])
 
   const location = useLocation()
   const hideLoginButton = location.pathname === '/login'
+
+  const unreadDocumentCount = useCallback(() => {
+    return (
+      (unreadPedagogicalDocumentsCount || 0) + (unreadVasuDocumentsCount || 0)
+    )
+  }, [unreadPedagogicalDocumentsCount, unreadVasuDocumentsCount])
 
   return (
     <HeaderContainer showMenu={showMenu} aria-hidden={props.ariaHidden}>
@@ -51,14 +62,14 @@ export default React.memo(function Header(props: { ariaHidden: boolean }) {
       <EvakaLogo />
       <DesktopNav
         unreadMessagesCount={unreadMessagesCount ?? 0}
-        unreadPedagogicalDocuments={unreadPedagogicalDocumentsCount ?? 0}
+        unreadChildDocuments={unreadDocumentCount()}
         hideLoginButton={hideLoginButton}
       />
       <MobileNav
         showMenu={showMenu}
         setShowMenu={setShowMenu}
         unreadMessagesCount={unreadMessagesCount ?? 0}
-        unreadPedagogicalDocumentsCount={unreadPedagogicalDocumentsCount ?? 0}
+        unreadChildDocumentsCount={unreadDocumentCount()}
         hideLoginButton={hideLoginButton}
       />
     </HeaderContainer>

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -43,7 +43,7 @@ type Props = {
   showMenu: boolean
   setShowMenu: Dispatch<SetStateAction<boolean>>
   unreadMessagesCount: number
-  unreadPedagogicalDocumentsCount: number
+  unreadChildDocumentsCount: number
   hideLoginButton: boolean
 }
 
@@ -51,7 +51,7 @@ export default React.memo(function MobileNav({
   showMenu,
   setShowMenu,
   unreadMessagesCount,
-  unreadPedagogicalDocumentsCount,
+  unreadChildDocumentsCount,
   hideLoginButton
 }: Props) {
   const { user } = useContext(AuthContext)
@@ -69,7 +69,7 @@ export default React.memo(function MobileNav({
         const showAttentionIndicator =
           !showMenu &&
           (unreadMessagesCount > 0 ||
-            unreadPedagogicalDocumentsCount > 0 ||
+            unreadChildDocumentsCount > 0 ||
             !!(user && !user.email))
 
         return (
@@ -91,9 +91,7 @@ export default React.memo(function MobileNav({
                     close={close}
                     user={user}
                     unreadMessagesCount={unreadMessagesCount}
-                    unreadPedagogicalDocumentsCount={
-                      unreadPedagogicalDocumentsCount
-                    }
+                    unreadChildDocumentsCount={unreadChildDocumentsCount}
                   />
                 )}
                 <VerticalSpacer />
@@ -221,12 +219,12 @@ const Navigation = React.memo(function Navigation({
   close,
   user,
   unreadMessagesCount,
-  unreadPedagogicalDocumentsCount
+  unreadChildDocumentsCount
 }: {
   close: () => void
   user: User
   unreadMessagesCount: number
-  unreadPedagogicalDocumentsCount: number
+  unreadChildDocumentsCount: number
 }) {
   const t = useTranslation()
 
@@ -248,7 +246,7 @@ const Navigation = React.memo(function Navigation({
           )}
         </StyledNavLink>
       )}
-      {user.accessibleFeatures.pedagogicalDocumentation && (
+      {user.accessibleFeatures.childDocumentation && (
         <StyledNavLink
           to="/child-documents"
           data-qa="nav-child-documents"
@@ -256,9 +254,9 @@ const Navigation = React.memo(function Navigation({
         >
           {t.header.nav.pedagogicalDocuments}
           {maybeLockElem}
-          {unreadPedagogicalDocumentsCount > 0 && (
+          {unreadChildDocumentsCount > 0 && (
             <FloatingCircledChar>
-              {unreadPedagogicalDocumentsCount}
+              {unreadChildDocumentsCount}
             </FloatingCircledChar>
           )}
         </StyledNavLink>

--- a/frontend/src/e2e-test/pages/citizen/citizen-header.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-header.ts
@@ -4,6 +4,7 @@
 
 import { Lang } from 'lib-customizations/citizen'
 
+import { waitUntilEqual, waitUntilFalse } from '../../utils'
 import { Page } from '../../utils/page'
 
 export default class CitizenHeader {
@@ -20,6 +21,9 @@ export default class CitizenHeader {
   #languageOptionList = this.page.find('[data-qa="select-lang"]')
   #userMenu = this.page.find(`[data-qa="user-menu-title-${this.type}"]`)
   #applyingTab = this.page.find('[data-qa="nav-applying"]')
+  #unreadChildDocumentsCount = this.page.findAllByDataQa(
+    'unread-child-documents-count'
+  )
 
   #languageOption(lang: Lang) {
     return this.#languageOptionList.find(`[data-qa="lang-${lang}"]`)
@@ -132,5 +136,16 @@ export default class CitizenHeader {
     }
 
     await personalDetailsLink.click()
+  }
+
+  async assertUnreadChildDocumentsCount(expectedCount: number) {
+    expectedCount != 0
+      ? await waitUntilEqual(
+          () => this.#unreadChildDocumentsCount.first().textContent,
+          expectedCount.toString()
+        )
+      : await waitUntilFalse(
+          () => this.#unreadChildDocumentsCount.first().visible
+        )
   }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-pedagogical-documents.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-pedagogical-documents.ts
@@ -17,7 +17,7 @@ export default class CitizenPedagogicalDocumentsPage {
   readonly #downloadAttachment = (id: string) =>
     this.page.find(`[data-qa="attachment-${id}-download"]`)
   readonly #unreadDocumentCount = this.page.find(
-    '[data-qa="unread-pedagogical-documents-count"]'
+    '[data-qa="unread-child-documents-count"]'
   )
 
   async assertUnreadPedagogicalDocumentIndicatorCount(expectedCount: number) {

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
@@ -227,7 +227,12 @@ export class VasuPreviewPage extends VasuPageCommon {
     await waitUntilEqual(() => this.#titleChildName.textContent, expectedName)
   }
 
+  async assertGivePermissionToShareSectionIsVisible() {
+    await this.#confirmButton.waitUntilVisible()
+  }
+
   async assertGivePermissionToShareSectionIsNotVisible() {
+    await this.#titleChildName.waitUntilVisible()
     await this.#confirmButton.waitUntilHidden()
   }
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-vasu.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-vasu.spec.ts
@@ -85,6 +85,7 @@ describe('Citizen vasu document page', () => {
     ])
 
     const vasuPage = await openDocument()
+    await header.assertUnreadChildDocumentsCount(1)
     await vasuPage.assertTitleChildName('Antero Onni Leevi Aatu Högfors')
     await vasuPage.givePermissionToShare()
 
@@ -94,6 +95,7 @@ describe('Citizen vasu document page', () => {
     await revokeVasuSharingPermission(vasuDocId)
     await page.reload()
     await vasuPage.assertGivePermissionToShareSectionIsNotVisible()
+    await header.assertUnreadChildDocumentsCount(0)
   })
 })
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-vasu.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-vasu.spec.ts
@@ -90,12 +90,10 @@ describe('Citizen vasu document page', () => {
     await vasuPage.givePermissionToShare()
 
     await vasuPage.assertGivePermissionToShareSectionIsNotVisible()
-    await page.reload()
-    await vasuPage.assertGivePermissionToShareSectionIsNotVisible()
+    await header.assertUnreadChildDocumentsCount(0)
     await revokeVasuSharingPermission(vasuDocId)
     await page.reload()
-    await vasuPage.assertGivePermissionToShareSectionIsNotVisible()
-    await header.assertUnreadChildDocumentsCount(0)
+    await vasuPage.assertGivePermissionToShareSectionIsVisible()
   })
 })
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -11,8 +11,8 @@ import { UUID } from '../../types'
 * Generated from fi.espoo.evaka.shared.security.CitizenFeatures
 */
 export interface CitizenFeatures {
+  childDocumentation: boolean
   messages: boolean
-  pedagogicalDocumentation: boolean
   reservations: boolean
 }
 

--- a/frontend/src/lib-components/atoms/RoundIcon.tsx
+++ b/frontend/src/lib-components/atoms/RoundIcon.tsx
@@ -121,6 +121,7 @@ type RoundIconProps = BaseProps & {
   bubble?: boolean
   bubblecolor?: string
   number?: number
+  iconColor?: string
 }
 
 const RoundIcon = React.memo(function RoundIcon({
@@ -138,7 +139,8 @@ const RoundIcon = React.memo(function RoundIcon({
   label,
   bubble,
   bubblecolor,
-  number
+  number,
+  iconColor
 }: RoundIconProps) {
   function onKeyDown(e: React.KeyboardEvent) {
     if (onClick && (e.key === ' ' || e.key === 'Enter')) onClick(e)
@@ -184,7 +186,7 @@ const RoundIcon = React.memo(function RoundIcon({
       {typeof content === 'string' ? (
         <span className="text">{content}</span>
       ) : (
-        <FontAwesomeIcon icon={content} />
+        <FontAwesomeIcon icon={content} color={iconColor} />
       )}
     </IconContainer>
   )

--- a/frontend/src/lib-components/atoms/RoundIcon.tsx
+++ b/frontend/src/lib-components/atoms/RoundIcon.tsx
@@ -7,7 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import classNames from 'classnames'
 import { readableColor, shade } from 'polished'
 import React from 'react'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 import { tabletMin } from 'lib-components/breakpoints'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
@@ -121,7 +121,6 @@ type RoundIconProps = BaseProps & {
   bubble?: boolean
   bubblecolor?: string
   number?: number
-  iconColor?: string
 }
 
 const RoundIcon = React.memo(function RoundIcon({
@@ -139,12 +138,19 @@ const RoundIcon = React.memo(function RoundIcon({
   label,
   bubble,
   bubblecolor,
-  number,
-  iconColor
+  number
 }: RoundIconProps) {
+  const { colors } = useTheme()
+
   function onKeyDown(e: React.KeyboardEvent) {
     if (onClick && (e.key === ' ' || e.key === 'Enter')) onClick(e)
   }
+
+  const readableIconColor = readableColor(
+    color,
+    colors.grayscale.g0,
+    colors.grayscale.g100
+  )
 
   if (label)
     return (
@@ -186,7 +192,7 @@ const RoundIcon = React.memo(function RoundIcon({
       {typeof content === 'string' ? (
         <span className="text">{content}</span>
       ) : (
-        <FontAwesomeIcon icon={content} color={iconColor} />
+        <FontAwesomeIcon icon={content} color={readableIconColor} />
       )}
     </IconContainer>
   )

--- a/frontend/src/lib-components/layout/Container.tsx
+++ b/frontend/src/lib-components/layout/Container.tsx
@@ -10,7 +10,8 @@ import styled from 'styled-components'
 import { faChevronDown, faChevronUp } from 'lib-icons'
 
 import { desktopMin } from '../breakpoints'
-import { defaultMargins, isSpacingSize, SpacingSize } from '../white-space'
+import { fontWeights } from '../typography'
+import { defaultMargins, Gap, isSpacingSize, SpacingSize } from '../white-space'
 
 export const Container = styled.div<{ verticalMargin?: string }>`
   margin: ${({ verticalMargin }) => (verticalMargin ? verticalMargin : '0')}
@@ -90,7 +91,12 @@ type CollapsibleContentAreaProps = ContentAreaProps & {
   toggleOpen: () => void
   title: ReactNode
   children: ReactNode
+  countIndicator?: number
 }
+
+const IconContainer = styled.div`
+  display: flex;
+`
 
 export const CollapsibleContentArea = React.memo(
   function CollapsibleContentArea({
@@ -98,6 +104,7 @@ export const CollapsibleContentArea = React.memo(
     toggleOpen,
     title,
     children,
+    countIndicator = 0,
     ...props
   }: CollapsibleContentAreaProps) {
     return (
@@ -109,10 +116,20 @@ export const CollapsibleContentArea = React.memo(
           role="button"
         >
           {title}
-          <TitleIcon
-            icon={open ? faChevronUp : faChevronDown}
-            data-qa="collapsible-trigger"
-          />
+          <IconContainer>
+            {countIndicator > 0 && (
+              <>
+                <CircledChar color="white" data-qa="count-indicator">
+                  {countIndicator}
+                </CircledChar>
+                <Gap horizontal={true} size="s" />
+              </>
+            )}
+            <TitleIcon
+              icon={open ? faChevronUp : faChevronDown}
+              data-qa="collapsible-trigger"
+            />
+          </IconContainer>
         </TitleContainer>
         <Collapsible open={open}>{children}</Collapsible>
       </ContentArea>
@@ -149,6 +166,23 @@ const TitleIcon = styled(FontAwesomeIcon)`
   color: ${(p) => p.theme.colors.main.m2};
   height: 24px !important;
   width: 24px !important;
+`
+
+export const CircledChar = styled.div`
+  width: ${defaultMargins.s};
+  height: ${defaultMargins.s};
+  border: 1px solid ${(p) => p.theme.colors.grayscale.g0};
+  color: ${(p) => p.theme.colors.grayscale.g0};
+  background: ${(p) => p.theme.colors.status.warning};
+  padding: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  border-radius: 100%;
+  font-family: 'Open Sans', sans-serif;
+  font-weight: ${fontWeights.bold};
+  font-size: ${defaultMargins.s};
 `
 
 const Collapsible = styled.div<{ open: boolean }>`

--- a/frontend/src/lib-components/layout/Container.tsx
+++ b/frontend/src/lib-components/layout/Container.tsx
@@ -5,12 +5,12 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import classNames from 'classnames'
 import React, { ReactNode } from 'react'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 import { faChevronDown, faChevronUp } from 'lib-icons'
 
+import RoundIcon from '../atoms/RoundIcon'
 import { desktopMin } from '../breakpoints'
-import { fontWeights } from '../typography'
 import { defaultMargins, Gap, isSpacingSize, SpacingSize } from '../white-space'
 
 export const Container = styled.div<{ verticalMargin?: string }>`
@@ -107,6 +107,7 @@ export const CollapsibleContentArea = React.memo(
     countIndicator = 0,
     ...props
   }: CollapsibleContentAreaProps) {
+    const { colors } = useTheme()
     return (
       <ContentArea {...props} data-status={open ? 'open' : 'closed'}>
         <TitleContainer
@@ -119,9 +120,12 @@ export const CollapsibleContentArea = React.memo(
           <IconContainer>
             {countIndicator > 0 && (
               <>
-                <CircledChar color="white" data-qa="count-indicator">
-                  {countIndicator}
-                </CircledChar>
+                <RoundIcon
+                  size="m"
+                  color={colors.status.warning}
+                  content={countIndicator.toString()}
+                  data-qa="count-indicator"
+                />
                 <Gap horizontal={true} size="s" />
               </>
             )}
@@ -167,24 +171,6 @@ const TitleIcon = styled(FontAwesomeIcon)`
   height: 24px !important;
   width: 24px !important;
 `
-
-export const CircledChar = styled.div`
-  width: ${defaultMargins.s};
-  height: ${defaultMargins.s};
-  border: 1px solid ${(p) => p.theme.colors.grayscale.g0};
-  color: ${(p) => p.theme.colors.grayscale.g0};
-  background: ${(p) => p.theme.colors.status.warning};
-  padding: 10px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  border-radius: 100%;
-  font-family: 'Open Sans', sans-serif;
-  font-weight: ${fontWeights.bold};
-  font-size: ${defaultMargins.s};
-`
-
 const Collapsible = styled.div<{ open: boolean }>`
   display: ${(props) => (props.open ? 'block' : 'none')};
 `

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlCitizen.kt
@@ -16,7 +16,7 @@ class AccessControlCitizen {
         return CitizenFeatures(
             messages = tx.citizenHasAccessToMessaging(user.id),
             reservations = tx.citizenHasAccessToReservations(user.id),
-            pedagogicalDocumentation = tx.citizenHasAccessToPedagogicalDocumentation(user.id)
+            childDocumentation = tx.citizenHasAccessToChildDocumentation(user.id)
         )
     }
 
@@ -80,7 +80,7 @@ SELECT EXISTS (
         return createQuery(sql).bind("personId", personId).mapTo<Boolean>().first()
     }
 
-    private fun Database.Read.citizenHasAccessToPedagogicalDocumentation(personId: PersonId): Boolean {
+    private fun Database.Read.citizenHasAccessToChildDocumentation(personId: PersonId): Boolean {
         // language=sql
         val sql = """
 SELECT EXISTS (

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/CitizenFeatures.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/CitizenFeatures.kt
@@ -7,5 +7,5 @@ package fi.espoo.evaka.shared.security
 data class CitizenFeatures(
     val messages: Boolean,
     val reservations: Boolean,
-    val pedagogicalDocumentation: Boolean
+    val childDocumentation: Boolean
 )


### PR DESCRIPTION
#### Summary
- Show total number of different unread documents on citizen front page
- Show number of unread vasu documents on citizen vasu listing heading
- It was agreed that the vasu unread state is the same as the given-permission-to-share -state, so that is used