### PR TITLE
Use strongly typed filters in invoicing search APIs

### DIFF
--- a/frontend/src/employee-frontend/api/invoicing.ts
+++ b/frontend/src/employee-frontend/api/invoicing.ts
@@ -8,18 +8,23 @@ import DateRange from 'lib-common/date-range'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { Absence } from 'lib-common/generated/api-types/daycare'
 import {
+  DistinctiveParams,
   FeeDecision,
   FeeDecisionDetailed,
+  FeeDecisionStatus,
   FeeDecisionSummary,
   Invoice,
   InvoiceCodes,
   InvoiceCorrection,
   InvoiceDetailed,
+  InvoiceDistinctiveParams,
+  InvoiceStatus,
   InvoiceSummary,
   NewInvoiceCorrection,
   PersonBasic,
   PersonDetailed,
   VoucherValueDecisionDetailed,
+  VoucherValueDecisionStatus,
   VoucherValueDecisionSummary
 } from 'lib-common/generated/api-types/invoicing'
 import { JsonOf } from 'lib-common/json'
@@ -29,34 +34,33 @@ import { UUID } from 'lib-common/types'
 import { API_URL, client } from './client'
 
 export interface SearchParams {
-  status?: string
-  area?: string
-  unit?: string
-  distinctions?: string
+  area?: string[]
+  unit?: UUID
   searchTerms?: string
 }
 
 export interface FeeDecisionSearchParams extends SearchParams {
-  startDate?: string
-  endDate?: string
+  status?: FeeDecisionStatus[]
+  distinctions?: DistinctiveParams[]
+  startDate?: LocalDate
+  endDate?: LocalDate
   searchByStartDate: boolean
-  financeDecisionHandlerId?: string
+  financeDecisionHandlerId?: UUID
 }
 
-export interface VoucherValueDecisionSearchParams {
-  status?: string
-  area?: string
-  unit?: string
-  searchTerms?: string
-  financeDecisionHandlerId?: string
-  startDate?: string
-  endDate?: string
+export interface VoucherValueDecisionSearchParams extends SearchParams {
+  status?: VoucherValueDecisionStatus
+  financeDecisionHandlerId?: UUID
+  startDate?: LocalDate
+  endDate?: LocalDate
   searchByStartDate: boolean
 }
 
 export interface InvoiceSearchParams extends SearchParams {
-  periodStart?: string
-  periodEnd?: string
+  status?: InvoiceStatus[]
+  distinctions?: InvoiceDistinctiveParams[]
+  periodStart?: LocalDate
+  periodEnd?: LocalDate
 }
 
 interface AbsenceParams {

--- a/frontend/src/employee-frontend/components/fee-decisions/FeeDecisionsPage.tsx
+++ b/frontend/src/employee-frontend/components/fee-decisions/FeeDecisionsPage.tsx
@@ -59,16 +59,14 @@ export default React.memo(function FeeDecisionsPage() {
 
   const loadDecisions = useCallback(() => {
     const status = searchFilters.status
-    const area = searchFilters.area.join(',')
-    const distinctiveDetails = searchFilters.distinctiveDetails.join(',')
     const params: FeeDecisionSearchParams = {
-      status: status.length > 0 ? status : undefined,
-      area: area.length > 0 ? area : undefined,
-      unit: searchFilters.unit ? searchFilters.unit : undefined,
-      distinctions: distinctiveDetails ? distinctiveDetails : undefined,
+      status: status.length > 0 ? [status] : undefined,
+      area: searchFilters.area,
+      unit: searchFilters.unit,
+      distinctions: searchFilters.distinctiveDetails,
       searchTerms: debouncedSearchTerms ? debouncedSearchTerms : undefined,
-      startDate: searchFilters.startDate?.formatIso(),
-      endDate: searchFilters.endDate?.formatIso(),
+      startDate: searchFilters.startDate,
+      endDate: searchFilters.endDate,
       searchByStartDate: searchFilters.searchByStartDate,
       financeDecisionHandlerId: searchFilters.financeDecisionHandlerId
     }

--- a/frontend/src/employee-frontend/components/invoices/invoices-state.ts
+++ b/frontend/src/employee-frontend/components/invoices/invoices-state.ts
@@ -136,17 +136,15 @@ export function useInvoicesState() {
 
   const loadInvoices = useRestApi(getInvoices, setInvoicesResult)
   const reloadInvoices = useCallback(() => {
-    const area = searchFilters.area.join(',')
     const status = searchFilters.status
-    const distinctiveDetails = searchFilters.distinctiveDetails.join(',')
     const params: InvoiceSearchParams = {
-      area: area.length > 0 ? area : undefined,
-      unit: searchFilters.unit ? searchFilters.unit : undefined,
-      status: status.length > 0 ? status : undefined,
-      distinctions: distinctiveDetails ? distinctiveDetails : undefined,
+      area: searchFilters.area,
+      unit: searchFilters.unit,
+      status: status.length > 0 ? [status] : undefined,
+      distinctions: searchFilters.distinctiveDetails,
       searchTerms: debouncedSearchTerms ? debouncedSearchTerms : undefined,
-      periodStart: searchFilters.startDate?.formatIso(),
-      periodEnd: searchFilters.endDate?.formatIso()
+      periodStart: searchFilters.startDate,
+      periodEnd: searchFilters.endDate
     }
     loadInvoices(
       state.page,

--- a/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionsPage.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionsPage.tsx
@@ -63,17 +63,16 @@ export default React.memo(function VoucherValueDecisionsPage() {
 
   const loadDecisions = useCallback(() => {
     const status = searchFilters.status
-    const area = searchFilters.area.join(',')
     const params: VoucherValueDecisionSearchParams = {
       status: status.length > 0 ? status : undefined,
-      area: area.length > 0 ? area : undefined,
-      unit: searchFilters.unit ? searchFilters.unit : undefined,
+      area: searchFilters.area,
+      unit: searchFilters.unit,
       searchTerms: debouncedSearchTerms ? debouncedSearchTerms : undefined,
       financeDecisionHandlerId: searchFilters.financeDecisionHandlerId
         ? searchFilters.financeDecisionHandlerId
         : undefined,
-      startDate: searchFilters.startDate?.formatIso(),
-      endDate: searchFilters.endDate?.formatIso(),
+      startDate: searchFilters.startDate,
+      endDate: searchFilters.endDate,
       searchByStartDate: searchFilters.searchByStartDate
     }
     reloadDecisions(page, pageSize, sortBy, sortDirection, params)

--- a/frontend/src/employee-frontend/state/invoicing-ui.tsx
+++ b/frontend/src/employee-frontend/state/invoicing-ui.tsx
@@ -35,13 +35,13 @@ export interface Checked {
 
 interface FeeDecisionSearchFilters {
   area: string[]
-  unit?: string
+  unit?: UUID
   status: FeeDecisionStatus
   distinctiveDetails: DistinctiveParams[]
   startDate: LocalDate | undefined
   endDate: LocalDate | undefined
   searchByStartDate: boolean
-  financeDecisionHandlerId: string | undefined
+  financeDecisionHandlerId: UUID | undefined
 }
 
 interface FeeDecisionSearchFilterState {
@@ -55,9 +55,9 @@ interface FeeDecisionSearchFilterState {
 
 interface ValueDecisionSearchFilters {
   area: string[]
-  unit?: string
+  unit?: UUID
   status: VoucherValueDecisionStatus
-  financeDecisionHandlerId?: string
+  financeDecisionHandlerId?: UUID
   startDate: LocalDate | undefined
   endDate: LocalDate | undefined
   searchByStartDate: boolean

--- a/frontend/src/lib-common/generated/api-types/invoicing.ts
+++ b/frontend/src/lib-common/generated/api-types/invoicing.ts
@@ -567,9 +567,9 @@ export interface ProductWithName {
 * Generated from fi.espoo.evaka.invoicing.controller.SearchFeeDecisionRequest
 */
 export interface SearchFeeDecisionRequest {
-  area: string | null
-  distinctions: string | null
-  endDate: string | null
+  area: string[] | null
+  distinctions: DistinctiveParams[] | null
+  endDate: LocalDate | null
   financeDecisionHandlerId: UUID | null
   page: number
   pageSize: number
@@ -577,8 +577,8 @@ export interface SearchFeeDecisionRequest {
   searchTerms: string | null
   sortBy: FeeDecisionSortParam | null
   sortDirection: SortDirection | null
-  startDate: string | null
-  status: string | null
+  startDate: LocalDate | null
+  status: FeeDecisionStatus[] | null
   unit: UUID | null
 }
 
@@ -586,16 +586,16 @@ export interface SearchFeeDecisionRequest {
 * Generated from fi.espoo.evaka.invoicing.controller.SearchInvoicesRequest
 */
 export interface SearchInvoicesRequest {
-  area: string | null
-  distinctions: string | null
+  area: string[] | null
+  distinctions: InvoiceDistinctiveParams[] | null
   page: number
   pageSize: number
-  periodEnd: string | null
-  periodStart: string | null
+  periodEnd: LocalDate | null
+  periodStart: LocalDate | null
   searchTerms: string | null
   sortBy: InvoiceSortParam | null
   sortDirection: SortDirection | null
-  status: string | null
+  status: InvoiceStatus[] | null
   unit: UUID | null
 }
 
@@ -603,8 +603,8 @@ export interface SearchInvoicesRequest {
 * Generated from fi.espoo.evaka.invoicing.controller.SearchVoucherValueDecisionRequest
 */
 export interface SearchVoucherValueDecisionRequest {
-  area: string | null
-  endDate: string | null
+  area: string[] | null
+  endDate: LocalDate | null
   financeDecisionHandlerId: UUID | null
   page: number
   pageSize: number
@@ -612,8 +612,8 @@ export interface SearchVoucherValueDecisionRequest {
   searchTerms: string | null
   sortBy: VoucherValueDecisionSortParam | null
   sortDirection: SortDirection | null
-  startDate: string | null
-  status: string | null
+  startDate: LocalDate | null
+  status: VoucherValueDecisionStatus
   unit: UUID | null
 }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -290,7 +290,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         val drafts = testDecisions.filter { it.status === FeeDecisionStatus.DRAFT }
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "status": "DRAFT"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "status": ["DRAFT"]}""")
             .asUser(user)
             .responseString()
 
@@ -306,7 +306,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         val sent = testDecisions.filter { it.status === FeeDecisionStatus.SENT }
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "status": "SENT"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "status": ["SENT"]}""")
             .asUser(user)
             .responseString()
 
@@ -321,7 +321,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         db.transaction { tx -> tx.upsertFeeDecisions(testDecisions) }
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "status": "DRAFT,SENT"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "status": ["DRAFT","SENT"]}""")
             .asUser(user)
             .responseString()
 
@@ -344,7 +344,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         db.transaction { tx -> tx.upsertFeeDecisions(listOf(testDecision, testDecisionMissingServiceNeed)) }
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "distinctions": "UNCONFIRMED_HOURS"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "distinctions": ["UNCONFIRMED_HOURS"]}""")
             .asUser(user)
             .responseString()
 
@@ -363,7 +363,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         }
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "distinctions": "EXTERNAL_CHILD"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "distinctions": ["EXTERNAL_CHILD"]}""")
             .asUser(user)
             .responseString()
 
@@ -382,7 +382,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         db.transaction { tx -> tx.upsertFeeDecisions(listOf(oldDecision, futureDecision)) }
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "distinctions": "RETROACTIVE"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "distinctions": ["RETROACTIVE"]}""")
             .asUser(user)
             .responseString()
 
@@ -397,7 +397,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         db.transaction { tx -> tx.upsertFeeDecisions(testDecisions) }
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "area": "test_area"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "area": ["test_area"]}""")
             .asUser(user)
             .responseString()
 
@@ -412,7 +412,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         db.transaction { tx -> tx.upsertFeeDecisions(testDecisions) }
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "area": "test_area", "status": "DRAFT"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "area": ["test_area"], "status": ["DRAFT"]}""")
             .asUser(user)
             .responseString()
 
@@ -427,7 +427,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         db.transaction { tx -> tx.upsertFeeDecisions(testDecisions) }
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "area": "non_existent"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "area": ["non_existent"]}""")
             .asUser(user)
             .responseString()
         assertEqualEnough(
@@ -1204,7 +1204,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         assertEquals(200, response.statusCode)
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "status": "DRAFT"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "status": ["DRAFT"]}""")
             .asUser(user)
             .responseString()
 
@@ -1232,7 +1232,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         assertEquals(200, response.statusCode)
 
         val (_, _, result) = http.post("/decisions/search")
-            .jsonBody("""{"page": "0", "pageSize": "50", "status": "DRAFT"}""")
+            .jsonBody("""{"page": "0", "pageSize": "50", "status": ["DRAFT"]}""")
             .asUser(user)
             .responseString()
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -157,7 +157,7 @@ class InvoiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         val drafts = testInvoices.filter { it.status === InvoiceStatus.DRAFT }.sortedBy { it.dueDate }
 
         val (_, response, result) = http.post("/invoices/search")
-            .jsonBody("""{"page": 1, "pageSize": 200, "status": "DRAFT"}""")
+            .jsonBody("""{"page": 1, "pageSize": 200, "status": ["DRAFT"]}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -174,7 +174,7 @@ class InvoiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         val sent = testInvoices.filter { it.status === InvoiceStatus.SENT }
 
         val (_, response, result) = http.post("/invoices/search")
-            .jsonBody("""{"page": 1, "pageSize": 200, "status": "SENT"}""")
+            .jsonBody("""{"page": 1, "pageSize": 200, "status": ["SENT"]}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -191,7 +191,7 @@ class InvoiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         val canceled = testInvoices.filter { it.status === InvoiceStatus.CANCELED }
 
         val (_, response, result) = http.post("/invoices/search")
-            .jsonBody("""{"page": 1, "pageSize": 200, "status": "CANCELED"}""")
+            .jsonBody("""{"page": 1, "pageSize": 200, "status": ["CANCELED"]}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -209,7 +209,7 @@ class InvoiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             testInvoices.filter { it.status == InvoiceStatus.SENT || it.status == InvoiceStatus.CANCELED }
 
         val (_, response, result) = http.post("/invoices/search")
-            .jsonBody("""{"page": 1, "pageSize": 200, "status": "SENT,CANCELED"}""")
+            .jsonBody("""{"page": 1, "pageSize": 200, "status": ["SENT","CANCELED"]}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -227,7 +227,7 @@ class InvoiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         val invoices = testInvoiceSubset.sortedBy { it.status }.reversed()
 
         val (_, response, result) = http.post("/invoices/search")
-            .jsonBody("""{"page": 1, "pageSize": 200, "status": "DRAFT,SENT,CANCELED"}""")
+            .jsonBody("""{"page": 1, "pageSize": 200, "status": ["DRAFT","SENT","CANCELED"]}""")
             .asUser(testUser)
             .responseString()
 
@@ -245,7 +245,7 @@ class InvoiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         val invoices = testInvoices.sortedBy { it.status }.reversed()
 
         val (_, response, result) = http.post("/invoices/search")
-            .jsonBody("""{"page": 1, "pageSize": 200, "area": "test_area"}""")
+            .jsonBody("""{"page": 1, "pageSize": 200, "area": ["test_area"]}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -262,7 +262,7 @@ class InvoiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         val invoices = testInvoices.sortedBy { it.status }.reversed()
 
         val (_, response, result) = http.post("/invoices/search")
-            .jsonBody("""{"page": 1, "pageSize": 200, "area": "test_area", "status": "DRAFT"}""")
+            .jsonBody("""{"page": 1, "pageSize": 200, "area": ["test_area"], "status": ["DRAFT"]}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -280,7 +280,7 @@ class InvoiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         db.transaction { tx -> tx.upsertInvoices(testInvoices) }
 
         val (_, response, result) = http.post("/invoices/search")
-            .jsonBody("""{"page": 1, "pageSize": 200, "area": "non_existent"}""")
+            .jsonBody("""{"page": 1, "pageSize": 200, "area": ["non_existent"]}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)
@@ -453,7 +453,7 @@ class InvoiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             .reversed()
 
         val (_, response, result) = http.post("/invoices/search")
-            .jsonBody("""{"page": 1, "pageSize": 2, "status": "DRAFT", "sortBy": "START", "sortDirection": "DESC"}""")
+            .jsonBody("""{"page": 1, "pageSize": 2, "status": ["DRAFT"], "sortBy": "START", "sortDirection": "DESC"}""")
             .asUser(testUser)
             .responseString()
         assertEquals(200, response.statusCode)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka.invoicing.controller
 
 import fi.espoo.evaka.Audit
-import fi.espoo.evaka.IncludeCodeGen
 import fi.espoo.evaka.invoicing.data.findFeeDecisionsForHeadOfFamily
 import fi.espoo.evaka.invoicing.data.getFeeDecision
 import fi.espoo.evaka.invoicing.data.searchFeeDecisions
@@ -34,7 +33,6 @@ import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
-import fi.espoo.evaka.shared.utils.parseEnum
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -43,7 +41,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 enum class FeeDecisionSortParam {
     HEAD_OF_FAMILY,
@@ -60,7 +57,6 @@ enum class SortDirection {
     DESC
 }
 
-@IncludeCodeGen
 enum class DistinctiveParams {
     UNCONFIRMED_HOURS,
     EXTERNAL_CHILD,
@@ -95,13 +91,13 @@ class FeeDecisionController(
                     body.pageSize,
                     body.sortBy ?: FeeDecisionSortParam.STATUS,
                     body.sortDirection ?: SortDirection.DESC,
-                    body.status?.split(",")?.mapNotNull { parseEnum<FeeDecisionStatus>(it) } ?: listOf(),
-                    body.area?.split(",") ?: listOf(),
+                    body.status ?: emptyList(),
+                    body.area ?: emptyList(),
                     body.unit,
-                    body.distinctions?.split(",")?.mapNotNull { parseEnum<DistinctiveParams>(it) } ?: listOf(),
+                    body.distinctions ?: emptyList(),
                     body.searchTerms ?: "",
-                    body.startDate?.let { LocalDate.parse(body.startDate, DateTimeFormatter.ISO_DATE) },
-                    body.endDate?.let { LocalDate.parse(body.endDate, DateTimeFormatter.ISO_DATE) },
+                    body.startDate,
+                    body.endDate,
                     body.searchByStartDate,
                     body.financeDecisionHandlerId
                 )
@@ -222,13 +218,13 @@ data class SearchFeeDecisionRequest(
     val pageSize: Int,
     val sortBy: FeeDecisionSortParam?,
     val sortDirection: SortDirection?,
-    val status: String?,
-    val area: String?,
+    val status: List<FeeDecisionStatus>?,
+    val area: List<String>?,
     val unit: DaycareId?,
-    val distinctions: String?,
+    val distinctions: List<DistinctiveParams>?,
     val searchTerms: String?,
-    val startDate: String?,
-    val endDate: String?,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
     val searchByStartDate: Boolean = false,
     val financeDecisionHandlerId: EmployeeId?
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka.invoicing.controller
 
 import fi.espoo.evaka.Audit
-import fi.espoo.evaka.IncludeCodeGen
 import fi.espoo.evaka.invoicing.data.deleteDraftInvoices
 import fi.espoo.evaka.invoicing.data.getDetailedInvoice
 import fi.espoo.evaka.invoicing.data.getHeadOfFamilyInvoices
@@ -30,7 +29,6 @@ import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
-import fi.espoo.evaka.shared.utils.parseEnum
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -41,9 +39,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
-@IncludeCodeGen
 enum class InvoiceDistinctiveParams {
     MISSING_ADDRESS
 }
@@ -83,13 +79,13 @@ class InvoiceController(
                         body.pageSize,
                         body.sortBy ?: InvoiceSortParam.STATUS,
                         body.sortDirection ?: SortDirection.DESC,
-                        body.status?.split(",")?.mapNotNull { parseEnum<InvoiceStatus>(it) } ?: listOf(),
-                        body.area?.split(",") ?: listOf(),
+                        body.status ?: emptyList(),
+                        body.area ?: emptyList(),
                         body.unit,
-                        body.distinctions?.split(",")?.mapNotNull { parseEnum<InvoiceDistinctiveParams>(it) } ?: listOf(),
+                        body.distinctions ?: emptyList(),
                         body.searchTerms ?: "",
-                        body.periodStart?.let { LocalDate.parse(body.periodStart, DateTimeFormatter.ISO_DATE) },
-                        body.periodEnd?.let { LocalDate.parse(body.periodEnd, DateTimeFormatter.ISO_DATE) }
+                        body.periodStart,
+                        body.periodEnd,
                     )
                 }
         }
@@ -197,11 +193,11 @@ data class SearchInvoicesRequest(
     val pageSize: Int,
     val sortBy: InvoiceSortParam?,
     val sortDirection: SortDirection?,
-    val status: String?,
-    val area: String?,
+    val status: List<InvoiceStatus>?,
+    val area: List<String>?,
     val unit: DaycareId?,
-    val distinctions: String?,
+    val distinctions: List<InvoiceDistinctiveParams>?,
     val searchTerms: String?,
-    val periodStart: String?,
-    val periodEnd: String?
+    val periodStart: LocalDate?,
+    val periodEnd: LocalDate?
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -51,7 +51,6 @@ import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
-import fi.espoo.evaka.shared.utils.parseEnum
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -60,7 +59,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 @RestController
 @RequestMapping("/value-decisions")
@@ -90,13 +88,12 @@ class VoucherValueDecisionController(
                         body.pageSize,
                         body.sortBy ?: VoucherValueDecisionSortParam.STATUS,
                         body.sortDirection ?: SortDirection.DESC,
-                        body.status?.let { parseEnum<VoucherValueDecisionStatus>(it) }
-                            ?: throw BadRequest("Status is a mandatory parameter"),
-                        body.area?.split(",") ?: listOf(),
+                        body.status,
+                        body.area ?: emptyList(),
                         body.unit,
                         body.searchTerms ?: "",
-                        body.startDate?.let { LocalDate.parse(body.startDate, DateTimeFormatter.ISO_DATE) },
-                        body.endDate?.let { LocalDate.parse(body.endDate, DateTimeFormatter.ISO_DATE) },
+                        body.startDate,
+                        body.endDate,
                         body.searchByStartDate,
                         body.financeDecisionHandlerId
                     )
@@ -293,13 +290,13 @@ data class SearchVoucherValueDecisionRequest(
     val pageSize: Int,
     val sortBy: VoucherValueDecisionSortParam?,
     val sortDirection: SortDirection?,
-    val status: String?,
-    val area: String?,
+    val status: VoucherValueDecisionStatus,
+    val area: List<String>?,
     val unit: DaycareId?,
     val searchTerms: String?,
     val financeDecisionHandlerId: EmployeeId?,
-    val startDate: String?,
-    val endDate: String?,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
     val searchByStartDate: Boolean = false
 )
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

No need to do manual string serialization/deserialization, since we have today support for fully typed filters.

The main motivation for this change is to eventually remove all special cases which need `IncludeCodeGen`, and then remove the annotation completely.