### PR TITLE
Add children directly into fridge families from dvv child info

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/MockDvvModificationsService.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/MockDvvModificationsService.kt
@@ -511,7 +511,26 @@ val modifications = mapOf<String, String>(
   ],
   "muutospv": "2021-09-14T12:01:04.568Z"
 }            
-    """.trimIndent()
+    """.trimIndent(),
+    "010170-123F" to """
+{
+  "henkilotunnus": "010170-123F",
+  "tietoryhmat": [
+    {
+      "tietoryhma": "LAPSI_SUPPEA",
+      "muutosattribuutti": "LISATTY",
+      "lapsi": {
+        "henkilotunnus": "010120A123K",
+        "sukupuoli": "PUUTTUU",
+        "kansalaisuuskoodi": "247"
+      },
+      "isaAiti": "ISA",
+      "lapsiVanhempiSuhdePaattynyt": false
+    }
+  ],
+  "muutospv": "2021-09-14T12:01:04.568Z"
+}
+"""
 )
 
 data class ModificationsRequest(

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModifications.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModifications.kt
@@ -41,7 +41,9 @@ data class DvvModification(
     JsonSubTypes.Type(value = CaretakerLimitedDvvInfoGroup::class, name = "HUOLTAJA_SUPPEA"),
     JsonSubTypes.Type(value = SsnDvvInfoGroup::class, name = "HENKILOTUNNUS_KORJAUS"),
     JsonSubTypes.Type(value = ResidenceCodeDvvInfoGroup::class, name = "VAKINAINEN_KOTIMAINEN_ASUINPAIKKATUNNUS"),
-    JsonSubTypes.Type(value = HomeMunicipalityDvvInfoGroup::class, name = "KOTIKUNTA")
+    JsonSubTypes.Type(value = HomeMunicipalityDvvInfoGroup::class, name = "KOTIKUNTA"),
+    JsonSubTypes.Type(value = ChildInfoGroup::class, name = "LAPSI"),
+    JsonSubTypes.Type(value = ChildInfoGroup::class, name = "LAPSI_SUPPEA")
 )
 
 interface DvvInfoGroup {
@@ -164,6 +166,16 @@ data class SsnDvvInfoGroup(
     val aktiivinenHenkilotunnus: String,
     val edellisetHenkilotunnukset: List<String>
 ) : DvvInfoGroup
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ChildInfoGroup(
+    override val tietoryhma: String,
+    val muutosattribuutti: String?,
+    val lapsi: DvvChild
+) : DvvInfoGroup
+
+@JsonIgnoreProperties("sukupuoli", "etunimet", "sukunimi", "kansalaisuuskoodi", "kansalaisuusnimi", "nimienLisatieto")
+data class DvvChild(val henkilotunnus: String?, val syntymapv: DvvDate?)
 
 data class DvvDate(
     val arvo: String,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add children into a fridge family starting from the child's date of birth if a child has been added to someone according to DVV. Otherwise handle the event as usual. I don't know if silently ignoring children that are already in another family is a good idea, but that's what happened originally anyway.

