### PR TITLE
Make effect of free absences on invoices configurable

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -4020,6 +4020,43 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
+    fun `Free absence type is treated as other absence if feature is disabled`() {
+        // 22 operational days
+        val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 1, 31))
+
+        // free absences for the whole month
+        val free = datesBetween(period.start, period.end).map { it to AbsenceType.FREE_ABSENCE }
+        initDataForAbsences(listOf(period), free)
+
+        // Override freeAbsenceGivesADailyRefund feature config
+        val generator = InvoiceGenerator(
+            DraftInvoiceGenerator(
+                productProvider,
+                featureConfig.copy(freeAbsenceGivesADailyRefund = false),
+                DefaultInvoiceGenerationLogic
+            )
+        )
+        db.transaction { generator.createAndStoreAllDraftInvoices(it, period) }
+
+        val result = db.read(getAllInvoices)
+        assertEquals(1, result.size)
+        result.first().let { invoice ->
+            assertEquals(14450, invoice.totalPrice)
+            assertEquals(2, invoice.rows.size)
+            invoice.rows[0].let { invoiceRow ->
+                assertEquals(1, invoiceRow.amount)
+                assertEquals(28900, invoiceRow.unitPrice)
+                assertEquals(28900, invoiceRow.price)
+            }
+            invoice.rows[1].let { invoiceRow ->
+                assertEquals(1, invoiceRow.amount)
+                assertEquals(-14450, invoiceRow.unitPrice)
+                assertEquals(-14450, invoiceRow.price)
+            }
+        }
+    }
+
+    @Test
     fun `invoice generation with Free logic`() {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 1, 31))
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -184,5 +184,6 @@ val testFeatureConfig = FeatureConfig(
     citizenReservationThresholdHours = 150,
     dailyFeeDivisorOperationalDaysOverride = null,
     freeSickLeaveOnContractDays = false,
+    freeAbsenceGivesADailyRefund = true,
     alwaysUseDaycareFinanceDecisionHandler = false
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -110,6 +110,7 @@ class EspooConfig {
         citizenReservationThresholdHours = 150,
         dailyFeeDivisorOperationalDaysOverride = null,
         freeSickLeaveOnContractDays = false, // Doesn't affect Espoo
+        freeAbsenceGivesADailyRefund = true,
         alwaysUseDaycareFinanceDecisionHandler = false, // Doesn't affect Espoo
     )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
@@ -685,7 +685,10 @@ class DraftInvoiceGenerator(
         dailyFeeDivisor: Int,
     ): Int {
         val forceMajeureAndFreeAbsences = absences
-            .filter { it.absenceType == AbsenceType.FORCE_MAJEURE || it.absenceType == AbsenceType.FREE_ABSENCE }
+            .filter {
+                it.absenceType == AbsenceType.FORCE_MAJEURE ||
+                    (featureConfig.freeAbsenceGivesADailyRefund && it.absenceType == AbsenceType.FREE_ABSENCE)
+            }
             .map { it.date }
         val forceMajeureDays = forceMajeureAndFreeAbsences.filter { period.includes(it) }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -42,6 +42,9 @@ data class FeatureConfig(
      */
     val freeSickLeaveOnContractDays: Boolean,
 
+    /** Controls whether FREE_ABSENCE absences give a daily refund on invoices or not */
+    val freeAbsenceGivesADailyRefund: Boolean,
+
     /** Whether to always use the marked daycare finance decision handler
      *
      *  If true, regardless of situation use the handler marked in the daycare settings


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Lets you treat absences of type `FREE_ABSENCE` like an "ordinary" absence instead of giving a daily refund.

