### PR TITLE
EVAKA-FIX serve attachments inline

### DIFF
--- a/apigw/src/enduser/routes.ts
+++ b/apigw/src/enduser/routes.ts
@@ -12,8 +12,8 @@ router.all('/citizen/*', createProxy())
 
 router.get('/decisions2/:decisionId/download', proxy)
 
-router.get('/attachments/:applicationId/download', proxy)
-router.get('/attachments/:attachmentId/download', proxy)
+router.get('/attachments/:applicationId/download/:filename', proxy)
+router.get('/attachments/:attachmentId/download/:filename', proxy)
 
 router.delete('/attachments/citizen/:id', proxy)
 

--- a/frontend/src/citizen-frontend/attachments.ts
+++ b/frontend/src/citizen-frontend/attachments.ts
@@ -61,6 +61,9 @@ export async function deleteAttachment(id: UUID): Promise<Result<void>> {
   }
 }
 
-export function getAttachmentUrl(attachmentId: UUID): string {
-  return `${API_URL}/attachments/${attachmentId}/download`
+export function getAttachmentUrl(
+  attachmentId: UUID,
+  requestedFilename: string
+): string {
+  return `${API_URL}/attachments/${attachmentId}/download/${requestedFilename}`
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -328,13 +328,13 @@ class CitizenApplicationEditor {
     )
   }
 
-  async assertUrgencyFileDownload(fileName: string) {
-    const [download] = await Promise.all([
-      this.page.waitForDownload(),
+  async assertUrgencyFileDownload() {
+    const [popup] = await Promise.all([
+      this.page.waitForPopup(),
       this.page
         .find('[data-qa="service-need-urgency-attachment-download"]')
         .click()
     ])
-    expect(download.suggestedFilename()).toEqual(fileName)
+    await popup.waitForSelector('img:not([src=""])')
   }
 }

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -201,6 +201,6 @@ describe('Citizen daycare applications', () => {
     await editorPage.markApplicationUrgentAndAddAttachment(testFilePath)
     await editorPage.assertAttachmentUploaded(testFileName)
     await editorPage.goToVerification()
-    await editorPage.assertUrgencyFileDownload(testFileName)
+    await editorPage.assertUrgencyFileDownload()
   })
 })

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -48,6 +48,10 @@ export class Page {
     return this.page.waitForEvent('download')
   }
 
+  async waitForPopup() {
+    return this.page.waitForEvent('popup')
+  }
+
   async pause() {
     return this.page.pause()
   }

--- a/frontend/src/employee-frontend/api/attachments.ts
+++ b/frontend/src/employee-frontend/api/attachments.ts
@@ -95,6 +95,9 @@ export const deleteAttachment = (id: UUID): Promise<Result<void>> =>
     .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 
-export function getAttachmentUrl(attachmentId: UUID): string {
-  return `${API_URL}/attachments/${attachmentId}/download`
+export function getAttachmentUrl(
+  attachmentId: UUID,
+  requestedFilename: string
+): string {
+  return `${API_URL}/attachments/${attachmentId}/download/${requestedFilename}`
 }

--- a/frontend/src/lib-components/employee/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/employee/messages/MessageEditor.tsx
@@ -136,7 +136,7 @@ interface Props {
   defaultSender: ReactSelectOption
   deleteAttachment: (id: UUID) => Promise<Result<void>>
   draftContent?: DraftContent
-  getAttachmentUrl: (attachmentId: UUID) => string
+  getAttachmentUrl: (attachmentId: UUID, fileName: string) => string
   i18n: MessageEditorI18n & FileUploadI18n
   initDraftRaw: (accountId: string) => Promise<Result<string>>
   mobileVersion?: boolean

--- a/frontend/src/lib-components/molecules/FileDownloadButton.tsx
+++ b/frontend/src/lib-components/molecules/FileDownloadButton.tsx
@@ -27,7 +27,7 @@ const DownloadButton = styled.button`
 
 interface FileDownloadButtonProps {
   file: Attachment
-  getFileUrl: (fileId: UUID) => string
+  getFileUrl: (fileId: UUID, fileName: string) => string
   afterOpen?: () => void
   icon?: IconDefinition | boolean
   'data-qa'?: string
@@ -42,7 +42,7 @@ export default React.memo(function FileDownloadButton({
   'data-qa': dataQa,
   text
 }: FileDownloadButtonProps) {
-  const url = getFileUrl(file.id)
+  const url = getFileUrl(file.id, file.name)
 
   const handleClick = useCallback(() => {
     window.open(url)

--- a/frontend/src/lib-components/molecules/FileUpload.tsx
+++ b/frontend/src/lib-components/molecules/FileUpload.tsx
@@ -81,7 +81,7 @@ interface FileUploadProps {
     onUploadProgress: (progressEvent: ProgressEvent) => void
   ) => Promise<Result<UUID>>
   onDelete: (id: UUID) => Promise<Result<void>>
-  getDownloadUrl: (id: UUID) => string
+  getDownloadUrl: (id: UUID, fileName: string) => string
   i18n: FileUploadI18n
   disabled?: boolean
   slim?: boolean

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -658,9 +658,10 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     private fun downloadAttachment(
         user: AuthenticatedUser,
         attachmentId: AttachmentId,
-        expectedStatus: Int = 200
+        expectedStatus: Int = 200,
+        requestedFilename: String = "evaka-logo.png"
     ) =
-        http.get("/attachments/$attachmentId/download")
+        http.get("/attachments/$attachmentId/download/$requestedFilename")
             .asUser(user)
             .response()
             .also { assertEquals(expectedStatus, it.second.statusCode) }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentIntegrationTest.kt
@@ -100,8 +100,8 @@ class PedagogicalDocumentIntegrationTest : FullApplicationTest(resetDbBeforeEach
         .responseString()
         .third
 
-    private fun getAttachmentAsUser(attachmentId: AttachmentId, user: AuthenticatedUser) =
-        http.get("/attachments/$attachmentId/download")
+    private fun getAttachmentAsUser(attachmentId: AttachmentId, user: AuthenticatedUser, requestedFilename: String = "evaka-logo.png") =
+        http.get("/attachments/$attachmentId/download/$requestedFilename")
             .asUser(user)
             .responseString()
             .second
@@ -200,7 +200,7 @@ class PedagogicalDocumentIntegrationTest : FullApplicationTest(resetDbBeforeEach
             attachment.id
         )
 
-        val res2 = getAttachmentAsUser(attachmentId, supervisor)
+        val res2 = getAttachmentAsUser(attachmentId, supervisor, attachment.name)
         assertEquals(200, res2.statusCode)
     }
 
@@ -237,7 +237,7 @@ class PedagogicalDocumentIntegrationTest : FullApplicationTest(resetDbBeforeEach
             attachment.id
         )
 
-        assertEquals(200, getAttachmentAsUser(attachment.id, staff).statusCode)
+        assertEquals(200, getAttachmentAsUser(attachment.id, staff, attachment.name).statusCode)
     }
 
     @Test
@@ -257,7 +257,7 @@ class PedagogicalDocumentIntegrationTest : FullApplicationTest(resetDbBeforeEach
             attachment.id
         )
 
-        assertEquals(200, getAttachmentAsUser(attachment.id, groupStaff).statusCode)
+        assertEquals(200, getAttachmentAsUser(attachment.id, groupStaff, attachment.name).statusCode)
     }
 
     @Test
@@ -316,7 +316,7 @@ class PedagogicalDocumentIntegrationTest : FullApplicationTest(resetDbBeforeEach
             attachment.id
         )
 
-        assertEquals(200, getAttachmentAsUser(attachment.id, guardian).statusCode)
+        assertEquals(200, getAttachmentAsUser(attachment.id, guardian, attachment.name).statusCode)
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -254,11 +254,12 @@ class AttachmentsController(
         return id
     }
 
-    @GetMapping("/{attachmentId}/download")
+    @GetMapping("/{attachmentId}/download/{requestedFilename}")
     fun getAttachment(
         db: Database,
         user: AuthenticatedUser,
-        @PathVariable attachmentId: AttachmentId
+        @PathVariable attachmentId: AttachmentId,
+        @PathVariable requestedFilename: String
     ): ResponseEntity<Any> {
         Audit.AttachmentsRead.log(targetId = attachmentId)
 
@@ -276,7 +277,9 @@ class AttachmentsController(
         }.exhaust()
         accessControl.requirePermissionFor(user, action, attachmentId)
 
-        return documentClient.responseAttachment(filesBucket, "$attachmentId", attachment.name)
+        if (requestedFilename != attachment.name) throw BadRequest("Requested file name doesn't match actual file name for $attachmentId")
+
+        return documentClient.responseInline(filesBucket, "$attachmentId")
     }
 
     @DeleteMapping(value = ["/{attachmentId}", "/citizen/{attachmentId}"])


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Serve all uploaded attachments inline. Must test this in non-local environment for nginx not being configured in our compose stack.