### PR TITLE
EVAKA-4469 Add special support section to vasu

### DIFF
--- a/frontend/src/citizen-frontend/child-documents/vasu/components/CheckboxQuestion.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/components/CheckboxQuestion.tsx
@@ -18,11 +18,22 @@ type Props = QuestionProps<CheckboxQuestion> & {
 
 export function CheckboxQuestion(props: Props) {
   const i18n = useTranslation()
-  const label = `${props.questionNumber} ${props.question.name}`
+  const checkboxLabel = props.question.label
+    ? props.question.name
+    : `${props.questionNumber} ${props.question.name}`
+  const numberedLabel =
+    props.question.label && `${props.questionNumber} ${props.question.label}`
+
   return (
     <ReadOnlyValue
-      label={label}
-      value={props.question.value ? i18n.common.yes : i18n.common.no}
+      label={numberedLabel ?? checkboxLabel}
+      value={
+        props.question.value
+          ? props.question.label
+            ? props.question.name
+            : i18n.common.yes
+          : i18n.common.no
+      }
       translations={props.translations}
     />
   )

--- a/frontend/src/citizen-frontend/child-documents/vasu/components/FollowupQuestion.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/components/FollowupQuestion.tsx
@@ -54,20 +54,26 @@ interface FollowupQuestionProps extends QuestionProps<Followup> {
 }
 
 export default React.memo(function FollowupQuestion({
-  question: { title, name, value },
-  translations
+  question: { title, name, value, continuesNumbering },
+  translations,
+  questionNumber
 }: FollowupQuestionProps) {
   return (
     <FollowupQuestionContainer data-qa="vasu-followup-question">
       <H2>{title}</H2>
-      <Label>{name}</Label>
-      {value.length > 0 ? (
-        value.map((entry, ix) => (
-          <FollowupEntryElement key={ix} entry={entry} />
-        ))
-      ) : (
-        <Dimmed>{translations.noRecord}</Dimmed>
-      )}
+      <Label>{`${
+        continuesNumbering ? `${questionNumber} ` : ''
+      }${name}`}</Label>
+
+      <div>
+        {value.length > 0 ? (
+          value.map((entry, ix) => (
+            <FollowupEntryElement key={ix} entry={entry} />
+          ))
+        ) : (
+          <Dimmed>{translations.noRecord}</Dimmed>
+        )}
+      </div>
     </FollowupQuestionContainer>
   )
 })

--- a/frontend/src/citizen-frontend/child-documents/vasu/components/RadioGroupQuestion.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/components/RadioGroupQuestion.tsx
@@ -5,6 +5,7 @@
 import React from 'react'
 
 import { RadioGroupQuestion } from 'lib-common/api-types/vasu'
+import LocalDate from 'lib-common/local-date'
 import { Label } from 'lib-components/typography'
 import { VasuTranslations } from 'lib-customizations/employee'
 
@@ -13,7 +14,13 @@ import { ValueOrNoRecord } from './ValueOrNoRecord'
 interface Props {
   questionNumber: string
   question: RadioGroupQuestion
-  selectedValue: string | null
+  selectedValue: {
+    key: string
+    range: {
+      start: LocalDate
+      end: LocalDate
+    } | null
+  } | null
   translations: VasuTranslations
 }
 
@@ -23,6 +30,13 @@ export function RadioGroupQuestion({
   selectedValue,
   translations
 }: Props) {
+  const selectedOption = options.find(
+    (option) => option.key === selectedValue?.key
+  )
+  const selectedDateRange = selectedValue?.range
+    ? ` ${selectedValue.range.start.format()}–${selectedValue.range.end.format()}`
+    : ''
+
   return (
     <div>
       <Label>
@@ -30,7 +44,7 @@ export function RadioGroupQuestion({
       </Label>
 
       <ValueOrNoRecord
-        text={options.find((option) => option.key === selectedValue)?.name}
+        text={selectedOption && `${selectedOption.name}${selectedDateRange}`}
         translations={translations}
       />
     </div>

--- a/frontend/src/citizen-frontend/child-documents/vasu/sections/CitizenDynamicSections.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/sections/CitizenDynamicSections.tsx
@@ -79,7 +79,7 @@ export function CitizenDynamicSections({
         <SectionContent
           opaque
           highlighted={false}
-          padBottom={!isLastQuestionFollowup}
+          padBottom={!isLastQuestionFollowup || state === 'DRAFT'}
           data-qa="vasu-document-section"
         >
           <H2 noMargin>

--- a/frontend/src/citizen-frontend/child-documents/vasu/vasu-content.ts
+++ b/frontend/src/citizen-frontend/child-documents/vasu/vasu-content.ts
@@ -81,6 +81,12 @@ function isFollowupJson(
   return question.type === 'FOLLOWUP'
 }
 
+function isRadioGroupQuestionJson(
+  question: JsonOf<VasuQuestion>
+): question is JsonOf<RadioGroupQuestion> {
+  return question.type === 'RADIO_GROUP'
+}
+
 export const mapVasuContent = (content: JsonOf<VasuContent>): VasuContent => ({
   sections: content.sections.map((section: JsonOf<VasuSection>) => ({
     ...section,
@@ -101,6 +107,14 @@ export const mapVasuContent = (content: JsonOf<VasuContent>): VasuContent => ({
                 editedAt: LocalDate.parseIso(entry.edited.editedAt)
               }
             }))
+          }
+        : isRadioGroupQuestionJson(question)
+        ? {
+            ...question,
+            dateRange: question.dateRange && {
+              start: LocalDate.parseIso(question.dateRange.start),
+              end: LocalDate.parseIso(question.dateRange.end)
+            }
           }
         : question
     )

--- a/frontend/src/e2e-test/pages/employee/vasu/pageSections.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/pageSections.ts
@@ -79,6 +79,40 @@ export class GoalsSection extends SimpleTextAreaSection {
   other = this.values.nth(2).innerText
 }
 
+export class SpecialSupportSection extends SimpleTextAreaSection {
+  specialSupportEnabledInput = this.find('[data-qa="checkbox-question"]')
+
+  get specialSupportEnabled() {
+    return this.values.nth(0).innerText
+  }
+
+  get optionalFields() {
+    return {
+      previousSpecialSupportInput: new TextInput(this.textareas.nth(0)),
+      currentSpecialSupportInput: new TextInput(this.textareas.nth(1)),
+      staffResponsibilitiesInput: new TextInput(this.textareas.nth(2)),
+      carerChildCooperationInput: new TextInput(this.textareas.nth(3)),
+
+      previousSpecialSupport: this.values.nth(1).innerText,
+      currentSpecialSupport: this.values.nth(2).innerText,
+      staffResponsibilities: this.values.nth(3).innerText,
+      carerChildCooperation: this.values.nth(4).innerText,
+      supportLevel: this.values.nth(5).innerText
+    }
+  }
+
+  supportLevelOptions = (key: string) =>
+    this.findByDataQa(`radio-group-date-question-option-${key}`)
+  supportLevelOptionRangeStart = (key: string) =>
+    new TextInput(
+      this.findByDataQa(`radio-group-date-question-option-${key}-range-start`)
+    )
+  supportLevelOptionRangeEnd = (key: string) =>
+    new TextInput(
+      this.findByDataQa(`radio-group-date-question-option-${key}-range-end`)
+    )
+}
+
 export class WellnessSupportSection extends SimpleTextAreaSection {
   wellnessInput = new TextInput(this.textareas.nth(0))
   wellness = this.values.nth(0).innerText
@@ -94,7 +128,7 @@ export class InfoSharedToSection extends Element {
     this.find(`[data-qa="multi-select-question-option-${key}"]`)
   otherInput = new TextInput(this.find('[data-qa="text-question-input"]'))
 
-  recipients = this.find(`[data-qa="value-or-no-record-8.1"]`)
+  recipients = this.find(`[data-qa="value-or-no-record-9.1"]`)
   other = this.find(`[data-qa="value-or-no-record"]`)
 }
 

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
@@ -15,6 +15,7 @@ import {
   InfoSharedToSection,
   OtherDocsAndPlansSection,
   PreviousVasuGoalsSection,
+  SpecialSupportSection,
   WellnessSupportSection
 } from './pageSections'
 
@@ -53,28 +54,32 @@ class VasuPageCommon {
     return new GoalsSection(this.getDocumentSection(3))
   }
 
+  get specialSupportSection(): SpecialSupportSection {
+    return new SpecialSupportSection(this.getDocumentSection(4))
+  }
+
   get wellnessSupportSection(): WellnessSupportSection {
-    return new WellnessSupportSection(this.getDocumentSection(4))
+    return new WellnessSupportSection(this.getDocumentSection(5))
   }
 
   get otherDocsAndPlansSection(): OtherDocsAndPlansSection {
-    return new OtherDocsAndPlansSection(this.getDocumentSection(5))
+    return new OtherDocsAndPlansSection(this.getDocumentSection(6))
   }
 
   get infoSharedToSection(): InfoSharedToSection {
-    return new InfoSharedToSection(this.getDocumentSection(6))
+    return new InfoSharedToSection(this.getDocumentSection(7))
   }
 
   get additionalInfoSection(): AdditionalInfoSection {
-    return new AdditionalInfoSection(this.getDocumentSection(7))
+    return new AdditionalInfoSection(this.getDocumentSection(8))
   }
 
   get discussionSection(): DiscussionSection {
-    return new DiscussionSection(this.getDocumentSection(8))
+    return new DiscussionSection(this.getDocumentSection(9))
   }
 
   get evaluationSection(): EvaluationSection {
-    return new EvaluationSection(this.getDocumentSection(9))
+    return new EvaluationSection(this.getDocumentSection(10))
   }
 
   get followupQuestionCount(): Promise<number> {
@@ -85,27 +90,26 @@ class VasuPageCommon {
 export class VasuEditPage extends VasuPageCommon {
   readonly modalOkButton = this.page.find('[data-qa="modal-okBtn"]')
 
-  readonly #followupNewInput = new TextInput(
-    this.page.findAll('[data-qa="vasu-followup-entry-new-input"]').first()
-  )
-  readonly #followupNewSaveButton = this.page.find(
-    '[data-qa="vasu-followup-entry-new-submit"]'
-  )
-  readonly #followupEntryTexts = this.page.findAll(
-    '[data-qa="vasu-followup-entry-text"]'
-  )
-  readonly #followupEntryMetadatas = this.page.findAll(
-    '[data-qa="vasu-followup-entry-metadata"]'
-  )
-  readonly #followupEntryEditButtons = this.page.findAll(
-    '[data-qa="vasu-followup-entry-edit-btn"]'
-  )
-  readonly #followupEntryInput = new TextInput(
-    this.page.find('[data-qa="vasu-followup-entry-edit-input"]')
-  )
-  readonly #followupEntrySaveButton = this.page.find(
-    '[data-qa="vasu-followup-entry-edit-submit"]'
-  )
+  #followup(nth: number) {
+    const question = this.page
+      .findAllByDataQa('vasu-followup-question')
+      .nth(nth)
+    return {
+      newInput: new TextInput(
+        question.findByDataQa('vasu-followup-entry-new-input')
+      ),
+      newSubmit: question.findByDataQa('vasu-followup-entry-new-submit'),
+      entryTexts: question.findAllByDataQa('vasu-followup-entry-text'),
+      entryMetadatas: question.findAllByDataQa('vasu-followup-entry-metadata'),
+      entryEditButtons: question.findAllByDataQa(
+        'vasu-followup-entry-edit-btn'
+      ),
+      entryInput: new TextInput(
+        question.findByDataQa('vasu-followup-entry-edit-input')
+      ),
+      entrySaveButton: question.findByDataQa('vasu-followup-entry-edit-submit')
+    }
+  }
 
   readonly #vasuPreviewBtn = this.page.find('[data-qa="vasu-preview-btn"]')
   readonly #vasuContainer = this.page.find('[data-qa="vasu-container"]')
@@ -127,23 +131,23 @@ export class VasuEditPage extends VasuPageCommon {
     await this.#multiSelectQuestionOptionTextInput(key).fill(text)
   }
 
-  async inputFollowupComment(comment: string) {
-    await this.#followupNewInput.type(comment)
-    await this.#followupNewSaveButton.click()
+  async inputFollowupComment(comment: string, nth: number) {
+    await this.#followup(nth).newInput.type(comment)
+    await this.#followup(nth).newSubmit.click()
   }
 
-  get followupEntryTexts(): Promise<Array<string>> {
-    return this.#followupEntryTexts.allInnerTexts()
+  followupEntryTexts(nth: number): Promise<Array<string>> {
+    return this.#followup(nth).entryTexts.allInnerTexts()
   }
 
-  get followupEntryMetadata(): Promise<Array<string>> {
-    return this.#followupEntryMetadatas.allInnerTexts()
+  followupEntryMetadata(nth: number): Promise<Array<string>> {
+    return this.#followup(nth).entryMetadatas.allInnerTexts()
   }
 
-  async editFollowupComment(ix: number, text: string) {
-    await this.#followupEntryEditButtons.nth(ix).click()
-    await this.#followupEntryInput.type(text)
-    await this.#followupEntrySaveButton.click()
+  async editFollowupComment(ix: number, text: string, nth: number) {
+    await this.#followup(nth).entryEditButtons.nth(ix).click()
+    await this.#followup(nth).entryInput.type(text)
+    await this.#followup(nth).entrySaveButton.click()
   }
 
   get previewBtn(): Element {

--- a/frontend/src/employee-frontend/components/vasu/components/CheckboxQuestion.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/CheckboxQuestion.tsx
@@ -30,7 +30,7 @@ export function CheckboxQuestion(props: Props) {
 
   return (
     <QuestionInfo info={props.question.info}>
-      {props.onChange && numberedLabel && <Label>{numberedLabel}</Label>}
+      {props.onChange && !!numberedLabel && <Label>{numberedLabel}</Label>}
 
       {props.onChange ? (
         <Checkbox

--- a/frontend/src/employee-frontend/components/vasu/components/CheckboxQuestion.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/CheckboxQuestion.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 
 import { CheckboxQuestion } from 'lib-common/api-types/vasu'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
+import { Label } from 'lib-components/typography'
 import { VasuTranslations } from 'lib-customizations/employee'
 
 import { useTranslation } from '../../../state/i18n'
@@ -21,19 +22,33 @@ type Props = QuestionProps<CheckboxQuestion> & {
 
 export function CheckboxQuestion(props: Props) {
   const { i18n } = useTranslation()
-  const label = `${props.questionNumber} ${props.question.name}`
+  const checkboxLabel = props.question.label
+    ? props.question.name
+    : `${props.questionNumber} ${props.question.name}`
+  const numberedLabel =
+    props.question.label && `${props.questionNumber} ${props.question.label}`
+
   return (
     <QuestionInfo info={props.question.info}>
+      {props.onChange && numberedLabel && <Label>{numberedLabel}</Label>}
+
       {props.onChange ? (
         <Checkbox
           checked={props.question.value}
-          label={label}
+          label={checkboxLabel}
           onChange={props.onChange}
+          data-qa="checkbox-question"
         />
       ) : (
         <ReadOnlyValue
-          label={label}
-          value={props.question.value ? i18n.common.yes : i18n.common.no}
+          label={numberedLabel ?? checkboxLabel}
+          value={
+            props.question.value
+              ? props.question.label
+                ? props.question.name
+                : i18n.common.yes
+              : i18n.common.no
+          }
           translations={props.translations}
         />
       )}

--- a/frontend/src/employee-frontend/components/vasu/components/FollowupQuestion.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/FollowupQuestion.tsx
@@ -173,9 +173,10 @@ interface FollowupQuestionProps extends QuestionProps<Followup> {
 export default React.memo(function FollowupQuestion({
   onChange,
   onEdited,
-  question: { title, name, value, info },
+  question: { title, name, value, info, continuesNumbering },
   translations,
-  permittedFollowupActions
+  permittedFollowupActions,
+  questionNumber
 }: FollowupQuestionProps) {
   const { i18n } = useTranslation()
 
@@ -186,27 +187,32 @@ export default React.memo(function FollowupQuestion({
     >
       <H2>{title}</H2>
       <QuestionInfo info={info}>
-        <Label>{name}</Label>
+        <Label>{`${
+          continuesNumbering ? `${questionNumber} ` : ''
+        }${name}`}</Label>
       </QuestionInfo>
-      {value.length > 0 ? (
-        value.map((entry, ix) => (
-          <FollowupEntryElement
-            key={ix}
-            entry={entry}
-            onEdited={onEdited}
-            permittedFollowupActions={permittedFollowupActions}
+
+      <div>
+        {value.length > 0 ? (
+          value.map((entry, ix) => (
+            <FollowupEntryElement
+              key={ix}
+              entry={entry}
+              onEdited={onEdited}
+              permittedFollowupActions={permittedFollowupActions}
+            />
+          ))
+        ) : (
+          <Dimmed>{translations.noRecord}</Dimmed>
+        )}
+        {onChange && (
+          <FollowupEntryEditor
+            buttonCaption={i18n.common.addNew}
+            onChange={onChange}
+            data-qa="vasu-followup-entry-new"
           />
-        ))
-      ) : (
-        <Dimmed>{translations.noRecord}</Dimmed>
-      )}
-      {onChange && (
-        <FollowupEntryEditor
-          buttonCaption={i18n.common.addNew}
-          onChange={onChange}
-          data-qa="vasu-followup-entry-new"
-        />
-      )}
+        )}
+      </div>
     </FollowupQuestionContainer>
   )
 })

--- a/frontend/src/employee-frontend/components/vasu/components/RadioGroupQuestion.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/RadioGroupQuestion.tsx
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { useState } from 'react'
 
-import { QuestionOption, RadioGroupQuestion } from 'lib-common/api-types/vasu'
-import Radio from 'lib-components/atoms/form/Radio'
+import { RadioGroupQuestion } from 'lib-common/api-types/vasu'
+import LocalDate from 'lib-common/local-date'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
@@ -13,13 +13,22 @@ import { VasuTranslations } from 'lib-customizations/employee'
 
 import QuestionInfo from '../QuestionInfo'
 
+import RadioGroupQuestionOption from './RadioGroupQuestionOption'
 import { ValueOrNoRecord } from './ValueOrNoRecord'
+
+export interface RadioGroupSelectedValue {
+  key: string
+  range: {
+    start: LocalDate
+    end: LocalDate
+  } | null
+}
 
 interface Props {
   questionNumber: string
   question: RadioGroupQuestion
-  selectedValue: string | null
-  onChange?: (selected: QuestionOption) => void
+  selectedValue: RadioGroupSelectedValue | null
+  onChange?: (selected: RadioGroupSelectedValue) => void
   translations: VasuTranslations
 }
 
@@ -30,6 +39,15 @@ export function RadioGroupQuestion({
   selectedValue,
   translations
 }: Props) {
+  const selectedOption = options.find(
+    (option) => option.key === selectedValue?.key
+  )
+  const selectedDateRange = selectedValue?.range
+    ? ` ${selectedValue.range.start.format()}–${selectedValue.range.end.format()}`
+    : ''
+
+  const [pendingSelected, setPendingSelected] = useState(selectedValue?.key)
+
   return (
     <div>
       <QuestionInfo info={info}>
@@ -43,18 +61,23 @@ export function RadioGroupQuestion({
           <Gap size="m" />
           <FixedSpaceColumn>
             {options.map((option) => (
-              <Radio
+              <RadioGroupQuestionOption
                 key={option.key}
-                checked={selectedValue === option.key}
-                label={option.name}
-                onChange={() => onChange(option)}
+                option={option}
+                onChange={(value) => {
+                  onChange(value)
+                  setPendingSelected(option.key)
+                }}
+                selectedValue={selectedValue}
+                isSelected={option.key === pendingSelected}
+                onSelected={() => setPendingSelected(option.key)}
               />
             ))}
           </FixedSpaceColumn>
         </>
       ) : (
         <ValueOrNoRecord
-          text={options.find((option) => option.key === selectedValue)?.name}
+          text={selectedOption && `${selectedOption.name}${selectedDateRange}`}
           translations={translations}
         />
       )}

--- a/frontend/src/employee-frontend/components/vasu/components/RadioGroupQuestionOption.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/RadioGroupQuestionOption.tsx
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import React, { useEffect, useState } from 'react'
+import styled, { useTheme } from 'styled-components'
+
+import { useTranslation } from 'employee-frontend/state/i18n'
+import { errorToInputInfo } from 'employee-frontend/utils/validation/input-info-helper'
+import { QuestionOption } from 'lib-common/api-types/vasu'
+import { ErrorKey } from 'lib-common/form-validation'
+import LocalDate from 'lib-common/local-date'
+import Radio from 'lib-components/atoms/form/Radio'
+import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
+import { fasExclamationTriangle } from 'lib-icons'
+
+import type { RadioGroupSelectedValue } from './RadioGroupQuestion'
+
+export const OptionContainer = styled.div`
+  display: flex;
+  gap: 8px;
+`
+
+const Warning = styled.span`
+  color: ${(p) => p.theme.colors.accents.a2orangeDark};
+`
+
+const WarningIcon = styled(FontAwesomeIcon)`
+  margin-left: 8px;
+  margin-right: 8px;
+`
+
+interface Props {
+  option: QuestionOption
+  selectedValue: RadioGroupSelectedValue | null
+  onChange: (selected: RadioGroupSelectedValue) => void
+  isSelected: boolean
+  onSelected: () => void
+}
+
+function usePendingUserInput<T>(
+  transform: (input: string) => T | null,
+  initialValue?: string
+) {
+  const [input, setInput] = useState(initialValue ?? '')
+  const [validated, setValidated] = useState<T>()
+
+  useEffect(() => {
+    const transformed = transform(input)
+
+    if (transformed) {
+      setValidated(transformed)
+    } else {
+      setValidated(undefined)
+    }
+  }, [input, transform])
+
+  return [input, setInput, validated] as [
+    string,
+    React.Dispatch<React.SetStateAction<string>>,
+    T | undefined
+  ]
+}
+
+const getRangeError = (
+  input: string,
+  valid: boolean,
+  otherValid: boolean
+): ErrorKey | undefined => {
+  if (!input) {
+    return 'required'
+  }
+
+  if (!valid) {
+    if (input) {
+      return 'validDate'
+    }
+
+    if (otherValid) {
+      return 'required'
+    }
+  }
+
+  return undefined
+}
+
+const transformDate = (d: string) => LocalDate.parseFiOrNull(d)
+
+export default React.memo(function RadioGroupQuestionOption({
+  option,
+  selectedValue,
+  onChange,
+  isSelected,
+  onSelected
+}: Props) {
+  const { i18n } = useTranslation()
+
+  const { colors } = useTheme()
+
+  const selectedStartDate =
+    (isSelected && selectedValue?.range?.start) || undefined
+  const selectedEndDate = (isSelected && selectedValue?.range?.end) || undefined
+
+  const [startInput, setStartInput, startDate] = usePendingUserInput(
+    transformDate,
+    selectedStartDate?.format()
+  )
+  const [endInput, setEndInput, endDate] = usePendingUserInput(
+    transformDate,
+    selectedEndDate?.format()
+  )
+
+  const rangeIsLinear =
+    startDate && endDate && startDate.isEqualOrBefore(endDate)
+
+  const startDateError = isSelected
+    ? getRangeError(startInput, !!startDate, !!endDate)
+    : undefined
+  const endDateError = isSelected
+    ? getRangeError(endInput, !!endDate, !!startDate)
+    : undefined
+
+  useEffect(() => {
+    if (
+      isSelected &&
+      startDate &&
+      endDate &&
+      !startDateError &&
+      !endDateError &&
+      rangeIsLinear
+    ) {
+      const rangeHasChanged =
+        !selectedValue?.range?.start.isEqual(startDate) ||
+        !selectedValue?.range?.end.isEqual(endDate)
+      if (rangeHasChanged) {
+        onChange({
+          range: {
+            start: startDate,
+            end: endDate
+          },
+          key: option.key
+        })
+      }
+    }
+  }, [
+    startDate,
+    endDate,
+    onChange,
+    option,
+    selectedValue,
+    isSelected,
+    startDateError,
+    endDateError,
+    rangeIsLinear
+  ])
+
+  return (
+    <OptionContainer>
+      <Radio
+        checked={isSelected}
+        label={option.name}
+        onChange={() =>
+          option.dateRange
+            ? onSelected()
+            : onChange({ key: option.key, range: null })
+        }
+        data-qa={`radio-group-date-question-option-${option.key}`}
+      />
+
+      {option.dateRange && (
+        <div>
+          <DatePicker
+            locale="fi"
+            date={isSelected ? startInput : ''}
+            onChange={setStartInput}
+            info={
+              startDateError &&
+              errorToInputInfo(startDateError, i18n.validationErrors)
+            }
+            isValidDate={(d) => !endDate || d.isEqualOrBefore(endDate)}
+            data-qa={`radio-group-date-question-option-${option.key}-range-start`}
+          />
+          <span>-</span>
+          <DatePicker
+            locale="fi"
+            date={isSelected ? endInput : ''}
+            onChange={setEndInput}
+            info={
+              endDateError &&
+              errorToInputInfo(endDateError, i18n.validationErrors)
+            }
+            isValidDate={(d) => !startDate || d.isEqualOrAfter(startDate)}
+            data-qa={`radio-group-date-question-option-${option.key}-range-end`}
+          />
+          {rangeIsLinear === false && (
+            <Warning>
+              <WarningIcon
+                icon={fasExclamationTriangle}
+                color={colors.status.warning}
+              />
+              {i18n.validationErrors.dateRangeNotLinear}
+            </Warning>
+          )}
+        </div>
+      )}
+    </OptionContainer>
+  )
+})

--- a/frontend/src/employee-frontend/components/vasu/components/RadioGroupQuestionOption.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/RadioGroupQuestionOption.tsx
@@ -7,10 +7,7 @@ import React, { useEffect, useState } from 'react'
 import styled, { useTheme } from 'styled-components'
 
 import { useTranslation } from 'employee-frontend/state/i18n'
-import { errorToInputInfo } from 'employee-frontend/utils/validation/input-info-helper'
 import { QuestionOption } from 'lib-common/api-types/vasu'
-import { ErrorKey } from 'lib-common/form-validation'
-import LocalDate from 'lib-common/local-date'
 import Radio from 'lib-components/atoms/form/Radio'
 import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
 import { fasExclamationTriangle } from 'lib-icons'
@@ -39,54 +36,6 @@ interface Props {
   onSelected: () => void
 }
 
-function usePendingUserInput<T>(
-  transform: (input: string) => T | null,
-  initialValue?: string
-) {
-  const [input, setInput] = useState(initialValue ?? '')
-  const [validated, setValidated] = useState<T>()
-
-  useEffect(() => {
-    const transformed = transform(input)
-
-    if (transformed) {
-      setValidated(transformed)
-    } else {
-      setValidated(undefined)
-    }
-  }, [input, transform])
-
-  return [input, setInput, validated] as [
-    string,
-    React.Dispatch<React.SetStateAction<string>>,
-    T | undefined
-  ]
-}
-
-const getRangeError = (
-  input: string,
-  valid: boolean,
-  otherValid: boolean
-): ErrorKey | undefined => {
-  if (!input) {
-    return 'required'
-  }
-
-  if (!valid) {
-    if (input) {
-      return 'validDate'
-    }
-
-    if (otherValid) {
-      return 'required'
-    }
-  }
-
-  return undefined
-}
-
-const transformDate = (d: string) => LocalDate.parseFiOrNull(d)
-
 export default React.memo(function RadioGroupQuestionOption({
   option,
   selectedValue,
@@ -102,34 +51,14 @@ export default React.memo(function RadioGroupQuestionOption({
     (isSelected && selectedValue?.range?.start) || undefined
   const selectedEndDate = (isSelected && selectedValue?.range?.end) || undefined
 
-  const [startInput, setStartInput, startDate] = usePendingUserInput(
-    transformDate,
-    selectedStartDate?.format()
-  )
-  const [endInput, setEndInput, endDate] = usePendingUserInput(
-    transformDate,
-    selectedEndDate?.format()
-  )
+  const [startDate, setStartDate] = useState(selectedStartDate ?? null)
+  const [endDate, setEndDate] = useState(selectedEndDate ?? null)
 
   const rangeIsLinear =
     startDate && endDate && startDate.isEqualOrBefore(endDate)
 
-  const startDateError = isSelected
-    ? getRangeError(startInput, !!startDate, !!endDate)
-    : undefined
-  const endDateError = isSelected
-    ? getRangeError(endInput, !!endDate, !!startDate)
-    : undefined
-
   useEffect(() => {
-    if (
-      isSelected &&
-      startDate &&
-      endDate &&
-      !startDateError &&
-      !endDateError &&
-      rangeIsLinear
-    ) {
+    if (isSelected && startDate && endDate && rangeIsLinear) {
       const rangeHasChanged =
         !selectedValue?.range?.start.isEqual(startDate) ||
         !selectedValue?.range?.end.isEqual(endDate)
@@ -150,8 +79,6 @@ export default React.memo(function RadioGroupQuestionOption({
     option,
     selectedValue,
     isSelected,
-    startDateError,
-    endDateError,
     rangeIsLinear
   ])
 
@@ -172,26 +99,22 @@ export default React.memo(function RadioGroupQuestionOption({
         <div>
           <DatePicker
             locale="fi"
-            date={isSelected ? startInput : ''}
-            onChange={setStartInput}
-            info={
-              startDateError &&
-              errorToInputInfo(startDateError, i18n.validationErrors)
-            }
-            isValidDate={(d) => !endDate || d.isEqualOrBefore(endDate)}
+            date={isSelected ? startDate : null}
+            onChange={setStartDate}
+            maxDate={endDate ?? undefined}
             data-qa={`radio-group-date-question-option-${option.key}-range-start`}
+            errorTexts={i18n.validationErrors}
+            hideErrorsBeforeTouched
           />
           <span>-</span>
           <DatePicker
             locale="fi"
-            date={isSelected ? endInput : ''}
-            onChange={setEndInput}
-            info={
-              endDateError &&
-              errorToInputInfo(endDateError, i18n.validationErrors)
-            }
-            isValidDate={(d) => !startDate || d.isEqualOrAfter(startDate)}
+            date={isSelected ? endDate : null}
+            onChange={setEndDate}
+            minDate={startDate ?? undefined}
             data-qa={`radio-group-date-question-option-${option.key}-range-end`}
+            errorTexts={i18n.validationErrors}
+            hideErrorsBeforeTouched
           />
           {rangeIsLinear === false && (
             <Warning>

--- a/frontend/src/employee-frontend/components/vasu/sections/DynamicSections.tsx
+++ b/frontend/src/employee-frontend/components/vasu/sections/DynamicSections.tsx
@@ -99,7 +99,7 @@ export function DynamicSections({
         <SectionContent
           opaque
           highlighted={highlightSection}
-          padBottom={!isLastQuestionFollowup}
+          padBottom={!isLastQuestionFollowup || state === 'DRAFT'}
           data-qa="vasu-document-section"
         >
           <H2 noMargin>

--- a/frontend/src/employee-frontend/components/vasu/templates/CreateParagraphModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/CreateParagraphModal.tsx
@@ -6,8 +6,8 @@ import React, { useState } from 'react'
 
 import { Paragraph } from 'lib-common/api-types/vasu'
 import { VasuSection } from 'lib-common/generated/api-types/vasu'
-import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import InputField from 'lib-components/atoms/form/InputField'
+import MultiSelect from 'lib-components/atoms/form/MultiSelect'
 import TextArea from 'lib-components/atoms/form/TextArea'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import FormModal from 'lib-components/molecules/modals/FormModal'
@@ -60,24 +60,16 @@ export default React.memo(function CreateParagraphModal({
         <Label>{t.id}</Label>
         <InputField value={identifier} onChange={setIdentifier} width="full" />
         <Label>{t.dependsOn}</Label>
-        {Array(dependsOn.length + 1)
-          .fill({})
-          .map((_, i) => (
-            <Combobox
-              key={i}
-              items={section.questions
-                .flatMap((q) => q.id)
-                .filter((id) => id && !dependsOn.includes(id))}
-              selectedItem={dependsOn[i]}
-              onChange={(value) => {
-                if (value) {
-                  const copy = Array.from(dependsOn)
-                  copy[i] = value
-                  setDependsOn(copy)
-                }
-              }}
-            />
-          ))}
+        <MultiSelect
+          value={dependsOn}
+          options={section.questions
+            .map((q) => q.id)
+            .filter((id): id is string => typeof id === 'string')}
+          onChange={setDependsOn}
+          getOptionId={(id) => id}
+          getOptionLabel={(id) => id}
+          placeholder=""
+        />
       </FixedSpaceColumn>
     </FormModal>
   )

--- a/frontend/src/employee-frontend/components/vasu/templates/CreateParagraphModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/CreateParagraphModal.tsx
@@ -5,6 +5,8 @@
 import React, { useState } from 'react'
 
 import { Paragraph } from 'lib-common/api-types/vasu'
+import { VasuSection } from 'lib-common/generated/api-types/vasu'
+import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import InputField from 'lib-components/atoms/form/InputField'
 import TextArea from 'lib-components/atoms/form/TextArea'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
@@ -16,16 +18,20 @@ import { useTranslation } from '../../../state/i18n'
 interface Props {
   onSave: (paragraph: Paragraph) => void
   onCancel: () => void
+  section: VasuSection
 }
 
 export default React.memo(function CreateParagraphModal({
   onCancel,
-  onSave
+  onSave,
+  section
 }: Props) {
   const { i18n } = useTranslation()
   const t = i18n.vasuTemplates.questionModal
   const [title, setTitle] = useState('')
   const [paragraph, setParagraph] = useState('')
+  const [identifier, setIdentifier] = useState('')
+  const [dependsOn, setDependsOn] = useState<string[]>([])
 
   return (
     <FormModal
@@ -37,7 +43,9 @@ export default React.memo(function CreateParagraphModal({
           paragraph,
           name: '',
           info: '',
-          ophKey: null
+          ophKey: null,
+          id: identifier || null,
+          dependsOn
         })
       }
       resolveLabel={i18n.common.confirm}
@@ -49,6 +57,27 @@ export default React.memo(function CreateParagraphModal({
         <InputField value={title} onChange={setTitle} width="full" />
         <Label>{t.paragraphText}</Label>
         <TextArea value={paragraph} onChange={setParagraph} />
+        <Label>{t.id}</Label>
+        <InputField value={identifier} onChange={setIdentifier} width="full" />
+        <Label>{t.dependsOn}</Label>
+        {Array(dependsOn.length + 1)
+          .fill({})
+          .map((_, i) => (
+            <Combobox
+              key={i}
+              items={section.questions
+                .flatMap((q) => q.id)
+                .filter((id) => id && !dependsOn.includes(id))}
+              selectedItem={dependsOn[i]}
+              onChange={(value) => {
+                if (value) {
+                  const copy = Array.from(dependsOn)
+                  copy[i] = value
+                  setDependsOn(copy)
+                }
+              }}
+            />
+          ))}
       </FixedSpaceColumn>
     </FormModal>
   )

--- a/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
@@ -19,6 +19,7 @@ import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import InputField from 'lib-components/atoms/form/InputField'
+import MultiSelect from 'lib-components/atoms/form/MultiSelect'
 import {
   FixedSpaceColumn,
   FixedSpaceRow
@@ -363,24 +364,16 @@ export default React.memo(function CreateQuestionModal({
 
         <FixedSpaceColumn spacing="xxs">
           <Label>{t.dependsOn}</Label>
-          {Array(dependsOn.length + 1)
-            .fill({})
-            .map((_, i) => (
-              <Combobox
-                key={i}
-                items={section.questions
-                  .flatMap((q) => q.id)
-                  .filter((id) => id && !dependsOn.includes(id))}
-                selectedItem={dependsOn[i]}
-                onChange={(value) => {
-                  if (value) {
-                    const copy = Array.from(dependsOn)
-                    copy[i] = value
-                    setDependsOn(copy)
-                  }
-                }}
-              />
-            ))}
+          <MultiSelect
+            value={dependsOn}
+            options={section.questions
+              .map((q) => q.id)
+              .filter((id): id is string => typeof id === 'string')}
+            onChange={setDependsOn}
+            getOptionId={(id) => id}
+            getOptionLabel={(id) => id}
+            placeholder=""
+          />
         </FixedSpaceColumn>
       </FixedSpaceColumn>
     </FormModal>

--- a/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
@@ -2,13 +2,18 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useState } from 'react'
+import styled, { useTheme } from 'styled-components'
 
 import {
+  QuestionOption,
   VasuQuestion,
   VasuQuestionType,
   vasuQuestionTypes
 } from 'lib-common/api-types/vasu'
+import { VasuSection } from 'lib-common/generated/api-types/vasu'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
@@ -20,33 +25,48 @@ import {
 } from 'lib-components/layout/flex-helpers'
 import FormModal from 'lib-components/molecules/modals/FormModal'
 import { Label } from 'lib-components/typography'
-import { faTrash } from 'lib-icons'
+import { faCalendarAlt, faCheckCircle, faTrash } from 'lib-icons'
 
 import { useTranslation } from '../../../state/i18n'
+
+const TopRightOverlayedIcon = styled(FontAwesomeIcon)`
+  transform: translate(70%, -175%) scale(0.8);
+  pointer-events: none;
+`
 
 interface Props {
   onSave: (question: VasuQuestion) => void
   onCancel: () => void
+  section: VasuSection
 }
 
 export default React.memo(function CreateQuestionModal({
   onCancel,
-  onSave
+  onSave,
+  section
 }: Props) {
   const { i18n } = useTranslation()
   const t = i18n.vasuTemplates.questionModal
   const [type, setType] =
     useState<Exclude<VasuQuestionType, 'PARAGRAPH'>>('TEXT')
   const [name, setName] = useState('')
-  const [options, setOptions] = useState([''])
+
+  const [options, setOptions] = useState<Omit<QuestionOption, 'key'>[]>([
+    { name: '' }
+  ])
   const [multiline, setMultiline] = useState(false)
   const [minSelections, setMinSelections] = useState(0)
   const [keys, setKeys] = useState([''])
   const [info, setInfo] = useState('')
   const [trackedInEvents, setTrackedInEvents] = useState(false)
   const [nameInEvents, setNameInEvents] = useState('')
+  const [identifier, setIdentifier] = useState('')
+  const [dependsOn, setDependsOn] = useState<string[]>([])
+  const [continuesNumbering, setContinuesNumbering] = useState(false)
+  const [label, setLabel] = useState('')
 
   function createQuestion(): VasuQuestion {
+    const id = identifier || null
     switch (type) {
       case 'TEXT':
         return {
@@ -55,7 +75,9 @@ export default React.memo(function CreateQuestionModal({
           name: name,
           info: info,
           multiline: multiline,
-          value: ''
+          value: '',
+          id,
+          dependsOn
         }
       case 'CHECKBOX':
         return {
@@ -63,7 +85,10 @@ export default React.memo(function CreateQuestionModal({
           ophKey: null,
           name: name,
           info: info,
-          value: false
+          value: false,
+          id,
+          dependsOn,
+          label: label || null
         }
       case 'RADIO_GROUP':
         return {
@@ -72,10 +97,13 @@ export default React.memo(function CreateQuestionModal({
           name: name,
           info: info,
           options: options.map((opt) => ({
-            key: opt,
-            name: opt
+            ...opt,
+            key: opt.name
           })),
-          value: null
+          value: null,
+          id,
+          dependsOn,
+          dateRange: null
         }
       case 'MULTISELECT':
         return {
@@ -84,12 +112,14 @@ export default React.memo(function CreateQuestionModal({
           name: name,
           info: info,
           options: options.map((opt) => ({
-            key: opt,
-            name: opt
+            ...opt,
+            key: opt.name
           })),
           minSelections: minSelections,
           maxSelections: null,
-          value: []
+          value: [],
+          id,
+          dependsOn
         }
       case 'MULTI_FIELD':
         return {
@@ -98,7 +128,9 @@ export default React.memo(function CreateQuestionModal({
           name,
           info,
           keys: keys.map((key) => ({ name: key })),
-          value: keys.map(() => '')
+          value: keys.map(() => ''),
+          id,
+          dependsOn
         }
       case 'MULTI_FIELD_LIST':
         return {
@@ -107,7 +139,9 @@ export default React.memo(function CreateQuestionModal({
           name,
           info,
           keys: keys.map((key) => ({ name: key })),
-          value: []
+          value: [],
+          id,
+          dependsOn
         }
       case 'DATE':
         return {
@@ -117,7 +151,9 @@ export default React.memo(function CreateQuestionModal({
           info,
           trackedInEvents,
           nameInEvents: trackedInEvents ? nameInEvents : '',
-          value: null
+          value: null,
+          id,
+          dependsOn
         }
       case 'FOLLOWUP':
         return {
@@ -126,10 +162,15 @@ export default React.memo(function CreateQuestionModal({
           name: name,
           info: info,
           title: '',
-          value: []
+          value: [],
+          id,
+          dependsOn,
+          continuesNumbering
         }
     }
   }
+
+  const theme = useTheme()
 
   return (
     <FormModal
@@ -173,11 +214,11 @@ export default React.memo(function CreateQuestionModal({
             {options.map((opt, i) => (
               <FixedSpaceRow spacing="xs" key={`opt-${i}`}>
                 <InputField
-                  value={opt}
+                  value={opt.name}
                   onChange={(val) =>
                     setOptions([
                       ...options.slice(0, i),
-                      val,
+                      { ...opt, name: val },
                       ...options.slice(i + 1)
                     ])
                   }
@@ -194,10 +235,36 @@ export default React.memo(function CreateQuestionModal({
                     ])
                   }}
                 />
+                {type === 'RADIO_GROUP' && (
+                  <div>
+                    <IconButton
+                      icon={faCalendarAlt}
+                      onClick={(e) => {
+                        e.preventDefault()
+                        setOptions([
+                          ...options.slice(0, i),
+                          {
+                            ...opt,
+                            dateRange: !opt.dateRange
+                          },
+                          ...options.slice(i + 1)
+                        ])
+                      }}
+                    />
+                    <TopRightOverlayedIcon
+                      icon={opt.dateRange ? faCheckCircle : faTimesCircle}
+                      color={
+                        opt.dateRange
+                          ? theme.colors.status.success
+                          : theme.colors.status.danger
+                      }
+                    />
+                  </div>
+                )}
               </FixedSpaceRow>
             ))}
             <InlineButton
-              onClick={() => setOptions([...options, ''])}
+              onClick={() => setOptions([...options, { name: '' }])}
               text={t.addNewOption}
             />
           </FixedSpaceColumn>
@@ -234,7 +301,7 @@ export default React.memo(function CreateQuestionModal({
                   disabled={keys.length < 2}
                   onClick={(e) => {
                     e.preventDefault()
-                    setOptions([...keys.slice(0, i), ...keys.slice(i + 1)])
+                    setKeys([...keys.slice(0, i), ...keys.slice(i + 1)])
                   }}
                 />
               </FixedSpaceRow>
@@ -263,9 +330,57 @@ export default React.memo(function CreateQuestionModal({
           </FixedSpaceColumn>
         )}
 
+        {type === 'FOLLOWUP' && (
+          <FixedSpaceColumn spacing="xxs">
+            <Checkbox
+              label={t.continuesNumbering}
+              checked={continuesNumbering}
+              onChange={setContinuesNumbering}
+            />
+          </FixedSpaceColumn>
+        )}
+
+        {type === 'CHECKBOX' && (
+          <FixedSpaceColumn spacing="xxs">
+            <Label>{t.checkboxLabel}</Label>
+            <InputField value={label} onChange={setLabel} width="full" />
+          </FixedSpaceColumn>
+        )}
+
         <FixedSpaceColumn spacing="xxs">
           <Label>{t.info}</Label>
           <InputField value={info} onChange={setInfo} width="full" />
+        </FixedSpaceColumn>
+
+        <FixedSpaceColumn spacing="xxs">
+          <Label>{t.id}</Label>
+          <InputField
+            value={identifier}
+            onChange={setIdentifier}
+            width="full"
+          />
+        </FixedSpaceColumn>
+
+        <FixedSpaceColumn spacing="xxs">
+          <Label>{t.dependsOn}</Label>
+          {Array(dependsOn.length + 1)
+            .fill({})
+            .map((_, i) => (
+              <Combobox
+                key={i}
+                items={section.questions
+                  .flatMap((q) => q.id)
+                  .filter((id) => id && !dependsOn.includes(id))}
+                selectedItem={dependsOn[i]}
+                onChange={(value) => {
+                  if (value) {
+                    const copy = Array.from(dependsOn)
+                    copy[i] = value
+                    setDependsOn(copy)
+                  }
+                }}
+              />
+            ))}
         </FixedSpaceColumn>
       </FixedSpaceColumn>
     </FormModal>

--- a/frontend/src/employee-frontend/components/vasu/templates/VasuTemplateEditor.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/VasuTemplateEditor.tsx
@@ -308,7 +308,7 @@ export default React.memo(function VasuTemplateEditor() {
   ) {
     return (
       <QuestionInfo info={question.info}>
-        {question.label && <H3>{`${questionNumber}. ${question.label}`}</H3>}
+        {!!question.label && <H3>{`${questionNumber}. ${question.label}`}</H3>}
         <Checkbox
           checked={question.value}
           label={
@@ -335,9 +335,19 @@ export default React.memo(function VasuTemplateEditor() {
             <Radio checked={false} label={opt.name} />
             {opt.dateRange && (
               <div>
-                <DatePicker locale="fi" date="" onChange={() => void 0} />
+                <DatePicker
+                  locale="fi"
+                  date={null}
+                  onChange={() => void 0}
+                  errorTexts={i18n.validationErrors}
+                />
                 <span>-</span>
-                <DatePicker locale="fi" date="" onChange={() => void 0} />
+                <DatePicker
+                  locale="fi"
+                  date={null}
+                  onChange={() => void 0}
+                  errorTexts={i18n.validationErrors}
+                />
               </div>
             )}
           </OptionContainer>

--- a/frontend/src/employee-frontend/components/vasu/use-vasu.ts
+++ b/frontend/src/employee-frontend/components/vasu/use-vasu.ts
@@ -13,7 +13,6 @@ import {
 
 import { Result } from 'lib-common/api'
 import {
-  Followup,
   FollowupEntry,
   GetVasuDocumentResponse,
   PermittedFollowupActions
@@ -165,8 +164,7 @@ export function useVasu(id: string): Vasu {
       content.sections.forEach((section) => {
         section.questions.forEach((question) => {
           if (question.type === 'FOLLOWUP') {
-            const followup = question as Followup
-            followup.value.forEach((entry: FollowupEntry) => {
+            question.value.forEach((entry: FollowupEntry) => {
               if (entry.id && !permittedFollowupActions[entry.id]) {
                 setPermittedFollowupActions({
                   ...permittedFollowupActions,

--- a/frontend/src/employee-frontend/components/vasu/vasu-content.ts
+++ b/frontend/src/employee-frontend/components/vasu/vasu-content.ts
@@ -81,6 +81,12 @@ function isFollowupJson(
   return question.type === 'FOLLOWUP'
 }
 
+function isRadioGroupQuestionJson(
+  question: JsonOf<VasuQuestion>
+): question is JsonOf<RadioGroupQuestion> {
+  return question.type === 'RADIO_GROUP'
+}
+
 export const mapVasuContent = (content: JsonOf<VasuContent>): VasuContent => ({
   sections: content.sections.map((section: JsonOf<VasuSection>) => ({
     ...section,
@@ -101,6 +107,14 @@ export const mapVasuContent = (content: JsonOf<VasuContent>): VasuContent => ({
                 editedAt: LocalDate.parseIso(entry.edited.editedAt)
               }
             }))
+          }
+        : isRadioGroupQuestionJson(question)
+        ? {
+            ...question,
+            dateRange: question.dateRange && {
+              start: LocalDate.parseIso(question.dateRange.start),
+              end: LocalDate.parseIso(question.dateRange.end)
+            }
           }
         : question
     )

--- a/frontend/src/lib-common/api-types/vasu.ts
+++ b/frontend/src/lib-common/api-types/vasu.ts
@@ -24,23 +24,34 @@ interface VasuQuestionCommon {
   name: string
   ophKey: string | null
   info: string
+  id: string | null
+  dependsOn: string[] | null
 }
 
 export interface TextQuestion extends VasuQuestionCommon {
+  type: 'TEXT'
   multiline: boolean
   value: string
 }
 
 export interface CheckboxQuestion extends VasuQuestionCommon {
+  type: 'CHECKBOX'
   value: boolean
+  label: string | null
 }
 
 export interface RadioGroupQuestion extends VasuQuestionCommon {
+  type: 'RADIO_GROUP'
   options: QuestionOption[]
   value: string | null
+  dateRange: {
+    start: LocalDate
+    end: LocalDate
+  } | null
 }
 
 export interface MultiSelectQuestion extends VasuQuestionCommon {
+  type: 'MULTISELECT'
   options: QuestionOption[]
   minSelections: number
   maxSelections: number | null
@@ -52,6 +63,7 @@ export interface QuestionOption {
   key: string
   name: string
   textAnswer?: boolean
+  dateRange?: boolean
 }
 
 export interface TextValueMap {
@@ -78,8 +90,10 @@ export interface DateQuestion extends VasuQuestionCommon {
 }
 
 export interface Followup extends VasuQuestionCommon {
+  type: 'FOLLOWUP'
   title: string
   value: FollowupEntry[]
+  continuesNumbering: boolean
 }
 
 export interface FollowupEntry {

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -3096,6 +3096,19 @@ export const fi = {
     addNewParagraph: 'Lisää uusi tekstikappale',
     hideSectionBeforeReady: 'Osio näytetään vasta laatimisen jälkeen',
     autoGrowingList: 'Automaattisesti kasvava lista',
+    onlyVisibleWhen: (conditions: string[]) =>
+      `Näkyvissä vain kun ${conditions
+        .slice(0, conditions.length - 1)
+        .join(', ')}${
+        conditions.length > 1
+          ? ` ja ${conditions[conditions.length - 1]}`
+          : conditions[0]
+      }.`,
+    visibilityConditions: {
+      unknownQuestion: 'tuntemattomaan kysymykseen on vastattu',
+      checked: (qn: string) => `kysymys ${qn} on valittuna`,
+      answered: (qn: string) => `kysymykseen ${qn} on vastattu`
+    },
     questionModal: {
       title: 'Uusi kysymys',
       type: 'Kysymyksen tyyppi',
@@ -3110,7 +3123,11 @@ export const fi = {
       dateIsTrackedInEvents:
         'Päivämäärä näytetään suunnitelman tapahtumissa nimellä',
       paragraphTitle: 'Kappaleen otsikko',
-      paragraphText: 'Kappaleen leipäteksti'
+      paragraphText: 'Kappaleen leipäteksti',
+      id: 'Viitetunniste',
+      dependsOn: 'Riippuvuudet',
+      continuesNumbering: 'Jatkaa numerointia',
+      checkboxLabel: 'Erillinen rastin viereinen teksti'
     },
     questionTypes: {
       TEXT: 'Tekstimuotoinen',
@@ -3180,6 +3197,8 @@ export const fi = {
     dateTooEarly: 'Valitse myöhäisempi päivä',
     dateTooLate: 'Valitse aikaisempi päivä',
     preferredStartDate: 'Aloituspäivä ei ole sallittu',
+    dateRangeNotLinear:
+      'Aikavälin aloituspäivä tulee olla ennen lopetuspäivää.',
     timeFormat: 'Tarkista',
     timeRequired: 'Pakollinen',
     unitNotSelected: 'Valitse vähintään yksi hakutoive',

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/OphQuestion.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/OphQuestion.kt
@@ -179,6 +179,76 @@ fun getDefaultVasuContent(lang: VasuLanguage) = VasuContent(
             )
         ),
         VasuSection(
+            name = "Tehostetun tai erityisen tuen tarve ja tukitoimet",
+            questions = listOf(
+                VasuQuestion.Paragraph(
+                    title = "",
+                    paragraph = "Täytetään, kun lapsella on tarve tuelle, josta tehdään hallintopäätös. Tuen tarvetta seurataan ja arvioidaan toimintakauden aikana."
+                ),
+                VasuQuestion.CheckboxQuestion(
+                    label = "Onko lapsella tehostetun tai erityisen tuen tarve, tai onko tuen taso muuttumassa?",
+                    name = "Kyllä, lapsella on tehostetun tai erityisen tuen tarve, tai tuen taso on muuttumassa",
+                    value = false,
+                    id = "special-support"
+                ),
+                VasuQuestion.TextQuestion(
+                    name = "Mahdolliset aiemmin toteutetut tukitoimet sekä niiden vaikuttavuuden arviointi",
+                    value = "",
+                    multiline = false,
+                    dependsOn = listOf("special-support")
+                ),
+                VasuQuestion.TextQuestion(
+                    name = "Arvio lapsen tarvitsemasta tuesta jatkossa sekä hänelle kohdennettujen tuen muotojen ja mahdollisten tukipalveluiden kuvaus",
+                    value = "",
+                    multiline = false,
+                    dependsOn = listOf("special-support")
+                ),
+                VasuQuestion.TextQuestion(
+                    name = "Henkilöstön ja tarvittavien muiden asiantuntijoiden vastuut ja työnjako lapsen tukeen liittyen",
+                    value = "",
+                    multiline = false,
+                    dependsOn = listOf("special-support")
+                ),
+                VasuQuestion.TextQuestion(
+                    name = "Kuvaus lapsen ja huoltajien kanssa tehdystä yhteistyöstä",
+                    value = "",
+                    multiline = false,
+                    dependsOn = listOf("special-support")
+                ),
+                VasuQuestion.RadioGroupQuestion(
+                    name = "Lapsen tuen taso jatkossa",
+                    options = listOf(
+                        QuestionOption(
+                            key = "general",
+                            name = "Yleinen tuki"
+                        ),
+                        QuestionOption(
+                            key = "during_range",
+                            name = "Tukipalvelut ajalla",
+                            dateRange = true
+                        ),
+                        QuestionOption(
+                            key = "intensified",
+                            name = "Tehostettu tuki"
+                        ),
+                        QuestionOption(
+                            key = "special",
+                            name = "Erityinen tuki"
+                        )
+                    ),
+                    value = null,
+                    dependsOn = listOf("special-support")
+                ),
+                VasuQuestion.Followup(
+                    title = "Tuen tarpeen ja toteutumisen arviointi toimintakauden aikana",
+                    name = "Tuen tarpeen ja tukitoimenpiteiden toteutumisen seurantaa ja arviointia toimintakauden aikana",
+                    value = listOf(),
+                    continuesNumbering = true,
+                    dependsOn = listOf("special-support")
+                )
+            )
+        ),
+        VasuSection(
             name = when (lang) {
                 VasuLanguage.FI -> "Lapsen hyvinvoinnin tukemiseen liittyvät muut huomioitavat asiat"
                 VasuLanguage.SV -> "Andra frågor som ska beaktas i samband med stöd för barnets välbefinnande"


### PR DESCRIPTION
#### Summary

- adds a new "label" field for checkbox questions to allow a separate question line and checkbox label
- adds question identifiers and dependencies to show certain questions only when other questions are filled in/selected
- adds an optionally enabled field next to radio buttons for specifying a date range
- adds option to continue numbering from previous question in a follow-up question
- new section in the default vasu for special support

_Pending Swedish translations._