### PR TITLE
Maximum surplus days invoice increase

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -24,6 +24,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecision
 import fi.espoo.evaka.invoicing.domain.FeeDecisionStatus
 import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.invoicing.domain.Invoice
+import fi.espoo.evaka.invoicing.domain.roundToEuros
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
@@ -58,6 +59,7 @@ import fi.espoo.evaka.testRoundTheClockDaycare
 import fi.espoo.evaka.toFeeDecisionServiceNeed
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Month
@@ -1683,18 +1685,18 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, result.size)
 
         result.first().let { invoice ->
-            assertEquals(32754, invoice.totalPrice)
+            assertEquals(24594, invoice.totalPrice)
             assertEquals(2, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(21700, invoiceRow.unitPrice)
+                assertEquals(21700, invoiceRow.price)
             }
             invoice.rows.last().let { invoiceRow ->
                 assertEquals(productProvider.contractSurplusDay, invoiceRow.product)
                 assertEquals(2, invoiceRow.amount)
-                assertEquals(1927, invoiceRow.unitPrice) // 28900 / 15
-                assertEquals(3854, invoiceRow.price)
+                assertEquals(1447, invoiceRow.unitPrice) // 21700 / 15
+                assertEquals(2894, invoiceRow.price)
             }
         }
     }
@@ -1724,24 +1726,24 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, result.size)
 
         result.first().let { invoice ->
-            assertEquals(30827, invoice.totalPrice)
+            assertEquals(23147, invoice.totalPrice)
             assertEquals(3, invoice.rows.size)
             invoice.rows[0].let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(21700, invoiceRow.unitPrice)
+                assertEquals(21700, invoiceRow.price)
             }
             invoice.rows[1].let { invoiceRow ->
                 assertEquals(productProvider.contractSurplusDay, invoiceRow.product)
                 assertEquals(2, invoiceRow.amount)
-                assertEquals(1927, invoiceRow.unitPrice) // 28900 / 15
-                assertEquals(3854, invoiceRow.price)
+                assertEquals(1447, invoiceRow.unitPrice) // 21700 / 15
+                assertEquals(2894, invoiceRow.price)
             }
             invoice.rows[2].let { invoiceRow ->
                 assertEquals(productProvider.dailyRefund, invoiceRow.product)
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(-1927, invoiceRow.unitPrice) // 28900 / 15
-                assertEquals(-1927, invoiceRow.price)
+                assertEquals(-1447, invoiceRow.unitPrice) // 21700 / 15
+                assertEquals(-1447, invoiceRow.price)
             }
         }
     }
@@ -1861,18 +1863,18 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, result.size)
 
         result.first().let { invoice ->
-            assertEquals(32754, invoice.totalPrice)
+            assertEquals(24594, invoice.totalPrice)
             assertEquals(2, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(21700, invoiceRow.unitPrice)
+                assertEquals(21700, invoiceRow.price)
             }
             invoice.rows.last().let { invoiceRow ->
                 assertEquals(productProvider.contractSurplusDay, invoiceRow.product)
                 assertEquals(2, invoiceRow.amount)
-                assertEquals(1927, invoiceRow.unitPrice) // 28900 / 15
-                assertEquals(3854, invoiceRow.price)
+                assertEquals(1447, invoiceRow.unitPrice) // 28900 / 15
+                assertEquals(2894, invoiceRow.price)
             }
         }
     }
@@ -1969,18 +1971,18 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, result.size)
 
         result.first().let { invoice ->
-            assertEquals(14450, invoice.totalPrice)
+            assertEquals(10850, invoice.totalPrice)
             assertEquals(2, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(21700, invoiceRow.unitPrice)
+                assertEquals(21700, invoiceRow.price)
             }
             invoice.rows.last().let { invoiceRow ->
                 assertEquals(productProvider.fullMonthAbsence, invoiceRow.product)
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(-14450, invoiceRow.unitPrice)
-                assertEquals(-14450, invoiceRow.price)
+                assertEquals(-10850, invoiceRow.unitPrice)
+                assertEquals(-10850, invoiceRow.price)
             }
         }
     }
@@ -2010,12 +2012,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, result.size)
 
         result.first().let { invoice ->
-            assertEquals(28900, invoice.totalPrice)
+            assertEquals(21700, invoice.totalPrice)
             assertEquals(1, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(21700, invoiceRow.unitPrice)
+                assertEquals(21700, invoiceRow.price)
             }
         }
     }
@@ -2043,18 +2045,18 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, result.size)
 
         result.first().let { invoice ->
-            assertEquals(26973, invoice.totalPrice)
+            assertEquals(20253, invoice.totalPrice)
             assertEquals(2, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(21700, invoiceRow.unitPrice)
+                assertEquals(21700, invoiceRow.price)
             }
             invoice.rows.last().let { invoiceRow ->
                 assertEquals(productProvider.dailyRefund, invoiceRow.product)
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(-1927, invoiceRow.unitPrice) // 28900 / 15
-                assertEquals(-1927, invoiceRow.price)
+                assertEquals(-1447, invoiceRow.unitPrice) // 21700 / 15
+                assertEquals(-1447, invoiceRow.price)
             }
         }
     }
@@ -2223,14 +2225,14 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             assertEquals(2, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(21700, invoiceRow.unitPrice)
+                assertEquals(21700, invoiceRow.price)
             }
             invoice.rows.last().let { invoiceRow ->
                 assertEquals(productProvider.dailyRefund, invoiceRow.product)
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(-28900, invoiceRow.unitPrice)
-                assertEquals(-28900, invoiceRow.price)
+                assertEquals(-21700, invoiceRow.unitPrice)
+                assertEquals(-21700, invoiceRow.price)
             }
         }
     }
@@ -2252,18 +2254,18 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, result.size)
 
         result.first().let { invoice ->
-            assertEquals(14450, invoice.totalPrice)
+            assertEquals(10850, invoice.totalPrice)
             assertEquals(2, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(21700, invoiceRow.unitPrice)
+                assertEquals(21700, invoiceRow.price)
             }
             invoice.rows.last().let { invoiceRow ->
                 assertEquals(productProvider.fullMonthAbsence, invoiceRow.product)
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(-14450, invoiceRow.unitPrice) // 28900 / 2
-                assertEquals(-14450, invoiceRow.price)
+                assertEquals(-10850, invoiceRow.unitPrice) // 21700 / 2
+                assertEquals(-10850, invoiceRow.price)
             }
         }
     }
@@ -2289,12 +2291,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         result.first().let { invoice ->
             // Full month invoice expected
-            assertEquals(28900, invoice.totalPrice)
+            assertEquals(21700, invoice.totalPrice)
             assertEquals(1, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(21700, invoiceRow.unitPrice)
+                assertEquals(21700, invoiceRow.price)
             }
         }
     }
@@ -3300,7 +3302,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                         // 15 contract days
                         serviceNeed = snDaycareContractDays15.toFeeDecisionServiceNeed(),
                         baseFee = 28900,
-                        fee = 28900,
+                        fee = 21700,
                         feeAlterations = listOf()
                     )
                 )
@@ -3322,12 +3324,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val result = db.read(getAllInvoices)
         assertEquals(1, result.size)
         result.first().let { invoice ->
-            assertEquals(19270, invoice.totalPrice)
+            assertEquals(14470, invoice.totalPrice)
             assertEquals(1, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->
                 assertEquals(10, invoiceRow.amount)
-                assertEquals(1927, invoiceRow.unitPrice) // 28900 / 15
-                assertEquals(19270, invoiceRow.price)
+                assertEquals(1447, invoiceRow.unitPrice) // 21700 / 15
+                assertEquals(14470, invoiceRow.price)
             }
         }
     }
@@ -3825,18 +3827,18 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, result.size)
 
         result.first().let { invoice ->
-            assertEquals(30827, invoice.totalPrice)
+            assertEquals(23147, invoice.totalPrice)
             assertEquals(2, invoice.rows.size)
             invoice.rows.first().let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(21700, invoiceRow.unitPrice)
+                assertEquals(21700, invoiceRow.price)
             }
             invoice.rows.last().let { invoiceRow ->
                 assertEquals(productProvider.contractSurplusDay, invoiceRow.product)
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(1927, invoiceRow.unitPrice) // 28900 / 15
-                assertEquals(1927, invoiceRow.price)
+                assertEquals(1447, invoiceRow.unitPrice) // 21700 / 15
+                assertEquals(1447, invoiceRow.price)
             }
         }
     }
@@ -3902,14 +3904,14 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             assertEquals(2, invoice.rows.size)
             invoice.rows[0].let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(14500, invoiceRow.unitPrice)
+                assertEquals(14500, invoiceRow.price)
             }
             invoice.rows[1].let { invoiceRow ->
                 assertEquals(productProvider.fullMonthSickLeave, invoiceRow.product)
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(-28900, invoiceRow.unitPrice)
-                assertEquals(-28900, invoiceRow.price)
+                assertEquals(-14500, invoiceRow.unitPrice)
+                assertEquals(-14500, invoiceRow.price)
             }
         }
     }
@@ -3961,24 +3963,24 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, result.size)
 
         result.first().let { invoice ->
-            assertEquals(17340, invoice.totalPrice)
+            assertEquals(8700, invoice.totalPrice)
             assertEquals(3, invoice.rows.size)
             invoice.rows[0].let { invoiceRow ->
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(28900, invoiceRow.unitPrice)
-                assertEquals(28900, invoiceRow.price)
+                assertEquals(14500, invoiceRow.unitPrice)
+                assertEquals(14500, invoiceRow.price)
             }
             invoice.rows[1].let { invoiceRow ->
                 assertEquals(productProvider.contractSurplusDay, invoiceRow.product)
                 assertEquals(2, invoiceRow.amount)
-                assertEquals(2890, invoiceRow.unitPrice) // 28900 / 10
-                assertEquals(5780, invoiceRow.price)
+                assertEquals(1450, invoiceRow.unitPrice) // 14500 / 10
+                assertEquals(2900, invoiceRow.price)
             }
             invoice.rows[2].let { invoiceRow ->
                 assertEquals(productProvider.partMonthSickLeave, invoiceRow.product)
                 assertEquals(1, invoiceRow.amount)
-                assertEquals(-17340, invoiceRow.unitPrice)
-                assertEquals(-17340, invoiceRow.price)
+                assertEquals(-8700, invoiceRow.unitPrice)
+                assertEquals(-8700, invoiceRow.price)
             }
         }
     }
@@ -4220,6 +4222,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                     placementType = PlacementType.DAYCARE,
                     serviceNeed = serviceNeed.toFeeDecisionServiceNeed(),
                     baseFee = 28900,
+                    fee = roundToEuros(serviceNeed.feeCoefficient * BigDecimal(28900)).toInt(),
                     feeAlterations = if (index > 0) {
                         listOf(
                             createFeeDecisionAlterationFixture(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Set the invoice maximum surplus day increase to maximum monthly fee before service need multiplier minus the child's monthly fee. Ensures that the invoice maximum is the price of a maximum service need.

