### PR TITLE
EVAKA HOTFIX unit realized occupancy in supervisor mobile

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
@@ -137,7 +137,7 @@ fun Database.Read.fetchUnitInfo(unitId: DaycareId, date: LocalDate): UnitInfo {
             FROM daycare_group g
             JOIN daycare ON g.daycare_id = daycare.id
             JOIN (
-                SELECT sa.group_id, 7 * (sa.count + sa.count_other) AS capacity, FALSE AS realtime
+                SELECT sa.group_id, 7 * sa.count AS capacity, FALSE AS realtime
                 FROM staff_attendance sa
                 WHERE sa.date = :date
         
@@ -284,7 +284,7 @@ WITH present_children AS (
     FROM daycare_group g
     JOIN daycare ON g.daycare_id = daycare.id
     JOIN (
-        SELECT sa.group_id, 7 * (sa.count + sa.count_other) as capacity, sa.count + sa.count_other AS count, FALSE AS realtime
+        SELECT sa.group_id, 7 * sa.count as capacity, sa.count AS count, FALSE AS realtime
         FROM staff_attendance sa
         WHERE sa.date = :date
 

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
@@ -234,8 +234,8 @@ data class UnitStats(
     val name: String,
     val presentChildren: Int,
     val totalChildren: Int,
-    val presentStaff: Int,
-    val totalStaff: Int,
+    val presentStaff: Double,
+    val totalStaff: Double,
     val utilization: Double
 )
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Do not include `staff_attendance.other_count` in staff count when calculating occupancy for employee mobile. Also fix the data types so that the decimals are included in the unit supervisor's unit list.
