### PR TITLE
Scroll to reservation modal inputs manually after focus on devices with a soft keyboard

### DIFF
--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -16,6 +16,7 @@ import {
   TimeRanges,
   validateForm
 } from 'lib-common/reservations'
+import { scrollIntoViewSoftKeyboard } from 'lib-common/utils/scrolling'
 import { SelectionChip } from 'lib-components/atoms/Chip'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import Select from 'lib-components/atoms/dropdowns/Select'
@@ -216,6 +217,9 @@ export default React.memo(function ReservationModal({
             )}
             hideErrorsBeforeTouched={!showAllErrors}
             data-qa="start-date"
+            onFocus={(ev) => {
+              scrollIntoViewSoftKeyboard(ev.target, 'start')
+            }}
           />
           <DatePickerSpacer />
           <DatePicker
@@ -233,6 +237,9 @@ export default React.memo(function ReservationModal({
               reservableDays[0]?.start
             }
             data-qa="end-date"
+            onFocus={(ev) => {
+              scrollIntoViewSoftKeyboard(ev.target, 'start')
+            }}
           />
         </FixedSpaceRow>
         <Gap size="m" />
@@ -255,6 +262,9 @@ export default React.memo(function ReservationModal({
               showAllErrors={showAllErrors}
               allowExtraTimeRange={childrenInShiftCare}
               dataQaPrefix="daily"
+              onFocus={(ev) => {
+                scrollIntoViewSoftKeyboard(ev.target)
+              }}
             />
           )}
 
@@ -301,6 +311,9 @@ export default React.memo(function ReservationModal({
                   showAllErrors={showAllErrors}
                   allowExtraTimeRange={childrenInShiftCare}
                   dataQaPrefix={`weekly-${index}`}
+                  onFocus={(ev) => {
+                    scrollIntoViewSoftKeyboard(ev.target)
+                  }}
                 />
               ) : null
             )}
@@ -344,6 +357,9 @@ export default React.memo(function ReservationModal({
                       showAllErrors={showAllErrors}
                       allowExtraTimeRange={childrenInShiftCare}
                       dataQaPrefix={`irregular-${date.formatIso()}`}
+                      onFocus={(ev) => {
+                        scrollIntoViewSoftKeyboard(ev.target)
+                      }}
                     />
                   )}
                 </Fragment>
@@ -368,6 +384,7 @@ const TimeInputs = React.memo(function TimeInputs(props: {
   showAllErrors: boolean
   allowExtraTimeRange: boolean
   dataQaPrefix?: string
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
 }) {
   const i18n = useTranslation()
 
@@ -409,6 +426,7 @@ const TimeInputs = React.memo(function TimeInputs(props: {
               ? `${props.dataQaPrefix}-start-time-0`
               : undefined
           }
+          onFocus={props.onFocus}
         />
         <span>–</span>
         <TimeInput
@@ -432,6 +450,7 @@ const TimeInputs = React.memo(function TimeInputs(props: {
           data-qa={
             props.dataQaPrefix ? `${props.dataQaPrefix}-end-time-0` : undefined
           }
+          onFocus={props.onFocus}
         />
       </FixedSpaceRow>
       {!extraTimeRange && props.allowExtraTimeRange ? (
@@ -476,6 +495,7 @@ const TimeInputs = React.memo(function TimeInputs(props: {
                   ? `${props.dataQaPrefix}-start-time-1`
                   : undefined
               }
+              onFocus={props.onFocus}
             />
             <span>–</span>
             <TimeInput
@@ -500,6 +520,7 @@ const TimeInputs = React.memo(function TimeInputs(props: {
                   ? `${props.dataQaPrefix}-end-time-1`
                   : undefined
               }
+              onFocus={props.onFocus}
             />
           </FixedSpaceRow>
           <IconButton

--- a/frontend/src/lib-common/utils/scrolling.ts
+++ b/frontend/src/lib-common/utils/scrolling.ts
@@ -40,6 +40,23 @@ export function scrollRefIntoView(
   scrollIntoViewWithTimeout(() => ref.current ?? undefined, timeout)
 }
 
+export function scrollIntoViewSoftKeyboard(
+  target: HTMLElement,
+  blockPosition: ScrollLogicalPosition = 'center'
+) {
+  const onResize = () => {
+    target.scrollIntoView({
+      block: blockPosition
+    })
+    window.visualViewport.removeEventListener('resize', onResize)
+  }
+
+  window.visualViewport.addEventListener('resize', onResize)
+  setTimeout(() => {
+    window.visualViewport.removeEventListener('resize', onResize)
+  }, 1000)
+}
+
 function scrollWithTimeout(
   getOptions: () => ScrollToOptions | undefined,
   timeout = 0,

--- a/frontend/src/lib-components/atoms/form/TimeInput.tsx
+++ b/frontend/src/lib-components/atoms/form/TimeInput.tsx
@@ -25,11 +25,13 @@ export interface TimeInputProps
   > {
   value: string
   onChange: (v: string) => void
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
 }
 
 export default React.memo(function TimeInput({
   value,
   onChange,
+  onFocus,
   ...props
 }: TimeInputProps) {
   const onChangeWithAutocomplete = useCallback(
@@ -44,14 +46,13 @@ export default React.memo(function TimeInput({
       onChange={onChangeWithAutocomplete}
       type="text"
       inputMode="numeric"
-      onFocus={onFocus}
+      onFocus={(event) => {
+        event.target.select()
+        onFocus?.(event)
+      }}
     />
   )
 })
-
-function onFocus(event: React.FocusEvent<HTMLInputElement>) {
-  event.target.select()
-}
 
 const ShorterInput = styled(InputField)`
   width: calc(3.2em + 24px);

--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
@@ -51,7 +51,7 @@ const DayPickerDiv = styled.div`
 type DatePickerProps = {
   date: string
   onChange: (date: string) => void
-  onFocus?: () => void
+  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void
   onBlur?: () => void
   locale: 'fi' | 'sv' | 'en'
   info?: InputInfo
@@ -175,9 +175,9 @@ export default React.memo(function DatePicker({
           onChange(date)
         }}
         disabled={disabled}
-        onFocus={() => {
+        onFocus={(ev) => {
           setShow(true)
-          onFocus()
+          onFocus(ev)
         }}
         onBlur={() => {
           onBlur()

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerInput.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerInput.tsx
@@ -15,7 +15,7 @@ interface Props {
   info?: InputInfo
   hideErrorsBeforeTouched?: boolean
   disabled?: boolean
-  onFocus: () => void
+  onFocus: (e: React.FocusEvent<HTMLInputElement>) => void
   onBlur: (e: React.FocusEvent<HTMLInputElement>) => void
   onKeyPress?: (e: React.KeyboardEvent) => void
   'data-qa'?: string


### PR DESCRIPTION
#### Summary

With some mobile devices, the soft keyboard that opens up when selecting an input in the reservation modal may sometimes overlap with the field. To work around this, whenever a field is focused into, the presence of a soft keyboard is detected with a viewport resize event and after which the input field is scrolled into middle of the view. For the calendar input, the scroll is top-aligned so that it's more likely the day picker will be visible.
