### PR TITLE
Occupancy report improvements part3

### DIFF
--- a/frontend/src/lib-components/layout/Table.tsx
+++ b/frontend/src/lib-components/layout/Table.tsx
@@ -120,6 +120,8 @@ export const Thead = styled.thead``
 
 export const Tbody = styled.tbody``
 
+export const Tfoot = styled.tfoot``
+
 const SortableIconContainer = styled.div`
   display: flex;
   flex-direction: column;

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -2899,6 +2899,7 @@ export const fi = {
           raw: 'Summa ja kasvattajamäärä erikseen'
         }
       },
+      unitsGroupedByArea: 'Toimintayksiköt alueittain',
       average: 'Keskiarvo',
       sum: 'Summa',
       caretakers: 'Kasvattajia',


### PR DESCRIPTION
#### Summary

Final part (part1: https://github.com/espoon-voltti/evaka/pull/2485, part2: https://github.com/espoon-voltti/evaka/pull/2532)

Group occupancy report rows by area

Adds averages by area and date.

![Screenshot_20220620_083317](https://user-images.githubusercontent.com/8450552/174531883-bf001067-d529-4f7f-adef-9abcb17b95d6.png)
