### PR TITLE
Add native date picker

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormClub.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormClub.tsx
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useMemo } from 'react'
+import React from 'react'
 
-import LocalDate from 'lib-common/local-date'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 
 import AdditionalDetailsSection from '../../applications/editor/AdditionalDetailsSection'
@@ -24,11 +23,6 @@ export default React.memo(function ApplicationFormClub({
   terms
 }: ApplicationFormProps) {
   const applicationType = 'CLUB'
-
-  const preferredStartDate = useMemo(
-    () => LocalDate.parseFiOrNull(formData.serviceNeed.preferredStartDate),
-    [formData.serviceNeed.preferredStartDate]
-  )
 
   const originalPreferredStartDate =
     apiData.status !== 'CREATED'
@@ -77,7 +71,7 @@ export default React.memo(function ApplicationFormClub({
         }
         applicationType={applicationType}
         preparatory={false}
-        preferredStartDate={preferredStartDate}
+        preferredStartDate={formData.serviceNeed.preferredStartDate}
         errors={errors.unitPreference}
         verificationRequested={verificationRequested}
         shiftCare={formData.serviceNeed.shiftCare}

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormDaycare.tsx
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { Loading, Result, Success } from 'lib-common/api'
 import { ServiceNeedOptionPublicInfo } from 'lib-common/generated/api-types/serviceneed'
-import LocalDate from 'lib-common/local-date'
 import { useRestApi } from 'lib-common/utils/useRestApi'
 import Loader from 'lib-components/atoms/Loader'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
@@ -57,11 +56,6 @@ export default React.memo(function ApplicationFormDaycare({
     loadServiceNeedOptions,
     shouldLoadServiceNeedOptions
   ])
-
-  const preferredStartDate = useMemo(
-    () => LocalDate.parseFiOrNull(formData.serviceNeed.preferredStartDate),
-    [formData.serviceNeed.preferredStartDate]
-  )
 
   const originalPreferredStartDate =
     apiData.status !== 'CREATED'
@@ -124,7 +118,7 @@ export default React.memo(function ApplicationFormDaycare({
             }
             applicationType={applicationType}
             preparatory={false}
-            preferredStartDate={preferredStartDate}
+            preferredStartDate={formData.serviceNeed.preferredStartDate}
             errors={errors.unitPreference}
             verificationRequested={verificationRequested}
             shiftCare={formData.serviceNeed.shiftCare}

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormPreschool.tsx
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useMemo } from 'react'
+import React from 'react'
 
-import LocalDate from 'lib-common/local-date'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 
 import AdditionalDetailsSection from '../../applications/editor/AdditionalDetailsSection'
@@ -24,11 +23,6 @@ export default React.memo(function ApplicationFormPreschool({
   terms
 }: ApplicationFormProps) {
   const applicationType = 'PRESCHOOL'
-
-  const preferredStartDate = useMemo(
-    () => LocalDate.parseFiOrNull(formData.serviceNeed.preferredStartDate),
-    [formData.serviceNeed.preferredStartDate]
-  )
 
   const originalPreferredStartDate =
     apiData.status !== 'CREATED'
@@ -85,7 +79,7 @@ export default React.memo(function ApplicationFormPreschool({
         }
         applicationType={applicationType}
         preparatory={formData.serviceNeed.preparatory}
-        preferredStartDate={preferredStartDate}
+        preferredStartDate={formData.serviceNeed.preferredStartDate}
         errors={errors.unitPreference}
         verificationRequested={verificationRequested}
         shiftCare={formData.serviceNeed.shiftCare}

--- a/frontend/src/citizen-frontend/applications/editor/contact-info/ChildSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/ChildSubSection.tsx
@@ -103,6 +103,7 @@ export default React.memo(function ChildSubSection({
               locale={lang}
               info={errorToInputInfo(errors.childMoveDate, t.validationErrors)}
               hideErrorsBeforeTouched={!verificationRequested}
+              errorTexts={t.validationErrors}
             />
           </FixedSpaceColumn>
           <Gap size="s" />

--- a/frontend/src/citizen-frontend/applications/editor/contact-info/GuardianSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/GuardianSubSection.tsx
@@ -201,6 +201,7 @@ export default React.memo(function GuardianSubSection({
                 t.validationErrors
               )}
               hideErrorsBeforeTouched={!verificationRequested}
+              errorTexts={t.validationErrors}
             />
           </FixedSpaceColumn>
           <Gap size="s" />

--- a/frontend/src/citizen-frontend/applications/editor/validations.ts
+++ b/frontend/src/citizen-frontend/applications/editor/validations.ts
@@ -17,8 +17,7 @@ import {
   requiredSelection,
   ssn,
   TIME_REGEXP,
-  validate,
-  validDate
+  validate
 } from 'lib-common/form-validation'
 import { ApplicationType } from 'lib-common/generated/api-types/application'
 import { DecisionType } from 'lib-common/generated/api-types/decision'
@@ -38,17 +37,17 @@ export const applicationHasErrors = (errors: ApplicationFormDataErrors) => {
   return totalErrors > 0
 }
 
-const minPreferredStartDate = (
+export const minPreferredStartDate = (
   originalPreferredStartDate: LocalDate | null
 ): LocalDate => {
   return originalPreferredStartDate ?? LocalDate.todayInSystemTz()
 }
 
-const maxPreferredStartDate = (): LocalDate => {
+export const maxPreferredStartDate = (): LocalDate => {
   return LocalDate.todayInSystemTz().addYears(1)
 }
 
-const maxDecisionStartDate = (
+export const maxDecisionStartDate = (
   startDate: LocalDate,
   type: DecisionType
 ): LocalDate => {
@@ -75,37 +74,18 @@ export const isValidPreferredStartDate = (
   return true
 }
 
-export const isValidDecisionStartDate = (
-  date: LocalDate,
-  startDate: string,
-  type: DecisionType
-): boolean => {
-  let parsedDate: LocalDate
-  try {
-    parsedDate = LocalDate.parseFiOrThrow(startDate)
-  } catch (e) {
-    if (e instanceof RangeError) {
-      return false
-    }
-    // Unexpected
-    throw e
-  }
-  return (
-    date.isEqualOrAfter(parsedDate) &&
-    date.isEqualOrBefore(maxDecisionStartDate(parsedDate, type))
-  )
-}
-
 const preferredStartDateValidator =
   (
     originalPreferredStartDate: LocalDate | null,
     type: ApplicationType,
     terms?: FiniteDateRange[]
   ) =>
-  (val: string, err: ErrorKey = 'preferredStartDate'): ErrorKey | undefined => {
-    const date = LocalDate.parseFiOrNull(val)
-    return date &&
-      isValidPreferredStartDate(date, originalPreferredStartDate, type, terms)
+  (
+    val: LocalDate | null,
+    err: ErrorKey = 'preferredStartDate'
+  ): ErrorKey | undefined => {
+    return val &&
+      isValidPreferredStartDate(val, originalPreferredStartDate, type, terms)
       ? undefined
       : err
   }
@@ -127,7 +107,6 @@ export const validateApplication = (
       preferredStartDate: validate(
         form.serviceNeed.preferredStartDate,
         required,
-        validDate,
         preferredStartDateValidator(
           apiData.status !== 'CREATED'
             ? apiData.form.preferences.preferredStartDate
@@ -176,7 +155,7 @@ export const validateApplication = (
     },
     contactInfo: {
       childMoveDate: form.contactInfo.childFutureAddressExists
-        ? validate(form.contactInfo.childMoveDate, required, validDate)
+        ? validate(form.contactInfo.childMoveDate, required)
         : undefined,
       childFutureStreet: form.contactInfo.childFutureAddressExists
         ? validate(form.contactInfo.childFutureStreet, required)
@@ -203,7 +182,7 @@ export const validateApplication = (
               emailVerificationCheck(form.contactInfo.guardianEmail)
             ),
       guardianMoveDate: form.contactInfo.guardianFutureAddressExists
-        ? validate(form.contactInfo.guardianMoveDate, required, validDate)
+        ? validate(form.contactInfo.guardianMoveDate, required)
         : undefined,
       guardianFutureStreet: form.contactInfo.guardianFutureAddressExists
         ? validate(form.contactInfo.guardianFutureStreet, required)

--- a/frontend/src/citizen-frontend/applications/editor/verification/ContactInfoSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/verification/ContactInfoSection.tsx
@@ -74,7 +74,7 @@ export default React.memo(function ContactInfoSection({
         {formData.childFutureAddressExists && (
           <>
             <Label>{tLocal.child.addressChangesAt}</Label>
-            <span>{formData.childMoveDate}</span>
+            <span>{formData.childMoveDate?.format()}</span>
 
             <Label>{tLocal.child.newAddress}</Label>
             <span>
@@ -114,7 +114,7 @@ export default React.memo(function ContactInfoSection({
         {formData.guardianFutureAddressExists && (
           <>
             <Label>{tLocal.guardian.addressChangesAt}</Label>
-            <span>{formData.guardianMoveDate}</span>
+            <span>{formData.guardianMoveDate?.format()}</span>
 
             <Label>{tLocal.guardian.newAddress}</Label>
             <span>

--- a/frontend/src/citizen-frontend/applications/editor/verification/ServiceNeedSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/verification/ServiceNeedSection.tsx
@@ -52,7 +52,7 @@ export default React.memo(function ServiceNeedSection({
               .preferredStartDate
           }
         </Label>
-        <span>{formData.serviceNeed.preferredStartDate}</span>
+        <span>{formData.serviceNeed.preferredStartDate?.format()}</span>
 
         {type === 'DAYCARE' && <ServiceNeedUrgency formData={formData} />}
         {type === 'CLUB' && (

--- a/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
@@ -47,14 +47,14 @@ function initialForm(
   const selectedChildren = availableChildren.map((child) => child.id)
   if (initialDate) {
     return {
-      startDate: initialDate.format(),
-      endDate: initialDate.format(),
+      startDate: initialDate,
+      endDate: initialDate,
       selectedChildren
     }
   }
   return {
-    startDate: LocalDate.todayInSystemTz().format(),
-    endDate: '',
+    startDate: LocalDate.todayInSystemTz(),
+    endDate: null,
     selectedChildren
   }
 }
@@ -136,33 +136,28 @@ export default React.memo(function AbsenceModal({
             date={form.startDate}
             onChange={(date) => updateForm({ startDate: date })}
             locale={lang}
-            isValidDate={(date) =>
-              LocalDate.todayInSystemTz().isEqualOrBefore(date)
-            }
+            minDate={LocalDate.todayInSystemTz()}
             info={
               errors &&
               errorToInputInfo(errors.startDate, i18n.validationErrors)
             }
             hideErrorsBeforeTouched={!showAllErrors}
             data-qa="start-date"
+            errorTexts={i18n.validationErrors}
           />
           <DatePickerSpacer />
           <DatePicker
             date={form.endDate}
             onChange={(date) => updateForm({ endDate: date })}
             locale={lang}
-            isValidDate={(date) =>
-              LocalDate.todayInSystemTz().isEqualOrBefore(date)
-            }
+            minDate={LocalDate.todayInSystemTz()}
             info={
               errors && errorToInputInfo(errors.endDate, i18n.validationErrors)
             }
             hideErrorsBeforeTouched={!showAllErrors}
-            initialMonth={
-              LocalDate.parseFiOrNull(form.startDate) ??
-              LocalDate.todayInSystemTz()
-            }
+            initialMonth={form.startDate ?? LocalDate.todayInSystemTz()}
             data-qa="end-date"
+            errorTexts={i18n.validationErrors}
           />
         </FixedSpaceRow>
         <Gap size="m" />
@@ -209,8 +204,8 @@ export default React.memo(function AbsenceModal({
 })
 
 interface Form {
-  startDate: string
-  endDate: string
+  startDate: LocalDate | null
+  endDate: LocalDate | null
   selectedChildren: string[]
   absenceType?: AbsenceType
 }
@@ -218,26 +213,9 @@ interface Form {
 const validateForm = (
   form: Form
 ): [AbsenceRequest] | [undefined, ErrorsOf<Form>] => {
-  const startDate = LocalDate.parseFiOrNull(form.startDate)
-  const endDate = LocalDate.parseFiOrNull(form.endDate)
-
   const errors: ErrorsOf<Form> = {
-    startDate:
-      form.startDate === ''
-        ? 'required'
-        : startDate === null
-        ? 'validDate'
-        : startDate.isBefore(LocalDate.todayInSystemTz())
-        ? 'dateTooEarly'
-        : undefined,
-    endDate:
-      form.endDate === ''
-        ? 'required'
-        : endDate === null
-        ? 'validDate'
-        : startDate && endDate.isBefore(startDate)
-        ? 'dateTooEarly'
-        : undefined,
+    startDate: !form.startDate ? 'required' : undefined,
+    endDate: !form.endDate ? 'required' : undefined,
     absenceType: form.absenceType === undefined ? 'required' : undefined
   }
 
@@ -249,7 +227,7 @@ const validateForm = (
     {
       childIds: form.selectedChildren,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      dateRange: new FiniteDateRange(startDate!, endDate!),
+      dateRange: new FiniteDateRange(form.startDate!, form.endDate!),
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       absenceType: form.absenceType!
     }

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components'
 
 import { Result } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
-import { validateIf, validDate } from 'lib-common/form-validation'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { scrollToRef } from 'lib-common/utils/scrolling'
@@ -117,8 +116,8 @@ const ChildIncome = React.memo(function ChildIncome({
 })
 
 interface ChildIncomeTypeSelectionData {
-  startDate: string
-  endDate: string
+  startDate: LocalDate | null
+  endDate: LocalDate | null
   highestFeeSelected: boolean
   grossSelected: boolean
   entrepreneurSelected: boolean
@@ -144,23 +143,12 @@ const ChildIncomeTimeRangeSelection = React.memo(
     const [lang] = useLang()
 
     const startDateInputInfo = useMemo(
-      () => errorToInputInfo(validDate(formData.startDate), t.validationErrors),
-      [formData.startDate, t]
-    )
-    const isValidEndDate = useCallback(
-      (date) => {
-        const startDate = LocalDate.parseFiOrNull(formData.startDate)
-        return startDate === null || startDate <= date
-      },
-      [formData.startDate]
-    )
-    const endDateInputInfo = useMemo(
       () =>
         errorToInputInfo(
-          validateIf(formData.endDate != '', formData.endDate, validDate),
+          formData.startDate ? undefined : 'validDate',
           t.validationErrors
         ),
-      [formData.endDate, t]
+      [formData.startDate, t]
     )
 
     return (
@@ -188,8 +176,11 @@ const ChildIncomeTimeRangeSelection = React.memo(
               info={startDateInputInfo}
               hideErrorsBeforeTouched
               locale={lang}
-              isValidDate={isValidStartDate}
+              isInvalidDate={(d) =>
+                isValidStartDate(d) ? null : t.validationErrors.unselectableDate
+              }
               data-qa="start-date"
+              errorTexts={t.validationErrors}
             />
           </div>
           <div>
@@ -199,11 +190,11 @@ const ChildIncomeTimeRangeSelection = React.memo(
               id="end-date"
               date={formData.endDate}
               onChange={useFieldDispatch(onChange, 'endDate')}
-              isValidDate={isValidEndDate}
-              info={endDateInputInfo}
+              minDate={formData.startDate ?? undefined}
               hideErrorsBeforeTouched
               locale={lang}
               data-qa="end-date"
+              errorTexts={t.validationErrors}
             />
           </div>
         </FixedSpaceRow>

--- a/frontend/src/citizen-frontend/income-statements/types/body.ts
+++ b/frontend/src/citizen-frontend/income-statements/types/body.ts
@@ -35,26 +35,22 @@ export function fromBody(
 ): IncomeStatementBody | null {
   if (!formData.assure) return null
 
-  const startDate = LocalDate.parseFiOrNull(formData.startDate)
-  const endDate =
-    formData.endDate == ''
-      ? null
-      : LocalDate.parseFiOrNull(formData.endDate) ?? invalid
-  if (startDate === null || endDate === invalid) return null
-  if (endDate && startDate > endDate) return null
+  const startDate = formData.startDate
+  if (startDate === null) return null
+  if (formData.endDate && startDate > formData.endDate) return null
 
   if (formData.highestFee) {
     if (personType === 'child') {
       return null
     }
-    return { type: 'HIGHEST_FEE', startDate, endDate }
+    return { type: 'HIGHEST_FEE', startDate, endDate: formData.endDate }
   }
 
   if (formData.childIncome) {
     return {
       type: 'CHILD_INCOME',
       startDate,
-      endDate,
+      endDate: formData.endDate,
       otherInfo: formData.otherInfo,
       attachmentIds: formData.attachments.map((a) => a.id)
     } as ChildIncomeBody
@@ -74,7 +70,7 @@ export function fromBody(
   return {
     type: 'INCOME' as const,
     startDate,
-    endDate,
+    endDate: formData.endDate,
     gross,
     entrepreneur,
     student: formData.student,
@@ -114,8 +110,7 @@ function validateEntrepreneur(formData: Form.Entrepreneur) {
     lightEntrepreneur,
     checkupConsent
   } = formData
-  const startOfEntrepreneurship =
-    LocalDate.parseFiOrNull(formData.startOfEntrepreneurship) ?? invalid
+  const startOfEntrepreneurship = formData.startOfEntrepreneurship ?? invalid
 
   const selfEmployed = validateSelfEmployed(formData.selfEmployed)
   const limitedCompany = validateLimitedCompany(formData.limitedCompany)
@@ -169,34 +164,27 @@ function validateSelfEmployed(formData: Form.SelfEmployed) {
 
 function validateEstimatedIncome(formData: {
   estimatedMonthlyIncome: string
-  incomeStartDate: string
-  incomeEndDate: string
+  incomeStartDate: LocalDate | null
+  incomeEndDate: LocalDate | null
 }) {
   const estimatedMonthlyIncome =
     stringToInt(formData.estimatedMonthlyIncome) ?? invalid
-  const incomeStartDate =
-    LocalDate.parseFiOrNull(formData.incomeStartDate) ?? invalid
-  const incomeEndDate =
-    formData.incomeEndDate != ''
-      ? LocalDate.parseFiOrNull(formData.incomeEndDate) ?? invalid
-      : null
 
-  if (
-    estimatedMonthlyIncome === invalid ||
-    incomeStartDate === invalid ||
-    incomeEndDate === invalid
-  ) {
+  if (estimatedMonthlyIncome === invalid || !formData.incomeStartDate) {
     return invalid
   }
 
-  if (incomeEndDate && incomeStartDate > incomeEndDate) {
+  if (
+    formData.incomeEndDate &&
+    formData.incomeStartDate > formData.incomeEndDate
+  ) {
     return invalid
   }
 
   return {
     estimatedMonthlyIncome,
-    incomeStartDate,
-    incomeEndDate
+    incomeStartDate: formData.incomeStartDate,
+    incomeEndDate: formData.incomeEndDate
   }
 }
 

--- a/frontend/src/citizen-frontend/income-statements/types/form.ts
+++ b/frontend/src/citizen-frontend/income-statements/types/form.ts
@@ -8,8 +8,8 @@ import { IncomeSource, OtherIncome } from 'lib-common/generated/enums'
 import LocalDate from 'lib-common/local-date'
 
 export interface IncomeStatementForm {
-  startDate: string
-  endDate: string
+  startDate: LocalDate | null
+  endDate: LocalDate | null
   highestFee: boolean
   childIncome: boolean
   gross: Gross
@@ -32,7 +32,7 @@ export interface Gross {
 export interface Entrepreneur {
   selected: boolean
   fullTime: boolean | null
-  startOfEntrepreneurship: string
+  startOfEntrepreneurship: LocalDate | null
   spouseWorksInCompany: boolean | null
   startupGrant: boolean
   checkupConsent: boolean
@@ -48,8 +48,8 @@ export interface SelfEmployed {
   attachments: boolean
   estimation: boolean
   estimatedMonthlyIncome: string
-  incomeStartDate: string
-  incomeEndDate: string
+  incomeStartDate: LocalDate | null
+  incomeEndDate: LocalDate | null
 }
 
 export interface LimitedCompany {
@@ -65,8 +65,8 @@ export interface Accountant {
 }
 
 export const empty: IncomeStatementForm = {
-  startDate: LocalDate.todayInSystemTz().format(),
-  endDate: '',
+  startDate: LocalDate.todayInSystemTz(),
+  endDate: null,
   highestFee: false,
   childIncome: false,
   gross: {
@@ -79,7 +79,7 @@ export const empty: IncomeStatementForm = {
   entrepreneur: {
     selected: false,
     fullTime: null,
-    startOfEntrepreneurship: '',
+    startOfEntrepreneurship: null,
     spouseWorksInCompany: null,
     startupGrant: false,
     checkupConsent: false,
@@ -88,8 +88,8 @@ export const empty: IncomeStatementForm = {
       attachments: false,
       estimation: false,
       estimatedMonthlyIncome: '',
-      incomeStartDate: '',
-      incomeEndDate: ''
+      incomeStartDate: null,
+      incomeEndDate: null
     },
     limitedCompany: {
       selected: false,
@@ -123,7 +123,7 @@ export const initialFormData = (
 ): IncomeStatementForm => {
   return {
     ...empty,
-    startDate: findValidStartDate(existingStartDates).format()
+    startDate: findValidStartDate(existingStartDates)
   }
 }
 
@@ -132,8 +132,8 @@ export function fromIncomeStatement(
 ): IncomeStatementForm {
   return {
     ...empty,
-    startDate: incomeStatement.startDate.format(),
-    endDate: incomeStatement.endDate?.format() ?? '',
+    startDate: incomeStatement.startDate,
+    endDate: incomeStatement.endDate,
     highestFee: incomeStatement.type === 'HIGHEST_FEE',
     ...(incomeStatement.type === 'INCOME'
       ? {
@@ -169,14 +169,14 @@ function mapEstimation(
   estimatedIncome: IncomeStatement.EstimatedIncome | null
 ): {
   estimatedMonthlyIncome: string
-  incomeStartDate: string
-  incomeEndDate: string
+  incomeStartDate: LocalDate | null
+  incomeEndDate: LocalDate | null
 } {
   return {
     estimatedMonthlyIncome:
       estimatedIncome?.estimatedMonthlyIncome?.toString() ?? '',
-    incomeStartDate: estimatedIncome?.incomeStartDate?.format() ?? '',
-    incomeEndDate: estimatedIncome?.incomeEndDate?.format() ?? ''
+    incomeStartDate: estimatedIncome?.incomeStartDate ?? null,
+    incomeEndDate: estimatedIncome?.incomeEndDate ?? null
   }
 }
 
@@ -187,7 +187,7 @@ function mapEntrepreneur(
   return {
     selected: true,
     fullTime: entrepreneur.fullTime,
-    startOfEntrepreneurship: entrepreneur.startOfEntrepreneurship.format(),
+    startOfEntrepreneurship: entrepreneur.startOfEntrepreneurship,
     spouseWorksInCompany: entrepreneur.spouseWorksInCompany,
     startupGrant: entrepreneur.startupGrant,
     checkupConsent: entrepreneur.checkupConsent,

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { ApplicationFormData } from 'lib-common/api-types/application/ApplicationFormData'
+import { JsonOf } from 'lib-common/json'
 
 import { waitUntilEqual, waitUntilDefined, waitUntilTrue } from '../../utils'
 import { FormInput, Section, sections } from '../../utils/application-forms'
@@ -210,11 +211,13 @@ class CitizenApplicationEditor {
     await element.type(value)
   }
 
-  async fillData(data: FormInput) {
+  async fillData(data: JsonOf<FormInput>) {
     await sections
       .map((section) => [section, data[section]])
       .filter(
-        (pair): pair is [Section, Partial<ApplicationFormData[Section]>] =>
+        (
+          pair
+        ): pair is [Section, Partial<JsonOf<ApplicationFormData>[Section]>] =>
           pair[1] !== undefined
       )
       .reduce(async (promise, [section, sectionData]) => {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -154,9 +154,7 @@ describe('Citizen daycare applications', () => {
     )
 
     await editorPage.setPreferredStartDate(mockedDate.addYears(2).format())
-    await editorPage.assertPreferredStartDateInfo(
-      'Aloituspäivä ei ole sallittu'
-    )
+    await editorPage.assertPreferredStartDateInfo('Valitse aikaisempi päivä')
 
     await editorPage.setPreferredStartDate(mockedDate.addMonths(4).format())
     await editorPage.assertPreferredStartDateInfo(undefined)
@@ -174,9 +172,7 @@ describe('Citizen daycare applications', () => {
 
     await applicationsPage.editApplication(applicationId)
     await editorPage.setPreferredStartDate(mockedDate.subDays(1).format())
-    await editorPage.assertPreferredStartDateInfo(
-      'Aloituspäivä ei ole sallittu'
-    )
+    await editorPage.assertPreferredStartDateInfo('Valitse myöhäisempi päivä')
   })
 
   test('Application can be made for restricted child', async () => {

--- a/frontend/src/e2e-test/utils/application-forms.ts
+++ b/frontend/src/e2e-test/utils/application-forms.ts
@@ -4,6 +4,7 @@
 
 import { ApplicationDetails } from 'lib-common/api-types/application/ApplicationDetails'
 import { ApplicationFormData } from 'lib-common/api-types/application/ApplicationFormData'
+import { JsonOf } from 'lib-common/json'
 
 import { clubFixture, daycareFixture } from '../dev-api/fixtures'
 import { PersonDetail } from '../dev-api/types'
@@ -49,7 +50,7 @@ export type FormInput = Partial<{
 }>
 
 export const minimalDaycareForm: {
-  form: FormInput
+  form: JsonOf<FormInput>
   validateResult: (
     result: ApplicationDetails,
     vtjSiblingsLivingInSameAddress: PersonDetail[]
@@ -125,7 +126,7 @@ export const minimalDaycareForm: {
 }
 
 export const fullDaycareForm: {
-  form: FormInput
+  form: JsonOf<FormInput>
   validateResult: (
     result: ApplicationDetails,
     vtjSiblingsLivingInSameAddress: PersonDetail[]
@@ -272,7 +273,7 @@ export const fullDaycareForm: {
 }
 
 export const minimalClubForm: {
-  form: FormInput
+  form: JsonOf<FormInput>
   validateResult: (result: ApplicationDetails) => void
 } = {
   form: {
@@ -332,7 +333,7 @@ export const minimalClubForm: {
 }
 
 export const fullClubForm: {
-  form: FormInput
+  form: JsonOf<FormInput>
   validateResult: (result: ApplicationDetails) => void
 } = {
   form: {
@@ -424,7 +425,7 @@ export const fullClubForm: {
 }
 
 export const minimalPreschoolForm: {
-  form: FormInput
+  form: JsonOf<FormInput>
   validateResult: (result: ApplicationDetails) => void
 } = {
   form: {
@@ -486,7 +487,7 @@ export const minimalPreschoolForm: {
 }
 
 export const fullPreschoolForm: {
-  form: FormInput
+  form: JsonOf<FormInput>
   validateResult: (
     result: ApplicationDetails,
     vtjSiblingsLivingInSameAddress: PersonDetail[]

--- a/frontend/src/employee-frontend/components/finance-basics/FeesSection.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeesSection.tsx
@@ -54,8 +54,8 @@ export default React.memo(function FeesSection() {
         editing: 'new',
         form: {
           ...copyForm(item),
-          validFrom: lastThresholdsEndDate?.format() ?? '',
-          validTo: ''
+          validFrom: lastThresholdsEndDate ?? null,
+          validTo: null
         }
       }),
     [setEditorState, lastThresholdsEndDate]
@@ -134,13 +134,13 @@ type EditorState =
 export type FormState = {
   [k in keyof Omit<FeeThresholds, 'validDuring'>]: string
 } & {
-  validFrom: string
-  validTo: string
+  validFrom: LocalDate | null
+  validTo: LocalDate | null
 }
 
 const emptyForm = (latestEndDate?: LocalDate): FormState => ({
-  validFrom: latestEndDate?.addDays(1).format() ?? '',
-  validTo: '',
+  validFrom: latestEndDate?.addDays(1) ?? null,
+  validTo: null,
   maxFee: '',
   minFee: '',
   minIncomeThreshold2: '',
@@ -171,8 +171,8 @@ const formatMulti = (multi: number) =>
   (multi * 100).toString().replace('.', ',')
 
 const copyForm = (feeThresholds: FeeThresholds): FormState => ({
-  validFrom: feeThresholds.validDuring.start.format() ?? '',
-  validTo: feeThresholds.validDuring.end?.format() ?? '',
+  validFrom: feeThresholds.validDuring.start,
+  validTo: feeThresholds.validDuring.end,
   maxFee: formatCents(feeThresholds.maxFee) ?? '',
   minFee: formatCents(feeThresholds.minFee) ?? '',
   minIncomeThreshold2: formatCents(feeThresholds.minIncomeThreshold2) ?? '',

--- a/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
@@ -124,18 +124,14 @@ const Modal = React.memo(function Modal({
   loadDecisions: () => void
 }) {
   const { i18n, lang } = useTranslation()
-  const [date, setDate] = useState<string>('')
-  const dateIsValid = LocalDate.parseFiOrNull(date)
+  const [date, setDate] = useState<LocalDate | null>(null)
 
   const resolve = useCallback(() => {
-    if (dateIsValid) {
-      return createRetroactiveFeeDecisions(
-        headOfFamily,
-        LocalDate.parseFiOrThrow(date)
-      )
+    if (date) {
+      return createRetroactiveFeeDecisions(headOfFamily, date)
     }
     return
-  }, [headOfFamily, date, dateIsValid])
+  }, [headOfFamily, date])
 
   const onSuccess = useCallback(() => {
     clear()
@@ -149,7 +145,7 @@ const Modal = React.memo(function Modal({
       title={i18n.personProfile.feeDecisions.createRetroactive}
       resolveAction={resolve}
       resolveLabel={i18n.common.create}
-      resolveDisabled={!dateIsValid}
+      resolveDisabled={!date}
       onSuccess={onSuccess}
       rejectAction={clear}
       rejectLabel={i18n.common.cancel}
@@ -160,17 +156,10 @@ const Modal = React.memo(function Modal({
           locale={lang}
           date={date}
           onChange={setDate}
-          info={
-            !dateIsValid
-              ? {
-                  status: 'warning',
-                  text: i18n.validationError.dateRange
-                }
-              : undefined
-          }
           hideErrorsBeforeTouched
           openAbove
           data-qa="retroactive-fee-decision-start-date"
+          errorTexts={i18n.validationErrors}
         />
       </FixedSpaceRow>
     </AsyncFormModal>

--- a/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
@@ -144,18 +144,14 @@ const Modal = React.memo(function Modal({
   loadDecisions: () => void
 }) {
   const { i18n, lang } = useTranslation()
-  const [date, setDate] = useState<string>('')
-  const dateIsValid = LocalDate.parseFiOrNull(date)
+  const [date, setDate] = useState<LocalDate | null>(null)
 
   const resolve = useCallback(() => {
-    if (dateIsValid) {
-      return createRetroactiveValueDecisions(
-        headOfFamily,
-        LocalDate.parseFiOrThrow(date)
-      )
+    if (date) {
+      return createRetroactiveValueDecisions(headOfFamily, date)
     }
     return
-  }, [headOfFamily, date, dateIsValid])
+  }, [headOfFamily, date])
 
   const onSuccess = useCallback(() => {
     clear()
@@ -169,7 +165,7 @@ const Modal = React.memo(function Modal({
       title={i18n.personProfile.voucherValueDecisions.createRetroactive}
       resolveAction={resolve}
       resolveLabel={i18n.common.create}
-      resolveDisabled={!dateIsValid}
+      resolveDisabled={!date}
       onSuccess={onSuccess}
       rejectAction={clear}
       rejectLabel={i18n.common.cancel}
@@ -181,16 +177,9 @@ const Modal = React.memo(function Modal({
           locale={lang}
           date={date}
           onChange={setDate}
-          info={
-            !dateIsValid
-              ? {
-                  status: 'warning',
-                  text: i18n.validationError.dateRange
-                }
-              : undefined
-          }
           hideErrorsBeforeTouched
           openAbove
+          errorTexts={i18n.validationErrors}
         />
       </FixedSpaceRow>
     </AsyncFormModal>

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
@@ -56,8 +56,8 @@ export default React.memo(function ReservationModalSingleChild({
 
   const [formData, setFormData] = useState<ReservationFormData>({
     selectedChildren: [child.id],
-    startDate: LocalDate.todayInSystemTz().format(),
-    endDate: '',
+    startDate: LocalDate.todayInSystemTz(),
+    endDate: null,
     repetition: 'DAILY',
     dailyTimes: [
       {
@@ -90,8 +90,8 @@ export default React.memo(function ReservationModalSingleChild({
   const shiftCareRange = useMemo(() => {
     if (formData.repetition !== 'IRREGULAR') return
 
-    const parsedStartDate = LocalDate.parseFiOrNull(formData.startDate)
-    const parsedEndDate = LocalDate.parseFiOrNull(formData.endDate)
+    const parsedStartDate = formData.startDate
+    const parsedEndDate = formData.endDate
 
     if (
       !parsedStartDate ||
@@ -159,12 +159,19 @@ export default React.memo(function ReservationModalSingleChild({
           data-qa="reservation-start-date"
           onChange={(date) => updateForm({ startDate: date })}
           locale={lang}
-          isValidDate={(date) => reservableDates.includes(date)}
+          isInvalidDate={(date) =>
+            reservableDates.includes(date)
+              ? null
+              : i18n.validationErrors.unselectableDate
+          }
+          minDate={reservableDates.start}
+          maxDate={reservableDates.end}
           info={errorToInputInfo(
             validationResult.errors?.startDate,
             i18n.validationErrors
           )}
           hideErrorsBeforeTouched={!showAllErrors}
+          errorTexts={i18n.validationErrors}
         />
         <DatePickerSpacer />
         <DatePicker
@@ -172,13 +179,20 @@ export default React.memo(function ReservationModalSingleChild({
           data-qa="reservation-end-date"
           onChange={(date) => updateForm({ endDate: date })}
           locale={lang}
-          isValidDate={(date) => reservableDates.includes(date)}
+          isInvalidDate={(date) =>
+            reservableDates.includes(date)
+              ? null
+              : i18n.validationErrors.unselectableDate
+          }
+          minDate={reservableDates.start}
+          maxDate={reservableDates.end}
           info={errorToInputInfo(
             validationResult.errors?.endDate,
             i18n.validationErrors
           )}
           hideErrorsBeforeTouched={!showAllErrors}
           initialMonth={LocalDate.todayInSystemTz()}
+          errorTexts={i18n.validationErrors}
         />
       </FixedSpaceRow>
       <Gap size="m" />

--- a/frontend/src/employee-frontend/components/vasu/components/DateQuestion.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/DateQuestion.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 
 import { useTranslation } from 'employee-frontend/state/i18n'
 import { DateQuestion } from 'lib-common/api-types/vasu'
@@ -28,23 +28,9 @@ export default React.memo(function DateQuestion({
   onChange,
   translations
 }: Props) {
-  const { lang } = useTranslation()
-  const [inputValue, setInputValue] = useState(value?.format() ?? '')
+  const { i18n, lang } = useTranslation()
 
-  useEffect(() => {
-    if (onChange) {
-      const date = LocalDate.parseFiOrNull(inputValue)
-      // Update actual date value only when input has valid content
-      if (date || !inputValue) {
-        onChange(date)
-      }
-    }
-  }, [inputValue]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const forceDate = () => {
-    const parsed = LocalDate.parseFiOrNull(inputValue)
-    setInputValue(parsed?.format() ?? '')
-  }
+  const [date, setDate] = useState<LocalDate | null>(null)
 
   return (
     <FixedSpaceColumn spacing="xxs">
@@ -55,11 +41,14 @@ export default React.memo(function DateQuestion({
       </QuestionInfo>
       {onChange ? (
         <DatePicker
-          date={inputValue}
-          onChange={setInputValue}
-          onBlur={forceDate}
+          date={date}
+          onChange={(d) => {
+            onChange(d)
+            setDate(d)
+          }}
           locale={lang}
           data-qa="date-question-picker"
+          errorTexts={i18n.validationErrors}
         />
       ) : (
         <ValueOrNoRecord text={value?.format()} translations={translations} />

--- a/frontend/src/employee-frontend/components/vasu/templates/VasuTemplateEditor.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/VasuTemplateEditor.tsx
@@ -395,7 +395,12 @@ export default React.memo(function VasuTemplateEditor() {
         <QuestionInfo info={question.info}>
           <H3 noMargin>{`${questionNumber}. ${question.name}`}</H3>
         </QuestionInfo>
-        <DatePicker date="" onChange={() => undefined} locale={lang} />
+        <DatePicker
+          date={null}
+          onChange={() => undefined}
+          locale={lang}
+          errorTexts={i18n.validationErrors}
+        />
         {!!question.nameInEvents && (
           <QuestionDetails>
             {`${i18n.vasuTemplates.questionModal.dateIsTrackedInEvents}: ${question.nameInEvents}`}

--- a/frontend/src/lib-common/api-types/application/ApplicationFormData.ts
+++ b/frontend/src/lib-common/api-types/application/ApplicationFormData.ts
@@ -8,6 +8,7 @@ import {
   ApplicationFormUpdate
 } from 'lib-common/api-types/application/ApplicationDetails'
 import { ApplicationAddress } from 'lib-common/api-types/application/ApplicationDetails'
+import { throwIfNull } from 'lib-common/form-validation'
 import {
   OtherGuardianAgreementStatus,
   ServiceNeedOption
@@ -15,7 +16,7 @@ import {
 import LocalDate from 'lib-common/local-date'
 
 export type ServiceNeedFormData = {
-  preferredStartDate: string
+  preferredStartDate: LocalDate | null
   urgent: boolean
   connectedDaycare: boolean
   startTime: string
@@ -46,7 +47,7 @@ export type ContactInfoFormData = {
   childSSN: string
   childStreet: string
   childFutureAddressExists: boolean
-  childMoveDate: string
+  childMoveDate: LocalDate | null
   childFutureStreet: string
   childFuturePostalCode: string
   childFuturePostOffice: string
@@ -60,7 +61,7 @@ export type ContactInfoFormData = {
   guardianEmailVerification: string
   guardianFutureAddressExists: boolean
   guardianFutureAddressEqualsChild: boolean
-  guardianMoveDate: string
+  guardianMoveDate: LocalDate | null
   guardianFutureStreet: string
   guardianFuturePostalCode: string
   guardianFuturePostOffice: string
@@ -181,8 +182,7 @@ export function apiDataToFormData(
 
   return {
     serviceNeed: {
-      preferredStartDate:
-        application.form.preferences.preferredStartDate?.format() ?? '',
+      preferredStartDate: application.form.preferences.preferredStartDate,
       urgent: application.form.preferences.urgent,
       connectedDaycare:
         application.type === 'PRESCHOOL' &&
@@ -222,8 +222,7 @@ export function apiDataToFormData(
       childSSN: application.form.child.person.socialSecurityNumber || '',
       childStreet: formatAddress(application.form.child.address),
       childFutureAddressExists: application.form.child.futureAddress !== null,
-      childMoveDate:
-        application.form.child.futureAddress?.movingDate?.format() ?? '',
+      childMoveDate: application.form.child.futureAddress?.movingDate ?? null,
       childFutureStreet: application.form.child.futureAddress?.street ?? '',
       childFuturePostalCode:
         application.form.child.futureAddress?.postalCode ?? '',
@@ -250,7 +249,7 @@ export function apiDataToFormData(
             application.form.guardian.futureAddress.postOffice) ??
         false,
       guardianMoveDate:
-        application.form.guardian.futureAddress?.movingDate?.format() ?? '',
+        application.form.guardian.futureAddress?.movingDate ?? null,
       guardianFutureStreet:
         application.form.guardian.futureAddress?.street ?? '',
       guardianFuturePostalCode:
@@ -304,8 +303,8 @@ export function formDataToApiData(
             postalCode: form.contactInfo.childFuturePostalCode,
             postOffice: form.contactInfo.childFuturePostOffice,
             movingDate: isDraft
-              ? LocalDate.parseFiOrNull(form.contactInfo.childMoveDate)
-              : LocalDate.parseFiOrThrow(form.contactInfo.childMoveDate)
+              ? form.contactInfo.childMoveDate
+              : throwIfNull(form.contactInfo.childMoveDate)
           }
         : null,
       allergies: type !== 'CLUB' ? form.additionalDetails.allergies : '',
@@ -320,8 +319,8 @@ export function formDataToApiData(
             postalCode: form.contactInfo.guardianFuturePostalCode,
             postOffice: form.contactInfo.guardianFuturePostOffice,
             movingDate: isDraft
-              ? LocalDate.parseFiOrNull(form.contactInfo.guardianMoveDate)
-              : LocalDate.parseFiOrThrow(form.contactInfo.guardianMoveDate)
+              ? form.contactInfo.guardianMoveDate
+              : throwIfNull(form.contactInfo.guardianMoveDate)
           }
         : null,
       phoneNumber: form.contactInfo.guardianPhone,
@@ -368,9 +367,7 @@ export function formDataToApiData(
       : [],
     preferences: {
       preferredUnits: form.unitPreference.preferredUnits,
-      preferredStartDate: LocalDate.parseFiOrNull(
-        form.serviceNeed.preferredStartDate
-      ),
+      preferredStartDate: form.serviceNeed.preferredStartDate,
       serviceNeed:
         type === 'DAYCARE' ||
         (type === 'PRESCHOOL' && form.serviceNeed.connectedDaycare)

--- a/frontend/src/lib-common/form-validation.ts
+++ b/frontend/src/lib-common/form-validation.ts
@@ -32,9 +32,14 @@ export type ErrorKey =
   | 'httpUrl'
 
 export const required = (
-  val: string,
+  val: unknown,
   err: ErrorKey = 'required'
-): ErrorKey | undefined => (val.trim().length === 0 ? err : undefined)
+): ErrorKey | undefined =>
+  val === undefined ||
+  val === null ||
+  (typeof val === 'string' && val.trim().length === 0)
+    ? err
+    : undefined
 
 export const requiredSelection = <T>(
   val: T | null | undefined,
@@ -93,7 +98,7 @@ export const validDate = (
 ): ErrorKey | undefined => (!LocalDate.parseFiOrNull(val) ? err : undefined)
 
 export const emailVerificationCheck =
-  (verification: string): StandardValidator =>
+  (verification: string): StandardValidator<string> =>
   (val, err: ErrorKey = 'emailsDoNotMatch') =>
     val === verification ? undefined : err
 
@@ -110,11 +115,11 @@ export const httpUrl = (
   }
 }
 
-type StandardValidator = (val: string, err?: ErrorKey) => ErrorKey | undefined
+type StandardValidator<T> = (val: T, err?: ErrorKey) => ErrorKey | undefined
 
-export const validate = (
-  val: string,
-  ...validators: StandardValidator[]
+export const validate = <T = string>(
+  val: T,
+  ...validators: StandardValidator<T>[]
 ): ErrorKey | undefined => {
   for (const validator of validators) {
     const err = validator(val)
@@ -123,13 +128,21 @@ export const validate = (
   return undefined
 }
 
-export const validateIf = (
+export const validateIf = <T = string>(
   condition: boolean,
-  val: string,
-  ...validators: StandardValidator[]
+  val: T,
+  ...validators: StandardValidator<T>[]
 ): ErrorKey | undefined => {
   if (condition) return validate(val, ...validators)
   return undefined
+}
+
+export const throwIfNull = <T>(value: T | null) => {
+  if (value === null) {
+    throw new Error('Value cannot be null')
+  }
+
+  return value
 }
 
 type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType[number]

--- a/frontend/src/lib-common/local-date.ts
+++ b/frontend/src/lib-common/local-date.ts
@@ -167,7 +167,8 @@ export default class LocalDate {
   formatIso(): string {
     const month = this.month.toString().padStart(2, '0')
     const date = this.date.toString().padStart(2, '0')
-    return `${this.year}-${month}-${date}`
+    const year = this.year.toString().padStart(4, '0')
+    return `${year}-${month}-${date}`
   }
   toJSON(): string {
     return this.formatIso()

--- a/frontend/src/lib-common/reservations.ts
+++ b/frontend/src/lib-common/reservations.ts
@@ -16,8 +16,8 @@ export type Repetition = 'DAILY' | 'WEEKLY' | 'IRREGULAR'
 
 export interface ReservationFormData {
   selectedChildren: UUID[]
-  startDate: string
-  endDate: string
+  startDate: LocalDate | null
+  endDate: LocalDate | null
   repetition: Repetition
   dailyTimes: TimeRanges
   weeklyTimes: Array<TimeRanges | undefined>
@@ -51,9 +51,14 @@ export type ValidationResult =
   | { errors: ReservationErrors }
   | { errors: undefined; requestPayload: DailyReservationRequest[] }
 
+export type ReservationFormDataForValidation = Omit<
+  ReservationFormData,
+  'endDate' | 'startDate'
+> & { endDate: LocalDate | null; startDate: LocalDate | null }
+
 export function validateForm(
   reservableDays: FiniteDateRange[],
-  formData: ReservationFormData
+  { startDate, endDate, ...formData }: ReservationFormDataForValidation
 ): ValidationResult {
   const errors: ReservationErrors = {}
 
@@ -61,7 +66,6 @@ export function validateForm(
     errors['selectedChildren'] = 'required'
   }
 
-  const startDate = LocalDate.parseFiOrNull(formData.startDate)
   if (
     startDate === null ||
     !reservableDays.some((r) => r.includes(startDate))
@@ -69,7 +73,6 @@ export function validateForm(
     errors['startDate'] = 'validDate'
   }
 
-  const endDate = LocalDate.parseFiOrNull(formData.endDate)
   if (endDate === null || !reservableDays.some((r) => r.includes(endDate))) {
     errors['endDate'] = 'validDate'
   } else if (startDate && endDate.isBefore(startDate)) {

--- a/frontend/src/lib-common/utils/usePendingUserInput.ts
+++ b/frontend/src/lib-common/utils/usePendingUserInput.ts
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react'
 export function usePendingUserInput<T>(
   transform: (input: string) => T | null,
   initialValue?: string
-) {
+): [string, React.Dispatch<React.SetStateAction<string>>, T | undefined] {
   const [input, setInput] = useState(initialValue ?? '')
   const [validated, setValidated] = useState<T>()
 
@@ -21,9 +21,5 @@ export function usePendingUserInput<T>(
     }
   }, [input, transform])
 
-  return [input, setInput, validated] as [
-    string,
-    React.Dispatch<React.SetStateAction<string>>,
-    T | undefined
-  ]
+  return [input, setInput, validated]
 }

--- a/frontend/src/lib-common/utils/usePendingUserInput.ts
+++ b/frontend/src/lib-common/utils/usePendingUserInput.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { useEffect, useState } from 'react'
+
+export function usePendingUserInput<T>(
+  transform: (input: string) => T | null,
+  initialValue?: string
+) {
+  const [input, setInput] = useState(initialValue ?? '')
+  const [validated, setValidated] = useState<T>()
+
+  useEffect(() => {
+    const transformed = transform(input)
+
+    if (transformed) {
+      setValidated(transformed)
+    } else {
+      setValidated(undefined)
+    }
+  }, [input, transform])
+
+  return [input, setInput, validated] as [
+    string,
+    React.Dispatch<React.SetStateAction<string>>,
+    T | undefined
+  ]
+}

--- a/frontend/src/lib-components/atoms/form/InputField.tsx
+++ b/frontend/src/lib-components/atoms/form/InputField.tsx
@@ -180,9 +180,10 @@ export type InputInfo = {
   status?: InfoStatus
 }
 
-export interface TextInputProps extends BaseProps {
+interface InputProps extends BaseProps {
   value: string
   onChange?: (value: string) => void
+  onChangeTarget?: (target: EventTarget & HTMLInputElement) => void
   onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void
   onKeyPress?: (e: React.KeyboardEvent) => void
@@ -199,8 +200,6 @@ export interface TextInputProps extends BaseProps {
   onKeyDown?: HTMLAttributes<HTMLInputElement>['onKeyDown']
   symbol?: string
   type?: string
-  min?: number
-  max?: number
   maxLength?: number
   step?: number
   id?: string
@@ -213,6 +212,19 @@ export interface TextInputProps extends BaseProps {
   inputRef?: RefObject<HTMLInputElement>
   wrapperClassName?: string
 }
+
+interface DateInputProps extends InputProps {
+  type: 'date'
+  min?: string
+  max?: string
+}
+
+interface OtherInputProps extends InputProps {
+  min?: number
+  max?: number
+}
+
+export type TextInputProps = OtherInputProps | DateInputProps
 
 export default React.memo(function InputField({
   value,
@@ -242,7 +254,9 @@ export default React.memo(function InputField({
   inputRef,
   'aria-describedby': ariaId,
   required,
-  autoFocus
+  autoFocus,
+  onChangeTarget,
+  ...rest
 }: TextInputProps) {
   const [touched, setTouched] = useState(false)
 
@@ -260,7 +274,10 @@ export default React.memo(function InputField({
         value={value}
         onChange={(e) => {
           e.preventDefault()
-          if (onChange && !readonly) onChange(e.target.value)
+          if (!readonly) {
+            onChange?.(e.target.value)
+            onChangeTarget?.(e.target)
+          }
         }}
         onFocus={onFocus}
         onBlur={(e) => {
@@ -287,6 +304,7 @@ export default React.memo(function InputField({
         required={required ?? false}
         ref={inputRef}
         autoFocus={autoFocus}
+        {...rest}
       />
       {showIcon && (
         <IconContainer clickable={clearable}>

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1838,7 +1838,8 @@ const en: Translations = {
     timeRequired: 'Required',
     unitNotSelected: 'Pick at least one choice',
     emailsDoNotMatch: 'The emails do not match',
-    httpUrl: 'Valid url format is https://example.com'
+    httpUrl: 'Valid url format is https://example.com',
+    unselectableDate: 'Invalid date'
   },
   login: {
     failedModal: {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1771,7 +1771,8 @@ export default {
     timeRequired: 'Pakollinen',
     unitNotSelected: 'Valitse vähintään yksi hakutoive',
     emailsDoNotMatch: 'Sähköpostiosoitteet eivät täsmää',
-    httpUrl: 'Anna muodossa https://example.com'
+    httpUrl: 'Anna muodossa https://example.com',
+    unselectableDate: 'Päivä ei ole sallittu'
   },
   login: {
     failedModal: {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1795,7 +1795,8 @@ const sv: Translations = {
     timeRequired: 'Nödvändig',
     unitNotSelected: 'Välj minst en enhet',
     emailsDoNotMatch: 'E-postadresserna är olika',
-    httpUrl: 'Ange i formen https://example.com'
+    httpUrl: 'Ange i formen https://example.com',
+    unselectableDate: 'Ogiltigt datum'
   },
   login: {
     failedModal: {

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.ts
@@ -3105,7 +3105,8 @@ export const fi = {
     timeRequired: 'Pakollinen',
     unitNotSelected: 'Valitse vähintään yksi hakutoive',
     emailsDoNotMatch: 'Sähköpostiosoitteet eivät täsmää',
-    httpUrl: 'Anna muodossa https://example.com'
+    httpUrl: 'Anna muodossa https://example.com',
+    unselectableDate: 'Päivä ei ole sallittu'
   },
   reloadNotification: {
     title: 'Uusi versio eVakasta saatavilla',


### PR DESCRIPTION
#### Summary

For Android, use the native date picker. Also refactors the date picker component to use `LocalDate` instead of raw strings, so that min/max date constraints can be consolidated into this one component to prevent repetition for the same thing. Moreover, the native date picker outputs a browser `Date` which is why it is useful to use `LocalDate` in the component state.
