### PR TITLE
Add skip to content accessibility links

### DIFF
--- a/frontend/src/citizen-frontend/AccessibilityStatement.tsx
+++ b/frontend/src/citizen-frontend/AccessibilityStatement.tsx
@@ -4,6 +4,7 @@
 
 import React, { useEffect } from 'react'
 
+import Main from 'lib-components/atoms/Main'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 
@@ -25,10 +26,12 @@ export default React.memo(function AccessibilityStatement({
 
   return (
     <>
-      <Container>
-        <ReturnButton label={t.common.return} />
-        <ContentArea opaque>{t.accessibilityStatement}</ContentArea>
-      </Container>
+      <Main>
+        <Container>
+          <ReturnButton label={t.common.return} />
+          <ContentArea opaque>{t.accessibilityStatement}</ContentArea>
+        </Container>
+      </Main>
       <Footer />
     </>
   )

--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from 'styled-components'
 import styled from 'styled-components'
 
 import { scrollElementToPos } from 'lib-common/utils/scrolling'
+import SkipToContent from 'lib-components/atoms/buttons/SkipToContent'
 import { desktopMin } from 'lib-components/breakpoints'
 import ErrorPage from 'lib-components/molecules/ErrorPage'
 import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
@@ -40,7 +41,7 @@ import IncomeStatementEditor from './income-statements/IncomeStatementEditor'
 import IncomeStatementView from './income-statements/IncomeStatementView'
 import IncomeStatements from './income-statements/IncomeStatements'
 import { Localization, useTranslation } from './localization'
-import MapView from './map/MapView'
+import MapPage from './map/MapPage'
 import MessagesPage from './messages/MessagesPage'
 import { MessageContextProvider } from './messages/state'
 import GlobalDialog from './overlay/GlobalDialog'
@@ -80,9 +81,11 @@ export default function App() {
 }
 
 const Content = React.memo(function Content() {
+  const t = useTranslation()
+
   const { modalOpen } = useContext(OverlayContext)
 
-  const mainRef = useRef<HTMLElement>(null)
+  const mainRef = useRef<HTMLDivElement>(null)
   const scrollMainToTop = useCallback(
     () =>
       scrollElementToPos(mainRef.current, {
@@ -95,13 +98,14 @@ const Content = React.memo(function Content() {
 
   return (
     <>
+      <SkipToContent target="main">{t.skipLinks.mainContent}</SkipToContent>
       <Header ariaHidden={modalOpen} />
-      <Main ariaHidden={modalOpen} ref={mainRef}>
+      <MainContainer ariaHidden={modalOpen} ref={mainRef}>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route
             path="/map"
-            element={<MapView scrollToTop={scrollMainToTop} />}
+            element={<MapPage scrollToTop={scrollMainToTop} />}
           />
           <Route
             path="/applying/*"
@@ -249,14 +253,14 @@ const Content = React.memo(function Content() {
           />
           <Route index element={<HandleRedirection />} />
         </Routes>
-      </Main>
+      </MainContainer>
     </>
   )
 })
 
 // eslint-disable-next-line react/display-name
-const Main = React.memo(
-  React.forwardRef(function Main(
+const MainContainer = React.memo(
+  React.forwardRef(function MainContainer(
     {
       ariaHidden,
       children
@@ -264,12 +268,12 @@ const Main = React.memo(
       ariaHidden: boolean
       children: ReactNode
     },
-    ref: React.ForwardedRef<HTMLElement>
+    ref: React.ForwardedRef<HTMLDivElement>
   ) {
     const { user } = useContext(AuthContext)
     const render = useCallback(() => <>{children}</>, [children])
     return (
-      <ScrollableMain id="main" aria-hidden={ariaHidden} ref={ref}>
+      <ScrollableMain aria-hidden={ariaHidden} ref={ref}>
         <UnwrapResult result={user}>{render}</UnwrapResult>
       </ScrollableMain>
     )
@@ -291,7 +295,7 @@ function HandleRedirection() {
   )
 }
 
-const ScrollableMain = styled.main`
+const ScrollableMain = styled.div`
   height: calc(100% - ${headerHeightMobile}px);
   overflow: auto;
 

--- a/frontend/src/citizen-frontend/LoginPage.tsx
+++ b/frontend/src/citizen-frontend/LoginPage.tsx
@@ -8,6 +8,7 @@ import { Navigate } from 'react-router-dom'
 import styled from 'styled-components'
 
 import LinkWrapperInlineBlock from 'lib-components/atoms/LinkWrapperInlineBlock'
+import Main from 'lib-components/atoms/Main'
 import LinkButton from 'lib-components/atoms/buttons/LinkButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
@@ -39,7 +40,7 @@ export default React.memo(function LoginPage() {
   }
 
   return (
-    <>
+    <Main>
       <TabletAndDesktop>
         <Gap size="L" />
       </TabletAndDesktop>
@@ -100,7 +101,7 @@ export default React.memo(function LoginPage() {
         </FixedSpaceColumn>
       </Container>
       <Footer />
-    </>
+    </Main>
   )
 })
 

--- a/frontend/src/citizen-frontend/applications/ApplicationCreation.tsx
+++ b/frontend/src/citizen-frontend/applications/ApplicationCreation.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components'
 import { Loading, Result } from 'lib-common/api'
 import { ApplicationType } from 'lib-common/generated/api-types/application'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
+import Main from 'lib-components/atoms/Main'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
@@ -78,108 +79,110 @@ export default React.memo(function ApplicationCreation() {
     <>
       <Container>
         <ReturnButton label={t.common.return} />
-        <ContentArea
-          opaque
-          paddingVertical="L"
-          data-qa="application-options-area"
-        >
-          <H1 noMargin>{t.applications.creation.title}</H1>
-          <Gap size="m" />
-          <H2 noMargin>
-            {child.firstName} {child.lastName}
-          </H2>
-          <Gap size="XL" />
-          <ExpandingInfo
-            data-qa="daycare-expanding-info"
-            info={t.applications.creation.daycareInfo}
-            ariaLabel={t.common.openExpandingInfo}
+        <Main>
+          <ContentArea
+            opaque
+            paddingVertical="L"
+            data-qa="application-options-area"
           >
-            <Radio
-              checked={selectedType === 'DAYCARE'}
-              onChange={() => setSelectedType('DAYCARE')}
-              label={t.applications.creation.daycareLabel}
-              data-qa="type-radio-DAYCARE"
-            />
-          </ExpandingInfo>
-          <Gap size="s" />
-          {featureFlags.preschoolEnabled && (
-            <>
-              <ExpandingInfo
-                info={t.applications.creation.preschoolInfo}
-                ariaLabel={t.common.openExpandingInfo}
-              >
-                <Radio
-                  checked={selectedType === 'PRESCHOOL'}
-                  onChange={() => setSelectedType('PRESCHOOL')}
-                  label={t.applications.creation.preschoolLabel}
-                  data-qa="type-radio-PRESCHOOL"
+            <H1 noMargin>{t.applications.creation.title}</H1>
+            <Gap size="m" />
+            <H2 noMargin>
+              {child.firstName} {child.lastName}
+            </H2>
+            <Gap size="XL" />
+            <ExpandingInfo
+              data-qa="daycare-expanding-info"
+              info={t.applications.creation.daycareInfo}
+              ariaLabel={t.common.openExpandingInfo}
+            >
+              <Radio
+                checked={selectedType === 'DAYCARE'}
+                onChange={() => setSelectedType('DAYCARE')}
+                label={t.applications.creation.daycareLabel}
+                data-qa="type-radio-DAYCARE"
+              />
+            </ExpandingInfo>
+            <Gap size="s" />
+            {featureFlags.preschoolEnabled && (
+              <>
+                <ExpandingInfo
+                  info={t.applications.creation.preschoolInfo}
+                  ariaLabel={t.common.openExpandingInfo}
+                >
+                  <Radio
+                    checked={selectedType === 'PRESCHOOL'}
+                    onChange={() => setSelectedType('PRESCHOOL')}
+                    label={t.applications.creation.preschoolLabel}
+                    data-qa="type-radio-PRESCHOOL"
+                  />
+                </ExpandingInfo>
+                <PreschoolDaycareInfo>
+                  {t.applications.creation.preschoolDaycareInfo}
+                </PreschoolDaycareInfo>
+                <Gap size="s" />
+              </>
+            )}
+            <ExpandingInfo
+              data-qa="club-expanding-info"
+              info={t.applications.creation.clubInfo}
+              ariaLabel={t.common.openExpandingInfo}
+            >
+              <Radio
+                checked={selectedType === 'CLUB'}
+                onChange={() => setSelectedType('CLUB')}
+                label={t.applications.creation.clubLabel}
+                data-qa="type-radio-CLUB"
+              />
+            </ExpandingInfo>
+            {duplicateExists ? (
+              <>
+                <Gap size="L" />
+                <AlertBox
+                  thin
+                  data-qa="duplicate-application-notification"
+                  message={t.applications.creation.duplicateWarning}
                 />
-              </ExpandingInfo>
-              <PreschoolDaycareInfo>
-                {t.applications.creation.preschoolDaycareInfo}
-              </PreschoolDaycareInfo>
-              <Gap size="s" />
-            </>
-          )}
-          <ExpandingInfo
-            data-qa="club-expanding-info"
-            info={t.applications.creation.clubInfo}
-            ariaLabel={t.common.openExpandingInfo}
-          >
-            <Radio
-              checked={selectedType === 'CLUB'}
-              onChange={() => setSelectedType('CLUB')}
-              label={t.applications.creation.clubLabel}
-              data-qa="type-radio-CLUB"
-            />
-          </ExpandingInfo>
-          {duplicateExists ? (
-            <>
-              <Gap size="L" />
-              <AlertBox
-                thin
-                data-qa="duplicate-application-notification"
-                message={t.applications.creation.duplicateWarning}
-              />
-            </>
-          ) : null}
-          {!duplicateExists && shouldUseTransferApplication && (
-            <>
-              <Gap size="L" />
-              <InfoBox
-                thin
-                data-qa="transfer-application-notification"
-                message={
-                  t.applications.creation.transferApplicationInfo[
-                    selectedType === 'DAYCARE' ? 'DAYCARE' : 'PRESCHOOL'
-                  ]
+              </>
+            ) : null}
+            {!duplicateExists && shouldUseTransferApplication && (
+              <>
+                <Gap size="L" />
+                <InfoBox
+                  thin
+                  data-qa="transfer-application-notification"
+                  message={
+                    t.applications.creation.transferApplicationInfo[
+                      selectedType === 'DAYCARE' ? 'DAYCARE' : 'PRESCHOOL'
+                    ]
+                  }
+                />
+              </>
+            )}
+            <Gap size="s" />
+            {t.applications.creation.applicationInfo}
+          </ContentArea>
+          <ContentArea opaque={false} paddingVertical="L">
+            <ButtonContainer justify="center">
+              <AsyncButton
+                primary
+                text={t.applications.creation.create}
+                disabled={selectedType === undefined || duplicateExists}
+                onClick={() =>
+                  selectedType !== undefined
+                    ? createApplication(childId, selectedType)
+                    : undefined
                 }
+                onSuccess={(id) => navigate(`/applications/${id}/edit`)}
+                data-qa="submit"
               />
-            </>
-          )}
-          <Gap size="s" />
-          {t.applications.creation.applicationInfo}
-        </ContentArea>
-        <ContentArea opaque={false} paddingVertical="L">
-          <ButtonContainer justify="center">
-            <AsyncButton
-              primary
-              text={t.applications.creation.create}
-              disabled={selectedType === undefined || duplicateExists}
-              onClick={() =>
-                selectedType !== undefined
-                  ? createApplication(childId, selectedType)
-                  : undefined
-              }
-              onSuccess={(id) => navigate(`/applications/${id}/edit`)}
-              data-qa="submit"
-            />
-            <Button
-              text={t.common.cancel}
-              onClick={() => navigate('/applying/applications')}
-            />
-          </ButtonContainer>
-        </ContentArea>
+              <Button
+                text={t.common.cancel}
+                onClick={() => navigate('/applying/applications')}
+              />
+            </ButtonContainer>
+          </ContentArea>
+        </Main>
       </Container>
       <Footer />
     </>

--- a/frontend/src/citizen-frontend/applications/Applications.tsx
+++ b/frontend/src/citizen-frontend/applications/Applications.tsx
@@ -11,7 +11,6 @@ import Container, { ContentArea } from 'lib-components/layout/Container'
 import { H1 } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
-import Footer from '../Footer'
 import ChildApplicationsBlock from '../applications/ChildApplicationsBlock'
 import { renderResult } from '../async-rendering'
 import { useTranslation } from '../localization'
@@ -29,39 +28,34 @@ export default React.memo(function Applications() {
   useTitle(t, t.applicationsList.title)
 
   return (
-    <>
-      <Container
-        data-qa="applications-list"
-        data-isloading={isLoading(guardianApplications)}
-      >
-        <Gap size="s" />
-        <ContentArea opaque paddingVertical="L">
-          <H1 noMargin>{t.applicationsList.title}</H1>
-          {t.applicationsList.summary}
-        </ContentArea>
-        <Gap size="s" />
+    <Container
+      data-qa="applications-list"
+      data-isloading={isLoading(guardianApplications)}
+    >
+      <Gap size="s" />
+      <ContentArea opaque paddingVertical="L">
+        <H1 noMargin>{t.applicationsList.title}</H1>
+        {t.applicationsList.summary}
+      </ContentArea>
+      <Gap size="s" />
 
-        {renderResult(guardianApplications, (guardianApplications) => (
-          <>
-            {sortBy(guardianApplications, (a) => a.childName).map(
-              (childApplications) => (
-                <Fragment key={childApplications.childId}>
-                  <ChildApplicationsBlock
-                    childId={childApplications.childId}
-                    childName={childApplications.childName}
-                    applicationSummaries={
-                      childApplications.applicationSummaries
-                    }
-                    reload={loadGuardianApplications}
-                  />
-                  <Gap size="s" />
-                </Fragment>
-              )
-            )}
-          </>
-        ))}
-      </Container>
-      <Footer />
-    </>
+      {renderResult(guardianApplications, (guardianApplications) => (
+        <>
+          {sortBy(guardianApplications, (a) => a.childName).map(
+            (childApplications) => (
+              <Fragment key={childApplications.childId}>
+                <ChildApplicationsBlock
+                  childId={childApplications.childId}
+                  childName={childApplications.childName}
+                  applicationSummaries={childApplications.applicationSummaries}
+                  reload={loadGuardianApplications}
+                />
+                <Gap size="s" />
+              </Fragment>
+            )
+          )}
+        </>
+      ))}
+    </Container>
   )
 })

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationEditor.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationEditor.tsx
@@ -17,6 +17,7 @@ import { UUID } from 'lib-common/types'
 import useBetterParams from 'lib-common/useNonNullableParams'
 import { scrollToTop } from 'lib-common/utils/scrolling'
 import { useApiState } from 'lib-common/utils/useRestApi'
+import Main from 'lib-components/atoms/Main'
 import Button from 'lib-components/atoms/buttons/Button'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import ReturnButton, {
@@ -398,11 +399,13 @@ const ApplicationEditorContent = React.memo(function DaycareApplicationEditor({
         <ReturnButton label={t.common.return} />
       )}
 
-      {verifying ? renderVerificationView() : renderEditor()}
+      <Main>
+        {verifying ? renderVerificationView() : renderEditor()}
 
-      <Gap size="m" />
+        <Gap size="m" />
 
-      {renderActions()}
+        {renderActions()}
+      </Main>
     </Container>
   )
 })

--- a/frontend/src/citizen-frontend/applications/read-view/ApplicationReadViewContents.tsx
+++ b/frontend/src/citizen-frontend/applications/read-view/ApplicationReadViewContents.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import { ApplicationDetails } from 'lib-common/api-types/application/ApplicationDetails'
 import { ApplicationFormData } from 'lib-common/api-types/application/ApplicationFormData'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
+import Main from 'lib-components/atoms/Main'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { H1 } from 'lib-components/typography'
@@ -33,28 +34,30 @@ export default React.memo(function ApplicationReadViewContents({
   return (
     <Container>
       <ReturnButton label={t.common.return} />
-      <ContentArea opaque>
-        <H1>{t.applications.editor.heading.title[type]}</H1>
-        <BasicsSection application={application} formData={formData} />
-        <HorizontalLine />
-        <ServiceNeedSection formData={formData} type={type} />
-        <HorizontalLine />
-        <UnitPreferenceSection formData={formData.unitPreference} />
-        <HorizontalLine />
-        <ContactInfoSection
-          formData={formData.contactInfo}
-          type={type}
-          showFridgeFamilySection={
-            type === 'DAYCARE' ||
-            (type === 'PRESCHOOL' && formData.serviceNeed.connectedDaycare)
-          }
-        />
-        <HorizontalLine />
-        <AdditionalDetailsSection
-          formData={formData}
-          showAllergiesAndDiet={type !== 'CLUB'}
-        />
-      </ContentArea>
+      <Main>
+        <ContentArea opaque>
+          <H1>{t.applications.editor.heading.title[type]}</H1>
+          <BasicsSection application={application} formData={formData} />
+          <HorizontalLine />
+          <ServiceNeedSection formData={formData} type={type} />
+          <HorizontalLine />
+          <UnitPreferenceSection formData={formData.unitPreference} />
+          <HorizontalLine />
+          <ContactInfoSection
+            formData={formData.contactInfo}
+            type={type}
+            showFridgeFamilySection={
+              type === 'DAYCARE' ||
+              (type === 'PRESCHOOL' && formData.serviceNeed.connectedDaycare)
+            }
+          />
+          <HorizontalLine />
+          <AdditionalDetailsSection
+            formData={formData}
+            showAllergiesAndDiet={type !== 'CLUB'}
+          />
+        </ContentArea>
+      </Main>
     </Container>
   )
 })

--- a/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
+++ b/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
@@ -7,6 +7,9 @@ import React from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import styled from 'styled-components'
 
+import Footer from 'citizen-frontend/Footer'
+import Main from 'lib-components/atoms/Main'
+import SkipToContent from 'lib-components/atoms/buttons/SkipToContent'
 import Tabs from 'lib-components/molecules/Tabs'
 import { Gap } from 'lib-components/white-space'
 import { colors } from 'lib-customizations/common'
@@ -64,37 +67,47 @@ export default React.memo(function ApplyingRouter({ scrollToTop }: Props) {
 
   return (
     <>
+      <SkipToContent target="applying-subnavigation">
+        {t.skipLinks.applyingSubNav}
+      </SkipToContent>
       <Gap size="s" />
       <WhiteBg>
-        <Tabs tabs={tabs} data-qa="applying-subnavigation" />
+        <Tabs
+          tabs={tabs}
+          data-qa="applying-subnavigation"
+          id="applying-subnavigation"
+        />
       </WhiteBg>
-      <Routes>
-        <Route
-          path="applications"
-          element={
-            <RequireAuth>
-              <Applications />
-            </RequireAuth>
-          }
-        />
-        <Route path="map" element={<MapView scrollToTop={scrollToTop} />} />
-        <Route
-          path="decisions"
-          element={
-            <RequireAuth>
-              <Decisions />
-            </RequireAuth>
-          }
-        />
-        <Route
-          path="/"
-          element={
-            <Navigate
-              to={isEndUser ? '/applying/applications' : '/applying/map'}
-            />
-          }
-        />
-      </Routes>
+      <Main>
+        <Routes>
+          <Route
+            path="applications"
+            element={
+              <RequireAuth>
+                <Applications />
+              </RequireAuth>
+            }
+          />
+          <Route path="map" element={<MapView scrollToTop={scrollToTop} />} />
+          <Route
+            path="decisions"
+            element={
+              <RequireAuth>
+                <Decisions />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/"
+            element={
+              <Navigate
+                to={isEndUser ? '/applying/applications' : '/applying/map'}
+              />
+            }
+          />
+        </Routes>
+      </Main>
+      <Footer />
     </>
   )
 })

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
 import { useApiState } from 'lib-common/utils/useRestApi'
+import Main from 'lib-components/atoms/Main'
 import { ContentArea } from 'lib-components/layout/Container'
 import {
   Desktop,
@@ -321,7 +322,9 @@ const DesktopOnly = styled(Desktop)`
 export default React.memo(function CalendarPageWrapper() {
   return (
     <>
-      <CalendarPage />
+      <Main>
+        <CalendarPage />
+      </Main>
       <Footer />
     </>
   )

--- a/frontend/src/citizen-frontend/child-documents/ChildDocuments.tsx
+++ b/frontend/src/citizen-frontend/child-documents/ChildDocuments.tsx
@@ -4,6 +4,8 @@
 
 import React from 'react'
 
+import Footer from 'citizen-frontend/Footer'
+import Main from 'lib-components/atoms/Main'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { H1 } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
@@ -18,26 +20,30 @@ export default React.memo(function ChildDocuments() {
   const t = useTranslation()
   return (
     <>
-      <Container>
-        <Gap size="s" />
+      <Main>
+        <Container>
+          <Gap size="s" />
 
-        <ContentArea opaque paddingVertical="L">
-          <H1 noMargin>{t.childDocuments.title}</H1>
-          <p>{t.childDocuments.description}</p>
-        </ContentArea>
+          <ContentArea opaque paddingVertical="L">
+            <H1 noMargin>{t.childDocuments.title}</H1>
+            <p>{t.childDocuments.description}</p>
+          </ContentArea>
 
-        <Gap size="s" />
+          <Gap size="s" />
 
-        {featureFlags.experimental?.citizenVasu && (
-          <>
-            <CitizenVasuAndLeops />
+          {featureFlags.experimental?.citizenVasu && (
+            <>
+              <CitizenVasuAndLeops />
 
-            <Gap size="s" />
-          </>
-        )}
+              <Gap size="s" />
+            </>
+          )}
 
-        <PedagogicalDocuments />
-      </Container>
+          <PedagogicalDocuments />
+        </Container>
+      </Main>
+
+      <Footer />
     </>
   )
 })

--- a/frontend/src/citizen-frontend/child-documents/PedagogicalDocuments.tsx
+++ b/frontend/src/citizen-frontend/child-documents/PedagogicalDocuments.tsx
@@ -12,7 +12,6 @@ import React, {
 } from 'react'
 import styled from 'styled-components'
 
-import Footer from 'citizen-frontend/Footer'
 import {
   Attachment,
   PedagogicalDocumentCitizen
@@ -347,14 +346,11 @@ export default React.memo(function PedagogicalDocuments() {
   }
 
   return (
-    <>
-      <Container>
-        {renderResult(pedagogicalDocuments, (items) => (
-          <PedagogicalDocumentsDisplay items={items} onRead={onRead} />
-        ))}
-        <Footer />
-      </Container>
-    </>
+    <Container>
+      {renderResult(pedagogicalDocuments, (items) => (
+        <PedagogicalDocumentsDisplay items={items} onRead={onRead} />
+      ))}
+    </Container>
   )
 })
 

--- a/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 
 import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
+import Main from 'lib-components/atoms/Main'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import DownloadButton from 'lib-components/atoms/buttons/DownloadButton'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
@@ -78,23 +79,25 @@ export default React.memo(function VasuPage() {
               <DownloadButton label={t.common.download} />
             </MobileDownloadButtonContainer>
           </ButtonContainer>
-          <CitizenVasuHeader document={vasu} />
-          <CitizenBasicsSection
-            sectionIndex={0}
-            type={vasu.type}
-            basics={vasu.basics}
-            childLanguage={vasu.basics.childLanguage}
-            templateRange={vasu.templateRange}
-            translations={translations}
-          />
-          <CitizenDynamicSections
-            sections={content.sections}
-            sectionIndex={dynamicSectionsOffset}
-            state={vasu.documentState}
-            translations={translations}
-          />
-          <Gap size="s" />
-          <CitizenVasuEvents document={vasu} content={content} />
+          <Main>
+            <CitizenVasuHeader document={vasu} />
+            <CitizenBasicsSection
+              sectionIndex={0}
+              type={vasu.type}
+              basics={vasu.basics}
+              childLanguage={vasu.basics.childLanguage}
+              templateRange={vasu.templateRange}
+              translations={translations}
+            />
+            <CitizenDynamicSections
+              sections={content.sections}
+              sectionIndex={dynamicSectionsOffset}
+              state={vasu.documentState}
+              translations={translations}
+            />
+            <Gap size="s" />
+            <CitizenVasuEvents document={vasu} content={content} />
+          </Main>
         </>
       )}
       {vasu && !guardianHasGivenPermissionToShare && (

--- a/frontend/src/citizen-frontend/children/ChildPage.tsx
+++ b/frontend/src/citizen-frontend/children/ChildPage.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
+import Main from 'lib-components/atoms/Main'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { Gap } from 'lib-components/white-space'
@@ -26,17 +27,19 @@ export default React.memo(function ChildPage() {
 
   return (
     <>
-      <Container>
-        <ReturnButton label={t.common.return} />
-        <Gap size="s" />
-        {renderResult(childResponse, (child) => (
-          <ContentArea opaque>
-            <ChildHeader child={child} />
-            <HorizontalLine slim dashed />
-            <PlacementTerminationSection childId={childId} />
-          </ContentArea>
-        ))}
-      </Container>
+      <Main>
+        <Container>
+          <ReturnButton label={t.common.return} />
+          <Gap size="s" />
+          {renderResult(childResponse, (child) => (
+            <ContentArea opaque>
+              <ChildHeader child={child} />
+              <HorizontalLine slim dashed />
+              <PlacementTerminationSection childId={childId} />
+            </ContentArea>
+          ))}
+        </Container>
+      </Main>
       <Footer />
     </>
   )

--- a/frontend/src/citizen-frontend/children/ChildrenPage.tsx
+++ b/frontend/src/citizen-frontend/children/ChildrenPage.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components'
 import Footer from 'citizen-frontend/Footer'
 import { Child } from 'lib-common/generated/api-types/children'
 import { useApiState } from 'lib-common/utils/useRestApi'
+import Main from 'lib-components/atoms/Main'
 import { RoundImage } from 'lib-components/atoms/RoundImage'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import { desktopMin } from 'lib-components/breakpoints'
@@ -120,23 +121,25 @@ export default React.memo(function ChildrenPage() {
 
   return (
     <>
-      <Container>
-        <Gap size="s" />
-        <ContentArea opaque>
-          <H1 noMargin>{t.children.title}</H1>
-          <P>{t.children.pageDescription}</P>
-        </ContentArea>
-        <Gap size="s" />
-        {renderResult(childrenResponse, ({ children }) => (
-          <Children>
-            {children.length > 0 ? (
-              children.map((c) => <ChildItem key={c.id} child={c} />)
-            ) : (
-              <P>{t.children.noChildren}</P>
-            )}
-          </Children>
-        ))}
-      </Container>
+      <Main>
+        <Container>
+          <Gap size="s" />
+          <ContentArea opaque>
+            <H1 noMargin>{t.children.title}</H1>
+            <P>{t.children.pageDescription}</P>
+          </ContentArea>
+          <Gap size="s" />
+          {renderResult(childrenResponse, ({ children }) => (
+            <Children>
+              {children.length > 0 ? (
+                children.map((c) => <ChildItem key={c.id} child={c} />)
+              ) : (
+                <P>{t.children.noChildren}</P>
+              )}
+            </Children>
+          ))}
+        </Container>
+      </Main>
       <Footer />
     </>
   )

--- a/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponseList.tsx
+++ b/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponseList.tsx
@@ -9,6 +9,7 @@ import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
+import Main from 'lib-components/atoms/Main'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
@@ -70,66 +71,68 @@ export default React.memo(function DecisionResponseList() {
           icon={faChevronLeft}
         />
         <Gap size="s" />
-        <ContentArea opaque>
-          <H1>{t.decisions.title}</H1>
-          {renderResult(decisionsRequest, (decisions) => (
-            <div>
-              <P width="800px">{t.decisions.applicationDecisions.summary}</P>
-              {unconfirmedDecisionsCount > 0 ? (
-                <AlertBox
-                  message={t.decisions.unconfirmedDecisions(
-                    unconfirmedDecisionsCount
-                  )}
-                  data-qa="alert-box-unconfirmed-decisions-count"
-                />
-              ) : null}
-              <Gap size="L" />
-              {sortDecisions(decisions).map((decision, i) => (
-                <React.Fragment key={decision.id}>
-                  <DecisionResponse
-                    decision={decision}
-                    blocked={isDecisionBlocked(decision, decisions)}
-                    rejectCascade={isRejectCascaded(decision, decisions)}
-                    refreshDecisionList={loadDecisions}
-                    handleReturnToPreviousPage={handleReturnToPreviousPage}
+        <Main>
+          <ContentArea opaque>
+            <H1>{t.decisions.title}</H1>
+            {renderResult(decisionsRequest, (decisions) => (
+              <div>
+                <P width="800px">{t.decisions.applicationDecisions.summary}</P>
+                {unconfirmedDecisionsCount > 0 ? (
+                  <AlertBox
+                    message={t.decisions.unconfirmedDecisions(
+                      unconfirmedDecisionsCount
+                    )}
+                    data-qa="alert-box-unconfirmed-decisions-count"
                   />
-                  {i < decisions.length - 1 ? <HorizontalLine /> : null}
-                </React.Fragment>
-              ))}
-            </div>
-          ))}
-          <Gap size="m" />
-        </ContentArea>
-        {displayDecisionWithNoResponseWarning && (
-          <InfoModal
-            title={
-              t.decisions.applicationDecisions.warnings
-                .decisionWithNoResponseWarning.title
-            }
-            icon={faExclamation}
-            type="warning"
-            text={
-              t.decisions.applicationDecisions.warnings
-                .decisionWithNoResponseWarning.text
-            }
-            resolve={{
-              label:
+                ) : null}
+                <Gap size="L" />
+                {sortDecisions(decisions).map((decision, i) => (
+                  <React.Fragment key={decision.id}>
+                    <DecisionResponse
+                      decision={decision}
+                      blocked={isDecisionBlocked(decision, decisions)}
+                      rejectCascade={isRejectCascaded(decision, decisions)}
+                      refreshDecisionList={loadDecisions}
+                      handleReturnToPreviousPage={handleReturnToPreviousPage}
+                    />
+                    {i < decisions.length - 1 ? <HorizontalLine /> : null}
+                  </React.Fragment>
+                ))}
+              </div>
+            ))}
+            <Gap size="m" />
+          </ContentArea>
+          {displayDecisionWithNoResponseWarning && (
+            <InfoModal
+              title={
                 t.decisions.applicationDecisions.warnings
-                  .decisionWithNoResponseWarning.resolveLabel,
-              action: () => {
-                navigate('/applying/decisions')
+                  .decisionWithNoResponseWarning.title
               }
-            }}
-            reject={{
-              label:
+              icon={faExclamation}
+              type="warning"
+              text={
                 t.decisions.applicationDecisions.warnings
-                  .decisionWithNoResponseWarning.rejectLabel,
-              action: () => {
-                setDisplayDecisionWithNoResponseWarning(false)
+                  .decisionWithNoResponseWarning.text
               }
-            }}
-          />
-        )}
+              resolve={{
+                label:
+                  t.decisions.applicationDecisions.warnings
+                    .decisionWithNoResponseWarning.resolveLabel,
+                action: () => {
+                  navigate('/applying/decisions')
+                }
+              }}
+              reject={{
+                label:
+                  t.decisions.applicationDecisions.warnings
+                    .decisionWithNoResponseWarning.rejectLabel,
+                action: () => {
+                  setDisplayDecisionWithNoResponseWarning(false)
+                }
+              }}
+            />
+          )}
+        </Main>
       </Container>
       <Footer />
     </>

--- a/frontend/src/citizen-frontend/decisions/decisions-page/Decisions.tsx
+++ b/frontend/src/citizen-frontend/decisions/decisions-page/Decisions.tsx
@@ -12,7 +12,6 @@ import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 import { H1 } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
-import Footer from '../../Footer'
 import ApplicationDecisionsBlock from '../../decisions/decisions-page/ApplicationDecisionsBlock'
 import { useTranslation } from '../../localization'
 import useTitle from '../../useTitle'
@@ -33,40 +32,37 @@ export default React.memo(function Decisions() {
     : 0
 
   return (
-    <>
-      <Container>
-        <Gap size="s" />
-        <ContentArea opaque paddingVertical="L">
-          <H1 noMargin>{t.decisions.title}</H1>
-          <Gap size="xs" />
-          {t.decisions.summary}
-          {unconfirmedDecisionsCount > 0 && (
-            <>
-              <Gap size="s" />
-              <AlertBox
-                message={t.decisions.unconfirmedDecisions(
-                  unconfirmedDecisionsCount
-                )}
-                data-qa="alert-box-unconfirmed-decisions-count"
-              />
-            </>
-          )}
-        </ContentArea>
-        <Gap size="s" />
-        {renderResult(applicationDecisions, (applicationDecisions) => (
+    <Container>
+      <Gap size="s" />
+      <ContentArea opaque paddingVertical="L">
+        <H1 noMargin>{t.decisions.title}</H1>
+        <Gap size="xs" />
+        {t.decisions.summary}
+        {unconfirmedDecisionsCount > 0 && (
           <>
-            {sortBy(applicationDecisions, (d) => d.childName).map(
-              (applicationDecision) => (
-                <Fragment key={applicationDecision.applicationId}>
-                  <ApplicationDecisionsBlock {...applicationDecision} />
-                  <Gap size="s" />
-                </Fragment>
-              )
-            )}
+            <Gap size="s" />
+            <AlertBox
+              message={t.decisions.unconfirmedDecisions(
+                unconfirmedDecisionsCount
+              )}
+              data-qa="alert-box-unconfirmed-decisions-count"
+            />
           </>
-        ))}
-      </Container>
-      <Footer />
-    </>
+        )}
+      </ContentArea>
+      <Gap size="s" />
+      {renderResult(applicationDecisions, (applicationDecisions) => (
+        <>
+          {sortBy(applicationDecisions, (d) => d.childName).map(
+            (applicationDecision) => (
+              <Fragment key={applicationDecision.applicationId}>
+                <ApplicationDecisionsBlock {...applicationDecision} />
+                <Gap size="s" />
+              </Fragment>
+            )
+          )}
+        </>
+      ))}
+    </Container>
   )
 })

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
@@ -10,6 +10,7 @@ import { IncomeStatement } from 'lib-common/api-types/incomeStatement'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
+import Main from 'lib-components/atoms/Main'
 
 import { renderResult } from '../async-rendering'
 
@@ -109,17 +110,19 @@ export default React.memo(function ChildIncomeStatementEditor() {
     }
 
     return (
-      <ChildIncomeStatementForm
-        incomeStatementId={id}
-        formData={formData}
-        showFormErrors={showFormErrors}
-        otherStartDates={startDates}
-        onChange={updateFormData}
-        onSave={save}
-        onSuccess={navigateToList}
-        onCancel={navigateToList}
-        ref={form}
-      />
+      <Main>
+        <ChildIncomeStatementForm
+          incomeStatementId={id}
+          formData={formData}
+          showFormErrors={showFormErrors}
+          otherStartDates={startDates}
+          onChange={updateFormData}
+          onSave={save}
+          onSuccess={navigateToList}
+          onCancel={navigateToList}
+          ref={form}
+        />
+      </Main>
     )
   })
 })

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementView.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementView.tsx
@@ -13,6 +13,7 @@ import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
+import Main from 'lib-components/atoms/Main'
 import ResponsiveInlineButton from 'lib-components/atoms/buttons/ResponsiveInlineButton'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
@@ -52,33 +53,35 @@ export default React.memo(function ChildIncomeStatementView() {
   return renderResult(result, (incomeStatement) => (
     <Container>
       <ReturnButton label={t.common.return} />
-      <ContentArea opaque>
-        <FixedSpaceRow spacing="L">
-          <H1>{t.income.view.title}</H1>
-          {!incomeStatement.handled && (
-            <EditButtonContainer>
-              <ResponsiveInlineButton
-                text={t.common.edit}
-                icon={faPen}
-                onClick={handleEdit}
-                data-qa="edit-button"
-              />
-            </EditButtonContainer>
+      <Main>
+        <ContentArea opaque>
+          <FixedSpaceRow spacing="L">
+            <H1>{t.income.view.title}</H1>
+            {!incomeStatement.handled && (
+              <EditButtonContainer>
+                <ResponsiveInlineButton
+                  text={t.common.edit}
+                  icon={faPen}
+                  onClick={handleEdit}
+                  data-qa="edit-button"
+                />
+              </EditButtonContainer>
+            )}
+          </FixedSpaceRow>
+          <Row
+            label={t.income.view.startDate}
+            value={incomeStatement.startDate.format()}
+            data-qa="start-date"
+          />
+          <Row
+            label={t.income.view.feeBasis}
+            value={t.income.view.statementTypes[incomeStatement.type]}
+          />
+          {incomeStatement.type === 'CHILD_INCOME' && (
+            <ChildIncomeInfo incomeStatement={incomeStatement} />
           )}
-        </FixedSpaceRow>
-        <Row
-          label={t.income.view.startDate}
-          value={incomeStatement.startDate.format()}
-          data-qa="start-date"
-        />
-        <Row
-          label={t.income.view.feeBasis}
-          value={t.income.view.statementTypes[incomeStatement.type]}
-        />
-        {incomeStatement.type === 'CHILD_INCOME' && (
-          <ChildIncomeInfo incomeStatement={incomeStatement} />
-        )}
-      </ContentArea>
+        </ContentArea>
+      </Main>
     </Container>
   ))
 })

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
@@ -10,6 +10,7 @@ import { IncomeStatement } from 'lib-common/api-types/incomeStatement'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
+import Main from 'lib-components/atoms/Main'
 
 import { renderResult } from '../async-rendering'
 
@@ -99,17 +100,19 @@ export default React.memo(function IncomeStatementEditor() {
     }
 
     return (
-      <IncomeStatementForm
-        incomeStatementId={id}
-        formData={formData}
-        showFormErrors={showFormErrors}
-        otherStartDates={startDates}
-        onChange={updateFormData}
-        onSave={save}
-        onSuccess={navigateToList}
-        onCancel={navigateToList}
-        ref={form}
-      />
+      <Main>
+        <IncomeStatementForm
+          incomeStatementId={id}
+          formData={formData}
+          showFormErrors={showFormErrors}
+          otherStartDates={startDates}
+          onChange={updateFormData}
+          onSave={save}
+          onSuccess={navigateToList}
+          onCancel={navigateToList}
+          ref={form}
+        />
+      </Main>
     )
   })
 })

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
@@ -19,6 +19,7 @@ import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
+import Main from 'lib-components/atoms/Main'
 import ResponsiveInlineButton from 'lib-components/atoms/buttons/ResponsiveInlineButton'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
@@ -57,31 +58,33 @@ export default React.memo(function IncomeStatementView() {
   return renderResult(result, (incomeStatement) => (
     <Container>
       <ReturnButton label={t.common.return} />
-      <ContentArea opaque>
-        <FixedSpaceRow spacing="L">
-          <H1>{t.income.view.title}</H1>
-          {!incomeStatement.handled && (
-            <EditButtonContainer>
-              <ResponsiveInlineButton
-                text={t.common.edit}
-                icon={faPen}
-                onClick={handleEdit}
-              />
-            </EditButtonContainer>
+      <Main>
+        <ContentArea opaque>
+          <FixedSpaceRow spacing="L">
+            <H1>{t.income.view.title}</H1>
+            {!incomeStatement.handled && (
+              <EditButtonContainer>
+                <ResponsiveInlineButton
+                  text={t.common.edit}
+                  icon={faPen}
+                  onClick={handleEdit}
+                />
+              </EditButtonContainer>
+            )}
+          </FixedSpaceRow>
+          <Row
+            label={t.income.view.startDate}
+            value={incomeStatement.startDate.format()}
+          />
+          <Row
+            label={t.income.view.feeBasis}
+            value={t.income.view.statementTypes[incomeStatement.type]}
+          />
+          {incomeStatement.type === 'INCOME' && (
+            <IncomeInfo incomeStatement={incomeStatement} />
           )}
-        </FixedSpaceRow>
-        <Row
-          label={t.income.view.startDate}
-          value={incomeStatement.startDate.format()}
-        />
-        <Row
-          label={t.income.view.feeBasis}
-          value={t.income.view.statementTypes[incomeStatement.type]}
-        />
-        {incomeStatement.type === 'INCOME' && (
-          <IncomeInfo incomeStatement={incomeStatement} />
-        )}
-      </ContentArea>
+        </ContentArea>
+      </Main>
     </Container>
   ))
 })

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
@@ -11,6 +11,7 @@ import { IncomeStatement } from 'lib-common/api-types/incomeStatement'
 import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Pagination from 'lib-components/Pagination'
+import Main from 'lib-components/atoms/Main'
 import ResponsiveAddButton from 'lib-components/atoms/buttons/ResponsiveAddButton'
 import ResponsiveInlineButton from 'lib-components/atoms/buttons/ResponsiveInlineButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
@@ -155,72 +156,75 @@ export default React.memo(function IncomeStatements() {
 
   return (
     <>
-      <Container>
-        <Gap size="s" />
-        <ContentArea opaque paddingVertical="L">
-          <H1 noMargin>{t.income.title}</H1>
-          {t.income.description}
-        </ContentArea>
-        <Gap size="s" />
-        <ContentArea opaque paddingVertical="L">
-          <HeadingContainer>
-            <H2>{t.income.table.title}</H2>
-            <ResponsiveAddButton
-              onClick={() => navigate('/income/new/edit')}
-              text={t.income.addNew}
-              data-qa="new-income-statement-btn"
-            />
-          </HeadingContainer>
-          {renderResult(incomeStatements, ({ data, pages }) => (
-            <>
-              <IncomeStatementsTable
-                items={data}
-                onRemoveIncomeStatement={(id) =>
-                  setDeletionState({
-                    status: 'confirming',
-                    rowToDelete: id
-                  })
-                }
+      <Main>
+        <Container>
+          <Gap size="s" />
+          <ContentArea opaque paddingVertical="L">
+            <H1 noMargin>{t.income.title}</H1>
+            {t.income.description}
+          </ContentArea>
+          <Gap size="s" />
+          <ContentArea opaque paddingVertical="L">
+            <HeadingContainer>
+              <H2>{t.income.table.title}</H2>
+              <ResponsiveAddButton
+                onClick={() => navigate('/income/new/edit')}
+                text={t.income.addNew}
+                data-qa="new-income-statement-btn"
               />
-              <Gap />
-              <Pagination
-                pages={pages}
-                currentPage={page}
-                setPage={setPage}
-                label={t.common.page}
-                hideIfOnlyOnePage={true}
+            </HeadingContainer>
+            {renderResult(incomeStatements, ({ data, pages }) => (
+              <>
+                <IncomeStatementsTable
+                  items={data}
+                  onRemoveIncomeStatement={(id) =>
+                    setDeletionState({
+                      status: 'confirming',
+                      rowToDelete: id
+                    })
+                  }
+                />
+                <Gap />
+                <Pagination
+                  pages={pages}
+                  currentPage={page}
+                  setPage={setPage}
+                  label={t.common.page}
+                  hideIfOnlyOnePage={true}
+                />
+              </>
+            ))}
+
+            {deletionState.status !== 'row-not-selected' && (
+              <InfoModal
+                type="warning"
+                title={t.income.table.deleteConfirm}
+                text={t.income.table.deleteDescription}
+                icon={faQuestion}
+                reject={{
+                  action: () =>
+                    setDeletionState({ status: 'row-not-selected' }),
+                  label: t.common.return
+                }}
+                resolve={{
+                  action: () => onDelete(deletionState.rowToDelete),
+                  label: t.common.delete,
+                  disabled: deletionState.status === 'deleting'
+                }}
+              />
+            )}
+          </ContentArea>
+          <Gap size="s" />
+          {renderResult(children, (children) => (
+            <>
+              <ChildrenIncomeStatements
+                childInfo={children}
+                onRemoveIncomeStatement={fetchChildren}
               />
             </>
           ))}
-
-          {deletionState.status !== 'row-not-selected' && (
-            <InfoModal
-              type="warning"
-              title={t.income.table.deleteConfirm}
-              text={t.income.table.deleteDescription}
-              icon={faQuestion}
-              reject={{
-                action: () => setDeletionState({ status: 'row-not-selected' }),
-                label: t.common.return
-              }}
-              resolve={{
-                action: () => onDelete(deletionState.rowToDelete),
-                label: t.common.delete,
-                disabled: deletionState.status === 'deleting'
-              }}
-            />
-          )}
-        </ContentArea>
-        <Gap size="s" />
-        {renderResult(children, (children) => (
-          <>
-            <ChildrenIncomeStatements
-              childInfo={children}
-              onRemoveIncomeStatement={fetchChildren}
-            />
-          </>
-        ))}
-      </Container>
+        </Container>
+      </Main>
       <Footer />
     </>
   )

--- a/frontend/src/citizen-frontend/map/MapPage.tsx
+++ b/frontend/src/citizen-frontend/map/MapPage.tsx
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+
+import Main from 'lib-components/atoms/Main'
+
+import MapView from './MapView'
+
+interface Props {
+  scrollToTop: () => void
+}
+
+export default React.memo(function MapPage({ scrollToTop }: Props) {
+  return (
+    <Main>
+      <MapView scrollToTop={scrollToTop} />
+    </Main>
+  )
+})

--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -10,6 +10,7 @@ import Footer, { footerHeightDesktop } from 'citizen-frontend/Footer'
 import { UnwrapResult } from 'citizen-frontend/async-rendering'
 import { combine } from 'lib-common/api'
 import { useApiState } from 'lib-common/utils/useRestApi'
+import Main from 'lib-components/atoms/Main'
 import { desktopMin, tabletMin } from 'lib-components/breakpoints'
 import AdaptiveFlex from 'lib-components/layout/AdaptiveFlex'
 import Container from 'lib-components/layout/Container'
@@ -80,31 +81,33 @@ export default React.memo(function MessagesPage() {
       <UnwrapResult result={combine(accountId, receivers)}>
         {([id, receivers]) => (
           <>
-            <StyledFlex breakpoint={tabletMin} horizontalSpacing="L">
-              <ThreadList
-                accountId={id}
-                setEditorVisible={showEditor}
-                newMessageButtonEnabled={!editorVisible}
-              />
-              {selectedThread ? (
-                <ThreadView accountId={id} thread={selectedThread} />
-              ) : (
-                <EmptyThreadView inboxEmpty={threads.length == 0} />
+            <Main>
+              <StyledFlex breakpoint={tabletMin} horizontalSpacing="L">
+                <ThreadList
+                  accountId={id}
+                  setEditorVisible={showEditor}
+                  newMessageButtonEnabled={!editorVisible}
+                />
+                {selectedThread ? (
+                  <ThreadView accountId={id} thread={selectedThread} />
+                ) : (
+                  <EmptyThreadView inboxEmpty={threads.length == 0} />
+                )}
+              </StyledFlex>
+              {editorVisible && (
+                <MessageEditor
+                  receiverOptions={receivers}
+                  onSend={(message) => sendMessage(message)}
+                  onSuccess={() => {
+                    refreshThreads()
+                    setEditorVisible(false)
+                  }}
+                  onFailure={() => setDisplaySendError(true)}
+                  onClose={() => setEditorVisible(false)}
+                  displaySendError={displaySendError}
+                />
               )}
-            </StyledFlex>
-            {editorVisible && (
-              <MessageEditor
-                receiverOptions={receivers}
-                onSend={(message) => sendMessage(message)}
-                onSuccess={() => {
-                  refreshThreads()
-                  setEditorVisible(false)
-                }}
-                onFailure={() => setDisplaySendError(true)}
-                onClose={() => setEditorVisible(false)}
-                displaySendError={displaySendError}
-              />
-            )}
+            </Main>
             <Footer />
           </>
         )}

--- a/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
+++ b/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
@@ -11,6 +11,7 @@ import { AuthContext, User } from 'citizen-frontend/auth/state'
 import { Result } from 'lib-common/api'
 import { email, phone } from 'lib-common/form-validation'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
+import Main from 'lib-components/atoms/Main'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
@@ -105,174 +106,182 @@ export default React.memo(function PersonalDetails() {
 
   return (
     <>
-      <Container>
-        <Gap size="L" />
-        <ContentArea opaque paddingVertical="L">
-          <H1 noMargin>{t.personalDetails.title}</H1>
-          {t.personalDetails.description}
-          {renderResult(user, (personalData) => {
-            if (personalData === undefined) {
-              return <Navigate replace to="/" />
-            }
+      <Main>
+        <Container>
+          <Gap size="L" />
+          <ContentArea opaque paddingVertical="L">
+            <H1 noMargin>{t.personalDetails.title}</H1>
+            {t.personalDetails.description}
+            {renderResult(user, (personalData) => {
+              if (personalData === undefined) {
+                return <Navigate replace to="/" />
+              }
 
-            const {
-              firstName,
-              lastName,
-              preferredName,
-              streetAddress,
-              postalCode,
-              postOffice,
-              phone,
-              backupPhone,
-              email,
-              userType
-            } = personalData
+              const {
+                firstName,
+                lastName,
+                preferredName,
+                streetAddress,
+                postalCode,
+                postOffice,
+                phone,
+                backupPhone,
+                email,
+                userType
+              } = personalData
 
-            const canEdit = userType === 'ENDUSER'
+              const canEdit = userType === 'ENDUSER'
 
-            return (
-              <>
-                {(email === null || !phone) && (
-                  <AlertBox
-                    message={getAlertMessage(email, phone)}
-                    data-qa="missing-email-or-phone-box"
-                  />
-                )}
-                <HorizontalLine />
-                <EditButtonRow>
-                  <InlineButton
-                    text={t.common.edit}
-                    icon={canEdit ? faPen : faLockAlt}
-                    onClick={canEdit ? startEditing : navigateToLogin}
-                    disabled={editing}
-                    data-qa={canEdit ? 'start-editing' : 'start-editing-login'}
-                  />
-                </EditButtonRow>
-                {formWrapper(
-                  <>
-                    <ListGrid rowGap="s" columnGap="L" labelWidth="max-content">
-                      <H2 noMargin>{t.personalDetails.personalInfo}</H2>
-                      <div />
-                      <Label>{t.personalDetails.name}</Label>
-                      <div>
-                        {firstName} {lastName}
-                      </div>
-                      <Label>{t.personalDetails.preferredName}</Label>
-                      {editing ? (
-                        <Select
-                          items={preferredNameOptions}
-                          selectedItem={editorState.preferredName}
-                          onChange={updateState.preferredName}
-                          data-qa="preferred-name"
-                        />
-                      ) : (
-                        <div data-qa="preferred-name">{preferredName}</div>
-                      )}
-                      <H2 noMargin>{t.personalDetails.contactInfo}</H2>
-                      <div />
-                      <Label>{t.personalDetails.address}</Label>
-                      <div>
-                        {!!streetAddress &&
-                          `${streetAddress}, ${postalCode} ${postOffice}`}
-                      </div>
-                      <Label>{t.personalDetails.phone}</Label>
-                      <div data-qa="phone">
+              return (
+                <>
+                  {(email === null || !phone) && (
+                    <AlertBox
+                      message={getAlertMessage(email, phone)}
+                      data-qa="missing-email-or-phone-box"
+                    />
+                  )}
+                  <HorizontalLine />
+                  <EditButtonRow>
+                    <InlineButton
+                      text={t.common.edit}
+                      icon={canEdit ? faPen : faLockAlt}
+                      onClick={canEdit ? startEditing : navigateToLogin}
+                      disabled={editing}
+                      data-qa={
+                        canEdit ? 'start-editing' : 'start-editing-login'
+                      }
+                    />
+                  </EditButtonRow>
+                  {formWrapper(
+                    <>
+                      <ListGrid
+                        rowGap="s"
+                        columnGap="L"
+                        labelWidth="max-content"
+                      >
+                        <H2 noMargin>{t.personalDetails.personalInfo}</H2>
+                        <div />
+                        <Label>{t.personalDetails.name}</Label>
+                        <div>
+                          {firstName} {lastName}
+                        </div>
+                        <Label>{t.personalDetails.preferredName}</Label>
                         {editing ? (
-                          <InputField
-                            type="text"
-                            width="m"
-                            value={editorState.phone}
-                            onChange={updateState.phone}
-                            info={errors.phone}
-                            hideErrorsBeforeTouched
-                            placeholder="0401234567"
+                          <Select
+                            items={preferredNameOptions}
+                            selectedItem={editorState.preferredName}
+                            onChange={updateState.preferredName}
+                            data-qa="preferred-name"
                           />
                         ) : (
-                          <div>
-                            {phone ? (
-                              phone
+                          <div data-qa="preferred-name">{preferredName}</div>
+                        )}
+                        <H2 noMargin>{t.personalDetails.contactInfo}</H2>
+                        <div />
+                        <Label>{t.personalDetails.address}</Label>
+                        <div>
+                          {!!streetAddress &&
+                            `${streetAddress}, ${postalCode} ${postOffice}`}
+                        </div>
+                        <Label>{t.personalDetails.phone}</Label>
+                        <div data-qa="phone">
+                          {editing ? (
+                            <InputField
+                              type="text"
+                              width="m"
+                              value={editorState.phone}
+                              onChange={updateState.phone}
+                              info={errors.phone}
+                              hideErrorsBeforeTouched
+                              placeholder="0401234567"
+                            />
+                          ) : (
+                            <div>
+                              {phone ? (
+                                phone
+                              ) : (
+                                <MandatoryValueMissingWarning
+                                  text={t.personalDetails.phoneMissing}
+                                />
+                              )}
+                            </div>
+                          )}
+                        </div>
+                        <Label>{t.personalDetails.backupPhone}</Label>
+                        <div data-qa="backup-phone">
+                          {editing ? (
+                            <InputField
+                              type="text"
+                              width="m"
+                              value={editorState.backupPhone}
+                              onChange={updateState.backupPhone}
+                              info={errors.backupPhone}
+                              hideErrorsBeforeTouched
+                              placeholder={
+                                t.personalDetails.backupPhonePlaceholder
+                              }
+                            />
+                          ) : (
+                            backupPhone
+                          )}
+                        </div>
+                        <Label>{t.personalDetails.email}</Label>
+                        {editing ? (
+                          <FixedSpaceColumn spacing="xs">
+                            <div data-qa="email">
+                              <InputField
+                                type="text"
+                                width="m"
+                                value={editorState.email}
+                                onChange={updateState.email}
+                                readonly={editorState.noEmail}
+                                info={errors.email}
+                                hideErrorsBeforeTouched
+                                placeholder={t.personalDetails.email}
+                              />
+                            </div>
+                            <FixedSpaceRow alignItems="center">
+                              <Checkbox
+                                label={t.personalDetails.noEmail}
+                                checked={editorState.noEmail}
+                                onChange={updateState.noEmail}
+                                data-qa="no-email"
+                              />
+                              <InfoButton
+                                onClick={toggleEmailInfo}
+                                aria-label={t.common.openExpandingInfo}
+                              />
+                            </FixedSpaceRow>
+                          </FixedSpaceColumn>
+                        ) : (
+                          <div data-qa="email">
+                            {email ? (
+                              email
                             ) : (
                               <MandatoryValueMissingWarning
-                                text={t.personalDetails.phoneMissing}
+                                text={t.personalDetails.emailMissing}
                               />
                             )}
                           </div>
                         )}
-                      </div>
-                      <Label>{t.personalDetails.backupPhone}</Label>
-                      <div data-qa="backup-phone">
-                        {editing ? (
-                          <InputField
-                            type="text"
-                            width="m"
-                            value={editorState.backupPhone}
-                            onChange={updateState.backupPhone}
-                            info={errors.backupPhone}
-                            hideErrorsBeforeTouched
-                            placeholder={
-                              t.personalDetails.backupPhonePlaceholder
-                            }
+                      </ListGrid>
+                      {editorState.showEmailInfo && (
+                        <>
+                          <ExpandingInfoBox
+                            info={t.personalDetails.emailInfo}
+                            close={toggleEmailInfo}
                           />
-                        ) : (
-                          backupPhone
-                        )}
-                      </div>
-                      <Label>{t.personalDetails.email}</Label>
-                      {editing ? (
-                        <FixedSpaceColumn spacing="xs">
-                          <div data-qa="email">
-                            <InputField
-                              type="text"
-                              width="m"
-                              value={editorState.email}
-                              onChange={updateState.email}
-                              readonly={editorState.noEmail}
-                              info={errors.email}
-                              hideErrorsBeforeTouched
-                              placeholder={t.personalDetails.email}
-                            />
-                          </div>
-                          <FixedSpaceRow alignItems="center">
-                            <Checkbox
-                              label={t.personalDetails.noEmail}
-                              checked={editorState.noEmail}
-                              onChange={updateState.noEmail}
-                              data-qa="no-email"
-                            />
-                            <InfoButton
-                              onClick={toggleEmailInfo}
-                              aria-label={t.common.openExpandingInfo}
-                            />
-                          </FixedSpaceRow>
-                        </FixedSpaceColumn>
-                      ) : (
-                        <div data-qa="email">
-                          {email ? (
-                            email
-                          ) : (
-                            <MandatoryValueMissingWarning
-                              text={t.personalDetails.emailMissing}
-                            />
-                          )}
-                        </div>
+                          <Gap size="s" />
+                        </>
                       )}
-                    </ListGrid>
-                    {editorState.showEmailInfo && (
-                      <>
-                        <ExpandingInfoBox
-                          info={t.personalDetails.emailInfo}
-                          close={toggleEmailInfo}
-                        />
-                        <Gap size="s" />
-                      </>
-                    )}
-                  </>
-                )}
-              </>
-            )
-          })}
-        </ContentArea>
-      </Container>
+                    </>
+                  )}
+                </>
+              )
+            })}
+          </ContentArea>
+        </Container>
+      </Main>
       <Footer />
     </>
   )

--- a/frontend/src/lib-components/atoms/Main.tsx
+++ b/frontend/src/lib-components/atoms/Main.tsx
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+import styled from 'styled-components'
+
+const MainContainer = styled.main`
+  outline: none;
+`
+
+export default React.memo(function Loader({
+  children
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <MainContainer tabIndex={-1} id="main">
+      {children}
+    </MainContainer>
+  )
+})

--- a/frontend/src/lib-components/atoms/buttons/SkipToContent.tsx
+++ b/frontend/src/lib-components/atoms/buttons/SkipToContent.tsx
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+import ReactDOM from 'react-dom'
+import styled from 'styled-components'
+
+import { buttonBorderRadius, defaultButtonTextStyle } from './button-commons'
+
+const SkipToContentLink = styled.a`
+  position: absolute;
+  z-index: 10000;
+  left: -1000px;
+
+  padding: 12px 24px;
+  margin-top: 12px;
+  margin-left: 12px;
+
+  display: block;
+  text-align: center;
+
+  border: 1px solid ${(p) => p.theme.colors.main.m2};
+  border-radius: ${buttonBorderRadius};
+  background: ${(p) => p.theme.colors.grayscale.g0};
+
+  cursor: pointer;
+
+  text-decoration: none;
+  ${(p) => defaultButtonTextStyle(p.theme)}
+  letter-spacing: 0.2px;
+
+  &:focus {
+    left: auto;
+  }
+`
+
+const container = document.createElement('div')
+document.body.prepend(container)
+
+export default React.memo(function SkipToContent({
+  target,
+  children
+}: {
+  target: string
+  children: React.ReactNode
+}) {
+  return ReactDOM.createPortal(
+    <SkipToContentLink href={`#${target}`}>{children}</SkipToContentLink>,
+    container
+  )
+})

--- a/frontend/src/lib-components/molecules/Tabs.tsx
+++ b/frontend/src/lib-components/molecules/Tabs.tsx
@@ -22,17 +22,19 @@ interface Tab {
 interface Props extends BaseProps {
   mobile?: boolean
   tabs: Tab[]
+  id?: string
 }
 
 export default React.memo(function Tabs({
   mobile,
   'data-qa': dataQa,
-  tabs
+  tabs,
+  id
 }: Props) {
   const maxWidth = mobile ? `${100 / tabs.length}vw` : undefined
   return (
     <Container>
-      <TabsContainer data-qa={dataQa} shadow={mobile}>
+      <TabsContainer data-qa={dataQa} shadow={mobile} id={id}>
         {tabs.map(({ id, link, label, counter }) => (
           <TabLinkContainer
             key={id}
@@ -50,7 +52,7 @@ export default React.memo(function Tabs({
   )
 })
 
-const TabsContainer = styled.div<{ shadow?: boolean }>`
+const TabsContainer = styled.nav<{ shadow?: boolean }>`
   display: flex;
   flex-direction: row;
   ${(p) =>

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -2084,7 +2084,11 @@ const en: Translations = {
         Open: Mon-Fri 8.00–16.15
       </P>
     </>
-  )
+  ),
+  skipLinks: {
+    mainContent: 'Skip to main content',
+    applyingSubNav: 'Skip to applications navigation'
+  }
 }
 
 export default en

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -2007,5 +2007,9 @@ export default {
         Avoinna: ma-pe klo 8.00–16.15
       </P>
     </>
-  )
+  ),
+  skipLinks: {
+    mainContent: 'Siirry pääsisältöön',
+    applyingSubNav: 'Siirry hakemusnavigaatioon'
+  }
 }

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -2037,7 +2037,11 @@ const sv: Translations = {
         Öppet mån.– fre. kl. 8.00–16.15
       </P>
     </>
-  )
+  ),
+  skipLinks: {
+    mainContent: 'Hoppa till innehållet',
+    applyingSubNav: 'Hoppa till ansökningsnavigationen'
+  }
 }
 
 export default sv


### PR DESCRIPTION
#### Summary

Adds `<main>` sections to all citizen pages; the `<main>` cannot be wrapped around the main router as footers, subnavigations, and return links are added within route components – the `<main>` should only contain the main content. With these, users can jump into the main content using the added links (active only when selected e.g. by using tab) and on the applications page there is a link to jump to the subnav as well.