### PR TITLE
Improve adding newly born children to families

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Service
@@ -26,7 +27,7 @@ class DvvModificationsBatchRefreshService(
 
     fun doDvvModificationsRefresh(db: Database.Connection, msg: AsyncJob.DvvModificationsRefresh) {
         logger.info("DvvModificationsRefresh: starting to process ${msg.ssns.size} ssns")
-        val modificationCount = dvvModificationsService.updatePersonsFromDvv(db, msg.ssns)
+        val modificationCount = dvvModificationsService.updatePersonsFromDvv(db, RealEvakaClock(), msg.ssns)
         logger.info("DvvModificationsRefresh: finished processing $modificationCount DVV person modifications for ${msg.ssns.size} ssns")
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.pis.service
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import org.springframework.stereotype.Service
 
 @Service
@@ -20,6 +21,6 @@ class VTJBatchRefreshService(
     }
 
     fun doVTJRefresh(db: Database.Connection, msg: AsyncJob.VTJRefresh) {
-        fridgeFamilyService.doVTJRefresh(db, msg)
+        fridgeFamilyService.doVTJRefresh(db, msg, RealEvakaClock())
     }
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Instead of having two conflicting ways to automatically add children to families, improve the original one by adding children born within 3 months from their date of birth.

