### PR TITLE
Don't assume error is always present

### DIFF
--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -127,16 +127,18 @@ function AsyncButton<T>({
               handleSuccess(result.value)
             }
           })
-          .catch((originalErr: Error) => {
+          .catch((originalErr: unknown) => {
             handleFailure(undefined)
-            if ('message' in originalErr && 'stack' in originalErr) {
-              const err = new Error(
-                `AsyncButton promise was rejected: ${originalErr.message}`
-              )
-              err.stack = originalErr.stack
-              Sentry.captureException(err)
-            } else {
-              Sentry.captureException(originalErr)
+            if (originalErr instanceof Error) {
+              if ('message' in originalErr && 'stack' in originalErr) {
+                const err = new Error(
+                  `AsyncButton promise was rejected: ${originalErr.message}`
+                )
+                err.stack = originalErr.stack
+                Sentry.captureException(err)
+              } else {
+                Sentry.captureException(originalErr)
+              }
             }
           })
       }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

A promise may be rejected with an undefined error, and we have plenty of `Cannot use 'in' operator to search for 'message' in undefined` errors in Sentry getting thrown from this code.