### PR TITLE
Fix reservation and absence modal min/max date

### DIFF
--- a/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
@@ -137,6 +137,7 @@ export default React.memo(function AbsenceModal({
             onChange={(date) => updateForm({ startDate: date })}
             locale={lang}
             minDate={LocalDate.todayInSystemTz()}
+            maxDate={form.endDate ?? undefined}
             info={
               errors &&
               errorToInputInfo(errors.startDate, i18n.validationErrors)
@@ -150,7 +151,11 @@ export default React.memo(function AbsenceModal({
             date={form.endDate}
             onChange={(date) => updateForm({ endDate: date })}
             locale={lang}
-            minDate={LocalDate.todayInSystemTz()}
+            minDate={
+              form.startDate?.isAfter(LocalDate.todayInSystemTz())
+                ? form.startDate
+                : LocalDate.todayInSystemTz()
+            }
             info={
               errors && errorToInputInfo(errors.endDate, i18n.validationErrors)
             }

--- a/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
@@ -14,14 +14,10 @@ import {
 } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
 import { formatPreferredName } from 'lib-common/names'
+import { scrollIntoViewSoftKeyboard } from 'lib-common/utils/scrolling'
 import { ChoiceChip, SelectionChip } from 'lib-components/atoms/Chip'
-import {
-  FixedSpaceFlexWrap,
-  FixedSpaceRow
-} from 'lib-components/layout/flex-helpers'
-import DatePicker, {
-  DatePickerSpacer
-} from 'lib-components/molecules/date-picker/DatePicker'
+import { FixedSpaceFlexWrap } from 'lib-components/layout/flex-helpers'
+import DateRangePicker from 'lib-components/molecules/date-picker/DateRangePicker'
 import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
 import { Label, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
@@ -131,40 +127,24 @@ export default React.memo(function AbsenceModal({
         </FixedSpaceFlexWrap>
         <Gap size="m" />
         <Label>{i18n.calendar.absenceModal.dateRange}</Label>
-        <FixedSpaceRow alignItems="flex-start" spacing="xs">
-          <DatePicker
-            date={form.startDate}
-            onChange={(date) => updateForm({ startDate: date })}
-            locale={lang}
-            minDate={LocalDate.todayInSystemTz()}
-            maxDate={form.endDate ?? undefined}
-            info={
-              errors &&
-              errorToInputInfo(errors.startDate, i18n.validationErrors)
-            }
-            hideErrorsBeforeTouched={!showAllErrors}
-            data-qa="start-date"
-            errorTexts={i18n.validationErrors}
-          />
-          <DatePickerSpacer />
-          <DatePicker
-            date={form.endDate}
-            onChange={(date) => updateForm({ endDate: date })}
-            locale={lang}
-            minDate={
-              form.startDate?.isAfter(LocalDate.todayInSystemTz())
-                ? form.startDate
-                : LocalDate.todayInSystemTz()
-            }
-            info={
-              errors && errorToInputInfo(errors.endDate, i18n.validationErrors)
-            }
-            hideErrorsBeforeTouched={!showAllErrors}
-            initialMonth={form.startDate ?? LocalDate.todayInSystemTz()}
-            data-qa="end-date"
-            errorTexts={i18n.validationErrors}
-          />
-        </FixedSpaceRow>
+        <DateRangePicker
+          start={form.startDate}
+          end={form.endDate}
+          onChange={(startDate, endDate) => updateForm({ startDate, endDate })}
+          locale={lang}
+          errorTexts={i18n.validationErrors}
+          hideErrorsBeforeTouched={!showAllErrors}
+          onFocus={(ev) => {
+            scrollIntoViewSoftKeyboard(ev.target, 'start')
+          }}
+          startInfo={
+            errors && errorToInputInfo(errors.startDate, i18n.validationErrors)
+          }
+          endInfo={
+            errors && errorToInputInfo(errors.endDate, i18n.validationErrors)
+          }
+          minDate={LocalDate.todayInSystemTz()}
+        />
         <Gap size="m" />
         <Label>{i18n.calendar.absenceModal.absenceType}</Label>
         <Gap size="s" />

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -29,9 +29,7 @@ import {
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
-import DatePicker, {
-  DatePickerSpacer
-} from 'lib-components/molecules/date-picker/DatePicker'
+import DateRangePicker from 'lib-components/molecules/date-picker/DateRangePicker'
 import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
 import { fontWeights, H2, Label, Light } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -97,11 +95,7 @@ export default React.memo(function ReservationModal({
   const shiftCareRange = useMemo(() => {
     if (formData.repetition !== 'IRREGULAR') return
 
-    if (
-      !formData.startDate ||
-      !formData.endDate ||
-      formData.endDate.isBefore(formData.endDate)
-    ) {
+    if (!formData.startDate || !formData.endDate) {
       return
     }
 
@@ -221,56 +215,28 @@ export default React.memo(function ReservationModal({
         >
           <Label>{i18n.calendar.reservationModal.dateRangeLabel}</Label>
         </ExpandingInfo>
-        <FixedSpaceRow>
-          <DatePicker
-            date={formData.startDate}
-            onChange={(date) => updateForm({ startDate: date })}
-            locale={lang}
-            isInvalidDate={isInvalidDate}
-            info={errorToInputInfo(
-              validationResult.errors?.startDate,
-              i18n.validationErrors
-            )}
-            hideErrorsBeforeTouched={!showAllErrors}
-            data-qa="start-date"
-            onFocus={(ev) => {
-              scrollIntoViewSoftKeyboard(ev.target, 'start')
-            }}
-            minDate={minDate}
-            maxDate={
-              formData.endDate &&
-              (!maxDate || formData.endDate.isBefore(maxDate))
-                ? formData.endDate
-                : maxDate
-            }
-            errorTexts={i18n.validationErrors}
-          />
-          <DatePickerSpacer />
-          <DatePicker
-            date={formData.endDate}
-            onChange={(date) => updateForm({ endDate: date })}
-            locale={lang}
-            isInvalidDate={isInvalidDate}
-            info={errorToInputInfo(
-              validationResult.errors?.endDate,
-              i18n.validationErrors
-            )}
-            hideErrorsBeforeTouched={!showAllErrors}
-            initialMonth={formData.startDate ?? reservableDays[0]?.start}
-            data-qa="end-date"
-            onFocus={(ev) => {
-              scrollIntoViewSoftKeyboard(ev.target, 'start')
-            }}
-            minDate={
-              formData.startDate &&
-              (!minDate || formData.startDate.isAfter(minDate))
-                ? formData.startDate
-                : minDate
-            }
-            maxDate={maxDate}
-            errorTexts={i18n.validationErrors}
-          />
-        </FixedSpaceRow>
+        <DateRangePicker
+          start={formData.startDate}
+          end={formData.endDate}
+          onChange={(startDate, endDate) => updateForm({ startDate, endDate })}
+          locale={lang}
+          errorTexts={i18n.validationErrors}
+          isInvalidDate={isInvalidDate}
+          minDate={minDate}
+          maxDate={maxDate}
+          hideErrorsBeforeTouched={!showAllErrors}
+          onFocus={(ev) => {
+            scrollIntoViewSoftKeyboard(ev.target, 'start')
+          }}
+          startInfo={errorToInputInfo(
+            validationResult.errors?.startDate,
+            i18n.validationErrors
+          )}
+          endInfo={errorToInputInfo(
+            validationResult.errors?.endDate,
+            i18n.validationErrors
+          )}
+        />
         <Gap size="m" />
 
         <TimeInputGrid>

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -237,7 +237,12 @@ export default React.memo(function ReservationModal({
               scrollIntoViewSoftKeyboard(ev.target, 'start')
             }}
             minDate={minDate}
-            maxDate={maxDate}
+            maxDate={
+              formData.endDate &&
+              (!maxDate || formData.endDate.isBefore(maxDate))
+                ? formData.endDate
+                : maxDate
+            }
             errorTexts={i18n.validationErrors}
           />
           <DatePickerSpacer />
@@ -256,7 +261,12 @@ export default React.memo(function ReservationModal({
             onFocus={(ev) => {
               scrollIntoViewSoftKeyboard(ev.target, 'start')
             }}
-            minDate={minDate}
+            minDate={
+              formData.startDate &&
+              (!minDate || formData.startDate.isAfter(minDate))
+                ? formData.startDate
+                : minDate
+            }
             maxDate={maxDate}
             errorTexts={i18n.validationErrors}
           />

--- a/frontend/src/lib-common/reservations.ts
+++ b/frontend/src/lib-common/reservations.ts
@@ -66,14 +66,15 @@ export function validateForm(
     errors['selectedChildren'] = 'required'
   }
 
-  if (
-    startDate === null ||
-    !reservableDays.some((r) => r.includes(startDate))
-  ) {
+  if (startDate === null) {
+    errors['startDate'] = 'required'
+  } else if (!reservableDays.some((r) => r.includes(startDate))) {
     errors['startDate'] = 'validDate'
   }
 
-  if (endDate === null || !reservableDays.some((r) => r.includes(endDate))) {
+  if (endDate === null) {
+    errors['endDate'] = 'required'
+  } else if (!reservableDays.some((r) => r.includes(endDate))) {
     errors['endDate'] = 'validDate'
   } else if (startDate && endDate.isBefore(startDate)) {
     errors['endDate'] = 'dateTooEarly'

--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
@@ -132,7 +132,7 @@ const checkDateInputSupport = () => {
   )
 }
 
-const nativeDatePickerEnabled = checkDateInputSupport()
+export const nativeDatePickerEnabled = checkDateInputSupport()
 
 export default React.memo(function DatePicker({
   date,

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+import React, { useEffect, useMemo, useState } from 'react'
+
+import LocalDate from 'lib-common/local-date'
+import { InputInfo } from 'lib-components/atoms/form/InputField'
+import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
+
+import DatePicker, {
+  DatePickerProps,
+  DatePickerSpacer,
+  nativeDatePickerEnabled
+} from './DatePicker'
+
+interface DateRangePickerProps {
+  start: LocalDate | null
+  end: LocalDate | null
+  onChange: (start: LocalDate | null, end: LocalDate | null) => void
+  errorTexts: DatePickerProps['errorTexts'] & {
+    dateTooEarly: string
+    dateTooLate: string
+  }
+  startInfo?: InputInfo
+  endInfo?: InputInfo
+}
+
+export default React.memo(function DateRangePicker({
+  start,
+  end,
+  onChange,
+  errorTexts,
+  ...datePickerProps
+}: DateRangePickerProps & Omit<DatePickerProps, 'date' | 'onChange'>) {
+  const [internalStart, setInternalStart] = useState(start)
+  const [internalEnd, setInternalEnd] = useState(end)
+  const [internalStartError, setInternalStartError] = useState<InputInfo>()
+  const [internalEndError, setInternalEndError] = useState<InputInfo>()
+
+  useEffect(() => {
+    setInternalStart(start)
+  }, [start])
+
+  useEffect(() => {
+    setInternalEnd(end)
+  }, [end])
+
+  useEffect(() => {
+    setInternalStartError(undefined)
+    setInternalEndError(undefined)
+
+    if (internalStart && internalEnd && internalStart.isAfter(internalEnd)) {
+      setInternalStartError({
+        text: errorTexts.dateTooLate,
+        status: 'warning'
+      })
+      setInternalEndError({
+        text: errorTexts.dateTooEarly,
+        status: 'warning'
+      })
+      return
+    }
+
+    if (start !== internalStart || end !== internalEnd) {
+      onChange(internalStart, internalEnd)
+    }
+  }, [internalStart, internalEnd, onChange, errorTexts, start, end])
+
+  const minDateForEnd = useMemo(
+    () =>
+      (nativeDatePickerEnabled &&
+      (!datePickerProps.minDate ||
+        internalStart?.isAfter(datePickerProps.minDate))
+        ? internalStart
+        : datePickerProps.minDate) ?? undefined,
+    [datePickerProps.minDate, internalStart]
+  )
+
+  const maxDateForStart = useMemo(
+    () =>
+      (nativeDatePickerEnabled &&
+      (!datePickerProps.maxDate ||
+        internalEnd?.isBefore(datePickerProps.maxDate))
+        ? internalEnd
+        : datePickerProps.maxDate) ?? undefined,
+    [datePickerProps.maxDate, internalEnd]
+  )
+
+  return (
+    <FixedSpaceRow>
+      <DatePicker
+        date={internalStart}
+        onChange={(date) => setInternalStart(date)}
+        data-qa="start-date"
+        initialMonth={internalStart ?? datePickerProps.minDate}
+        {...datePickerProps}
+        maxDate={maxDateForStart}
+        info={
+          internalStartError ??
+          datePickerProps.startInfo ??
+          datePickerProps.info
+        }
+        errorTexts={errorTexts}
+      />
+      <DatePickerSpacer />
+      <DatePicker
+        date={internalEnd}
+        onChange={(date) => setInternalEnd(date)}
+        data-qa="end-date"
+        initialMonth={internalEnd ?? minDateForEnd}
+        {...datePickerProps}
+        minDate={minDateForEnd}
+        info={
+          internalEndError ?? datePickerProps.endInfo ?? datePickerProps.info
+        }
+        errorTexts={errorTexts}
+      />
+    </FixedSpaceRow>
+  )
+})


### PR DESCRIPTION
#### Summary

Fixes issues in the reservation modal where native date pickers do not open the correct initial month for the end date because the min date was not updated accordingly with the start date. Additionally, the absence modal lacked similar checks too that caused issues down the line when creating date ranges.