### PR TITLE
Use EvakaClock in async jobs

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
@@ -27,6 +27,7 @@ import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.dev.insertTestClubApplicationForm
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.test.validClubApplication
 import fi.espoo.evaka.test.validDaycareApplication
 import fi.espoo.evaka.testAdult_1
@@ -110,7 +111,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest(resetDbBefor
         assertApplicationIsSent(applicationId)
 
         assertEquals(1, asyncJobRunner.getPendingJobCount())
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         val sentMails = MockEmailClient.emails
         assertEquals(1, sentMails.size)
@@ -150,7 +151,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest(resetDbBefor
         assertEquals(200, res.statusCode)
 
         assertApplicationIsSent(applicationId)
-        asyncJobRunner.runPendingJobsSync(1)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 1)
 
         val sentMails = MockEmailClient.emails
         assertEquals(1, sentMails.size)
@@ -192,7 +193,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest(resetDbBefor
         assertApplicationIsSent(applicationId)
         assertEquals(1, asyncJobRunner.getPendingJobCount())
 
-        asyncJobRunner.runPendingJobsSync(1)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 1)
         assertEquals(0, asyncJobRunner.getPendingJobCount())
 
         val sentMails = MockEmailClient.emails
@@ -227,7 +228,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest(resetDbBefor
         assertEquals(200, res.statusCode)
         assertApplicationIsSent(applicationId)
 
-        asyncJobRunner.runPendingJobsSync(1)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 1)
         assertEquals(0, asyncJobRunner.getPendingJobCount())
 
         val sentMails = MockEmailClient.emails
@@ -259,7 +260,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest(resetDbBefor
         assertEquals(200, res.statusCode)
         assertApplicationIsSent(applicationId)
 
-        asyncJobRunner.runPendingJobsSync(1)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 1)
         assertEquals(0, asyncJobRunner.getPendingJobCount())
 
         val sentMails = MockEmailClient.emails
@@ -335,7 +336,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest(resetDbBefor
         assertApplicationIsSent(applicationId)
         assertEquals(1, asyncJobRunner.getPendingJobCount())
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         val sentMails = MockEmailClient.emails
         assertEquals(0, sentMails.size)
@@ -368,7 +369,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest(resetDbBefor
         assertApplicationIsSent(applicationId)
         assertEquals(1, asyncJobRunner.getPendingJobCount())
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         val result = db.read { r -> r.fetchApplicationDetails(applicationId) }
         assertEquals(manuallySetSentDate, result?.sentDate)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -47,9 +47,11 @@ import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snPreschoolDaycare45
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_4
@@ -976,6 +978,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         )
 
     private fun sendDecisionsWithoutProposalTest(
+        clock: EvakaClock = RealEvakaClock(),
         child: DevPerson,
         applier: DevPerson,
         secondDecisionTo: DevPerson?,
@@ -1004,9 +1007,9 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         db.transaction { tx ->
             service.sendDecisionsWithoutProposal(tx, serviceWorker, applicationId)
         }
-        asyncJobRunner.runPendingJobsSync()
-        asyncJobRunner.runPendingJobsSync()
-        sfiAsyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(clock)
+        asyncJobRunner.runPendingJobsSync(clock)
+        sfiAsyncJobRunner.runPendingJobsSync(clock)
 
         // then
         db.read {
@@ -1150,9 +1153,10 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             )
             service.confirmPlacementProposalChanges(tx, serviceWorker, testDaycare.id)
         }
-        asyncJobRunner.runPendingJobsSync()
-        asyncJobRunner.runPendingJobsSync()
-        sfiAsyncJobRunner.runPendingJobsSync()
+        val clock = RealEvakaClock()
+        asyncJobRunner.runPendingJobsSync(clock)
+        asyncJobRunner.runPendingJobsSync(clock)
+        sfiAsyncJobRunner.runPendingJobsSync(clock)
         db.read { tx ->
             // then
             val application = tx.fetchApplicationDetails(applicationId)!!
@@ -1214,9 +1218,10 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             )
             service.confirmPlacementProposalChanges(tx, serviceWorker, testDaycare.id)
         }
-        asyncJobRunner.runPendingJobsSync()
-        asyncJobRunner.runPendingJobsSync()
-        sfiAsyncJobRunner.runPendingJobsSync()
+        val clock = RealEvakaClock()
+        asyncJobRunner.runPendingJobsSync(clock)
+        asyncJobRunner.runPendingJobsSync(clock)
+        sfiAsyncJobRunner.runPendingJobsSync(clock)
         db.read { tx ->
             // then
             val application = tx.fetchApplicationDetails(applicationId)!!

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -19,6 +19,8 @@ import fi.espoo.evaka.shared.dev.TestDecision
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.dev.insertTestDecision
+import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.job.ScheduledJobs
 import fi.espoo.evaka.test.validDaycareApplication
 import fi.espoo.evaka.testAdult_6
@@ -175,10 +177,10 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest(resetDbBe
         }
     }
 
-    private fun runPendingDecisionEmailAsyncJobs(): Int {
+    private fun runPendingDecisionEmailAsyncJobs(clock: EvakaClock = RealEvakaClock()): Int {
         scheduledJobs.sendPendingDecisionReminderEmails(db)
         val jobCount = asyncJobRunner.getPendingJobCount()
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(clock)
 
         return jobCount
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -31,6 +31,7 @@ import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestApplication
 import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.test.DecisionTableRow
 import fi.espoo.evaka.test.getApplicationStatus
 import fi.espoo.evaka.test.getDecisionRowsByApplication
@@ -360,7 +361,7 @@ WHERE id = :unitId
             .response()
         assertTrue(res.isSuccessful)
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         val rows = db.read { r -> r.getDecisionRowsByApplication(applicationId).list() }
         rows.forEach { row ->

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -32,6 +32,7 @@ import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snDaycareFullDay35
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
@@ -667,7 +668,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             .responseString()
         assertEquals(200, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 2)
 
         val activated = draft.copy(
             decisionNumber = 1,
@@ -698,7 +699,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             .response()
         assertEquals(200, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 2)
 
         val activated = draft.copy(
             decisionNumber = 1,
@@ -729,7 +730,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             .response()
         assertEquals(200, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 2)
 
         val activated = draft.copy(
             decisionNumber = 1,
@@ -760,7 +761,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             .response()
         assertEquals(200, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 2)
 
         val activated = draft.copy(
             decisionNumber = 1,
@@ -799,7 +800,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             .responseString()
         assertEquals(200, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 2)
 
         val activated = draft.copy(
             decisionNumber = 1,
@@ -837,7 +838,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             .responseString()
         assertEquals(200, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 2)
 
         val activated = draft.copy(
             decisionNumber = 1,
@@ -878,7 +879,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             .responseString()
         assertEquals(200, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 2)
 
         val activated = oldDecision.copy(
             decisionNumber = 1,
@@ -912,7 +913,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
 
         assertEquals(200, res.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 2)
 
         val (_, _, result) = http.get("/decisions/${draft.id}")
             .asUser(user)
@@ -974,7 +975,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             .response()
         assertEquals(200, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 2)
 
         val (_, _, result) = http.get("/decisions/${draftWithFutureDates.id}")
             .asUser(user)
@@ -1515,7 +1516,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             .responseString()
         assertEquals(200, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync(2)
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 2)
 
         val (_, _, result1) = http.get("/decisions/${decision.id}")
             .asUser(user)
@@ -1682,7 +1683,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             .responseString()
         assertEquals(200, response.statusCode)
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
         return decision
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/PaymentsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/PaymentsIntegrationTest.kt
@@ -35,6 +35,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snDefaultDaycare
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
@@ -308,7 +309,7 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             )
             decision.id
         }
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
     }
 
     private fun searchPayments(params: SearchPaymentsRequest): Paged<Payment> {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -39,6 +39,7 @@ import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testAdult_3
@@ -499,7 +500,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
             .asUser(serviceWorker)
             .responseObject<List<DaycarePlacementWithDetails>>(jsonMapper)
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         return data.get().first().id
     }
@@ -526,7 +527,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 assertEquals(200, res.statusCode)
             }
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
     }
 
     private fun updatePlacement(id: PlacementId, startDate: LocalDate, endDate: LocalDate) {
@@ -543,7 +544,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 assertEquals(200, res.statusCode)
             }
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
     }
 
     private fun deletePlacement(id: PlacementId) {
@@ -554,7 +555,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 assertEquals(200, res.statusCode)
             }
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
     }
 
     private fun changeHeadOfFamily(child: DevPerson, headOfFamilyId: PersonId) {
@@ -572,7 +573,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
             .objectBody(body, mapper = jsonMapper)
             .response()
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
     }
 
     private fun searchValueDecisions(status: String, searchTerms: String = ""): Paged<VoucherValueDecisionSummary> {
@@ -609,7 +610,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 }
             }
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
         return decisionIds
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -52,6 +52,7 @@ import fi.espoo.evaka.shared.dev.insertTestServiceNeed
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snDaycareContractDays15
 import fi.espoo.evaka.snDaycareFullDay25to35
 import fi.espoo.evaka.snDaycareFullDayPartWeek25
@@ -103,7 +104,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val placementPeriod = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertTrue(decisions.isEmpty())
@@ -115,7 +116,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycareNotInvoiced.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(0, decisions.size)
@@ -128,7 +129,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions[0].children.size)
@@ -141,7 +142,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions[0].children.size)
@@ -157,7 +158,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions[0].children.size)
@@ -172,7 +173,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -184,12 +185,12 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val original = getAllFeeDecisions()
         assertEquals(1, original.size)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val result = getAllFeeDecisions()
         assertEquals(1, original.size)
@@ -220,7 +221,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val result = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, result.size)
@@ -243,7 +244,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, placementPeriod, PRESCHOOL, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val result = getAllFeeDecisions()
 
@@ -256,7 +257,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, placementPeriod, PREPARATORY, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val result = getAllFeeDecisions()
 
@@ -269,7 +270,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, placementPeriod, PRESCHOOL_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val result = getAllFeeDecisions()
 
@@ -284,7 +285,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, placementPeriod, PREPARATORY_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val result = getAllFeeDecisions()
 
@@ -302,7 +303,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertServiceNeed(placementId, FiniteDateRange(start, end), snDaycareContractDays15.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val result = getAllFeeDecisions()
 
@@ -316,7 +317,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE_FIVE_YEAR_OLDS, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val result = getAllFeeDecisions()
 
@@ -331,7 +332,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, placementPeriod, DAYCARE_PART_TIME_FIVE_YEAR_OLDS, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val result = getAllFeeDecisions()
 
@@ -346,7 +347,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val placementId = insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val original = getAllFeeDecisions()
         assertEquals(1, original.size)
@@ -354,7 +355,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         val serviceNeed = snDaycareFullDayPartWeek25
         insertServiceNeed(placementId, placementPeriod.asFiniteDateRange()!!, serviceNeed.id)
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val updated = getAllFeeDecisions()
         assertEquals(1, updated.size)
@@ -367,7 +368,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val placementId = insertPlacement(testChild_1.id, placementPeriod, DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val original = getAllFeeDecisions()
         assertEquals(1, original.size)
@@ -376,7 +377,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val serviceNeedPeriod = FiniteDateRange(LocalDate.of(2019, 7, 1), LocalDate.of(2019, 12, 31))
         val serviceNeed = snDaycareFullDay25to35
         insertServiceNeed(placementId, serviceNeedPeriod, serviceNeed.id)
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val updated = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, updated.size)
@@ -399,7 +400,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), placementPeriod)
         insertServiceNeed(placementId, serviceNeedPeriod, serviceNeed.id)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val original = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, original.size)
@@ -414,7 +415,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         db.transaction { tx ->
             tx.execute("DELETE FROM service_need WHERE placement_id = ?", placementId)
-            generator.generateNewDecisionsForChild(tx, testChild_1.id, serviceNeedPeriod.start)
+            generator.generateNewDecisionsForChild(tx, RealEvakaClock(), testChild_1.id, serviceNeedPeriod.start)
         }
 
         val updated = getAllFeeDecisions()
@@ -428,7 +429,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 12, 31))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, period.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(0, decisions.size)
@@ -459,7 +460,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 )
             )
 
-            generator.generateNewDecisionsForAdult(tx, testAdult_1.id, period.start)
+            generator.generateNewDecisionsForAdult(tx, RealEvakaClock(), testAdult_1.id, period.start)
         }
 
         val decisions = getAllFeeDecisions()
@@ -492,7 +493,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 )
             )
 
-            generator.generateNewDecisionsForAdult(tx, testAdult_1.id, period.start)
+            generator.generateNewDecisionsForAdult(tx, RealEvakaClock(), testAdult_1.id, period.start)
         }
 
         val decisions = getAllFeeDecisions()
@@ -510,7 +511,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, PRESCHOOL_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -545,7 +546,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, PRESCHOOL_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -580,7 +581,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, PRESCHOOL_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -613,7 +614,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, PRESCHOOL_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -641,7 +642,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, PREPARATORY_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -676,7 +677,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, PREPARATORY_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -711,7 +712,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, PREPARATORY_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -744,7 +745,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, placementPeriod, PREPARATORY_DAYCARE, testDaycare.id)
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, testChild_2.id), placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -776,7 +777,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         // Unlike other income, child income should affect only that child's fees
         insertIncome(testChild_1.id, 600000, placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -814,7 +815,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id, childTurning18Id), placementPeriod)
         insertIncome(testAdult_1.id, 330000, placementPeriod)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, placementPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, placementPeriod.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
@@ -872,7 +873,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 )
             )
 
-            generator.generateNewDecisionsForAdult(tx, testAdult_1.id, period.start)
+            generator.generateNewDecisionsForAdult(tx, RealEvakaClock(), testAdult_1.id, period.start)
         }
 
         val decisions = getAllFeeDecisions()
@@ -921,7 +922,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 )
             )
 
-            generator.generateNewDecisionsForAdult(tx, testAdult_1.id, period.start)
+            generator.generateNewDecisionsForAdult(tx, RealEvakaClock(), testAdult_1.id, period.start)
         }
 
         val decisions = getAllFeeDecisions()
@@ -958,7 +959,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 )
             )
 
-            generator.generateNewDecisionsForAdult(tx, testAdult_1.id, period.start)
+            generator.generateNewDecisionsForAdult(tx, RealEvakaClock(), testAdult_1.id, period.start)
         }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
@@ -1056,7 +1057,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 )
             )
 
-            generator.generateNewDecisionsForAdult(tx, testAdult_1.id, newerPeriod.start)
+            generator.generateNewDecisionsForAdult(tx, RealEvakaClock(), testAdult_1.id, newerPeriod.start)
         }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
@@ -1092,7 +1093,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, period.copy(start = period.start.plusMonths(1)), DAYCARE, testDaycare.id)
         insertPlacement(testChild_3.id, period.copy(start = period.start.plusMonths(2)), DAYCARE, testDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(3, decisions.size)
@@ -1187,7 +1188,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_2.id, period_2, DAYCARE, testDaycare.id)
         insertPlacement(testChild_3.id, period_3, DAYCARE, testDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period_1.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period_1.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(3, decisions.size)
@@ -1251,7 +1252,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertPlacement(testChild_2.id, period, DAYCARE, testDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
@@ -1298,7 +1299,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, subPeriod_1)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
@@ -1344,7 +1345,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, incomePeriod)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(1, decisions.size)
@@ -1366,7 +1367,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         }
 
         deleteIncomes()
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, incomePeriod.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, incomePeriod.start) }
 
         val newDecisions = getAllFeeDecisions()
         assertEquals(1, newDecisions.size)
@@ -1397,7 +1398,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, subPeriod_1)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
@@ -1435,7 +1436,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         }
 
         deleteIncomes()
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, subPeriod_1.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, subPeriod_1.start) }
 
         val newDecisions = getAllFeeDecisions()
         assertEquals(1, newDecisions.size)
@@ -1473,7 +1474,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_3.id, wholePeriod, DAYCARE, testDaycare.id)
         insertPlacement(testChild_4.id, wholePeriod, DAYCARE, testDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, wholePeriod.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, wholePeriod.start) }
 
         val testAdult1decisions = getAllFeeDecisions().filter { it.headOfFamilyId == testAdult_1.id }
         assertEquals(2, testAdult1decisions.size)
@@ -1503,8 +1504,8 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertIncome(testAdult_2.id, 310200, period)
 
         db.transaction {
-            generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start)
-            generator.generateNewDecisionsForAdult(it, testAdult_2.id, period.start)
+            generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start)
+            generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_2.id, period.start)
         }
 
         val decisions = getAllFeeDecisions()
@@ -1535,8 +1536,8 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertIncome(testAdult_2.id, 310200, period)
 
         db.transaction {
-            generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start)
-            generator.generateNewDecisionsForAdult(it, testAdult_2.id, period.start)
+            generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start)
+            generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_2.id, period.start)
         }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
@@ -1574,8 +1575,8 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertIncome(testAdult_2.id, 310200, period)
 
         db.transaction {
-            generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start)
-            generator.generateNewDecisionsForAdult(it, testAdult_2.id, period.start)
+            generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start)
+            generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_2.id, period.start)
         }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
@@ -1612,8 +1613,8 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertIncome(testAdult_2.id, 310200, period)
 
         db.transaction {
-            generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start)
-            generator.generateNewDecisionsForAdult(it, testAdult_2.id, period.start)
+            generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start)
+            generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_2.id, period.start)
         }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
@@ -1644,7 +1645,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertIncome(testAdult_1.id, 310200, period)
         insertIncome(testAdult_2.id, 310200, period)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
@@ -1692,7 +1693,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertIncome(testAdult_1.id, 310200, period)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
@@ -1737,7 +1738,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
         insertFeeAlteration(testChild_1.id, 50.0, period)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1769,7 +1770,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPlacement(testChild_1.id, combinedPeriod, DAYCARE, testDaycare.id)
         insertEchaIncome(testAdult_1.id, combinedPeriod)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, combinedPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, combinedPeriod.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
@@ -1833,7 +1834,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val newPeriod = originalPeriod.copy(end = originalPeriod.end!!.minusDays(7))
         insertPlacement(testChild_1.id, newPeriod, DAYCARE, testDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, newPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, newPeriod.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1864,7 +1865,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val newPeriod = originalPeriod.copy(end = originalPeriod.end!!.minusDays(7))
         insertPlacement(testChild_1.id, newPeriod, DAYCARE, testDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, newPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, newPeriod.start) }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
         assertEquals(2, decisions.size)
@@ -1882,7 +1883,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val period = DateRange(LocalDate.of(2014, 6, 1), LocalDate.of(2015, 6, 1))
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, period.start) }
 
         val decisions = getAllFeeDecisions()
         assertEquals(1, decisions.size)
@@ -1925,7 +1926,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 )
             )
 
-            generator.generateNewDecisionsForAdult(tx, testAdult_1.id, familyPeriod.start)
+            generator.generateNewDecisionsForAdult(tx, RealEvakaClock(), testAdult_1.id, familyPeriod.start)
         }
 
         val decisions = getAllFeeDecisions().sortedBy { it.validFrom }
@@ -1977,7 +1978,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         ).let { fixture ->
             db.transaction { tx ->
                 tx.upsertFeeDecisions(listOf(fixture))
-                generator.generateNewDecisionsForAdult(tx, testAdult_1.id, period.start)
+                generator.generateNewDecisionsForAdult(tx, RealEvakaClock(), testAdult_1.id, period.start)
             }
         }
 
@@ -2013,7 +2014,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
             testDaycare.id
         )
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val feeDecisions = getAllFeeDecisions()
         assertEquals(1, feeDecisions.size)
@@ -2040,7 +2041,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPartnership(testAdult_1.id, testAdult_2.id, period)
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, period.start) }
         assertEquals(1, getAllFeeDecisions().size)
     }
 
@@ -2053,7 +2054,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         insertPartnership(testAdult_1.id, testAdult_2.id, period)
         insertPlacement(testChild_1.id, period, DAYCARE, testDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_2.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_2.id, period.start) }
         assertEquals(1, getAllFeeDecisions().size)
     }
 
@@ -2083,7 +2084,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         )
         db.transaction { it.upsertFeeDecisions(listOf(sentDecision)) }
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
         val feeDecisions = getAllFeeDecisions()
         assertEquals(2, feeDecisions.size)
         assertEquals(1, feeDecisions.filter { it.status == FeeDecisionStatus.SENT }.size)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGeneratorIntegrationTest.kt
@@ -22,6 +22,7 @@ import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
@@ -82,7 +83,7 @@ class FinanceDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBefor
         insertPlacement(testChild_2.id, period, DAYCARE, testVoucherDaycare.id)
         insertPlacement(testChild_3.id, period, DAYCARE, testDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val feeDecisions = getAllFeeDecisions()
         assertEquals(1, feeDecisions.size)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
@@ -33,6 +33,7 @@ import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snDaycareFiveYearOldsFullDayPartWeek25
 import fi.espoo.evaka.snDaycareFullDayPartWeek25
 import fi.espoo.evaka.snDefaultDaycare
@@ -74,7 +75,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertFamilyRelations(testAdult_1.id, listOf(testChild_1.id), period)
         insertPlacement(testChild_1.id, period, PlacementType.DAYCARE, testVoucherDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
@@ -107,7 +108,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertPlacement(testChild_1.id, period, PlacementType.DAYCARE, testVoucherDaycare.id)
         insertFeeAlteration(testChild_1.id, 50.0, period)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
@@ -144,7 +145,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertFamilyRelations(testAdult_1.id, listOf(testChild.id), period)
         insertPlacement(testChild.id, period, PlacementType.DAYCARE, testVoucherDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
@@ -177,7 +178,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         val serviceNeedPeriod = period.copy(start = period.start.plusMonths(5))
         insertServiceNeed(placementId, serviceNeedPeriod.asFiniteDateRange()!!, snDaycareFullDayPartWeek25.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
@@ -207,7 +208,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertFamilyRelations(testAdult_1.id, listOf(testChild_2.id), period)
         insertPlacement(testChild_2.id, period, PlacementType.DAYCARE_FIVE_YEAR_OLDS, testVoucherDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -228,7 +229,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertFamilyRelations(testAdult_1.id, listOf(testChild_2.id), period)
         insertPlacement(testChild_2.id, period, PlacementType.DAYCARE_PART_TIME_FIVE_YEAR_OLDS, testVoucherDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -249,7 +250,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertFamilyRelations(testAdult_1.id, listOf(testChild_2.id), period)
         insertPlacement(testChild_2.id, period, PlacementType.PRESCHOOL, testVoucherDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(0, voucherValueDecisions.size)
@@ -261,7 +262,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertFamilyRelations(testAdult_1.id, listOf(testChild_2.id), period)
         insertPlacement(testChild_2.id, period, PlacementType.PREPARATORY, testVoucherDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -283,7 +284,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         val placementId = insertPlacement(testChild_2.id, period, PlacementType.DAYCARE, testVoucherDaycare.id)
         insertServiceNeed(placementId, period.asFiniteDateRange()!!, snDaycareFiveYearOldsFullDayPartWeek25.id)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -308,7 +309,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
             PlacementType.DAYCARE_FIVE_YEAR_OLDS, testVoucherDaycare.id
         )
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
@@ -341,7 +342,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertPlacement(testChild_2.id, period, PlacementType.DAYCARE, testVoucherDaycare.id)
         insertAssistanceNeed(testChild_2.id, period.asFiniteDateRange()!!, 3.0)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions()
         assertEquals(1, voucherValueDecisions.size)
@@ -368,7 +369,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertPlacement(testChild_2.id, wholePeriod, PlacementType.DAYCARE, testVoucherDaycare.id)
         insertPartnership(testAdult_1.id, testAdult_2.id, firstPeriod)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_2.id, firstPeriod.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_2.id, firstPeriod.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
@@ -404,7 +405,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertIncome(testAdult_1.id, 310200, period)
         insertIncome(testChild_1.id, 600000, period)
 
-        db.transaction { generator.generateNewDecisionsForAdult(it, testAdult_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForAdult(it, RealEvakaClock(), testAdult_1.id, period.start) }
 
         val voucherValueDecisions = getAllVoucherValueDecisions().sortedBy { it.validFrom }
         assertEquals(2, voucherValueDecisions.size)
@@ -439,7 +440,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertPartnership(testAdult_1.id, testAdult_2.id, period)
         insertPlacement(testChild_1.id, period, PlacementType.DAYCARE_FIVE_YEAR_OLDS, testVoucherDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_1.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_1.id, period.start) }
         assertEquals(1, getAllVoucherValueDecisions().size)
     }
 
@@ -452,7 +453,7 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
         insertPartnership(testAdult_1.id, testAdult_2.id, period)
         insertPlacement(testChild_1.id, period, PlacementType.DAYCARE_FIVE_YEAR_OLDS, testVoucherDaycare.id)
 
-        db.transaction { generator.generateNewDecisionsForChild(it, testChild_2.id, period.start) }
+        db.transaction { generator.generateNewDecisionsForChild(it, RealEvakaClock(), testChild_2.id, period.start) }
         assertEquals(1, getAllVoucherValueDecisions().size)
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -29,6 +29,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.BeforeEach
@@ -114,7 +115,7 @@ class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest(reset
             recipients = personAccounts,
             user = employee,
         )
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         assertEquals(
             testAddresses.toSet(),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationServiceIntegrationTest.kt
@@ -34,6 +34,7 @@ import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
@@ -123,7 +124,7 @@ class PedagogicalDocumentNotificationServiceIntegrationTest : FullApplicationTes
             user = employee,
             PedagogicalDocumentPostBody(testChild_1.id, "foobar")
         )
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         assertEquals(
             testAddresses.toSet(),
@@ -152,7 +153,7 @@ class PedagogicalDocumentNotificationServiceIntegrationTest : FullApplicationTes
         }
         assertEmailSent(doc.id, false)
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         assertEmailSent(doc.id)
     }
@@ -163,13 +164,13 @@ class PedagogicalDocumentNotificationServiceIntegrationTest : FullApplicationTes
             user = employee,
             PedagogicalDocumentPostBody(testChild_1.id, "")
         )
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         assertEmailSent(doc.id, false)
 
         updateDocument(user = employee, doc.id, PedagogicalDocumentPostBody(testChild_1.id, "babar"))
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         assertEmailSent(doc.id)
     }
@@ -180,13 +181,13 @@ class PedagogicalDocumentNotificationServiceIntegrationTest : FullApplicationTes
             user = employee,
             PedagogicalDocumentPostBody(testChild_1.id, "")
         )
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         assertEmailSent(doc.id, false)
 
         uploadDocumentAttachment(employee, doc.id)
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         assertEmailSent(doc.id, true)
     }
@@ -212,7 +213,7 @@ class PedagogicalDocumentNotificationServiceIntegrationTest : FullApplicationTes
             user = employee,
             PedagogicalDocumentPostBody(testChild_1.id, "foobar")
         )
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         assertEquals(
             testAddresses.toSet(),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChild_1
@@ -87,7 +88,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest(resetDbBeforeE
         )
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_1.id), any())).thenReturn(dto)
 
-        service.doVTJRefresh(db, AsyncJob.VTJRefresh(testAdult_1.id))
+        service.doVTJRefresh(db, RealEvakaClock(), AsyncJob.VTJRefresh(testAdult_1.id))
         verify(parentshipService).createParentship(
             any(),
             eq(testChild_1.id),
@@ -110,7 +111,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest(resetDbBeforeE
             )
         )
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_1.id), any())).thenReturn(dto)
-        service.doVTJRefresh(db, AsyncJob.VTJRefresh(testAdult_1.id))
+        service.doVTJRefresh(db, RealEvakaClock(), AsyncJob.VTJRefresh(testAdult_1.id))
         verifyNoInteractions(parentshipService)
     }
 
@@ -146,7 +147,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest(resetDbBeforeE
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_1.id), any())).thenReturn(dto1)
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_2.id), any())).thenReturn(dto2)
 
-        service.doVTJRefresh(db, AsyncJob.VTJRefresh(testAdult_1.id))
+        service.doVTJRefresh(db, RealEvakaClock(), AsyncJob.VTJRefresh(testAdult_1.id))
         verify(parentshipService).createParentship(
             any(),
             eq(testChild_1.id),
@@ -190,7 +191,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest(resetDbBeforeE
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_1.id), any())).thenReturn(dto1)
         whenever(personService.getPersonWithChildren(any(), eq(user), eq(testAdult_2.id), any())).thenReturn(dto2)
 
-        service.doVTJRefresh(db, AsyncJob.VTJRefresh(testAdult_1.id))
+        service.doVTJRefresh(db, RealEvakaClock(), AsyncJob.VTJRefresh(testAdult_1.id))
         verifyNoInteractions(parentshipService)
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueAreaReportTest.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snDefaultDaycare
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
@@ -176,7 +177,7 @@ class ServiceVoucherValueAreaReportTest : FullApplicationTest(resetDbBeforeEach 
             decision
         }
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         return decision
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueUnitReportTest.kt
@@ -34,6 +34,7 @@ import fi.espoo.evaka.shared.dev.DevFeeAlteration
 import fi.espoo.evaka.shared.dev.insertTestFeeAlteration
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snDefaultDaycare
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1
@@ -549,7 +550,7 @@ class ServiceVoucherValueUnitReportTest : FullApplicationTest(resetDbBeforeEach 
             decision.id
         }
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         return db.read { it.getValueDecisionsByIds(listOf(id)).first() }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.AsyncJobRunnerConfig
 import fi.espoo.evaka.shared.config.getTestDataSource
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.domain.europeHelsinki
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -40,7 +41,7 @@ class ScheduledJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
     @Test
     fun `a job specified by DailySchedule is scheduled and executed correctly`() {
         val executedJob = AtomicReference<ScheduledJob?>(null)
-        asyncJobRunner.registerHandler { _, msg: AsyncJob.RunScheduledJob ->
+        asyncJobRunner.registerHandler { _, _, msg: AsyncJob.RunScheduledJob ->
             val previous = executedJob.getAndSet(msg.job)
             assertNull(previous)
         }
@@ -60,7 +61,7 @@ class ScheduledJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
             }
         }
 
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
         assertEquals(executedJob.get(), ScheduledJob.EndOfDayAttendanceUpkeep)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.decision.DecisionService
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
 
@@ -23,7 +24,7 @@ class DecisionMessageProcessor(
         asyncJobRunner.registerHandler(::runSendJob)
     }
 
-    fun runCreateJob(db: Database.Connection, msg: AsyncJob.NotifyDecisionCreated) = db.transaction { tx ->
+    fun runCreateJob(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.NotifyDecisionCreated) = db.transaction { tx ->
         val user = msg.user
         val decisionId = msg.decisionId
 
@@ -36,7 +37,7 @@ class DecisionMessageProcessor(
         }
     }
 
-    fun runSendJob(db: Database.Connection, msg: AsyncJob.SendDecision) = db.transaction { tx ->
+    fun runSendJob(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.SendDecision) = db.transaction { tx ->
         val decisionId = msg.decisionId
 
         decisionService.deliverDecisionToGuardians(tx, decisionId)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
@@ -42,7 +43,7 @@ class PendingDecisionEmailService(
         else -> "$senderNameFi <$senderAddress>"
     }
 
-    fun doSendPendingDecisionsEmail(db: Database.Connection, msg: AsyncJob.SendPendingDecisionEmail) {
+    fun doSendPendingDecisionsEmail(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.SendPendingDecisionEmail) {
         logger.info("Sending pending decision reminder email to guardian ${msg.guardianId}")
         sendPendingDecisionEmail(db, msg)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/SendApplicationReceivedEmailAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/SendApplicationReceivedEmailAsyncJobs.kt
@@ -20,7 +20,7 @@ class SendApplicationReceivedEmailAsyncJobs(
 ) {
 
     init {
-        asyncJobRunner.registerHandler(::runSendApplicationEmail)
+        asyncJobRunner.registerHandler { db, _, msg: AsyncJob.SendApplicationEmail -> runSendApplicationEmail(db, msg) }
     }
 
     private fun runSendApplicationEmail(db: Database.Connection, msg: AsyncJob.SendApplicationEmail) {

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.dvv
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.RealEvakaClock
 import mu.KotlinLogging
@@ -25,7 +26,7 @@ class DvvModificationsBatchRefreshService(
         asyncJobRunner.registerHandler(::doDvvModificationsRefresh)
     }
 
-    fun doDvvModificationsRefresh(db: Database.Connection, msg: AsyncJob.DvvModificationsRefresh) {
+    fun doDvvModificationsRefresh(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.DvvModificationsRefresh) {
         logger.info("DvvModificationsRefresh: starting to process ${msg.ssns.size} ssns")
         val modificationCount = dvvModificationsService.updatePersonsFromDvv(db, RealEvakaClock(), msg.ssns)
         logger.info("DvvModificationsRefresh: finished processing $modificationCount DVV person modifications for ${msg.ssns.size} ssns")

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
-import fi.espoo.evaka.shared.domain.RealEvakaClock
 import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Service
@@ -28,7 +27,7 @@ class DvvModificationsBatchRefreshService(
 
     fun doDvvModificationsRefresh(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.DvvModificationsRefresh) {
         logger.info("DvvModificationsRefresh: starting to process ${msg.ssns.size} ssns")
-        val modificationCount = dvvModificationsService.updatePersonsFromDvv(db, RealEvakaClock(), msg.ssns)
+        val modificationCount = dvvModificationsService.updatePersonsFromDvv(db, clock, msg.ssns)
         logger.info("DvvModificationsRefresh: finished processing $modificationCount DVV person modifications for ${msg.ssns.size} ssns")
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -214,12 +214,13 @@ class VoucherValueDecisionController(
     fun generateRetroactiveDecisions(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: PersonId,
         @RequestBody body: CreateRetroactiveFeeDecisionsBody
     ) {
         Audit.VoucherValueDecisionHeadOfFamilyCreateRetroactive.log(targetId = id)
         accessControl.requirePermissionFor(user, Action.Person.GENERATE_RETROACTIVE_VOUCHER_VALUE_DECISIONS, id)
-        db.connect { dbc -> dbc.transaction { generator.createRetroactiveValueDecisions(it, id, body.from) } }
+        db.connect { dbc -> dbc.transaction { generator.createRetroactiveValueDecisions(it, clock, id, body.from) } }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
@@ -37,9 +37,9 @@ class FeeDecisionGenerationJobProcessor(
         db.transaction { tx ->
             when (msg.person) {
                 is AsyncJob.GenerateFinanceDecisions.Person.Adult ->
-                    generator.generateNewDecisionsForAdult(tx, msg.person.adultId, msg.dateRange.start)
+                    generator.generateNewDecisionsForAdult(tx, clock, msg.person.adultId, msg.dateRange.start)
                 is AsyncJob.GenerateFinanceDecisions.Person.Child ->
-                    generator.generateNewDecisionsForChild(tx, msg.person.childId, msg.dateRange.start)
+                    generator.generateNewDecisionsForChild(tx, clock, msg.person.childId, msg.dateRange.start)
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Component
@@ -26,12 +27,12 @@ class FeeDecisionGenerationJobProcessor(
         asyncJobRunner.registerHandler<AsyncJob.GenerateFinanceDecisions>(::runJob)
     }
 
-    fun runJob(db: Database.Connection, msg: AsyncJob.NotifyFeeThresholdsUpdated) {
+    fun runJob(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.NotifyFeeThresholdsUpdated) {
         logger.info { "Handling fee thresholds update event for date range (id: ${msg.dateRange})" }
         db.transaction { planFinanceDecisionGeneration(it, asyncJobRunner, msg.dateRange, listOf()) }
     }
 
-    fun runJob(db: Database.Connection, msg: AsyncJob.GenerateFinanceDecisions) {
+    fun runJob(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.GenerateFinanceDecisions) {
         logger.info { "Generating finance decisions with parameters $msg" }
         db.transaction { tx ->
             when (msg.person) {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
@@ -40,7 +40,7 @@ import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
-import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.asDistinctPeriods
 import fi.espoo.evaka.shared.domain.mergePeriods
 import org.jdbi.v3.core.kotlin.mapTo
@@ -52,6 +52,7 @@ internal fun Database.Transaction.handleValueDecisionChanges(
     featureConfig: FeatureConfig,
     jsonMapper: JsonMapper,
     incomeTypesProvider: IncomeTypesProvider,
+    clock: EvakaClock,
     from: LocalDate,
     child: ChildWithDateOfBirth,
     families: List<FridgeFamily>
@@ -101,7 +102,7 @@ internal fun Database.Transaction.handleValueDecisionChanges(
     val updatedDecisions = updateExistingDecisions(from, newDrafts, existingDrafts, activeDecisions)
     deleteValueDecisions(existingDrafts.map { it.id })
     upsertValueDecisions(updatedDecisions.updatedDrafts)
-    updateVoucherValueDecisionEndDates(updatedDecisions.updatedActiveDecisions, HelsinkiDateTime.now())
+    updateVoucherValueDecisionEndDates(updatedDecisions.updatedActiveDecisions, clock.now())
 }
 
 private fun generateNewValueDecisions(

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -46,7 +46,7 @@ class KoskiClient(
         .build()
 
     init {
-        asyncJobRunner?.registerHandler { db, msg: AsyncJob.UploadToKoski ->
+        asyncJobRunner?.registerHandler { db, _, msg: AsyncJob.UploadToKoski ->
             uploadToKoski(
                 db, msg,
                 today = LocalDate.now(

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -24,7 +24,6 @@ import fi.espoo.evaka.shared.KoskiStudyRightId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.domain.europeHelsinki
 import fi.espoo.voltti.logging.loggers.error
 import mu.KotlinLogging
 import java.time.LocalDate
@@ -46,13 +45,8 @@ class KoskiClient(
         .build()
 
     init {
-        asyncJobRunner?.registerHandler { db, _, msg: AsyncJob.UploadToKoski ->
-            uploadToKoski(
-                db, msg,
-                today = LocalDate.now(
-                    europeHelsinki
-                )
-            )
+        asyncJobRunner?.registerHandler { db, clock, msg: AsyncJob.UploadToKoski ->
+            uploadToKoski(db, msg, clock.today())
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
@@ -28,7 +28,7 @@ class KoskiUpdateService(
     private val env: EvakaEnv
 ) {
     init {
-        asyncJobRunner.registerHandler { db, msg: AsyncJob.ScheduleKoskiUploads -> scheduleKoskiUploads(db, msg.params) }
+        asyncJobRunner.registerHandler { db, _, msg: AsyncJob.ScheduleKoskiUploads -> scheduleKoskiUploads(db, msg.params) }
     }
 
     fun scheduleKoskiUploads(db: Database.Connection, params: KoskiSearchParams) {

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailService.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.springframework.stereotype.Service
 
@@ -93,7 +94,7 @@ class MessageNotificationEmailService(
         }
     }
 
-    fun sendMessageNotification(db: Database.Connection, msg: AsyncJob.SendMessageNotificationEmail) {
+    fun sendMessageNotification(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.SendMessageNotificationEmail) {
         val (threadId, messageRecipientId, personEmail, language, urgent) = msg
 
         db.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailService.kt
@@ -106,7 +106,7 @@ class MessageNotificationEmailService(
                 htmlBody = getHtml(language, threadId, urgent),
                 textBody = getText(language, threadId, urgent)
             )
-            tx.markNotificationAsSent(messageRecipientId, HelsinkiDateTime.now())
+            tx.markNotificationAsSent(messageRecipientId, clock.now())
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingAsyncJobs.kt
@@ -14,7 +14,7 @@ class PairingAsyncJobs(
     asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     init {
-        asyncJobRunner.registerHandler(::runGarbageCollectPairing)
+        asyncJobRunner.registerHandler { db, _, msg: AsyncJob.GarbageCollectPairing -> runGarbageCollectPairing(db, msg) }
     }
 
     private fun runGarbageCollectPairing(db: Database.Connection, msg: AsyncJob.GarbageCollectPairing) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationService.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.db.updateExactlyOne
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
@@ -122,7 +123,7 @@ SELECT EXISTS(
         }
     }
 
-    fun sendNotification(db: Database.Connection, msg: AsyncJob.SendPedagogicalDocumentNotificationEmail) {
+    fun sendNotification(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.SendPedagogicalDocumentNotificationEmail) {
         val (pedagogicalDocumentId, recipientEmail, language) = msg
 
         db.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -36,7 +36,7 @@ class FamilyInitializerService(
         asyncJobRunner.registerHandler(::handleInitializeFamilyFromApplication)
     }
 
-    fun handleInitializeFamilyFromApplication(db: Database.Connection, msg: AsyncJob.InitializeFamilyFromApplication) {
+    fun handleInitializeFamilyFromApplication(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.InitializeFamilyFromApplication) {
         val user = msg.user
         val application = db.read { it.fetchApplicationDetails(msg.applicationId) }
             ?: error("Could not initialize family, application ${msg.applicationId} not found")

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FamilyInitializerService.kt
@@ -19,7 +19,6 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.psqlCause
 import fi.espoo.evaka.shared.domain.EvakaClock
-import fi.espoo.evaka.shared.domain.RealEvakaClock
 import mu.KotlinLogging
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException
 import org.postgresql.util.PSQLState
@@ -42,7 +41,7 @@ class FamilyInitializerService(
             ?: error("Could not initialize family, application ${msg.applicationId} not found")
 
         val members = db.transaction { parseFridgeFamilyMembersFromApplication(it, user, application) }
-        db.transaction { initFamilyFromApplication(it, RealEvakaClock(), members) }
+        db.transaction { initFamilyFromApplication(it, clock, members) }
     }
 
     private fun initFamilyFromApplication(tx: Database.Transaction, evakaClock: EvakaClock, members: FridgeFamilyMembers) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
-import fi.espoo.evaka.shared.domain.RealEvakaClock
 import org.springframework.stereotype.Service
 
 @Service
@@ -22,6 +21,6 @@ class VTJBatchRefreshService(
     }
 
     fun doVTJRefresh(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.VTJRefresh) {
-        fridgeFamilyService.doVTJRefresh(db, msg, RealEvakaClock())
+        fridgeFamilyService.doVTJRefresh(db, msg, clock)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshService.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.pis.service
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.RealEvakaClock
 import org.springframework.stereotype.Service
 
@@ -20,7 +21,7 @@ class VTJBatchRefreshService(
         asyncJobRunner.registerHandler(::doVTJRefresh)
     }
 
-    fun doVTJRefresh(db: Database.Connection, msg: AsyncJob.VTJRefresh) {
+    fun doVTJRefresh(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.VTJRefresh) {
         fridgeFamilyService.doVTJRefresh(db, msg, RealEvakaClock())
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/patu/PatuAsyncJobProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/patu/PatuAsyncJobProcessor.kt
@@ -18,7 +18,7 @@ class PatuAsyncJobProcessor(
     private val patuIntegrationClient: PatuIntegrationClient
 ) {
     init {
-        asyncJobRunner.registerHandler(::runSendPatuReport)
+        asyncJobRunner.registerHandler { db, _, msg: AsyncJob.SendPatuReport -> runSendPatuReport(db, msg) }
     }
 
     fun runSendPatuReport(dbc: Database.Connection, msg: AsyncJob.SendPatuReport) {

--- a/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiAsyncJobs.kt
@@ -14,7 +14,7 @@ class SfiAsyncJobs(
     asyncJobRunner: AsyncJobRunner<SuomiFiAsyncJob>
 ) {
     init {
-        asyncJobRunner.registerHandler { _, payload: SuomiFiAsyncJob.SendMessage ->
+        asyncJobRunner.registerHandler { _, _, payload: SuomiFiAsyncJob.SendMessage ->
             sendMessagePDF(payload.message)
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -197,9 +197,9 @@ class DevApi(
     private val filesBucket = bucketEnv.attachments
     private val digitransit = MockDigitransit()
 
-    private fun runAllAsyncJobs() {
+    private fun runAllAsyncJobs(clock: EvakaClock) {
         listOf(asyncJobRunner, vardaAsyncJobRunner, suomiFiAsyncJobRunner).forEach {
-            it.runPendingJobsSync()
+            it.runPendingJobsSync(clock)
             it.waitUntilNoRunningJobs(timeout = Duration.ofSeconds(20))
         }
     }
@@ -210,9 +210,9 @@ class DevApi(
     }
 
     @PostMapping("/reset-db")
-    fun resetDatabase(db: Database) {
+    fun resetDatabase(db: Database, clock: EvakaClock) {
         // Run async jobs before database reset to avoid database locks/deadlocks
-        runAllAsyncJobs()
+        runAllAsyncJobs(clock)
 
         db.connect { dbc ->
             dbc.waitUntilNoQueriesRunning(timeout = Duration.ofSeconds(10))
@@ -227,8 +227,8 @@ class DevApi(
     }
 
     @PostMapping("/run-jobs")
-    fun runJobs() {
-        runAllAsyncJobs()
+    fun runJobs(clock: EvakaClock) {
+        runAllAsyncJobs(clock)
     }
 
     @PostMapping("/care-areas")

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.removeOldAsyncJobs
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.europeHelsinki
 import fi.espoo.evaka.varda.VardaResetService
@@ -62,7 +63,7 @@ class ScheduledJobs(
 ) {
 
     init {
-        asyncJobRunner.registerHandler { db, msg: AsyncJob.RunScheduledJob ->
+        asyncJobRunner.registerHandler { db, _: EvakaClock, msg: AsyncJob.RunScheduledJob ->
             val logMeta = mapOf("jobName" to msg.job.name)
             logger.info(logMeta) { "Running scheduled job ${msg.job.name}" }
             msg.job.fn(this, db)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -22,6 +22,7 @@ import fi.espoo.evaka.shared.async.removeOldAsyncJobs
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.domain.europeHelsinki
 import fi.espoo.evaka.varda.VardaResetService
 import fi.espoo.evaka.varda.VardaUpdateService
@@ -140,7 +141,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun koskiUpdate(db: Database.Connection) {
-        koskiUpdateService.scheduleKoskiUploads(db, KoskiSearchParams())
+        koskiUpdateService.scheduleKoskiUploads(db, RealEvakaClock(), KoskiSearchParams())
     }
 
     fun vardaUpdate(db: Database.Connection) {

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaResetService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaResetService.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.VardaAsyncJob
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.varda.integration.VardaClient
 import fi.espoo.evaka.varda.integration.VardaTokenProvider
 import mu.KotlinLogging
@@ -58,12 +59,12 @@ class VardaResetService(
         }
     }
 
-    fun resetVardaChildByAsyncJob(db: Database.Connection, msg: VardaAsyncJob.ResetVardaChild) {
+    fun resetVardaChildByAsyncJob(db: Database.Connection, clock: EvakaClock, msg: VardaAsyncJob.ResetVardaChild) {
         logger.info("VardaUpdate: starting to reset child ${msg.childId}")
         resetVardaChild(db, client, msg.childId, feeDecisionMinDate, municipalOrganizerOid)
     }
 
-    fun deleteVardaChildByAsyncJob(db: Database.Connection, msg: VardaAsyncJob.DeleteVardaChild) {
+    fun deleteVardaChildByAsyncJob(db: Database.Connection, clock: EvakaClock, msg: VardaAsyncJob.DeleteVardaChild) {
         logger.info("VardaUpdate: starting to delete child ${msg.vardaChildId}")
         deleteChildDataFromVardaAndDbByVardaId(db, client, msg.vardaChildId)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.VardaAsyncJob
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.minEndDate
 import fi.espoo.evaka.varda.integration.VardaClient
@@ -89,7 +90,7 @@ class VardaUpdateService(
         }
     }
 
-    fun updateVardaChildByAsyncJob(db: Database.Connection, msg: VardaAsyncJob.UpdateVardaChild) {
+    fun updateVardaChildByAsyncJob(db: Database.Connection, clock: EvakaClock, msg: VardaAsyncJob.UpdateVardaChild) {
         logger.info("VardaUpdate: starting to update child ${msg.serviceNeedDiffByChild.childId}")
         updateVardaChild(db, client, msg.serviceNeedDiffByChild, feeDecisionMinDate, ophMunicipalityOid)
         logger.info("VardaUpdate: successfully updated child ${msg.serviceNeedDiffByChild.childId}")


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This allows service integration tests to control the used clock when they call `asyncJobRunner.runPendingJobsSync`.

This does *not* help E2E tests at the moment, because they don't disable async job runner background processing which always uses a real clock. So, even if they call the synchronous API  with a mocked clock, there's no guarantee a background thread hasn't already handled the job with the real clock.