### PR TITLE
Send more realistic assistance action date ranges when Koski accepts just one

### DIFF
--- a/service/src/main/resources/db/migration/R__koski_views.sql
+++ b/service/src/main/resources/db/migration/R__koski_views.sql
@@ -40,7 +40,7 @@ TABLE (
     oph_unit_oid text, oph_organizer_oid text,
     full_range daterange, placement_ranges daterange[], all_placements_in_past bool, last_of_child bool, preparatory_absences jsonb,
     developmental_disability_1 daterange[], developmental_disability_2 daterange[],
-    extended_compulsory_education daterange, transport_benefit daterange,
+    extended_compulsory_education daterange[], transport_benefit daterange[],
     special_assistance_decision_with_group daterange[], special_assistance_decision_without_group daterange[]
 ) AS $$
     SELECT
@@ -91,16 +91,12 @@ TABLE (
     ) an ON true
     JOIN LATERAL (
         SELECT
-            nullif(daterange(
-                min(start_date) FILTER (WHERE 'EXTENDED_COMPULSORY_EDUCATION' = ANY(measures)),
-                max(end_date) FILTER (WHERE 'EXTENDED_COMPULSORY_EDUCATION' = ANY(measures)),
-                '[]'
-            ), daterange(null, null)) AS extended_compulsory_education,
-            nullif(daterange(
-                min(start_date) FILTER (WHERE 'TRANSPORT_BENEFIT' = ANY(measures)),
-                max(end_date) FILTER (WHERE 'TRANSPORT_BENEFIT' = ANY(measures)),
-                '[]'
-            ), daterange(null, null)) AS transport_benefit,
+            array_agg(date_interval) FILTER (
+                WHERE 'EXTENDED_COMPULSORY_EDUCATION' = ANY(measures)
+            ) AS extended_compulsory_education,
+            array_agg(date_interval) FILTER (
+                WHERE 'TRANSPORT_BENEFIT' = ANY(measures)
+            ) AS transport_benefit,
             array_agg(date_interval) FILTER (
                 WHERE 'SPECIAL_ASSISTANCE_DECISION' = ANY(measures) AND 'SPECIAL_GROUP' = ANY(actions)
             ) AS special_assistance_decision_with_group,


### PR DESCRIPTION
In these two cases, Koski only accepts a single date range, but our data model allows any number of date ranges to exist. Instead of taking a blind min/max of the ranges, join them using Timeline and pick the largest one.

**This change invalidates Koski caches and causes a large amount of async jobs**

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

