### PR TITLE
Only consider active message accounts as recipients

### DIFF
--- a/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { UUID } from 'lib-common/types'
+
+import config from '../../config'
+import {
+  insertDaycareGroupFixtures,
+  insertGuardianFixtures,
+  resetDatabase,
+  upsertMessageAccounts
+} from '../../dev-api'
+import {
+  AreaAndPersonFixtures,
+  initializeAreaAndPersonData
+} from '../../dev-api/data-init'
+import { daycareGroupFixture, Fixture } from '../../dev-api/fixtures'
+import { EmployeeDetail } from '../../dev-api/types'
+import CitizenMessagesPage from '../../pages/citizen/citizen-messages'
+import MessagesPage from '../../pages/employee/messages/messages-page'
+import { waitUntilEqual } from '../../utils'
+import { Page } from '../../utils/page'
+import { employeeLogin, enduserLogin, enduserLoginWeak } from '../../utils/user'
+
+let staffPage: Page
+let citizenPage: Page
+let childId: UUID
+let staff: EmployeeDetail
+let fixtures: AreaAndPersonFixtures
+
+beforeEach(async () => {
+  await resetDatabase()
+  fixtures = await initializeAreaAndPersonData()
+  await insertDaycareGroupFixtures([daycareGroupFixture])
+
+  staff = (
+    await Fixture.employeeStaff(fixtures.daycareFixture.id)
+      .withGroupAcl(daycareGroupFixture.id)
+      .save()
+  ).data
+
+  const unitId = fixtures.daycareFixture.id
+  childId = fixtures.enduserChildFixtureJari.id
+
+  const daycarePlacementFixture = await Fixture.placement()
+    .with({
+      childId,
+      unitId
+    })
+    .save()
+  await Fixture.groupPlacement()
+    .with({
+      daycarePlacementId: daycarePlacementFixture.data.id,
+      daycareGroupId: daycareGroupFixture.id
+    })
+    .save()
+  await upsertMessageAccounts()
+  await insertGuardianFixtures([
+    {
+      childId: childId,
+      guardianId: fixtures.enduserGuardianFixture.id
+    }
+  ])
+})
+
+async function initStaffPage() {
+  staffPage = await Page.open()
+  await employeeLogin(staffPage, staff)
+}
+
+async function initCitizenPage() {
+  citizenPage = await Page.open()
+  await enduserLogin(citizenPage)
+}
+
+async function initCitizenPageWeak() {
+  citizenPage = await Page.open()
+  await enduserLoginWeak(citizenPage)
+}
+
+const defaultReply = 'Testivastaus testiviestiin'
+
+const defaultMessage = {
+  title: 'Otsikko',
+  content: 'Testiviestin sisältö'
+}
+
+describe('Sending and receiving messages', () => {
+  const initConfigurations = [
+    { init: initCitizenPage, name: 'direct login' },
+    { init: initCitizenPageWeak, name: 'weak login' }
+  ]
+
+  for (const configuration of initConfigurations) {
+    describe(`Interactions with ${configuration.name}`, () => {
+      beforeEach(async () => {
+        await Promise.all([initStaffPage(), configuration.init()])
+      })
+
+      test('Staff sends message and citizen replies', async () => {
+        await staffPage.goto(`${config.employeeUrl}/messages`)
+        const messagesPage = new MessagesPage(staffPage)
+        await messagesPage.sendNewMessage(defaultMessage)
+
+        await citizenPage.goto(config.enduserMessagesUrl)
+        const citizenMessagesPage = new CitizenMessagesPage(citizenPage)
+        await citizenMessagesPage.assertThreadContent(defaultMessage)
+        await citizenMessagesPage.replyToFirstThread(defaultReply)
+        await waitUntilEqual(() => citizenMessagesPage.getMessageCount(), 2)
+
+        await staffPage.goto(`${config.employeeUrl}/messages`)
+        await waitUntilEqual(() => messagesPage.getReceivedMessageCount(), 1)
+        await messagesPage.assertMessageContent(1, defaultReply)
+      })
+    })
+  }
+})

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -409,6 +409,7 @@ personal_accounts AS (
     JOIN daycare_acl acl ON acl.daycare_id = p.unit_id
     JOIN message_account acc ON acc.employee_id = acl.employee_id
     JOIN message_account_name_view acc_name ON acc_name.id = acc.id
+    WHERE active IS TRUE
 ),
 group_accounts AS (
     SELECT acc.id, g.name, 'GROUP' AS type

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -622,7 +622,7 @@ INSERT INTO guardian (guardian_id, child_id) VALUES (:guardianId, :childId) ON C
             dbc.transaction { tx ->
                 tx.execute("INSERT INTO message_account (daycare_group_id) SELECT id FROM daycare_group ON CONFLICT DO NOTHING")
                 tx.execute("INSERT INTO message_account (person_id) SELECT id FROM person ON CONFLICT DO NOTHING")
-                tx.execute("INSERT INTO message_account (employee_id) SELECT id FROM employee ON CONFLICT DO NOTHING")
+                tx.execute("INSERT INTO message_account (employee_id) SELECT employee_id FROM daycare_acl WHERE role = 'UNIT_SUPERVISOR' ON CONFLICT DO NOTHING")
             }
         }
     }


### PR DESCRIPTION
#### Summary
If an employee is first supervisor, then staff, she has a deactivated message account. Deactivated message accounts should not be used as recipients. With this fix citizen is only able to send messages to groups, not staff who worked previously as the unit's supervisor

