### PR TITLE
Fix attendance upkeep not taking backup care into account

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -85,9 +85,10 @@ WITH attendances_to_end AS (
         -- No placement to this unit anymore, as of today
         NOT EXISTS (
             SELECT 1 FROM placement p
+            LEFT JOIN backup_care bc ON ca.child_id = bc.child_id AND current_date BETWEEN bc.start_date AND bc.end_date
             WHERE
                 p.child_id = ca.child_id AND
-                p.unit_id = ca.unit_id AND
+                (p.unit_id = ca.unit_id OR bc.unit_id = ca.unit_id) AND
                 current_date BETWEEN p.start_date AND p.end_date
         )
     )


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Previously attendance upkeep would end attendances at midnight for every child that had a backup placement into another unit.

