### PR TITLE
Improve realtime occupancy graph for shift care units

### DIFF
--- a/frontend/src/employee-frontend/components/unit/TabAttendances.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabAttendances.tsx
@@ -6,7 +6,7 @@ import React, { useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { UserContext } from 'employee-frontend/state/user'
-import { isLoading, Result } from 'lib-common/api'
+import { combine, isLoading, Result } from 'lib-common/api'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
@@ -125,14 +125,17 @@ export default React.memo(function TabAttendances() {
           </div>
         </DataList>
         <Gap />
-        {renderResult(unitData, (unitData) =>
-          unitData.unitOccupancies ? (
-            <Occupancy
-              filters={filters}
-              occupancies={unitData.unitOccupancies}
-              realtimeStaffAttendanceEnabled={realtimeStaffAttendanceEnabled}
-            />
-          ) : null
+        {renderResult(
+          combine(unitData, unitInformation),
+          ([unitData, unitInformation]) =>
+            unitData.unitOccupancies ? (
+              <Occupancy
+                filters={filters}
+                occupancies={unitData.unitOccupancies}
+                realtimeStaffAttendanceEnabled={realtimeStaffAttendanceEnabled}
+                shiftCareUnit={unitInformation.daycare.roundTheClock}
+              />
+            ) : null
         )}
       </ContentArea>
       <Gap size="s" />

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
@@ -49,12 +49,14 @@ type Props = {
   filters: UnitFilters
   occupancies: UnitOccupancies
   realtimeStaffAttendanceEnabled: boolean
+  shiftCareUnit: boolean
 }
 
 export default React.memo(function OccupancyContainer({
   filters,
   occupancies,
-  realtimeStaffAttendanceEnabled
+  realtimeStaffAttendanceEnabled,
+  shiftCareUnit
 }: Props) {
   const { startDate, endDate } = filters
 
@@ -74,6 +76,7 @@ export default React.memo(function OccupancyContainer({
           realtimeOccupancies={
             realtimeStaffAttendanceEnabled ? occupancies.realtime : null
           }
+          shiftCareUnit={shiftCareUnit}
         />
       ) : (
         <WrapBox>

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancySingleDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancySingleDay.tsx
@@ -29,20 +29,25 @@ interface Props {
   plannedOccupancies: OccupancyResponse
   realizedOccupancies: OccupancyResponse
   realtimeOccupancies: RealtimeOccupancy | null
+  shiftCareUnit: boolean
 }
 
 const OccupancySingleDay = React.memo(function OccupancySingleDay({
   occupancies,
   plannedOccupancies,
   realizedOccupancies,
-  realtimeOccupancies
+  realtimeOccupancies,
+  shiftCareUnit
 }: Props) {
   const { i18n } = useTranslation()
 
   if (realtimeOccupancies) {
     return (
       <Container>
-        <OccupancyDayGraph occupancy={realtimeOccupancies} />
+        <OccupancyDayGraph
+          occupancy={realtimeOccupancies}
+          shiftCareUnit={shiftCareUnit}
+        />
       </Container>
     )
   }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceQueriesTest.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.HelsinkiDateTimeRange
 import fi.espoo.evaka.testDaycare
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -98,7 +99,10 @@ class RealtimeStaffAttendanceQueriesTest : PureJdbiTest(resetDbBeforeEach = true
             assertEquals(listOf("One", "Three", "Four", "Two"), attendances.map { a -> a.firstName })
             assertEquals(listOf(group1.id, group1.id, group2.id, group2.id), attendances.flatMap { a -> a.groupIds })
 
-            val occupancyAttendances = it.getStaffOccupancyAttendances(testDaycare.id, now.toLocalDate())
+            val occupancyAttendances = it.getStaffOccupancyAttendances(
+                testDaycare.id,
+                HelsinkiDateTimeRange(now.atStartOfDay(), now.atEndOfDay())
+            )
             assertEquals(listOf(0.0, 0.0, 3.5, 3.5), occupancyAttendances.map { a -> a.capacity })
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
@@ -37,26 +37,6 @@ class OccupancyController(
     private val acl: AccessControlList,
     private val placementPlanService: PlacementPlanService
 ) {
-    @GetMapping("/by-unit/{unitId}/realtime")
-    fun getRealtimeOccupancy(
-        db: Database,
-        user: AuthenticatedUser,
-        @PathVariable unitId: DaycareId,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
-    ): RealtimeOccupancy {
-        Audit.OccupancyRead.log(targetId = unitId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_OCCUPANCIES, unitId)
-
-        return db.connect { dbc ->
-            dbc.read {
-                RealtimeOccupancy(
-                    childAttendances = it.getChildOccupancyAttendances(unitId, date),
-                    staffAttendances = it.getStaffOccupancyAttendances(unitId, date)
-                )
-            }
-        }
-    }
-
     @GetMapping("/by-unit/{unitId}")
     fun getOccupancyPeriods(
         db: Database,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -88,6 +88,7 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
     jdbi.registerArgument(externalIdArgumentFactory)
     jdbi.registerArgument(idArgumentFactory)
     jdbi.registerArgument(helsinkiDateTimeArgumentFactory)
+    jdbi.registerArgument(helsinkiDateTimeRangeArgumentFactory)
     jdbi.registerArgument(productKeyArgumentFactory)
     jdbi.register(finiteDateRangeColumnMapper)
     jdbi.register(dateRangeColumnMapper)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
@@ -28,6 +28,7 @@ import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.HelsinkiDateTimeRange
 import org.jdbi.v3.core.argument.Argument
 import org.jdbi.v3.core.argument.ArgumentFactory
 import org.jdbi.v3.core.argument.NullArgument
@@ -81,6 +82,13 @@ val idArgumentFactory = customArgumentFactory<Id<*>>(Types.OTHER) { CustomObject
 
 val helsinkiDateTimeArgumentFactory = customArgumentFactory<HelsinkiDateTime>(Types.TIMESTAMP_WITH_TIMEZONE) {
     CustomObjectArgument(it.toZonedDateTime().toOffsetDateTime())
+}
+
+val helsinkiDateTimeRangeArgumentFactory = pgObjectArgumentFactory<HelsinkiDateTimeRange> {
+    PGobject().apply {
+        type = "tstzrange"
+        value = "[${it.start.toInstant()},${it.end.toInstant()})"
+    }
 }
 
 val productKeyArgumentFactory = customArgumentFactory<ProductKey>(Types.VARCHAR) { CustomStringArgument(it.value) }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Fixes realtime occupancy graph not showing ongoing attendances that started yesterday. Also improve the graph's maximum time range for shift care units.

