### PR TITLE
EVAKA-4469 Save assistance need decision when navigating away

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormDaycare.tsx
@@ -47,7 +47,7 @@ export default React.memo(function ApplicationFormDaycare({
 
   useEffect(() => {
     if (shouldLoadServiceNeedOptions) {
-      loadServiceNeedOptions(['DAYCARE', 'DAYCARE_PART_TIME'])
+      void loadServiceNeedOptions(['DAYCARE', 'DAYCARE_PART_TIME'])
     } else {
       setServiceNeedOptions((prev) => (prev.isLoading ? Success.of([]) : prev))
     }

--- a/frontend/src/citizen-frontend/messages/state.tsx
+++ b/frontend/src/citizen-frontend/messages/state.tsx
@@ -135,7 +135,7 @@ export const MessageContextProvider = React.memo(
     useEffect(() => {
       if (threads.currentPage > 0) {
         setThreads((state) => ({ ...state, loadingResult: Loading.of() }))
-        loadMessages(threads.currentPage, t.messages.staffAnnotation)
+        void loadMessages(threads.currentPage, t.messages.staffAnnotation)
       }
     }, [loadMessages, threads.currentPage, t.messages.staffAnnotation])
 
@@ -238,7 +238,7 @@ export const MessageContextProvider = React.memo(
         })
 
         void markThreadRead(selectedThread.id).then(() => {
-          refreshUnreadMessagesCount()
+          void refreshUnreadMessagesCount()
         })
       }
     }, [selectedThread, accountId, refreshUnreadMessagesCount])

--- a/frontend/src/employee-frontend/components/ApplicationPage.tsx
+++ b/frontend/src/employee-frontend/components/ApplicationPage.tsx
@@ -166,7 +166,7 @@ export default React.memo(function ApplicationPage() {
 
   useEffect(() => {
     if (shouldLoadServiceNeedOptions) {
-      loadServiceNeedOptions(['DAYCARE', 'DAYCARE_PART_TIME'])
+      void loadServiceNeedOptions(['DAYCARE', 'DAYCARE_PART_TIME'])
     } else {
       setServiceNeedOptions((prev) => (prev.isLoading ? Success.of([]) : prev))
     }

--- a/frontend/src/employee-frontend/components/SettingsPage.tsx
+++ b/frontend/src/employee-frontend/components/SettingsPage.tsx
@@ -50,7 +50,9 @@ export default React.memo(function SettingsPage() {
 
   const [settings, setSettings] = useState<Result<Settings>>(Loading.of())
   const loadSettings = useRestApi(getSettings, setSettings)
-  useEffect(loadSettings, [loadSettings])
+  useEffect(() => {
+    void loadSettings()
+  }, [loadSettings])
 
   const submit = useCallback(() => {
     if (!settings.isSuccess) return

--- a/frontend/src/employee-frontend/components/UnitFeaturesPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitFeaturesPage.tsx
@@ -46,7 +46,9 @@ export default React.memo(function UnitFeaturesPage() {
   )
 
   const load = useRestApi(getUnitFeatures, setUnitsResult)
-  useEffect(load, [load])
+  useEffect(() => {
+    void load()
+  }, [load])
 
   // editable live copy of data
   const [units, setUnits] = useState<Result<UnitFeatures[]>>(Loading.of())
@@ -76,7 +78,7 @@ export default React.memo(function UnitFeaturesPage() {
           )
         )
       } else {
-        load()
+        void load()
       }
     })
   }

--- a/frontend/src/employee-frontend/components/applications/ApplicationsPage.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsPage.tsx
@@ -110,7 +110,7 @@ export default React.memo(function ApplicationsPage() {
       voucherApplications: debouncedApplicationSearchFilters.voucherApplications
     }
 
-    reloadApplications(page, pageSize, sortBy, sortDirection, params)
+    void reloadApplications(page, pageSize, sortBy, sortDirection, params)
   }, [
     page,
     sortBy,

--- a/frontend/src/employee-frontend/components/child-information/BackupPickup.tsx
+++ b/frontend/src/employee-frontend/components/child-information/BackupPickup.tsx
@@ -53,7 +53,9 @@ function BackupPickup({ id }: BackupPickupProps) {
   >(undefined)
 
   const loadBackupPickups = useRestApi(getChildBackupPickups, setResult)
-  useEffect(() => loadBackupPickups(id), [id, loadBackupPickups])
+  useEffect(() => {
+    void loadBackupPickups(id)
+  }, [id, loadBackupPickups])
 
   const openEditBackupPickupModal = (pickup: ChildBackupPickup) => {
     setBackupPickup(pickup)
@@ -69,7 +71,7 @@ function BackupPickup({ id }: BackupPickupProps) {
     if (result.isSuccess && backupPickup) {
       await removeBackupPickup(backupPickup.id)
       setBackupPickup(undefined)
-      loadBackupPickups(id)
+      void loadBackupPickups(id)
       clearUiMode()
     }
   }
@@ -81,7 +83,7 @@ function BackupPickup({ id }: BackupPickupProps) {
     async function saveBackupPickup() {
       if (name !== '' && phone !== '') {
         await createBackupPickup(id, { name, phone })
-        loadBackupPickups(id)
+        void loadBackupPickups(id)
         setBackupPickup(undefined)
         clearUiMode()
       }
@@ -131,7 +133,7 @@ function BackupPickup({ id }: BackupPickupProps) {
           name: name !== '' ? name : backupPickup.name,
           phone: phone !== '' ? phone : backupPickup.phone
         })
-        loadBackupPickups(id)
+        void loadBackupPickups(id)
         setBackupPickup(undefined)
         clearUiMode()
       }

--- a/frontend/src/employee-frontend/components/child-information/FamilyContacts.tsx
+++ b/frontend/src/employee-frontend/components/child-information/FamilyContacts.tsx
@@ -51,7 +51,9 @@ export default React.memo(function FamilyContacts({
   const { permittedActions } = useContext(ChildContext)
 
   const loadContacts = useRestApi(getFamilyContacts, setResult)
-  useEffect(() => loadContacts(id), [id, loadContacts])
+  useEffect(() => {
+    void loadContacts(id)
+  }, [id, loadContacts])
 
   const contactPriorityOptions = result
     .map((contacts) => {
@@ -67,7 +69,7 @@ export default React.memo(function FamilyContacts({
     .getOrElse([1])
 
   function onCancel() {
-    loadContacts(id)
+    void loadContacts(id)
   }
 
   function onSubmit(personId: UUID) {
@@ -83,7 +85,7 @@ export default React.memo(function FamilyContacts({
             phone: person.phone ?? null,
             backupPhone: person.backupPhone ?? null
           }).then(() => {
-            loadContacts(id)
+            void loadContacts(id)
           })
         })
     })
@@ -228,7 +230,7 @@ export default React.memo(function FamilyContacts({
                               contactPersonId: row.id,
                               priority: value ? Number(value) : null
                             }).then(() => {
-                              loadContacts(id)
+                              void loadContacts(id)
                             })
                           }}
                           placeholder="-"

--- a/frontend/src/employee-frontend/components/child-information/VasuAndLeops.tsx
+++ b/frontend/src/employee-frontend/components/child-information/VasuAndLeops.tsx
@@ -172,7 +172,7 @@ function VasuInitialization({
         filteredTemplates?.isSuccess &&
         filteredTemplates.value.length === 1
       ) {
-        createVasu(childId, filteredTemplates.value[0].id)
+        void createVasu(childId, filteredTemplates.value[0].id)
       }
     },
     [childId, createVasu, filteredTemplates]

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionEditPage.tsx
@@ -18,7 +18,7 @@ import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
-import Button from 'lib-components/atoms/buttons/Button'
+import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Content, { ContentArea } from 'lib-components/layout/Container'
 import StickyFooter from 'lib-components/layout/StickyFooter'
@@ -43,7 +43,8 @@ export default React.memo(function AssistanceNeedDecisionEditPage() {
 
   const { i18n } = useTranslation()
 
-  const { formState, setFormState, status } = useAssistanceNeedDecision(id)
+  const { formState, setFormState, status, forceSave } =
+    useAssistanceNeedDecision(id)
 
   const navigate = useNavigate()
 
@@ -137,25 +138,28 @@ export default React.memo(function AssistanceNeedDecisionEditPage() {
       <Gap size="m" />
       <StickyFooter>
         <FooterContainer>
-          <Button
-            onClick={() => navigate(`/child-information/${childId}`)}
+          <AsyncButton
+            primary
+            text={i18n.childInformation.assistanceNeedDecision.leavePage}
+            onClick={forceSave}
+            onSuccess={() => navigate(`/child-information/${childId}`)}
             data-qa="leave-page-button"
-          >
-            {i18n.childInformation.assistanceNeedDecision.leavePage}
-          </Button>
+            hideSuccess
+          />
           <AutosaveStatusIndicator status={status} />
           <FlexGap />
-          <Button
+          <AsyncButton
             primary
-            onClick={() =>
+            text={i18n.childInformation.assistanceNeedDecision.preview}
+            onClick={forceSave}
+            onSuccess={() =>
               navigate(
                 `/child-information/${childId}/assistance-need-decision/${id}`
               )
             }
             data-qa="preview-button"
-          >
-            {i18n.childInformation.assistanceNeedDecision.preview}
-          </Button>
+            hideSuccess
+          />
         </FooterContainer>
       </StickyFooter>
     </>

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/assistance-need-decision-form.ts
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/assistance-need-decision-form.ts
@@ -20,6 +20,7 @@ export type AssistanceNeedDecisionInfo = {
     SetStateAction<AssistanceNeedDecisionForm | undefined>
   >
   status: AutosaveStatus
+  forceSave: () => Promise<Result<void>>
 }
 
 export function useAssistanceNeedDecision(
@@ -43,7 +44,7 @@ export function useAssistanceNeedDecision(
     [id]
   )
 
-  const { status, setDirty } = useAutosave({
+  const { status, setDirty, forceSave } = useAutosave({
     load: loadDecision,
     onLoaded: setFormState,
     save: putAssistanceNeedDecision,
@@ -58,6 +59,7 @@ export function useAssistanceNeedDecision(
   return {
     formState,
     setFormState,
-    status
+    status,
+    forceSave
   }
 }

--- a/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
@@ -90,7 +90,9 @@ function CreatePlacementModal({ childId, reload }: Props) {
 
   const loadUnits = useRestApi(getDaycares, setUnits)
 
-  useEffect(loadUnits, [loadUnits])
+  useEffect(() => {
+    void loadUnits()
+  }, [loadUnits])
 
   const submitForm = () => {
     if (!form.unit?.id) return

--- a/frontend/src/employee-frontend/components/common/PersonSearch.tsx
+++ b/frontend/src/employee-frontend/components/common/PersonSearch.tsx
@@ -85,7 +85,7 @@ function PersonSearch({
 
   const searchPeople = useRestApi(searchFn, setPersons)
   useEffect(() => {
-    searchPeople(debouncedQuery)
+    void searchPeople(debouncedQuery)
   }, [searchPeople, debouncedQuery])
 
   const filterPeople = (people: PersonSummary[]) =>

--- a/frontend/src/employee-frontend/components/employees/EmployeePage.tsx
+++ b/frontend/src/employee-frontend/components/employees/EmployeePage.tsx
@@ -35,7 +35,7 @@ export default React.memo(function EmployeePage() {
   const loadEmployee = useRestApi(getEmployeeDetails, setEmployee)
 
   useEffect(() => {
-    loadEmployee(id)
+    void loadEmployee(id)
   }, [loadEmployee, id])
 
   useEffect(() => {
@@ -92,7 +92,7 @@ export default React.memo(function EmployeePage() {
               text={i18n.common.save}
               onClick={() => updateEmployee(id, form.globalRoles)}
               onSuccess={() => {
-                loadEmployee(id)
+                void loadEmployee(id)
                 setForm(null)
               }}
             />

--- a/frontend/src/employee-frontend/components/employees/EmployeesPage.tsx
+++ b/frontend/src/employee-frontend/components/employees/EmployeesPage.tsx
@@ -66,7 +66,7 @@ export default React.memo(function EmployeesPage() {
   const loadEmployees = useRestApi(searchEmployees, setEmployeesResult)
 
   useEffect(() => {
-    loadEmployees(page, PAGE_SIZE, debouncedSearchTerm)
+    void loadEmployees(page, PAGE_SIZE, debouncedSearchTerm)
   }, [loadEmployees, page, debouncedSearchTerm])
 
   useEffect(() => setPage(1), [searchTerm])

--- a/frontend/src/employee-frontend/components/fee-decisions/FeeDecisionsPage.tsx
+++ b/frontend/src/employee-frontend/components/fee-decisions/FeeDecisionsPage.tsx
@@ -69,7 +69,7 @@ export default React.memo(function FeeDecisionsPage() {
       searchByStartDate: searchFilters.searchByStartDate,
       financeDecisionHandlerId: searchFilters.financeDecisionHandlerId
     }
-    reloadDecisions(page, pageSize, sortBy, sortDirection, params)
+    void reloadDecisions(page, pageSize, sortBy, sortDirection, params)
   }, [
     page,
     sortBy,

--- a/frontend/src/employee-frontend/components/invoices/invoices-state.ts
+++ b/frontend/src/employee-frontend/components/invoices/invoices-state.ts
@@ -148,7 +148,7 @@ export function useInvoicesState() {
       periodStart: searchFilters.startDate,
       periodEnd: searchFilters.endDate
     }
-    loadInvoices(
+    void loadInvoices(
       state.page,
       pageSize,
       state.sortBy,

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -202,13 +202,13 @@ export const MessageContextProvider = React.memo(
       }
       switch (selectedAccount.view) {
         case 'RECEIVED':
-          loadReceivedMessages(selectedAccount.account.id, page, PAGE_SIZE)
+          void loadReceivedMessages(selectedAccount.account.id, page, PAGE_SIZE)
           break
         case 'SENT':
-          loadSentMessages(selectedAccount.account.id, page, PAGE_SIZE)
+          void loadSentMessages(selectedAccount.account.id, page, PAGE_SIZE)
           break
         case 'DRAFTS':
-          loadMessageDrafts(selectedAccount.account.id)
+          void loadMessageDrafts(selectedAccount.account.id)
       }
     }, [
       loadMessageDrafts,

--- a/frontend/src/employee-frontend/components/payments/payments-state.ts
+++ b/frontend/src/employee-frontend/components/payments/payments-state.ts
@@ -140,7 +140,7 @@ export function usePaymentsState() {
 
   const loadPayments = useRestApi(getPayments, setPaymentsResult)
   const reloadPayments = useCallback(() => {
-    loadPayments({
+    void loadPayments({
       ...searchFilters,
       searchTerms: debouncedSearchTerms,
       page: state.page,

--- a/frontend/src/employee-frontend/components/reports/Decisions.tsx
+++ b/frontend/src/employee-frontend/components/reports/Decisions.tsx
@@ -59,7 +59,7 @@ export default React.memo(function Decisions() {
   const loadReport = useRestApi(getDecisionsReport, setRows)
 
   useEffect(() => {
-    loadReport(filters)
+    void loadReport(filters)
   }, [loadReport, filters])
 
   const filteredRows: DecisionsReportRow[] = useMemo(

--- a/frontend/src/employee-frontend/components/vasu/templates/VasuTemplateEditor.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/VasuTemplateEditor.tsx
@@ -88,7 +88,9 @@ export default React.memo(function VasuTemplateEditor() {
     useState<[number, number, VasuSection]>() // [section, question]
 
   const loadTemplate = useRestApi(getVasuTemplate, setTemplate)
-  useEffect(() => loadTemplate(id), [id, loadTemplate])
+  useEffect(() => {
+    void loadTemplate(id)
+  }, [id, loadTemplate])
   useWarnOnUnsavedChanges(dirty, i18n.vasuTemplates.unsavedWarning)
   usePrompt(i18n.vasuTemplates.unsavedWarning, dirty)
 

--- a/frontend/src/employee-frontend/components/vasu/templates/VasuTemplatesPage.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/VasuTemplatesPage.tsx
@@ -38,7 +38,9 @@ export default React.memo(function VasuTemplatesPage() {
   const [templateToEdit, setTemplateToEdit] = useState<VasuTemplateSummary>()
 
   const loadTemplates = useRestApi(getVasuTemplateSummaries, setTemplates)
-  useEffect(loadTemplates, [loadTemplates])
+  useEffect(() => {
+    void loadTemplates()
+  }, [loadTemplates])
 
   return (
     <Container>
@@ -107,7 +109,7 @@ export default React.memo(function VasuTemplatesPage() {
               if (createModalOpen) {
                 navigate(`/vasu-templates/${id}`)
               } else {
-                loadTemplates()
+                void loadTemplates()
                 setTemplateToEdit(undefined)
               }
             }}

--- a/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionsPage.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionsPage.tsx
@@ -77,7 +77,7 @@ export default React.memo(function VoucherValueDecisionsPage() {
       endDate: searchFilters.endDate,
       searchByStartDate: searchFilters.searchByStartDate
     }
-    reloadDecisions(page, pageSize, sortBy, sortDirection, params)
+    void reloadDecisions(page, pageSize, sortBy, sortDirection, params)
   }, [
     page,
     sortBy,

--- a/frontend/src/employee-frontend/state/child.tsx
+++ b/frontend/src/employee-frontend/state/child.tsx
@@ -80,7 +80,9 @@ export const ChildContextProvider = React.memo(function ChildContextProvider({
     []
   )
   const loadChild = useRestApi(getChildDetails, setFullChildResponse)
-  useEffect(() => loadChild(id), [loadChild, id])
+  useEffect(() => {
+    void loadChild(id)
+  }, [loadChild, id])
 
   const person = useMemo(
     () => childResponse.map((response) => response.person),

--- a/frontend/src/employee-frontend/state/person.tsx
+++ b/frontend/src/employee-frontend/state/person.tsx
@@ -74,7 +74,9 @@ export const PersonContextProvider = React.memo(function PersonContextProvider({
     []
   )
   const loadPerson = useRestApi(getPersonDetails, setFullPersonResponse)
-  useEffect(() => loadPerson(id), [loadPerson, id])
+  useEffect(() => {
+    void loadPerson(id)
+  }, [loadPerson, id])
 
   const [family, reloadFamily] = useApiState(() => getFamilyOverview(id), [id])
 

--- a/frontend/src/employee-frontend/utils/income.ts
+++ b/frontend/src/employee-frontend/utils/income.ts
@@ -21,7 +21,7 @@ export function useIncomeTypeOptions() {
     setIncomeTypeOptions
   )
   useEffect(() => {
-    loadIncomeTypeOptions()
+    void loadIncomeTypeOptions()
   }, [loadIncomeTypeOptions])
 
   return incomeTypeOptions

--- a/frontend/src/employee-frontend/utils/use-autosave.ts
+++ b/frontend/src/employee-frontend/utils/use-autosave.ts
@@ -30,6 +30,7 @@ export type Autosave = {
   status: AutosaveStatus
   setStatus: React.Dispatch<React.SetStateAction<AutosaveStatus>>
   setDirty: () => void
+  forceSave: () => Promise<Result<void>>
 }
 
 export type AutosaveParams<T, F extends ApiFunction> = {
@@ -96,7 +97,9 @@ export function useAutosave<T, F extends ApiFunction>({
 
   const saveNow = useCallback(() => {
     setStatus((prev) => ({ ...prev, state: 'saving' }))
-    internalSave(...getSaveParameters())
+    return internalSave(...getSaveParameters()).then((res) =>
+      res.map(() => undefined)
+    )
   }, [internalSave, getSaveParameters])
 
   const [debouncedSave] = useDebouncedCallback(saveNow, debounceInterval)
@@ -127,6 +130,7 @@ export function useAutosave<T, F extends ApiFunction>({
   return {
     status,
     setStatus,
-    setDirty
+    setDirty,
+    forceSave: saveNow
   }
 }

--- a/frontend/src/employee-mobile-frontend/state/messages.tsx
+++ b/frontend/src/employee-mobile-frontend/state/messages.tsx
@@ -166,7 +166,7 @@ export const MessageContextProvider = React.memo(
 
     useEffect(() => {
       if (selectedAccount && !selectedThread) {
-        loadReceivedMessages(selectedAccount.account.id, page, PAGE_SIZE)
+        void loadReceivedMessages(selectedAccount.account.id, page, PAGE_SIZE)
         reloadUnreadCounts()
       }
     }, [

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -52,6 +52,7 @@ export interface Props<T> {
   disabled?: boolean
   className?: string
   'data-qa'?: string
+  hideSuccess?: boolean
 }
 
 function AsyncButton<T>({
@@ -66,6 +67,7 @@ function AsyncButton<T>({
   onClick,
   onSuccess,
   onFailure,
+  hideSuccess = false,
   ...props
 }: Props<T>) {
   const { colors } = useTheme()
@@ -176,12 +178,14 @@ function AsyncButton<T>({
 
   const showIcon = buttonState.state !== 'idle'
 
-  const container = useSpring<{ x: number }>({ x: showIcon ? 1 : 0 })
+  const container = useSpring<{ x: number }>({
+    x: !hideSuccess && showIcon ? 1 : 0
+  })
   const spinner = useSpring<{ opacity: number }>({
     opacity: isInProgress ? 1 : 0
   })
   const checkmark = useSpring<{ opacity: number }>({
-    opacity: isSuccess ? 1 : 0
+    opacity: !hideSuccess && isSuccess ? 1 : 0
   })
   const cross = useSpring<{ opacity: number }>({
     opacity: isFailure ? 1 : 0

--- a/frontend/src/lib-components/employee/messages/useDraft.ts
+++ b/frontend/src/lib-components/employee/messages/useDraft.ts
@@ -53,7 +53,7 @@ export function useDraft({
   useEffect(() => {
     if (!id && saveState === 'dirty' && !initializing && draft) {
       setInitializing(true)
-      initDraft(draft.accountId)
+      void initDraft(draft.accountId)
     }
   }, [id, initDraft, draft, saveState, initializing])
 
@@ -66,7 +66,7 @@ export function useDraft({
   const saveNow = useCallback(
     (params: SaveDraftParams) => {
       setSaveState('saving')
-      save(params)
+      void save(params)
     },
     [save]
   )


### PR DESCRIPTION
#### Summary

- Adds saving of the assistance need decision form when clicking the exit or preview buttons before navigation
- Modifies the `useRestApi` hook function to return the result of the action so that the function can be used in `AsyncButton`s
- New option in `AsyncButton` that hides the success checkmark
  - Useful in buttons that cause immediate navigation, as the animation is not useful there