### PR TITLE
Bump spring boot to 2.7.1

### DIFF
--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -66,6 +66,6 @@ dependencies {
     api(platform("org.jdbi:jdbi3-bom:3.28.0"))
     api(platform("org.jetbrains.kotlin:kotlin-bom:1.6.21"))
     api(platform("org.junit:junit-bom:5.8.2"))
-    api(platform("org.springframework.boot:spring-boot-dependencies:2.7.0"))
+    api(platform("org.springframework.boot:spring-boot-dependencies:2.7.1"))
     api(platform("software.amazon.awssdk:bom:2.17.164"))
 }

--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -55,4 +55,13 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         ]]></notes>
         <cve>CVE-2022-34305</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppressed as this does not affect evaka
+
+        Versions of the Amazon AWS Apache Log4j hotpatch package before log4j-cve-2021-44228-hotpatch-1.3.5 are affected 
+        by a race condition that could lead to a local privilege escalation
+        ]]></notes>
+        <cve>CVE-2022-33915</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Summary
-Suppress CVE-2022-33915 for now
-bump spring boot version

