### PR TITLE
Fix race condition in useAutosave w/ saving-dirty

### DIFF
--- a/frontend/src/employee-frontend/utils/use-autosave.ts
+++ b/frontend/src/employee-frontend/utils/use-autosave.ts
@@ -78,7 +78,16 @@ export function useAutosave<T, F extends ApiFunction>({
       loading: () => null,
       failure: () => setStatus((prev) => ({ ...prev, state: 'save-error' })),
       success: () => {
-        setStatus({ state: 'clean', savedAt: new Date() })
+        setStatus((prev) => {
+          if (prev.state === 'saving-dirty') {
+            return {
+              ...prev,
+              state: 'dirty'
+            }
+          }
+
+          return { state: 'clean', savedAt: new Date() }
+        })
       }
     })
   }, [])


### PR DESCRIPTION
#### Summary

If a save debounce happens while another save is happening, the first save will change the status to clean on completion, which is not correct as there is dirty data waiting to be saved from the second save. The language selection test happened to be timed in such a way that often the autosave status would be clean when it hadn't actually saved the language, because the first save debounce that happens on page load changed the status to clean when the language wasn't updated after all.