### PR TITLE
EVAKA-4469 Vasu updates and changes

### DIFF
--- a/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
@@ -67,7 +67,7 @@ export default React.memo(function VasuPage() {
     setGuardianHasGivenPermissionToShare
   } = useVasu(id)
 
-  const dynamicSectionsOffset = 1
+  const dynamicSectionsOffset = content.hasDynamicFirstSection ? 0 : 1
 
   return (
     <VasuContainer gapSize="zero" data-qa="vasu-preview">
@@ -81,19 +81,22 @@ export default React.memo(function VasuPage() {
           </ButtonContainer>
           <Main>
             <CitizenVasuHeader document={vasu} />
-            <CitizenBasicsSection
-              sectionIndex={0}
-              type={vasu.type}
-              basics={vasu.basics}
-              childLanguage={vasu.basics.childLanguage}
-              templateRange={vasu.templateRange}
-              translations={translations}
-            />
+            {!content.hasDynamicFirstSection && (
+              <CitizenBasicsSection
+                sectionIndex={0}
+                type={vasu.type}
+                basics={vasu.basics}
+                childLanguage={vasu.basics.childLanguage}
+                templateRange={vasu.templateRange}
+                translations={translations}
+              />
+            )}
             <CitizenDynamicSections
               sections={content.sections}
               sectionIndex={dynamicSectionsOffset}
               state={vasu.documentState}
               translations={translations}
+              vasu={vasu}
             />
             <Gap size="s" />
             <CitizenVasuEvents document={vasu} content={content} />

--- a/frontend/src/citizen-frontend/child-documents/vasu/components/FollowupQuestion.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/components/FollowupQuestion.tsx
@@ -5,52 +5,14 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { Followup, FollowupEntry } from 'lib-common/api-types/vasu'
-import { PermittedFollowupActions } from 'lib-common/api-types/vasu'
-import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
+import { Followup } from 'lib-common/api-types/vasu'
 import { Dimmed, H2, Label } from 'lib-components/typography'
-import { defaultMargins } from 'lib-components/white-space'
 import { VasuTranslations } from 'lib-customizations/employee'
-
-import { useTranslation } from '../../../localization'
 
 import { QuestionProps } from './question-props'
 
-const FollowupEntryElement = React.memo(function FollowupEntryElement({
-  entry
-}: {
-  entry: FollowupEntry
-}) {
-  const i18n = useTranslation()
-
-  return (
-    <Entry>
-      <EntryText data-qa="vasu-followup-entry-text">{entry.text}</EntryText>
-      <FixedSpaceRow>
-        <Dimmed data-qa="vasu-followup-entry-metadata">
-          {entry.date.format()} {entry.authorName}
-          {entry.edited &&
-            `, ${i18n.vasu.edited} ${entry.edited?.editedAt.format() ?? ''} ${
-              entry.edited?.editorName ?? ''
-            }`}
-        </Dimmed>
-      </FixedSpaceRow>
-    </Entry>
-  )
-})
-
-const Entry = styled.div`
-  margin: ${defaultMargins.m} 0px;
-`
-
-const EntryText = styled.p`
-  white-space: pre-line;
-  margin: 0px 0px ${defaultMargins.xxs} 0px;
-`
-
 interface FollowupQuestionProps extends QuestionProps<Followup> {
   translations: VasuTranslations
-  permittedFollowupActions?: PermittedFollowupActions
 }
 
 export default React.memo(function FollowupQuestion({
@@ -67,9 +29,13 @@ export default React.memo(function FollowupQuestion({
 
       <div>
         {value.length > 0 ? (
-          value.map((entry, ix) => (
-            <FollowupEntryElement key={ix} entry={entry} />
-          ))
+          <ul>
+            {value.map((entry, ix) => (
+              <li key={ix}>
+                {entry.date.format()}: {entry.text}
+              </li>
+            ))}
+          </ul>
         ) : (
           <Dimmed>{translations.noRecord}</Dimmed>
         )}

--- a/frontend/src/citizen-frontend/child-documents/vasu/components/MultiFieldQuestion.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/components/MultiFieldQuestion.tsx
@@ -5,7 +5,9 @@
 import React from 'react'
 
 import { MultiFieldQuestion } from 'lib-common/api-types/vasu'
+import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { Label } from 'lib-components/typography'
+import { Gap } from 'lib-components/white-space'
 import { VasuTranslations } from 'lib-customizations/employee'
 
 import { ValueOrNoRecord } from './ValueOrNoRecord'
@@ -26,13 +28,30 @@ export default React.memo(function MultiFieldQuestion({
         {questionNumber} {question.name}
       </Label>
 
-      <ValueOrNoRecord
-        text={question.value
-          .map((v) => v.trim())
-          .join(' ')
-          .trim()}
-        translations={translations}
-      />
+      {question.separateRows ? (
+        <>
+          <Gap size="s" />
+          <FixedSpaceColumn spacing="s">
+            {question.keys.map((key, index) => (
+              <FixedSpaceColumn key={key.name} spacing="xxs">
+                <Label>{key.name}</Label>
+                <ValueOrNoRecord
+                  text={question.value[index]}
+                  translations={translations}
+                />
+              </FixedSpaceColumn>
+            ))}
+          </FixedSpaceColumn>
+        </>
+      ) : (
+        <ValueOrNoRecord
+          text={question.value
+            .map((v) => v.trim())
+            .join(' ')
+            .trim()}
+          translations={translations}
+        />
+      )}
     </div>
   )
 })

--- a/frontend/src/citizen-frontend/child-documents/vasu/components/StaticInfoSubsection.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/components/StaticInfoSubsection.tsx
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+
+import FiniteDateRange from 'lib-common/finite-date-range'
+import { CurriculumType, VasuBasics } from 'lib-common/generated/api-types/vasu'
+import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import { Label } from 'lib-components/typography'
+import { Gap } from 'lib-components/white-space'
+import { VasuTranslations } from 'lib-customizations/employee'
+
+type Props = {
+  basics: VasuBasics
+  translations: VasuTranslations
+  type: CurriculumType
+  templateRange: FiniteDateRange
+}
+
+export default React.memo(function StaticInfoSubsection({
+  basics,
+  translations,
+  type,
+  templateRange
+}: Props) {
+  const t = translations.staticSections.basics
+
+  return (
+    <FixedSpaceColumn spacing="xxs">
+      <Label>{t.name}</Label>
+      <div>
+        {basics.child.firstName} {basics.child.lastName}
+      </div>
+
+      <Gap size="s" />
+
+      <Label>{t.dateOfBirth}</Label>
+      <div>{basics.child.dateOfBirth.format()}</div>
+
+      <Gap size="s" />
+
+      <Label>{t.placements[type]}</Label>
+      {basics.placements?.map((p) => (
+        <div key={p.range.start.formatIso()}>
+          {p.unitName} ({p.groupName}) {p.range.start.format()} -{' '}
+          {p.range.end.isAfter(templateRange.end) ? '' : p.range.end.format()}
+        </div>
+      ))}
+
+      <Gap size="s" />
+
+      <Label>{t.guardians}</Label>
+      {basics.guardians.map((g) => (
+        <div key={g.id}>
+          {g.firstName} {g.lastName}
+        </div>
+      ))}
+    </FixedSpaceColumn>
+  )
+})

--- a/frontend/src/citizen-frontend/child-documents/vasu/components/VasuStateChip.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/components/VasuStateChip.tsx
@@ -9,7 +9,7 @@ import { StaticChip } from 'lib-components/atoms/Chip'
 import colors from 'lib-customizations/common'
 
 const vasuStateChip: Record<VasuDocumentState, string> = {
-  DRAFT: colors.accents.a5orangeLight,
+  DRAFT: colors.accents.a7mint,
   READY: colors.accents.a4violet,
   REVIEWED: colors.main.m1,
   CLOSED: colors.grayscale.g15

--- a/frontend/src/citizen-frontend/child-documents/vasu/sections/CitizenDynamicSections.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/sections/CitizenDynamicSections.tsx
@@ -24,7 +24,9 @@ import MultiFieldQuestionElem from '../components/MultiFieldQuestion'
 import { MultiSelectQuestion as MultiSelectQuestionElem } from '../components/MultiSelectQuestion'
 import ParagraphElem from '../components/Paragraph'
 import { RadioGroupQuestion as RadioGroupQuestionElem } from '../components/RadioGroupQuestion'
+import StaticInfoSubsection from '../components/StaticInfoSubsection'
 import { TextQuestion as TextQuestionElem } from '../components/TextQuestion'
+import { CitizenVasuMetadata } from '../use-vasu'
 import {
   getQuestionNumber,
   isCheckboxQuestion,
@@ -35,6 +37,7 @@ import {
   isMultiSelectQuestion,
   isParagraph,
   isRadioGroupQuestion,
+  isStaticInfoSubsection,
   isTextQuestion
 } from '../vasu-content'
 
@@ -43,13 +46,15 @@ interface Props {
   sectionIndex: number
   state: VasuDocumentState
   translations: VasuTranslations
+  vasu: CitizenVasuMetadata
 }
 
 export function CitizenDynamicSections({
   sections,
   sectionIndex: sectionOffset,
   state,
-  translations
+  translations,
+  vasu
 }: Props) {
   const content = sections.map((section, sectionIndex) => {
     if (section.hideBeforeReady && state === 'DRAFT') {
@@ -160,6 +165,13 @@ export function CitizenDynamicSections({
                     />
                   ) : isParagraph(question) ? (
                     <ParagraphElem question={question} />
+                  ) : isStaticInfoSubsection(question) ? (
+                    <StaticInfoSubsection
+                      type={vasu.type}
+                      basics={vasu.basics}
+                      templateRange={vasu.templateRange}
+                      translations={translations}
+                    />
                   ) : undefined}
                 </Fragment>
               )

--- a/frontend/src/citizen-frontend/child-documents/vasu/use-vasu.ts
+++ b/frontend/src/citizen-frontend/child-documents/vasu/use-vasu.ts
@@ -29,7 +29,7 @@ export interface CitizenVasuStatus {
   savedAt?: Date
 }
 
-type CitizenVasuMetadata = Omit<
+export type CitizenVasuMetadata = Omit<
   VasuDocument,
   | 'content'
   | 'authorsContent'
@@ -50,7 +50,10 @@ interface CitizenVasu {
 export function useVasu(id: string): CitizenVasu {
   const [status, setStatus] = useState<CitizenVasuStatus>({ state: 'loading' })
   const [vasu, setVasu] = useState<CitizenVasuMetadata>()
-  const [content, setContent] = useState<VasuContent>({ sections: [] })
+  const [content, setContent] = useState<VasuContent>({
+    sections: [],
+    hasDynamicFirstSection: false
+  })
   const [childLanguage, setChildLanguage] = useState<ChildLanguage | null>(null)
   const [
     guardianHasGivenPermissionToShare,

--- a/frontend/src/citizen-frontend/child-documents/vasu/vasu-content.ts
+++ b/frontend/src/citizen-frontend/child-documents/vasu/vasu-content.ts
@@ -12,10 +12,12 @@ import {
   MultiSelectQuestion,
   Paragraph,
   RadioGroupQuestion,
+  StaticInfoSubsection,
   TextQuestion,
   VasuQuestion
 } from 'lib-common/api-types/vasu'
 import { VasuContent, VasuSection } from 'lib-common/generated/api-types/vasu'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 
@@ -69,6 +71,12 @@ export function isParagraph(question: VasuQuestion): question is Paragraph {
   return question.type === 'PARAGRAPH'
 }
 
+export function isStaticInfoSubsection(
+  question: VasuQuestion
+): question is StaticInfoSubsection {
+  return question.type === 'STATIC_INFO_SUBSECTION'
+}
+
 function isDateQuestionJson(
   question: JsonOf<VasuQuestion>
 ): question is JsonOf<DateQuestion> {
@@ -88,6 +96,7 @@ function isRadioGroupQuestionJson(
 }
 
 export const mapVasuContent = (content: JsonOf<VasuContent>): VasuContent => ({
+  ...content,
   sections: content.sections.map((section: JsonOf<VasuSection>) => ({
     ...section,
     questions: section.questions.map((question: JsonOf<VasuQuestion>) =>
@@ -105,7 +114,11 @@ export const mapVasuContent = (content: JsonOf<VasuContent>): VasuContent => ({
               edited: entry.edited && {
                 ...entry.edited,
                 editedAt: LocalDate.parseIso(entry.edited.editedAt)
-              }
+              },
+              createdDate:
+                typeof entry.createdDate === 'string'
+                  ? HelsinkiDateTime.parseIso(entry.createdDate)
+                  : undefined
             }))
           }
         : isRadioGroupQuestionJson(question)
@@ -132,7 +145,7 @@ export function getQuestionNumber(
       break
     }
 
-    if (!isParagraph(q) && !isFollowup(q)) {
+    if (!isParagraph(q) && !isFollowup(q) && !isStaticInfoSubsection(q)) {
       questionIndex += 1
     }
   }

--- a/frontend/src/e2e-test/pages/employee/vasu/pageSections.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/pageSections.ts
@@ -4,7 +4,26 @@
 
 import { TextInput, Element } from '../../../utils/page'
 
-export class AuthorsSection extends Element {
+class SimpleTextAreaSection extends Element {
+  protected readonly textareas = this.findAll('[data-qa="text-question-input"]')
+  protected readonly values = this.findAll('[data-qa="value-or-no-record"]')
+}
+
+export class BasicInfoSection extends SimpleTextAreaSection {
+  readonly childName = this.findByDataQa('vasu-basic-info-child-name').innerText
+  readonly childDateOfBirth = this.findByDataQa('vasu-basic-info-child-dob')
+    .innerText
+  placement = (nth: number) =>
+    this.findAllByDataQa('vasu-basic-info-placement').nth(nth).innerText
+  guardian = (nth: number) =>
+    this.findAllByDataQa('vasu-basic-info-guardian').nth(nth).innerText
+  readonly additionalContactInfoInput = new TextInput(this.textareas.nth(0))
+  get additionalContactInfo() {
+    return this.values.nth(0).innerText
+  }
+}
+
+export class AuthoringSection extends SimpleTextAreaSection {
   readonly #primaryInputs = this.findAll(
     '[data-qa="multi-field-question"] input'
   )
@@ -27,6 +46,9 @@ export class AuthorsSection extends Element {
   otherPhoneNumberInput = (ix: number) =>
     new TextInput(this.otherFieldsInputs(ix).nth(3))
 
+  childPOVInput = new TextInput(this.textareas.nth(4))
+  guardianPOVInput = new TextInput(this.textareas.nth(5))
+
   readonly #primaryValue = this.findAll(
     '[data-qa="multi-field-question"] [data-qa="value-or-no-record"]'
   ).first()
@@ -46,64 +68,53 @@ export class AuthorsSection extends Element {
   get otherValues(): Promise<string> {
     return this.#otherFieldsValues.innerText
   }
+
+  get childPOV() {
+    return this.values.nth(2).innerText
+  }
+
+  get guardianPOV() {
+    return this.values.nth(3).innerText
+  }
 }
 
-class SimpleTextAreaSection extends Element {
-  protected readonly textareas = this.findAll('[data-qa="text-question-input"]')
-  protected readonly values = this.findAll('[data-qa="value-or-no-record"]')
+export class CooperationSection extends SimpleTextAreaSection {
+  collaboratorsInput = new TextInput(this.textareas.nth(0))
+  methodsOfCooperationInput = new TextInput(this.textareas.nth(1))
+
+  collaborators = this.values.nth(0).innerText
+  methodsOfCooperation = this.values.nth(1).innerText
 }
 
-export class ConsiderationsSection extends SimpleTextAreaSection {
-  childsViewInput = new TextInput(this.textareas.nth(0))
-  guardiansViewInput = new TextInput(this.textareas.nth(1))
+export class VasuGoalsSection extends SimpleTextAreaSection {
+  goalsRealizationInput = new TextInput(this.textareas.nth(0))
+  specialNeedsEstimationInput = new TextInput(this.textareas.nth(1))
+  otherObservationsInput = new TextInput(this.textareas.nth(2))
 
-  childsView = this.values.nth(0).innerText
-  guardiansView = this.values.nth(1).innerText
-}
-
-export class PreviousVasuGoalsSection extends SimpleTextAreaSection {
-  goalsRealizedInput = new TextInput(this.textareas.nth(0))
-  otherObservationsInput = new TextInput(this.textareas.nth(1))
-
-  goalsRealized = this.values.nth(0).innerText
-  otherObservations = this.values.nth(1).innerText
+  goalsRealization = this.values.nth(0).innerText
+  specialNeedsEstimation = this.values.nth(1).innerText
+  otherObservations = this.values.nth(2).innerText
 }
 
 export class GoalsSection extends SimpleTextAreaSection {
   childsStrengthsInput = new TextInput(this.textareas.nth(0))
-  goalsForTeachersInput = new TextInput(this.textareas.nth(1))
-  otherInput = new TextInput(this.textareas.nth(2))
+  languageViewsInput = new TextInput(this.textareas.nth(1))
+  pedagogicalSupportInput = new TextInput(this.textareas.nth(2))
+  structuralSupportInput = new TextInput(this.textareas.nth(3))
+  therapeuticSupportInput = new TextInput(this.textareas.nth(4))
+  staffGoalsInput = new TextInput(this.textareas.nth(5))
+  actionsInput = new TextInput(this.textareas.nth(6))
+  otherInput = new TextInput(this.textareas.nth(7))
 
   childsStrengths = this.values.nth(0).innerText
-  goalsForTeachers = this.values.nth(1).innerText
-  other = this.values.nth(2).innerText
-}
-
-export class SpecialSupportSection extends SimpleTextAreaSection {
-  specialSupportEnabledInput = this.find('[data-qa="checkbox-question"]')
-
-  get specialSupportEnabled() {
-    return this.values.nth(0).innerText
-  }
-
-  get optionalFields() {
-    return {
-      previousSpecialSupportInput: new TextInput(this.textareas.nth(0)),
-      currentSpecialSupportInput: new TextInput(this.textareas.nth(1)),
-      staffResponsibilitiesInput: new TextInput(this.textareas.nth(2)),
-      carerChildCooperationInput: new TextInput(this.textareas.nth(3))
-    }
-  }
-
-  get optionalFieldValues() {
-    return {
-      previousSpecialSupport: this.values.nth(1).innerText,
-      currentSpecialSupport: this.values.nth(2).innerText,
-      staffResponsibilities: this.values.nth(3).innerText,
-      carerChildCooperation: this.values.nth(4).innerText,
-      supportLevel: this.values.nth(5).innerText
-    }
-  }
+  languageViews = this.values.nth(1).innerText
+  pedagogicalSupport = this.values.nth(2).innerText
+  structuralSupport = this.values.nth(3).innerText
+  therapeuticSupport = this.values.nth(4).innerText
+  staffGoals = this.values.nth(5).innerText
+  actions = this.values.nth(6).innerText
+  supportLevel = this.values.nth(7).innerText
+  other = this.values.nth(8).innerText
 
   supportLevelOptions = (key: string) =>
     this.findByDataQa(`radio-group-date-question-option-${key}`)
@@ -117,9 +128,9 @@ export class SpecialSupportSection extends SimpleTextAreaSection {
     )
 }
 
-export class WellnessSupportSection extends SimpleTextAreaSection {
-  wellnessInput = new TextInput(this.textareas.nth(0))
-  wellness = this.values.nth(0).innerText
+export class OtherSection extends SimpleTextAreaSection {
+  otherInput = new TextInput(this.textareas.nth(0))
+  other = this.values.nth(0).innerText
 }
 
 export class OtherDocsAndPlansSection extends SimpleTextAreaSection {
@@ -132,13 +143,8 @@ export class InfoSharedToSection extends Element {
     this.find(`[data-qa="multi-select-question-option-${key}"]`)
   otherInput = new TextInput(this.find('[data-qa="text-question-input"]'))
 
-  recipients = this.find(`[data-qa="value-or-no-record-9.1"]`)
+  recipients = this.find(`[data-qa="value-or-no-record-8.1"]`)
   other = this.find(`[data-qa="value-or-no-record"]`)
-}
-
-export class AdditionalInfoSection extends SimpleTextAreaSection {
-  infoInput = new TextInput(this.textareas.nth(0))
-  info = this.values.nth(0).innerText
 }
 
 export class DiscussionSection extends SimpleTextAreaSection {
@@ -152,13 +158,7 @@ export class DiscussionSection extends SimpleTextAreaSection {
 }
 
 export class EvaluationSection extends SimpleTextAreaSection {
-  dateInput = new TextInput(this.find('[data-qa="date-question-picker"]'))
-  participantsInput = new TextInput(this.textareas.nth(0))
-  collaborationWithGuardiansInput = new TextInput(this.textareas.nth(1))
-  evaluationOfGoalsInput = new TextInput(this.textareas.nth(2))
+  descriptionInput = new TextInput(this.textareas.nth(0))
 
-  date = this.values.nth(0).innerText
-  participants = this.values.nth(1).innerText
-  collaborationWithGuardians = this.values.nth(2).innerText
-  evaluationOfGoals = this.values.nth(3).innerText
+  description = this.values.nth(0).innerText
 }

--- a/frontend/src/employee-frontend/components/common/AutosaveStatusIndicator.tsx
+++ b/frontend/src/employee-frontend/components/common/AutosaveStatusIndicator.tsx
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import styled from 'styled-components'
 
 import { useTranslation } from 'employee-frontend/state/i18n'
 import { AutosaveStatus } from 'employee-frontend/utils/use-autosave'
 import { formatTime } from 'lib-common/date'
-import { fontWeights, P } from 'lib-components/typography'
-import { theme } from 'lib-customizations/common'
+import { InformationText } from 'lib-components/typography'
 
 export default React.memo(function AutosaveStatusIndicator({
   status
@@ -37,18 +35,8 @@ export default React.memo(function AutosaveStatusIndicator({
   }
 
   return (
-    <Indicator
-      preserveWhiteSpace
-      noMargin
-      color={theme.colors.grayscale.g70}
-      data-status={status.state}
-      data-qa="autosave-indicator"
-    >
+    <InformationText data-status={status.state} data-qa="autosave-indicator">
       {formatStatus(status)}
-    </Indicator>
+    </InformationText>
   )
 })
-
-const Indicator = styled(P)`
-  font-weight: ${fontWeights.bold};
-`

--- a/frontend/src/employee-frontend/components/common/VasuStateChip.tsx
+++ b/frontend/src/employee-frontend/components/common/VasuStateChip.tsx
@@ -9,7 +9,7 @@ import { StaticChip } from 'lib-components/atoms/Chip'
 import colors from 'lib-customizations/common'
 
 const vasuStateChip: Record<VasuDocumentState, string> = {
-  DRAFT: colors.accents.a5orangeLight,
+  DRAFT: colors.accents.a7mint,
   READY: colors.accents.a4violet,
   REVIEWED: colors.main.m1,
   CLOSED: colors.grayscale.g15

--- a/frontend/src/employee-frontend/components/vasu/QuestionInfo.tsx
+++ b/frontend/src/employee-frontend/components/vasu/QuestionInfo.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
+import styled from 'styled-components'
 
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 
@@ -13,13 +14,18 @@ interface Props {
   info: string | null
 }
 
+const WhitespacePre = styled.div`
+  white-space: pre-wrap;
+`
+
 export default React.memo(function QuestionInfo({ children, info }: Props) {
   const { i18n } = useTranslation()
   if (info) {
     return (
       <ExpandingInfo
-        info={<div>{info}</div>}
+        info={<WhitespacePre>{info}</WhitespacePre>}
         ariaLabel={i18n.common.openExpandingInfo}
+        width="full"
       >
         {children}
       </ExpandingInfo>

--- a/frontend/src/employee-frontend/components/vasu/VasuEditPage.tsx
+++ b/frontend/src/employee-frontend/components/vasu/VasuEditPage.tsx
@@ -10,9 +10,10 @@ import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
 import Button from 'lib-components/atoms/buttons/Button'
 import Spinner from 'lib-components/atoms/state/Spinner'
-import ButtonContainer from 'lib-components/layout/ButtonContainer'
-import FullWidthDiv from 'lib-components/layout/FullWidthDiv'
-import StickyFooter from 'lib-components/layout/StickyFooter'
+import StickyFooter, {
+  StickyFooterContainer
+} from 'lib-components/layout/StickyFooter'
+import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { defaultMargins } from 'lib-components/white-space'
 
 import { useTranslation } from '../../state/i18n'
@@ -25,13 +26,6 @@ import { DynamicSections } from './sections/DynamicSections'
 import { VasuEvents } from './sections/VasuEvents'
 import { VasuHeader } from './sections/VasuHeader'
 import { useVasu } from './use-vasu'
-
-const FooterContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: ${defaultMargins.s};
-`
 
 const StatusContainer = styled.div`
   display: flex;
@@ -50,83 +44,69 @@ export default React.memo(function VasuEditPage() {
   const { i18n } = useTranslation()
   const navigate = useNavigate()
 
-  const {
-    vasu,
-    content,
-    setContent,
-    childLanguage,
-    setChildLanguage,
-    status,
-    translations,
-    editFollowupEntry,
-    permittedFollowupActions
-  } = useVasu(id)
+  const { vasu, content, setContent, status, translations } = useVasu(id)
 
   const showSpinner = status.state === 'saving'
 
-  const dynamicSectionsOffset = 1
+  const dynamicSectionsOffset = content.hasDynamicFirstSection ? 0 : 1
 
   return (
-    <VasuContainer
-      gapSize="s"
-      data-qa="vasu-container"
-      data-status={status.state}
-    >
-      {vasu && (
-        <>
-          <VasuHeader document={vasu} />
-          <BasicsSection
-            sectionIndex={0}
-            type={vasu.type}
-            basics={vasu.basics}
-            childLanguage={childLanguage}
-            setChildLanguage={setChildLanguage}
-            templateRange={vasu.templateRange}
-            translations={translations}
-          />
-          <DynamicSections
-            sectionIndex={dynamicSectionsOffset}
-            sections={content.sections}
-            setContent={setContent}
-            editFollowupEntry={(entry) =>
-              editFollowupEntry({
-                documentId: vasu.id,
-                entryId: entry.id,
-                text: entry.text
-              })
-            }
-            state={vasu.documentState}
-            permittedFollowupActions={permittedFollowupActions}
-            translations={translations}
-          />
-          <VasuEvents document={vasu} content={content} />
-        </>
-      )}
+    <>
+      <VasuContainer
+        gapSize="s"
+        data-qa="vasu-container"
+        data-status={status.state}
+      >
+        {vasu && (
+          <>
+            <VasuHeader document={vasu} />
+            {!content.hasDynamicFirstSection && (
+              <BasicsSection
+                sectionIndex={0}
+                type={vasu.type}
+                basics={vasu.basics}
+                childLanguage={vasu.basics.childLanguage}
+                templateRange={vasu.templateRange}
+                translations={translations}
+              />
+            )}
+            <DynamicSections
+              sectionIndex={dynamicSectionsOffset}
+              sections={content.sections}
+              setContent={setContent}
+              state={vasu.documentState}
+              translations={translations}
+              vasu={vasu}
+            />
+            <VasuEvents document={vasu} content={content} />
+          </>
+        )}
+      </VasuContainer>
       <StickyFooter>
-        <FooterContainer>
-          <StatusContainer>
-            <AutosaveStatusIndicator status={status} />
-            {showSpinner && <Spinner />}
-          </StatusContainer>
+        <StickyFooterContainer>
           {vasu && (
-            <FullWidthDiv>
-              <ButtonContainer>
-                <Button
-                  text={i18n.vasu.checkInPreview}
-                  disabled={status.state != 'clean'}
-                  onClick={() => navigate(`/vasu/${vasu.id}`)}
-                  data-qa="vasu-preview-btn"
-                  primary
-                />
+            <FixedSpaceRow justifyContent="space-between" flexWrap="wrap">
+              <FixedSpaceRow spacing="s">
                 <LeaveVasuPageButton
                   disabled={status.state != 'clean'}
                   childId={vasu.basics.child.id}
                 />
-              </ButtonContainer>
-            </FullWidthDiv>
+                <StatusContainer>
+                  <AutosaveStatusIndicator status={status} />
+                  {showSpinner && <Spinner />}
+                </StatusContainer>
+              </FixedSpaceRow>
+              <Button
+                text={i18n.vasu.checkInPreview}
+                disabled={status.state != 'clean'}
+                onClick={() => navigate(`/vasu/${vasu.id}`)}
+                data-qa="vasu-preview-btn"
+                primary
+              />
+            </FixedSpaceRow>
           )}
-        </FooterContainer>
+        </StickyFooterContainer>
       </StickyFooter>
-    </VasuContainer>
+    </>
   )
 })

--- a/frontend/src/employee-frontend/components/vasu/VasuPage.tsx
+++ b/frontend/src/employee-frontend/components/vasu/VasuPage.tsx
@@ -30,26 +30,29 @@ export default React.memo(function VasuPage() {
 
   const { vasu, content, translations } = useVasu(id)
 
-  const dynamicSectionsOffset = 1
+  const dynamicSectionsOffset = content.hasDynamicFirstSection ? 0 : 1
 
   return (
     <VasuContainer gapSize="zero" data-qa="vasu-preview">
       {vasu && (
         <>
           <VasuHeader document={vasu} />
-          <BasicsSection
-            sectionIndex={0}
-            type={vasu.type}
-            basics={vasu.basics}
-            childLanguage={vasu.basics.childLanguage}
-            templateRange={vasu.templateRange}
-            translations={translations}
-          />
+          {!content.hasDynamicFirstSection && (
+            <BasicsSection
+              sectionIndex={0}
+              type={vasu.type}
+              basics={vasu.basics}
+              childLanguage={vasu.basics.childLanguage}
+              templateRange={vasu.templateRange}
+              translations={translations}
+            />
+          )}
           <DynamicSections
             sections={content.sections}
             sectionIndex={dynamicSectionsOffset}
             state={vasu.documentState}
             translations={translations}
+            vasu={vasu}
           />
           <Gap size="s" />
           <VasuEvents document={vasu} content={content} />

--- a/frontend/src/employee-frontend/components/vasu/api.ts
+++ b/frontend/src/employee-frontend/components/vasu/api.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Failure, Result, Success } from 'lib-common/api'
-import { GetVasuDocumentResponse } from 'lib-common/api-types/vasu'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import {
   UpdateDocumentRequest,
@@ -79,17 +78,10 @@ export async function getVasuDocumentSummaries(
     .catch((e) => Failure.fromError(e))
 }
 
-export async function getVasuDocument(
-  id: UUID
-): Promise<Result<GetVasuDocumentResponse>> {
+export async function getVasuDocument(id: UUID): Promise<Result<VasuDocument>> {
   return client
-    .get<JsonOf<GetVasuDocumentResponse>>(`/vasu/${id}`)
-    .then((res) =>
-      Success.of({
-        vasu: mapVasuDocumentResponse(res.data.vasu),
-        permittedFollowupActions: res.data.permittedFollowupActions
-      })
-    )
+    .get<JsonOf<VasuDocument>>(`/vasu/${id}`)
+    .then((res) => Success.of(mapVasuDocumentResponse(res.data)))
     .catch((e) => Failure.fromError(e))
 }
 
@@ -123,24 +115,4 @@ export async function updateDocumentState({
     .post(`/vasu/${documentId}/update-state`, { eventType })
     .then(() => Success.of(null))
     .catch((e) => Failure.fromError(e))
-}
-
-export interface EditFollowupEntryParams {
-  documentId: UUID
-  entryId?: UUID
-  text: string
-}
-export async function editFollowupEntry({
-  documentId,
-  entryId,
-  text
-}: EditFollowupEntryParams): Promise<Result<null>> {
-  return entryId
-    ? client
-        .post(`/vasu/${documentId}/edit-followup/${entryId}`, {
-          text
-        })
-        .then(() => Success.of(null))
-        .catch((e) => Failure.fromError(e))
-    : Failure.of({ message: 'cannot edit without entry ID' })
 }

--- a/frontend/src/employee-frontend/components/vasu/components/MultiFieldQuestion.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/MultiFieldQuestion.tsx
@@ -3,15 +3,14 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
+import styled from 'styled-components'
 
 import { MultiFieldQuestion } from 'lib-common/api-types/vasu'
 import InputField from 'lib-components/atoms/form/InputField'
-import {
-  FixedSpaceColumn,
-  FixedSpaceRow
-} from 'lib-components/layout/flex-helpers'
+import TextArea from 'lib-components/atoms/form/TextArea'
+import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { Label } from 'lib-components/typography'
-import { Gap } from 'lib-components/white-space'
+import { defaultMargins, Gap } from 'lib-components/white-space'
 import { VasuTranslations } from 'lib-customizations/employee'
 
 import QuestionInfo from '../QuestionInfo'
@@ -23,6 +22,12 @@ interface Props extends QuestionProps<MultiFieldQuestion> {
   onChange?: (index: number, value: string) => void
   translations: VasuTranslations
 }
+
+export const FixedSpaceRowOrColumns = styled.div<{ columns?: boolean }>`
+  display: flex;
+  flex-direction: ${(p) => (p.columns ? 'column' : 'row')};
+  gap: ${defaultMargins.s};
+`
 
 export default React.memo(function MultiFieldQuestion({
   onChange,
@@ -40,18 +45,46 @@ export default React.memo(function MultiFieldQuestion({
       {onChange ? (
         <>
           <Gap size="m" />
-          <FixedSpaceRow>
+          <FixedSpaceRowOrColumns columns={question.separateRows}>
             {question.keys.map((key, index) => (
               <FixedSpaceColumn key={key.name} spacing="xxs">
-                <Label>{key.name}</Label>
-                <InputField
-                  value={question.value[index]}
-                  onChange={(v) => onChange(index, v)}
-                  width="m"
+                <QuestionInfo info={key.info ?? null}>
+                  <Label>{key.name}</Label>
+                </QuestionInfo>
+                {question.separateRows ? (
+                  <TextArea
+                    value={question.value[index]}
+                    onChange={(v) => onChange(index, v)}
+                    data-qa="text-question-input"
+                  />
+                ) : (
+                  <InputField
+                    value={question.value[index]}
+                    onChange={(v) => onChange(index, v)}
+                    width="m"
+                    data-qa="text-question-input"
+                  />
+                )}
+              </FixedSpaceColumn>
+            ))}
+          </FixedSpaceRowOrColumns>
+        </>
+      ) : question.separateRows ? (
+        <>
+          <Gap size="s" />
+          <FixedSpaceColumn spacing="s">
+            {question.keys.map((key, index) => (
+              <FixedSpaceColumn key={key.name} spacing="xxs">
+                <QuestionInfo info={key.info ?? null}>
+                  <Label>{key.name}</Label>
+                </QuestionInfo>
+                <ValueOrNoRecord
+                  text={question.value[index]}
+                  translations={translations}
                 />
               </FixedSpaceColumn>
             ))}
-          </FixedSpaceRow>
+          </FixedSpaceColumn>
         </>
       ) : (
         <ValueOrNoRecord

--- a/frontend/src/employee-frontend/components/vasu/components/RadioGroupQuestionOption.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/RadioGroupQuestionOption.tsx
@@ -10,7 +10,10 @@ import { useTranslation } from 'employee-frontend/state/i18n'
 import { QuestionOption } from 'lib-common/api-types/vasu'
 import Radio from 'lib-components/atoms/form/Radio'
 import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
+import { Bold } from 'lib-components/typography'
 import { fasExclamationTriangle } from 'lib-icons'
+
+import QuestionInfo from '../QuestionInfo'
 
 import type { RadioGroupSelectedValue } from './RadioGroupQuestion'
 
@@ -81,6 +84,14 @@ export default React.memo(function RadioGroupQuestionOption({
     isSelected,
     rangeIsLinear
   ])
+
+  if (option.isIntervention) {
+    return (
+      <QuestionInfo info={option.info ?? null}>
+        <Bold>{option.name}</Bold>
+      </QuestionInfo>
+    )
+  }
 
   return (
     <OptionContainer>

--- a/frontend/src/employee-frontend/components/vasu/components/StaticInfoSubsection.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/StaticInfoSubsection.tsx
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+
+import FiniteDateRange from 'lib-common/finite-date-range'
+import { CurriculumType, VasuBasics } from 'lib-common/generated/api-types/vasu'
+import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import { Label } from 'lib-components/typography'
+import { Gap } from 'lib-components/white-space'
+import { VasuTranslations } from 'lib-customizations/employee'
+
+type Props = {
+  basics: VasuBasics
+  translations: VasuTranslations
+  type: CurriculumType
+  templateRange: FiniteDateRange
+}
+
+export default React.memo(function StaticInfoSubsection({
+  basics,
+  translations,
+  type,
+  templateRange
+}: Props) {
+  const t = translations.staticSections.basics
+
+  return (
+    <FixedSpaceColumn spacing="xxs">
+      <Label>{t.name}</Label>
+      <div data-qa="vasu-basic-info-child-name">
+        {basics.child.firstName} {basics.child.lastName}
+      </div>
+
+      <Gap size="s" />
+
+      <Label>{t.dateOfBirth}</Label>
+      <div data-qa="vasu-basic-info-child-dob">
+        {basics.child.dateOfBirth.format()}
+      </div>
+
+      <Gap size="s" />
+
+      <Label>{t.placements[type]}</Label>
+      {basics.placements?.map((p) => (
+        <div
+          key={p.range.start.formatIso()}
+          data-qa="vasu-basic-info-placement"
+        >
+          {p.unitName} ({p.groupName}) {p.range.start.format()} -{' '}
+          {p.range.end.isAfter(templateRange.end) ? '' : p.range.end.format()}
+        </div>
+      ))}
+
+      <Gap size="s" />
+
+      <Label>{t.guardians}</Label>
+      {basics.guardians.map((g) => (
+        <div key={g.id} data-qa="vasu-basic-info-guardian">
+          {g.firstName} {g.lastName}
+        </div>
+      ))}
+    </FixedSpaceColumn>
+  )
+})

--- a/frontend/src/employee-frontend/components/vasu/sections/BasicsSection.tsx
+++ b/frontend/src/employee-frontend/components/vasu/sections/BasicsSection.tsx
@@ -21,6 +21,7 @@ import { Gap } from 'lib-components/white-space'
 import { VasuTranslations } from 'lib-customizations/employee'
 
 import QuestionInfo from '../QuestionInfo'
+import StaticInfoSubsection from '../components/StaticInfoSubsection'
 import { ValueOrNoRecord } from '../components/ValueOrNoRecord'
 
 interface Props {
@@ -52,34 +53,12 @@ export function BasicsSection({
 
       <Gap size="m" />
 
-      <Label>{t.name}</Label>
-      <div>
-        {basics.child.firstName} {basics.child.lastName}
-      </div>
-
-      <Gap size="s" />
-
-      <Label>{t.dateOfBirth}</Label>
-      <div>{basics.child.dateOfBirth.format()}</div>
-
-      <Gap size="s" />
-
-      <Label>{t.placements[type]}</Label>
-      {basics.placements?.map((p) => (
-        <div key={p.range.start.formatIso()}>
-          {p.unitName} ({p.groupName}) {p.range.start.format()} -{' '}
-          {p.range.end.isAfter(templateRange.end) ? '' : p.range.end.format()}
-        </div>
-      ))}
-
-      <Gap size="s" />
-
-      <Label>{t.guardians}</Label>
-      {basics.guardians.map((g) => (
-        <div key={g.id}>
-          {g.firstName} {g.lastName}
-        </div>
-      ))}
+      <StaticInfoSubsection
+        type={type}
+        basics={basics}
+        templateRange={templateRange}
+        translations={translations}
+      />
 
       {childLanguage && (
         <>

--- a/frontend/src/employee-frontend/components/vasu/sections/DynamicSections.tsx
+++ b/frontend/src/employee-frontend/components/vasu/sections/DynamicSections.tsx
@@ -37,7 +37,9 @@ import {
   RadioGroupQuestion as RadioGroupQuestionElem,
   RadioGroupSelectedValue
 } from '../components/RadioGroupQuestion'
+import StaticInfoSubsection from '../components/StaticInfoSubsection'
 import { TextQuestion as TextQuestionElem } from '../components/TextQuestion'
+import { VasuMetadata } from '../use-vasu'
 import {
   getQuestionNumber,
   isCheckboxQuestion,
@@ -48,6 +50,7 @@ import {
   isMultiSelectQuestion,
   isParagraph,
   isRadioGroupQuestion,
+  isStaticInfoSubsection,
   isTextQuestion
 } from '../vasu-content'
 
@@ -56,9 +59,8 @@ interface Props {
   sectionIndex: number
   setContent?: Dispatch<SetStateAction<VasuContent>>
   state: VasuDocumentState
-  permittedFollowupActions?: { [key: string]: string[] }
   translations: VasuTranslations
-  editFollowupEntry?: (entry: FollowupEntry) => void
+  vasu: VasuMetadata
 }
 
 export function DynamicSections({
@@ -66,9 +68,8 @@ export function DynamicSections({
   sectionIndex: sectionOffset,
   setContent,
   state,
-  permittedFollowupActions,
   translations,
-  editFollowupEntry
+  vasu
 }: Props) {
   const content = sections.map((section, sectionIndex) => {
     if (section.hideBeforeReady && state === 'DRAFT') {
@@ -293,23 +294,28 @@ export function DynamicSections({
                       question={question}
                       questionNumber={questionNumber}
                       translations={translations}
-                      permittedFollowupActions={permittedFollowupActions}
                       onChange={
                         setContent
-                          ? (value: FollowupEntry) =>
+                          ? (value: FollowupEntry[]) =>
                               setContent((prev) => {
                                 const clone = cloneDeep(prev)
                                 const question1 = clone.sections[sectionIndex]
                                   .questions[questionIndex] as Followup
-                                question1.value.push(value)
+                                question1.value = value
                                 return clone
                               })
                           : undefined
                       }
-                      onEdited={editFollowupEntry}
                     />
                   ) : isParagraph(question) ? (
                     <ParagraphElem question={question} />
+                  ) : isStaticInfoSubsection(question) ? (
+                    <StaticInfoSubsection
+                      type={vasu.type}
+                      basics={vasu.basics}
+                      templateRange={vasu.templateRange}
+                      translations={translations}
+                    />
                   ) : undefined}
                 </Fragment>
               )

--- a/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
@@ -20,10 +20,12 @@ import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import InputField from 'lib-components/atoms/form/InputField'
 import MultiSelect from 'lib-components/atoms/form/MultiSelect'
+import TextArea from 'lib-components/atoms/form/TextArea'
 import {
   FixedSpaceColumn,
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
+import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 import FormModal from 'lib-components/molecules/modals/FormModal'
 import { Label } from 'lib-components/typography'
 import { faCalendarAlt, faCheckCircle, faTrash } from 'lib-icons'
@@ -57,7 +59,9 @@ export default React.memo(function CreateQuestionModal({
   ])
   const [multiline, setMultiline] = useState(false)
   const [minSelections, setMinSelections] = useState(0)
-  const [keys, setKeys] = useState([''])
+  const [keys, setKeys] = useState<{ name: string; info?: string }[]>([
+    { name: '' }
+  ])
   const [info, setInfo] = useState('')
   const [trackedInEvents, setTrackedInEvents] = useState(false)
   const [nameInEvents, setNameInEvents] = useState('')
@@ -65,6 +69,7 @@ export default React.memo(function CreateQuestionModal({
   const [dependsOn, setDependsOn] = useState<string[]>([])
   const [continuesNumbering, setContinuesNumbering] = useState(false)
   const [label, setLabel] = useState('')
+  const [separateRows, setSeparateRows] = useState(false)
 
   function createQuestion(): VasuQuestion {
     const id = identifier || null
@@ -128,10 +133,11 @@ export default React.memo(function CreateQuestionModal({
           ophKey: null,
           name,
           info,
-          keys: keys.map((key) => ({ name: key })),
+          keys,
           value: keys.map(() => ''),
           id,
-          dependsOn
+          dependsOn,
+          separateRows
         }
       case 'MULTI_FIELD_LIST':
         return {
@@ -139,7 +145,7 @@ export default React.memo(function CreateQuestionModal({
           ophKey: null,
           name,
           info,
-          keys: keys.map((key) => ({ name: key })),
+          keys,
           value: [],
           id,
           dependsOn
@@ -167,6 +173,15 @@ export default React.memo(function CreateQuestionModal({
           id,
           dependsOn,
           continuesNumbering
+        }
+      case 'STATIC_INFO_SUBSECTION':
+        return {
+          type: 'STATIC_INFO_SUBSECTION',
+          ophKey: null,
+          name: name,
+          info: info,
+          id,
+          dependsOn
         }
     }
   }
@@ -289,29 +304,59 @@ export default React.memo(function CreateQuestionModal({
           <FixedSpaceColumn spacing="xxs">
             <Label>{t.keys}</Label>
             {keys.map((key, i) => (
-              <FixedSpaceRow spacing="xs" key={`key-${i}`}>
-                <InputField
-                  value={key}
-                  onChange={(val) =>
-                    setKeys([...keys.slice(0, i), val, ...keys.slice(i + 1)])
-                  }
-                  width="m"
-                />
-                <IconButton
-                  icon={faTrash}
-                  disabled={keys.length < 2}
-                  onClick={(e) => {
-                    e.preventDefault()
-                    setKeys([...keys.slice(0, i), ...keys.slice(i + 1)])
-                  }}
-                />
-              </FixedSpaceRow>
+              <ExpandingInfo
+                info={
+                  <TextArea
+                    value={key.info ?? ''}
+                    onChange={(val) =>
+                      setKeys([
+                        ...keys.slice(0, i),
+                        { ...key, info: val || undefined },
+                        ...keys.slice(i + 1)
+                      ])
+                    }
+                  />
+                }
+                ariaLabel=""
+                key={`key-${i}`}
+                width="full"
+              >
+                <FixedSpaceRow spacing="xs" alignItems="center">
+                  <InputField
+                    value={key.name}
+                    onChange={(val) =>
+                      setKeys([
+                        ...keys.slice(0, i),
+                        { ...key, name: val },
+                        ...keys.slice(i + 1)
+                      ])
+                    }
+                    width="m"
+                  />
+                  <IconButton
+                    icon={faTrash}
+                    disabled={keys.length < 2}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      setKeys([...keys.slice(0, i), ...keys.slice(i + 1)])
+                    }}
+                  />
+                </FixedSpaceRow>
+              </ExpandingInfo>
             ))}
             <InlineButton
-              onClick={() => setKeys([...keys, ''])}
+              onClick={() => setKeys([...keys, { name: '' }])}
               text={t.addNewKey}
             />
           </FixedSpaceColumn>
+        )}
+
+        {type === 'MULTI_FIELD' && (
+          <Checkbox
+            label={t.multifieldSeparateRows}
+            checked={separateRows}
+            onChange={setSeparateRows}
+          />
         )}
 
         {type === 'DATE' && (

--- a/frontend/src/employee-frontend/components/vasu/vasu-content.ts
+++ b/frontend/src/employee-frontend/components/vasu/vasu-content.ts
@@ -12,10 +12,12 @@ import {
   MultiSelectQuestion,
   Paragraph,
   RadioGroupQuestion,
+  StaticInfoSubsection,
   TextQuestion,
   VasuQuestion
 } from 'lib-common/api-types/vasu'
 import { VasuContent, VasuSection } from 'lib-common/generated/api-types/vasu'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 
@@ -69,6 +71,12 @@ export function isParagraph(question: VasuQuestion): question is Paragraph {
   return question.type === 'PARAGRAPH'
 }
 
+export function isStaticInfoSubsection(
+  question: VasuQuestion
+): question is StaticInfoSubsection {
+  return question.type === 'STATIC_INFO_SUBSECTION'
+}
+
 function isDateQuestionJson(
   question: JsonOf<VasuQuestion>
 ): question is JsonOf<DateQuestion> {
@@ -88,6 +96,7 @@ function isRadioGroupQuestionJson(
 }
 
 export const mapVasuContent = (content: JsonOf<VasuContent>): VasuContent => ({
+  ...content,
   sections: content.sections.map((section: JsonOf<VasuSection>) => ({
     ...section,
     questions: section.questions.map((question: JsonOf<VasuQuestion>) =>
@@ -105,7 +114,11 @@ export const mapVasuContent = (content: JsonOf<VasuContent>): VasuContent => ({
               edited: entry.edited && {
                 ...entry.edited,
                 editedAt: LocalDate.parseIso(entry.edited.editedAt)
-              }
+              },
+              createdDate:
+                typeof entry.createdDate === 'string'
+                  ? HelsinkiDateTime.parseIso(entry.createdDate)
+                  : undefined
             }))
           }
         : isRadioGroupQuestionJson(question)
@@ -132,7 +145,7 @@ export function getQuestionNumber(
       break
     }
 
-    if (!isParagraph(q) && !isFollowup(q)) {
+    if (!isParagraph(q) && !isFollowup(q) && !isStaticInfoSubsection(q)) {
       questionIndex += 1
     }
   }

--- a/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
@@ -93,14 +93,15 @@ export const ThreadView = React.memo(function ThreadView({
       <div ref={endOfMessagesRef} />
       <ThreadViewReplyContainer>
         <ThreadViewReply>
-          <TextArea
-            value={replyContent}
-            onChange={onUpdateContent}
-            className="thread-view-input"
-            wrapperClassName="thread-view-input-wrapper"
-            placeholder={i18n.messages.inputPlaceholder}
-            data-qa="thread-reply-input"
-          />
+          <div className="thread-view-input-wrapper">
+            <TextArea
+              value={replyContent}
+              onChange={onUpdateContent}
+              className="thread-view-input"
+              placeholder={i18n.messages.inputPlaceholder}
+              data-qa="thread-reply-input"
+            />
+          </div>
           <RoundIconButton
             onClick={onSubmitReply}
             disabled={replyContent.length === 0}

--- a/frontend/src/lib-common/api-types/vasu.ts
+++ b/frontend/src/lib-common/api-types/vasu.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { VasuDocument } from 'lib-common/generated/api-types/vasu'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 
 import LocalDate from '../local-date'
 
@@ -14,7 +14,8 @@ export const vasuQuestionTypes = [
   'MULTI_FIELD',
   'MULTI_FIELD_LIST',
   'DATE',
-  'FOLLOWUP'
+  'FOLLOWUP',
+  'STATIC_INFO_SUBSECTION'
 ] as const
 
 export type VasuQuestionType = typeof vasuQuestionTypes[number] | 'PARAGRAPH'
@@ -64,6 +65,8 @@ export interface QuestionOption {
   name: string
   textAnswer?: boolean
   dateRange?: boolean
+  isIntervention?: boolean
+  info?: string
 }
 
 export interface TextValueMap {
@@ -74,6 +77,7 @@ export interface MultiFieldQuestion extends VasuQuestionCommon {
   type: 'MULTI_FIELD'
   keys: Field[]
   value: string[]
+  separateRows: boolean
 }
 
 export interface MultiFieldListQuestion extends VasuQuestionCommon {
@@ -103,6 +107,7 @@ export interface FollowupEntry {
   id?: string
   authorId?: string
   edited?: FollowupEntryEditDetails
+  createdDate?: HelsinkiDateTime
 }
 
 export interface FollowupEntryEditDetails {
@@ -117,6 +122,10 @@ export interface Paragraph extends VasuQuestionCommon {
   paragraph: string
 }
 
+export interface StaticInfoSubsection extends VasuQuestionCommon {
+  type: 'STATIC_INFO_SUBSECTION'
+}
+
 export type VasuQuestion =
   | TextQuestion
   | CheckboxQuestion
@@ -127,16 +136,9 @@ export type VasuQuestion =
   | DateQuestion
   | Followup
   | Paragraph
-
-export type PermittedFollowupActions = {
-  [key: string]: string[]
-}
-
-export interface GetVasuDocumentResponse {
-  permittedFollowupActions: PermittedFollowupActions
-  vasu: VasuDocument
-}
+  | StaticInfoSubsection
 
 interface Field {
   name: string
+  info?: string
 }

--- a/frontend/src/lib-common/generated/action.d.ts
+++ b/frontend/src/lib-common/generated/action.d.ts
@@ -317,8 +317,6 @@ export type VasuDocument =
   | 'READ'
   | 'UPDATE'
 
-export type VasuDocumentFollowup = 'UPDATE'
-
 export type VasuTemplate =
   | 'COPY'
   | 'DELETE'

--- a/frontend/src/lib-common/generated/api-types/vasu.ts
+++ b/frontend/src/lib-common/generated/api-types/vasu.ts
@@ -7,7 +7,6 @@
 
 import FiniteDateRange from '../../finite-date-range'
 import LocalDate from '../../local-date'
-import { Action } from '../action'
 import { UUID } from '../../types'
 import { VasuQuestion } from '../../api-types/vasu'
 
@@ -84,21 +83,6 @@ export type CurriculumType =
   | 'PRESCHOOL'
 
 /**
-* Generated from fi.espoo.evaka.vasu.VasuController.EditFollowupEntryRequest
-*/
-export interface EditFollowupEntryRequest {
-  text: string
-}
-
-/**
-* Generated from fi.espoo.evaka.vasu.VasuController.GetVasuDocumentResponse
-*/
-export interface GetVasuDocumentResponse {
-  permittedFollowupActions: Record<string, Action.VasuDocumentFollowup[]>
-  vasu: VasuDocument
-}
-
-/**
 * Generated from fi.espoo.evaka.vasu.VasuController.UpdateDocumentRequest
 */
 export interface UpdateDocumentRequest {
@@ -130,6 +114,7 @@ export interface VasuChild {
 * Generated from fi.espoo.evaka.vasu.VasuContent
 */
 export interface VasuContent {
+  hasDynamicFirstSection: boolean | null
   sections: VasuSection[]
 }
 

--- a/frontend/src/lib-components/atoms/form/TextArea.tsx
+++ b/frontend/src/lib-components/atoms/form/TextArea.tsx
@@ -55,8 +55,7 @@ export default React.memo(function TextArea({
   'aria-describedby': ariaId,
   hideErrorsBeforeTouched,
   required,
-  inputRef,
-  wrapperClassName = undefined
+  inputRef
 }: TextAreaInputProps) {
   const [touched, setTouched] = useState(false)
 
@@ -75,7 +74,7 @@ export default React.memo(function TextArea({
   )
 
   return (
-    <div className={wrapperClassName}>
+    <>
       <StyledTextArea
         value={value}
         onChange={handleChange}
@@ -107,7 +106,7 @@ export default React.memo(function TextArea({
           <UnderRowStatusIcon status={info?.status} />
         </InputFieldUnderRow>
       )}
-    </div>
+    </>
   )
 })
 

--- a/frontend/src/lib-components/layout/StickyFooter.tsx
+++ b/frontend/src/lib-components/layout/StickyFooter.tsx
@@ -35,3 +35,7 @@ const Footer = styled.footer`
 const ContentContainer = styled(Container)`
   padding: ${defaultMargins.xs} 0;
 `
+
+export const StickyFooterContainer = styled.div`
+  padding: ${defaultMargins.xs};
+`

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -1157,7 +1157,8 @@ export const fi = {
       PRESCHOOL: 'Lapsen esiopetuksen oppimissuunnitelman tapahtumat'
     },
     noRecord: 'Ei merkintää',
-    checkInPreview: 'Tarkista esikatselussa'
+    checkInPreview: 'Tarkista esikatselussa',
+    newFollowUpEntryPlaceholder: 'Kirjoita uusi kirjaus...'
   },
   personSearch: {
     search: 'Etsi henkilötunnuksella',
@@ -3323,7 +3324,8 @@ export const fi = {
       id: 'Viitetunniste',
       dependsOn: 'Riippuvuudet',
       continuesNumbering: 'Jatkaa numerointia',
-      checkboxLabel: 'Erillinen rastin viereinen teksti'
+      checkboxLabel: 'Erillinen rastin viereinen teksti',
+      multifieldSeparateRows: 'Tekstikentät erillisillä riveillä'
     },
     questionTypes: {
       TEXT: 'Tekstimuotoinen',
@@ -3333,7 +3335,8 @@ export const fi = {
       MULTI_FIELD: 'Nimettyjä tekstikenttiä',
       MULTI_FIELD_LIST: 'Kasvava lista nimettyjä tekstikenttiä',
       DATE: 'Päivämäärä',
-      FOLLOWUP: 'Seuranta'
+      FOLLOWUP: 'Seuranta',
+      STATIC_INFO_SUBSECTION: 'Perustiedot'
     },
     errorCodes: {
       EXPIRED_START: 'Päättyneen pohjan alkupäivää ei voi muuttaa',

--- a/service/codegen/src/main/kotlin/evaka/codegen/actionenum/Definitions.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/actionenum/Definitions.kt
@@ -37,7 +37,6 @@ val generatedFiles = listOf(
             generateEnum<Action.ServiceNeed>(),
             generateEnum<Action.Unit>(),
             generateEnum<Action.VasuDocument>(),
-            generateEnum<Action.VasuDocumentFollowup>(),
             generateEnum<Action.VasuTemplate>(),
         )
     ),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuIntegrationTest.kt
@@ -390,10 +390,10 @@ class VasuIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     private fun getVasuDocument(id: VasuDocumentId): VasuDocument {
         val (_, res, result) = http.get("/vasu/$id")
             .asUser(adminUser)
-            .responseObject<VasuController.GetVasuDocumentResponse>(jsonMapper)
+            .responseObject<VasuDocument>(jsonMapper)
 
         assertEquals(200, res.statusCode)
-        return result.get().vasu
+        return result.get()
     }
 
     private fun putVasuDocument(id: VasuDocumentId, request: VasuController.UpdateDocumentRequest) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
@@ -63,6 +63,11 @@ data class EmployeeWithDaycareRoles(
     val daycareRoles: List<DaycareRole> = listOf()
 )
 
+data class EmployeeIdWithName(
+    val id: EmployeeId,
+    val name: String
+)
+
 fun Database.Transaction.createEmployee(employee: NewEmployee): Employee = createUpdate(
     // language=SQL
     """
@@ -366,3 +371,17 @@ RETURNING id
         .mapTo<EmployeeId>()
         .toList()
 }
+
+fun Database.Read.getEmployeeNamesByIds(employeeIds: List<EmployeeId>) =
+    createQuery(
+        """
+SELECT id, concat(first_name, ' ', last_name) name
+FROM employee
+WHERE id = ANY(:ids)
+        """.trimIndent()
+    )
+        .bind("ids", employeeIds.toTypedArray())
+        .mapTo<EmployeeIdWithName>()
+        .toList()
+        .map { it.id to it.name }
+        .toMap()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -144,7 +144,6 @@ typealias StaffOccupancyCoefficientId = Id<DatabaseTable.StaffOccupancyCoefficie
 typealias VardaDecisionId = Id<DatabaseTable.VardaDecision>
 typealias VardaPlacementId = Id<DatabaseTable.VardaPlacement>
 typealias VasuDocumentId = Id<DatabaseTable.VasuDocument>
-typealias VasuDocumentFollowupEntryId = Pair<VasuDocumentId, UUID>
 typealias VasuTemplateId = Id<DatabaseTable.VasuTemplate>
 typealias VoucherValueId = Id<DatabaseTable.VoucherValue>
 typealias VoucherValueDecisionId = Id<DatabaseTable.VoucherValueDecision>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -40,7 +40,6 @@ import fi.espoo.evaka.shared.PedagogicalDocumentId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
-import fi.espoo.evaka.shared.VasuDocumentFollowupEntryId
 import fi.espoo.evaka.shared.VasuDocumentId
 import fi.espoo.evaka.shared.VasuTemplateId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
@@ -721,16 +720,6 @@ sealed interface Action {
         ),
         EVENT_RETURNED_TO_REVIEWED,
         EVENT_MOVED_TO_CLOSED;
-
-        override fun toString(): String = "${javaClass.name}.$name"
-    }
-
-    enum class VasuDocumentFollowup(override vararg val defaultRules: ScopedActionRule<in VasuDocumentFollowupEntryId>) : ScopedAction<VasuDocumentFollowupEntryId> {
-        UPDATE(
-            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER).withUnitFeatures(PilotFeature.VASU_AND_PEDADOC).inPlacementUnitOfChildOfVasuDocumentFollowupEntry(),
-            HasGroupRole(STAFF).withUnitFeatures(PilotFeature.VASU_AND_PEDADOC).inPlacementGroupOfChildOfVasuDocumentFollowupEntry(),
-            IsEmployee.authorOfVasuDocumentFollowupEntry()
-        );
 
         override fun toString(): String = "${javaClass.name}.$name"
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasGroupRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasGroupRole.kt
@@ -6,7 +6,6 @@ package fi.espoo.evaka.shared.security.actionrule
 
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.Id
-import fi.espoo.evaka.shared.VasuDocumentFollowupEntryId
 import fi.espoo.evaka.shared.VasuDocumentId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -90,24 +89,6 @@ AND curriculum_document.id = ANY(:ids)
                 .bind("userId", user.id)
                 .bind("ids", ids.toTypedArray())
                 .mapTo()
-        }
-    )
-
-    fun inPlacementGroupOfChildOfVasuDocumentFollowupEntry() = DatabaseActionRule(
-        this,
-        object : DatabaseActionRule.Query<VasuDocumentFollowupEntryId, HasGroupRole> {
-            override fun execute(
-                tx: Database.Read,
-                user: AuthenticatedUser,
-                now: HelsinkiDateTime,
-                targets: Set<VasuDocumentFollowupEntryId>
-            ): Map<VasuDocumentFollowupEntryId, DatabaseActionRule.Deferred<HasGroupRole>> {
-                val vasuDocuments =
-                    inPlacementGroupOfChildOfVasuDocument().query.execute(tx, user, now, targets.map { it.first }.toSet())
-                return targets.mapNotNull { target -> vasuDocuments[target.first]?.let { target to it } }.toMap()
-            }
-            override fun equals(other: Any?): Boolean = other?.javaClass == javaClass
-            override fun hashCode(): Int = this.javaClass.hashCode()
         }
     )
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
@@ -29,7 +29,6 @@ import fi.espoo.evaka.shared.PedagogicalDocumentId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.ServiceNeedId
-import fi.espoo.evaka.shared.VasuDocumentFollowupEntryId
 import fi.espoo.evaka.shared.VasuDocumentId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -480,24 +479,6 @@ AND curriculum_document.id = ANY(:ids)
                 .bind("userId", user.id)
                 .bind("ids", ids.toTypedArray())
                 .mapTo()
-        }
-    )
-
-    fun inPlacementUnitOfChildOfVasuDocumentFollowupEntry() = DatabaseActionRule(
-        this,
-        object : DatabaseActionRule.Query<VasuDocumentFollowupEntryId, HasUnitRole> {
-            override fun execute(
-                tx: Database.Read,
-                user: AuthenticatedUser,
-                now: HelsinkiDateTime,
-                targets: Set<VasuDocumentFollowupEntryId>
-            ): Map<VasuDocumentFollowupEntryId, DatabaseActionRule.Deferred<HasUnitRole>> {
-                val vasuDocuments =
-                    inPlacementUnitOfChildOfVasuDocument().query.execute(tx, user, now, targets.map { it.first }.toSet())
-                return targets.mapNotNull { target -> vasuDocuments[target.first]?.let { target to it } }.toMap()
-            }
-            override fun equals(other: Any?): Boolean = other?.javaClass == javaClass
-            override fun hashCode(): Int = this.javaClass.hashCode()
         }
     )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsEmployee.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsEmployee.kt
@@ -13,12 +13,10 @@ import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.MessageDraftId
 import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.PairingId
-import fi.espoo.evaka.shared.VasuDocumentFollowupEntryId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControlDecision
-import fi.espoo.evaka.vasu.getVasuFollowupEntry
 import org.jdbi.v3.core.kotlin.mapTo
 
 private typealias FilterByEmployee<T> = (tx: Database.Read, user: AuthenticatedUser.Employee, now: HelsinkiDateTime, targets: Set<T>) -> Iterable<T>
@@ -79,14 +77,6 @@ AND id = ANY(:ids)
                 .bind("userId", user.id)
                 .bind("ids", ids.toTypedArray())
                 .mapTo()
-        }
-    )
-
-    fun authorOfVasuDocumentFollowupEntry() = DatabaseActionRule(
-        this,
-        Query<VasuDocumentFollowupEntryId> { tx, user, _, ids ->
-            // TODO: replace naive loop with a batch operation
-            ids.filter { id -> tx.getVasuFollowupEntry(id).authorId == user.id.raw }
         }
     )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/OphQuestion.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/OphQuestion.kt
@@ -28,11 +28,33 @@ fun getDefaultTemplateContent(type: CurriculumType, lang: VasuLanguage) = when (
 }
 
 fun getDefaultVasuContent(lang: VasuLanguage) = VasuContent(
+    hasDynamicFirstSection = true,
     sections = listOf(
         VasuSection(
             name = when (lang) {
-                VasuLanguage.FI -> "Lapsen varhaiskasvatussuunnitelman laatijat"
-                VasuLanguage.SV -> "Uppgörande av barnets plan för småbarnspedagogik"
+                VasuLanguage.FI -> "Perustiedot"
+                VasuLanguage.SV -> ""
+            },
+            questions = listOf(
+                VasuQuestion.StaticInfoSubSection(),
+                VasuQuestion.TextQuestion(
+                    name = when (lang) {
+                        VasuLanguage.FI -> "Yhteydenpitoon liittyviä lisätietoja"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Yhteydenpitoon liittyvät lisätiedot voivat esimerkiksi olla yhteishuoltajuuteen tai turvakieltoon liittyviä asioita."
+                        VasuLanguage.SV -> ""
+                    },
+                    value = "",
+                    multiline = true
+                )
+            )
+        ),
+        VasuSection(
+            name = when (lang) {
+                VasuLanguage.FI -> "Lapsen varhaiskasvatussuunnitelman laatiminen"
+                VasuLanguage.SV -> ""
             },
             questions = listOf(
                 VasuQuestion.MultiField(
@@ -60,31 +82,27 @@ fun getDefaultVasuContent(lang: VasuLanguage) = VasuContent(
                             listOf(Field("Förnamn"), Field("Efternamn"), Field("Titel"), Field("Telefonnummer"))
                     },
                     value = listOf()
-                )
-            )
-        ),
-        VasuSection(
-            name = when (lang) {
-                VasuLanguage.FI -> "Näkemyksien huomioiminen"
-                VasuLanguage.SV -> "Barnets och vårdnadshavarnas delaktighet i uppgörandet av planen"
-            },
-            questions = listOf(
+                ),
                 VasuQuestion.TextQuestion(
                     name = when (lang) {
-                        VasuLanguage.FI -> "Miten lapsen näkökulma ja mielipiteet on otettu huomioon"
-                        VasuLanguage.SV -> "Hur har barnets perspektiv och synpunkter beaktats"
+                        VasuLanguage.FI -> "Miten lapsen näkökulma ja mielipiteet otetaan huomioon"
+                        VasuLanguage.SV -> ""
                     },
                     info = when (lang) {
-                        VasuLanguage.FI -> "Lapsen näkökulma on läsnä keskustelussa koko ajan. Lapsi voi myös osallistua keskusteluun osan ajasta: ikätason mukaan lapsen osallisuutta vasukeskusteluissa lisätään. Lapsi voi esimerkiksi esitellä mielipaikkojaan, muuta oppimisympäristöä tai lempilelujaan sisällä tai ulkona. Keskustelkaa tiimissä otsikossa mainituista asioista niin, että kaikki tiimin jäsenet tuovat ilmi oman näkemyksensä havaintojen ja pedagogisen dokumentoinnin perusteella. Kirjaa lyhyt yhteenveto tähän. Jos et löydä juuri sopivaa ”lokeroa” mielestänne tärkeän asian kirjaamiselle, palatkaa vasutekstin äärelle tai jutelkaa esimiehenne/työkavereittenne kanssa."
-                        VasuLanguage.SV -> "Barnets perspektiv är ständigt närvarande i samtalet. Barnet kan också delta i samtalet en del av tiden: beroende på ålder ökas barnets deltagande i samtalen i anslutning till planen för småbarnspedagogik. Barnet kan till exempel visa sina favoritplatser, annan inlärningsmiljö eller sina favoritleksaker inomhus eller utomhus. Diskutera barnets perspektiv så att alla teammedlemmar uttrycker sina synpunkter baserade på observationer och pedagogisk dokumentation. Skriv en kort sammanfattning här. Om du inte hittar ett lämpligt ställe för ett ärende som ni tycker är viktigt, gå tillbaka till texten för planen för småbarnspedagogik eller prata med er chef/era medarbetare."
+                        VasuLanguage.FI -> "Tässä kuvataan, millaisten keskustelujen ja toiminnan kautta lapsi osallistuu oman varhaiskasvatuksensa suunnitteluun ja arviointiin. Lapsen varhaiskasvatussuunnitelmaa tehtäessä keskustellaan lapsen vahvuuksista, kiinnostuksen kohteista, osaamisesta ja yksilöllisistä tarpeista. Lapsen toiveita, mielipiteitä ja odotuksia selvitetään erilaisin tavoin lapsen ikä- ja kehitystaso huomioiden."
+                        VasuLanguage.SV -> ""
                     },
                     multiline = true,
                     value = ""
                 ),
                 VasuQuestion.TextQuestion(
                     name = when (lang) {
-                        VasuLanguage.FI -> "Miten huoltajien näkemykset otetaan huomioon ja miten yhteistyö on järjestetty"
-                        VasuLanguage.SV -> "Hur har vårdnadshavarnas synpunkter beaktats och hur samarbetet med vårdnadshavarna ordnats"
+                        VasuLanguage.FI -> "Miten huoltajien näkemykset otetaan huomioon ja yhteistyötä toteutetaan"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Tässä kuvataan, miten huoltajien kanssa keskustellaan lapsen oppimisesta, kasvusta ja hyvinvoinnista toimintavuoden aikana. Huoltajien on mahdollista pohtia oman lapsensa varhaiskasvatukseen liittyviä toiveita ja odotuksia ennen vasu-keskustelua Lapsi kotioloissa -lomakkeen avulla. Lisäksi huoltajalla on mahdollisuus keskustella muiden huoltajien kanssa lasten oppimiseen, kasvuun ja hyvinvointiin liittyvistä asioista erilaisissa varhaiskasvatusyksikön tilaisuuksissa.\nTähän kohtaan voidaan kirjata perheen kielelliseen, kulttuuriseen tai katsomukselliseen taustaan liittyvät toiveet ja yhdessä sovitut asiat, kuten esimerkiksi kotikielet, tulkkauspalveluiden käyttö tai miten katsomuksellisista asioista keskustellaan."
+                        VasuLanguage.SV -> ""
                     },
                     multiline = true,
                     value = ""
@@ -93,26 +111,74 @@ fun getDefaultVasuContent(lang: VasuLanguage) = VasuContent(
         ),
         VasuSection(
             name = when (lang) {
-                VasuLanguage.FI -> "Aiemman varhaiskasvatussuunnitelman tavoitteet ja toimenpiteet"
-                VasuLanguage.SV -> "Mål och åtgärder i den föregående barnets plan för småbarnspedagogik"
+                VasuLanguage.FI -> "Monialainen yhteistyö"
+                VasuLanguage.SV -> ""
             },
             questions = listOf(
                 VasuQuestion.TextQuestion(
                     name = when (lang) {
-                        VasuLanguage.FI -> "Tavoitteiden toteutuminen"
-                        VasuLanguage.SV -> "Genomförande av målen"
+                        VasuLanguage.FI -> "Yhteistyökumppanit ja yhteystiedot"
+                        VasuLanguage.SV -> ""
                     },
                     info = when (lang) {
-                        VasuLanguage.FI -> "Kirjoita tähän lyhyesti niistä asioista, joita edellisessä vasukeskustelussa, yhdessä huoltajien kanssa asetitte pedagogisen toiminnan tavoitteiksi. Jos jatkat toisen tekemää suunnitelmaa, mainitse siitä ja muista laittaa omat nimikirjaimesi tekstin perään."
-                        VasuLanguage.SV -> "Skriv här kortfattat om vad ni tillsammans med vårdnadshavarna satte som mål för den pedagogiska verksamheten i det föregående samtalet för barnets plan. Om du fortsätter en plan som utarbetats av någon annan, ange det och kom ihåg att skriva dina egna initialer efter texten."
+                        VasuLanguage.FI -> "Tähän kohtaan voidaan kirjata monialaisen yhteistyön toteuttaminen, esimerkiksi lastenneuvolan tai lastensuojelun kanssa. Lisäksi kirjataan monialaisten toimijoiden organisaatiot, nimet ja yhteystiedot."
+                        VasuLanguage.SV -> ""
                     },
                     multiline = true,
                     value = ""
                 ),
                 VasuQuestion.TextQuestion(
                     name = when (lang) {
-                        VasuLanguage.FI -> "Muut havainnot lapsen edellisestä vasusta"
-                        VasuLanguage.SV -> "Andra iakttagelser om föregående barnets plan för småbarnspedagogik"
+                        VasuLanguage.FI -> "Sovitut yhteistyötavat, vastuut ja palvelut"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Tähän kirjataan yhteisesti sovitut asiat. Mahdollisen tuen edellyttämän yhteistyön ja palvelujen näkökulmasta huomioidaan\n\n• yhteistyö lapsen ja huoltajan kanssa\n• lapsen tuen toteuttamisen vastuut \n• erityisasiantuntijoiden palvelujen käyttö \n• sosiaali- ja terveydenhuollon sekä muiden tarvittavien asiantuntijoiden antama ohjaus ja konsultaatio\n• mahdollisten kuljetusten järjestelyt ja vastuut."
+                        VasuLanguage.SV -> ""
+                    },
+                    multiline = true,
+                    value = ""
+                )
+            )
+        ),
+        VasuSection(
+            name = when (lang) {
+                VasuLanguage.FI -> "Lapsen varhaiskasvatussuunnitelman tavoitteiden ja toimenpiteiden toteutumisen arviointi"
+                VasuLanguage.SV -> ""
+            },
+            questions = listOf(
+                VasuQuestion.TextQuestion(
+                    name = when (lang) {
+                        VasuLanguage.FI -> "Tavoitteiden ja toimenpiteiden toteutuminen"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Mitkä toiminnalle asetetut tavoitteet ja toimenpiteet ovat toteutuneet? Miten ne ovat toteutuneet? Mikä on edistänyt/estänyt tavoitteiden ja toimenpiteiden toteutumista? Arviointi kohdistuu toiminnan, järjestelyjen, oppimisympäristöjen ja pedagogiikan arviointiin, ei lapsen arviointiin. Arvioinnin yhteydessä henkilöstö sekä huoltaja ja lapsi pohtivat kuinka hyvin lapsen vasuun kirjatut kasvatukselle, opetukselle ja hoidolle asetetut tavoitteet ovat toteutuneet ja ovatko toimenpiteet olleet tarkoituksenmukaisia."
+                        VasuLanguage.SV -> ""
+                    },
+                    multiline = true,
+                    value = ""
+                ),
+                VasuQuestion.TextQuestion(
+                    name = when (lang) {
+                        VasuLanguage.FI -> "Lapsen tuen arviointi"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Ovatko lapselle annettu tuki ja tukitoimenpiteet olleet toimivia ja riittäviä? Miten sovitut pedagogiset, rakenteelliset ja/tai hoidolliset tuen muodot ovat toteutuneet, ja mitkä ovat olleet niiden vaikutukset? Miten sovitut yhteistyökäytännöt ovat toteutuneet? Lapsen tuen tarvetta sekä tuen riittävyyttä, tarkoituksenmukaisuutta ja vaikuttavuutta on arvioitava ja seurattava sekä lapsen vasua päivitettävä aina tuen tarpeen muuttuessa. Tuen vaikuttavuuden arviointi pitää sisällään kuvauksen tukitoimista, niiden vaikuttavuuden arvioinnista ja kehittämisestä sekä perustelut siitä, millaisista tuen toimista lapsi hyötyy ja mitkä parhaiten toteuttavat yksilöllisesti lapsen etua. Jos lapsi saa tehostettua tai erityistä tukea, tai tukipalveluita osana yleistä tukea lapsen vasua päivitetään hallinnollisen päätöksen sisällön mukaisesti."
+                        VasuLanguage.SV -> ""
+                    },
+                    multiline = true,
+                    value = ""
+                ),
+                VasuQuestion.TextQuestion(
+                    name = when (lang) {
+                        VasuLanguage.FI -> "Muut havainnot lapselle aiemmin laaditusta varhaiskasvatussuunnitelmasta"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Lapsen vasu tulee arvioida ja tarkistaa vähintään kerran vuodessa tai useammin jos lapsen tarpeet sitä edellyttävät. Lapsen vasua arvioitaessa arviointi kohdistuu pedagogiikan toteutumiseen, oppimisympäristöihin ja toiminnan järjestelyihin sekä mahdolliseen tuen vaikuttavuuteen ja tukitoimien toteutumiseen. Lapsen vasun tarkistaminen perustuu lapsen vasun arviointiin yhdessä lapsen ja huoltajan kanssa. Tarkoituksena on varmistaa, että lapsen vasusta muodostuu jatkumo. Tässä osiossa tarkastellaan aiemmin laadittua lapsen vasua ja arvioidaan siihen kirjattujen tavoitteiden toteutumista. Mikäli lapsen vasua ollaan laatimassa ensimmäistä kertaa, tätä arviointia ei luonnollisesti tehdä. Lapsen vasun tavoitteita sekä niiden toteuttamista seurataan ja arvioidaan säännöllisesti."
+                        VasuLanguage.SV -> ""
                     },
                     multiline = true,
                     value = ""
@@ -131,133 +197,178 @@ fun getDefaultVasuContent(lang: VasuLanguage) = VasuContent(
                         VasuLanguage.SV -> "Barnets styrkor, intressen och behov samt hur man beaktar dem"
                     },
                     info = when (lang) {
-                        VasuLanguage.FI -> "Keskustelkaa tiimissä otsikossa mainituista asioista niin, että kaikki tiimin jäsenet tuovat ilmi oman näkemyksensä havaintojen ja pedagogisen dokumentoinnin perusteella. Kirjaa lyhyt yhteenveto tähän. Jos et löydä juuri sopivaa \"lokeroa\" mielestänne tärkeän asian kirjaamiselle, palatkaa vasutekstin äärelle tai jutelkaa esimiehenne/työkavereittenne kanssa. Luo huoltajien kanssa käytävään keskusteluun miellyttävä ilmapiiri. Valmistaudu niin, että myös hankalista asioista on mahdollista puhua."
-                        VasuLanguage.SV -> "Diskutera de frågor som nämns i rubriken så att alla teammedlemmar uttrycker sina synpunkter baserade på observationer och pedagogisk dokumentation. Skriv en kort sammanfattning här. Om du inte hittar ett lämpligt ställe för ett ärende som ni tycker är viktigt, gå tillbaka till texten för planen för småbarnspedagogik eller prata med er chef/era medarbetare. Skapa en trevlig atmosfär i samtalet med vårdnadshavarna. Förbered dig så att även svåra saker kan diskuteras."
+                        VasuLanguage.FI -> "Tähän kuvataan lapsen keskeiset vahvuudet ja kiinnostuksen kohteet sekä tarpeet tavoitteiden asettamisen ja toiminnan suunnittelun pohjaksi."
+                        VasuLanguage.SV -> ""
                     },
                     multiline = true,
                     value = ""
                 ),
                 VasuQuestion.TextQuestion(
                     name = when (lang) {
-                        VasuLanguage.FI -> "Tavoitteet henkilöstön pedagogiselle toiminnalle sekä toimenpiteet ja menetelmät tavoitteiden saavuttamiseksi"
-                        VasuLanguage.SV -> "Mål för personalens pedagogiska verksamhet samt åtgärder och metoder för att uppnå målen"
+                        VasuLanguage.FI -> "Kieleen ja kulttuuriin liittyviä tarkentavia näkökulmia"
+                        VasuLanguage.SV -> ""
                     },
                     info = when (lang) {
-                        VasuLanguage.FI -> "Valitkaa yhdessä huoltajien kanssa 1-3 tavoitetta tulevalle pedagogiselle toiminnalle. Jotain sellaista, jolla on merkitystä juuri tämän lapsen kohdalla."
-                        VasuLanguage.SV -> "Välj tillsammans med vårdnadshavarna 1–3 mål för framtida pedagogisk verksamhet. Målen för den pedagogiska verksamheten ska ha betydelse för just detta barn."
+                        VasuLanguage.FI -> "Tässä kohdassa kirjataan, miten edistetään monipuolisesti vieraskielisten ja monikielisten lasten kielitaidon sekä kieli- ja kulttuuri-identiteettien ja itsetunnon kehittymistä. Huoltajien kanssa keskustellaan myös lapsen oman äidinkielen/äidinkielien tukemisesta."
+                        VasuLanguage.SV -> ""
+                    },
+                    multiline = true,
+                    value = ""
+                ),
+                VasuQuestion.MultiField(
+                    name = when (lang) {
+                        VasuLanguage.FI -> "Mahdolliset lapsen kehityksen, oppimisen ja hyvinvoinnin tukeen liittyvät tarpeet sekä lapsen tuen toteuttamiseen liittyvät tuen muodot (pedagogiset, rakenteelliset ja hoidolliset)"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Tähän kohtaan kirjataan lapsen tukeen liittyvät mahdolliset muut tarpeet sekä lapsen tuen toteuttamiseen liittyvät pedagogiset, rakenteelliset ja hoidolliset tuen muodot. Tähän kirjataan myös mahdolliset lapselle annettavat tukipalvelut. Lapsen vasua hyödynnetään tehtäessä hallinnollista päätöstä annettavasta tehostetusta tai erityisestä tuesta tai yleisen tuen tukipalveluista. Mikäli lapsen tuen tarvetta on arvioitu lapsen vasussa, tulee arviointi huomioida annettaessa tehostetun tai erityisen tuen hallinnollista päätöstä tai päätöstä yleisen tuen tukipalveluista. Lapsen vasua päivitetään hallintopäätöksen sisällön mukaisesti. Lisäksi lapsen vasuun kirjataan mahdolliset sosiaali- ja terveyspalvelut, kuten lapsen saama kuntoutus, jos se on olennaista lapsen varhaiskasvatuksen järjestämisen näkökulmasta."
+                        VasuLanguage.SV -> ""
+                    },
+                    keys = when (lang) {
+                        VasuLanguage.FI ->
+                            listOf(
+                                Field(
+                                    name = "Pedagogiset tuen muodot",
+                                    info = "• varhaiskasvatuspäivän rakenteeseen ja päivärytmiin liittyvät ratkaisut \n" +
+                                        "• oppimisympäristöihin liittyvät ratkaisut \n" +
+                                        "• tarvittavat erityispedagogiset menetelmät \n" +
+                                        "• vuorovaikutus- ja kommunikointitavat, esimerkiksi viittomien ja kuvien käyttö \n" +
+                                        "• käytännöt, miten lapsi pääsee osalliseksi vertaisryhmän toimintaa, esimerkiksi esteettömyyden huomiointi."
+                                ),
+                                Field(
+                                    name = "Rakenteelliset tuen muodot",
+                                    info = "• tuen toteuttamiseen liittyvän osaamisen ja erityispedagogisen osaamisen vahvistaminen \n" +
+                                        "• henkilöstön mitoitukseen ja rakenteeseen liittyvät ratkaisut \n" +
+                                        "• lapsiryhmän kokoon ja ryhmärakenteeseen liittyvät ratkaisut \n" +
+                                        "• tulkitsemis- ja avustamispalvelut sekä apuvälineiden käyttö \n" +
+                                        "• pien- tai erityisryhmä tai muu tarvittava ryhmämuoto \n" +
+                                        "• varhaiskasvatuksen erityisopettajan osa- tai kokoaikainen opetus tai konsultaatio."
+                                ),
+                                Field(
+                                    name = "Hoidolliset tuen muodot",
+                                    info = "• perushoitoon, hoivaan ja avustamiseen liittyvät menetelmät \n" +
+                                        "• terveydenhoidolliset tarpeet, esimerkiksi lapsen pitkäaikaissairauksien hoitoon, lääkitykseen, ruokavalioon ja liikkumiseen liittyvä avustaminen ja apuvälineet.\n"
+                                )
+                            )
+                        VasuLanguage.SV ->
+                            listOf(Field(""), Field(""), Field(""))
+                    },
+                    value = listOf("", "", ""),
+                    separateRows = true
+                ),
+                VasuQuestion.TextQuestion(
+                    name = when (lang) {
+                        VasuLanguage.FI -> "Tavoitteet henkilöstön pedagogiselle toiminnalle"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Tähän kirjataan keskeiset tavoitteet henkilöstön pedagogiselle toiminnalle. Tavoitteiden asettamisessa tulee hyödyntää lapsen vahvuuksia, kiinnostuksen kohteita ja tarpeita. Tässä osassa huomioidaan lapsen orastavat taidot ja se, miten niitä voidaan edistää pedagogisella toiminnalla. Olennaista on kirjata tavoitteet lapsen kasvatukselle, opetukselle ja hoidolle. Tässä huomioidaan myös laaja-alaisen osaamisen osa-alueita ja oppimisen alueita. Lisäksi tähän kirjataan mahdolliset kehityksen, oppimisen ja hyvinvoinnin tuen kannalta merkitykselliset tavoitteet. Tavoitteita asetettaessa otetaan huomioon lapsiryhmä ja ryhmän kokonaistilanne, tavoitteiden konkreettisuus ja arvioitavuus."
+                        VasuLanguage.SV -> ""
                     },
                     multiline = true,
                     value = ""
                 ),
                 VasuQuestion.TextQuestion(
                     name = when (lang) {
-                        VasuLanguage.FI -> "Mahdolliset muut kehityksen ja oppimisen tukeen liittyvät tarpeet sekä tuen toteuttamiseen liittyvät tavoitteet ja sovitut järjestelyt"
-                        VasuLanguage.SV -> "Eventuella andra behov som rör stöd för utveckling och lärande samt mål och överenskomna arrangemang för genomförandet av stödet"
+                        VasuLanguage.FI -> "Toimenpiteet ja menetelmät tavoitteiden saavuttamiseksi"
+                        VasuLanguage.SV -> ""
                     },
                     info = when (lang) {
-                        VasuLanguage.FI -> "Tähän kirjoitetaan rakenteelliset tukitoimet ja muu sellainen lapsen hyvinvointiin liittyvä tuki, joka ei käy ilmi pedagogisen toiminnan kuvauksessa."
-                        VasuLanguage.SV -> "Strukturella stödåtgärder och annat stöd som rör barnets välbefinnande och som inte framgår av beskrivningen av den pedagogiska verksamheten skrivs här."
+                        VasuLanguage.FI -> "Tässä kirjataan konkreettiset pedagogiset toimenpiteet ja menetelmät pedagogiselle toiminnalle asetettujen tavoitteiden saavuttamiseksi. Menetelmät tulee kirjata niin konkreettisina, että niiden toteutumisen arviointi on mahdollista."
+                        VasuLanguage.SV -> ""
                     },
                     multiline = true,
                     value = ""
-                ),
-                VasuQuestion.Followup(
-                    title = when (lang) {
-                        VasuLanguage.FI -> "Täydennykset ja jatkuva arviointi toimintakauden aikana"
-                        VasuLanguage.SV -> ""
-                    },
-                    name = when (lang) {
-                        VasuLanguage.FI -> "Tavoitteiden ja toimenpiteiden toteutumisen arviointia ja tarkennuksia toimintakauden aikana lapsen tarpeiden mukaan sekä mahdollinen huoltajien kanssa tehty yhteistyö"
-                        VasuLanguage.SV -> ""
-                    },
-                    info = when (lang) {
-                        VasuLanguage.FI -> "Laadittu-tilassa olevaa varhaiskasvatussuunnitelmaa päivitetään pääasiassa lisäämällä uutta tekstiä Täydennykset ja jatkuva arviointi -osioon. Sinne voidaan mm. lisätä huomioita koskien lapsen kehitystä, arjen tapahtumia sekä huoltajien kanssa käytyjä keskusteluja."
-                        VasuLanguage.SV -> ""
-                    },
-                    value = emptyList()
-                )
-            )
-        ),
-        VasuSection(
-            name = "Tehostetun tai erityisen tuen tarve ja tukitoimet",
-            questions = listOf(
-                VasuQuestion.Paragraph(
-                    title = "",
-                    paragraph = "Täytetään, kun lapsella on tarve tuelle, josta tehdään hallintopäätös. Tuen tarvetta seurataan ja arvioidaan toimintakauden aikana."
-                ),
-                VasuQuestion.CheckboxQuestion(
-                    label = "Onko lapsella tehostetun tai erityisen tuen tarve, tai onko tuen taso muuttumassa?",
-                    name = "Kyllä, lapsella on tehostetun tai erityisen tuen tarve, tai tuen taso on muuttumassa",
-                    value = false,
-                    id = "special-support"
-                ),
-                VasuQuestion.TextQuestion(
-                    name = "Mahdolliset aiemmin toteutetut tukitoimet sekä niiden vaikuttavuuden arviointi",
-                    value = "",
-                    multiline = false,
-                    dependsOn = listOf("special-support")
-                ),
-                VasuQuestion.TextQuestion(
-                    name = "Arvio lapsen tarvitsemasta tuesta jatkossa sekä hänelle kohdennettujen tuen muotojen ja mahdollisten tukipalveluiden kuvaus",
-                    value = "",
-                    multiline = false,
-                    dependsOn = listOf("special-support")
-                ),
-                VasuQuestion.TextQuestion(
-                    name = "Henkilöstön ja tarvittavien muiden asiantuntijoiden vastuut ja työnjako lapsen tukeen liittyen",
-                    value = "",
-                    multiline = false,
-                    dependsOn = listOf("special-support")
-                ),
-                VasuQuestion.TextQuestion(
-                    name = "Kuvaus lapsen ja huoltajien kanssa tehdystä yhteistyöstä",
-                    value = "",
-                    multiline = false,
-                    dependsOn = listOf("special-support")
                 ),
                 VasuQuestion.RadioGroupQuestion(
                     name = "Lapsen tuen taso jatkossa",
                     options = listOf(
                         QuestionOption(
                             key = "general",
-                            name = "Yleinen tuki"
+                            name = when (lang) {
+                                VasuLanguage.FI -> "Yleinen tuki"
+                                VasuLanguage.SV -> ""
+                            }
+                        ),
+                        QuestionOption(
+                            key = "",
+                            name = when (lang) {
+                                VasuLanguage.FI -> "Lapsen tuen toteuttamista koskeva hallintopäätös"
+                                VasuLanguage.SV -> ""
+                            },
+                            isIntervention = true,
+                            info = when (lang) {
+                                VasuLanguage.FI -> "Tämä kohta kirjataan, jos lapsen tuesta on annettu hallintopäätös. Lapsen vasuun kirjataan myös päivämäärä, jos hallintopäätös kumotaan. Muihin huomioihin voidaan kirjata hallintopäätökseen liittyviä tarkentavia näkökulmia."
+                                VasuLanguage.SV -> ""
+                            }
                         ),
                         QuestionOption(
                             key = "during_range",
-                            name = "Tukipalvelut ajalla",
+                            name = when (lang) {
+                                VasuLanguage.FI -> "Tukipalvelut ajalla"
+                                VasuLanguage.SV -> ""
+                            },
                             dateRange = true
                         ),
                         QuestionOption(
                             key = "intensified",
-                            name = "Tehostettu tuki"
+                            name = when (lang) {
+                                VasuLanguage.FI -> "Tehostettu tuki"
+                                VasuLanguage.SV -> ""
+                            }
                         ),
                         QuestionOption(
                             key = "special",
-                            name = "Erityinen tuki"
+                            name = when (lang) {
+                                VasuLanguage.FI -> "Erityinen tuki"
+                                VasuLanguage.SV -> ""
+                            }
                         )
                     ),
-                    value = null,
-                    dependsOn = listOf("special-support")
+                    value = null
+                ),
+                VasuQuestion.TextQuestion(
+                    name = when (lang) {
+                        VasuLanguage.FI -> "Muita huomioita"
+                        VasuLanguage.SV -> ""
+                    },
+                    multiline = true,
+                    value = ""
                 ),
                 VasuQuestion.Followup(
-                    title = "Tuen tarpeen ja toteutumisen arviointi toimintakauden aikana",
-                    name = "Tuen tarpeen ja tukitoimenpiteiden toteutumisen seurantaa ja arviointia toimintakauden aikana",
-                    value = listOf(),
-                    continuesNumbering = true,
-                    dependsOn = listOf("special-support")
+                    title = when (lang) {
+                        VasuLanguage.FI -> "Tarkennuksia toimintavuoden aikana lapsen tarpeiden mukaan"
+                        VasuLanguage.SV -> ""
+                    },
+                    name = when (lang) {
+                        VasuLanguage.FI -> "Päivämäärä ja kirjaus"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Tämän kohdan tarkoituksena on varmistaa lapsen vasuun kirjattujen tavoitteiden ja toimenpiteiden toteutumisen jatkuva arviointi. Jatkuvalla arvioinnilla tarkoitetaan havainnoinnin ja pedagogisen dokumentoinnin avulla tarkennettavia tavoitteita ja toimenpiteitä. Näistä keskustellaan huoltajien kanssa päivittäisissä kohtaamisissa. Jatkuvan arvioinnin avulla lapsen vasu pysyy ajan tasalla."
+                        VasuLanguage.SV -> ""
+                    },
+                    value = emptyList(),
+                    continuesNumbering = true
                 )
             )
         ),
         VasuSection(
             name = when (lang) {
-                VasuLanguage.FI -> "Lapsen hyvinvoinnin tukemiseen liittyvät muut huomioitavat asiat"
-                VasuLanguage.SV -> "Andra frågor som ska beaktas i samband med stöd för barnets välbefinnande"
+                VasuLanguage.FI -> "Muut mahdolliset lapsen varhaiskasvatuksessa huomioitavat asiat"
+                VasuLanguage.SV -> ""
             },
             questions = listOf(
                 VasuQuestion.TextQuestion(
                     name = when (lang) {
-                        VasuLanguage.FI -> "Esimerkiksi päiväuniin, ruokailuun tai ulkoiluun liittyvät asiat"
-                        VasuLanguage.SV -> "Frågor som rör bland annat vila, måltider eller utevistelse"
+                        VasuLanguage.FI -> "Muita huomioita"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI ->
+                            "Tähän osioon kirjataan muita huomioitavia asioita, kuten esimerkiksi lepoon, ruokailuun tai pukemiseen liittyvät asiat.\n" +
+                                "Keskustele tarvittaessa huoltajien ajatuksista tyttöjen ympärileikkauksesta, ks. erillinen ohje Tyttöjen sukuelinten silpomisen estäminen. Tähän kirjataan huoltajien ajatukset asiasta. Jos huoli herää, toimi em. ohjeistuksen mukaan."
+                        VasuLanguage.SV -> ""
                     },
                     multiline = true,
                     value = ""
@@ -266,14 +377,18 @@ fun getDefaultVasuContent(lang: VasuLanguage) = VasuContent(
         ),
         VasuSection(
             name = when (lang) {
-                VasuLanguage.FI -> "Muut asiakirjat ja suunnitelmat"
-                VasuLanguage.SV -> "Övriga handlingar och planer"
+                VasuLanguage.FI -> "Laatimisessa hyödynnetyt muut mahdolliset asiakirjat ja suunnitelmat "
+                VasuLanguage.SV -> ""
             },
             questions = listOf(
                 VasuQuestion.TextQuestion(
                     name = when (lang) {
-                        VasuLanguage.FI -> "Varhaiskasvatussuunnitelman laatimisessa hyödynnetyt muut mahdolliset asiakirjat ja suunnitelmat"
-                        VasuLanguage.SV -> "Eventuella övriga handlingar och planer som använts vid uppgörande av barnets plan för småbarnspedagogik"
+                        VasuLanguage.FI -> "Muut asiakirjat ja suunnitelmat"
+                        VasuLanguage.SV -> ""
+                    },
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Lapsen vasun laatimisessa voidaan hyödyntää muita mahdollisia suunnitelmia kuten esimerkiksi lapsen vasun liitteenä oleva lääkehoitosuunnitelma ja Hyve4-lomakkeet."
+                        VasuLanguage.SV -> ""
                     },
                     multiline = true,
                     value = ""
@@ -283,13 +398,13 @@ fun getDefaultVasuContent(lang: VasuLanguage) = VasuContent(
         VasuSection(
             name = when (lang) {
                 VasuLanguage.FI -> "Tiedonsaajatahot"
-                VasuLanguage.SV -> "Barnets plan för småbarnspedagogik delges till följande:"
+                VasuLanguage.SV -> "Barnets plan för småbarnspedagogik delges till följande"
             },
             questions = listOf(
                 VasuQuestion.MultiSelectQuestion(
                     name = when (lang) {
-                        VasuLanguage.FI -> "Tämä varhaiskasvatussuunnitelma luovutetaan huoltajan/huoltajien luvalla:"
-                        VasuLanguage.SV -> "Barnets plan överlämnas med vårdnadshavarnas tillstånd till:"
+                        VasuLanguage.FI -> "Tämä varhaiskasvatussuunnitelma luovutetaan huoltajan/huoltajien luvalla"
+                        VasuLanguage.SV -> "Barnets plan överlämnas med vårdnadshavarnas tillstånd till"
                     },
                     options = listOf(
                         QuestionOption(
@@ -338,22 +453,6 @@ fun getDefaultVasuContent(lang: VasuLanguage) = VasuContent(
         ),
         VasuSection(
             name = when (lang) {
-                VasuLanguage.FI -> "Lisätietoja"
-                VasuLanguage.SV -> "Ytterligare information"
-            },
-            questions = listOf(
-                VasuQuestion.TextQuestion(
-                    name = when (lang) {
-                        VasuLanguage.FI -> "Lisätietoja suunnitelmaan, sen laatimiseen tai keskusteluihin liittyen"
-                        VasuLanguage.SV -> "Ytterligare information om planen, dess uppgörandet eller samtalen"
-                    },
-                    multiline = true,
-                    value = ""
-                )
-            )
-        ),
-        VasuSection(
-            name = when (lang) {
                 VasuLanguage.FI -> "Lapsen varhaiskasvatussuunnitelmakeskustelu"
                 VasuLanguage.SV -> "Samtal om barnets plan för småbarnspedagogik"
             },
@@ -371,7 +470,10 @@ fun getDefaultVasuContent(lang: VasuLanguage) = VasuContent(
                         VasuLanguage.SV -> "Datum för samtalet om barnets plan för småbarnspedagogik"
                     },
                     trackedInEvents = true,
-                    nameInEvents = "Varhaiskasvatussuunnitelmakeskustelu",
+                    nameInEvents = when (lang) {
+                        VasuLanguage.FI -> "Varhaiskasvatussuunnitelmakeskustelu"
+                        VasuLanguage.SV -> ""
+                    },
                     value = null
                 ),
                 VasuQuestion.TextQuestion(
@@ -394,47 +496,18 @@ fun getDefaultVasuContent(lang: VasuLanguage) = VasuContent(
         ),
         VasuSection(
             name = when (lang) {
-                VasuLanguage.FI -> "Toteutumisen arviointi"
-                VasuLanguage.SV -> "Utvärdering av genomförandet"
+                VasuLanguage.FI -> "Seuranta- ja arviointiajankohdat"
+                VasuLanguage.SV -> ""
             },
-            hideBeforeReady = true,
-            questions = listOfNotNull(
-                VasuQuestion.Paragraph(
-                    title = when (lang) {
-                        VasuLanguage.FI -> "Lapsen varhaiskasvatussuunnitelman arviointikeskustelu huoltajien kanssa"
+            questions = listOf(
+                VasuQuestion.TextQuestion(
+                    name = when (lang) {
+                        VasuLanguage.FI -> "Ajankohdat ja kuvaus"
                         VasuLanguage.SV -> ""
                     },
-                    paragraph = ""
-                ),
-                VasuQuestion.DateQuestion(
-                    name = when (lang) {
-                        VasuLanguage.FI -> "Arviointikeskustelun päivämäärä"
-                        VasuLanguage.SV -> "Datum för utvärderingssamtalet"
-                    },
-                    trackedInEvents = true,
-                    nameInEvents = "Arviointikeskustelu",
-                    value = null
-                ),
-                VasuQuestion.TextQuestion(
-                    name = when (lang) {
-                        VasuLanguage.FI -> "Arviointikeskusteluun osallistuneet huoltajat"
-                        VasuLanguage.SV -> "Vårdnadshavare som deltog i utvärderingssamtalet"
-                    },
-                    multiline = true,
-                    value = ""
-                ),
-                VasuQuestion.TextQuestion(
-                    name = when (lang) {
-                        VasuLanguage.FI -> "Huoltajan/huoltajien kanssa tehty yhteistyö sekä näkemys varhaiskasvatussuunnitelman sisällöstä"
-                        VasuLanguage.SV -> "Samarbete med vårdnadshavaren/-havarna och synpunkter på innehållet i barnets plan"
-                    },
-                    multiline = true,
-                    value = ""
-                ),
-                VasuQuestion.TextQuestion(
-                    name = when (lang) {
-                        VasuLanguage.FI -> "Tavoitteiden ja toimenpiteiden toteutumisen arviointi"
-                        VasuLanguage.SV -> "Utvärdering av hur målen och åtgärderna har genomförts"
+                    info = when (lang) {
+                        VasuLanguage.FI -> "Tähän kohtaan kirjataan huoltajan kanssa yhdessä sovittu jatkosuunnitelma ja milloin suunnitelmaa seuraavan kerran arvioidaan."
+                        VasuLanguage.SV -> ""
                     },
                     multiline = true,
                     value = ""

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuControllerCitizen.kt
@@ -93,11 +93,8 @@ class VasuControllerCitizen(
             dbc.read { tx ->
                 val doc = tx.getLatestPublishedVasuDocument(id) ?: throw NotFound("document $id not found")
                 CitizenGetVasuDocumentResponse(
-                    vasu = doc,
-                    guardianHasGivenPermissionToShare = doc.basics.guardians.find {
-                            g ->
-                        g.id.raw == user.rawId()
-                    }?.let { it.hasGivenPermissionToShare } ?: false
+                    vasu = doc.redact(),
+                    guardianHasGivenPermissionToShare = doc.basics.guardians.find { it.id.raw == user.rawId() }?.hasGivenPermissionToShare ?: false
                 )
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuQueries.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.vasu
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.PersonId
-import fi.espoo.evaka.shared.VasuDocumentFollowupEntryId
 import fi.espoo.evaka.shared.VasuDocumentId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapJsonColumn
@@ -326,24 +325,6 @@ private fun Database.Read.getVasuPlacements(id: VasuDocumentId): List<VasuPlacem
         .bind("id", id)
         .mapTo<VasuPlacement>()
         .list()
-}
-
-fun Database.Read.getVasuFollowupEntry(id: VasuDocumentFollowupEntryId): FollowupEntry {
-    val (docId, entryId) = id
-    return createQuery(
-        """
-        WITH followup_entries AS (
-            SELECT jsonb_path_query(content, '$.sections[*].questions ? (@.type=="FOLLOWUP").value[*]') AS entry 
-            FROM curriculum_content
-            WHERE document_id = :docId AND master = true
-        )
-        SELECT entry FROM followup_entries WHERE entry ->> 'id' = :entryId
-        """
-    )
-        .bind("docId", docId)
-        .bind("entryId", entryId.toString())
-        .map { row -> row.mapJsonColumn<FollowupEntry>("entry") }
-        .one()
 }
 
 fun Database.Transaction.setVasuGuardianHasGivenPermissionToShare(docId: VasuDocumentId, guardianId: PersonId) {


### PR DESCRIPTION
#### Summary

- Updated the vasu default template to match the new guidelines
- Made the first section a dynamic section so that it can be customized in the template editor
  - Backwards compatible: added a flag for newly created templates to indicate a dynamic first section so that flagless (i.e., old templates) still have the static basic info section
- Added intervention radio group options, which are not real options but text guides in between options
- Overhauled follow-up questions: the editor is an infinitely growing list of entries, which contains a configurable entry date and text
  - Removed special handling of follow-up entries and now they're sent and modified using the regular vasu modification handler with some special handling
  - Employee names for follow-up entries (created/edited) are not saved in the document JSON, instead only the ID is and the names are filled in when the document is retrieved
  - Employee IDs (and more importantly, names) are always redacted in citizen's version of the vasu
- Changed the color of the draft vasu status chip
