### PR TITLE
Fix autosave force-saving for cancellations

### DIFF
--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -179,7 +179,7 @@ function AsyncButton<T>({
   const showIcon = buttonState.state !== 'idle'
 
   const container = useSpring<{ x: number }>({
-    x: !hideSuccess && showIcon ? 1 : 0
+    x: (!hideSuccess || !isSuccess) && showIcon ? 1 : 0
   })
   const spinner = useSpring<{ opacity: number }>({
     opacity: isInProgress ? 1 : 0


### PR DESCRIPTION
#### Summary

The autosave force-saving feature did not properly account for cancelled requests. Cancellations happened often in the e2e tests (but not always) in the assistance need decision edit page because the debounce happened to be almost the same time as it takes to click the buttons, thus cancelling the button-clicking request and preventing navigation. This made two assistance need decision e2e tests flaky.