### PR TITLE
EVAKA-4469 Require unit field for assistance need decisions

### DIFF
--- a/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-edit-page.ts
+++ b/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-edit-page.ts
@@ -64,4 +64,10 @@ export default class AssistanceNeedDecisionEditPage {
       title
     )
   }
+
+  async selectUnit(unit: string): Promise<void> {
+    await new Combobox(
+      this.page.findByDataQa('unit-select')
+    ).fillAndSelectFirst(unit)
+  }
 }

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
@@ -119,6 +119,7 @@ describe('Assistance Need Decisions - Edit page', () => {
 
   test('Clicking the preview button opens the decision in preview mode', async () => {
     await assistanceNeedDecisionEditPage.assertDeciderSelectVisible()
+    await assistanceNeedDecisionEditPage.selectUnit(daycareFixture.name)
     await assistanceNeedDecisionEditPage.clickPreviewButton()
 
     await page.page.waitForURL(

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionPage.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -45,6 +45,17 @@ export default React.memo(function AssistanceNeedDecisionPage() {
       ...i18n
     }
   } = useTranslation()
+
+  useEffect(() => {
+    if (assistanceNeedDecision.getOrElse(undefined)?.hasMissingFields) {
+      navigate(
+        `/child-information/${childId}/assistance-need-decision/${id}/edit`,
+        {
+          replace: true
+        }
+      )
+    }
+  }, [assistanceNeedDecision, childId, id, navigate])
 
   const canBeEdited = assistanceNeedDecision
     .map(

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
@@ -20,7 +20,7 @@ import LocalDate from 'lib-common/local-date'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
-import InputField from 'lib-components/atoms/form/InputField'
+import InputField, { InputInfo } from 'lib-components/atoms/form/InputField'
 import Radio from 'lib-components/atoms/form/Radio'
 import {
   FixedSpaceColumn,
@@ -159,16 +159,23 @@ const EmployeeSelectWithTitle = React.memo(function EmployeeSelectWithTitle({
   )
 })
 
+export type FieldInfos = Record<
+  keyof AssistanceNeedDecisionForm,
+  InputInfo | undefined
+>
+
 type AssistanceNeedDecisionFormProps = {
   formState: AssistanceNeedDecisionForm
   setFormState: React.Dispatch<
     SetStateAction<AssistanceNeedDecisionForm | undefined>
   >
+  fieldInfos: FieldInfos
 }
 
 export default React.memo(function AssistanceNeedDecisionForm({
   formState,
-  setFormState
+  setFormState,
+  fieldInfos
 }: AssistanceNeedDecisionFormProps) {
   const [units] = useApiState(() => getUnits([], 'ALL'), [])
   const [employees] = useApiState(() => getEmployees(), [])
@@ -207,6 +214,7 @@ export default React.memo(function AssistanceNeedDecisionForm({
           onChange={(val) => setFieldVal({ pedagogicalMotivation: val })}
           placeholder={t.genericPlaceholder}
           data-qa="pedagogical-motivation-field"
+          info={fieldInfos.pedagogicalMotivation}
         />
       </FieldWithInfo>
 
@@ -292,6 +300,7 @@ export default React.memo(function AssistanceNeedDecisionForm({
             setFieldVal({ structuralMotivationDescription: val })
           }
           placeholder={t.structuralMotivationPlaceholder}
+          info={fieldInfos.structuralMotivationDescription}
         />
       </FieldWithInfo>
 
@@ -304,6 +313,7 @@ export default React.memo(function AssistanceNeedDecisionForm({
           value={formState.careMotivation ?? ''}
           onChange={(val) => setFieldVal({ careMotivation: val })}
           placeholder={t.genericPlaceholder}
+          info={fieldInfos.careMotivation}
         />
       </FieldWithInfo>
 
@@ -372,6 +382,7 @@ export default React.memo(function AssistanceNeedDecisionForm({
           value={formState.servicesMotivation ?? ''}
           onChange={(val) => setFieldVal({ servicesMotivation: val })}
           placeholder={t.servicesPlaceholder}
+          info={fieldInfos.servicesMotivation}
         />
       </FieldWithInfo>
 
@@ -386,6 +397,8 @@ export default React.memo(function AssistanceNeedDecisionForm({
             setFieldVal({ guardiansHeardOn: date })
           }}
           errorTexts={i18n.validationErrors}
+          hideErrorsBeforeTouched
+          info={fieldInfos.guardiansHeardOn}
         />
       </FixedSpaceColumn>
 
@@ -430,6 +443,7 @@ export default React.memo(function AssistanceNeedDecisionForm({
           value={formState.viewOfGuardians ?? ''}
           onChange={(val) => setFieldVal({ viewOfGuardians: val })}
           placeholder={t.genericPlaceholder}
+          info={fieldInfos.viewOfGuardians}
         />
       </FieldWithInfo>
 
@@ -482,6 +496,8 @@ export default React.memo(function AssistanceNeedDecisionForm({
             setFieldVal({ startDate: date })
           }}
           errorTexts={i18n.validationErrors}
+          hideErrorsBeforeTouched
+          info={fieldInfos.startDate}
         />
       </FieldWithInfo>
 
@@ -497,6 +513,8 @@ export default React.memo(function AssistanceNeedDecisionForm({
             onChange={(unit) =>
               setFieldVal({ selectedUnit: unit && { id: unit.id } })
             }
+            info={fieldInfos.selectedUnit}
+            data-qa="unit-select"
           />
         ))}
         <Gap size="s" />
@@ -509,6 +527,7 @@ export default React.memo(function AssistanceNeedDecisionForm({
           value={formState.motivationForDecision ?? ''}
           onChange={(val) => setFieldVal({ motivationForDecision: val })}
           placeholder={t.genericPlaceholder}
+          info={fieldInfos.motivationForDecision}
         />
       </FixedSpaceColumn>
 

--- a/frontend/src/lib-common/generated/api-types/assistanceneed.ts
+++ b/frontend/src/lib-common/generated/api-types/assistanceneed.ts
@@ -204,6 +204,7 @@ export interface AssistanceNeedDecisionRequest {
 */
 export interface AssistanceNeedDecisionResponse {
   decision: AssistanceNeedDecision
+  hasMissingFields: boolean
   permittedActions: Action.AssistanceNeedDecision[]
 }
 

--- a/frontend/src/lib-components/atoms/dropdowns/Combobox.tsx
+++ b/frontend/src/lib-components/atoms/dropdowns/Combobox.tsx
@@ -11,6 +11,8 @@ import styled from 'styled-components'
 
 import { faChevronDown, faChevronUp, faTimes } from 'lib-icons'
 
+import UnderRowStatusIcon from '../StatusIcon'
+import { InputFieldUnderRow, InputInfo } from '../form/InputField'
 import { SpinnerSegment } from '../state/Spinner'
 
 import { borderRadius, borderStyles, DropdownProps, Root } from './shared'
@@ -27,6 +29,7 @@ export interface ComboboxProps<T> extends DropdownProps<T, HTMLInputElement> {
     menuEmptyItem?: (label: string) => React.ReactNode
   }
   fullWidth?: boolean
+  info?: InputInfo
 }
 
 export interface MenuItemProps<T> {
@@ -41,6 +44,14 @@ const InputWrapper = styled.div`
   ${borderStyles};
   &.active {
     border-color: transparent;
+  }
+
+  &.success {
+    border-color: ${(p) => p.theme.colors.status.success};
+  }
+
+  &.warning {
+    border-color: ${(p) => p.theme.colors.status.warning};
   }
 `
 
@@ -278,87 +289,97 @@ function Combobox<T>(props: ComboboxProps<T>) {
     }
   }, [isOpen, setInputValue, itemToString, selectedItem])
   return (
-    <Root
-      data-qa={dataQa}
-      className={classNames({ active: isOpen, 'full-width': fullWidth })}
-      onClick={enabled ? toggleMenu : undefined}
-    >
-      <InputWrapper
-        {...getComboboxProps({
-          disabled,
-          className: classNames({ active: isOpen })
-        })}
+    <>
+      <Root
+        data-qa={dataQa}
+        className={classNames({ active: isOpen, 'full-width': fullWidth })}
+        onClick={enabled ? toggleMenu : undefined}
       >
-        <Input
-          {...getInputProps({
-            id,
-            name,
+        <InputWrapper
+          {...getComboboxProps({
             disabled,
-            placeholder,
-            onFocus
-          })}
-        />
-        {clearable && selectedItem && (
-          <>
-            <Button
-              data-qa="clear"
-              onClick={enabled ? onClickClear : undefined}
-            >
-              <FontAwesomeIcon icon={faTimes} />
-            </Button>
-            <Separator>&nbsp;</Separator>
-          </>
-        )}
-        <Button
-          data-qa="toggle"
-          type="button"
-          {...getToggleButtonProps({
-            disabled,
-            // avoid toggling the menu twice
-            onClick: stopPropagation
+            className: classNames({ active: isOpen }, props.info?.status)
           })}
         >
-          <FontAwesomeIcon icon={isOpen ? faChevronUp : faChevronDown} />
-        </Button>
-      </InputWrapper>
-      <MenuWrapper onClick={stopPropagation}>
-        <Menu
-          className={classNames({ closed: !isOpen })}
-          {...getMenuProps({
-            // styled-components and downshift typings don't play nice together
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
-            ref: menuRef as any
-          })}
-        >
-          {isOpen && (
+          <Input
+            {...getInputProps({
+              id,
+              name,
+              disabled,
+              placeholder,
+              onFocus
+            })}
+          />
+          {clearable && selectedItem && (
             <>
-              {isLoading ? (
-                <MenuItemWrapper>
-                  <SpinnerSegment />
-                </MenuItemWrapper>
-              ) : filteredItems.length === 0 ? (
-                <MenuItemWrapper>
-                  {renderEmptyResult(menuEmptyLabel ?? '')}
-                </MenuItemWrapper>
-              ) : (
-                filteredItems.map((item, index) => (
-                  <MenuItemWrapper
-                    data-qa="item"
-                    key={index}
-                    {...getItemProps({ item, index })}
-                  >
-                    {renderMenuItem({
-                      item,
-                      highlighted: highlightedIndex === index
-                    })}
-                  </MenuItemWrapper>
-                ))
-              )}
+              <Button
+                data-qa="clear"
+                onClick={enabled ? onClickClear : undefined}
+              >
+                <FontAwesomeIcon icon={faTimes} />
+              </Button>
+              <Separator>&nbsp;</Separator>
             </>
           )}
-        </Menu>
-      </MenuWrapper>
-    </Root>
+          <Button
+            data-qa="toggle"
+            type="button"
+            {...getToggleButtonProps({
+              disabled,
+              // avoid toggling the menu twice
+              onClick: stopPropagation
+            })}
+          >
+            <FontAwesomeIcon icon={isOpen ? faChevronUp : faChevronDown} />
+          </Button>
+        </InputWrapper>
+        <MenuWrapper onClick={stopPropagation}>
+          <Menu
+            className={classNames({ closed: !isOpen })}
+            {...getMenuProps({
+              // styled-components and downshift typings don't play nice together
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
+              ref: menuRef as any
+            })}
+          >
+            {isOpen && (
+              <>
+                {isLoading ? (
+                  <MenuItemWrapper>
+                    <SpinnerSegment />
+                  </MenuItemWrapper>
+                ) : filteredItems.length === 0 ? (
+                  <MenuItemWrapper>
+                    {renderEmptyResult(menuEmptyLabel ?? '')}
+                  </MenuItemWrapper>
+                ) : (
+                  filteredItems.map((item, index) => (
+                    <MenuItemWrapper
+                      data-qa="item"
+                      key={index}
+                      {...getItemProps({ item, index })}
+                    >
+                      {renderMenuItem({
+                        item,
+                        highlighted: highlightedIndex === index
+                      })}
+                    </MenuItemWrapper>
+                  ))
+                )}
+              </>
+            )}
+          </Menu>
+        </MenuWrapper>
+      </Root>
+      {props.info && (
+        <InputFieldUnderRow className={classNames(props.info.status)}>
+          <span data-qa={dataQa ? `${dataQa}-info` : undefined}>
+            {props.info.text}
+          </span>
+          <UnderRowStatusIcon status={props.info.status} />
+        </InputFieldUnderRow>
+      )}
+    </>
   )
 }
 

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -700,6 +700,11 @@ export const fi = {
         description:
           'Haluatko varmasti poistaa päätöspohjan? Kaikki päätöspohjaan täydennetyt tiedot menetetään.'
       },
+      validation: {
+        title: 'Päätösesityksen tarkistus',
+        description:
+          'Ole hyvä ja tarkista seuraavat tiedot päätösesityksestä ennen esikatselua:'
+      },
       genericPlaceholder: 'Kirjoita',
       formLanguage: 'Lomakkeen kieli',
       neededTypesOfAssistance: 'Lapsen tarvitsemat tuen muodot',


### PR DESCRIPTION
#### Summary

The assistance need decisions decision-maker report does not display rows that do not have a unit associated with the decision due to a JOIN in the query; as such, the unit is a required field. There are other required fields (from a non-technical aspect) as well, but those will be decided on later. Moreover, support for the validation field info was only added to the unit dropdown and some other easy cases; when other required fields are decided on the rest of the field infos can be implemented in the more complex cases.
