### PR TITLE
Miscellanious UI tweaks

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -10,7 +10,6 @@ import styled from 'styled-components'
 
 import { scrollElementToPos } from 'lib-common/utils/scrolling'
 import SkipToContent from 'lib-components/atoms/buttons/SkipToContent'
-import { desktopMin } from 'lib-components/breakpoints'
 import ErrorPage from 'lib-components/molecules/ErrorPage'
 import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
 import { theme } from 'lib-customizations/common'
@@ -33,7 +32,6 @@ import ChildPage from './children/ChildPage'
 import ChildrenPage from './children/ChildrenPage'
 import DecisionResponseList from './decisions/decision-response-page/DecisionResponseList'
 import Header from './header/Header'
-import { headerHeightDesktop, headerHeightMobile } from './header/const'
 import { HolidayPeriodsContextProvider } from './holiday-periods/state'
 import ChildIncomeStatementEditor from './income-statements/ChildIncomeStatementEditor'
 import ChildIncomeStatementView from './income-statements/ChildIncomeStatementView'
@@ -66,7 +64,6 @@ export default function App() {
                       <Content />
                       <GlobalDialog />
                       <LoginErrorModal translations={i18n.login.failedModal} />
-                      <CitizenReloadNotification />
                       <div id="modal-container" />
                     </HolidayPeriodsContextProvider>
                   </PedagogicalDocumentsContextProvider>
@@ -79,6 +76,11 @@ export default function App() {
     </BrowserRouter>
   )
 }
+
+const FullPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`
 
 const Content = React.memo(function Content() {
   const t = useTranslation()
@@ -97,9 +99,10 @@ const Content = React.memo(function Content() {
   )
 
   return (
-    <>
+    <FullPageContainer>
       <SkipToContent target="main">{t.skipLinks.mainContent}</SkipToContent>
       <Header ariaHidden={modalOpen} />
+      <CitizenReloadNotification />
       <MainContainer ariaHidden={modalOpen} ref={mainRef}>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
@@ -254,7 +257,7 @@ const Content = React.memo(function Content() {
           <Route index element={<HandleRedirection />} />
         </Routes>
       </MainContainer>
-    </>
+    </FullPageContainer>
   )
 })
 
@@ -296,10 +299,5 @@ function HandleRedirection() {
 }
 
 const ScrollableMain = styled.div`
-  height: calc(100% - ${headerHeightMobile}px);
-  overflow: auto;
-
-  @media (min-width: ${desktopMin}) {
-    height: calc(100% - ${headerHeightDesktop}px);
-  }
+  flex-grow: 1;
 `

--- a/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
+++ b/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
@@ -4,7 +4,7 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React from 'react'
-import { Navigate, Route, Routes } from 'react-router-dom'
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 
 import Footer from 'citizen-frontend/Footer'
@@ -34,6 +34,7 @@ export default React.memo(function ApplyingRouter({ scrollToTop }: Props) {
   const t = useTranslation()
   const user = useUser()
   const isEndUser = user?.userType === 'ENDUSER'
+  const { pathname } = useLocation()
 
   const maybeLockElem = !isEndUser && (
     <FontAwesomeIcon icon={faLockAlt} size="xs" />
@@ -88,7 +89,15 @@ export default React.memo(function ApplyingRouter({ scrollToTop }: Props) {
               </RequireAuth>
             }
           />
-          <Route path="map" element={<MapView scrollToTop={scrollToTop} />} />
+          <Route
+            path="map"
+            element={
+              <>
+                <Gap size="s" />
+                <MapView scrollToTop={scrollToTop} />
+              </>
+            }
+          />
           <Route
             path="decisions"
             element={
@@ -107,7 +116,7 @@ export default React.memo(function ApplyingRouter({ scrollToTop }: Props) {
           />
         </Routes>
       </Main>
-      <Footer />
+      {pathname !== '/applying/map' && <Footer />}
     </>
   )
 })

--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -17,6 +17,7 @@ import {
   ReservationChild
 } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
+import { scrollToPos } from 'lib-common/utils/scrolling'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { fontWeights, H1, H2 } from 'lib-components/typography'
@@ -27,10 +28,11 @@ import { faCalendarPlus, faTreePalm, faUserMinus } from 'lib-icons'
 import { headerHeightDesktop } from '../header/const'
 import { useHolidayPeriods } from '../holiday-periods/state'
 import { useLang, useTranslation } from '../localization'
-import { scrollMainToPos } from '../utils'
 
 import { asWeeklyData, WeeklyData } from './CalendarListView'
+import { useCalendarModalState } from './CalendarPage'
 import { HistoryOverlay } from './HistoryOverlay'
+import HolidayPeriodCta from './HolidayPeriodCta'
 import ReportHolidayLabel from './ReportHolidayLabel'
 import { ChildImageData, getChildImages } from './RoundChildImages'
 import { Reservations } from './calendar-elements'
@@ -61,18 +63,14 @@ export default React.memo(function CalendarGridView({
   const i18n = useTranslation()
   const monthlyData = useMemo(() => asMonthlyData(dailyData), [dailyData])
   const headerRef = useRef<HTMLDivElement>(null)
-  const todayRef = useRef<HTMLButtonElement>()
+  const todayRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
-    const pos = todayRef.current?.getBoundingClientRect().top
+    const top = todayRef.current?.getBoundingClientRect().top
 
-    if (pos) {
-      const offset =
-        headerHeightDesktop + (headerRef.current?.clientHeight ?? 0) + 16
-
-      scrollMainToPos({
-        left: 0,
-        top: pos - offset
+    if (top) {
+      scrollToPos({
+        top: top - headerHeightDesktop - 32
       })
     }
   }, [])
@@ -90,6 +88,8 @@ export default React.memo(function CalendarGridView({
   )
 
   const childImages = useMemo(() => getChildImages(childData), [childData])
+
+  const { openHolidayModal } = useCalendarModalState()
 
   return (
     <>
@@ -121,6 +121,8 @@ export default React.memo(function CalendarGridView({
             </ButtonContainer>
           </PageHeaderRow>
         </Container>
+
+        <HolidayPeriodCta openModal={openHolidayModal} />
       </StickyHeader>
       <Container>
         {monthlyData.map(({ month, year, weeks }) => (
@@ -232,7 +234,7 @@ const Month = React.memo(function Month({
   childData: ReservationChild[]
   weeks: WeeklyData[]
   holidayPeriods: FiniteDateRange[]
-  todayRef: MutableRefObject<HTMLButtonElement | undefined>
+  todayRef: MutableRefObject<HTMLButtonElement | null>
   selectedDate: LocalDate | undefined
   selectDate: (date: LocalDate) => void
   includeWeekends: boolean
@@ -291,7 +293,7 @@ const Week = React.memo(function Week({
   childData: ReservationChild[]
   week: WeeklyData
   holidayPeriods: FiniteDateRange[]
-  todayRef: MutableRefObject<HTMLButtonElement | undefined>
+  todayRef: MutableRefObject<HTMLButtonElement | null>
   selectedDate: LocalDate | undefined
   selectDate: (date: LocalDate) => void
   dayIsReservable: (dailyData: DailyReservationData) => boolean
@@ -340,7 +342,7 @@ const Day = React.memo(function Day({
   day: DailyReservationData
   childData: ReservationChild[]
   holidayPeriods: FiniteDateRange[]
-  todayRef: MutableRefObject<HTMLButtonElement | undefined>
+  todayRef: MutableRefObject<HTMLButtonElement | null>
   dateType: DateType
   selected: boolean
   selectDate: (date: LocalDate) => void

--- a/frontend/src/citizen-frontend/calendar/CalendarListView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarListView.tsx
@@ -20,6 +20,8 @@ import { faPlus } from 'lib-icons'
 
 import { useTranslation } from '../localization'
 
+import { useCalendarModalState } from './CalendarPage'
+import HolidayPeriodCta from './HolidayPeriodCta'
 import { getChildImages } from './RoundChildImages'
 import WeekElem from './WeekElem'
 
@@ -45,8 +47,13 @@ export default React.memo(function CalendarListView({
 
   const childImages = useMemo(() => getChildImages(childData), [childData])
 
+  const { openHolidayModal } = useCalendarModalState()
+
   return (
     <>
+      <HolidayPeriodCtaContainer>
+        <HolidayPeriodCta openModal={openHolidayModal} topAligned />
+      </HolidayPeriodCtaContainer>
       <FixedSpaceColumn spacing="zero">
         {weeklyData.map((w) => (
           <WeekElem
@@ -112,4 +119,10 @@ const HoverButton = styled(Button)`
 
 const Icon = styled(FontAwesomeIcon)`
   margin-right: ${defaultMargins.xs};
+`
+
+const HolidayPeriodCtaContainer = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 20;
 `

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -19,7 +19,6 @@ import {
   Desktop,
   MobileAndTablet
 } from 'lib-components/layout/responsive-layout'
-import { Gap } from 'lib-components/white-space'
 
 import Footer from '../Footer'
 import RequireAuth from '../RequireAuth'
@@ -32,7 +31,6 @@ import ActionPickerModal from './ActionPickerModal'
 import CalendarGridView from './CalendarGridView'
 import CalendarListView from './CalendarListView'
 import DayView from './DayView'
-import HolidayPeriodCta from './HolidayPeriodCta'
 import ReservationModal from './ReservationModal'
 import { getReservations } from './api'
 import FixedPeriodSelectionModal from './holiday-modal/FixedPeriodSelectionModal'
@@ -65,7 +63,7 @@ const CalendarPage = React.memo(function CalendarPage() {
     openAbsenceModal,
     openDayModal,
     closeModal
-  } = useModalState()
+  } = useCalendarModalState()
 
   const refreshOnQuestionnaireAnswer = useCallback(() => {
     refreshQuestionnaires()
@@ -127,7 +125,6 @@ const CalendarPage = React.memo(function CalendarPage() {
 
   return renderResult(data, (response) => (
     <div data-qa="calendar-page" data-isloading={isLoading(data)}>
-      <HolidayPeriodCta openModal={openHolidayModal} />
       <MobileAndTablet>
         <ContentArea opaque paddingVertical="zero" paddingHorizontal="zero">
           <CalendarListView
@@ -141,7 +138,6 @@ const CalendarPage = React.memo(function CalendarPage() {
         </ContentArea>
       </MobileAndTablet>
       <DesktopOnly>
-        <Gap size="s" />
         <CalendarGridView
           childData={response.children}
           dailyData={response.dailyData}
@@ -231,7 +227,7 @@ interface UseModalStateResult {
   closeModal: () => void
 }
 
-function useModalState(): UseModalStateResult {
+export function useCalendarModalState(): UseModalStateResult {
   const location = useLocation()
   const navigate = useNavigate()
 

--- a/frontend/src/citizen-frontend/calendar/HolidayPeriodCta.tsx
+++ b/frontend/src/citizen-frontend/calendar/HolidayPeriodCta.tsx
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useCallback } from 'react'
+import styled from 'styled-components'
 
 import { useDataStatus } from 'lib-common/utils/result-to-data-status'
 import Toast from 'lib-components/molecules/Toast'
+import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faTreePalm } from 'lib-icons'
 
@@ -14,9 +16,11 @@ import { HolidayCta, NoCta, useHolidayPeriods } from '../holiday-periods/state'
 import { useTranslation } from '../localization'
 
 export default React.memo(function HolidayPeriodCta({
-  openModal
+  openModal,
+  topAligned
 }: {
   openModal: () => void
+  topAligned?: boolean
 }) {
   const { holidayCta, ctaClosed, closeCta } = useHolidayPeriods()
   const status = useDataStatus(holidayCta)
@@ -43,7 +47,11 @@ export default React.memo(function HolidayPeriodCta({
   }, [closeCta, openModal])
 
   return (
-    <div data-qa="holiday-period-cta-container" data-status={status}>
+    <CtaToastContainer
+      data-qa="holiday-period-cta-container"
+      data-status={status}
+      topAligned={topAligned}
+    >
       <UnwrapResult
         result={holidayCta}
         loading={() => null}
@@ -56,14 +64,21 @@ export default React.memo(function HolidayPeriodCta({
               iconColor={colors.status.warning}
               onClick={cta.type === 'questionnaire' ? clickAction : undefined}
               onClose={closeCta}
-              offsetTop="64px"
-              offsetTopDesktop="180px"
             >
               <span data-qa="holiday-period-cta">{getCtaText(cta)}</span>
             </Toast>
           ) : null
         }
       </UnwrapResult>
-    </div>
+    </CtaToastContainer>
   )
 })
+
+const CtaToastContainer = styled.div<{ topAligned?: boolean }>`
+  position: absolute;
+  top: ${(p) =>
+    p.topAligned ? defaultMargins.s : `calc(100% + ${defaultMargins.s})`};
+  right: ${defaultMargins.s};
+  z-index: 100;
+  padding-left: 16px;
+`

--- a/frontend/src/citizen-frontend/calendar/WeekElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/WeekElem.tsx
@@ -11,14 +11,13 @@ import {
 } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
 import { capitalizeFirstLetter } from 'lib-common/string'
+import { scrollToPos } from 'lib-common/utils/scrolling'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { fontWeights, H2, H3 } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 
-import { headerHeightMobile } from '../header/const'
 import { useLang, useTranslation } from '../localization'
-import { scrollMainToPos } from '../utils'
 
 import { WeeklyData } from './CalendarListView'
 import { HistoryOverlay } from './HistoryOverlay'
@@ -137,16 +136,12 @@ const DayElem = React.memo(function DayElem({
   }, [selectDate, dailyReservations.date])
 
   useEffect(() => {
-    if (ref.current) {
-      const pos = ref.current?.getBoundingClientRect().top
+    const top = ref.current?.getBoundingClientRect().top
 
-      if (pos) {
-        const offset = headerHeightMobile + 16
-        scrollMainToPos({
-          left: 0,
-          top: pos - offset
-        })
-      }
+    if (top) {
+      scrollToPos({
+        top: top - 32
+      })
     }
   }, [])
 

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -59,12 +59,12 @@ export default React.memo(function DesktopNav({
                 <>
                   {user.accessibleFeatures.reservations && (
                     <StyledNavLink to="/calendar" data-qa="nav-calendar">
-                      {t.header.nav.calendar}
+                      <NavLinkText text={t.header.nav.calendar} />
                     </StyledNavLink>
                   )}
                   {user.accessibleFeatures.messages && (
                     <StyledNavLink to="/messages" data-qa="nav-messages">
-                      {t.header.nav.messages}{' '}
+                      <NavLinkText text={t.header.nav.messages} />{' '}
                       {unreadMessagesCount > 0 ? (
                         <CircledChar
                           aria-label={`${t.header.nav.messageCount(
@@ -83,7 +83,7 @@ export default React.memo(function DesktopNav({
                       to="/child-documents"
                       data-qa="nav-child-documents"
                     >
-                      {t.header.nav.pedagogicalDocuments}
+                      <NavLinkText text={t.header.nav.pedagogicalDocuments} />
                       {maybeLockElem}
                       {isEnduser && unreadChildDocuments > 0 && (
                         <CircledChar data-qa="unread-child-documents-count">
@@ -93,10 +93,10 @@ export default React.memo(function DesktopNav({
                     </StyledNavLink>
                   )}
                   <StyledNavLink to="/children" data-qa="nav-children">
-                    {t.header.nav.children} {maybeLockElem}
+                    <NavLinkText text={t.header.nav.children} /> {maybeLockElem}
                   </StyledNavLink>
                   <StyledNavLink to="/applying" data-qa="nav-applying">
-                    {t.header.nav.applications}
+                    <NavLinkText text={t.header.nav.applications} />
                   </StyledNavLink>
                 </>
               ) : null}
@@ -117,6 +117,14 @@ export default React.memo(function DesktopNav({
       }}
     </UnwrapResult>
   )
+})
+
+const NavLinkText = React.memo(function NavLinkText({
+  text
+}: {
+  text: string
+}) {
+  return <div data-text={text}>{text}</div>
 })
 
 const Container = styled.div`
@@ -153,13 +161,27 @@ const StyledNavLink = styled(NavLink)`
     padding: 0 ${defaultMargins.m};
   }
 
-  &:hover {
+  &:hover,
+  [data-text]::before {
     font-weight: ${fontWeights.bold};
+  }
+
+  &:hover .circled-char,
+  &.active .circled-char {
+    border-width: 2px;
+    padding: 10px;
   }
 
   &.active {
     border-bottom-color: ${colors.grayscale.g0};
     font-weight: ${fontWeights.bold};
+  }
+
+  [data-text]::before {
+    display: block;
+    height: 0;
+    visibility: hidden;
+    content: attr(data-text);
   }
 `
 
@@ -179,16 +201,19 @@ const Icon = styled(FontAwesomeIcon)`
   font-size: 1.25rem;
 `
 
-export const CircledChar = styled.div`
+export const CircledChar = styled.div.attrs({
+  className: 'circled-char'
+})`
   width: ${defaultMargins.s};
   height: ${defaultMargins.s};
   border: 1px solid ${colors.grayscale.g0};
-  padding: 10px;
+  padding: 11px;
   display: flex;
   justify-content: center;
   align-items: center;
   text-align: center;
   border-radius: 100%;
+  letter-spacing: 0;
 `
 
 interface LanguageMenuProps {

--- a/frontend/src/citizen-frontend/header/EvakaLogo.tsx
+++ b/frontend/src/citizen-frontend/header/EvakaLogo.tsx
@@ -6,12 +6,15 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
+import { useTranslation } from 'citizen-frontend/localization'
 import { EvakaLogo } from 'lib-components/atoms/EvakaLogo'
 import { desktopMin, desktopSmall } from 'lib-components/breakpoints'
 
 export default React.memo(function Logo() {
+  const t = useTranslation()
+
   return (
-    <Container to="/">
+    <Container to="/" aria-label={t.header.goToHomepage}>
       <EvakaLogo />
     </Container>
   )

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -74,7 +74,11 @@ export default React.memo(function MobileNav({
 
         return (
           <Container ref={ref} data-qa="mobile-nav">
-            <MenuButton onClick={toggleMenu} data-qa="menu-button">
+            <MenuButton
+              onClick={toggleMenu}
+              data-qa="menu-button"
+              aria-label={showMenu ? t.header.closeMenu : t.header.openMenu}
+            >
               <AttentionIndicator
                 toggled={showAttentionIndicator}
                 data-qa="attention-indicator-mobile"
@@ -235,12 +239,12 @@ const Navigation = React.memo(function Navigation({
     <Nav>
       {user.accessibleFeatures.reservations && (
         <StyledNavLink to="/calendar" onClick={close} data-qa="nav-calendar">
-          {t.header.nav.calendar}
+          <NavLinkText text={t.header.nav.calendar} />
         </StyledNavLink>
       )}
       {user.accessibleFeatures.messages && (
         <StyledNavLink to="/messages" onClick={close} data-qa="nav-messages">
-          {t.header.nav.messages}
+          <NavLinkText text={t.header.nav.messages} />
           {unreadMessagesCount > 0 && (
             <FloatingCircledChar>{unreadMessagesCount}</FloatingCircledChar>
           )}
@@ -252,7 +256,7 @@ const Navigation = React.memo(function Navigation({
           data-qa="nav-child-documents"
           onClick={close}
         >
-          {t.header.nav.pedagogicalDocuments}
+          <NavLinkText text={t.header.nav.pedagogicalDocuments} />
           {maybeLockElem}
           {unreadChildDocumentsCount > 0 && (
             <FloatingCircledChar>
@@ -262,13 +266,21 @@ const Navigation = React.memo(function Navigation({
         </StyledNavLink>
       )}
       <StyledNavLink to="/children" onClick={close} data-qa="nav-children">
-        {t.header.nav.children} {maybeLockElem}
+        <NavLinkText text={t.header.nav.children} /> {maybeLockElem}
       </StyledNavLink>
       <StyledNavLink to="/applying" onClick={close} data-qa="nav-applications">
-        {t.header.nav.applications} {maybeLockElem}
+        <NavLinkText text={t.header.nav.applications} /> {maybeLockElem}
       </StyledNavLink>
     </Nav>
   )
+})
+
+const NavLinkText = React.memo(function NavLinkText({
+  text
+}: {
+  text: string
+}) {
+  return <div data-text={text}>{text}</div>
 })
 
 const Nav = styled.nav`
@@ -295,14 +307,29 @@ const StyledNavLink = styled(NavLink)`
   margin: ${defaultMargins.xxs} 0;
   border-bottom: 2px solid transparent;
 
-  &:hover {
+  &:hover,
+  [data-text]::before {
     font-weight: ${fontWeights.bold};
     border-color: ${colors.grayscale.g0};
+  }
+
+  &:hover .circled-char,
+  &.active .circled-char {
+    border-width: 2px;
+    padding: 10px;
   }
 
   &.active {
     font-weight: ${fontWeights.bold};
     border-color: ${colors.grayscale.g0};
+  }
+
+  [data-text]::before {
+    display: block;
+    height: 0;
+    visibility: hidden;
+    content: attr(data-text);
+    text-align: center;
   }
 `
 

--- a/frontend/src/citizen-frontend/index.css
+++ b/frontend/src/citizen-frontend/index.css
@@ -8,8 +8,6 @@ body {
   font-family: 'Open Sans', 'Arial', sans-serif;
   background-color: #f5f5f5;
   margin: 0;
-  height: 100vh;
-  overflow: hidden;
 }
 
 @media print {

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -134,30 +134,34 @@ export default class CitizenCalendarPage {
     }
   }
 
-  #ctaContainer = this.page.findByDataQa('holiday-period-cta-container')
+  #ctaContainers = this.page.findAllByDataQa('holiday-period-cta-container')
 
   async getHolidayCtaContent(): Promise<string> {
     await waitUntilEqual(
-      () => this.#ctaContainer.getAttribute('data-status'),
+      () => this.#ctaContainers.nth(1).getAttribute('data-status'),
       'success'
     )
-    return this.#ctaContainer.findByDataQa('holiday-period-cta').innerText
+    return this.#ctaContainers.nth(1).findByDataQa('holiday-period-cta')
+      .innerText
   }
 
   async clickHoliayCta(): Promise<void> {
     await waitUntilEqual(
-      () => this.#ctaContainer.getAttribute('data-status'),
+      () => this.#ctaContainers.nth(1).getAttribute('data-status'),
       'success'
     )
-    return this.#ctaContainer.findByDataQa('holiday-period-cta').click()
+    return this.#ctaContainers.nth(1).findByDataQa('holiday-period-cta').click()
   }
 
   async assertHolidayCtaNotVisible(): Promise<void> {
     await waitUntilEqual(
-      () => this.#ctaContainer.getAttribute('data-status'),
+      () => this.#ctaContainers.nth(1).getAttribute('data-status'),
       'success'
     )
-    await waitUntilEqual(() => this.#ctaContainer.findAll('> *').count(), 0)
+    await waitUntilEqual(
+      () => this.#ctaContainers.nth(1).findAll('> *').count(),
+      0
+    )
   }
 }
 

--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -116,6 +116,10 @@ export default function App() {
             <StateProvider>
               <Router basename="/employee">
                 <Header />
+                <ReloadNotification
+                  i18n={i18n.reloadNotification}
+                  apiVersion={authStatus?.apiVersion}
+                />
                 <Routes>
                   <Route
                     path="/login"
@@ -639,10 +643,6 @@ export default function App() {
                 </Routes>
                 <Footer />
                 <ErrorMessage />
-                <ReloadNotification
-                  i18n={i18n.reloadNotification}
-                  apiVersion={authStatus?.apiVersion}
-                />
                 <LoginErrorModal translations={i18n.login.failedModal} />
                 <PairingModal />
               </Router>

--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -59,6 +59,7 @@ export default function App() {
           )}
         >
           <UserContextProvider>
+            <MobileReloadNotification />
             <Router basename="/employee/mobile">
               <Routes>
                 <Route path="/landing" element={<MobileLander />} />
@@ -82,7 +83,6 @@ export default function App() {
                 <Route index element={<Navigate replace to="/landing" />} />
               </Routes>
             </Router>
-            <MobileReloadNotification />
           </UserContextProvider>
         </ErrorBoundary>
       </ThemeProvider>

--- a/frontend/src/lib-components/molecules/ReloadNotification.tsx
+++ b/frontend/src/lib-components/molecules/ReloadNotification.tsx
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { useTheme } from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 import { appVersion } from 'lib-common/globals'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import { defaultMargins } from 'lib-components/white-space'
 import { faInfo, faRedo } from 'lib-icons'
 
 import InlineButton from '../atoms/buttons/InlineButton'
@@ -51,19 +52,43 @@ export default function ReloadNotification({ apiVersion, i18n }: Props) {
   }, [maybeShow])
 
   return show ? (
-    <Toast icon={faInfo} iconColor={theme.colors.main.m1} onClose={close}>
-      <FixedSpaceColumn spacing="xs">
-        <div>{i18n.title}</div>
-        <div>
-          <InlineButton
-            icon={faRedo}
-            text={i18n.buttonText}
-            onClick={() => {
-              window.location.reload()
-            }}
-          />
-        </div>
-      </FixedSpaceColumn>
-    </Toast>
+    <OuterContainer>
+      <ToastContainer>
+        <Toast icon={faInfo} iconColor={theme.colors.main.m1} onClose={close}>
+          <FixedSpaceColumn spacing="xs">
+            <div>{i18n.title}</div>
+            <div>
+              <ReloadButton
+                icon={faRedo}
+                text={i18n.buttonText}
+                onClick={() => {
+                  window.location.reload()
+                }}
+              />
+            </div>
+          </FixedSpaceColumn>
+        </Toast>
+      </ToastContainer>
+    </OuterContainer>
   ) : null
 }
+
+const ToastContainer = styled.div`
+  padding: ${defaultMargins.s};
+  position: absolute;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+`
+
+const OuterContainer = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  height: 0;
+`
+
+const ReloadButton = styled(InlineButton)`
+  white-space: normal;
+  text-align: left;
+`

--- a/frontend/src/lib-components/molecules/Toast.tsx
+++ b/frontend/src/lib-components/molecules/Toast.tsx
@@ -4,13 +4,13 @@
 
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import React from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import { faTimes } from 'lib-icons'
 
 import RoundIcon from '../atoms/RoundIcon'
 import IconButton from '../atoms/buttons/IconButton'
-import { desktopMin, tabletMin } from '../breakpoints'
+import { tabletMin } from '../breakpoints'
 import { FixedSpaceRow } from '../layout/flex-helpers'
 import { modalZIndex } from '../layout/z-helpers'
 import { defaultMargins } from '../white-space'
@@ -30,17 +30,10 @@ export default React.memo(function Toast({
   iconColor,
   onClick,
   onClose,
-  offsetTop,
-  offsetTopDesktop,
   children
 }: Props) {
   return (
-    <ToastRoot
-      role="dialog"
-      offsetTop={offsetTop}
-      offsetTopDesktop={offsetTopDesktop}
-      showPointer={!!onClick}
-    >
+    <ToastRoot role="dialog" showPointer={!!onClick}>
       <FixedSpaceRow alignItems="center">
         <RoundIcon
           content={icon}
@@ -58,24 +51,13 @@ export default React.memo(function Toast({
 })
 
 const ToastRoot = styled.div<{
-  offsetTop?: string
-  offsetTopDesktop?: string
   showPointer: boolean
 }>`
-  position: fixed;
-  top: ${(p) => p.offsetTop ?? '8px'};
-  right: 8px;
-  width: 360px;
+  width: 100%;
   @media (min-width: ${tabletMin}) {
     right: 16px;
     width: 480px;
-  }
-  @media (min-width: ${desktopMin}) {
-    ${(p) =>
-      p.offsetTopDesktop &&
-      css`
-        top: ${p.offsetTopDesktop};
-      `}
+    max-width: 360px;
   }
   padding: ${defaultMargins.s};
   background-color: ${(p) => p.theme.colors.grayscale.g0};

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -117,7 +117,10 @@ const en: Translations = {
       en: 'In English'
     },
     login: 'Log in',
-    logout: 'Log out'
+    logout: 'Log out',
+    openMenu: 'Open menu',
+    closeMenu: 'Close menu',
+    goToHomepage: 'Go to homepage'
   },
   footer: {
     cityLabel: '© City of Espoo',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -116,7 +116,10 @@ export default {
       en: 'In English'
     },
     login: 'Kirjaudu sisään',
-    logout: 'Kirjaudu ulos'
+    logout: 'Kirjaudu ulos',
+    openMenu: 'Avaa valikko',
+    closeMenu: 'Sulje valikko',
+    goToHomepage: 'Siirry etusivulle'
   },
   footer: {
     cityLabel: '© Espoon kaupunki',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -117,7 +117,10 @@ const sv: Translations = {
       en: 'In English'
     },
     login: 'Logga in',
-    logout: 'Logga ut'
+    logout: 'Logga ut',
+    openMenu: 'Öppna menyn',
+    closeMenu: 'Stäng menyn',
+    goToHomepage: 'Gå till hemsidan'
   },
   footer: {
     cityLabel: '© Esbo stad',


### PR DESCRIPTION
#### Summary

- Fix main header nav links shifting when hovering due to font-weight changes, and make the notification count circle bold-like as well when needed
- Remove calculations for the page height and 100vh from body
- Remove footer from the applying map page (it went over the map)
- Fix scrolling to the current date in the calendar
- Modify toasts to depend on the parent component for their position
  - Fix holiday period CTA toast on desktop to be relative to the calendar subheader
  - Fix holiday period CTA toast on mobile to be below the main header if visible
  - Make the reload toast be below the main header
- Add some missing aria labels