### PR TITLE
EVAKA-4287 daily service time citizen calendar

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -71,6 +71,7 @@ interface ChildWithReservations {
   absence: AbsenceType | undefined
   reservations: TimeRange[]
   attendances: OpenTimeRange[]
+  dayOff: boolean
   reservationEditable: boolean
   markedByEmployee: boolean
 }
@@ -100,13 +101,15 @@ function getChildrenWithReservations(
       const reservationEditable =
         !markedByEmployee &&
         (!dailyData.isHoliday || child.inShiftCareUnit) &&
-        child.maxOperationalDays.includes(date.getIsoDayOfWeek())
+        child.maxOperationalDays.includes(date.getIsoDayOfWeek()) &&
+        !childReservations?.dayOff
 
       return {
         child,
         absence: childReservations?.absence ?? undefined,
         reservations: childReservations?.reservations ?? [],
         attendances: childReservations?.attendances ?? [],
+        dayOff: childReservations?.dayOff ?? false,
         reservationEditable,
         markedByEmployee
       }
@@ -216,6 +219,7 @@ export default React.memo(function DayView({
                     absence,
                     reservations,
                     attendances,
+                    dayOff,
                     reservationEditable,
                     markedByEmployee
                   } = childWithReservation
@@ -268,6 +272,8 @@ export default React.memo(function DayView({
                             absence={absence}
                             markedByEmployee={markedByEmployee}
                           />
+                        ) : reservations.length === 0 && dayOff ? (
+                          <DayOff />
                         ) : (
                           <Reservations reservations={reservations} />
                         )}
@@ -669,6 +675,35 @@ const Absence = React.memo(function Absence({
         <FixedSpaceColumn>
           {i18n.calendar.absenceMarkedByEmployee}
         </FixedSpaceColumn>
+        <FixedSpaceColumn>
+          <InfoButton
+            onClick={onClick}
+            aria-label={i18n.common.openExpandingInfo}
+          />
+        </FixedSpaceColumn>
+      </FixedSpaceRow>
+      {open && (
+        <Colspan2>
+          <ExpandingInfoBox
+            width="auto"
+            info={i18n.calendar.contactStaffToEditAbsence}
+            close={onClick}
+          />
+        </Colspan2>
+      )}
+    </>
+  )
+})
+
+const DayOff = React.memo(function DayOff() {
+  const i18n = useTranslation()
+  const [open, setOpen] = useState(false)
+  const onClick = useCallback(() => setOpen((prev) => !prev), [])
+
+  return (
+    <>
+      <FixedSpaceRow data-qa="day-off">
+        <FixedSpaceColumn>{i18n.calendar.dayOff}</FixedSpaceColumn>
         <FixedSpaceColumn>
           <InfoButton
             onClick={onClick}

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -27,7 +27,7 @@ import RoundChildImages, { ChildImageData } from './RoundChildImages'
 type DailyChildGroupElementType =
   | 'attendance'
   | 'reservation'
-  | 'day-off' // TODO: EVAKA-4287
+  | 'day-off'
   | 'absent'
   | 'missing-reservation'
   | 'absent-free'
@@ -95,6 +95,8 @@ export const Reservations = React.memo(function Reservations({
                 ? i18n.calendar.absent
                 : group.type === 'absent-free'
                 ? i18n.calendar.absentFree
+                : group.type === 'day-off'
+                ? i18n.calendar.dayOff
                 : group.text}
             </GroupedElementText>
           </FixedSpaceRow>
@@ -167,6 +169,13 @@ const groupChildren = (
             text: child.reservations
               .map(({ startTime, endTime }) => `${startTime}–${endTime}`)
               .join(', ')
+          }
+        }
+
+        if (child.dayOff) {
+          return {
+            childId: child.childId,
+            type: 'day-off'
           }
         }
 

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/DailyRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/DailyRepetitionTimeInputGrid.tsx
@@ -60,15 +60,27 @@ export default React.memo(function DailyRepetitionTimeInputGrid({
     updateForm
   ])
 
+  const label = (
+    <Label>{`${i18n.common.datetime.weekdaysShort[includedDays[0] - 1]}-${
+      i18n.common.datetime.weekdaysShort[
+        includedDays[includedDays.length - 1] - 1
+      ]
+    }`}</Label>
+  )
+
+  if (formData.dailyTimes === 'day-off') {
+    return (
+      <>
+        <div>{label}</div>
+        <div>{i18n.calendar.reservationModal.dayOff}</div>
+        <div />
+      </>
+    )
+  }
+
   return (
     <TimeInputs
-      label={
-        <Label>{`${i18n.common.datetime.weekdaysShort[includedDays[0] - 1]}-${
-          i18n.common.datetime.weekdaysShort[
-            includedDays[includedDays.length - 1] - 1
-          ]
-        }`}</Label>
-      }
+      label={label}
       times={formData.dailyTimes}
       updateTimes={(dailyTimes) => updateForm({ dailyTimes })}
       validationErrors={validationResult.errors?.dailyTimes}

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/IrregularRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/IrregularRepetitionTimeInputGrid.tsx
@@ -15,6 +15,7 @@ import { RepetitionTimeInputGridProps } from './RepetitionTimeInputGrid'
 import TimeInputs from './TimeInputs'
 import {
   allChildrenAreAbsent,
+  allChildrenHaveDayOff,
   bindUnboundedTimeRanges,
   emptyTimeRange,
   getCommonTimeRanges,
@@ -44,7 +45,7 @@ export default React.memo(function IrregularRepetitionTimeInputGrid({
     updateForm({
       irregularTimes: Object.fromEntries(
         [...selectedRange.dates()].map<
-          [string, TimeRanges | 'absent' | undefined]
+          [string, TimeRanges | 'absent' | 'day-off' | undefined]
         >((rangeDate) => {
           const existingTimes = reservations.find(({ date }) =>
             rangeDate.isEqual(date)
@@ -52,6 +53,12 @@ export default React.memo(function IrregularRepetitionTimeInputGrid({
 
           if (!existingTimes) {
             return [rangeDate.formatIso(), emptyTimeRange]
+          }
+
+          if (
+            allChildrenHaveDayOff([existingTimes], formData.selectedChildren)
+          ) {
+            return [rangeDate.formatIso(), 'day-off']
           }
 
           if (

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -24,8 +24,8 @@ interface BaseTimeInputProps {
 }
 
 interface TimeInputWithAbsencesProps extends BaseTimeInputProps {
-  times: TimeRanges | 'absent' | undefined
-  updateTimes: (v: TimeRanges | 'absent' | undefined) => void
+  times: TimeRanges | 'absent' | 'day-off' | undefined
+  updateTimes: (v: TimeRanges | 'absent' | 'day-off' | undefined) => void
   showAbsences: true
 }
 
@@ -66,6 +66,16 @@ export default React.memo(function TimeInputs(props: TimeInputProps) {
             onClick={() => props.updateTimes(emptyTimeRange)}
           />
         </div>
+      </>
+    )
+  }
+
+  if (props.times === 'day-off') {
+    return (
+      <>
+        <div>{props.label}</div>
+        <div>{i18n.calendar.reservationModal.dayOff}</div>
+        <div />
       </>
     )
   }

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/WeeklyRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/WeeklyRepetitionTimeInputGrid.tsx
@@ -14,6 +14,7 @@ import { RepetitionTimeInputGridProps } from './RepetitionTimeInputGrid'
 import TimeInputs from './TimeInputs'
 import {
   allChildrenAreAbsent,
+  allChildrenHaveDayOff,
   bindUnboundedTimeRanges,
   emptyTimeRange,
   getCommonTimeRanges,
@@ -57,6 +58,15 @@ export default React.memo(function WeeklyRepetitionTimeInputGrid({
           const relevantReservations = reservations.filter(({ date }) =>
             dayOfWeekDays.some((d) => d.isEqual(date))
           )
+
+          if (
+            allChildrenHaveDayOff(
+              relevantReservations,
+              formData.selectedChildren
+            )
+          ) {
+            return 'day-off'
+          }
 
           if (
             allChildrenAreAbsent(

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/utils.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/utils.ts
@@ -41,6 +41,18 @@ export const allChildrenAreAbsent = (
     )
   )
 
+export const allChildrenHaveDayOff = (
+  dayData: DailyReservationData[],
+  childIds: string[]
+) =>
+  dayData.every((reservations) =>
+    childIds.every((childId) =>
+      reservations.children.some(
+        (child) => child.childId === childId && !!child.dayOff
+      )
+    )
+  )
+
 export const bindUnboundedTimeRanges = (ranges: TimeRange[]): TimeRanges => {
   if (ranges.length === 1) {
     return ranges as [TimeRange]

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
@@ -47,8 +47,9 @@ const reservableDates = new FiniteDateRange(
 
 type EmployeeReservationFormData = Omit<
   ReservationFormData,
-  'weeklyTimes' | 'irregularTimes'
+  'weeklyTimes' | 'irregularTimes' | 'dailyTimes'
 > & {
+  dailyTimes: TimeRanges
   weeklyTimes: Array<TimeRanges | undefined>
   irregularTimes: Record<string, TimeRanges | undefined>
 }

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -26,6 +26,7 @@ export interface ChildDailyData {
   absence: AbsenceType | null
   attendances: OpenTimeRange[]
   childId: UUID
+  dayOff: boolean
   markedByEmployee: boolean
   reservations: TimeRange[]
 }

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -242,6 +242,7 @@ const en: Translations = {
     title: 'Calendar',
     holiday: 'Holiday',
     absent: 'Absent',
+    dayOff: 'Day off',
     absentFree: 'Free absence',
     absences: {
       SICKLEAVE: 'Sickness absence'
@@ -277,7 +278,8 @@ const en: Translations = {
       },
       start: 'Start',
       end: 'End',
-      absent: 'Absent'
+      absent: 'Absent',
+      dayOff: 'Day off'
     },
     absenceModal: {
       title: 'Report absence',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -242,6 +242,7 @@ export default {
     holiday: 'Pyhäpäivä',
     absent: 'Poissa',
     absentFree: 'Maksuton poissaolo',
+    dayOff: 'Vapaapäivä',
     absences: {
       SICKLEAVE: 'Sairauspoissaolo'
     },
@@ -277,7 +278,8 @@ export default {
       },
       start: 'Alkaa',
       end: 'Päättyy',
-      absent: 'Poissa'
+      absent: 'Poissa',
+      dayOff: 'Vapaapäivä'
     },
     absenceModal: {
       title: 'Ilmoita poissaolo',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -243,6 +243,7 @@ const sv: Translations = {
     holiday: 'Helgdag',
     absent: 'Frånvarande',
     absentFree: 'Gratis frånvaro',
+    dayOff: 'Ledighet',
     absences: {
       SICKLEAVE: 'Sjukskriven'
     },
@@ -276,7 +277,8 @@ const sv: Translations = {
       },
       start: 'Börjar',
       end: 'Slutar',
-      absent: 'Frånvarande'
+      absent: 'Frånvarande',
+      dayOff: 'Ledighet'
     },
     absenceModal: {
       title: 'Anmäl frånvaro',


### PR DESCRIPTION
#### Summary

- Show days off in the reservation modal, if all selected children have days off during the selected days
- Show days off in the calendar view
- Show days off in the day view
- Fixed bug where unrelated placements ended up in the daily reservation data; if a child had multiple placements, the child's daily data would be copied as many times as there are placements
  - Cause: placement start and end times were not checked to be relevant to the inspected date

