### PR TITLE
Suppress CVE-2022-31569

### DIFF
--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -64,4 +64,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         ]]></notes>
         <cve>CVE-2022-33915</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        The RipudamanKaushikDal/projects repository does not affect evaka, misidentification
+        ]]></notes>
+        <cve>CVE-2022-31569</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Does not affect evaka; misidentification due to a too-eager CPE. See: https://github.com/jeremylong/DependencyCheck/issues/4671, https://github.com/advisories/GHSA-g7h7-rg53-h2g9, https://github.com/github/securitylab/issues/669#issuecomment-1186015526