### PR TITLE
EVAKA-4407 employee staff attendance desktop editor

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -336,6 +336,10 @@ export class UnitAttendancesPage {
   async assertFormWarning() {
     await this.page.findByDataQa('form-error-warning').waitUntilVisible()
   }
+
+  personCountSum(nth: number) {
+    return this.page.findAllByDataQa('person-count-sum').nth(nth).innerText
+  }
 }
 
 export class ReservationModal extends Modal {
@@ -482,16 +486,13 @@ export class StaffAttendanceDetailsModal extends Element {
     await this.findByDataQa('close').click()
   }
 
-  get summaryPlan() {
-    return this.findByDataQa('staff-attendance-summary-plan').innerText
-  }
-
-  get summaryRealized() {
-    return this.findByDataQa('staff-attendance-summary-realized').innerText
-  }
-
-  get summaryHours() {
-    return this.findByDataQa('staff-attendance-summary-hours').innerText
+  async summary() {
+    return {
+      plan: await this.findByDataQa('staff-attendance-summary-plan').innerText,
+      realized: await this.findByDataQa('staff-attendance-summary-realized')
+        .innerText,
+      hours: await this.findByDataQa('staff-attendance-summary-hours').innerText
+    }
   }
 
   gapWarning(index: number) {

--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -481,4 +481,16 @@ export class StaffAttendanceDetailsModal extends Element {
   async close() {
     await this.findByDataQa('close').click()
   }
+
+  get summaryPlan() {
+    return this.findByDataQa('staff-attendance-summary-plan').innerText
+  }
+
+  get summaryRealized() {
+    return this.findByDataQa('staff-attendance-summary-realized').innerText
+  }
+
+  get summaryHours() {
+    return this.findByDataQa('staff-attendance-summary-hours').innerText
+  }
 }

--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -493,4 +493,8 @@ export class StaffAttendanceDetailsModal extends Element {
   get summaryHours() {
     return this.findByDataQa('staff-attendance-summary-hours').innerText
   }
+
+  gapWarning(index: number) {
+    return this.findByDataQa(`attendance-gap-warning-${index}`).innerText
+  }
 }

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -495,6 +495,29 @@ describe('Realtime staff attendances', () => {
         departure: '14:30'
       })
     })
+    test('Gaps in attendances are warned about', async () => {
+      const modal = await calendarPage.openDetails(groupStaff.id, mockedToday)
+      await modal.setDepartureTime(0, '12:00')
+      await modal.addNewAttendance()
+      await modal.setGroup(1, groupId)
+      await modal.setType(1, 'TRAINING')
+      await modal.setArrivalTime(1, '12:30')
+      await modal.setDepartureTime(1, '13:00')
+      await modal.addNewAttendance()
+      await modal.setGroup(2, groupId)
+      await modal.setType(2, 'PRESENT')
+      await modal.setArrivalTime(2, '13:20')
+      await modal.setDepartureTime(2, '14:30')
+
+      await waitUntilEqual(
+        () => modal.gapWarning(1),
+        'Kirjaus puuttuu välillä 12:00 – 12:30'
+      )
+      await waitUntilEqual(
+        () => modal.gapWarning(2),
+        'Kirjaus puuttuu välillä 13:00 – 13:20'
+      )
+    })
   })
   describe('Entries to multiple groups', () => {
     beforeEach(async () => {

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -416,6 +416,11 @@ describe('Realtime staff attendances', () => {
       const modal = await calendarPage.openDetails(groupStaff.id, mockedToday)
       await modal.setDepartureTime(0, '15:00')
       await modal.save()
+
+      await waitUntilEqual(() => modal.summaryPlan, '–')
+      await waitUntilEqual(() => modal.summaryRealized, '07:00 – 15:00')
+      await waitUntilEqual(() => modal.summaryHours, '8:00')
+
       await modal.close()
       await calendarPage.assertArrivalDeparture({
         rowIx: 1,
@@ -429,8 +434,13 @@ describe('Realtime staff attendances', () => {
         groupStaff.id,
         mockedToday.addDays(1)
       )
-      await modal.setDepartureTime(0, '15:00')
+      await modal.setDepartureTime(0, '16:00')
       await modal.save()
+
+      await waitUntilEqual(() => modal.summaryPlan, '–')
+      await waitUntilEqual(() => modal.summaryRealized, '→ – 16:00')
+      await waitUntilEqual(() => modal.summaryHours, '33:00')
+
       await modal.close()
       await calendarPage.assertArrivalDeparture({
         rowIx: 1,
@@ -442,7 +452,7 @@ describe('Realtime staff attendances', () => {
         rowIx: 1,
         nth: 1,
         arrival: '→',
-        departure: '15:00'
+        departure: '16:00'
       })
     })
     test('Multiple new entries can be added', async () => {
@@ -464,6 +474,11 @@ describe('Realtime staff attendances', () => {
       await modal.setArrivalTime(3, '14:30')
       await modal.setDepartureTime(3, '15:00')
       await modal.save()
+
+      await waitUntilEqual(() => modal.summaryPlan, '–')
+      await waitUntilEqual(() => modal.summaryRealized, '07:00 – 15:00')
+      await waitUntilEqual(() => modal.summaryHours, '8:00')
+
       await modal.close()
       await calendarPage.assertArrivalDeparture({
         rowIx: 1,

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -417,9 +417,11 @@ describe('Realtime staff attendances', () => {
       await modal.setDepartureTime(0, '15:00')
       await modal.save()
 
-      await waitUntilEqual(() => modal.summaryPlan, '–')
-      await waitUntilEqual(() => modal.summaryRealized, '07:00 – 15:00')
-      await waitUntilEqual(() => modal.summaryHours, '8:00')
+      await waitUntilEqual(() => modal.summary(), {
+        plan: '–',
+        realized: '07:00 – 15:00',
+        hours: '8:00'
+      })
 
       await modal.close()
       await calendarPage.assertArrivalDeparture({
@@ -437,9 +439,11 @@ describe('Realtime staff attendances', () => {
       await modal.setDepartureTime(0, '16:00')
       await modal.save()
 
-      await waitUntilEqual(() => modal.summaryPlan, '–')
-      await waitUntilEqual(() => modal.summaryRealized, '→ – 16:00')
-      await waitUntilEqual(() => modal.summaryHours, '33:00')
+      await waitUntilEqual(() => modal.summary(), {
+        plan: '–',
+        realized: '→ – 16:00',
+        hours: '33:00'
+      })
 
       await modal.close()
       await calendarPage.assertArrivalDeparture({
@@ -475,9 +479,11 @@ describe('Realtime staff attendances', () => {
       await modal.setDepartureTime(3, '15:00')
       await modal.save()
 
-      await waitUntilEqual(() => modal.summaryPlan, '–')
-      await waitUntilEqual(() => modal.summaryRealized, '07:00 – 15:00')
-      await waitUntilEqual(() => modal.summaryHours, '8:00')
+      await waitUntilEqual(() => modal.summary(), {
+        plan: '–',
+        realized: '07:00 – 15:00',
+        hours: '8:00'
+      })
 
       await modal.close()
       await calendarPage.assertArrivalDeparture({
@@ -571,6 +577,26 @@ describe('Realtime staff attendances', () => {
         arrival: '07:00',
         departure: '15:00'
       })
+    })
+  })
+  describe('Staff count sums in the table', () => {
+    beforeEach(async () => {
+      calendarPage = await openAttendancesPage()
+    })
+    test('Total staff counts', async () => {
+      await waitUntilEqual(() => calendarPage.personCountSum(0), '– hlö')
+      await calendarPage.selectGroup(groupId)
+      await calendarPage.clickEditOnRow(0)
+      await calendarPage.setNthArrivalDeparture(0, 0, '12:00', '15:00')
+      await calendarPage.setNthArrivalDeparture(0, 4, '09:00', '10:00')
+      await calendarPage.setNthArrivalDeparture(0, 5, '10:00', '13:00')
+      await calendarPage.closeInlineEditor()
+      await waitUntilEqual(() => calendarPage.personCountSum(0), '1 hlö')
+      await waitUntilEqual(() => calendarPage.personCountSum(4), '1 hlö')
+      await waitUntilEqual(() => calendarPage.personCountSum(5), '1 hlö')
+      await waitUntilEqual(() => calendarPage.personCountSum(1), '– hlö')
+      await waitUntilEqual(() => calendarPage.personCountSum(2), '– hlö')
+      await waitUntilEqual(() => calendarPage.personCountSum(3), '– hlö')
     })
   })
 })

--- a/frontend/src/employee-frontend/api/staff-attendance.ts
+++ b/frontend/src/employee-frontend/api/staff-attendance.ts
@@ -30,6 +30,7 @@ const mapExternalAttendance = ({
 
 const mapEmployeeAttendance = ({
   attendances,
+  plannedAttendances,
   ...rest
 }: JsonOf<EmployeeAttendance>): EmployeeAttendance => ({
   ...rest,
@@ -37,6 +38,11 @@ const mapEmployeeAttendance = ({
     ...rest,
     arrived: HelsinkiDateTime.parseIso(arrived),
     departed: departed ? HelsinkiDateTime.parseIso(departed) : null
+  })),
+  plannedAttendances: plannedAttendances.map(({ start, end, ...rest }) => ({
+    ...rest,
+    start: HelsinkiDateTime.parseIso(start),
+    end: HelsinkiDateTime.parseIso(end)
   }))
 })
 

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/attendance-elements.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/attendance-elements.tsx
@@ -91,7 +91,7 @@ export const DayTr = styled(Tr)<TrProps>`
       border-top: 2px solid ${colors.status.success};
     }
   }
-  &:last-child {
+  &:last-child(2) {
     > ${DayTd}.is-today {
       border-bottom: 2px solid ${colors.status.success};
     }

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -172,6 +172,7 @@ export interface EmployeeAttendance {
   groups: UUID[]
   hasFutureAttendances: boolean
   lastName: string
+  plannedAttendances: PlannedStaffAttendance[]
 }
 
 /**

--- a/frontend/src/lib-components/atoms/buttons/AsyncIconButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncIconButton.tsx
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React, { useState } from 'react'
+
+import IconButton, { IconButtonProps } from './IconButton'
+
+export interface AsyncIconButtonProps extends IconButtonProps {
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => Promise<void>
+}
+
+export default React.memo(function AsyncIconButton({
+  onClick,
+  ...props
+}: AsyncIconButtonProps) {
+  const [disabled, setDisabled] = useState(false)
+
+  return (
+    <IconButton
+      onClick={async (e) => {
+        setDisabled(true)
+        await onClick(e)
+        setDisabled(false)
+      }}
+      disabled={disabled || props.disabled}
+      {...props}
+    />
+  )
+})

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -1938,7 +1938,8 @@ export const fi = {
       formErrorWarning:
         'Tarkista antamasi läsnäolotiedot. Muutoksesi voi jäädä tallentamatta, jos ne ei ole kelvollisia. Ohita varoitus klikkaamalla.',
       incalculableSum:
-        'Tunteja ei voi laskea, koska päivän kirjauksista puuttuu viimeinen lähtöaika.'
+        'Tunteja ei voi laskea, koska päivän kirjauksista puuttuu viimeinen lähtöaika.',
+      gapWarning: (gapRange: string) => `Kirjaus puuttuu välillä ${gapRange}`
     },
     error: {
       placement: {

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -1920,6 +1920,10 @@ export const fi = {
     staffAttendance: {
       startTime: 'tulo',
       endTime: 'lähtö',
+      summary: 'Yhteenveto',
+      plan: 'Suunnitelma',
+      realized: 'Toteutuma',
+      hours: 'Tunnit',
       dailyAttendances: 'Päivän kirjaukset',
       addNewAttendance: 'Lisää uusi kirjaus',
       saveChanges: 'Tallenna muutokset',
@@ -1932,7 +1936,9 @@ export const fi = {
         JUSTIFIED_CHANGE: 'Perusteltu muutos'
       },
       formErrorWarning:
-        'Tarkista antamasi läsnäolotiedot. Muutoksesi voi jäädä tallentamatta, jos ne ei ole kelvollisia. Ohita varoitus klikkaamalla.'
+        'Tarkista antamasi läsnäolotiedot. Muutoksesi voi jäädä tallentamatta, jos ne ei ole kelvollisia. Ohita varoitus klikkaamalla.',
+      incalculableSum:
+        'Tunteja ei voi laskea, koska päivän kirjauksista puuttuu viimeinen lähtöaika.'
     },
     error: {
       placement: {

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -1939,7 +1939,9 @@ export const fi = {
         'Tarkista antamasi läsnäolotiedot. Muutoksesi voi jäädä tallentamatta, jos ne ei ole kelvollisia. Ohita varoitus klikkaamalla.',
       incalculableSum:
         'Tunteja ei voi laskea, koska päivän kirjauksista puuttuu viimeinen lähtöaika.',
-      gapWarning: (gapRange: string) => `Kirjaus puuttuu välillä ${gapRange}`
+      gapWarning: (gapRange: string) => `Kirjaus puuttuu välillä ${gapRange}`,
+      personCount: 'Henkilökuntaa paikalla',
+      personCountAbbr: 'hlö'
     },
     error: {
       placement: {

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -52,7 +52,7 @@ class RealtimeStaffAttendanceController(
                 val range = FiniteDateRange(start, end)
                 val attendancesByEmployee = it.getStaffAttendancesForDateRange(unitId, range).groupBy { raw -> raw.employeeId }
                 val attendanceEmployeeToGroups = it.getGroupsForEmployees(attendancesByEmployee.keys)
-                val plannedAttendances = it.getPlannedStaffAttendanceForDays(attendancesByEmployee.keys.toList(), range.dates().toList())
+                val plannedAttendances = it.getPlannedStaffAttendanceForDays(attendancesByEmployee.keys, range)
                 val staffWithAttendance = attendancesByEmployee.entries.map { (employeeId, data) ->
                     EmployeeAttendance(
                         employeeId = employeeId,
@@ -71,7 +71,7 @@ class RealtimeStaffAttendanceController(
                             )
                         },
                         hasFutureAttendances = data[0].hasFutureAttendances,
-                        plannedAttendances = plannedAttendances.filter { it.employeeId == employeeId }.map { it.toPlannedStaffAttendance() }
+                        plannedAttendances = plannedAttendances[employeeId] ?: emptyList()
                     )
                 }
                 val staffForAttendanceCalendar = it.getCurrentStaffForAttendanceCalendar(unitId, range.start, range.end)
@@ -86,7 +86,7 @@ class RealtimeStaffAttendanceController(
                             lastName = emp.lastName,
                             currentOccupancyCoefficient = emp.currentOccupancyCoefficient ?: BigDecimal.ZERO, listOf(),
                             hasFutureAttendances = emp.hasFutureAttendances,
-                            plannedAttendances = plannedAttendances.filter { it.employeeId == emp.id }.map { it.toPlannedStaffAttendance() }
+                            plannedAttendances = plannedAttendances[emp.id] ?: emptyList()
                         )
                     }
                 StaffAttendanceResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -52,6 +52,7 @@ class RealtimeStaffAttendanceController(
                 val range = FiniteDateRange(start, end)
                 val attendancesByEmployee = it.getStaffAttendancesForDateRange(unitId, range).groupBy { raw -> raw.employeeId }
                 val attendanceEmployeeToGroups = it.getGroupsForEmployees(attendancesByEmployee.keys)
+                val plannedAttendances = it.getPlannedStaffAttendanceForDays(attendancesByEmployee.keys.toList(), range.dates().toList())
                 val staffWithAttendance = attendancesByEmployee.entries.map { (employeeId, data) ->
                     EmployeeAttendance(
                         employeeId = employeeId,
@@ -69,7 +70,8 @@ class RealtimeStaffAttendanceController(
                                 att.type
                             )
                         },
-                        hasFutureAttendances = data[0].hasFutureAttendances
+                        hasFutureAttendances = data[0].hasFutureAttendances,
+                        plannedAttendances = plannedAttendances.filter { it.employeeId == employeeId }.map { it.toPlannedStaffAttendance() }
                     )
                 }
                 val staffForAttendanceCalendar = it.getCurrentStaffForAttendanceCalendar(unitId, range.start, range.end)
@@ -83,7 +85,8 @@ class RealtimeStaffAttendanceController(
                             firstName = emp.firstName,
                             lastName = emp.lastName,
                             currentOccupancyCoefficient = emp.currentOccupancyCoefficient ?: BigDecimal.ZERO, listOf(),
-                            hasFutureAttendances = emp.hasFutureAttendances
+                            hasFutureAttendances = emp.hasFutureAttendances,
+                            plannedAttendances = plannedAttendances.filter { it.employeeId == emp.id }.map { it.toPlannedStaffAttendance() }
                         )
                     }
                 StaffAttendanceResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
@@ -120,12 +120,3 @@ data class PlannedStaffAttendance(
     val end: HelsinkiDateTime,
     val type: StaffAttendanceType
 )
-
-data class PlannedStaffAttendanceWithEmployeeId(
-    val start: HelsinkiDateTime,
-    val end: HelsinkiDateTime,
-    val type: StaffAttendanceType,
-    val employeeId: EmployeeId
-) {
-    fun toPlannedStaffAttendance() = PlannedStaffAttendance(start, end, type)
-}

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
@@ -106,7 +106,8 @@ data class EmployeeAttendance(
     val lastName: String,
     val currentOccupancyCoefficient: BigDecimal,
     val attendances: List<Attendance>,
-    val hasFutureAttendances: Boolean
+    val hasFutureAttendances: Boolean,
+    val plannedAttendances: List<PlannedStaffAttendance>
 )
 
 data class StaffAttendanceResponse(
@@ -119,3 +120,12 @@ data class PlannedStaffAttendance(
     val end: HelsinkiDateTime,
     val type: StaffAttendanceType
 )
+
+data class PlannedStaffAttendanceWithEmployeeId(
+    val start: HelsinkiDateTime,
+    val end: HelsinkiDateTime,
+    val type: StaffAttendanceType,
+    val employeeId: EmployeeId
+) {
+    fun toPlannedStaffAttendance() = PlannedStaffAttendance(start, end, type)
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
@@ -438,6 +438,21 @@ WHERE employee_id = :employeeId AND tstzrange(start_time, end_time) && tstzrange
         .mapTo<PlannedStaffAttendance>()
         .toList()
 
+fun Database.Read.getPlannedStaffAttendanceForDays(
+    employeeIds: List<EmployeeId>,
+    days: List<LocalDate>
+): List<PlannedStaffAttendanceWithEmployeeId> =
+    createQuery(
+        """
+SELECT start_time AS start, end_time AS end, type, employee_id FROM staff_attendance_plan
+WHERE employee_id = ANY(:employeeIds) AND (date(start_time) = ANY(:days) OR date(end_time) = ANY(:days))
+"""
+    )
+        .bind("employeeIds", employeeIds.toTypedArray())
+        .bind("days", days.toTypedArray())
+        .mapTo<PlannedStaffAttendanceWithEmployeeId>()
+        .toList()
+
 fun Database.Read.getOngoingAttendance(employeeId: EmployeeId): StaffAttendance? = createQuery(
     """
 SELECT id, employee_id, group_id, arrived, departed, occupancy_coefficient, type

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
@@ -10,6 +10,8 @@ import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.StaffAttendanceExternalId
 import fi.espoo.evaka.shared.StaffAttendanceId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.db.mapColumn
+import fi.espoo.evaka.shared.db.mapRow
 import fi.espoo.evaka.shared.db.updateExactlyOne
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -439,19 +441,20 @@ WHERE employee_id = :employeeId AND tstzrange(start_time, end_time) && tstzrange
         .toList()
 
 fun Database.Read.getPlannedStaffAttendanceForDays(
-    employeeIds: List<EmployeeId>,
-    days: List<LocalDate>
-): List<PlannedStaffAttendanceWithEmployeeId> =
+    employeeIds: Collection<EmployeeId>,
+    range: FiniteDateRange
+): Map<EmployeeId, List<PlannedStaffAttendance>> =
     createQuery(
         """
 SELECT start_time AS start, end_time AS end, type, employee_id FROM staff_attendance_plan
-WHERE employee_id = ANY(:employeeIds) AND (date(start_time) = ANY(:days) OR date(end_time) = ANY(:days))
+WHERE employee_id = ANY(:employeeIds) AND (tstzrange(start_time, end_time) && tstzrange(:startTime, :endTime))
 """
     )
         .bind("employeeIds", employeeIds.toTypedArray())
-        .bind("days", days.toTypedArray())
-        .mapTo<PlannedStaffAttendanceWithEmployeeId>()
-        .toList()
+        .bind("startTime", HelsinkiDateTime.of(range.start, LocalTime.MIDNIGHT))
+        .bind("endTime", HelsinkiDateTime.of(range.end.plusDays(1), LocalTime.MIDNIGHT))
+        .map { row -> Pair(row.mapColumn<EmployeeId>("employee_id"), row.mapRow<PlannedStaffAttendance>()) }
+        .groupBy({ it.first }, { it.second })
 
 fun Database.Read.getOngoingAttendance(employeeId: EmployeeId): StaffAttendance? = createQuery(
     """

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -34,6 +34,7 @@ import org.jdbi.v3.postgres.PostgresPlugin
 import org.postgresql.util.PGobject
 import java.lang.reflect.Type
 import java.sql.ResultSet
+import java.time.LocalDate
 import java.util.Optional
 import java.util.UUID
 import java.util.function.Function
@@ -112,6 +113,7 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
             value = "[${it.start},${it.end}]"
         }
     }
+    jdbi.registerArrayType(LocalDate::class.java, "date")
     jdbi.registerArrayType { elementType, _ ->
         Optional.ofNullable(
             (elementType as? Class<*>)?.let { elementClass ->


### PR DESCRIPTION
#### Summary

- Add browsing of days in the staff attendance details modal
- Add summary of the current day in the staff attendance details modal
- Show a warning if there is a gap between attendances  in the staff attendance details modal
- Fix details modal button to only be visible on days with other attendances
- Add a sum row of staff to the table (TBD: only excluding training and other work (current implementation) or only including present)
