### PR TITLE
Refactor staff attendance table

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -69,7 +69,7 @@ const CalendarPage = React.memo(function CalendarPage() {
 
   const refreshOnQuestionnaireAnswer = useCallback(() => {
     refreshQuestionnaires()
-    loadDefaultRange()
+    void loadDefaultRange()
   }, [loadDefaultRange, refreshQuestionnaires])
 
   const dayIsReservable = useCallback(

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
@@ -148,7 +148,7 @@ export default React.memo(function IncomeStatements() {
           })
         }
         setDeletionState({ status: 'row-not-selected' })
-        fetchIncomeStatements()
+        void fetchIncomeStatements()
       })
     },
     [fetchIncomeStatements, setErrorMessage, t]

--- a/frontend/src/employee-frontend/components/PersonalMobileDevicesPage.tsx
+++ b/frontend/src/employee-frontend/components/PersonalMobileDevicesPage.tsx
@@ -52,7 +52,7 @@ export default React.memo(function PersonalMobileDevicesPage() {
   )
   const closeModal = useCallback(() => {
     setOpenModal(undefined)
-    reloadDevices()
+    void reloadDevices()
   }, [reloadDevices])
 
   if (!user) {

--- a/frontend/src/employee-frontend/components/UnitFeaturesPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitFeaturesPage.tsx
@@ -76,7 +76,7 @@ export default React.memo(function UnitFeaturesPage() {
         setUndoAction([unitIds, features, !enable])
       }
 
-      reloadUnits()
+      void reloadUnits()
       setSubmitting(false)
 
       return result

--- a/frontend/src/employee-frontend/components/application-page/ApplicationNoteBox.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationNoteBox.tsx
@@ -59,13 +59,13 @@ interface ReadProps {
   note: ApplicationNote
   editable: boolean
   deletable: boolean
-  onStartEdit: () => undefined | void
-  onDelete: () => undefined | void
+  onStartEdit: () => void
+  onDelete: () => void
 }
 
 interface InputProps {
-  onSave: () => undefined | void
-  onCancel: () => undefined | void
+  onSave: () => void
+  onCancel: () => void
 }
 
 interface EditProps extends InputProps {
@@ -74,8 +74,8 @@ interface EditProps extends InputProps {
 
 interface CreateProps extends InputProps {
   applicationId: UUID
-  onSave: () => undefined | void
-  onCancel: () => undefined | void
+  onSave: () => void
+  onCancel: () => void
 }
 
 type Props = ReadProps | EditProps | CreateProps

--- a/frontend/src/employee-frontend/components/application-page/ApplicationNotes.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationNotes.tsx
@@ -49,7 +49,7 @@ export default React.memo(function ApplicationNotes({
               note={note}
               onSave={() => {
                 setEditing(null)
-                loadNotes()
+                void loadNotes()
               }}
               onCancel={() => setEditing(null)}
             />
@@ -82,7 +82,7 @@ export default React.memo(function ApplicationNotes({
             applicationId={applicationId}
             onSave={() => {
               setCreating(false)
-              loadNotes()
+              void loadNotes()
             }}
             onCancel={() => setCreating(false)}
           />

--- a/frontend/src/employee-frontend/components/child-information/AssistanceNeedDecisionSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/AssistanceNeedDecisionSection.tsx
@@ -67,7 +67,7 @@ export default React.memo(function AssistanceNeedDecisionSection({
           onClose={(shouldRefresh) => {
             setRemovingDecision(undefined)
             if (shouldRefresh) {
-              reloadDecisions()
+              void reloadDecisions()
             }
           }}
           childId={id}
@@ -137,7 +137,7 @@ export default React.memo(function AssistanceNeedDecisionSection({
                 },
                 viewOfGuardians: null
               }).then((decision) => {
-                reloadDecisions()
+                void reloadDecisions()
                 setIsCreatingDecision(false)
 
                 decision.map(({ id: decisionId }) =>

--- a/frontend/src/employee-frontend/components/child-information/AssistanceNeedVoucherCoefficientSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/AssistanceNeedVoucherCoefficientSection.tsx
@@ -69,7 +69,7 @@ export default React.memo(function AssistanceNeedVoucherCoefficientSection({
               clearUiMode()
               setActiveCoefficient(undefined)
               if (shouldRefresh) {
-                reloadCoefficients()
+                void reloadCoefficients()
               }
             }}
           />

--- a/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
@@ -61,7 +61,7 @@ export default React.memo(function DailyServiceTimesSection({
             setUIMode(undefined)
 
             if (shouldRefresh) {
-              loadData()
+              void loadData()
             }
           }}
         />
@@ -103,7 +103,7 @@ export default React.memo(function DailyServiceTimesSection({
                 setCreationFormOpen(false)
 
                 if (shouldRefresh) {
-                  loadData()
+                  void loadData()
                 }
               }}
               childId={id}

--- a/frontend/src/employee-frontend/components/child-information/FeeAlteration.tsx
+++ b/frontend/src/employee-frontend/components/child-information/FeeAlteration.tsx
@@ -51,7 +51,7 @@ export default React.memo(function FeeAlteration({ id, startOpen }: Props) {
 
   const onSuccess = useCallback(() => {
     clearUiMode()
-    loadFeeAlterations()
+    void loadFeeAlterations()
   }, [clearUiMode, loadFeeAlterations])
   const onFailure = useCallback(() => {
     setErrorMessage({
@@ -122,7 +122,7 @@ export default React.memo(function FeeAlteration({ id, startOpen }: Props) {
               deleteFeeAlteration(deleted.id).then((res) => {
                 setDeleted(undefined)
                 if (res.isSuccess) {
-                  loadFeeAlterations()
+                  void loadFeeAlterations()
                 } else {
                   setErrorMessage({
                     type: 'error',

--- a/frontend/src/employee-frontend/components/child-information/MessageBlocklist.tsx
+++ b/frontend/src/employee-frontend/components/child-information/MessageBlocklist.tsx
@@ -52,7 +52,7 @@ export default React.memo(function MessageBlocklist({ id, startOpen }: Props) {
         })
       }
       setSaving(false)
-      loadData()
+      void loadData()
     },
     [i18n, id, loadData, setErrorMessage]
   )

--- a/frontend/src/employee-frontend/components/child-information/PedagogicalDocuments.tsx
+++ b/frontend/src/employee-frontend/components/child-information/PedagogicalDocuments.tsx
@@ -57,7 +57,9 @@ export default React.memo(function PedagogicalDocuments({
   >(undefined)
 
   useEffect(() => {
-    if (open) loadData()
+    if (open) {
+      void loadData()
+    }
   }, [open, loadData])
 
   const [expandingInfo, setExpandingInfo] = useState<string>()

--- a/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
@@ -63,7 +63,7 @@ interface FormState {
 }
 
 interface CommonProps {
-  onReload: () => undefined | void
+  onReload: () => void
   assistanceActions: AssistanceActionResponse[]
   assistanceActionOptions: AssistanceActionOption[]
 }

--- a/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionRow.tsx
@@ -27,7 +27,7 @@ import { isActiveDateRange } from '../../../utils/date'
 export interface Props {
   assistanceAction: AssistanceAction
   permittedActions: Action.AssistanceAction[]
-  onReload: () => undefined | void
+  onReload: () => void
   assistanceActions: AssistanceActionResponse[]
   assistanceActionOptions: AssistanceActionOption[]
   refSectionTop: MutableRefObject<HTMLElement | null>

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
@@ -70,7 +70,7 @@ interface FormState {
 const coefficientRegex = /^\d(([.,])(\d){1,2})?$/
 
 interface CommonProps {
-  onReload: () => undefined | void
+  onReload: () => void
   assistanceNeeds: AssistanceNeedResponse[]
   assistanceBasisOptions: AssistanceBasisOption[]
 }

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
@@ -25,7 +25,7 @@ import { isActiveDateRange } from '../../../utils/date'
 export interface Props {
   assistanceNeed: AssistanceNeed
   permittedActions: Action.AssistanceNeed[]
-  onReload: () => undefined | void
+  onReload: () => void
   assistanceNeeds: AssistanceNeedResponse[]
   assistanceBasisOptions: AssistanceBasisOption[]
   refSectionTop: MutableRefObject<HTMLElement | null>

--- a/frontend/src/employee-frontend/components/child-information/person-details/AdditionalInformation.tsx
+++ b/frontend/src/employee-frontend/components/child-information/person-details/AdditionalInformation.tsx
@@ -80,7 +80,7 @@ export default React.memo(function AdditionalInformation({ id }: Props) {
   )
   const onSuccess = useCallback(() => {
     clearUiMode()
-    loadData()
+    void loadData()
   }, [clearUiMode, loadData])
 
   const valueWidth = '600px'

--- a/frontend/src/employee-frontend/components/holiday-periods/HolidayPeriodsPage.tsx
+++ b/frontend/src/employee-frontend/components/holiday-periods/HolidayPeriodsPage.tsx
@@ -158,7 +158,7 @@ export default React.memo(function HolidayPeriodsPage() {
             resolveLabel={i18n.common.remove}
             onSuccess={() => {
               setPeriodToDelete(undefined)
-              refreshPeriods()
+              void refreshPeriods()
             }}
           />
         )}
@@ -174,7 +174,7 @@ export default React.memo(function HolidayPeriodsPage() {
             resolveLabel={i18n.common.remove}
             onSuccess={() => {
               setQuestionnaireToDelete(undefined)
-              refreshQuestionnaires()
+              void refreshQuestionnaires()
             }}
           />
         )}

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -270,7 +270,7 @@ export const MessageContextProvider = React.memo(
         if (hasUnreadMessages) {
           void markThreadRead(accountId, thread.id).then(() => {
             refreshMessages(accountId)
-            refreshUnreadCounts()
+            void refreshUnreadCounts()
           })
         }
       },

--- a/frontend/src/employee-frontend/components/person-profile/PersonFridgePartner.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFridgePartner.tsx
@@ -54,7 +54,7 @@ const PersonFridgePartner = React.memo(function PersonFridgePartner({
 
   // FIXME: This component shouldn't know about family's dependency on its data
   const reload = () => {
-    loadData()
+    void loadData()
     reloadFamily()
   }
 

--- a/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
@@ -140,7 +140,7 @@ export const Incomes = React.memo(function Incomes({
 
   // FIXME: This component shouldn't know about family's dependency on its data
   const reloadIncomes = useCallback(() => {
-    loadIncomes()
+    void loadIncomes()
     reloadFamily()
   }, [loadIncomes, reloadFamily])
   useEffect(reloadIncomes, [reloadIncomes])

--- a/frontend/src/employee-frontend/components/person-profile/PersonInvoiceCorrections.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonInvoiceCorrections.tsx
@@ -125,7 +125,7 @@ export default React.memo(function PersonInvoiceCorrections({
 
   const onSaveSuccess = useCallback(() => {
     cancelEditing()
-    reloadCorrections()
+    void reloadCorrections()
   }, [cancelEditing, reloadCorrections])
 
   const deleteCorrection = useCallback(
@@ -150,7 +150,9 @@ export default React.memo(function PersonInvoiceCorrections({
 
   const onNoteUpdateSuccess = useCallback(() => {
     setNoteModalState(undefined)
-    if (noteModalState && noteModalState.id !== 'new') reloadCorrections()
+    if (noteModalState && noteModalState.id !== 'new') {
+      void reloadCorrections()
+    }
   }, [noteModalState, reloadCorrections])
 
   return (

--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReportDecision.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReportDecision.tsx
@@ -117,7 +117,7 @@ export default React.memo(function AssistanceNeedDecisionsReportDecision() {
           onClose={(shouldRefresh) => {
             setDecisionModalStatus(undefined)
             if (shouldRefresh) {
-              reloadDecision()
+              void reloadDecision()
             }
           }}
           decisionId={id}
@@ -129,7 +129,7 @@ export default React.memo(function AssistanceNeedDecisionsReportDecision() {
         <MismatchDecisionMakerModal
           onClose={() => {
             setMismatchDecisionMakerModalOpen(false)
-            reloadDecision()
+            void reloadDecision()
           }}
           decisionId={id}
         />

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/StaffOccupancyCoefficients.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/StaffOccupancyCoefficients.tsx
@@ -46,7 +46,7 @@ export function StaffOccupancyCoefficients({ allowEditing }: Props) {
         coefficient: checked ? 7 : 0
       }).then(() => {
         setSaving(false)
-        reload()
+        void reload()
       })
     },
     [reload, unitId]

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitAccessControl.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitAccessControl.tsx
@@ -652,7 +652,7 @@ export default React.memo(function UnitAccessControl({
   const confirmRemoveDevice = useCallback(async () => {
     if (mobileId) {
       await deleteMobileDevice(mobileId)
-      reloadMobileDevices()
+      void reloadMobileDevices()
     }
     closeRemoveModal()
   }, [closeRemoveModal, mobileId, reloadMobileDevices])
@@ -681,7 +681,7 @@ export default React.memo(function UnitAccessControl({
     async (name: string) => {
       if (mobileId) {
         await putMobileDeviceName(mobileId, name)
-        reloadMobileDevices()
+        void reloadMobileDevices()
         clearUiMode()
       }
     },

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -222,20 +222,24 @@ function graphData(
   const lastChildAttendance = childData[childData.length - 1]
 
   // If staff is still present, extend the graph up to current time
-  if (lastStaffAttendance.y > 0 && isBefore(lastStaffAttendance.x, now)) {
+  if (
+    lastStaffAttendance &&
+    lastStaffAttendance.y > 0 &&
+    isBefore(lastStaffAttendance.x, now)
+  ) {
     staffData.push({ ...lastStaffAttendance, x: new Date(now) })
     childData.push({ ...lastChildAttendance, x: new Date(now) })
   }
 
   const xMin = shiftCareUnit
-    ? firstStaffAttendance.x.getTime()
+    ? firstStaffAttendance?.x.getTime() ?? 0
     : min([
         // 6 AM
         setTime(new Date(), 6, 0),
         staffData[0].x
       ]).getTime()
   const xMax = shiftCareUnit
-    ? staffData[staffData.length - 1].x.getTime()
+    ? staffData[staffData.length - 1]?.x.getTime() ?? 0
     : max([
         // 6 PM
         setTime(new Date(), 18, 0),

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -105,6 +105,9 @@ export default React.memo(function UnitAttendanceReservationsView({
       ).then(() => {
         if (!cancelled) {
           setWeek((week) =>
+            // strict equality check: ensure the current week is the
+            // same one as when originally started, even when switching
+            // going x* -> y -> x the save at * should be ignored at the end
             week.dateRange === dateRange
               ? {
                   ...week,

--- a/frontend/src/employee-frontend/state/person.tsx
+++ b/frontend/src/employee-frontend/state/person.tsx
@@ -86,8 +86,8 @@ export const PersonContextProvider = React.memo(function PersonContextProvider({
   )
 
   const reloadFridgeChildren = useCallback(() => {
-    reloadFamily()
-    loadFridgeChildren()
+    void reloadFamily()
+    void loadFridgeChildren()
   }, [reloadFamily, loadFridgeChildren])
 
   const person = useMemo(
@@ -99,7 +99,7 @@ export const PersonContextProvider = React.memo(function PersonContextProvider({
       setPersonResponse((prev) =>
         prev.map((response) => ({ ...response, person }))
       )
-      reloadFamily()
+      void reloadFamily()
     },
     [reloadFamily]
   )

--- a/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkAbsentBeforehand.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/actions/MarkAbsentBeforehand.tsx
@@ -109,7 +109,7 @@ export default React.memo(function MarkAbsentBeforehand() {
       await deleteAbsenceRange(unitId, childId, deleteRange)
     }
     setDeleteRange(undefined)
-    loadFutureAbsences()
+    void loadFutureAbsences()
     setUiMode('default')
   }, [childId, deleteRange, loadFutureAbsences, unitId])
 

--- a/frontend/src/employee-mobile-frontend/components/staff/StaffPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff/StaffPage.tsx
@@ -71,8 +71,8 @@ export default React.memo(function StaffPage() {
   const updateAttendance = useCallback(
     async (attendance: StaffAttendanceUpdate) => {
       await postStaffAttendance(attendance)
-      reloadStaff()
-      reloadRealizedOccupancyToday()
+      void reloadStaff()
+      void reloadRealizedOccupancyToday()
       return Success.of()
     },
     [reloadRealizedOccupancyToday, reloadStaff]

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -170,6 +170,7 @@ export interface EmployeeAttendance {
   employeeId: UUID
   firstName: string
   groups: UUID[]
+  hasFutureAttendances: boolean
   lastName: string
 }
 
@@ -180,6 +181,7 @@ export interface ExternalAttendance {
   arrived: HelsinkiDateTime
   departed: HelsinkiDateTime | null
   groupId: UUID
+  hasFutureAttendances: boolean
   id: UUID
   name: string
   occupancyCoefficient: number

--- a/frontend/src/lib-components/atoms/buttons/IconButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/IconButton.tsx
@@ -15,6 +15,7 @@ interface ButtonProps {
   size: IconSize | undefined
   gray?: boolean
   white?: boolean
+  color?: string
 }
 
 const StyledButton = styled.button<ButtonProps>`
@@ -71,7 +72,9 @@ const StyledButton = styled.button<ButtonProps>`
     }
   }};
   color: ${(p) =>
-    p.gray
+    p.color
+      ? p.color
+      : p.gray
       ? p.theme.colors.grayscale.g70
       : p.white
       ? p.theme.colors.grayscale.g0
@@ -97,7 +100,9 @@ const StyledButton = styled.button<ButtonProps>`
 
   &:hover .icon-wrapper {
     color: ${(p) =>
-      p.gray
+      p.color
+        ? p.color
+        : p.gray
         ? p.theme.colors.grayscale.g70
         : p.white
         ? p.theme.colors.grayscale.g0
@@ -106,7 +111,11 @@ const StyledButton = styled.button<ButtonProps>`
 
   &:active .icon-wrapper {
     color: ${(p) =>
-      p.gray ? p.theme.colors.grayscale.g100 : p.theme.colors.main.m2Active};
+      p.color
+        ? p.color
+        : p.gray
+        ? p.theme.colors.grayscale.g100
+        : p.theme.colors.main.m2Active};
   }
 
   &.disabled {
@@ -138,8 +147,10 @@ export default React.memo(function IconButton({
   disabled,
   size,
   gray,
-  white
-}: IconButtonProps) {
+  white,
+  color,
+  ...props
+}: IconButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
     <StyledButton
       type="button"
@@ -151,6 +162,8 @@ export default React.memo(function IconButton({
       size={size}
       gray={gray}
       white={white}
+      color={color}
+      {...props}
     >
       <div className="icon-wrapper">
         <FontAwesomeIcon icon={icon} />

--- a/frontend/src/lib-components/atoms/state/Spinner.tsx
+++ b/frontend/src/lib-components/atoms/state/Spinner.tsx
@@ -49,14 +49,16 @@ const SpinnerWrapper = styled.div<SpinnerWrapperProps>`
 interface SpinnerSegmentProps {
   size?: SpacingSize
   margin?: SpacingSize
+  'data-qa'?: string
 }
 
 export const SpinnerSegment = React.memo(function SpinnerSegment({
   margin = 'm',
-  size = 'XXL'
+  size = 'XXL',
+  'data-qa': dataQa
 }: SpinnerSegmentProps) {
   return (
-    <SpinnerWrapper margin={defaultMargins[margin]}>
+    <SpinnerWrapper margin={defaultMargins[margin]} data-qa={dataQa}>
       <Spinner size={defaultMargins[size]} />
     </SpinnerWrapper>
   )

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -1930,7 +1930,9 @@ export const fi = {
         TRAINING: 'Koulutus',
         OVERTIME: 'Ylityö',
         JUSTIFIED_CHANGE: 'Perusteltu muutos'
-      }
+      },
+      formErrorWarning:
+        'Tarkista antamasi läsnäolotiedot. Muutoksesi voi jäädä tallentamatta, jos ne ei ole kelvollisia. Ohita varoitus klikkaamalla.'
     },
     error: {
       placement: {

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -31,6 +31,7 @@ import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
+import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -55,6 +56,8 @@ val preparatoryMinimumDuration: Duration = Duration.ofHours(1)
 
 val connectedDaycareBuffer: Duration = Duration.ofMinutes(15)
 val fiveYearOldFreeLimit: Duration = Duration.ofHours(4) + Duration.ofMinutes(15)
+
+private val logger = KotlinLogging.logger {}
 
 @RestController
 @RequestMapping("/attendances")
@@ -114,6 +117,7 @@ class ChildAttendanceController(
                         )
                     }
                 } catch (e: Exception) {
+                    logger.error(e.toString())
                     throw mapPSQLException(e)
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -31,7 +31,6 @@ import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
-import mu.KotlinLogging
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -56,8 +55,6 @@ val preparatoryMinimumDuration: Duration = Duration.ofHours(1)
 
 val connectedDaycareBuffer: Duration = Duration.ofMinutes(15)
 val fiveYearOldFreeLimit: Duration = Duration.ofHours(4) + Duration.ofMinutes(15)
-
-private val logger = KotlinLogging.logger {}
 
 @RestController
 @RequestMapping("/attendances")
@@ -117,7 +114,6 @@ class ChildAttendanceController(
                         )
                     }
                 } catch (e: Exception) {
-                    logger.error(e.toString())
                     throw mapPSQLException(e)
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -72,7 +72,7 @@ class RealtimeStaffAttendanceController(
                         hasFutureAttendances = data[0].hasFutureAttendances
                     )
                 }
-                val staffForAttendanceCalendar = it.getCurrentStaffForAttendanceCalendar(unitId, range.end)
+                val staffForAttendanceCalendar = it.getCurrentStaffForAttendanceCalendar(unitId, range.start, range.end)
                 val noAttendanceEmployeeToGroups = it.getGroupsForEmployees(staffForAttendanceCalendar.map { emp -> emp.id }.toSet())
                 val staffWithoutAttendance = staffForAttendanceCalendar
                     .filter { emp -> !attendancesByEmployee.keys.contains(emp.id) }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -68,10 +68,11 @@ class RealtimeStaffAttendanceController(
                                 att.occupancyCoefficient,
                                 att.type
                             )
-                        }
+                        },
+                        hasFutureAttendances = data[0].hasFutureAttendances
                     )
                 }
-                val staffForAttendanceCalendar = it.getCurrentStaffForAttendanceCalendar(unitId)
+                val staffForAttendanceCalendar = it.getCurrentStaffForAttendanceCalendar(unitId, range.end)
                 val noAttendanceEmployeeToGroups = it.getGroupsForEmployees(staffForAttendanceCalendar.map { emp -> emp.id }.toSet())
                 val staffWithoutAttendance = staffForAttendanceCalendar
                     .filter { emp -> !attendancesByEmployee.keys.contains(emp.id) }
@@ -81,7 +82,8 @@ class RealtimeStaffAttendanceController(
                             groups = noAttendanceEmployeeToGroups[emp.id] ?: listOf(),
                             firstName = emp.firstName,
                             lastName = emp.lastName,
-                            currentOccupancyCoefficient = emp.currentOccupancyCoefficient ?: BigDecimal.ZERO, listOf()
+                            currentOccupancyCoefficient = emp.currentOccupancyCoefficient ?: BigDecimal.ZERO, listOf(),
+                            hasFutureAttendances = emp.hasFutureAttendances
                         )
                     }
                 StaffAttendanceResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
@@ -84,7 +84,8 @@ data class ExternalAttendance(
     val groupId: GroupId,
     val arrived: HelsinkiDateTime,
     val departed: HelsinkiDateTime?,
-    val occupancyCoefficient: BigDecimal
+    val occupancyCoefficient: BigDecimal,
+    val hasFutureAttendances: Boolean
 ) {
     val type = StaffAttendanceType.PRESENT
 }
@@ -104,7 +105,8 @@ data class EmployeeAttendance(
     val firstName: String,
     val lastName: String,
     val currentOccupancyCoefficient: BigDecimal,
-    val attendances: List<Attendance>
+    val attendances: List<Attendance>,
+    val hasFutureAttendances: Boolean
 )
 
 data class StaffAttendanceResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.domain.HelsinkiDateTimeRange
 import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.kotlin.mapTo
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
 
@@ -263,6 +264,7 @@ data class RawAttendance(
     val employeeId: EmployeeId,
     val firstName: String,
     val lastName: String,
+    val hasFutureAttendances: Boolean
 )
 
 fun Database.Read.getStaffAttendancesForDateRange(unitId: DaycareId, range: FiniteDateRange): List<RawAttendance> =
@@ -278,7 +280,12 @@ SELECT
     sa.type,
     emp.first_name,
     emp.last_name,
-    soc.coefficient AS currentOccupancyCoefficient
+    soc.coefficient AS currentOccupancyCoefficient,
+    EXISTS(
+        SELECT 1 FROM staff_attendance_realtime osar
+        JOIN daycare_group odg on osar.group_id = odg.id
+        WHERE osar.employee_id = sa.employee_id AND osar.arrived > :end AND odg.daycare_id = :unitId
+    ) AS has_future_attendances
 FROM staff_attendance_realtime sa
 JOIN daycare_group dg on sa.group_id = dg.id
 JOIN employee emp ON sa.employee_id = emp.id
@@ -297,11 +304,21 @@ data class RawAttendanceEmployee(
     val firstName: String,
     val lastName: String,
     val currentOccupancyCoefficient: BigDecimal?,
+    val hasFutureAttendances: Boolean
 )
 
-fun Database.Read.getCurrentStaffForAttendanceCalendar(unitId: DaycareId): List<RawAttendanceEmployee> = createQuery(
+fun Database.Read.getCurrentStaffForAttendanceCalendar(
+    unitId: DaycareId,
+    end: LocalDate
+): List<RawAttendanceEmployee> = createQuery(
     """
-SELECT DISTINCT dacl.employee_id as id, emp.first_name, emp.last_name, soc.coefficient AS currentOccupancyCoefficient
+SELECT DISTINCT
+    dacl.employee_id as id, emp.first_name, emp.last_name, soc.coefficient AS currentOccupancyCoefficient,
+    EXISTS(
+        SELECT 1 FROM staff_attendance_realtime sar
+        JOIN daycare_group dg on sar.group_id = dg.id
+        WHERE sar.employee_id = dacl.employee_id AND sar.arrived > :end AND dg.daycare_id = :unitId
+    ) AS has_future_attendances
 FROM daycare_acl dacl
 JOIN employee emp on emp.id = dacl.employee_id
 LEFT JOIN daycare_group_acl dgacl ON dgacl.employee_id = emp.id
@@ -310,12 +327,19 @@ WHERE dacl.daycare_id = :unitId AND (dacl.role IN ('STAFF', 'SPECIAL_EDUCATION_T
     """.trimIndent()
 )
     .bind("unitId", unitId)
+    .bind("end", end)
     .mapTo<RawAttendanceEmployee>()
     .list()
 
 fun Database.Read.getExternalStaffAttendancesByDateRange(unitId: DaycareId, range: FiniteDateRange): List<ExternalAttendance> = createQuery(
     """
-    SELECT sae.id, sae.name, sae.group_id, sae.arrived, sae.departed, sae.occupancy_coefficient
+    SELECT
+        sae.id, sae.name, sae.group_id, sae.arrived, sae.departed, sae.occupancy_coefficient,
+        EXISTS(
+            SELECT 1 FROM staff_attendance_external osae
+            JOIN daycare_group odg on osae.group_id = odg.id
+            WHERE osae.name = sae.name AND osae.arrived > :end AND odg.daycare_id = :unitId
+        ) AS has_future_attendances
     FROM staff_attendance_external sae
     JOIN daycare_group dg on sae.group_id = dg.id
     WHERE dg.daycare_id = :unitId AND tstzrange(sae.arrived, sae.departed) && tstzrange(:start, :end)


### PR DESCRIPTION
#### Summary

The staff attendance table wasn't handling overnight attendances properly. Instead of splitting overnight attendances into two, the internal attendance table row state is instead now almost equal to the server's state, where multi-day attendances are grouped into one. An exception to this are the empty placeholder attendances added on load.

With this refactor, the attendance table is more aware of the relationship between start and end times, namely that if there is an open attendance it must be closed before another one can be added. Also, the behaviour related to uncoupling overnight attendances is more reliable now, and the frontend couples overnight attendances automatically too.

This PR also fixes a subtle issue with the `useApiState` where old request responses were not ignored properly, causing incorrect data being shown in some rare situations (but commonly in E2E tests where switching between unit calendar weeks was extremely quick and became desynced due to this bug).
