### PR TITLE
Trigger build on pull request activity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push]
+on: [push, pull_request]
 
 env:
   ECR_REGISTRY: 307238562370.dkr.ecr.eu-west-1.amazonaws.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+    - master
 
 env:
   ECR_REGISTRY: 307238562370.dkr.ecr.eu-west-1.amazonaws.com


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- trigger build on pull request activity
- limit push events to master branch (`push` without branch restriction causes double builds in pull requests, because both `push` and `pull_reques` events are triggered)
- limiting push to main branch means CI no longer runs if a branch is pushed but a pull request is not made. This can be improved later by e.g. using a known prefix for branches which should be built