### PR TITLE
EVAKA-4469 citizen unread assistance need decisions

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -31,6 +31,7 @@ import VasuPage from './child-documents/vasu/VasuPage'
 import AssistanceNeedDecisionPage from './children/AssistanceNeedDecisionPage'
 import ChildPage from './children/ChildPage'
 import ChildrenPage from './children/ChildrenPage'
+import { ChildrenContextProvider } from './children/state'
 import DecisionResponseList from './decisions/decision-response-page/DecisionResponseList'
 import Header from './header/Header'
 import { HolidayPeriodsContextProvider } from './holiday-periods/state'
@@ -62,10 +63,14 @@ export default function App() {
                 <MessageContextProvider>
                   <PedagogicalDocumentsContextProvider>
                     <HolidayPeriodsContextProvider>
-                      <Content />
-                      <GlobalDialog />
-                      <LoginErrorModal translations={i18n.login.failedModal} />
-                      <div id="modal-container" />
+                      <ChildrenContextProvider>
+                        <Content />
+                        <GlobalDialog />
+                        <LoginErrorModal
+                          translations={i18n.login.failedModal}
+                        />
+                        <div id="modal-container" />
+                      </ChildrenContextProvider>
                     </HolidayPeriodsContextProvider>
                   </PedagogicalDocumentsContextProvider>
                 </MessageContextProvider>

--- a/frontend/src/citizen-frontend/children/AssistanceNeedDecisionPage.tsx
+++ b/frontend/src/citizen-frontend/children/AssistanceNeedDecisionPage.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { useContext, useEffect } from 'react'
 
 import Footer from 'citizen-frontend/Footer'
 import { renderResult } from 'citizen-frontend/async-rendering'
@@ -21,7 +21,11 @@ import { Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faArrowDownToLine } from 'lib-icons'
 
-import { getAssistanceNeedDecision } from './api'
+import {
+  getAssistanceNeedDecision,
+  markAssistanceNeedDecisionAsRead
+} from './api'
+import { ChildrenContext } from './state'
 
 export default React.memo(function AssistanceNeedDecisionPage() {
   const { id } = useNonNullableParams<{ childId: UUID; id: UUID }>()
@@ -32,6 +36,15 @@ export default React.memo(function AssistanceNeedDecisionPage() {
   )
 
   const i18n = useTranslation()
+
+  const { refreshUnreadAssistanceNeedDecisionCounts } =
+    useContext(ChildrenContext)
+
+  useEffect(() => {
+    void markAssistanceNeedDecisionAsRead(id).then(() => {
+      refreshUnreadAssistanceNeedDecisionCounts()
+    })
+  }, [id, refreshUnreadAssistanceNeedDecisionCounts])
 
   return (
     <>

--- a/frontend/src/citizen-frontend/children/ChildPage.tsx
+++ b/frontend/src/citizen-frontend/children/ChildPage.tsx
@@ -37,9 +37,7 @@ export default React.memo(function ChildPage() {
                 <ChildHeader child={child} />
               </ContentArea>
               <Gap size="s" />
-              <ContentArea opaque>
-                <AssistanceNeedSection childId={childId} />
-              </ContentArea>
+              <AssistanceNeedSection childId={childId} />
               <Gap size="s" />
               <ContentArea opaque>
                 <PlacementTerminationSection childId={childId} />

--- a/frontend/src/citizen-frontend/children/ChildrenPage.tsx
+++ b/frontend/src/citizen-frontend/children/ChildrenPage.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback } from 'react'
+import React, { useCallback, useContext, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -10,6 +10,7 @@ import Footer from 'citizen-frontend/Footer'
 import { Child } from 'lib-common/generated/api-types/children'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Main from 'lib-components/atoms/Main'
+import RoundIcon from 'lib-components/atoms/RoundIcon'
 import { RoundImage } from 'lib-components/atoms/RoundImage'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import { desktopMin } from 'lib-components/breakpoints'
@@ -34,6 +35,7 @@ import { renderResult } from '../async-rendering'
 import { useTranslation } from '../localization'
 
 import { getChildren } from './api'
+import { ChildrenContext } from './state'
 
 const Children = styled.div`
   display: flex;
@@ -79,9 +81,24 @@ const ChildItem = React.memo(function ChildItem({ child }: { child: Child }) {
     [navigate, child.id]
   )
 
+  const { unreadAssistanceNeedDecisionCounts } = useContext(ChildrenContext)
+
+  const unreadCount = useMemo(
+    () =>
+      unreadAssistanceNeedDecisionCounts.find(
+        ({ childId }) => childId === child.id
+      )?.count ?? 0,
+    [unreadAssistanceNeedDecisionCounts, child]
+  )
+
   const name = `${child.firstName} ${child.lastName}`
   return (
-    <ChildContainer onClick={navigateToChild} opaque data-qa="child">
+    <ChildContainer
+      onClick={navigateToChild}
+      opaque
+      data-qa="child"
+      data-qa-value={child.id}
+    >
       <RoundImage
         size="XL"
         sizeDesktop="XXL"
@@ -109,6 +126,16 @@ const ChildItem = React.memo(function ChildItem({ child }: { child: Child }) {
         </NameAndGroup>
       </Desktop>
       <ChevronContainer>
+        {unreadCount > 0 && (
+          <RoundIcon
+            content={unreadCount.toString()}
+            color={colors.status.warning}
+            aria-label={`${unreadCount} ${t.children.assistanceNeed.unreadCount}`}
+            size="m"
+            data-qa="unread-count"
+          />
+        )}
+        <Gap horizontal size="s" />
         <IconButton icon={faChevronRight} />
       </ChevronContainer>
     </ChildContainer>

--- a/frontend/src/citizen-frontend/children/api.ts
+++ b/frontend/src/citizen-frontend/children/api.ts
@@ -6,7 +6,8 @@ import { Failure, Result, Success } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import {
   AssistanceNeedDecision,
-  AssistanceNeedDecisionCitizenListItem
+  AssistanceNeedDecisionCitizenListItem,
+  UnreadAssistanceNeedDecisionItem
 } from 'lib-common/generated/api-types/assistanceneed'
 import {
   Child,
@@ -151,5 +152,25 @@ export function getAssistanceNeedDecision(
       `/citizen/children/assistance-need-decision/${id}`
     )
     .then((res) => Success.of(mapToAssistanceNeedDecision(res.data)))
+    .catch((e) => Failure.fromError(e))
+}
+
+export function markAssistanceNeedDecisionAsRead(
+  id: UUID
+): Promise<Result<void>> {
+  return client
+    .post(`/citizen/children/assistance-need-decision/${id}/read`)
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
+}
+
+export function getAssistanceNeedDecisionUnreadCounts(): Promise<
+  Result<UnreadAssistanceNeedDecisionItem[]>
+> {
+  return client
+    .get<JsonOf<UnreadAssistanceNeedDecisionItem[]>>(
+      `/citizen/children/assistance-need-decisions/unread-counts`
+    )
+    .then(({ data }) => Success.of(data))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/citizen-frontend/children/state.tsx
+++ b/frontend/src/citizen-frontend/children/state.tsx
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React, { createContext } from 'react'
+
+import { useUser } from 'citizen-frontend/auth/state'
+import { Success } from 'lib-common/api'
+import { UnreadAssistanceNeedDecisionItem } from 'lib-common/generated/api-types/assistanceneed'
+import { useApiState } from 'lib-common/utils/useRestApi'
+
+import { getAssistanceNeedDecisionUnreadCounts } from './api'
+
+interface ChildrenContext {
+  unreadAssistanceNeedDecisionCounts: UnreadAssistanceNeedDecisionItem[]
+  refreshUnreadAssistanceNeedDecisionCounts: () => void
+}
+
+const defaultValue: ChildrenContext = {
+  unreadAssistanceNeedDecisionCounts: [],
+  refreshUnreadAssistanceNeedDecisionCounts: () => undefined
+}
+
+export const ChildrenContext = createContext(defaultValue)
+
+export const ChildrenContextProvider = React.memo(
+  function ChildrenContextProvider({
+    children
+  }: {
+    children: React.ReactNode
+  }) {
+    const user = useUser()
+
+    const [
+      unreadAssistanceNeedDecisionCounts,
+      refreshUnreadAssistanceNeedDecisionCounts
+    ] = useApiState(
+      () =>
+        !user
+          ? Promise.resolve(Success.of([]))
+          : getAssistanceNeedDecisionUnreadCounts(),
+      [user]
+    )
+
+    return (
+      <ChildrenContext.Provider
+        value={{
+          unreadAssistanceNeedDecisionCounts:
+            unreadAssistanceNeedDecisionCounts.getOrElse([]),
+          refreshUnreadAssistanceNeedDecisionCounts
+        }}
+      >
+        {children}
+      </ChildrenContext.Provider>
+    )
+  }
+)

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -34,12 +34,14 @@ import { getLogoutUri } from './const'
 interface Props {
   unreadMessagesCount: number
   unreadChildDocuments: number
+  unreadChildren: number
   hideLoginButton: boolean
 }
 
 export default React.memo(function DesktopNav({
   unreadMessagesCount,
   unreadChildDocuments,
+  unreadChildren,
   hideLoginButton
 }: Props) {
   const { user } = useContext(AuthContext)
@@ -93,7 +95,13 @@ export default React.memo(function DesktopNav({
                     </StyledNavLink>
                   )}
                   <StyledNavLink to="/children" data-qa="nav-children">
-                    <NavLinkText text={t.header.nav.children} /> {maybeLockElem}
+                    <NavLinkText text={t.header.nav.children} />
+                    {maybeLockElem}
+                    {isEnduser && unreadChildren > 0 && (
+                      <CircledChar data-qa="unread-children-count">
+                        {unreadChildren}
+                      </CircledChar>
+                    )}
                   </StyledNavLink>
                   <StyledNavLink to="/applying" data-qa="nav-applying">
                     <NavLinkText text={t.header.nav.applications} />

--- a/frontend/src/citizen-frontend/header/Header.tsx
+++ b/frontend/src/citizen-frontend/header/Header.tsx
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useContext, useEffect, useState } from 'react'
+import sumBy from 'lodash/sumBy'
+import React, { useContext, useEffect, useMemo, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 
+import { ChildrenContext } from 'citizen-frontend/children/state'
 import { desktopMin } from 'lib-components/breakpoints'
 import colors from 'lib-customizations/common'
 
@@ -40,18 +42,29 @@ export default React.memo(function Header(props: { ariaHidden: boolean }) {
     refreshUnreadVasuDocumentsCount
   } = useContext<ChildDocumentsState>(ChildDocumentsContext)
 
+  const {
+    unreadAssistanceNeedDecisionCounts,
+    refreshUnreadAssistanceNeedDecisionCounts
+  } = useContext(ChildrenContext)
+
   useEffect(() => {
     if (user) {
       refreshUnreadPedagogicalDocumentsCount()
       refreshUnreadVasuDocumentsCount()
+      refreshUnreadAssistanceNeedDecisionCounts()
     }
-  }, [refreshUnreadVasuDocumentsCount, refreshUnreadPedagogicalDocumentsCount, user])
+  }, [refreshUnreadVasuDocumentsCount, refreshUnreadPedagogicalDocumentsCount, refreshUnreadAssistanceNeedDecisionCounts, user])
 
   const location = useLocation()
   const hideLoginButton = location.pathname === '/login'
 
   const unreadDocumentCount =
     (unreadPedagogicalDocumentsCount || 0) + (unreadVasuDocumentsCount || 0)
+
+  const unreadChildrenCount = useMemo(
+    () => sumBy(unreadAssistanceNeedDecisionCounts, ({ count }) => count),
+    [unreadAssistanceNeedDecisionCounts]
+  )
 
   return (
     <HeaderContainer showMenu={showMenu} aria-hidden={props.ariaHidden}>
@@ -60,6 +73,7 @@ export default React.memo(function Header(props: { ariaHidden: boolean }) {
       <DesktopNav
         unreadMessagesCount={unreadMessagesCount ?? 0}
         unreadChildDocuments={unreadDocumentCount}
+        unreadChildren={unreadChildrenCount}
         hideLoginButton={hideLoginButton}
       />
       <MobileNav
@@ -67,6 +81,7 @@ export default React.memo(function Header(props: { ariaHidden: boolean }) {
         setShowMenu={setShowMenu}
         unreadMessagesCount={unreadMessagesCount ?? 0}
         unreadChildDocumentsCount={unreadDocumentCount}
+        unreadChildrenCount={unreadChildrenCount}
         hideLoginButton={hideLoginButton}
       />
     </HeaderContainer>

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -44,6 +44,7 @@ type Props = {
   setShowMenu: Dispatch<SetStateAction<boolean>>
   unreadMessagesCount: number
   unreadChildDocumentsCount: number
+  unreadChildrenCount: number
   hideLoginButton: boolean
 }
 
@@ -52,6 +53,7 @@ export default React.memo(function MobileNav({
   setShowMenu,
   unreadMessagesCount,
   unreadChildDocumentsCount,
+  unreadChildrenCount,
   hideLoginButton
 }: Props) {
   const { user } = useContext(AuthContext)
@@ -70,6 +72,7 @@ export default React.memo(function MobileNav({
           !showMenu &&
           (unreadMessagesCount > 0 ||
             unreadChildDocumentsCount > 0 ||
+            unreadChildrenCount > 0 ||
             !!(user && !user.email))
 
         return (
@@ -96,6 +99,7 @@ export default React.memo(function MobileNav({
                     user={user}
                     unreadMessagesCount={unreadMessagesCount}
                     unreadChildDocumentsCount={unreadChildDocumentsCount}
+                    unreadChildrenCount={unreadChildrenCount}
                   />
                 )}
                 <VerticalSpacer />
@@ -223,12 +227,14 @@ const Navigation = React.memo(function Navigation({
   close,
   user,
   unreadMessagesCount,
-  unreadChildDocumentsCount
+  unreadChildDocumentsCount,
+  unreadChildrenCount
 }: {
   close: () => void
   user: User
   unreadMessagesCount: number
   unreadChildDocumentsCount: number
+  unreadChildrenCount: number
 }) {
   const t = useTranslation()
 
@@ -266,7 +272,11 @@ const Navigation = React.memo(function Navigation({
         </StyledNavLink>
       )}
       <StyledNavLink to="/children" onClick={close} data-qa="nav-children">
-        <NavLinkText text={t.header.nav.children} /> {maybeLockElem}
+        <NavLinkText text={t.header.nav.children} />
+        {maybeLockElem}
+        {unreadChildrenCount > 0 && (
+          <FloatingCircledChar>{unreadChildrenCount}</FloatingCircledChar>
+        )}
       </StyledNavLink>
       <StyledNavLink to="/applying" onClick={close} data-qa="nav-applications">
         <NavLinkText text={t.header.nav.applications} /> {maybeLockElem}

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1348,7 +1348,8 @@ export class Fixture {
         smallerGroup: false,
         specialGroup: false
       },
-      viewOfGuardians: null
+      viewOfGuardians: null,
+      unreadGuardianIds: null
     })
   }
 
@@ -1408,7 +1409,8 @@ export class Fixture {
         smallerGroup: true,
         specialGroup: false
       },
-      viewOfGuardians: 'VOG text'
+      viewOfGuardians: 'VOG text',
+      unreadGuardianIds: null
     })
   }
 

--- a/frontend/src/e2e-test/dev-api/types.ts
+++ b/frontend/src/e2e-test/dev-api/types.ts
@@ -511,6 +511,7 @@ export interface AssistanceNeedDecision {
     specialGroup: boolean
   }
   viewOfGuardians: string | null
+  unreadGuardianIds: UUID[] | null
 }
 
 export interface DevIncome {

--- a/frontend/src/e2e-test/pages/citizen/citizen-children.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-children.ts
@@ -4,6 +4,7 @@
 
 import LocalDate from 'lib-common/local-date'
 
+import { waitUntilEqual } from '../../utils'
 import { Page, TextInput } from '../../utils/page'
 
 export class CitizenChildrenPage {
@@ -24,6 +25,16 @@ export class CitizenChildrenPage {
   async openChildPage(childName: string) {
     await this.#childRows.find(`h2:has-text("${childName}")`).click()
     await this.page.find(`h1:has-text("${childName}")`).waitUntilVisible()
+  }
+
+  async assertChildUnreadCount(childId: string, count: number) {
+    await waitUntilEqual(
+      () =>
+        this.page
+          .find(`[data-qa="child"][data-qa-value="${childId}"]`)
+          .findByDataQa('unread-count').innerText,
+      count.toString()
+    )
   }
 }
 
@@ -120,10 +131,35 @@ export class CitizenChildPage {
     return this.page.findAllByDataQa('assistance-need-decision-row').count()
   }
 
-  async getAssistanceNeedDecisionRowClick(nth: number) {
+  async assistanceNeedDecisionRowClick(nth: number) {
     return this.page
       .findAllByDataQa('assistance-need-decision-row')
       .nth(nth)
       .click()
+  }
+
+  async assertUnreadAssistanceNeedDecisions(count: number) {
+    await waitUntilEqual(
+      () =>
+        this.page.findByDataQa('assistance-need-decision-unread-count')
+          .innerText,
+      count.toString()
+    )
+  }
+
+  async assertAssistanceNeedDecisionRowUnread(nth: number) {
+    await this.page
+      .findAllByDataQa('assistance-need-decision-row')
+      .nth(nth)
+      .findByDataQa('unopened-indicator')
+      .waitUntilVisible()
+  }
+
+  async assertNotAssistanceNeedDecisionRowUnread(nth: number) {
+    await this.page
+      .findAllByDataQa('assistance-need-decision-row')
+      .nth(nth)
+      .findByDataQa('unopened-indicator')
+      .waitUntilHidden()
   }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-header.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-header.ts
@@ -24,6 +24,7 @@ export default class CitizenHeader {
   #unreadChildDocumentsCount = this.page.findAllByDataQa(
     'unread-child-documents-count'
   )
+  #unreadChildrenCount = this.page.findAllByDataQa('unread-children-count')
 
   #languageOption(lang: Lang) {
     return this.#languageOptionList.find(`[data-qa="lang-${lang}"]`)
@@ -147,5 +148,14 @@ export default class CitizenHeader {
       : await waitUntilFalse(
           () => this.#unreadChildDocumentsCount.first().visible
         )
+  }
+
+  async assertUnreadChildrenCount(expectedCount: number) {
+    expectedCount != 0
+      ? await waitUntilEqual(
+          () => this.#unreadChildrenCount.first().textContent,
+          expectedCount.toString()
+        )
+      : await waitUntilFalse(() => this.#unreadChildrenCount.first().visible)
   }
 }

--- a/frontend/src/lib-common/generated/api-types/assistanceneed.ts
+++ b/frontend/src/lib-common/generated/api-types/assistanceneed.ts
@@ -115,6 +115,7 @@ export interface AssistanceNeedDecisionCitizenListItem {
   decisionMade: LocalDate | null
   endDate: LocalDate | null
   id: UUID
+  isUnread: boolean
   selectedUnit: UnitInfoBasics | null
   startDate: LocalDate | null
   status: AssistanceNeedDecisionStatus
@@ -330,6 +331,14 @@ export interface UnitInfo {
 export interface UnitInfoBasics {
   id: UUID | null
   name: string | null
+}
+
+/**
+* Generated from fi.espoo.evaka.assistanceneed.decision.UnreadAssistanceNeedDecisionItem
+*/
+export interface UnreadAssistanceNeedDecisionItem {
+  childId: UUID
+  count: number
 }
 
 /**

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1978,6 +1978,7 @@ const en: Translations = {
     },
     assistanceNeed: {
       title: 'Support need',
+      unreadCount: 'unread',
       decisions: {
         title: 'Support need decisions',
         form: 'Form',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1906,6 +1906,7 @@ export default {
     },
     assistanceNeed: {
       title: 'Tuen tarve',
+      unreadCount: 'lukematonta',
       decisions: {
         title: 'Tuen tarpeen päätökset',
         form: 'Lomake',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1933,6 +1933,7 @@ const sv: Translations = {
     },
     assistanceNeed: {
       title: 'Behov av stöd',
+      unreadCount: 'olästa',
       decisions: {
         title: 'Beslut om behov av stöd',
         form: 'Form',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AssistanceNeedDecisionAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AssistanceNeedDecisionAccessControlTest.kt
@@ -82,7 +82,8 @@ class AssistanceNeedDecisionAccessControlTest : AccessControlTest() {
                     otherRepresentativeDetails = null,
                     assistanceLevel = null,
                     assistanceServicesTime = null,
-                    motivationForDecision = null
+                    motivationForDecision = null,
+                    unreadGuardianIds = null
                 )
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -60,6 +60,8 @@ enum class Audit(
     ChildAssistanceNeedDecisionCreate("evaka.child.assistance-need-decision.create"),
     ChildAssistanceNeedDecisionDelete("evaka.child.assistance-need-decision.delete"),
     ChildAssistanceNeedDecisionDownloadCitizen("evaka.citizen.child.assistance-need-decision.download"),
+    ChildAssistanceNeedDecisionGetUnreadCountCitizen("evaka.citizen.child.assistance-need-decision.get-unread-count"),
+    ChildAssistanceNeedDecisionMarkReadCitizen("evaka.citizen.child.assistance-need-decision.mark-as-read"),
     ChildAssistanceNeedDecisionRead("evaka.child.assistance-need-decision.read"),
     ChildAssistanceNeedDecisionReadCitizen("evaka.citizen.child.assistance-need-decision.read"),
     ChildAssistanceNeedDecisionUpdate("evaka.child.assistance-need-decision.update"),

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecision.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecision.kt
@@ -251,5 +251,11 @@ data class AssistanceNeedDecisionCitizenListItem(
     @Nested("selected_unit")
     val selectedUnit: UnitInfoBasics?,
 
-    val assistanceLevel: AssistanceLevel?
+    val assistanceLevel: AssistanceLevel?,
+    val isUnread: Boolean
+)
+
+data class UnreadAssistanceNeedDecisionItem(
+    val childId: ChildId,
+    val count: Int
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
@@ -216,12 +216,16 @@ class AssistanceNeedDecisionController(
                     throw BadRequest("Already-decided decisions cannot be decided again")
                 }
 
-                tx.updateAssistanceNeedDecision(
+                if (decision.child?.id == null) {
+                    throw BadRequest("The assistance need decision needs to be associated with a child")
+                }
+
+                tx.decideAssistanceNeedDecision(
                     id,
-                    decision.copy(
-                        status = body.status,
-                        decisionMade = if (body.status == AssistanceNeedDecisionStatus.NEEDS_WORK) null else LocalDate.now()
-                    ).toForm()
+                    body.status,
+                    if (body.status == AssistanceNeedDecisionStatus.NEEDS_WORK) null else LocalDate.now(),
+                    if (body.status == AssistanceNeedDecisionStatus.NEEDS_WORK) null
+                    else tx.getChildGuardians(decision.child.id)
                 )
 
                 if (body.status != AssistanceNeedDecisionStatus.NEEDS_WORK) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -779,7 +779,7 @@ fun Database.Transaction.insertTestAssistanceNeedDecision(
           expert_responsibilities, guardians_heard_on, view_of_guardians, other_representative_heard, other_representative_details, 
           assistance_level, assistance_services_time, motivation_for_decision, decision_maker_employee_id,
           decision_maker_title, preparer_1_employee_id, preparer_1_title, preparer_2_employee_id, preparer_2_title,
-          preparer_1_phone_number, preparer_2_phone_number
+          preparer_1_phone_number, preparer_2_phone_number, unread_guardian_ids
         )
         VALUES (
             :id,
@@ -822,7 +822,8 @@ fun Database.Transaction.insertTestAssistanceNeedDecision(
             :preparer2EmployeeId,
             :preparer2Title,
             :preparer1PhoneNumber,
-            :preparer2PhoneNumber
+            :preparer2PhoneNumber,
+            :unreadGuardianIds
         )
         RETURNING id
         """.trimIndent()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1509,7 +1509,9 @@ data class DevAssistanceNeedDecision(
 
     val assistanceLevel: AssistanceLevel?,
     val assistanceServicesTime: FiniteDateRange?,
-    val motivationForDecision: String?
+    val motivationForDecision: String?,
+
+    val unreadGuardianIds: List<PersonId>?
 )
 
 data class DevChildAttendance(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -183,7 +183,8 @@ sealed interface Action {
         }
         enum class AssistanceNeedDecision(override vararg val defaultRules: ScopedActionRule<in AssistanceNeedDecisionId>) : ScopedAction<AssistanceNeedDecisionId> {
             READ(IsCitizen(allowWeakLogin = false).guardianOfChildOfAssistanceNeedDecision()),
-            DOWNLOAD(IsCitizen(allowWeakLogin = false).guardianOfChildOfAssistanceNeedDecision());
+            DOWNLOAD(IsCitizen(allowWeakLogin = false).guardianOfChildOfAssistanceNeedDecision()),
+            MARK_AS_READ(IsCitizen(allowWeakLogin = false).guardianOfChildOfAssistanceNeedDecision());
 
             override fun toString(): String = "${javaClass.name}.$name"
         }
@@ -236,7 +237,8 @@ sealed interface Action {
             READ_INCOME_STATEMENTS(IsCitizen(allowWeakLogin = false).self()),
             READ_VTJ_DETAILS(IsCitizen(allowWeakLogin = true).self()),
             UPDATE_PERSONAL_DATA(IsCitizen(allowWeakLogin = false).self()),
-            READ_DAILY_SERVICE_TIME_NOTIFICATIONS(IsCitizen(allowWeakLogin = true).self());
+            READ_DAILY_SERVICE_TIME_NOTIFICATIONS(IsCitizen(allowWeakLogin = true).self()),
+            READ_UNREAD_ASSISTANCE_NEED_DECISION_COUNT(IsCitizen(allowWeakLogin = false).self());
 
             override fun toString(): String = "${javaClass.name}.$name"
         }

--- a/service/src/main/resources/db/migration/V252__assistance_need_decision_read.sql
+++ b/service/src/main/resources/db/migration/V252__assistance_need_decision_read.sql
@@ -1,0 +1,2 @@
+ALTER TABLE assistance_need_decision
+  ADD COLUMN unread_guardian_ids uuid[];

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -249,3 +249,4 @@ V248__time_series_daily_service_times.sql
 V249__non_nullable_timerange.sql
 V250__daily_service_times_notification.sql
 V251__assistance_need_decision_pdf.sql
+V252__assistance_need_decision_read.sql


### PR DESCRIPTION
#### Summary

- Adds an unread assistance need decision count indicator to the header/navigation, the list of children page, the child page (collapsible's header), and in the table itself
- Marks decisions read when they are opened