### PR TITLE
Fix attendance calendar navigation causing deletion

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -310,6 +310,20 @@ describe('Realtime staff attendances', () => {
         departure: '→'
       })
     })
+    test('Navigating to the previous week does not delete an open attendance', async () => {
+      const rowIx = 0
+      await calendarPage.clickEditOnRow(rowIx)
+      await calendarPage.setNthArrivalDeparture(0, 0, '15:00', '')
+      await calendarPage.closeInlineEditor()
+      await calendarPage.changeWeekToDate(mockedToday.subWeeks(1))
+      await calendarPage.changeWeekToDate(mockedToday)
+      await calendarPage.assertArrivalDeparture({
+        rowIx,
+        nth: 0,
+        arrival: '15:00',
+        departure: '–'
+      })
+    })
     test('A warning is shown if open range is added with a future attendance', async () => {
       await calendarPage.clickEditOnRow(0)
       await calendarPage.setNthArrivalDeparture(0, 6, '09:00', '10:00')

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -354,7 +354,7 @@ const AttendanceRow = React.memo(function AttendanceRow({
   groupFilter,
   selectedGroup,
   weekSavingFns,
-  hasFutureAttendances
+  hasFutureAttendances: _hasFutureAttendances
 }: AttendanceRowProps) {
   const { i18n } = useTranslation()
 
@@ -387,6 +387,7 @@ const AttendanceRow = React.memo(function AttendanceRow({
   )
 
   const [form, setForm] = useState<FormAttendance[]>()
+  const [hasFutureAttendances, setHasFutureAttendances] = useState(false)
 
   const [hasHiddenDailyAttendances, setHasHiddenDailyAttendances] =
     useState(false)
@@ -428,6 +429,7 @@ const AttendanceRow = React.memo(function AttendanceRow({
         .map(({ date }) => emptyAttendanceOn(date))
 
       setForm([...formAttendances, ...newEmptyAttendances])
+      setHasFutureAttendances(_hasFutureAttendances)
       return
     }
 
@@ -473,7 +475,14 @@ const AttendanceRow = React.memo(function AttendanceRow({
 
       return [...restoredAttendances, ...newEmptyAttendances]
     })
-  }, [groupFilter, attendances, operationalDays, editing])
+    setHasFutureAttendances(_hasFutureAttendances)
+  }, [
+    groupFilter,
+    attendances,
+    operationalDays,
+    editing,
+    _hasFutureAttendances
+  ])
 
   const createAttendance = useCallback(
     (date: LocalDate, data: Partial<FormAttendance>) =>


### PR DESCRIPTION
#### Summary

When there is a future attendance, it must be that no open attendances may be made. When switching to the previous week after creating an open attendance, the future attendance flag would update (to true) before the actual form, causing the form validation hook to remove the newly-created open attendance as it seemed invalid (because it is an open attendance and there is a future attendance – even though there isn't).
