### PR TITLE
Fix button inside button semantics in messages

### DIFF
--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
+import { Link } from 'react-router-dom'
+import styled from 'styled-components'
 
 import { formatDateOrTime } from 'lib-common/date'
 import { MessageThread } from 'lib-common/generated/api-types/messaging'
@@ -42,6 +44,7 @@ export default React.memo(function ThreadListItem({
       active={active}
       onClick={onClick}
       data-qa="thread-list-item"
+      tabIndex={0}
     >
       <FixedSpaceColumn>
         <Header isRead={!hasUnreadMessages}>
@@ -54,6 +57,11 @@ export default React.memo(function ThreadListItem({
             labels={i18n.messages.types}
           />
         </Header>
+        <SrOnly>
+          <Link to={`/messages/${thread.id}`} tabIndex={-1}>
+            {i18n.messages.openMessage}
+          </Link>
+        </SrOnly>
         <TitleAndDate isRead={!hasUnreadMessages}>
           <Truncated>{thread.title}</Truncated>
           <span>{formatDateOrTime(lastMessage.sentAt)}</span>
@@ -78,3 +86,12 @@ export default React.memo(function ThreadListItem({
     </Container>
   )
 })
+
+const SrOnly = styled.div`
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+`

--- a/frontend/src/lib-components/molecules/ThreadListItem.tsx
+++ b/frontend/src/lib-components/molecules/ThreadListItem.tsx
@@ -31,7 +31,7 @@ export const Truncated = styled.span`
     margin-right: ${defaultMargins.s};
   }
 `
-export const Container = styled.button<{ isRead: boolean; active: boolean }>`
+export const Container = styled.div<{ isRead: boolean; active: boolean }>`
   text-align: left;
   width: 100%;
 

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -321,6 +321,7 @@ const en: Translations = {
     noMessagesInfo: 'Sent and received messages are displayed here.',
     noSelectedMessage: 'A message is not selected',
     emptyInbox: 'Your inbox is empty',
+    openMessage: 'Open message',
     recipients: 'Recipients',
     send: 'Send',
     sender: 'Sender',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -318,6 +318,7 @@ export default {
     inboxTitle: 'Viestit',
     noMessagesInfo: 'Tässä näet saapuneet ja lähetetyt viestisi',
     emptyInbox: 'Viestilaatikkosi on tyhjä',
+    openMessage: 'Avaa viesti',
     noSelectedMessage: 'Ei valittua viestiä',
     recipients: 'Vastaanottajat',
     send: 'Lähetä',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -318,6 +318,7 @@ const sv: Translations = {
     noMessagesInfo: 'Skickade och mottagna meddelanden visas här.',
     noSelectedMessage: 'Inget valt meddelande',
     emptyInbox: 'Din inkorg är tom.',
+    openMessage: 'Öppna meddelande',
     recipients: 'Mottagare',
     send: 'Skicka',
     sender: 'Avsändare',


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Buttons shouldn't have buttons inside them (in this case, a download button inside the message button), so the parent button was changed to a tabbable div and a screen-reader-only link inside the div was made to preserve the accessibility benefits the parent button gave.
