### PR TITLE
Fix query param sync and add date to calendar params

### DIFF
--- a/frontend/src/employee-frontend/components/unit/TabAttendances.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabAttendances.tsx
@@ -60,8 +60,11 @@ export default React.memo(function TabAttendances() {
   const { unitInformation, unitData, filters, setFilters } =
     useContext(UnitContext)
   const [mode, setMode] = useState<CalendarMode>('month')
+  const selectedDateParam = useQuery().get('date')
   const [selectedDate, setSelectedDate] = useState<LocalDate>(
-    LocalDate.todayInSystemTz()
+    selectedDateParam
+      ? LocalDate.parseIso(selectedDateParam)
+      : LocalDate.todayInSystemTz()
   )
   const { roles } = useContext(UserContext)
 
@@ -69,9 +72,10 @@ export default React.memo(function TabAttendances() {
   const [groupId, setGroupId] = useState<AttendanceGroupFilter>(() =>
     groupParam ? getDefaultGroup(groupParam) : null
   )
-  useSyncQueryParams(
-    groupId ? { group: groupId } : ({} as Record<string, string>)
-  )
+  useSyncQueryParams({
+    ...(groupId ? { group: groupId } : {}),
+    date: selectedDate.toString()
+  })
   const [groups] = useApiState(() => getDaycareGroups(unitId), [unitId])
 
   const reservationEnabled = unitInformation

--- a/frontend/src/lib-common/utils/useSyncQueryParams.ts
+++ b/frontend/src/lib-common/utils/useSyncQueryParams.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import isEqual from 'lodash/isEqual'
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
@@ -9,10 +10,18 @@ import { useSearchParams } from 'react-router-dom'
  * Keeps current URL's query params up to date with the queryParams object
  */
 export function useSyncQueryParams(queryParams: Record<string, string>) {
-  const [, setSearchParams] = useSearchParams()
-  const newSearchParams = new URLSearchParams(queryParams).toString()
+  const [currentParams, setSearchParams] = useSearchParams()
 
   useEffect(() => {
-    setSearchParams(newSearchParams)
-  }, [newSearchParams, setSearchParams])
+    if (
+      !isEqual(
+        Object.fromEntries(Array.from(currentParams.entries())),
+        queryParams
+      )
+    ) {
+      setSearchParams(queryParams, {
+        replace: true
+      })
+    }
+  }, [currentParams, queryParams, setSearchParams])
 }

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1826,7 +1826,7 @@ const sv: Translations = {
     description:
       'På denna sida publiceras barnets plan för lärande samt bilder och andra dokument som berör utveckling, välbefinnande och vardagen inom enheten.',
     deletionDisclaimer:
-      'Dessa dokument kommer att raderas när barnets plats upphör. Ladda ner dokumenten till din egen enhet som du vill behålla.'
+      'Dessa dokument kommer att raderas när barnets plats upphör. Ladda ner dokumenten till din egen enhet som du vill behålla dem.'
   },
   pedagogicalDocuments: {
     title: 'Tillväxt och inlärning',


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The employee attendance calendar did not save the current date in the URL's state, thus losing the week state sometimes when navigating between pages. Also, the query param sync hook did not always work.