### PR TITLE
Remove SSNs and children for weak auth citizens

### DIFF
--- a/apigw/src/enduser/routes/auth-status.ts
+++ b/apigw/src/enduser/routes/auth-status.ts
@@ -9,7 +9,6 @@ import { appCommit } from '../../shared/config'
 export default toRequestHandler(async (req, res) => {
   if (req.user && req.user.id) {
     const data = await getUserDetails(req, req.user.id)
-    data.userType = req.user.userType
     res.status(200).send({ loggedIn: true, user: data, apiVersion: appCommit })
   } else {
     res.status(200).send({ loggedIn: false, apiVersion: appCommit })

--- a/frontend/src/citizen-frontend/RequireAuth.tsx
+++ b/frontend/src/citizen-frontend/RequireAuth.tsx
@@ -21,11 +21,9 @@ export default React.memo(function RequireAuth({
   const { user } = useContext(AuthContext)
 
   const isStrong = user
-    .map((usr) => usr?.userType === 'ENDUSER')
+    .map((usr) => usr?.authLevel === 'STRONG')
     .getOrElse(false)
-  const isWeak = user
-    .map((usr) => usr?.userType === 'CITIZEN_WEAK')
-    .getOrElse(false)
+  const isWeak = user.map((usr) => usr?.authLevel === 'WEAK').getOrElse(false)
   const isLoggedIn = isStrong || isWeak
 
   return isLoggedIn ? (

--- a/frontend/src/citizen-frontend/applications/ApplicationCreation.tsx
+++ b/frontend/src/citizen-frontend/applications/ApplicationCreation.tsx
@@ -23,7 +23,7 @@ import { Gap, defaultMargins } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/citizen'
 
 import Footer from '../Footer'
-import { useUser } from '../auth/state'
+import { useStrongUser } from '../auth/state'
 import { useTranslation } from '../localization'
 import useTitle from '../useTitle'
 
@@ -37,7 +37,7 @@ export default React.memo(function ApplicationCreation() {
   const navigate = useNavigate()
   const { childId } = useNonNullableParams<{ childId: string }>()
   const t = useTranslation()
-  const user = useUser()
+  const user = useStrongUser()
   useTitle(t, t.applications.creation.title)
   const child = useMemo(
     () => user?.children.find(({ id }) => childId === id),

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationEditor.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationEditor.tsx
@@ -35,7 +35,7 @@ import ApplicationFormDaycare from '../../applications/editor/ApplicationFormDay
 import ApplicationFormPreschool from '../../applications/editor/ApplicationFormPreschool'
 import ApplicationVerificationView from '../../applications/editor/verification/ApplicationVerificationView'
 import { renderResult } from '../../async-rendering'
-import { useUser } from '../../auth/state'
+import { useStrongUser } from '../../auth/state'
 import { useTranslation } from '../../localization'
 import { OverlayContext } from '../../overlay/state'
 import useTitle from '../../useTitle'
@@ -74,7 +74,7 @@ const ApplicationEditorContent = React.memo(function DaycareApplicationEditor({
 }: ApplicationEditorContentProps) {
   const t = useTranslation()
   const navigate = useNavigate()
-  const user = useUser()
+  const user = useStrongUser()
 
   const { setErrorMessage, setInfoMessage, clearInfoMessage } =
     useContext(OverlayContext)

--- a/frontend/src/citizen-frontend/applications/read-view/ApplicationReadView.tsx
+++ b/frontend/src/citizen-frontend/applications/read-view/ApplicationReadView.tsx
@@ -13,7 +13,7 @@ import Container from 'lib-components/layout/Container'
 import Footer from '../../Footer'
 import ApplicationReadViewContents from '../../applications/read-view/ApplicationReadViewContents'
 import { renderResult } from '../../async-rendering'
-import { useUser } from '../../auth/state'
+import { useStrongUser } from '../../auth/state'
 import { useTranslation } from '../../localization'
 import useTitle from '../../useTitle'
 import { getApplication } from '../api'
@@ -21,7 +21,7 @@ import { getApplication } from '../api'
 export default React.memo(function ApplicationReadView() {
   const { applicationId } = useNonNullableParams<{ applicationId: UUID }>()
   const t = useTranslation()
-  const user = useUser()
+  const user = useStrongUser()
   const [apiData] = useApiState(
     () => getApplication(applicationId),
     [applicationId]

--- a/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
+++ b/frontend/src/citizen-frontend/applying/ApplyingRouter.tsx
@@ -33,7 +33,7 @@ export interface Props {
 export default React.memo(function ApplyingRouter({ scrollToTop }: Props) {
   const t = useTranslation()
   const user = useUser()
-  const isEndUser = user?.userType === 'ENDUSER'
+  const isEndUser = user?.authLevel === 'STRONG'
   const { pathname } = useLocation()
 
   const maybeLockElem = !isEndUser && (

--- a/frontend/src/citizen-frontend/auth/api.ts
+++ b/frontend/src/citizen-frontend/auth/api.ts
@@ -3,14 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Failure, Result, Success } from 'lib-common/api'
+import { UserDetailsResponse } from 'lib-common/api-types/vtjclient'
 
 import { client } from '../api-client'
 
-import { User } from './state'
-
 export type AuthStatus =
   | { loggedIn: false; apiVersion: string }
-  | { loggedIn: true; user: User; apiVersion: string }
+  | { loggedIn: true; user: UserDetailsResponse; apiVersion: string }
 
 export function getAuthStatus(): Promise<Result<AuthStatus>> {
   return client

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -48,7 +48,7 @@ export default React.memo(function DesktopNav({
   return (
     <UnwrapResult result={user} loading={() => null}>
       {(user) => {
-        const isEnduser = user?.userType === 'ENDUSER'
+        const isEnduser = user?.authLevel === 'STRONG'
         const maybeLockElem = !isEnduser && (
           <FontAwesomeIcon icon={faLockAlt} size="xs" />
         )
@@ -269,7 +269,7 @@ const UserMenu = React.memo(function UserMenu({ user }: { user: User }) {
     setOpen(false)
   )
   const showUserAttentionIndicator = !user.email
-  const maybeLockElem = user.userType !== 'ENDUSER' && (
+  const maybeLockElem = user.authLevel !== 'STRONG' && (
     <FontAwesomeIcon icon={faLockAlt} size="xs" />
   )
 

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -232,7 +232,7 @@ const Navigation = React.memo(function Navigation({
 }) {
   const t = useTranslation()
 
-  const maybeLockElem = user.userType !== 'ENDUSER' && (
+  const maybeLockElem = user.authLevel !== 'STRONG' && (
     <FontAwesomeIcon icon={faLockAlt} size="xs" />
   )
   return (
@@ -379,7 +379,7 @@ const UserNameSubMenu = React.memo(function UserNameSubMenu({
     () => setShow((previous) => !previous),
     [setShow]
   )
-  const maybeLockElem = user.userType !== 'ENDUSER' && (
+  const maybeLockElem = user.authLevel !== 'STRONG' && (
     <FontAwesomeIcon icon={faLockAlt} size="xs" />
   )
 

--- a/frontend/src/citizen-frontend/header/const.ts
+++ b/frontend/src/citizen-frontend/header/const.ts
@@ -18,7 +18,7 @@ export const getStrongLoginUri = (path?: string) =>
 
 export const getLogoutUri = (user: User) =>
   `/api/application/auth/${
-    user?.userType === 'CITIZEN_WEAK' ? 'evaka-customer' : 'saml'
+    user?.authLevel === 'WEAK' ? 'evaka-customer' : 'saml'
   }/logout`
 
 export const headerHeightDesktop = 80

--- a/frontend/src/citizen-frontend/holiday-periods/state.tsx
+++ b/frontend/src/citizen-frontend/holiday-periods/state.tsx
@@ -65,7 +65,7 @@ export const HolidayPeriodsContextProvider = React.memo(
       .map<QuestionnaireAvailability>((val) =>
         !val || !user
           ? false
-          : val.questionnaire.requiresStrongAuth && user.userType !== 'ENDUSER'
+          : val.questionnaire.requiresStrongAuth && user.authLevel !== 'STRONG'
           ? 'with-strong-auth'
           : true
       )

--- a/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
+++ b/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
@@ -127,10 +127,10 @@ export default React.memo(function PersonalDetails() {
                 phone,
                 backupPhone,
                 email,
-                userType
+                authLevel
               } = personalData
 
-              const canEdit = userType === 'ENDUSER'
+              const canEdit = authLevel === 'STRONG'
 
               return (
                 <>

--- a/frontend/src/lib-common/api-types/vtjclient.ts
+++ b/frontend/src/lib-common/api-types/vtjclient.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { UUID } from 'lib-common/types'
+
+export interface Child {
+  firstName: string
+  id: UUID
+  lastName: string
+  socialSecurityNumber: string
+}
+
+export interface CitizenFeatures {
+  childDocumentation: boolean
+  messages: boolean
+  reservations: boolean
+}
+
+export interface CitizenUserDetails {
+  accessibleFeatures: CitizenFeatures
+  backupPhone: string
+  email: string | null
+  firstName: string
+  id: UUID
+  lastName: string
+  phone: string
+  postOffice: string
+  postalCode: string
+  preferredName: string
+  streetAddress: string
+}
+
+interface BaseUserDetailsResponse {
+  authLevel: 'STRONG' | 'WEAK'
+  details: CitizenUserDetails
+}
+
+export interface WeakUserDetailsResponse extends BaseUserDetailsResponse {
+  authLevel: 'WEAK'
+}
+
+export interface StrongUserDetailsResponse extends BaseUserDetailsResponse {
+  authLevel: 'STRONG'
+  socialSecurityNumber: string
+  children: Child[]
+}
+
+export type UserDetailsResponse =
+  | WeakUserDetailsResponse
+  | StrongUserDetailsResponse

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -9,15 +9,6 @@ import HelsinkiDateTime from '../../helsinki-date-time'
 import { UUID } from '../../types'
 
 /**
-* Generated from fi.espoo.evaka.shared.security.CitizenFeatures
-*/
-export interface CitizenFeatures {
-  childDocumentation: boolean
-  messages: boolean
-  reservations: boolean
-}
-
-/**
 * Generated from fi.espoo.evaka.shared.domain.Coordinate
 */
 export interface Coordinate {

--- a/frontend/src/lib-common/generated/api-types/vtjclient.ts
+++ b/frontend/src/lib-common/generated/api-types/vtjclient.ts
@@ -5,37 +5,7 @@
 // GENERATED FILE: no manual modifications
 /* eslint-disable import/order, prettier/prettier */
 
-import { CitizenFeatures } from './shared'
-import { UUID } from '../../types'
 
-/**
-* Generated from fi.espoo.evaka.vtjclient.controllers.VtjController.Child
-*/
-export interface Child {
-  firstName: string
-  id: UUID
-  lastName: string
-  socialSecurityNumber: string
-}
-
-/**
-* Generated from fi.espoo.evaka.vtjclient.controllers.VtjController.CitizenUserDetails
-*/
-export interface CitizenUserDetails {
-  accessibleFeatures: CitizenFeatures
-  backupPhone: string
-  children: Child[]
-  email: string | null
-  firstName: string
-  id: UUID
-  lastName: string
-  phone: string
-  postOffice: string
-  postalCode: string
-  preferredName: string
-  socialSecurityNumber: string
-  streetAddress: string
-}
 
 /**
 * Generated from fi.espoo.evaka.vtjclient.dto.Nationality


### PR DESCRIPTION
#### Summary
The auth status endpoint always returned social security numbers and children even when weakly authenticated.

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

