### PR TITLE
EVAKA-4469 Enable phone fields for preparators

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
@@ -555,6 +555,7 @@ export default React.memo(function AssistanceNeedDecisionForm({
             }
             phoneLabel={i18n.common.form.phone}
             selectedPhone={formState.preparedBy1?.phoneNumber}
+            hasPhoneField
           />
           <EmployeeSelectWithTitle
             employeeLabel={t.preparator}
@@ -577,6 +578,7 @@ export default React.memo(function AssistanceNeedDecisionForm({
             }
             phoneLabel={i18n.common.form.phone}
             selectedPhone={formState.preparedBy2?.phoneNumber}
+            hasPhoneField
           />
           <EmployeeSelectWithTitle
             employeeLabel={t.decisionMaker}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The phone number fields were never enabled for preparators mistakenly.