### PR TITLE
Add unit occupancy chart tooltip rounding

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -116,19 +116,19 @@ const Graph = React.memo(function Graph({ occupancy, shiftCareUnit }: Props) {
               </tr>
               <tr>
                 <td>{i18n.unit.occupancy.realtime.children}</td>
-                <td>{child}</td>
+                <td>{parseFloat(child.toFixed(1))}</td>
               </tr>
               <tr>
                 <td>{i18n.unit.occupancy.realtime.childrenPresent}</td>
-                <td>{childrenPresent}</td>
+                <td>{parseFloat(childrenPresent.toFixed(1))}</td>
               </tr>
               <tr>
                 <td>{i18n.unit.occupancy.realtime.staffPresent}</td>
-                <td>{staffPresent}</td>
+                <td>{parseFloat(staffPresent.toFixed(1))}</td>
               </tr>
               <tr>
                 <td>{i18n.unit.occupancy.realtime.staffRequired}</td>
-                <td>{staffRequired}</td>
+                <td>{parseFloat(staffRequired.toFixed(1))}</td>
               </tr>
             </tbody>
           </table>
@@ -233,11 +233,13 @@ function graphData(
 
   const xMin = shiftCareUnit
     ? firstStaffAttendance?.x.getTime() ?? 0
-    : min([
-        // 6 AM
-        setTime(new Date(), 6, 0),
-        staffData[0].x
-      ]).getTime()
+    : min(
+        [
+          // 6 AM
+          setTime(new Date(), 6, 0),
+          staffData[0]?.x
+        ].filter((time): time is Date => !!time)
+      ).getTime()
   const xMax = shiftCareUnit
     ? staffData[staffData.length - 1]?.x.getTime() ?? 0
     : max([


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- Fix an exception being thrown if `staffData` is a zero-length array
- Round occupancy chart tooltip numbers to max 1 decimal