### PR TITLE
EVAKA-4469 Modify assistance need decisions to have multiple assistance levels

### DIFF
--- a/frontend/src/citizen-frontend/children/AssistanceNeedSection.tsx
+++ b/frontend/src/citizen-frontend/children/AssistanceNeedSection.tsx
@@ -116,21 +116,25 @@ export default React.memo(function AssistanceNeedSection({
                   </FixedSpaceRow>
                 </Td>
                 <Td data-qa="assistance-level">
-                  {decision.assistanceLevel &&
-                    {
-                      ASSISTANCE_ENDS:
-                        t.children.assistanceNeed.decisions.decision
-                          .assistanceLevel.assistanceEnds,
-                      ASSISTANCE_SERVICES_FOR_TIME:
-                        t.children.assistanceNeed.decisions.decision
-                          .assistanceLevel.assistanceServicesForTime,
-                      ENHANCED_ASSISTANCE:
-                        t.children.assistanceNeed.decisions.decision
-                          .assistanceLevel.enhancedAssistance,
-                      SPECIAL_ASSISTANCE:
-                        t.children.assistanceNeed.decisions.decision
-                          .assistanceLevel.specialAssistance
-                    }[decision.assistanceLevel]}
+                  {decision.assistanceLevels
+                    .map(
+                      (level) =>
+                        ({
+                          ASSISTANCE_ENDS:
+                            t.children.assistanceNeed.decisions.decision
+                              .assistanceLevel.assistanceEnds,
+                          ASSISTANCE_SERVICES_FOR_TIME:
+                            t.children.assistanceNeed.decisions.decision
+                              .assistanceLevel.assistanceServicesForTime,
+                          ENHANCED_ASSISTANCE:
+                            t.children.assistanceNeed.decisions.decision
+                              .assistanceLevel.enhancedAssistance,
+                          SPECIAL_ASSISTANCE:
+                            t.children.assistanceNeed.decisions.decision
+                              .assistanceLevel.specialAssistance
+                        }[level])
+                    )
+                    .join(', ')}
                 </Td>
                 <Td data-qa="validity-period">
                   {decision.startDate?.format() ?? ''} –{' '}

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1300,7 +1300,7 @@ export class Fixture {
   static assistanceNeedDecision(): AssistanceNeedDecisionBuilder {
     return new AssistanceNeedDecisionBuilder({
       id: uuidv4(),
-      assistanceLevel: 'SPECIAL_ASSISTANCE',
+      assistanceLevels: ['SPECIAL_ASSISTANCE'],
       assistanceServicesTime: null,
       careMotivation: null,
       childId: 'not_set',
@@ -1358,7 +1358,7 @@ export class Fixture {
   static preFilledAssistanceNeedDecision(): AssistanceNeedDecisionBuilder {
     return new AssistanceNeedDecisionBuilder({
       id: uuidv4(),
-      assistanceLevel: 'ASSISTANCE_SERVICES_FOR_TIME',
+      assistanceLevels: ['ASSISTANCE_SERVICES_FOR_TIME'],
       assistanceServicesTime: new FiniteDateRange(
         LocalDate.of(2020, 7, 8),
         LocalDate.of(2020, 8, 8)

--- a/frontend/src/e2e-test/dev-api/types.ts
+++ b/frontend/src/e2e-test/dev-api/types.ts
@@ -446,12 +446,12 @@ export interface AssistanceNeed {
 }
 
 export interface AssistanceNeedDecision {
-  assistanceLevel:
+  assistanceLevels: Array<
     | 'ASSISTANCE_ENDS'
     | 'ASSISTANCE_SERVICES_FOR_TIME'
     | 'ENHANCED_ASSISTANCE'
     | 'SPECIAL_ASSISTANCE'
-    | null
+  >
   assistanceServicesTime: FiniteDateRange | null
   careMotivation: string | null
   childId: UUID

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-page.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-page.spec.ts
@@ -469,7 +469,7 @@ describe('Citizen children page', () => {
         .with({
           selectedUnit: { id: fixtures.daycareFixture.id },
           status: 'ACCEPTED',
-          assistanceLevel: 'SPECIAL_ASSISTANCE',
+          assistanceLevels: ['SPECIAL_ASSISTANCE', 'ENHANCED_ASSISTANCE'],
           startDate: LocalDate.of(2020, 2, 5),
           endDate: LocalDate.of(2021, 5, 11),
           decisionMade: LocalDate.of(2020, 1, 17)
@@ -481,7 +481,7 @@ describe('Citizen children page', () => {
       await childPage.openAssistanceNeedCollapsible()
 
       await waitUntilEqual(() => childPage.getAssistanceNeedDecisionRow(0), {
-        assistanceLevel: 'Erityinen tuki',
+        assistanceLevel: 'Erityinen tuki, Tehostettu tuki',
         selectedUnit: fixtures.daycareFixture.name,
         validityPeriod: '05.02.2020 – 11.05.2021',
         decisionMade: '17.01.2020',
@@ -494,7 +494,7 @@ describe('Citizen children page', () => {
         .with({
           selectedUnit: { id: fixtures.daycareFixture.id },
           status: 'REJECTED',
-          assistanceLevel: 'ENHANCED_ASSISTANCE',
+          assistanceLevels: ['ENHANCED_ASSISTANCE'],
           startDate: LocalDate.of(2022, 2, 10),
           decisionMade: LocalDate.of(2021, 1, 17)
         })
@@ -518,7 +518,7 @@ describe('Citizen children page', () => {
         .with({
           selectedUnit: { id: fixtures.daycareFixture.id },
           status: 'NEEDS_WORK',
-          assistanceLevel: 'ENHANCED_ASSISTANCE',
+          assistanceLevels: ['ENHANCED_ASSISTANCE'],
           startDate: LocalDate.of(2022, 2, 10),
           decisionMade: LocalDate.of(2021, 1, 17)
         })
@@ -529,7 +529,7 @@ describe('Citizen children page', () => {
         .with({
           selectedUnit: { id: fixtures.daycareFixture.id },
           status: 'DRAFT',
-          assistanceLevel: 'ENHANCED_ASSISTANCE',
+          assistanceLevels: ['ENHANCED_ASSISTANCE'],
           startDate: LocalDate.of(2020, 2, 5),
           endDate: LocalDate.of(2021, 5, 11),
           decisionMade: LocalDate.of(2021, 1, 17)
@@ -552,7 +552,7 @@ describe('Citizen children page', () => {
         .with({
           selectedUnit: { id: fixtures.daycareFixture.id },
           status: 'ACCEPTED',
-          assistanceLevel: 'SPECIAL_ASSISTANCE',
+          assistanceLevels: ['SPECIAL_ASSISTANCE'],
           startDate: LocalDate.of(2020, 2, 5),
           endDate: LocalDate.of(2021, 5, 11),
           decisionMade: LocalDate.of(2020, 1, 17),
@@ -565,7 +565,7 @@ describe('Citizen children page', () => {
         .with({
           selectedUnit: { id: fixtures.daycareFixture.id },
           status: 'REJECTED',
-          assistanceLevel: 'SPECIAL_ASSISTANCE',
+          assistanceLevels: ['SPECIAL_ASSISTANCE'],
           startDate: LocalDate.of(2019, 2, 5),
           endDate: LocalDate.of(2020, 1, 11),
           decisionMade: LocalDate.of(2018, 1, 17),
@@ -578,7 +578,7 @@ describe('Citizen children page', () => {
         .with({
           selectedUnit: { id: fixtures.daycareFixture.id },
           status: 'ACCEPTED',
-          assistanceLevel: 'SPECIAL_ASSISTANCE',
+          assistanceLevels: ['SPECIAL_ASSISTANCE'],
           startDate: LocalDate.of(2020, 2, 5),
           endDate: LocalDate.of(2021, 5, 11),
           decisionMade: LocalDate.of(2020, 1, 17),
@@ -608,7 +608,7 @@ describe('Citizen children page', () => {
         .with({
           selectedUnit: { id: fixtures.daycareFixture.id },
           status: 'ACCEPTED',
-          assistanceLevel: 'SPECIAL_ASSISTANCE',
+          assistanceLevels: ['SPECIAL_ASSISTANCE'],
           startDate: LocalDate.of(2020, 2, 5),
           endDate: LocalDate.of(2021, 5, 11),
           decisionMade: LocalDate.of(2020, 1, 17),
@@ -691,7 +691,7 @@ describe('Citizen assistance need decision page', () => {
       .with({
         selectedUnit: { id: fixtures.daycareFixture.id },
         status: 'ACCEPTED',
-        assistanceLevel: 'ENHANCED_ASSISTANCE',
+        assistanceLevels: ['ENHANCED_ASSISTANCE'],
         startDate: LocalDate.of(2020, 2, 5),
         endDate: LocalDate.of(2021, 5, 11),
         decisionMade: LocalDate.of(2021, 1, 17),

--- a/frontend/src/employee-frontend/components/child-information/AssistanceNeedDecisionSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/AssistanceNeedDecisionSection.tsx
@@ -86,7 +86,7 @@ export default React.memo(function AssistanceNeedDecisionSection({
             onClick={() => {
               setIsCreatingDecision(true)
               void createAssistanceNeedDecision(id, {
-                assistanceLevel: null,
+                assistanceLevels: [],
                 assistanceServicesTime: null,
                 careMotivation: null,
                 decisionMade: null,

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
@@ -21,7 +21,6 @@ import { useApiState } from 'lib-common/utils/useRestApi'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import InputField, { InputInfo } from 'lib-components/atoms/form/InputField'
-import Radio from 'lib-components/atoms/form/Radio'
 import {
   FixedSpaceColumn,
   FixedSpaceRow
@@ -189,12 +188,18 @@ export default React.memo(function AssistanceNeedDecisionForm({
     [formState, setFormState]
   )
 
-  const renderAssistanceLevelRadio = useCallback(
+  const renderAssistanceLevelMultiCheckbox = useCallback(
     (level: AssistanceLevel, label: string) => (
-      <Radio
-        checked={formState.assistanceLevel === level}
+      <Checkbox
+        checked={formState.assistanceLevels.includes(level)}
         label={label}
-        onChange={() => setFieldVal({ assistanceLevel: level })}
+        onChange={(checked) =>
+          setFieldVal({
+            assistanceLevels: checked
+              ? [...formState.assistanceLevels, level]
+              : formState.assistanceLevels.filter((level2) => level !== level2)
+          })
+        }
       />
     ),
     [formState, setFieldVal]
@@ -450,12 +455,12 @@ export default React.memo(function AssistanceNeedDecisionForm({
       <H2>{t.decisionAndValidity}</H2>
       <FixedSpaceColumn spacing={defaultMargins.s}>
         <Label>{t.futureLevelOfAssistance}</Label>
-        {renderAssistanceLevelRadio(
+        {renderAssistanceLevelMultiCheckbox(
           'ASSISTANCE_ENDS',
           t.assistanceLevel.assistanceEnds
         )}
         <FixedSpaceRow alignItems="center">
-          {renderAssistanceLevelRadio(
+          {renderAssistanceLevelMultiCheckbox(
             'ASSISTANCE_SERVICES_FOR_TIME',
             t.assistanceLevel.assistanceServicesForTime
           )}
@@ -478,11 +483,11 @@ export default React.memo(function AssistanceNeedDecisionForm({
             }
           />
         </FixedSpaceRow>
-        {renderAssistanceLevelRadio(
+        {renderAssistanceLevelMultiCheckbox(
           'ENHANCED_ASSISTANCE',
           t.assistanceLevel.enhancedAssistance
         )}
-        {renderAssistanceLevelRadio(
+        {renderAssistanceLevelMultiCheckbox(
           'SPECIAL_ASSISTANCE',
           t.assistanceLevel.specialAssistance
         )}

--- a/frontend/src/lib-common/generated/api-types/assistanceneed.ts
+++ b/frontend/src/lib-common/generated/api-types/assistanceneed.ts
@@ -45,7 +45,7 @@ export interface AssistanceNeed {
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecision
 */
 export interface AssistanceNeedDecision {
-  assistanceLevel: AssistanceLevel | null
+  assistanceLevels: AssistanceLevel[]
   assistanceServicesTime: FiniteDateRange | null
   careMotivation: string | null
   child: AssistanceNeedDecisionChild | null
@@ -111,7 +111,7 @@ export interface AssistanceNeedDecisionChild {
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionCitizenListItem
 */
 export interface AssistanceNeedDecisionCitizenListItem {
-  assistanceLevel: AssistanceLevel | null
+  assistanceLevels: AssistanceLevel[]
   decisionMade: LocalDate | null
   endDate: LocalDate | null
   id: UUID
@@ -145,7 +145,7 @@ export interface AssistanceNeedDecisionEmployeeForm {
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionForm
 */
 export interface AssistanceNeedDecisionForm {
-  assistanceLevel: AssistanceLevel | null
+  assistanceLevels: AssistanceLevel[]
   assistanceServicesTime: FiniteDateRange | null
   careMotivation: string | null
   decisionMade: LocalDate | null

--- a/frontend/src/lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly.tsx
+++ b/frontend/src/lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly.tsx
@@ -280,10 +280,9 @@ export default React.memo(function AssistanceNeedDecisionReadOnly({
           <div>
             <OptionalLabelledValue
               label={t.futureLevelOfAssistance}
-              value={
-                decision.assistanceLevel &&
-                assistanceLevelTexts[decision.assistanceLevel]
-              }
+              value={decision.assistanceLevels
+                .map((level) => assistanceLevelTexts[level])
+                .join(', ')}
               data-qa="future-level-of-assistance"
             />
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
@@ -105,7 +105,7 @@ class AssistanceNeedDecisionIntegrationTest : FullApplicationTest(resetDbBeforeE
         otherRepresentativeHeard = false,
         otherRepresentativeDetails = null,
 
-        assistanceLevel = AssistanceLevel.ENHANCED_ASSISTANCE,
+        assistanceLevels = setOf(AssistanceLevel.ENHANCED_ASSISTANCE),
         assistanceServicesTime = null,
         motivationForDecision = "Motivation for decision"
     )
@@ -175,7 +175,7 @@ class AssistanceNeedDecisionIntegrationTest : FullApplicationTest(resetDbBeforeE
         assertEquals(testDecision.otherRepresentativeHeard, assistanceNeedDecision.otherRepresentativeHeard)
         assertEquals(testDecision.otherRepresentativeDetails, assistanceNeedDecision.otherRepresentativeDetails)
 
-        assertEquals(testDecision.assistanceLevel, assistanceNeedDecision.assistanceLevel)
+        assertEquals(testDecision.assistanceLevels, assistanceNeedDecision.assistanceLevels)
         assertEquals(testDecision.assistanceServicesTime, assistanceNeedDecision.assistanceServicesTime)
         assertEquals(testDecision.motivationForDecision, assistanceNeedDecision.motivationForDecision)
     }
@@ -518,7 +518,7 @@ class AssistanceNeedDecisionIntegrationTest : FullApplicationTest(resetDbBeforeE
                 otherRepresentativeHeard = false,
                 otherRepresentativeDetails = null,
 
-                assistanceLevel = AssistanceLevel.ASSISTANCE_SERVICES_FOR_TIME,
+                assistanceLevels = setOf(AssistanceLevel.ASSISTANCE_SERVICES_FOR_TIME),
                 assistanceServicesTime = FiniteDateRange(LocalDate.of(2020, 1, 2), LocalDate.of(2020, 6, 5)),
                 motivationForDecision = "Motivation for decision",
                 hasDocument = false,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/AssistanceNeedDecisionsReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/AssistanceNeedDecisionsReportTest.kt
@@ -86,7 +86,7 @@ class AssistanceNeedDecisionsReportTest : FullApplicationTest(resetDbBeforeEach 
         otherRepresentativeHeard = false,
         otherRepresentativeDetails = null,
 
-        assistanceLevel = AssistanceLevel.ENHANCED_ASSISTANCE,
+        assistanceLevels = setOf(AssistanceLevel.ENHANCED_ASSISTANCE),
         assistanceServicesTime = null,
         motivationForDecision = "Motivation for decision"
     )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AssistanceNeedDecisionAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AssistanceNeedDecisionAccessControlTest.kt
@@ -80,7 +80,7 @@ class AssistanceNeedDecisionAccessControlTest : AccessControlTest() {
                     viewOfGuardians = null,
                     otherRepresentativeHeard = false,
                     otherRepresentativeDetails = null,
-                    assistanceLevel = null,
+                    assistanceLevels = emptySet(),
                     assistanceServicesTime = null,
                     motivationForDecision = null,
                     unreadGuardianIds = null

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecision.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecision.kt
@@ -54,7 +54,7 @@ data class AssistanceNeedDecision(
     val otherRepresentativeHeard: Boolean,
     val otherRepresentativeDetails: String?,
 
-    val assistanceLevel: AssistanceLevel?,
+    val assistanceLevels: Set<AssistanceLevel>,
     val assistanceServicesTime: FiniteDateRange?,
     val motivationForDecision: String?,
 
@@ -84,7 +84,7 @@ data class AssistanceNeedDecision(
         viewOfGuardians,
         otherRepresentativeHeard,
         otherRepresentativeDetails,
-        assistanceLevel,
+        assistanceLevels,
         assistanceServicesTime,
         motivationForDecision
     )
@@ -124,7 +124,7 @@ data class AssistanceNeedDecisionForm(
     val otherRepresentativeHeard: Boolean,
     val otherRepresentativeDetails: String?,
 
-    val assistanceLevel: AssistanceLevel?,
+    val assistanceLevels: Set<AssistanceLevel>,
     val assistanceServicesTime: FiniteDateRange?,
     val motivationForDecision: String?
 )
@@ -251,7 +251,7 @@ data class AssistanceNeedDecisionCitizenListItem(
     @Nested("selected_unit")
     val selectedUnit: UnitInfoBasics?,
 
-    val assistanceLevel: AssistanceLevel?,
+    val assistanceLevels: Set<AssistanceLevel>,
     val isUnread: Boolean
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
@@ -30,7 +30,7 @@ fun Database.Transaction.insertAssistanceNeedDecision(
           service_opt_consultation_special_ed, service_opt_part_time_special_ed, service_opt_full_time_special_ed,
           service_opt_interpretation_and_assistance_services, service_opt_special_aides, services_motivation,
           expert_responsibilities, guardians_heard_on, view_of_guardians, other_representative_heard, other_representative_details, 
-          assistance_level, assistance_services_time, motivation_for_decision, decision_maker_employee_id,
+          assistance_levels, assistance_services_time, motivation_for_decision, decision_maker_employee_id,
           decision_maker_title, preparer_1_employee_id, preparer_1_title, preparer_2_employee_id, preparer_2_title,
           preparer_1_phone_number, preparer_2_phone_number
         )
@@ -63,7 +63,7 @@ fun Database.Transaction.insertAssistanceNeedDecision(
             :viewOfGuardians,
             :otherRepresentativeHeard,
             :otherRepresentativeDetails, 
-            :assistanceLevel,
+            :assistanceLevels,
             :assistanceServicesTime,
             :motivationForDecision,
             :decisionMakerEmployeeId,
@@ -146,7 +146,7 @@ fun Database.Read.getAssistanceNeedDecisionById(id: AssistanceNeedDecisionId): A
           service_opt_consultation_special_ed, service_opt_part_time_special_ed, service_opt_full_time_special_ed,
           service_opt_interpretation_and_assistance_services, service_opt_special_aides, services_motivation,
           expert_responsibilities, guardians_heard_on, view_of_guardians, other_representative_heard, other_representative_details, 
-          assistance_level, assistance_services_time, motivation_for_decision,
+          assistance_levels, assistance_services_time, motivation_for_decision,
           decision_maker_employee_id, decision_maker_title, concat(dm.first_name, ' ', dm.last_name) decision_maker_name,
           preparer_1_employee_id, preparer_1_title, concat(p1.first_name, ' ', p1.last_name) preparer_1_name, p1.email preparer_1_email, preparer_1_phone_number,
           preparer_2_employee_id, preparer_2_title, concat(p2.first_name, ' ', p2.last_name) preparer_2_name, p2.email preparer_2_email, preparer_2_phone_number,
@@ -214,7 +214,7 @@ fun Database.Transaction.updateAssistanceNeedDecision(
             view_of_guardians = :viewOfGuardians,
             other_representative_heard = :otherRepresentativeHeard,
             other_representative_details = :otherRepresentativeDetails,
-            assistance_level = :assistanceLevel,
+            assistance_levels = :assistanceLevels,
             assistance_services_time = :assistanceServicesTime,
             motivation_for_decision = :motivationForDecision,
             decision_maker_employee_id = :decisionMakerEmployeeId,
@@ -325,7 +325,7 @@ fun Database.Read.getAssistanceNeedDecisionsByChildIdForCitizen(
     //language=sql
     val sql =
         """
-        SELECT ad.id, start_date, end_date, status, decision_made, assistance_level,
+        SELECT ad.id, start_date, end_date, status, decision_made, assistance_levels,
             selected_unit selected_unit_id, unit.name selected_unit_name,
             (:guardianId = ANY(unread_guardian_ids)) AS is_unread
         FROM assistance_need_decision ad

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -777,7 +777,7 @@ fun Database.Transaction.insertTestAssistanceNeedDecision(
           service_opt_consultation_special_ed, service_opt_part_time_special_ed, service_opt_full_time_special_ed,
           service_opt_interpretation_and_assistance_services, service_opt_special_aides, services_motivation,
           expert_responsibilities, guardians_heard_on, view_of_guardians, other_representative_heard, other_representative_details, 
-          assistance_level, assistance_services_time, motivation_for_decision, decision_maker_employee_id,
+          assistance_levels, assistance_services_time, motivation_for_decision, decision_maker_employee_id,
           decision_maker_title, preparer_1_employee_id, preparer_1_title, preparer_2_employee_id, preparer_2_title,
           preparer_1_phone_number, preparer_2_phone_number, unread_guardian_ids
         )
@@ -812,7 +812,7 @@ fun Database.Transaction.insertTestAssistanceNeedDecision(
             :viewOfGuardians,
             :otherRepresentativeHeard,
             :otherRepresentativeDetails, 
-            :assistanceLevel,
+            :assistanceLevels,
             :assistanceServicesTime,
             :motivationForDecision,
             :decisionMakerEmployeeId,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1523,7 +1523,7 @@ data class DevAssistanceNeedDecision(
     val otherRepresentativeHeard: Boolean,
     val otherRepresentativeDetails: String?,
 
-    val assistanceLevel: AssistanceLevel?,
+    val assistanceLevels: Set<AssistanceLevel>,
     val assistanceServicesTime: FiniteDateRange?,
     val motivationForDecision: String?,
 

--- a/service/src/main/resources/WEB-INF/templates/assistance-need/decision.html
+++ b/service/src/main/resources/WEB-INF/templates/assistance-need/decision.html
@@ -167,21 +167,18 @@ SPDX-License-Identifier: LGPL-2.1-or-later
           <h2 th:text="#{decisionAndValidity}"></h2>
           <div
             class="decision-details"
-            th:if="${decision.assistanceLevel} != null"
+            th:unless="${decision.assistanceLevels.empty}"
           >
             <h3 th:text="#{futureLevelOfAssistance}"></h3>
-            <div>
-              <span
-                th:text="#{${'assistanceLevel.' + decision.assistanceLevel}}"
-              ></span>
-              <th:block
-                th:if="${decision.assistanceServicesTime} != null and ${decision.assistanceLevel.toString()} == 'ASSISTANCE_SERVICES_FOR_TIME'"
-              >
-                <span
+            <span th:each="assistanceLevel, i : ${decision.assistanceLevels}">
+              <span th:text="#{${'assistanceLevel.' + assistanceLevel}}"></span
+              ><th:block
+                th:if="${decision.assistanceServicesTime} != null and ${assistanceLevel.toString()} == 'ASSISTANCE_SERVICES_FOR_TIME'"
+                ><span
                   th:replace="~{shared/common :: date-range(${decision.assistanceServicesTime.start}, ${decision.assistanceServicesTime.end})}"
-                ></span>
-              </th:block>
-            </div>
+                ></span></th:block
+              ><span th:unless="${i.last}">,</span>
+            </span>
           </div>
           <div class="decision-details" th:if="${decision.startDate} != null">
             <h3 th:text="#{startDate}"></h3>

--- a/service/src/main/resources/db/migration/V254__multiple_assistance_need_levels.sql
+++ b/service/src/main/resources/db/migration/V254__multiple_assistance_need_levels.sql
@@ -1,0 +1,3 @@
+ALTER TABLE assistance_need_decision ADD COLUMN assistance_levels text[] DEFAULT array[]::text[];
+UPDATE assistance_need_decision SET assistance_levels = array[assistance_level] WHERE assistance_level IS NOT NULL;
+ALTER TABLE assistance_need_decision DROP COLUMN assistance_level;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -251,3 +251,4 @@ V250__daily_service_times_notification.sql
 V251__assistance_need_decision_pdf.sql
 V252__assistance_need_decision_read.sql
 V253__child_consent.sql
+V254__multiple_assistance_need_levels.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Instead of having just one assistance level for a decision, the decision should have the possibility of having more than one level (radio -> checkbox group).