### PR TITLE
Wrap info button with inline text

### DIFF
--- a/frontend/src/citizen-frontend/LoginPage.tsx
+++ b/frontend/src/citizen-frontend/LoginPage.tsx
@@ -29,6 +29,10 @@ import { useUser } from './auth/state'
 import { getStrongLoginUri, getWeakLoginUri } from './header/const'
 import { useTranslation } from './localization'
 
+const ParagraphInfoButton = styled(InfoButton)`
+  margin-left: ${defaultMargins.xs};
+`
+
 export default React.memo(function LoginPage() {
   const i18n = useTranslation()
   const user = useUser()
@@ -64,13 +68,13 @@ export default React.memo(function LoginPage() {
           <ContentArea opaque>
             <H2 noMargin>{i18n.loginPage.applying.title}</H2>
             <Gap size="m" />
-            <FlexRow>
-              <P noMargin>{i18n.loginPage.applying.paragraph}</P>
-              <InfoButton
+            <P noMargin>
+              {i18n.loginPage.applying.paragraph}
+              <ParagraphInfoButton
                 aria-label={i18n.common.openExpandingInfo}
                 onClick={() => setShowInfoBoxText(!showInfoBoxText)}
               />
-            </FlexRow>
+            </P>
             {showInfoBoxText && (
               <ExpandingInfoBox
                 info={i18n.loginPage.applying.infoBoxText}
@@ -107,9 +111,4 @@ export default React.memo(function LoginPage() {
 
 const MapLink = styled(LinkWrapperInlineBlock)`
   font-weight: ${fontWeights.semibold};
-`
-
-const FlexRow = styled.div`
-  display: flex;
-  gap: ${defaultMargins.xs};
 `

--- a/frontend/src/citizen-frontend/applications/editor/AdditionalDetailsSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/AdditionalDetailsSection.tsx
@@ -65,6 +65,7 @@ export default React.memo(function AdditionalDetailsSection({
               data-qa="diet-expanding-info"
               info={t.applications.editor.additionalDetails.dietInfo}
               ariaLabel={t.common.openExpandingInfo}
+              inlineChildren
             >
               <Label>{t.applications.editor.additionalDetails.dietLabel}</Label>
             </ExpandingInfo>
@@ -84,6 +85,7 @@ export default React.memo(function AdditionalDetailsSection({
             <ExpandingInfo
               info={t.applications.editor.additionalDetails.allergiesInfo}
               ariaLabel={t.common.openExpandingInfo}
+              inlineChildren
             >
               <Label>
                 {t.applications.editor.additionalDetails.allergiesLabel}

--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -130,6 +130,7 @@ export default React.memo(function PreferredStartSubSection({
             data-qa="startdate-instructions"
             info={t.applications.editor.serviceNeed.startDate.instructions}
             ariaLabel={t.common.openExpandingInfo}
+            inlineChildren
           >
             <Label htmlFor={labelId}>
               {t.applications.editor.serviceNeed.startDate.label[type]} *

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -193,6 +193,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
               ]
             }
             ariaLabel={t.common.openExpandingInfo}
+            inlineChildren
           >
             <Label>
               {t.applications.editor.serviceNeed.dailyTime

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -114,6 +114,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
               ]
             }
             ariaLabel={t.common.openExpandingInfo}
+            inlineChildren
           >
             <Label>
               {t.applications.editor.serviceNeed.dailyTime

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -227,6 +227,7 @@ export default React.memo(function ReservationModal({
                         )
                       : i18n.calendar.reservationModal.noReservableDays
                   }
+                  inlineChildren
                 >
                   <Label>{i18n.calendar.reservationModal.dateRangeLabel}</Label>
                 </ExpandingInfo>

--- a/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
@@ -114,6 +114,7 @@ export default React.memo(function VasuPage() {
                     : t.vasu.givePermissionToShareInfoLeops
                 }
                 ariaLabel={t.common.openExpandingInfo}
+                inlineChildren
               >
                 <Label>
                   {vasu.type === 'DAYCARE'

--- a/frontend/src/citizen-frontend/children/PlacementTerminationForm.tsx
+++ b/frontend/src/citizen-frontend/children/PlacementTerminationForm.tsx
@@ -200,6 +200,7 @@ export default React.memo(function PlacementTerminationForm({
         <ExpandingInfo
           info={t.children.placementTermination.lastDayInfo}
           ariaLabel={t.common.openExpandingInfo}
+          inlineChildren
         >
           <Label>{t.children.placementTermination.lastDayOfPresence}</Label>
         </ExpandingInfo>

--- a/frontend/src/lib-components/molecules/ExpandingInfo.tsx
+++ b/frontend/src/lib-components/molecules/ExpandingInfo.tsx
@@ -102,6 +102,7 @@ type ExpandingInfoProps = {
   width?: 'fixed' | 'full' | 'auto'
   margin?: SpacingSize
   'data-qa'?: string
+  inlineChildren?: boolean
 }
 
 export default React.memo(function ExpandingInfo({
@@ -110,23 +111,38 @@ export default React.memo(function ExpandingInfo({
   ariaLabel,
   width = 'fixed',
   margin,
-  'data-qa': dataQa
+  'data-qa': dataQa,
+  inlineChildren
 }: ExpandingInfoProps) {
   const [expanded, setExpanded] = useState<boolean>(false)
   const toggleExpanded = useCallback(() => setExpanded((prev) => !prev), [])
   const close = useCallback(() => setExpanded(false), [])
 
+  const content = inlineChildren ? (
+    <div>
+      {children}
+      <InlineInfoButton
+        onClick={toggleExpanded}
+        aria-label={ariaLabel}
+        margin={margin ?? 'zero'}
+        data-qa={dataQa}
+      />
+    </div>
+  ) : (
+    <FixedSpaceRow spacing="xs" alignItems="center">
+      <div>{children}</div>
+      <InfoButton
+        onClick={toggleExpanded}
+        aria-label={ariaLabel}
+        margin={margin ?? 'zero'}
+        data-qa={dataQa}
+      />
+    </FixedSpaceRow>
+  )
+
   return (
     <span aria-live="polite">
-      <FixedSpaceRow spacing="xs" alignItems="center">
-        <div>{children}</div>
-        <InfoButton
-          onClick={toggleExpanded}
-          aria-label={ariaLabel}
-          margin={margin ?? 'zero'}
-          data-qa={dataQa}
-        />
-      </FixedSpaceRow>
+      {content}
       {expanded && (
         <ExpandingInfoBox
           info={info}
@@ -169,6 +185,10 @@ export const InfoButton = React.memo(function InfoButton({
     </RoundIconButton>
   )
 })
+
+const InlineInfoButton = styled(InfoButton)`
+  margin-left: ${defaultMargins.xs};
+`
 
 export const ExpandingInfoBox = React.memo(function ExpandingInfoBox({
   info,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Especially apparent on mobile devices, the info button was always positioned to the right of wrapped text instead of directly next to the last character of inline text.