### PR TITLE
Accessibility and UI updates

### DIFF
--- a/frontend/src/citizen-frontend/LoginPage.tsx
+++ b/frontend/src/citizen-frontend/LoginPage.tsx
@@ -104,6 +104,7 @@ export default React.memo(function LoginPage() {
               <ExpandingInfoBox
                 info={i18n.loginPage.applying.infoBoxText}
                 close={() => setShowInfoBoxText(false)}
+                closeLabel={i18n.common.close}
               />
             )}
             <ul>

--- a/frontend/src/citizen-frontend/LoginPage.tsx
+++ b/frontend/src/citizen-frontend/LoginPage.tsx
@@ -97,6 +97,7 @@ export default React.memo(function LoginPage() {
               <ParagraphInfoButton
                 aria-label={i18n.common.openExpandingInfo}
                 onClick={() => setShowInfoBoxText(!showInfoBoxText)}
+                open={showInfoBoxText}
               />
             </P>
             {showInfoBoxText && (

--- a/frontend/src/citizen-frontend/applications/ApplicationCreation.tsx
+++ b/frontend/src/citizen-frontend/applications/ApplicationCreation.tsx
@@ -97,6 +97,7 @@ export default React.memo(function ApplicationCreation() {
               data-qa="daycare-expanding-info"
               info={t.applications.creation.daycareInfo}
               ariaLabel={t.common.openExpandingInfo}
+              closeLabel={t.common.close}
             >
               <Radio
                 checked={selectedType === 'DAYCARE'}
@@ -117,6 +118,7 @@ export default React.memo(function ApplicationCreation() {
                 <ExpandingInfo
                   info={t.applications.creation.preschoolInfo}
                   ariaLabel={t.common.openExpandingInfo}
+                  closeLabel={t.common.close}
                 >
                   <PreschoolDaycareInfo>
                     {t.applications.creation.preschoolDaycareInfo}
@@ -130,6 +132,7 @@ export default React.memo(function ApplicationCreation() {
               data-qa="club-expanding-info"
               info={t.applications.creation.clubInfo}
               ariaLabel={t.common.openExpandingInfo}
+              closeLabel={t.common.close}
             >
               <Radio
                 checked={selectedType === 'CLUB'}

--- a/frontend/src/citizen-frontend/applications/editor/AdditionalDetailsSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/AdditionalDetailsSection.tsx
@@ -65,6 +65,7 @@ export default React.memo(function AdditionalDetailsSection({
               data-qa="diet-expanding-info"
               info={t.applications.editor.additionalDetails.dietInfo}
               ariaLabel={t.common.openExpandingInfo}
+              closeLabel={t.common.close}
               inlineChildren
             >
               <Label>{t.applications.editor.additionalDetails.dietLabel}</Label>
@@ -85,6 +86,7 @@ export default React.memo(function AdditionalDetailsSection({
             <ExpandingInfo
               info={t.applications.editor.additionalDetails.allergiesInfo}
               ariaLabel={t.common.openExpandingInfo}
+              closeLabel={t.common.close}
               inlineChildren
             >
               <Label>

--- a/frontend/src/citizen-frontend/applications/editor/contact-info/ChildSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/ChildSubSection.tsx
@@ -65,6 +65,7 @@ export default React.memo(function ChildSubSection({
         data-qa="child-future-address-info"
         info={t.applications.editor.contactInfo.futureAddressInfo}
         ariaLabel={t.common.openExpandingInfo}
+        closeLabel={t.common.close}
       >
         <Checkbox
           label={t.applications.editor.contactInfo.hasFutureAddress}

--- a/frontend/src/citizen-frontend/applications/editor/contact-info/GuardianSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/GuardianSubSection.tsx
@@ -147,6 +147,7 @@ export default React.memo(function GuardianSubSection({
         data-qa="guardian-future-address-info"
         info={t.applications.editor.contactInfo.futureAddressInfo}
         ariaLabel={t.common.openExpandingInfo}
+        closeLabel={t.common.close}
       >
         <Checkbox
           label={t.applications.editor.contactInfo.hasFutureAddress}

--- a/frontend/src/citizen-frontend/applications/editor/service-need/AssistanceNeedSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/AssistanceNeedSubSection.tsx
@@ -36,6 +36,7 @@ export default React.memo(function AssistanceNeedSubSection({
           <ExpandingInfo
             info={t.applications.editor.serviceNeed.preparatoryInfo}
             ariaLabel={t.common.openExpandingInfo}
+            closeLabel={t.common.close}
           >
             <Checkbox
               checked={formData.preparatory}
@@ -57,6 +58,7 @@ export default React.memo(function AssistanceNeedSubSection({
           t.applications.editor.serviceNeed.assistanceNeedInstructions[type]
         }
         ariaLabel={t.common.openExpandingInfo}
+        closeLabel={t.common.close}
         data-qa={`assistanceNeedInstructions-${type}`}
       >
         <Checkbox

--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -130,6 +130,7 @@ export default React.memo(function PreferredStartSubSection({
             data-qa="startdate-instructions"
             info={t.applications.editor.serviceNeed.startDate.instructions}
             ariaLabel={t.common.openExpandingInfo}
+            closeLabel={t.common.close}
             inlineChildren
           >
             <Label htmlFor={labelId}>
@@ -234,6 +235,7 @@ export default React.memo(function PreferredStartSubSection({
                 t.applications.editor.serviceNeed.clubDetails.wasOnDaycareInfo
               }
               ariaLabel={t.common.openExpandingInfo}
+              closeLabel={t.common.close}
               margin="xs"
               data-qa="wasOnDaycare-info"
             >
@@ -257,6 +259,7 @@ export default React.memo(function PreferredStartSubSection({
                 t.applications.editor.serviceNeed.clubDetails.wasOnClubCareInfo
               }
               ariaLabel={t.common.openExpandingInfo}
+              closeLabel={t.common.close}
               margin="xs"
             >
               <Checkbox

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -193,6 +193,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
               ]
             }
             ariaLabel={t.common.openExpandingInfo}
+            closeLabel={t.common.close}
             inlineChildren
           >
             <Label>
@@ -259,6 +260,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
         data-qa="shiftcare-instructions"
         info={t.applications.editor.serviceNeed.shiftCare.instructions}
         ariaLabel={t.common.openExpandingInfo}
+        closeLabel={t.common.close}
         margin="xs"
       >
         <Checkbox

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -114,6 +114,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
               ]
             }
             ariaLabel={t.common.openExpandingInfo}
+            closeLabel={t.common.close}
             inlineChildren
           >
             <Label>
@@ -161,6 +162,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
           <ExpandingInfo
             info={t.applications.editor.serviceNeed.shiftCare.instructions}
             ariaLabel={t.common.openExpandingInfo}
+            closeLabel={t.common.close}
             margin="xs"
           >
             <Checkbox

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -679,6 +679,7 @@ const Absence = React.memo(function Absence({
           <InfoButton
             onClick={onClick}
             aria-label={i18n.common.openExpandingInfo}
+            open={open}
           />
         </FixedSpaceColumn>
       </FixedSpaceRow>

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -689,6 +689,7 @@ const Absence = React.memo(function Absence({
             width="auto"
             info={i18n.calendar.contactStaffToEditAbsence}
             close={onClick}
+            closeLabel={i18n.common.close}
           />
         </Colspan2>
       )}
@@ -718,6 +719,7 @@ const DayOff = React.memo(function DayOff() {
             width="auto"
             info={i18n.calendar.contactStaffToEditAbsence}
             close={onClick}
+            closeLabel={i18n.common.close}
           />
         </Colspan2>
       )}

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -35,6 +35,7 @@ import {
 } from 'lib-components/molecules/ExpandingInfo'
 import {
   ModalCloseButton,
+  ModalHeader,
   PlainModal
 } from 'lib-components/molecules/modals/BaseModal'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
@@ -197,7 +198,9 @@ export default React.memo(function DayView({
                   disabled={!previousDate}
                   altText={i18n.calendar.previousDay}
                 />
-                <DayOfWeek>{date.format('EEEEEE d.M.yyyy', lang)}</DayOfWeek>
+                <ModalHeader headingComponent={DayOfWeek}>
+                  {date.format('EEEEEE d.M.yyyy', lang)}
+                </ModalHeader>
                 <IconButton
                   icon={faChevronRight}
                   onClick={navigateToNextDate}

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -228,6 +228,7 @@ export default React.memo(function ReservationModal({
                       : i18n.calendar.reservationModal.noReservableDays
                   }
                   inlineChildren
+                  closeLabel={i18n.common.close}
                 >
                   <Label>{i18n.calendar.reservationModal.dateRangeLabel}</Label>
                 </ExpandingInfo>

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -30,7 +30,10 @@ import { tabletMin } from 'lib-components/breakpoints'
 import { FixedSpaceFlexWrap } from 'lib-components/layout/flex-helpers'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 import DateRangePicker from 'lib-components/molecules/date-picker/DateRangePicker'
-import { PlainModal } from 'lib-components/molecules/modals/BaseModal'
+import {
+  ModalHeader,
+  PlainModal
+} from 'lib-components/molecules/modals/BaseModal'
 import { H1, H2, Label, Light } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import { faTimes } from 'lib-icons'
@@ -155,9 +158,15 @@ export default React.memo(function ReservationModal({
             <div>
               <ModalSection>
                 <Gap size="L" sizeOnMobile="zero" />
-                <H1 data-qa="title" noMargin>
+                <ModalHeader
+                  headingComponent={(props) => (
+                    <H1 noMargin data-qa="title" {...props}>
+                      {props.children}
+                    </H1>
+                  )}
+                >
                   {i18n.calendar.reservationModal.title}
-                </H1>
+                </ModalHeader>
               </ModalSection>
 
               <Gap size="zero" sizeOnMobile="s" />

--- a/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
+++ b/frontend/src/citizen-frontend/child-documents/vasu/VasuPage.tsx
@@ -116,6 +116,7 @@ export default React.memo(function VasuPage() {
                   </div>
                 }
                 ariaLabel={t.common.openExpandingInfo}
+                closeLabel={t.common.close}
                 inlineChildren
               >
                 <P>

--- a/frontend/src/citizen-frontend/children/ChildHeader.tsx
+++ b/frontend/src/citizen-frontend/children/ChildHeader.tsx
@@ -52,7 +52,7 @@ export default React.memo(function ChildHeader({
       />
       <div>
         <H1 noMargin data-qa="child-name">
-          {firstName} {lastName}
+          {`${firstName} ${lastName}`}
         </H1>
         {group && <Title>{group.name}</Title>}
       </div>

--- a/frontend/src/citizen-frontend/children/ChildPage.tsx
+++ b/frontend/src/citizen-frontend/children/ChildPage.tsx
@@ -42,9 +42,7 @@ export default React.memo(function ChildPage() {
               <Gap size="s" />
               <AssistanceNeedSection childId={childId} />
               <Gap size="s" />
-              <ContentArea opaque>
-                <PlacementTerminationSection childId={childId} />
-              </ContentArea>
+              <PlacementTerminationSection childId={childId} />
             </>
           ))}
         </Container>

--- a/frontend/src/citizen-frontend/children/ChildrenPage.tsx
+++ b/frontend/src/citizen-frontend/children/ChildrenPage.tsx
@@ -116,6 +116,14 @@ const ChildItem = React.memo(function ChildItem({ child }: { child: Child }) {
       opaque
       data-qa="child"
       data-qa-value={child.id}
+      role="menuitem"
+      aria-label={`${name}${child.group ? `, ${child.group.name}` : ''}${
+        unreadCount + unconsentedCount
+          ? `, ${unreadCount + unconsentedCount} ${
+              t.children.assistanceNeed.unreadCount
+            }`
+          : ''
+      }`}
     >
       <RoundImage
         size="XL"
@@ -127,7 +135,7 @@ const ChildItem = React.memo(function ChildItem({ child }: { child: Child }) {
         }
         fallbackContent={faUser}
         fallbackColor={colors.grayscale.g15}
-        alt={t.children.childPicture}
+        aria-hidden="true"
       />
       <MobileAndTablet>
         <NameAndGroup>
@@ -156,7 +164,7 @@ const ChildItem = React.memo(function ChildItem({ child }: { child: Child }) {
           />
         )}
         <Gap horizontal size="s" />
-        <IconButton icon={faChevronRight} />
+        <IconButton icon={faChevronRight} aria-hidden="true" />
       </ChevronContainer>
     </ChildContainer>
   )
@@ -177,7 +185,7 @@ export default React.memo(function ChildrenPage() {
           </ContentArea>
           <Gap size="s" />
           {renderResult(childrenResponse, ({ children }) => (
-            <Children>
+            <Children role="menu">
               {children.length > 0 ? (
                 children.map((c) => <ChildItem key={c.id} child={c} />)
               ) : (

--- a/frontend/src/citizen-frontend/children/PlacementTerminationForm.tsx
+++ b/frontend/src/citizen-frontend/children/PlacementTerminationForm.tsx
@@ -200,6 +200,7 @@ export default React.memo(function PlacementTerminationForm({
         <ExpandingInfo
           info={t.children.placementTermination.lastDayInfo}
           ariaLabel={t.common.openExpandingInfo}
+          closeLabel={t.common.close}
           inlineChildren
         >
           <Label>{t.children.placementTermination.lastDayOfPresence}</Label>

--- a/frontend/src/citizen-frontend/children/PlacementTerminationSection.tsx
+++ b/frontend/src/citizen-frontend/children/PlacementTerminationSection.tsx
@@ -36,7 +36,7 @@ export default React.memo(function PlacementTerminationSection({
 
   return (
     <CollapsibleContentArea
-      title={<H2>t.children.placementTermination.title</H2>}
+      title={<H2>{t.children.placementTermination.title}</H2>}
       open={open}
       toggleOpen={() => setOpen(!open)}
       opaque

--- a/frontend/src/citizen-frontend/children/PlacementTerminationSection.tsx
+++ b/frontend/src/citizen-frontend/children/PlacementTerminationSection.tsx
@@ -2,13 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { useState } from 'react'
 
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
+import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
-import CollapsibleSection from 'lib-components/molecules/CollapsibleSection'
 import { H2, P } from 'lib-components/typography'
 
 import { renderResult } from '../async-rendering'
@@ -32,12 +32,14 @@ export default React.memo(function PlacementTerminationSection({
     [childId]
   )
 
+  const [open, setOpen] = useState(false)
+
   return (
-    <CollapsibleSection
-      title={t.children.placementTermination.title}
-      startCollapsed
-      fitted
-      headingComponent={H2}
+    <CollapsibleContentArea
+      title={<H2>t.children.placementTermination.title</H2>}
+      open={open}
+      toggleOpen={() => setOpen(!open)}
+      opaque
     >
       {renderResult(placementsResponse, ({ placements }) => {
         const terminatedPlacements = placements.filter((p) =>
@@ -72,6 +74,6 @@ export default React.memo(function PlacementTerminationSection({
           </FixedSpaceColumn>
         )
       })}
-    </CollapsibleSection>
+    </CollapsibleContentArea>
   )
 })

--- a/frontend/src/citizen-frontend/children/PlacementTerminationSection.tsx
+++ b/frontend/src/citizen-frontend/children/PlacementTerminationSection.tsx
@@ -36,7 +36,7 @@ export default React.memo(function PlacementTerminationSection({
 
   return (
     <CollapsibleContentArea
-      title={<H2>{t.children.placementTermination.title}</H2>}
+      title={<H2 noMargin>{t.children.placementTermination.title}</H2>}
       open={open}
       toggleOpen={() => setOpen(!open)}
       opaque

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -124,7 +124,7 @@ const NavLinkText = React.memo(function NavLinkText({
   return (
     <div>
       <SpaceReservingText aria-hidden="true">{text}</SpaceReservingText>
-      <div>{text}</div>
+      <div data-qa="nav-text">{text}</div>
     </div>
   )
 })
@@ -404,6 +404,7 @@ const HeaderNavLink = React.memo(function HeaderNavLink({
   notificationCount?: number
   text: string
   lockElem?: React.ReactNode
+  'data-qa'?: string
 }) {
   const t = useTranslation()
 
@@ -424,6 +425,7 @@ const HeaderNavLink = React.memo(function HeaderNavLink({
       {!!notificationCount && (
         <CircledChar
           aria-label={`${notificationCount} ${t.header.notifications}`}
+          data-qa={props['data-qa'] && `${props['data-qa']}-notification-count`}
         >
           {notificationCount}
         </CircledChar>

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -364,7 +364,7 @@ const DropDownIcon = styled(FontAwesomeIcon)`
 
 const DropDown = styled.ul<{ alignRight: boolean }>`
   position: absolute;
-  z-index: 10;
+  z-index: 30;
   list-style: none;
   margin: 0;
   padding: 0;

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -132,7 +132,12 @@ const NavLinkText = React.memo(function NavLinkText({
 }: {
   text: string
 }) {
-  return <div data-text={text}>{text}</div>
+  return (
+    <div>
+      <SpaceReservingText aria-hidden="true">{text}</SpaceReservingText>
+      <div>{text}</div>
+    </div>
+  )
 })
 
 const Container = styled.div`
@@ -169,8 +174,7 @@ const StyledNavLink = styled(NavLink)`
     padding: 0 ${defaultMargins.m};
   }
 
-  &:hover,
-  [data-text]::before {
+  &:hover {
     font-weight: ${fontWeights.bold};
   }
 
@@ -184,13 +188,13 @@ const StyledNavLink = styled(NavLink)`
     border-bottom-color: ${colors.grayscale.g0};
     font-weight: ${fontWeights.bold};
   }
+`
 
-  [data-text]::before {
-    display: block;
-    height: 0;
-    visibility: hidden;
-    content: attr(data-text);
-  }
+const SpaceReservingText = styled.span`
+  font-weight: ${fontWeights.bold};
+  display: block;
+  height: 0;
+  visibility: hidden;
 `
 
 const Login = styled(Link)`

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -256,8 +256,9 @@ const LanguageMenu = React.memo(function LanguageMenu({
                 setOpen(false)
               }}
               data-qa={`lang-${l}`}
+              lang={l}
             >
-              <LanguageShort>{l}</LanguageShort>
+              <LanguageShort aria-hidden="true">{l}</LanguageShort>
               <span>{t.header.lang[l]}</span>
             </DropDownItem>
           ))}

--- a/frontend/src/citizen-frontend/header/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/header/DesktopNav.tsx
@@ -60,52 +60,41 @@ export default React.memo(function DesktopNav({
               {user ? (
                 <>
                   {user.accessibleFeatures.reservations && (
-                    <StyledNavLink to="/calendar" data-qa="nav-calendar">
-                      <NavLinkText text={t.header.nav.calendar} />
-                    </StyledNavLink>
+                    <HeaderNavLink
+                      to="/calendar"
+                      data-qa="nav-calendar"
+                      text={t.header.nav.calendar}
+                    />
                   )}
                   {user.accessibleFeatures.messages && (
-                    <StyledNavLink to="/messages" data-qa="nav-messages">
-                      <NavLinkText text={t.header.nav.messages} />{' '}
-                      {unreadMessagesCount > 0 ? (
-                        <CircledChar
-                          aria-label={`${t.header.nav.messageCount(
-                            unreadMessagesCount
-                          )}`}
-                        >
-                          {unreadMessagesCount}
-                        </CircledChar>
-                      ) : (
-                        ''
-                      )}
-                    </StyledNavLink>
+                    <HeaderNavLink
+                      to="/messages"
+                      data-qa="nav-messages"
+                      text={t.header.nav.messages}
+                      notificationCount={unreadMessagesCount}
+                    />
                   )}
                   {user.accessibleFeatures.childDocumentation && (
-                    <StyledNavLink
+                    <HeaderNavLink
                       to="/child-documents"
                       data-qa="nav-child-documents"
-                    >
-                      <NavLinkText text={t.header.nav.pedagogicalDocuments} />
-                      {maybeLockElem}
-                      {isEnduser && unreadChildDocuments > 0 && (
-                        <CircledChar data-qa="unread-child-documents-count">
-                          {unreadChildDocuments}
-                        </CircledChar>
-                      )}
-                    </StyledNavLink>
+                      lockElem={maybeLockElem}
+                      text={t.header.nav.pedagogicalDocuments}
+                      notificationCount={unreadChildDocuments}
+                    />
                   )}
-                  <StyledNavLink to="/children" data-qa="nav-children">
-                    <NavLinkText text={t.header.nav.children} />
-                    {maybeLockElem}
-                    {isEnduser && unreadChildren > 0 && (
-                      <CircledChar data-qa="unread-children-count">
-                        {unreadChildren}
-                      </CircledChar>
-                    )}
-                  </StyledNavLink>
-                  <StyledNavLink to="/applying" data-qa="nav-applying">
-                    <NavLinkText text={t.header.nav.applications} />
-                  </StyledNavLink>
+                  <HeaderNavLink
+                    to="/children"
+                    data-qa="nav-children"
+                    text={t.header.nav.children}
+                    notificationCount={unreadChildren}
+                    lockElem={maybeLockElem}
+                  />
+                  <HeaderNavLink
+                    to="/applying"
+                    data-qa="nav-applying"
+                    text={t.header.nav.applications}
+                  />
                 </>
               ) : null}
             </Nav>
@@ -403,3 +392,42 @@ const DropDownItem = styled.button<{ selected: boolean }>`
 const LanguageShort = styled.span`
   text-transform: uppercase;
 `
+
+const HeaderNavLink = React.memo(function HeaderNavLink({
+  notificationCount,
+  text,
+  lockElem,
+  ...props
+}: {
+  onClick?: () => void
+  to: string
+  notificationCount?: number
+  text: string
+  lockElem?: React.ReactNode
+}) {
+  const t = useTranslation()
+
+  return (
+    <StyledNavLink
+      {...props}
+      aria-label={`${text}${
+        lockElem ? `, ${t.header.requiresStrongAuth}` : ''
+      }${
+        notificationCount && notificationCount > 0
+          ? `, ${notificationCount} ${t.header.notifications}`
+          : ''
+      }`}
+      role="menuitem"
+    >
+      <NavLinkText text={text} />
+      {lockElem}
+      {!!notificationCount && (
+        <CircledChar
+          aria-label={`${notificationCount} ${t.header.notifications}`}
+        >
+          {notificationCount}
+        </CircledChar>
+      )}
+    </StyledNavLink>
+  )
+})

--- a/frontend/src/citizen-frontend/header/Header.tsx
+++ b/frontend/src/citizen-frontend/header/Header.tsx
@@ -104,7 +104,7 @@ export default React.memo(function Header(props: { ariaHidden: boolean }) {
 })
 
 const HeaderContainer = styled.header<{ showMenu: boolean }>`
-  z-index: 9;
+  z-index: 25;
   color: ${colors.grayscale.g0};
   background-color: ${colors.main.m2};
   display: grid;

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -163,7 +163,7 @@ const MenuContainer = styled.div`
   width: 100vw;
   height: calc(100% - ${headerHeightMobile}px);
   padding: ${defaultMargins.s};
-  z-index: 5;
+  z-index: 25;
   display: flex;
   flex-direction: column;
 `

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -245,45 +245,48 @@ const Navigation = React.memo(function Navigation({
     <FontAwesomeIcon icon={faLockAlt} size="xs" />
   )
   return (
-    <Nav>
+    <Nav role="menu">
       {user.accessibleFeatures.reservations && (
-        <StyledNavLink to="/calendar" onClick={close} data-qa="nav-calendar">
-          <NavLinkText text={t.header.nav.calendar} />
-        </StyledNavLink>
+        <HeaderNavLink
+          to="/calendar"
+          onClick={close}
+          data-qa="nav-calendar"
+          text={t.header.nav.calendar}
+        />
       )}
       {user.accessibleFeatures.messages && (
-        <StyledNavLink to="/messages" onClick={close} data-qa="nav-messages">
-          <NavLinkText text={t.header.nav.messages} />
-          {unreadMessagesCount > 0 && (
-            <FloatingCircledChar>{unreadMessagesCount}</FloatingCircledChar>
-          )}
-        </StyledNavLink>
+        <HeaderNavLink
+          to="/messages"
+          onClick={close}
+          data-qa="nav-messages"
+          text={t.header.nav.messages}
+          notificationCount={unreadMessagesCount}
+        />
       )}
       {user.accessibleFeatures.childDocumentation && (
-        <StyledNavLink
+        <HeaderNavLink
           to="/child-documents"
           data-qa="nav-child-documents"
           onClick={close}
-        >
-          <NavLinkText text={t.header.nav.pedagogicalDocuments} />
-          {maybeLockElem}
-          {unreadChildDocumentsCount > 0 && (
-            <FloatingCircledChar>
-              {unreadChildDocumentsCount}
-            </FloatingCircledChar>
-          )}
-        </StyledNavLink>
+          text={t.header.nav.pedagogicalDocuments}
+          notificationCount={unreadChildDocumentsCount}
+          lockElem={maybeLockElem}
+        />
       )}
-      <StyledNavLink to="/children" onClick={close} data-qa="nav-children">
-        <NavLinkText text={t.header.nav.children} />
-        {maybeLockElem}
-        {unreadChildrenCount > 0 && (
-          <FloatingCircledChar>{unreadChildrenCount}</FloatingCircledChar>
-        )}
-      </StyledNavLink>
-      <StyledNavLink to="/applying" onClick={close} data-qa="nav-applications">
-        <NavLinkText text={t.header.nav.applications} /> {maybeLockElem}
-      </StyledNavLink>
+      <HeaderNavLink
+        to="/children"
+        onClick={close}
+        data-qa="nav-children"
+        text={t.header.nav.children}
+        notificationCount={unreadChildrenCount}
+        lockElem={maybeLockElem}
+      />
+      <HeaderNavLink
+        to="/applying"
+        onClick={close}
+        data-qa="nav-applications"
+        text={t.header.nav.applications}
+      />
     </Nav>
   )
 })
@@ -301,14 +304,10 @@ const NavLinkText = React.memo(function NavLinkText({
   )
 })
 
-const Nav = styled.nav`
+const Nav = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-`
-
-const FloatingCircledChar = styled(CircledChar)`
-  float: right;
 `
 
 const StyledNavLink = styled(NavLink)`
@@ -465,3 +464,42 @@ const SubMenuLink = styled(StyledNavLink)`
 const UserName = styled.span`
   font-weight: ${fontWeights.semibold};
 `
+
+const HeaderNavLink = React.memo(function HeaderNavLink({
+  notificationCount,
+  text,
+  lockElem,
+  ...props
+}: {
+  onClick: () => void
+  to: string
+  notificationCount?: number
+  text: string
+  lockElem?: React.ReactNode
+}) {
+  const t = useTranslation()
+
+  return (
+    <StyledNavLink
+      {...props}
+      aria-label={`${text}${
+        lockElem ? `, ${t.header.requiresStrongAuth}` : ''
+      }${
+        notificationCount && notificationCount > 0
+          ? `, ${notificationCount} ${t.header.notifications}`
+          : ''
+      }`}
+      role="menuitem"
+    >
+      <NavLinkText text={text} />
+      {lockElem}
+      {!!notificationCount && (
+        <CircledChar
+          aria-label={`${notificationCount} ${t.header.notifications}`}
+        >
+          {notificationCount}
+        </CircledChar>
+      )}
+    </StyledNavLink>
+  )
+})

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -476,6 +476,7 @@ const HeaderNavLink = React.memo(function HeaderNavLink({
   notificationCount?: number
   text: string
   lockElem?: React.ReactNode
+  'data-qa'?: string
 }) {
   const t = useTranslation()
 
@@ -496,6 +497,7 @@ const HeaderNavLink = React.memo(function HeaderNavLink({
       {!!notificationCount && (
         <CircledChar
           aria-label={`${notificationCount} ${t.header.notifications}`}
+          data-qa={props['data-qa'] && `${props['data-qa']}-notification-count`}
         >
           {notificationCount}
         </CircledChar>

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -293,7 +293,12 @@ const NavLinkText = React.memo(function NavLinkText({
 }: {
   text: string
 }) {
-  return <div data-text={text}>{text}</div>
+  return (
+    <div>
+      <SpaceReservingText aria-hidden="true">{text}</SpaceReservingText>
+      <div>{text}</div>
+    </div>
+  )
 })
 
 const Nav = styled.nav`
@@ -320,8 +325,7 @@ const StyledNavLink = styled(NavLink)`
   margin: ${defaultMargins.xxs} 0;
   border-bottom: 2px solid transparent;
 
-  &:hover,
-  [data-text]::before {
+  &:hover {
     font-weight: ${fontWeights.bold};
     border-color: ${colors.grayscale.g0};
   }
@@ -336,14 +340,15 @@ const StyledNavLink = styled(NavLink)`
     font-weight: ${fontWeights.bold};
     border-color: ${colors.grayscale.g0};
   }
+`
 
-  [data-text]::before {
-    display: block;
-    height: 0;
-    visibility: hidden;
-    content: attr(data-text);
-    text-align: center;
-  }
+const SpaceReservingText = styled.span`
+  display: block;
+  height: 0;
+  visibility: hidden;
+  text-align: center;
+  font-weight: ${fontWeights.bold};
+  border-color: ${colors.grayscale.g0};
 `
 
 const VerticalSpacer = styled.div`

--- a/frontend/src/citizen-frontend/header/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/header/MobileNav.tsx
@@ -174,6 +174,7 @@ const LanguageMenu = React.memo(function LanguageMenu({
   close: () => void
 }) {
   const [lang, setLang] = useLang()
+  const t = useTranslation()
 
   return (
     <LangList>
@@ -185,6 +186,8 @@ const LanguageMenu = React.memo(function LanguageMenu({
               setLang(l)
               close()
             }}
+            aria-label={t.header.lang[l]}
+            lang={l}
           >
             {l}
           </LangButton>

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
@@ -89,12 +89,14 @@ const IncomeStatementsTable = React.memo(function IncomeStatementsTable({
                       icon={faPen}
                       text={t.common.edit}
                       onClick={onEdit(item.id)}
+                      altText={t.common.edit}
                     />
                     <Gap size="xs" horizontal />
                     <ResponsiveInlineButton
                       icon={faTrash}
                       text={t.common.delete}
                       onClick={() => onRemoveIncomeStatement(item.id)}
+                      altText={t.common.delete}
                     />
                   </>
                 )}

--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom'
 
 import { formatDateOrTime } from 'lib-common/date'
 import { MessageThread } from 'lib-common/generated/api-types/messaging'
-import { SrOnly } from 'lib-components/atoms/SrOnly'
+import { ScreenReaderOnly } from 'lib-components/atoms/ScreenReaderOnly'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import FileDownloadButton from 'lib-components/molecules/FileDownloadButton'
 import {
@@ -57,11 +57,11 @@ export default React.memo(function ThreadListItem({
             labels={i18n.messages.types}
           />
         </Header>
-        <SrOnly>
+        <ScreenReaderOnly>
           <Link to={`/messages/${thread.id}`} tabIndex={-1}>
             {i18n.messages.openMessage}
           </Link>
-        </SrOnly>
+        </ScreenReaderOnly>
         <TitleAndDate isRead={!hasUnreadMessages}>
           <Truncated>{thread.title}</Truncated>
           <span>{formatDateOrTime(lastMessage.sentAt)}</span>

--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -4,10 +4,10 @@
 
 import React from 'react'
 import { Link } from 'react-router-dom'
-import styled from 'styled-components'
 
 import { formatDateOrTime } from 'lib-common/date'
 import { MessageThread } from 'lib-common/generated/api-types/messaging'
+import { SrOnly } from 'lib-components/atoms/SrOnly'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import FileDownloadButton from 'lib-components/molecules/FileDownloadButton'
 import {
@@ -88,12 +88,3 @@ export default React.memo(function ThreadListItem({
     </Container>
   )
 })
-
-const SrOnly = styled.div`
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-`

--- a/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
+++ b/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
@@ -270,6 +270,7 @@ export default React.memo(function PersonalDetails() {
                           <ExpandingInfoBox
                             info={t.personalDetails.emailInfo}
                             close={toggleEmailInfo}
+                            closeLabel={t.common.close}
                           />
                           <Gap size="s" />
                         </>

--- a/frontend/src/e2e-test/pages/citizen/citizen-header.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-header.ts
@@ -20,11 +20,13 @@ export default class CitizenHeader {
   #languageMenuToggle = this.page.find('[data-qa="button-select-language"]')
   #languageOptionList = this.page.find('[data-qa="select-lang"]')
   #userMenu = this.page.find(`[data-qa="user-menu-title-${this.type}"]`)
-  #applyingTab = this.page.find('[data-qa="nav-applying"]')
+  #applyingTab = this.page.findByDataQa('nav-applying').findByDataQa('nav-text')
   #unreadChildDocumentsCount = this.page.findAllByDataQa(
-    'unread-child-documents-count'
+    'nav-child-documents-notification-count'
   )
-  #unreadChildrenCount = this.page.findAllByDataQa('unread-children-count')
+  #unreadChildrenCount = this.page.findAllByDataQa(
+    'nav-children-notification-count'
+  )
 
   #languageOption(lang: Lang) {
     return this.#languageOptionList.find(`[data-qa="lang-${lang}"]`)

--- a/frontend/src/e2e-test/pages/citizen/citizen-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-income.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Checkbox, Page, TextInput } from '../../utils/page'
+import { Checkbox, Page, Radio, TextInput } from '../../utils/page'
 
 export default class CitizenIncomePage {
   constructor(private readonly page: Page) {}
@@ -53,7 +53,9 @@ export default class CitizenIncomePage {
   }
 
   async selectEntrepreneurSpouse(yesNo: 'yes' | 'no') {
-    await this.page.find(`[data-qa="entrepreneur-spouse-${yesNo}"]`).click()
+    await new Radio(
+      this.page.findByDataQa(`entrepreneur-spouse-${yesNo}`)
+    ).check()
   }
 
   private async toggleCheckbox(

--- a/frontend/src/e2e-test/pages/citizen/citizen-pedagogical-documents.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-pedagogical-documents.ts
@@ -17,7 +17,7 @@ export default class CitizenPedagogicalDocumentsPage {
   readonly #downloadAttachment = (id: string) =>
     this.page.find(`[data-qa="attachment-${id}-download"]`)
   readonly #unreadDocumentCount = this.page.find(
-    '[data-qa="unread-child-documents-count"]'
+    '[data-qa="nav-child-documents-notification-count"]'
   )
 
   async assertUnreadPedagogicalDocumentIndicatorCount(expectedCount: number) {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-map.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-map.spec.ts
@@ -81,12 +81,12 @@ describe('Citizen map page', () => {
     await mapPage.listItemFor(clubFixture).waitUntilHidden()
     await mapPage.listItemFor(preschoolFixture).waitUntilVisible()
 
-    await mapPage.clubFilter.click()
+    await mapPage.clubFilter.check()
     await mapPage.listItemFor(clubFixture).waitUntilVisible()
     await mapPage.listItemFor(daycare2Fixture).waitUntilHidden()
     await mapPage.listItemFor(preschoolFixture).waitUntilHidden()
 
-    await mapPage.preschoolFilter.click()
+    await mapPage.preschoolFilter.check()
     await mapPage.listItemFor(clubFixture).waitUntilHidden()
     await mapPage.listItemFor(preschoolFixture).waitUntilVisible()
     await mapPage.listItemFor(daycare2Fixture).waitUntilHidden()

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -320,7 +320,31 @@ export class Radio extends Checkable {
   }
 }
 
-export class SelectionChip extends Checkable {}
+export class SelectionChip extends Element {
+  async check() {
+    if (!this.checked) {
+      await this.click()
+      await this.waitUntilChecked(true)
+    }
+  }
+
+  async uncheck() {
+    if (await this.checked) {
+      await this.click()
+      await this.waitUntilChecked(false)
+    }
+  }
+
+  get checked(): Promise<boolean> {
+    return this.getAttribute('aria-checked').then(
+      (ariaChecked) => ariaChecked === 'true'
+    )
+  }
+
+  async waitUntilChecked(checked = true) {
+    await waitUntilEqual(() => this.checked, checked)
+  }
+}
 
 export class Select extends Element {
   #input = this.find('select')

--- a/frontend/src/employee-frontend/components/SettingsPage.tsx
+++ b/frontend/src/employee-frontend/components/SettingsPage.tsx
@@ -135,6 +135,7 @@ const SettingRow = React.memo(function SettingRow({
         <ExpandingInfo
           info={i18n.settings.options[option].description}
           ariaLabel={i18n.common.openExpandingInfo}
+          closeLabel={i18n.common.close}
           width="full"
         >
           {i18n.settings.options[option].title}

--- a/frontend/src/employee-frontend/components/absences/AbsenceLegend.tsx
+++ b/frontend/src/employee-frontend/components/absences/AbsenceLegend.tsx
@@ -71,6 +71,7 @@ export const AbsenceLegend = React.memo(function AbsenceLegend({
           key={t}
           info={i18n.absences.absenceTypeInfo[t]}
           ariaLabel={i18n.common.openExpandingInfo}
+          closeLabel={i18n.common.close}
         >
           <AbsenceLegendRow>
             {icons ? (

--- a/frontend/src/employee-frontend/components/child-information/PedagogicalDocuments.tsx
+++ b/frontend/src/employee-frontend/components/child-information/PedagogicalDocuments.tsx
@@ -156,7 +156,11 @@ export default React.memo(function PedagogicalDocuments({
         </P>
       )}
       {!!expandingInfo && (
-        <ExpandingInfoBox info={expandingInfo} close={closeExpandingInfo} />
+        <ExpandingInfoBox
+          info={expandingInfo}
+          close={closeExpandingInfo}
+          closeLabel={i18n.common.close}
+        />
       )}
 
       {renderResult(pedagogicalDocuments, (pedagogicalDocuments) => (

--- a/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-action/AssistanceActionForm.tsx
@@ -262,6 +262,7 @@ export default React.memo(function AssistanceActionForm(props: Props) {
                       info={option.descriptionFi}
                       ariaLabel=""
                       width="full"
+                      closeLabel={i18n.common.close}
                     >
                       <CheckboxRow>
                         <Checkbox
@@ -342,6 +343,7 @@ export default React.memo(function AssistanceActionForm(props: Props) {
                       )}
                       ariaLabel=""
                       width="full"
+                      closeLabel={i18n.common.close}
                     >
                       <CheckboxRow key={measure}>
                         <Checkbox

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedForm.tsx
@@ -269,6 +269,7 @@ export default React.memo(function AssistanceNeedForm(props: Props) {
                     i18n.childInformation.assistanceNeed.fields.capacityFactor
                   }
                   width="full"
+                  closeLabel={i18n.common.close}
                 >
                   <CoefficientInputContainer>
                     <InputField
@@ -309,6 +310,7 @@ export default React.memo(function AssistanceNeedForm(props: Props) {
                       info={basis.descriptionFi}
                       ariaLabel=""
                       width="full"
+                      closeLabel={i18n.common.close}
                     >
                       <CheckboxRow key={basis.value}>
                         <Checkbox

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/AssistanceNeedRow.tsx
@@ -129,6 +129,7 @@ export default React.memo(function AssistanceNeedRow({
                     }
                     ariaLabel=""
                     width="full"
+                    closeLabel={i18n.common.close}
                   >
                     <span data-qa="assistance-need-multiplier">
                       {formatDecimal(assistanceNeed.capacityFactor)}

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
@@ -38,9 +38,15 @@ const FieldWithInfo = React.memo(function FieldWithInfo({
   spacing?: string
   children: React.ReactNode
 }) {
+  const { i18n } = useTranslation()
+
   return (
     <FixedSpaceColumn spacing={spacing || defaultMargins.s}>
-      <ExpandingInfo info={info} ariaLabel={info}>
+      <ExpandingInfo
+        info={info}
+        ariaLabel={i18n.common.openExpandingInfo}
+        closeLabel={i18n.common.close}
+      >
         <Label>{label}</Label>
       </ExpandingInfo>
       {children}

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/voucher-coefficient/AssistanceNeedVoucherCoefficientForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/voucher-coefficient/AssistanceNeedVoucherCoefficientForm.tsx
@@ -211,6 +211,7 @@ export default React.memo(function AssistanceNeedVoucherCoefficientForm(
             info={<div>{t.form.titleInfo}</div>}
             ariaLabel={i18n.common.openExpandingInfo}
             width="full"
+            closeLabel={i18n.common.close}
           >
             <LabelLike>{t.form.title}</LabelLike>
           </ExpandingInfo>

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/voucher-coefficient/AssistanceNeedVoucherCoefficientRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/voucher-coefficient/AssistanceNeedVoucherCoefficientRow.tsx
@@ -75,6 +75,7 @@ export default React.memo(function AssistanceNeedVoucherCoefficientRow({
               }
               ariaLabel={i18n.common.openExpandingInfo}
               width="full"
+              closeLabel={i18n.common.close}
             >
               <LabelLike>
                 {

--- a/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsEditor.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsEditor.tsx
@@ -263,6 +263,7 @@ export default React.memo(function FeeThresholdsEditor({
         <ExpandingInfo
           info={i18n.financeBasics.fees.thresholdIncreaseInfo}
           ariaLabel={i18n.common.openExpandingInfo}
+          closeLabel={i18n.common.close}
         >
           <Label htmlFor="thresholdIncrease">
             {i18n.financeBasics.fees.thresholdIncrease}

--- a/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsItem.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsItem.tsx
@@ -126,6 +126,7 @@ export const FeeThresholdsItem = React.memo(function FeeThresholdsItem({
           <ExpandingInfo
             info={i18n.financeBasics.fees.thresholdIncreaseInfo}
             ariaLabel={i18n.common.openExpandingInfo}
+            closeLabel={i18n.common.close}
           >
             <Label>{i18n.financeBasics.fees.thresholdIncrease}</Label>
           </ExpandingInfo>

--- a/frontend/src/employee-frontend/components/person-shared/PersonDetails.tsx
+++ b/frontend/src/employee-frontend/components/person-shared/PersonDetails.tsx
@@ -344,6 +344,7 @@ export default React.memo(function PersonDetails({
                     <ExpandingInfoBox
                       info={i18n.personProfile.ssnAddingDisabledInfo}
                       close={toggleShowSsnAddingDisabledInfo}
+                      closeLabel={i18n.common.close}
                     />
                   ),
                   onlyValue: true

--- a/frontend/src/employee-frontend/components/vasu/QuestionInfo.tsx
+++ b/frontend/src/employee-frontend/components/vasu/QuestionInfo.tsx
@@ -26,6 +26,7 @@ export default React.memo(function QuestionInfo({ children, info }: Props) {
         info={<WhitespacePre>{info}</WhitespacePre>}
         ariaLabel={i18n.common.openExpandingInfo}
         width="full"
+        closeLabel={i18n.common.close}
       >
         {children}
       </ExpandingInfo>

--- a/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/CreateQuestionModal.tsx
@@ -320,6 +320,7 @@ export default React.memo(function CreateQuestionModal({
                 ariaLabel=""
                 key={`key-${i}`}
                 width="full"
+                closeLabel=""
               >
                 <FixedSpaceRow spacing="xs" alignItems="center">
                   <InputField

--- a/frontend/src/lib-common/themes/espoo-theme.ts
+++ b/frontend/src/lib-common/themes/espoo-theme.ts
@@ -62,7 +62,7 @@ const theme: Theme = {
       }
     },
     h3: {
-      weight: 400,
+      weight: 500,
       bold: 600,
       mobile: {
         weight: 500

--- a/frontend/src/lib-components/atoms/Chip.tsx
+++ b/frontend/src/lib-components/atoms/Chip.tsx
@@ -9,7 +9,6 @@ import { readableColor } from 'polished'
 import React, { useCallback } from 'react'
 import styled, { css } from 'styled-components'
 
-import { useUniqueId } from 'lib-common/utils/useUniqueId'
 import { faCheck } from 'lib-icons'
 
 import { tabletMin } from '../breakpoints'
@@ -62,10 +61,8 @@ export const SelectionChip = React.memo(function SelectionChip({
   'data-qa': dataQa,
   showIcon = true
 }: SelectionChipProps) {
-  const ariaId = useUniqueId('selection-chip')
-
   const onClick = useCallback(
-    (e: React.MouseEvent<HTMLElement>) => {
+    (e: React.UIEvent<HTMLElement>) => {
       e.preventDefault()
       onChange(!selected)
     },
@@ -73,33 +70,30 @@ export const SelectionChip = React.memo(function SelectionChip({
   )
 
   return (
-    <div data-qa={dataQa} onClick={onClick}>
-      <SelectionChipWrapper>
-        <SelectionChipInnerWrapper
-          className={classNames({ checked: selected })}
+    <SelectionChipWrapper
+      role="checkbox"
+      aria-label={text}
+      aria-checked={selected}
+      onClick={onClick}
+      onKeyUp={(ev) => ev.key === 'Enter' && onClick(ev)}
+      data-qa={dataQa}
+      tabIndex={0}
+    >
+      <SelectionChipInnerWrapper className={classNames({ checked: selected })}>
+        {showIcon && selected && (
+          <IconWrapper>
+            <FontAwesomeIcon icon={faCheck} />
+          </IconWrapper>
+        )}
+        <StyledLabel
+          className={classNames({ checked: showIcon && selected })}
+          aria-hidden="true"
+          onClick={preventDefault}
         >
-          <HiddenInput
-            type="checkbox"
-            onChange={() => onChange(!selected)}
-            onClick={preventDefault}
-            checked={selected}
-            id={ariaId}
-          />
-          {showIcon && selected && (
-            <IconWrapper>
-              <FontAwesomeIcon icon={faCheck} />
-            </IconWrapper>
-          )}
-          <StyledLabel
-            className={classNames({ checked: showIcon && selected })}
-            htmlFor={ariaId}
-            onClick={preventDefault}
-          >
-            {text}
-          </StyledLabel>
-        </SelectionChipInnerWrapper>
-      </SelectionChipWrapper>
-    </div>
+          {text}
+        </StyledLabel>
+      </SelectionChipInnerWrapper>
+    </SelectionChipWrapper>
   )
 })
 
@@ -133,13 +127,13 @@ const SelectionChipWrapper = styled.div`
   border-radius: 1000px;
   cursor: pointer;
   outline: none;
+  border: 2px solid transparent;
 
   &:focus,
   &:focus-within {
-    border: 2px solid ${(p) => p.theme.colors.main.m1};
-    border-radius: 1000px;
-    margin: -2px;
+    border-color: ${(p) => p.theme.colors.main.m1};
   }
+
   padding: 2px;
 `
 
@@ -153,6 +147,7 @@ const SelectionChipInnerWrapper = styled.div`
   background-color: ${(p) => p.theme.colors.grayscale.g0};
   color: ${(p) => p.theme.colors.main.m2};
   border: 1px solid ${(p) => p.theme.colors.main.m2};
+  min-height: 36px;
   &.checked {
     background-color: ${(p) => p.theme.colors.main.m2};
     color: ${(p) => p.theme.colors.grayscale.g0};
@@ -161,16 +156,6 @@ const SelectionChipInnerWrapper = styled.div`
   @media (max-width: ${tabletMin}) {
     height: 40px;
   }
-`
-
-const HiddenInput = styled.input`
-  outline: none;
-  appearance: none;
-  border: none;
-  background: none;
-  margin: 0;
-  height: 32px;
-  width: 0;
 `
 
 const IconWrapper = styled.div`

--- a/frontend/src/lib-components/atoms/ScreenReaderOnly.tsx
+++ b/frontend/src/lib-components/atoms/ScreenReaderOnly.tsx
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const SrOnly = styled.div`
+export const ScreenReaderOnly = styled.div`
   position: absolute;
   left: -10000px;
   top: auto;

--- a/frontend/src/lib-components/atoms/SrOnly.tsx
+++ b/frontend/src/lib-components/atoms/SrOnly.tsx
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import styled from 'styled-components'
+
+export const SrOnly = styled.div`
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+`

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -19,10 +19,11 @@ import { Failure, Result } from 'lib-common/api'
 import { isAutomatedTest } from 'lib-common/utils/helpers'
 import { faCheck, faTimes } from 'lib-icons'
 
+import { SrOnly } from '../SrOnly'
 import { StyledButton } from './Button'
 
 const onSuccessTimeout = isAutomatedTest ? 10 : 500
-const clearStateTimeout = isAutomatedTest ? 25 : 2000
+const clearStateTimeout = isAutomatedTest ? 25 : 3000
 
 type ButtonState<T> =
   | { state: 'idle' | 'in-progress' | 'failure' }
@@ -112,7 +113,8 @@ function AsyncButton<T>({
       } else {
         setButtonState(inProgress)
         maybePromise
-          .then((result) => {
+          .then(async (result) => {
+            await new Promise((r) => setTimeout(r, 1000))
             if (!mountedRef.current) return
             if (result.isSuccess) {
               handleSuccess(result.value)
@@ -198,11 +200,22 @@ function AsyncButton<T>({
         primary: !!primary && !showIcon,
         disabled
       })}
-      disabled={disabled || showIcon}
+      disabled={disabled}
       onClick={handleClick}
       {...props}
       data-status={buttonState.state === 'idle' ? '' : buttonState.state}
+      aria-busy={buttonState.state === 'in-progress'}
     >
+      {buttonState.state === 'in-progress' && (
+        <SrOnly aria-live="polite" id="in-progress">
+          Ladataan
+        </SrOnly>
+      )}
+      {buttonState.state === 'success' && (
+        <SrOnly aria-live="assertive" id="success">
+          Valmis
+        </SrOnly>
+      )}
       <Content>
         <IconContainer
           style={{

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -20,6 +20,7 @@ import { isAutomatedTest } from 'lib-common/utils/helpers'
 import { faCheck, faTimes } from 'lib-icons'
 
 import { SrOnly } from '../SrOnly'
+
 import { StyledButton } from './Button'
 
 const onSuccessTimeout = isAutomatedTest ? 10 : 500

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -19,7 +19,7 @@ import { Failure, Result } from 'lib-common/api'
 import { isAutomatedTest } from 'lib-common/utils/helpers'
 import { faCheck, faTimes } from 'lib-icons'
 
-import { SrOnly } from '../SrOnly'
+import { ScreenReaderOnly } from '../ScreenReaderOnly'
 
 import { StyledButton } from './Button'
 
@@ -208,14 +208,14 @@ function AsyncButton<T>({
       aria-busy={buttonState.state === 'in-progress'}
     >
       {buttonState.state === 'in-progress' && (
-        <SrOnly aria-live="polite" id="in-progress">
+        <ScreenReaderOnly aria-live="polite" id="in-progress">
           Ladataan
-        </SrOnly>
+        </ScreenReaderOnly>
       )}
       {buttonState.state === 'success' && (
-        <SrOnly aria-live="assertive" id="success">
+        <ScreenReaderOnly aria-live="assertive" id="success">
           Valmis
-        </SrOnly>
+        </ScreenReaderOnly>
       )}
       <Content>
         <IconContainer

--- a/frontend/src/lib-components/atoms/buttons/ResponsiveAddButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/ResponsiveAddButton.tsx
@@ -15,7 +15,12 @@ interface ResponsiveAddButtonProps extends AddButtonProps {
 
 const ResponsiveText = styled.span<{ breakpoint: string }>`
   @media (max-width: ${(p) => p.breakpoint}) {
-    display: none;
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
   }
 `
 

--- a/frontend/src/lib-components/atoms/form/Checkbox.tsx
+++ b/frontend/src/lib-components/atoms/form/Checkbox.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames'
 import React, { useRef } from 'react'
 import styled from 'styled-components'
 
+import { useUniqueId } from 'lib-common/utils/useUniqueId'
 import { ExpandingInfoButtonSlot } from 'lib-components/molecules/ExpandingInfo'
 import { faCheck } from 'lib-icons'
 
@@ -138,6 +139,8 @@ export default React.memo(function Checkbox({
 }: CheckboxProps) {
   const inputRef = useRef<HTMLInputElement>(null)
 
+  const ariaId = useUniqueId('checkbox')
+
   return (
     <Wrapper
       onClick={() => {
@@ -152,7 +155,7 @@ export default React.memo(function Checkbox({
           type="checkbox"
           checked={checked}
           data-qa={dataQa ? `${dataQa}-input` : undefined}
-          aria-label={label}
+          id={ariaId}
           disabled={disabled}
           onChange={(e) => {
             e.stopPropagation()
@@ -167,7 +170,7 @@ export default React.memo(function Checkbox({
       </Box>
       {!hiddenLabel && (
         <LabelContainer>
-          <label>{label}</label>
+          <label htmlFor={ariaId}>{label}</label>
           <ExpandingInfoButtonSlot />
         </LabelContainer>
       )}

--- a/frontend/src/lib-components/atoms/form/Checkbox.tsx
+++ b/frontend/src/lib-components/atoms/form/Checkbox.tsx
@@ -19,7 +19,6 @@ const diameter = '30px'
 const Wrapper = styled.div`
   display: flex;
   align-items: flex-start;
-  cursor: pointer;
   width: fit-content;
 
   &.disabled {
@@ -49,7 +48,6 @@ const LabelContainer = styled.div`
   font-size: 1rem;
   margin-top: 6px;
   margin-left: ${defaultMargins.s};
-  cursor: pointer;
 `
 
 const Box = styled.div`
@@ -104,6 +102,8 @@ const IconWrapper = styled.div`
 
   font-size: 25px;
   color: ${(p) => p.theme.colors.grayscale.g0};
+
+  pointer-events: none; // let click event go through icon to the checkbox
 `
 
 interface CommonProps extends BaseProps {
@@ -142,14 +142,7 @@ export default React.memo(function Checkbox({
   const ariaId = useUniqueId('checkbox')
 
   return (
-    <Wrapper
-      onClick={() => {
-        inputRef.current?.focus()
-        if (!disabled && onChange) onChange(!checked)
-      }}
-      className={classNames(className, { disabled })}
-      data-qa={dataQa}
-    >
+    <Wrapper className={classNames(className, { disabled })} data-qa={dataQa}>
       <Box>
         <CheckboxInput
           type="checkbox"
@@ -159,7 +152,7 @@ export default React.memo(function Checkbox({
           disabled={disabled}
           onChange={(e) => {
             e.stopPropagation()
-            if (onChange) onChange(!checked)
+            if (onChange) onChange(e.target.checked)
           }}
           readOnly={!onChange}
           ref={inputRef}

--- a/frontend/src/lib-components/atoms/form/Radio.tsx
+++ b/frontend/src/lib-components/atoms/form/Radio.tsx
@@ -19,7 +19,6 @@ const diameter = '36px'
 const Wrapper = styled.div`
   display: inline-flex;
   align-items: flex-start;
-  cursor: pointer;
   width: fit-content;
 
   &.disabled {
@@ -47,7 +46,6 @@ const Wrapper = styled.div`
 const LabelContainer = styled.div<SizeProps>`
   margin-top: ${(p) => (p.small ? '3px' : '6px')};
   margin-left: ${defaultMargins.s};
-  cursor: pointer;
 `
 
 interface SizeProps {
@@ -103,6 +101,8 @@ const IconWrapper = styled.div<SizeProps>`
 
   font-size: ${(p) => (p.small ? '20px' : '25px')};
   color: ${(p) => p.theme.colors.grayscale.g0};
+
+  pointer-events: none; // let click event go through icon to the radio button
 `
 
 type RadioProps = BaseProps & {
@@ -133,7 +133,6 @@ export default React.memo(function Radio({
     <Wrapper
       onClick={() => {
         inputRef.current?.focus()
-        if (!disabled && onChange) onChange()
       }}
       className={classNames(className, { disabled })}
       data-qa={dataQa}

--- a/frontend/src/lib-components/atoms/form/Radio.tsx
+++ b/frontend/src/lib-components/atoms/form/Radio.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames'
 import React, { ReactNode, useRef } from 'react'
 import styled from 'styled-components'
 
+import { useUniqueId } from 'lib-common/utils/useUniqueId'
 import { ExpandingInfoButtonSlot } from 'lib-components/molecules/ExpandingInfo'
 import { faCheck } from 'lib-icons'
 
@@ -125,7 +126,8 @@ export default React.memo(function Radio({
   ...props
 }: RadioProps) {
   const inputRef = useRef<HTMLInputElement>(null)
-  const ariaLabel: string = 'ariaLabel' in props ? props.ariaLabel : props.label
+
+  const ariaId = useUniqueId('radio')
 
   return (
     <Wrapper
@@ -141,7 +143,8 @@ export default React.memo(function Radio({
           type="radio"
           checked={checked}
           name={name}
-          aria-label={ariaLabel}
+          id={id ?? ariaId}
+          aria-label={'ariaLabel' in props ? props.ariaLabel : undefined}
           disabled={disabled}
           onChange={(e) => {
             e.stopPropagation()
@@ -150,14 +153,13 @@ export default React.memo(function Radio({
           readOnly={!onChange}
           ref={inputRef}
           small={small}
-          id={id}
         />
         <IconWrapper small={small}>
           <FontAwesomeIcon icon={faCheck} />
         </IconWrapper>
       </Circle>
       <LabelContainer small={small}>
-        <label htmlFor={id}>{props.label}</label>
+        <label htmlFor={id ?? ariaId}>{props.label}</label>
         <ExpandingInfoButtonSlot />
       </LabelContainer>
     </Wrapper>

--- a/frontend/src/lib-components/layout/Container.tsx
+++ b/frontend/src/lib-components/layout/Container.tsx
@@ -126,6 +126,7 @@ export const CollapsibleContentArea = React.memo(
           data-qa={props['data-qa'] ? `${props['data-qa']}-header` : undefined}
           className={classNames({ open })}
           role="button"
+          aria-expanded={open}
         >
           {title}
           <IconContainer>

--- a/frontend/src/lib-components/molecules/CollapsibleSection.tsx
+++ b/frontend/src/lib-components/molecules/CollapsibleSection.tsx
@@ -77,6 +77,9 @@ type CollapsibleSectionProps = BaseProps & {
   headingComponent?: React.FC<HeadingProps>
 }
 
+/**
+ * @deprecated use CollapsibleContentArea instead
+ */
 export default React.memo(function CollapsibleSection({
   title,
   icon,

--- a/frontend/src/lib-components/molecules/ExpandingInfo.tsx
+++ b/frontend/src/lib-components/molecules/ExpandingInfo.tsx
@@ -116,6 +116,7 @@ const ExpandingInfoToggleContext = React.createContext<
       ariaLabel: string
       margin?: SpacingSize
       dataQa?: string
+      expanded: boolean
       toggleExpanded: () => void
       hasSlot: (has: boolean) => void
     }
@@ -169,6 +170,7 @@ export default React.memo(function ExpandingInfo({
         aria-label={ariaLabel}
         margin={margin ?? 'zero'}
         data-qa={dataQa}
+        open={expanded}
       />
     </div>
   ) : (
@@ -179,6 +181,7 @@ export default React.memo(function ExpandingInfo({
         aria-label={ariaLabel}
         margin={margin ?? 'zero'}
         data-qa={dataQa}
+        open={expanded}
       />
     </FixedSpaceRow>
   )
@@ -190,7 +193,8 @@ export default React.memo(function ExpandingInfo({
         ariaLabel,
         margin,
         dataQa,
-        hasSlot: setHasSlot
+        hasSlot: setHasSlot,
+        expanded
       }}
     >
       <span aria-live="polite">
@@ -233,6 +237,7 @@ export const ExpandingInfoButtonSlot = React.memo(
         aria-label={info.ariaLabel}
         margin={info.margin ?? 'zero'}
         data-qa={info.dataQa}
+        open={info.expanded}
       />
     )
   }
@@ -243,13 +248,15 @@ export const InfoButton = React.memo(function InfoButton({
   'aria-label': ariaLabel,
   margin,
   className,
-  'data-qa': dataQa
+  'data-qa': dataQa,
+  open
 }: {
   onClick: React.MouseEventHandler<HTMLButtonElement>
   'aria-label': string
   margin?: SpacingSize
   className?: string
   'data-qa'?: string
+  open?: boolean
 }) {
   const { colors } = useTheme()
 
@@ -263,6 +270,7 @@ export const InfoButton = React.memo(function InfoButton({
       type="button"
       role="button"
       aria-label={ariaLabel}
+      aria-expanded={open}
     >
       <FontAwesomeIcon icon={fasInfo} />
     </RoundIconButton>

--- a/frontend/src/lib-components/molecules/ExpandingInfo.tsx
+++ b/frontend/src/lib-components/molecules/ExpandingInfo.tsx
@@ -109,6 +109,7 @@ type ExpandingInfoProps = {
   margin?: SpacingSize
   'data-qa'?: string
   inlineChildren?: boolean
+  closeLabel: string
 }
 
 const ExpandingInfoToggleContext = React.createContext<
@@ -138,7 +139,8 @@ export default React.memo(function ExpandingInfo({
   width = 'fixed',
   margin,
   'data-qa': dataQa,
-  inlineChildren
+  inlineChildren,
+  closeLabel
 }: ExpandingInfoProps) {
   const group = useContext(ExpandingInfoGroupContext)
 
@@ -204,6 +206,7 @@ export default React.memo(function ExpandingInfo({
             info={info}
             width={width}
             close={close}
+            closeLabel={closeLabel}
             data-qa={dataQa}
           />
         )}
@@ -286,13 +289,15 @@ export const ExpandingInfoBox = React.memo(function ExpandingInfoBox({
   close,
   width = 'fixed',
   className,
-  'data-qa': dataQa
+  'data-qa': dataQa,
+  closeLabel
 }: {
   info: ReactNode
   close: () => void
   width?: 'fixed' | 'full' | 'auto'
   className?: string
   'data-qa'?: string
+  closeLabel: string
 }) {
   const { colors } = useTheme()
 
@@ -305,7 +310,12 @@ export const ExpandingInfoBox = React.memo(function ExpandingInfoBox({
           {info}
         </InfoContainer>
 
-        <IconButton onClick={close} icon={faTimes} gray />
+        <IconButton
+          onClick={close}
+          icon={faTimes}
+          aria-label={closeLabel}
+          gray
+        />
       </InfoBoxContentArea>
     </InfoBoxContainer>
   )

--- a/frontend/src/lib-components/molecules/modals/BaseModal.tsx
+++ b/frontend/src/lib-components/molecules/modals/BaseModal.tsx
@@ -4,7 +4,7 @@
 
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React from 'react'
+import React, { FocusEventHandler, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import IconButton from 'lib-components/atoms/buttons/IconButton'
@@ -57,7 +57,17 @@ export default React.memo(function BaseModal(props: Props) {
                 <Gap size="m" />
               </>
             )}
-            {!!props.title && <H1 data-qa="title">{props.title}</H1>}
+            {!!props.title && (
+              <ModalHeader
+                headingComponent={(props) => (
+                  <H1 {...props} data-qa="title">
+                    {props.children}
+                  </H1>
+                )}
+              >
+                {props.title}
+              </ModalHeader>
+            )}
             {!!props.text && (
               <P data-qa="text" preserveWhiteSpace>
                 {props.text}
@@ -216,5 +226,29 @@ export const PlainModal = React.memo(function PlainModal(
         </ModalContainer>
       </StaticallyPositionedModal>
     </ModalBackground>
+  )
+})
+
+export const ModalHeader = React.memo(function ModalHeader({
+  children,
+  headingComponent: HeadingComponent = H1,
+  ...props
+}: {
+  children: React.ReactNode
+  headingComponent: React.ComponentType<{
+    tabIndex?: number
+    onBlur?: FocusEventHandler<HTMLElement>
+  }>
+}) {
+  const [isFocusable, setIsFocusable] = useState(true)
+
+  return (
+    <HeadingComponent
+      tabIndex={isFocusable ? 0 : undefined}
+      onBlur={() => setIsFocusable(false)}
+      {...props}
+    >
+      {children}
+    </HeadingComponent>
   )
 })

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -123,7 +123,9 @@ const en: Translations = {
     logout: 'Log out',
     openMenu: 'Open menu',
     closeMenu: 'Close menu',
-    goToHomepage: 'Go to homepage'
+    goToHomepage: 'Go to homepage',
+    notifications: 'notifications',
+    requiresStrongAuth: 'requires strong authentication'
   },
   footer: {
     cityLabel: '© City of Espoo',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -97,7 +97,8 @@ const en: Translations = {
         'December'
       ]
     },
-    closeModal: 'Close popup'
+    closeModal: 'Close popup',
+    close: 'Close'
   },
   header: {
     nav: {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -94,7 +94,8 @@ export default {
         'Joulukuu'
       ]
     },
-    closeModal: 'Sulje ponnahdusikkuna'
+    closeModal: 'Sulje ponnahdusikkuna',
+    close: 'Close'
   },
   header: {
     nav: {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -120,7 +120,9 @@ export default {
     logout: 'Kirjaudu ulos',
     openMenu: 'Avaa valikko',
     closeMenu: 'Sulje valikko',
-    goToHomepage: 'Siirry etusivulle'
+    goToHomepage: 'Siirry etusivulle',
+    notifications: 'ilmoitusta',
+    requiresStrongAuth: 'vaatii vahvan tunnistautumisen'
   },
   footer: {
     cityLabel: '© Espoon kaupunki',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -95,7 +95,8 @@ const sv: Translations = {
         'December'
       ]
     },
-    closeModal: 'Stäng popup'
+    closeModal: 'Stäng popup',
+    close: 'Stäng'
   },
   header: {
     nav: {

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -121,7 +121,9 @@ const sv: Translations = {
     logout: 'Logga ut',
     openMenu: 'Öppna menyn',
     closeMenu: 'Stäng menyn',
-    goToHomepage: 'Gå till hemsidan'
+    goToHomepage: 'Gå till hemsidan',
+    notifications: 'meddelanden',
+    requiresStrongAuth: 'kräver stark autentisering'
   },
   footer: {
     cityLabel: '© Esbo stad',

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -175,7 +175,8 @@ export const fi = {
     },
     nb: 'Huom',
     validTo: (date: string) => `Voimassa ${date} saakka`,
-    closeModal: 'Sulje ponnahdusikkuna'
+    closeModal: 'Sulje ponnahdusikkuna',
+    close: 'Sulje'
   },
   header: {
     applications: 'Hakemukset',


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
- Changed z-indexes to put holiday CTA banner under the mobile nav
- Updated font weight of H3s
- Modified AsyncButton to be more accessible
- Added aria-expanded to info buttons and expanding containers
- Modified selectable chips to be more accessible
- Modified language menu to hide abbreviations for screen readers, and make screen readers read the language in the actual language
- Added label for the close button in info boxes
- Fixed header double-reading links
- Added alt texts to income statements table
- Joined child name text nodes so that screen readers do not read them separately
- Improved accessibility of the children page by making the list of links a menu
- Fixed checkbox and radio button labels
- Made navigation items more accessible with more accurate labels
- Made modal headers focus first (does not work on iOS VoiceOver)