### PR TITLE
Replace regex with simple middleware

### DIFF
--- a/apigw/src/enduser/app.ts
+++ b/apigw/src/enduser/app.ts
@@ -5,7 +5,6 @@
 import cookieParser from 'cookie-parser'
 import express, { Router } from 'express'
 import helmet from 'helmet'
-import nocache from 'nocache'
 import passport from 'passport'
 import { requireAuthentication } from '../shared/auth'
 import createEvakaCustomerSamlStrategy, {
@@ -28,15 +27,20 @@ import session, {
 import publicRoutes from './publicRoutes'
 import routes from './routes'
 import authStatus from './routes/auth-status'
+import { cacheControl } from '../shared/middleware/cache-control'
 
 const app = express()
 const redisClient = createRedisClient()
 trustReverseProxy(app)
 app.set('etag', false)
 
-const allRoutesExceptChildImages =
-  /^(?!\/api\/application\/citizen\/child-images\/)/
-app.use(allRoutesExceptChildImages, nocache())
+app.use(
+  cacheControl((req) =>
+    req.path.startsWith('/api/application/citizen/child-images/')
+      ? 'allow-cache'
+      : 'forbid-cache'
+  )
+)
 
 app.use(
   helmet({

--- a/apigw/src/internal/app.ts
+++ b/apigw/src/internal/app.ts
@@ -5,7 +5,6 @@
 import cookieParser from 'cookie-parser'
 import express, { Router } from 'express'
 import helmet from 'helmet'
-import nocache from 'nocache'
 import passport from 'passport'
 import { requireAuthentication } from '../shared/auth'
 import createAdSamlStrategy, {
@@ -43,14 +42,20 @@ import mobileDeviceSession, {
 import authStatus from './routes/auth-status'
 import AsyncRedisClient from '../shared/async-redis-client'
 import expressBasicAuth from 'express-basic-auth'
+import { cacheControl } from '../shared/middleware/cache-control'
 
 const app = express()
 const redisClient = createRedisClient()
 trustReverseProxy(app)
 app.set('etag', false)
 
-const allRoutesExceptChildImages = /^(?!\/api\/internal\/child-images\/)/
-app.use(allRoutesExceptChildImages, nocache())
+app.use(
+  cacheControl((req) =>
+    req.path.startsWith('/api/internal/child-images/')
+      ? 'allow-cache'
+      : 'forbid-cache'
+  )
+)
 
 app.use(
   helmet({

--- a/apigw/src/shared/middleware/cache-control.ts
+++ b/apigw/src/shared/middleware/cache-control.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import express from 'express'
+import nocache from 'nocache'
+
+export const cacheControl = (
+  allowCaching: (req: express.Request) => 'allow-cache' | 'forbid-cache'
+): express.RequestHandler => {
+  const forbidCaching = nocache()
+  return (req, res, next) => {
+    return allowCaching(req) === 'allow-cache'
+      ? next()
+      : forbidCaching(req, res, next)
+  }
+}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Using a regex causes Datadog to include it in all paths, which makes it more difficult to understand metrics. Use string.startsWith instead.


![image](https://user-images.githubusercontent.com/94033/183361056-b9fe195f-f5ac-4cee-a8e3-dc16af5de736.png)
