### PR TITLE
EVAKA-4407 realtime staff attendance type in occupancy calculation

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
@@ -361,14 +361,11 @@ export default React.memo(function StaffAttendanceDetailsModal({
             ) : totalMinutes === 0 ? (
               '-'
             ) : (
-              `${Math.floor(totalMinutes / 60)}:${(totalMinutes % 60)
-                .toString()
-                .padStart(2, '0')}${
+              `${formatMinutes(totalMinutes)}${
                 plannedAttendances && plannedAttendances.length > 0
-                  ? ` (${Math.sign(diffPlannedTotalMinutes) === 1 ? '+' : ''}${
-                      Math.sign(diffPlannedTotalMinutes) *
-                      Math.floor(Math.abs(diffPlannedTotalMinutes) / 60)
-                    }.${Math.abs(diffPlannedTotalMinutes) % 60})`
+                  ? ` (${
+                      Math.sign(diffPlannedTotalMinutes) === 1 ? '+' : '-'
+                    }${formatMinutes(Math.abs(diffPlannedTotalMinutes))})`
                   : ''
               }`
             )}
@@ -630,6 +627,12 @@ function validateEditState(
   })
 
   return [body, errors]
+}
+
+function formatMinutes(minutes: number) {
+  return `${Math.floor(minutes / 60)}:${Math.floor(minutes % 60)
+    .toString()
+    .padStart(2, '0')}`
 }
 
 const Content = styled.div`

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FixtureBuilder.kt
@@ -475,6 +475,7 @@ class FixtureBuilder(
         private var to: HelsinkiDateTime? = null
         private var groupId: GroupId? = null
         private var coefficient: BigDecimal? = null
+        private var type: StaffAttendanceType? = null
 
         fun arriving(time: HelsinkiDateTime) = this.apply { this.from = time }
         fun arriving(date: LocalDate, time: LocalTime) = this.apply { this.from = HelsinkiDateTime.Companion.of(date, time) }
@@ -486,13 +487,15 @@ class FixtureBuilder(
 
         fun withCoefficient(coefficient: BigDecimal) = this.apply { this.coefficient = coefficient }
 
+        fun withType(type: StaffAttendanceType) = this.apply { this.type = type }
+
         fun inGroup(groupId: GroupId) = this.apply { this.groupId = groupId }
 
         fun save(): EmployeeFixture {
             tx.createUpdate(
                 """
-                INSERT INTO staff_attendance_realtime (employee_id, group_id, arrived, departed, occupancy_coefficient)
-                VALUES (:employeeId, :groupId, :arrived, :departed, :coefficient)
+                INSERT INTO staff_attendance_realtime (employee_id, group_id, arrived, departed, occupancy_coefficient, type)
+                VALUES (:employeeId, :groupId, :arrived, :departed, :coefficient, :type)
                 """.trimIndent()
             )
                 .bind("employeeId", employeeFixture.employeeId)
@@ -500,6 +503,7 @@ class FixtureBuilder(
                 .bind("arrived", from ?: error("arrival time must be set"))
                 .bind("departed", to)
                 .bind("coefficient", coefficient ?: error("occupancyCoefficient must be set"))
+                .bind("type", type ?: error("type must be set"))
                 .updateExactlyOne()
 
             return employeeFixture

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancyTest.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.FixtureBuilder
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.attendance.ExternalStaffArrival
 import fi.espoo.evaka.attendance.ExternalStaffDeparture
+import fi.espoo.evaka.attendance.StaffAttendanceType
 import fi.espoo.evaka.attendance.markExternalStaffArrival
 import fi.espoo.evaka.attendance.markExternalStaffDeparture
 import fi.espoo.evaka.attendance.occupancyCoefficientSeven
@@ -70,7 +71,8 @@ class RealtimeOccupancyTest : FullApplicationTest(resetDbBeforeEach = true) {
                 .withGroupAccess(testDaycare.id, groupId)
                 .saveAnd {
                     addRealtimeAttendance().inGroup(groupId).arriving(LocalTime.of(7, 0))
-                        .departing(LocalTime.of(16, 45)).withCoefficient(occupancyCoefficientSeven).save()
+                        .departing(LocalTime.of(16, 45)).withCoefficient(occupancyCoefficientSeven)
+                        .withType(StaffAttendanceType.PRESENT).save()
                 }
 
             tx.markExternalStaffArrival(

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/Occupancy.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.occupancy
 
+import fi.espoo.evaka.attendance.StaffAttendanceType
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.daycare.service.AbsenceCategory
 import fi.espoo.evaka.placement.PlacementType
@@ -229,11 +230,12 @@ private inline fun <reified K : OccupancyGroupingKey> Database.Read.getCaretaker
         sum(c.amount)
     """.trimIndent()
 
+    val presentStaffAttendanceTypes = "'{${StaffAttendanceType.values().filter { it.presentInGroup() }.joinToString()}}'::staff_attendance_type[]"
     val caretakersJoin = if (type == OccupancyType.REALIZED) """
         LEFT JOIN (
             SELECT group_id, arrived, departed, occupancy_coefficient
             FROM staff_attendance_realtime
-            WHERE departed IS NOT NULL
+            WHERE departed IS NOT NULL AND type = ANY($presentStaffAttendanceTypes)
             UNION ALL
             SELECT group_id, arrived, departed, occupancy_coefficient
             FROM staff_attendance_external

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancy.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/RealtimeOccupancy.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.occupancy
 
 import fi.espoo.evaka.ForceCodeGenType
+import fi.espoo.evaka.attendance.StaffAttendanceType
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -132,6 +133,7 @@ fun Database.Read.getChildOccupancyAttendances(
     .mapTo<ChildOccupancyAttendance>()
     .list()
 
+val presentStaffAttendanceTypes = "'{${StaffAttendanceType.values().filter { it.presentInGroup() }.joinToString()}}'::staff_attendance_type[]"
 fun Database.Read.getStaffOccupancyAttendances(
     unitId: DaycareId,
     timeRange: HelsinkiDateTimeRange
@@ -141,6 +143,7 @@ fun Database.Read.getStaffOccupancyAttendances(
     FROM staff_attendance_realtime sa
     JOIN daycare_group dg ON dg.id = sa.group_id
     WHERE dg.daycare_id = :unitId AND tstzrange(sa.arrived, sa.departed) && :timeRange
+    AND type = ANY($presentStaffAttendanceTypes)
     
     UNION ALL
     


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Leave out staff in training or other work from occupancy calculations since the staff is not actually present in a group. Also fix staff attendance total hours formatting.

