### PR TITLE
EVAKA-4469 Allow reading of employees for special ed teachers

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -165,7 +165,7 @@ sealed interface Action {
         ACCESS_MESSAGING(HasUnitRole(UNIT_SUPERVISOR, STAFF, SPECIAL_EDUCATION_TEACHER).inAnyUnit(), IsMobile(requirePinLogin = true).any()),
 
         CREATE_EMPLOYEE,
-        READ_EMPLOYEES(HasGlobalRole(SERVICE_WORKER), HasUnitRole(UNIT_SUPERVISOR).inAnyUnit()),
+        READ_EMPLOYEES(HasGlobalRole(SERVICE_WORKER), HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER).inAnyUnit()),
         SEARCH_EMPLOYEES;
 
         override fun toString(): String = "${javaClass.name}.$name"


### PR DESCRIPTION
Assistance need decision preparer/decision-maker dropdowns require access to the global employee list. Apparently the list of employees is not very secret internally, as one could use other organisational tools to access names and email addresses of the employees.

