### PR TITLE
EVAKA-4469 Update assistance need decision texts

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
@@ -156,11 +156,9 @@ describe('Assistance Need Decisions - Language', () => {
   })
 
   test('Change language to swedish', async () => {
-    await assistanceNeedDecisionEditPage.assertPageTitle(
-      'Päätös tuen tarpeesta'
-    )
+    await assistanceNeedDecisionEditPage.assertPageTitle('Päätös tuesta')
     await assistanceNeedDecisionEditPage.selectLanguage('Ruotsi')
-    await assistanceNeedDecisionEditPage.assertPageTitle('Beslut om stödbehov')
+    await assistanceNeedDecisionEditPage.assertPageTitle('Beslut om stöd')
     await assistanceNeedDecisionEditPage.waitUntilSaved()
 
     await page.goto(
@@ -172,9 +170,7 @@ describe('Assistance Need Decisions - Language', () => {
     )
     const assistanceNeedDecisionPreviewPage =
       new AssistanceNeedDecisionPreviewPage(page)
-    await assistanceNeedDecisionPreviewPage.assertPageTitle(
-      'Beslut om stödbehov'
-    )
+    await assistanceNeedDecisionPreviewPage.assertPageTitle('Beslut om stöd')
   })
 })
 

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1988,7 +1988,7 @@ const en: Translations = {
       title: 'Support need',
       unreadCount: 'unread',
       decisions: {
-        title: 'Support need decisions',
+        title: 'Support decisions',
         form: 'Form',
         assistanceLevel: 'Level of support',
         validityPeriod: 'Valid',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1917,7 +1917,7 @@ export default {
       title: 'Tuen tarve',
       unreadCount: 'lukematonta',
       decisions: {
-        title: 'Tuen tarpeen päätökset',
+        title: 'Tuen päätökset',
         form: 'Lomake',
         assistanceLevel: 'Tuen taso',
         validityPeriod: 'Voimassa',
@@ -1926,7 +1926,7 @@ export default {
         status: 'Tila',
         openDecision: 'Avaa päätös',
         decision: {
-          pageTitle: 'Päätös tuen tarpeesta',
+          pageTitle: 'Päätös tuesta',
           neededTypesOfAssistance: 'Lapsen tarvitsemat tuen muodot',
           pedagogicalMotivation: 'Pedagogiset tuen muodot ja perustelut',
           structuralMotivation: 'Rakenteelliset tuen muodot ja perustelut',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -1945,7 +1945,7 @@ const sv: Translations = {
       title: 'Behov av stöd',
       unreadCount: 'olästa',
       decisions: {
-        title: 'Beslut om behov av stöd',
+        title: 'Beslut om stöd',
         form: 'Form',
         assistanceLevel: 'Nivå av stöd',
         validityPeriod: 'Giltig',
@@ -1954,7 +1954,7 @@ const sv: Translations = {
         status: 'Status',
         openDecision: 'Öppet beslut',
         decision: {
-          pageTitle: 'Beslut om stödbehov',
+          pageTitle: 'Beslut om stöd',
           neededTypesOfAssistance: 'Former av stöd enligt barnets behov',
           pedagogicalMotivation: 'Former och motiveringar för pedagogiskt stöd',
           structuralMotivation: 'Strukturella former av stöd och motivering',

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -40,7 +40,7 @@ export const fi = {
     welcomePage: 'Tervetuloa eVakaan',
     vasuPage: 'Vasu 2021',
     vasuTemplates: 'Vasu-pohjat',
-    assistanceNeedDecision: 'Päätös tuen tarpeesta'
+    assistanceNeedDecision: 'Päätös tuesta'
   },
   common: {
     yes: 'Kyllä',
@@ -692,10 +692,10 @@ export const fi = {
       }
     },
     assistanceNeedDecision: {
-      pageTitle: 'Päätös tuen tarpeesta',
-      sectionTitle: 'Tuen tarpeen päätökset',
+      pageTitle: 'Päätös tuesta',
+      sectionTitle: 'Tuen päätökset',
       description:
-        'Hyväksytyt ja hylätyt päätökset tuen tarpeesta näkyvät huoltajalle eVakassa.',
+        'Hyväksytyt ja hylätyt päätökset tuesta näkyvät huoltajalle eVakassa.',
       table: {
         form: 'Lomake',
         inEffect: 'Voimassa',
@@ -2692,8 +2692,8 @@ export const fi = {
         'Vähemmän pitkälle jalostettu laaja tietoaineisto, josta voi itse muodostaa erilaisia raportteja.'
     },
     assistanceNeedDecisions: {
-      title: 'Tuen tarpeen päätökset',
-      description: 'Päättäjälle lähetetyt tuen tarpeen päätökset.',
+      title: 'Tuen päätökset',
+      description: 'Päättäjälle lähetetyt tuen päätökset.',
       sentToDecisionMaker: 'Lähetetty päättäjälle',
       decisionMade: 'Päätös tehty',
       status: 'Tila',
@@ -2748,9 +2748,9 @@ export const fi = {
         'assistance_need.child_id': 'Tuen tarpeita',
         'assistance_need_decision.child_id': 'Tuen tarpeen päätöksiä',
         'assistance_need_decision_guardian.person_id':
-          'Tuen tarpeen päätöksen huoltajana',
+          'Tuen päätöksen huoltajana',
         'assistance_need_voucher_coefficient.child_id':
-          'Tuen tarpeen palvelusetelikertoimia',
+          'Tuen palvelusetelikertoimia',
         'attachment.uploaded_by_person': 'Liitteitä',
         'attendance_reservation.child_id': 'Läsnäolo -varauksia',
         'attendance_reservation.created_by_guardian_id':

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/sv.tsx
@@ -14,7 +14,7 @@ export const sv = {
     ...fi.childInformation,
     assistanceNeedDecision: {
       ...fi.childInformation.assistanceNeedDecision,
-      pageTitle: 'Beslut om stödbehov',
+      pageTitle: 'Beslut om stöd',
       genericPlaceholder: 'Skriv',
       formLanguage: 'Formulärets språk',
       neededTypesOfAssistance: 'Former av stöd enligt barnets behov',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
@@ -42,7 +42,6 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 private val logger = KotlinLogging.logger {}
 
@@ -379,7 +378,7 @@ class AssistanceNeedDecisionIntegrationTest : FullApplicationTest(resetDbBeforeE
 
         val messages = MockSfiMessagesClient.getMessages()
         assertEquals(1, messages.size)
-        assertContains(messages[0].first.messageContent, "päätös tuen tarpeesta")
+        assertContains(messages[0].first.messageContent, "päätös tuesta")
         assertNotNull(messages[0].second)
     }
 
@@ -490,12 +489,10 @@ class AssistanceNeedDecisionIntegrationTest : FullApplicationTest(resetDbBeforeE
             MockEmailClient.emails.map { it.toAddress }.toSet()
         )
         assertEquals(
-            "Päätös tuen tarpeesta / Beslut om behov av stöd / Decision on support need",
+            "Päätös eVakassa / Beslut i eVaka / Decision on eVaka",
             getEmailFor(testAdult_4).subject
         )
         assertEquals("Test email sender fi <testemail_fi@test.com>", getEmailFor(testAdult_4).fromAddress)
-        assertTrue(getEmailFor(testAdult_4).htmlBody.contains("/children/${testChild_1.id}/assistance-need-decision/${assistanceNeedDecision.id}"))
-        assertTrue(getEmailFor(testAdult_4).textBody.contains("/children/${testChild_1.id}/assistance-need-decision/${assistanceNeedDecision.id}"))
     }
 
     private fun getEmailFor(person: DevPerson): MockEmail {

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
@@ -96,9 +96,9 @@ class AssistanceNeedDecisionService(
                     "$decisionId - $guardianId",
                     email,
                     fromAddress,
-                    emailMessageProvider.getAssistanceNeedDecisionEmailSubject(),
-                    emailMessageProvider.getAssistanceNeedDecisionEmailHtml(decision.child.id, decision.id),
-                    emailMessageProvider.getAssistanceNeedDecisionEmailText(decision.child.id, decision.id)
+                    emailMessageProvider.getDecisionEmailSubject(),
+                    emailMessageProvider.getDecisionEmailHtml(decision.child.id, decision.id),
+                    emailMessageProvider.getDecisionEmailText(decision.child.id, decision.id)
                 )
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -13,7 +13,7 @@ class EvakaEmailMessageProvider : IEmailMessageProvider {
     override val subjectForClubApplicationReceivedEmail: String = "Olemme vastaanottaneet hakemuksenne / Vi har tagit emot din ansökan / We have received your application"
     override val subjectForDaycareApplicationReceivedEmail: String = "Olemme vastaanottaneet hakemuksenne / Vi har tagit emot din ansökan / We have received your application"
     override val subjectForPreschoolApplicationReceivedEmail: String = "Olemme vastaanottaneet hakemuksenne / Vi har tagit emot din ansökan / We have received your application"
-    override val subjectForAssistanceNeedDecisionEmail: String = "Päätös tuen tarpeesta / Beslut om behov av stöd / Decision on support need"
+    override val subjectForDecisionEmail: String = "Päätös eVakassa / Beslut i eVaka / Decision on eVaka"
 
     override fun getPendingDecisionEmailHtml(): String {
         return """
@@ -517,44 +517,44 @@ class EvakaEmailMessageProvider : IEmailMessageProvider {
             """.trimIndent()
     }
 
-    override fun getAssistanceNeedDecisionEmailHtml(
+    override fun getDecisionEmailHtml(
         childId: ChildId,
         decisionId: AssistanceNeedDecisionId
     ): String = """
         <p>Hyvä(t) huoltaja(t),</p>
-        <p>Lapsellenne on tehty päätös tuen tarpeesta.</p>
-        <p>Päätös on nähtävissä eVakassa osoitteessa <a href="https://www.espoonvarhaiskasvatus.fi/children/$childId/assistance-need-decision/$decisionId">https://www.espoonvarhaiskasvatus.fi/children/$childId/assistance-need-decision/$decisionId</a>.</p>
+        <p>Lapsellenne on tehty päätös.</p>
+        <p>Päätös on nähtävissä eVakassa osoitteessa <a href="https://www.espoonvarhaiskasvatus.fi/">https://www.espoonvarhaiskasvatus.fi/</a>.</p>
         <hr>
         <p>Bästa vårdnadshavare,</p>
-        <p>Beslut har fattats om ditt barns behov av stöd.</p>
-        <p>Beslutet finns att se i eVaka på <a href="https://www.esbosmabarnspedagogik.fi/children/$childId/assistance-need-decision/$decisionId">https://www.esbosmabarnspedagogik.fi/children/$childId/assistance-need-decision/$decisionId</a>.</p>
+        <p>Beslut har fattats angående ditt barn.</p>
+        <p>Beslutet finns att se i eVaka på <a href="https://www.esbosmabarnspedagogik.fi/">https://www.esbosmabarnspedagogik.fi/</a>.</p>
         <hr>
         <p>Dear guardian(s),</p>
-        <p>A decision has been made on your child's need for support.</p>
-        <p>The decision can be viewed on eVaka at <a href="https://www.espoonvarhaiskasvatus.fi/children/$childId/assistance-need-decision/$decisionId">https://www.espoonvarhaiskasvatus.fi/children/$childId/assistance-need-decision/$decisionId</a>.</p>
+        <p>A decision has been made regarding your child.</p>
+        <p>The decision can be viewed on eVaka at <a href="https://www.espoonvarhaiskasvatus.fi/">https://www.espoonvarhaiskasvatus.fi/</a>.</p>
     """.trimIndent()
 
-    override fun getAssistanceNeedDecisionEmailText(childId: ChildId, decisionId: AssistanceNeedDecisionId): String = """
+    override fun getDecisionEmailText(childId: ChildId, decisionId: AssistanceNeedDecisionId): String = """
         Hyvä(t) huoltaja(t),
         
-        Lapsellenne on tehty päätös tuen tarpeesta.
+        Lapsellenne on tehty päätös.
         
-        Päätös on nähtävissä eVakassa osoitteessa https://www.espoonvarhaiskasvatus.fi/children/$childId/assistance-need-decision/$decisionId.
+        Päätös on nähtävissä eVakassa osoitteessa https://www.espoonvarhaiskasvatus.fi/.
         
         -----
         
         Bästa vårdnadshavare,
         
-        Beslut har fattats om ditt barns behov av stöd.
+        Beslut har fattats angående ditt barn.
         
-        Beslutet finns att se i eVaka på https://www.esbosmabarnspedagogik.fi/children/$childId/assistance-need-decision/$decisionId.
+        Beslutet finns att se i eVaka på https://www.esbosmabarnspedagogik.fi/.
         
         -----
         
         Dear guardian(s),
         
-        A decision has been made on your child's need for support.
+        A decision has been made regarding your child.
         
-        The decision can be viewed on eVaka at https://www.espoonvarhaiskasvatus.fi/children/$childId/assistance-need-decision/$decisionId.
+        The decision can be viewed on eVaka at https://www.espoonvarhaiskasvatus.fi/.
     """.trimIndent()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
@@ -13,7 +13,7 @@ interface IEmailMessageProvider {
     val subjectForClubApplicationReceivedEmail: String
     val subjectForDaycareApplicationReceivedEmail: String
     val subjectForPreschoolApplicationReceivedEmail: String
-    val subjectForAssistanceNeedDecisionEmail: String
+    val subjectForDecisionEmail: String
 
     fun getPendingDecisionEmailSubject(): String {
         return subjectForPendingDecisionEmail + getMessagePostfix()
@@ -43,12 +43,12 @@ interface IEmailMessageProvider {
     fun getPreschoolApplicationReceivedEmailHtml(withinApplicationPeriod: Boolean): String
     fun getPreschoolApplicationReceivedEmailText(withinApplicationPeriod: Boolean): String
 
-    fun getAssistanceNeedDecisionEmailSubject(): String {
-        return subjectForAssistanceNeedDecisionEmail + getMessagePostfix()
+    fun getDecisionEmailSubject(): String {
+        return subjectForDecisionEmail + getMessagePostfix()
     }
 
-    fun getAssistanceNeedDecisionEmailHtml(childId: ChildId, decisionId: AssistanceNeedDecisionId): String
-    fun getAssistanceNeedDecisionEmailText(childId: ChildId, decisionId: AssistanceNeedDecisionId): String
+    fun getDecisionEmailHtml(childId: ChildId, decisionId: AssistanceNeedDecisionId): String
+    fun getDecisionEmailText(childId: ChildId, decisionId: AssistanceNeedDecisionId): String
 
     private fun getMessagePostfix(): String {
         return if (System.getenv("VOLTTI_ENV") == "staging") " [staging]" else ""

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageProvider.kt
@@ -82,7 +82,7 @@ Klientavgiften för småbarnspedagogik gäller tills vidare och familjen är sky
     override fun getAssistanceNeedDecisionContent(lang: MessageLanguage): String = when (lang) {
         MessageLanguage.FI ->
             """
-            Lapsellenne on tehty päätös tuen tarpeesta. Voit katsella päätöstä eVakassa.
+            Lapsellenne on tehty päätös tuesta. Voit katsella päätöstä eVakassa.
     
             Koska olette ottanut Suomi.fi -palvelun käyttöönne, on päätös myös luettavissa alla olevista liitteistä.
             
@@ -94,7 +94,7 @@ Klientavgiften för småbarnspedagogik gäller tills vidare och familjen är sky
             """.trimIndent()
         MessageLanguage.SV ->
             """
-            Beslut om behov av stöd har fattats för ditt barn. Du kan se beslutet i eVaka.
+            Beslut om behov har fattats för ditt barn. Du kan se beslutet i eVaka.
             
             Eftersom du har tagit Suomi.fi-tjänsten i bruk, kan du också läsa beslutet i bilagorna nedan.
             """.trimIndent()

--- a/service/src/main/resources/WEB-INF/templates/assistance-need/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/assistance-need/decision.properties
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: 2017-2021 City of Espoo
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
-header.1=PÄÄTÖS tuen tarpeesta
+header.1=PÄÄTÖS tuesta
 header.2=<strong>Salassapidettävä</strong><br />Varhaiskasvatuslaki 15 §
 
-decision.title=PÄÄTÖS TUEN TARPEESTA
+decision.title=PÄÄTÖS TUESTA
 
 decision.details.child.prefix=Lapsellenne
 decision.details.child={0} (s. {1})
-decision.details.date=<strong>on tehty päätös tuen tarpeesta ajalle</strong>
+decision.details.date=<strong>on tehty päätös tuesta ajalle</strong>
 
 neededTypesOfAssistance=Lapsen tarvitsemat tuen muodot
 pedagogicalMotivation=Pedagogiset tuen muodot ja perustelut

--- a/service/src/main/resources/WEB-INF/templates/assistance-need/decision_sv.properties
+++ b/service/src/main/resources/WEB-INF/templates/assistance-need/decision_sv.properties
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: 2017-2021 City of Espoo
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
-header.1=BESLUT om stödbehov
+header.1=BESLUT om stöd
 header.2=<strong>Konfidentiellt</strong><br />Lagen om småbarnspedagogik 15 §
 
-decision.title=BESLUT OM STÖDBEHOV
+decision.title=BESLUT OM STÖD
 
 decision.details.child.prefix=Till ert barn
 decision.details.child={0} (f. {1})
-decision.details.date=<strong>har gjorts beslut om stödbehov för tiden</strong>
+decision.details.date=<strong>har gjorts beslut om stöd för tiden</strong>
 
 
 neededTypesOfAssistance=Former av stöd enligt barnets behov


### PR DESCRIPTION
#### Summary
- The official term does not contain "need", i.e., "tuen päätös" not "tuen tarpeen päätös"
- The email message and title shouldn't contain information that can tell the reader it is a decision regarding assistance
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

