### PR TITLE
EVAKA-4557 Oulu invoicing changes

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -3836,7 +3836,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val period = DateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 1, 31))
 
         // 14 operational days first
-        // then 1 sickleabe
+        // then 1 sickleave
         val sickleaveDays = listOf(LocalDate.of(2019, 1, 22) to AbsenceType.SICKLEAVE)
         // then planned absences
         val plannedAbsenceDays = listOf(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -195,5 +195,6 @@ val testFeatureConfig = FeatureConfig(
     paymentNumberSeriesStart = 9000000000,
     unplannedAbsencesAreContractSurplusDays = true,
     maxContractDaySurplusThreshold = null,
+    useContractDaysAsDailyFeeDivisor = true,
     enabledChildConsentTypes = setOf(ChildConsentType.EVAKA_PROFILE_PICTURE),
 )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -194,5 +194,6 @@ val testFeatureConfig = FeatureConfig(
     invoiceNumberSeriesStart = 5000000000,
     paymentNumberSeriesStart = 9000000000,
     unplannedAbsencesAreContractSurplusDays = true,
+    maxContractDaySurplusThreshold = null,
     enabledChildConsentTypes = setOf(ChildConsentType.EVAKA_PROFILE_PICTURE),
 )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -193,5 +193,6 @@ val testFeatureConfig = FeatureConfig(
     alwaysUseDaycareFinanceDecisionHandler = false,
     invoiceNumberSeriesStart = 5000000000,
     paymentNumberSeriesStart = 9000000000,
+    unplannedAbsencesAreContractSurplusDays = true,
     enabledChildConsentTypes = setOf(ChildConsentType.EVAKA_PROFILE_PICTURE),
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -126,6 +126,7 @@ class EspooConfig {
         invoiceNumberSeriesStart = 5000000000,
         paymentNumberSeriesStart = 1, // Payments are not yet in use in Espoo
         unplannedAbsencesAreContractSurplusDays = false, // Doesn't affect Espoo
+        maxContractDaySurplusThreshold = null, // Doesn't affect Espoo
         enabledChildConsentTypes = setOf(ChildConsentType.EVAKA_PROFILE_PICTURE),
     )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -125,6 +125,7 @@ class EspooConfig {
         alwaysUseDaycareFinanceDecisionHandler = false, // Doesn't affect Espoo
         invoiceNumberSeriesStart = 5000000000,
         paymentNumberSeriesStart = 1, // Payments are not yet in use in Espoo
+        unplannedAbsencesAreContractSurplusDays = false, // Doesn't affect Espoo
         enabledChildConsentTypes = setOf(ChildConsentType.EVAKA_PROFILE_PICTURE),
     )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -127,6 +127,7 @@ class EspooConfig {
         paymentNumberSeriesStart = 1, // Payments are not yet in use in Espoo
         unplannedAbsencesAreContractSurplusDays = false, // Doesn't affect Espoo
         maxContractDaySurplusThreshold = null, // Doesn't affect Espoo
+        useContractDaysAsDailyFeeDivisor = true, // Doesn't affect Espoo
         enabledChildConsentTypes = setOf(ChildConsentType.EVAKA_PROFILE_PICTURE),
     )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -85,8 +85,6 @@ class InvoiceGenerator(private val draftInvoiceGenerator: DraftInvoiceGenerator)
         val operationalDays = tx.operationalDays(range.start.year, range.start.month)
 
         val allAbsences = tx.getAbsenceStubs(range, setOf(AbsenceCategory.BILLABLE))
-
-        val absences = allAbsences.filter { it.absenceType != AbsenceType.PLANNED_ABSENCE }
         val plannedAbsences =
             allAbsences.filter { it.absenceType == AbsenceType.PLANNED_ABSENCE }.groupBy { it.childId }
                 .map { (childId, absences) -> childId to absences.map { it.date }.toSet() }.toMap()
@@ -105,7 +103,7 @@ class InvoiceGenerator(private val draftInvoiceGenerator: DraftInvoiceGenerator)
             areaIds = areaIds,
             operationalDays = operationalDays,
             feeThresholds = feeThresholds,
-            absences = absences,
+            absences = allAbsences,
             plannedAbsences = plannedAbsences,
             freeChildren = freeChildren,
             codebtors = codebtors

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -74,6 +74,9 @@ data class FeatureConfig(
     /** Optionally set a threshold of surplus contract days after which the monthly maximum is invoiced. */
     val maxContractDaySurplusThreshold: Int?,
 
+    /** Controls whether to use the number of contract days or the number of operational days as daily price divisor */
+    val useContractDaysAsDailyFeeDivisor: Boolean,
+
     /** Enabled child consent types
      *
      * All of the enabled child consent types. The consent section will be hidden if no consent

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -68,6 +68,9 @@ data class FeatureConfig(
      */
     val paymentNumberSeriesStart: Long?,
 
+    /** Controls whether unplanned absences are counted as surplus contract days on invoices or not */
+    val unplannedAbsencesAreContractSurplusDays: Boolean,
+
     /** Enabled child consent types
      *
      * All of the enabled child consent types. The consent section will be hidden if no consent

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -71,6 +71,9 @@ data class FeatureConfig(
     /** Controls whether unplanned absences are counted as surplus contract days on invoices or not */
     val unplannedAbsencesAreContractSurplusDays: Boolean,
 
+    /** Optionally set a threshold of surplus contract days after which the monthly maximum is invoiced. */
+    val maxContractDaySurplusThreshold: Int?,
+
     /** Enabled child consent types
      *
      * All of the enabled child consent types. The consent section will be hidden if no consent


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
- Make effect of unplanned absences in contract days invoicing configurable
- Add an optional maximum to contract days surpluses after which the invoice defaults to monthly maximum
- Add option to split contract day invoices by the number of operational days instead of contract days

