### PR TITLE
EVAKA-4574 Require backup care to be during a placement

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1014,17 +1014,18 @@ export function createPreschoolDaycarePlacementFixture(
 export function createBackupCareFixture(
   childId: string,
   unitId: string,
-  groupId?: string
+  groupId?: string,
+  period: { start: string; end: string } = {
+    start: '2023-02-01',
+    end: '2023-02-03'
+  }
 ): BackupCare {
   return {
     id: 'b501d5e7-efcd-49e9-9371-23262b5cd51f',
     childId,
     unitId: unitId,
     groupId,
-    period: {
-      start: '2023-02-01',
-      end: '2023-02-03'
-    }
+    period
   }
 }
 

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -147,6 +147,14 @@ describe('Sending and receiving messages', () => {
       })
 
       test('Unit supervisor sends a message to backup care child and citizen replies', async () => {
+        await Fixture.placement()
+          .with({
+            childId: enduserChildFixtureKaarina.id,
+            unitId: fixtures.daycareFixturePrivateVoucher.id,
+            startDate: LocalDate.todayInSystemTz().formatIso(),
+            endDate: LocalDate.todayInSystemTz().formatIso()
+          })
+          .save()
         await insertBackupCareFixtures([
           {
             id: uuidv4(),

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -9,6 +9,8 @@ import {
   Page as PlaywrightPage
 } from 'playwright'
 
+import LocalDate from 'lib-common/local-date'
+
 import { EvakaBrowserContextOptions, newBrowserContext } from '../browser'
 
 import { BoundingBox, waitUntilDefined, waitUntilEqual, waitUntilTrue } from '.'
@@ -267,8 +269,8 @@ export class DatePicker extends Element {
 export class DatePickerDeprecated extends Element {
   #input = new TextInput(this.find('input'))
 
-  async fill(text: string) {
-    await this.#input.fill(text)
+  async fill(text: string | LocalDate) {
+    await this.#input.fill(typeof text === 'string' ? text : text.format())
     await this.#input.press('Enter')
   }
 }

--- a/frontend/src/employee-frontend/components/child-information/BackupCare.tsx
+++ b/frontend/src/employee-frontend/components/child-information/BackupCare.tsx
@@ -5,14 +5,12 @@
 import orderBy from 'lodash/orderBy'
 import React, { useContext, useEffect, useState } from 'react'
 
-import { Loading } from 'lib-common/api'
 import { UUID } from 'lib-common/types'
 import Loader from 'lib-components/atoms/Loader'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { H2 } from 'lib-components/typography'
 
-import { getChildBackupCares } from '../../api/child/backup-care'
 import BackupCareForm from '../../components/child-information/backup-care/BackupCareForm'
 import BackupCareRow from '../../components/child-information/backup-care/BackupCareRow'
 import { ChildContext } from '../../state'
@@ -26,20 +24,15 @@ export interface Props {
 
 export default function BackupCare({ id, startOpen }: Props) {
   const { i18n } = useTranslation()
-  const { backupCares, setBackupCares, permittedActions } =
+  const { backupCares, loadBackupCares, permittedActions } =
     useContext(ChildContext)
   const { uiMode, toggleUiMode } = useContext(UIContext)
 
   const [open, setOpen] = useState(startOpen)
 
   useEffect(() => {
-    void getChildBackupCares(id).then((backupCares) => {
-      setBackupCares(backupCares)
-    })
-    return () => {
-      setBackupCares(Loading.of())
-    }
-  }, [id, setBackupCares])
+    void loadBackupCares()
+  }, [id, loadBackupCares])
 
   return (
     <CollapsibleContentArea

--- a/frontend/src/employee-frontend/components/child-information/Placements.tsx
+++ b/frontend/src/employee-frontend/components/child-information/Placements.tsx
@@ -32,8 +32,12 @@ interface Props {
 
 export default React.memo(function Placements({ id, startOpen }: Props) {
   const { i18n } = useTranslation()
-  const { placements, loadPlacements, reloadPermittedActions } =
-    useContext<ChildState>(ChildContext)
+  const {
+    placements,
+    loadPlacements,
+    reloadPermittedActions,
+    loadBackupCares
+  } = useContext<ChildState>(ChildContext)
   const [serviceNeedOptions] = useApiState(getServiceNeedOptions, [])
   const { uiMode, toggleUiMode } = useContext(UIContext)
 
@@ -91,6 +95,7 @@ export default React.memo(function Placements({ id, startOpen }: Props) {
                     placement={p}
                     onRefreshNeeded={() => {
                       loadPlacements()
+                      void loadBackupCares()
                       reloadPermittedActions()
                     }}
                     checkOverlaps={checkOverlaps}

--- a/frontend/src/employee-frontend/components/child-information/backup-care/BackupCareRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/backup-care/BackupCareRow.tsx
@@ -12,10 +12,7 @@ import Title from 'lib-components/atoms/Title'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { faQuestion } from 'lib-icons'
 
-import {
-  getChildBackupCares,
-  removeBackupCare
-} from '../../../api/child/backup-care'
+import { removeBackupCare } from '../../../api/child/backup-care'
 import BackupCareForm from '../../../components/child-information/backup-care/BackupCareForm'
 import Toolbar from '../../../components/common/Toolbar'
 import { ChildContext } from '../../../state'
@@ -58,7 +55,7 @@ export default function BackupCareRow({
 }: Props) {
   const { i18n } = useTranslation()
   const { uiMode, toggleUiMode, clearUiMode } = useContext(UIContext)
-  const { setBackupCares } = useContext(ChildContext)
+  const { loadBackupCares } = useContext(ChildContext)
 
   return (
     <div>
@@ -75,9 +72,7 @@ export default function BackupCareRow({
             action: () =>
               removeBackupCare(backupCare.id)
                 .then(() => clearUiMode())
-                .then(() =>
-                  getChildBackupCares(childId).then((sn) => setBackupCares(sn))
-                ),
+                .then(() => loadBackupCares()),
             label: i18n.common.remove
           }}
         />

--- a/frontend/src/employee-frontend/components/common/Toolbar.tsx
+++ b/frontend/src/employee-frontend/components/common/Toolbar.tsx
@@ -84,13 +84,11 @@ function Toolbar({
   const { roles } = useContext(UserContext)
 
   const editAllowed: boolean =
-    editable ||
-    (editableFor === undefined && editable === undefined) ||
-    (editableFor !== undefined && requireRole(roles, ...editableFor))
+    editable !== false &&
+    (editableFor === undefined || requireRole(roles, ...editableFor))
   const deleteAllowed: boolean =
-    deletable ||
-    (deletableFor === undefined && deletable === undefined) ||
-    (deletableFor !== undefined && requireRole(roles, ...deletableFor))
+    deletable !== false &&
+    (deletableFor === undefined || requireRole(roles, ...deletableFor))
 
   return (
     <ToolbarWrapper data-qa={dataQa}>

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -89,7 +89,7 @@ interface Props {
     staffAttendanceIds: UUID[],
     externalStaffAttendanceIds: UUID[]
   ) => Promise<Result<void>[]>
-  reloadStaffAttendances: () => Promise<void>
+  reloadStaffAttendances: () => Promise<Result<unknown>>
   groups: Result<DaycareGroup[]>
   groupFilter: (id: UUID) => boolean
   selectedGroup: UUID | null
@@ -500,7 +500,7 @@ interface AttendanceRowProps extends BaseProps {
     staffAttendanceIds: UUID[],
     externalStaffAttendanceIds: UUID[]
   ) => Promise<Result<void>[]>
-  reloadStaffAttendances: () => Promise<void>
+  reloadStaffAttendances: () => Promise<Result<unknown>>
   openDetails?: (v: { employeeId: string; date: LocalDate }) => void
   groupFilter: (id: UUID) => boolean
   selectedGroup: UUID | null // for new attendances

--- a/frontend/src/lib-common/finite-date-range.ts
+++ b/frontend/src/lib-common/finite-date-range.ts
@@ -84,12 +84,12 @@ export default class FiniteDateRange {
   }
 
   leftAdjacentTo(other: FiniteDateRange | DateRange): boolean {
-    return this.end.addDays(1) == other.start
+    return this.end.addDays(1).isEqual(other.start)
   }
 
   rightAdjacentTo(other: FiniteDateRange | DateRange): boolean {
     if (other.end) {
-      return other.end.addDays(1) == this.start
+      return other.end.addDays(1).isEqual(this.start)
     } else {
       return false
     }

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -1061,7 +1061,9 @@ export const fi = {
       serviceNeedMissingTooltip2: 'päivältä.',
       deletePlacement: {
         btn: 'Poista sijoitus',
-        confirmTitle: 'Haluatko varmasti perua tämän sijoituksen?'
+        confirmTitle: 'Haluatko varmasti perua tämän sijoituksen?',
+        hasDependingBackupCares:
+          'Lapsen varasijoitus on riippuvainen tästä sijoituksesta, joten tämän sijoituksen poistaminen voi muuttaa tai poistaa varasijoituksen.'
       },
       createPlacement: {
         btn: 'Luo uusi sijoitus',
@@ -1081,7 +1083,9 @@ export const fi = {
       },
       warning: {
         overlap: 'Ajalle on jo sijoitus',
-        ghostUnit: 'Yksikkö on merkitty haamuyksiköksi'
+        ghostUnit: 'Yksikkö on merkitty haamuyksiköksi',
+        backupCareDepends:
+          'Varasijoitus on riippuvainen tästä sijoituksesta, ja muutettu aikaväli voi poistaa tai muttaa varasijoitusta.'
       },
       serviceNeeds: {
         title: 'Sijoituksen palveluntarpeet',
@@ -1124,7 +1128,9 @@ export const fi = {
       editing: 'muokkauksessa',
       create: 'Luo uusi varasijoitus',
       dateRange: 'Varasijoitus ajalle',
-      unit: 'Yksikkö'
+      unit: 'Yksikkö',
+      validationNoMatchingPlacement:
+        'Varasijoitus ei ole minkään lapsen sijoituksen aikana.'
     },
     backupPickups: {
       title: 'Varahakijat',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
@@ -128,6 +128,7 @@ class DaycareControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
         db.transaction {
             it.insertTestDaycareGroup(group)
             it.createDaycareGroupMessageAccount(group.id)
+            it.insertTestPlacement(childId = childId, unitId = daycareId)
             it.insertTestBackupCare(
                 DevBackupCare(
                     childId = childId,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -404,6 +404,12 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         createExpiredDailyNote(now)
 
         val validNoteId = db.transaction {
+            it.insertTestPlacement(
+                unitId = testDaycare.id,
+                childId = testChild_2.id,
+                startDate = LocalDate.now().minusDays(150),
+                endDate = LocalDate.now().plusDays(150)
+            )
             it.insertTestBackupCare(
                 DevBackupCare(
                     childId = testChild_2.id,

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareQueries.kt
@@ -149,3 +149,105 @@ WHERE id = :id
 """
 ).bind("id", id)
     .execute()
+
+fun Database.Read.getBackupCareChildId(id: BackupCareId): ChildId = createQuery(
+    // language=SQL
+    """
+    SELECT child_id FROM backup_care WHERE id = :id
+    """.trimIndent()
+)
+    .bind("id", id)
+    .mapTo<ChildId>()
+    .one()
+
+fun Database.Transaction.deleteOrMoveConflictingBackupCares(childId: ChildId, oldRange: FiniteDateRange, newRange: FiniteDateRange?) {
+    if (newRange == null) {
+        createUpdate(
+            // language=SQL
+            """
+            DELETE FROM backup_care
+            WHERE child_id = :childId AND :range @> daterange(start_date, end_date, '[]')
+            """.trimIndent()
+        )
+            .bind("childId", childId)
+            .bind("range", oldRange)
+            .execute()
+
+        createUpdate(
+            // language=SQL
+            """
+            UPDATE backup_care
+            SET end_date = :startDate - INTERVAL '1 day'
+            WHERE child_id = :childId AND :startDate BETWEEN start_date AND end_date
+            """.trimIndent()
+        )
+            .bind("childId", childId)
+            .bind("startDate", oldRange.start)
+            .execute()
+
+        createUpdate(
+            // language=SQL
+            """
+            UPDATE backup_care
+            SET start_date = :endDate + INTERVAL '1 day'
+            WHERE child_id = :childId AND :endDate BETWEEN start_date AND end_date
+            """.trimIndent()
+        )
+            .bind("childId", childId)
+            .bind("endDate", oldRange.end)
+            .execute()
+    } else {
+        createUpdate(
+            // language=SQL
+            """
+            DELETE FROM backup_care
+            WHERE child_id = :childId
+               -- delete backup cares that were previously wholly contained within the range but would no longer
+              AND (daterange(start_date, end_date, '[]') @> :oldRange AND NOT(daterange(start_date, end_date, '[]') @> :newRange))
+               -- also delete backup cares that would have reversed validity period after shrinking
+               OR (start_date BETWEEN :oldStart AND :newStart AND :newStart > end_date)
+               OR (end_date BETWEEN :newEnd AND :oldEnd AND :newEnd < start_date)
+            """.trimIndent()
+        )
+            .bind("childId", childId)
+            .bind("oldRange", oldRange)
+            .bind("newRange", newRange)
+            .bind("newStart", newRange.start)
+            .bind("oldStart", oldRange.start)
+            .bind("newEnd", newRange.end)
+            .bind("oldEnd", oldRange.end)
+            .execute()
+
+        if (newRange.start.isAfter(oldRange.start)) {
+            // the range was shrunk by moving the start date to a later date
+            createUpdate(
+                // language=SQL
+                """
+                UPDATE backup_care
+                SET start_date = :newStart
+                WHERE child_id = :childId AND start_date BETWEEN :oldStart AND :newStart
+                """.trimIndent()
+            )
+                .bind("childId", childId)
+                .bind("newStart", newRange.start)
+                .bind("oldStart", oldRange.start)
+                .execute()
+        }
+
+        if (newRange.end.isBefore(oldRange.end)) {
+            // the range was shrunk by moving the end date to an earlier date
+            createUpdate(
+                // language=SQL
+                """
+                UPDATE backup_care
+                SET end_date = :newEnd
+                WHERE child_id = :childId AND end_date BETWEEN :newEnd AND :oldEnd
+                """.trimIndent()
+            )
+                .bind("childId", childId)
+                .bind("newEnd", newRange.end)
+                .bind("oldEnd", oldRange.end)
+                .execute()
+        }
+    }
+}


### PR DESCRIPTION
#### Summary

- Added database trigger to enforce that backup cares must be during a placement
  - Triggers both ways: when placements are modified/deleted, or when backup cares are modified/added
- Added automatic adjusting of backup care validity periods when placements are modified/deleted
- Added UI elements to warn about automatic adjusting of backup care periods whenever relevant
