### PR TITLE
Fix unit page resetting URL state

### DIFF
--- a/frontend/src/employee-frontend/components/UnitPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitPage.tsx
@@ -9,7 +9,13 @@ import React, {
   useMemo,
   useState
 } from 'react'
-import { Navigate, Route, Routes, useNavigate } from 'react-router-dom'
+import {
+  Navigate,
+  Route,
+  Routes,
+  useNavigate,
+  useSearchParams
+} from 'react-router-dom'
 import styled from 'styled-components'
 
 import { UnitResponse } from 'employee-frontend/api/unit'
@@ -99,12 +105,17 @@ const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
       .join(',')
   }
 
+  const [searchParams, setSearchParams] = useSearchParams()
+
   useEffect(() => {
     const openList = openGroupsToStringList(openGroups)
-    openList.length > 0
-      ? navigate(`?open_groups=${openList}`, { replace: true })
-      : navigate('?', { replace: true })
-  }, [openGroups, navigate])
+    if (openList.length > 0) {
+      searchParams.set('open_groups', openList)
+      setSearchParams(searchParams, {
+        replace: true
+      })
+    }
+  }, [openGroups, navigate, setSearchParams, searchParams])
 
   const tabs = useMemo(
     () => [

--- a/frontend/src/lib-common/utils/useSyncQueryParams.ts
+++ b/frontend/src/lib-common/utils/useSyncQueryParams.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import isEqual from 'lodash/isEqual'
+import partition from 'lodash/partition'
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
@@ -13,15 +14,17 @@ export function useSyncQueryParams(queryParams: Record<string, string>) {
   const [currentParams, setSearchParams] = useSearchParams()
 
   useEffect(() => {
-    if (
-      !isEqual(
-        Object.fromEntries(Array.from(currentParams.entries())),
-        queryParams
+    const [relevantParams, extraParams] = partition(
+      Array.from(currentParams.entries()),
+      ([key]) => Object.keys(queryParams).includes(key)
+    )
+    if (!isEqual(Object.fromEntries(relevantParams), queryParams)) {
+      setSearchParams(
+        { ...Object.fromEntries(extraParams), ...queryParams },
+        {
+          replace: true
+        }
       )
-    ) {
-      setSearchParams(queryParams, {
-        replace: true
-      })
     }
   }, [currentParams, queryParams, setSearchParams])
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The main unit page reset the URL state, causing the calendar state to be reset on page load.