### PR TITLE
Fix flaky mobile messages e2e test

### DIFF
--- a/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
@@ -270,6 +270,7 @@ describe('Child message thread', () => {
     await userSeesNewMessagesIndicator()
     await staffLoginsToMessagesPage()
 
+    await nav.selectGroup(daycareGroup.data.id)
     await messagesPage.messagesExist()
     await messagesPage.openFirstThread()
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The unit groups were sometimes inserted out-of-order (i.e., sometimes "daycareGroup2" was before "daycareGroup" in the table), which caused the first (and as such selected by default) group to be the "second group" in the employee mobile; one test assumed the first group is always the first group in the database, but when this didn't happen the wrong group was selected (by default) and no messages were displayed for this unrelated group.