### PR TITLE
Use update instead of upsert for message drafts

### DIFF
--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -210,9 +210,9 @@ export interface UnreadCountByAccountAndGroup {
 }
 
 /**
-* Generated from fi.espoo.evaka.messaging.UpsertableDraftContent
+* Generated from fi.espoo.evaka.messaging.UpdatableDraftContent
 */
-export interface UpsertableDraftContent {
+export interface UpdatableDraftContent {
   content: string
   recipientIds: UUID[]
   recipientNames: string[]

--- a/frontend/src/lib-components/employee/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/employee/messages/MessageEditor.tsx
@@ -13,7 +13,7 @@ import {
   DraftContent,
   AuthorizedMessageAccount,
   PostMessageBody,
-  UpsertableDraftContent
+  UpdatableDraftContent
 } from 'lib-common/generated/api-types/messaging'
 import { UUID } from 'lib-common/types'
 import { useDebounce } from 'lib-common/utils/useDebounce'
@@ -55,13 +55,13 @@ import Combobox from '../../atoms/dropdowns/Combobox'
 import Checkbox from '../../atoms/form/Checkbox'
 import { InfoBox } from '../../molecules/MessageBoxes'
 
-type Message = UpsertableDraftContent & {
+type Message = UpdatableDraftContent & {
   sender: ReactSelectOption
   recipientAccountIds: UUID[]
   attachments: Attachment[]
 }
 
-const messageToUpsertableDraftWithAccount = (m: Message): Draft => ({
+const messageToUpdatableDraftWithAccount = (m: Message): Draft => ({
   content: m.content,
   urgent: m.urgent,
   recipientIds: m.recipientIds,
@@ -212,7 +212,7 @@ export default React.memo(function MessageEditor({
 
   useEffect(
     function syncDraftContentOnMessageChanges() {
-      contentTouched && setDraft(messageToUpsertableDraftWithAccount(message))
+      contentTouched && setDraft(messageToUpdatableDraftWithAccount(message))
     },
     [contentTouched, message, setDraft]
   )

--- a/frontend/src/lib-components/employee/messages/types.ts
+++ b/frontend/src/lib-components/employee/messages/types.ts
@@ -6,7 +6,7 @@ import {
   Group,
   MessageReceiver,
   AuthorizedMessageAccount,
-  UpsertableDraftContent
+  UpdatableDraftContent
 } from 'lib-common/generated/api-types/messaging'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
@@ -24,7 +24,7 @@ export const isGroupMessageAccount = (
 export interface SaveDraftParams {
   accountId: UUID
   draftId: UUID
-  content: UpsertableDraftContent
+  content: UpdatableDraftContent
 }
 
 export const deserializeReceiver = (

--- a/frontend/src/lib-components/employee/messages/useDraft.ts
+++ b/frontend/src/lib-components/employee/messages/useDraft.ts
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import { Result } from 'lib-common/api'
-import { UpsertableDraftContent } from 'lib-common/generated/api-types/messaging'
+import { UpdatableDraftContent } from 'lib-common/generated/api-types/messaging'
 import { UUID } from 'lib-common/types'
 import { isAutomatedTest } from 'lib-common/utils/helpers'
 import { useDebouncedCallback } from 'lib-common/utils/useDebouncedCallback'
@@ -14,7 +14,7 @@ import { SaveDraftParams } from 'lib-components/employee/messages/types'
 
 type SaveState = 'clean' | 'dirty' | 'saving'
 
-export type Draft = UpsertableDraftContent & { accountId: UUID }
+export type Draft = UpdatableDraftContent & { accountId: UUID }
 
 const draftToSaveParams = ({ accountId, ...content }: Draft, id: string) => ({
   content,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/DraftQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/DraftQueriesTest.kt
@@ -39,7 +39,7 @@ class DraftQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         val id = db.transaction { it.initDraft(accountId) }
 
-        val fullContent = UpsertableDraftContent(
+        val fullContent = UpdatableDraftContent(
             type = type,
             title = title,
             content = content,
@@ -47,20 +47,20 @@ class DraftQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             recipientNames = recipientNames,
             urgent = false
         )
-        upsert(id, fullContent)
+        update(id, fullContent)
         assertContent(fullContent)
 
-        upsert(id, fullContent.copy(title = "Dogs"))
+        update(id, fullContent.copy(title = "Dogs"))
         assertContent(fullContent.copy(title = "Dogs"))
 
         db.transaction { it.deleteDraft(accountId, id) }
         assertEquals(0, db.read { it.getDrafts(accountId) }.size)
     }
 
-    private fun upsert(draftId: MessageDraftId, content: UpsertableDraftContent) =
-        db.transaction { it.upsertDraft(accountId, draftId, content) }
+    private fun update(draftId: MessageDraftId, content: UpdatableDraftContent) =
+        db.transaction { it.updateDraft(accountId, draftId, content) }
 
-    private fun assertContent(expected: UpsertableDraftContent) {
+    private fun assertContent(expected: UpdatableDraftContent) {
         val actual = db.read { it.getDrafts(accountId)[0] }
         assertEquals(expected.title, actual.title)
         assertEquals(expected.type, actual.type)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/DraftContent.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/DraftContent.kt
@@ -23,7 +23,7 @@ data class DraftContent(
     val attachments: List<MessageAttachment>,
 )
 
-data class UpsertableDraftContent(
+data class UpdatableDraftContent(
     val type: MessageType,
     val title: String,
     val content: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/DraftQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/DraftQueries.kt
@@ -7,7 +7,6 @@ package fi.espoo.evaka.messaging
 import fi.espoo.evaka.shared.MessageAccountId
 import fi.espoo.evaka.shared.MessageDraftId
 import fi.espoo.evaka.shared.db.Database
-import org.jdbi.v3.core.kotlin.bindKotlin
 
 fun Database.Read.getDrafts(accountId: MessageAccountId): List<DraftContent> =
     this.createQuery(
@@ -44,7 +43,7 @@ fun Database.Transaction.initDraft(accountId: MessageAccountId): MessageDraftId 
         .one()
 }
 
-fun Database.Transaction.upsertDraft(accountId: MessageAccountId, id: MessageDraftId, draft: UpsertableDraftContent) =
+fun Database.Transaction.updateDraft(accountId: MessageAccountId, id: MessageDraftId, draft: UpdatableDraftContent) =
     createUpdate(
         """
         UPDATE message_draft

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/DraftQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/DraftQueries.kt
@@ -44,26 +44,24 @@ fun Database.Transaction.initDraft(accountId: MessageAccountId): MessageDraftId 
         .one()
 }
 
-fun Database.Transaction.upsertDraft(accountId: MessageAccountId, id: MessageDraftId, draft: UpsertableDraftContent) {
-    this.createUpdate(
+fun Database.Transaction.upsertDraft(accountId: MessageAccountId, id: MessageDraftId, draft: UpsertableDraftContent) =
+    createUpdate(
         """
-        INSERT INTO message_draft (id, account_id, title, content, urgent, type, recipient_ids, recipient_names)
-        VALUES (:id, :accountId, :title, :content, :urgent, :type, :recipientIds, :recipientNames)
-        ON CONFLICT (id)
-        DO UPDATE SET
-             account_id = excluded.account_id,
-             title = excluded.title,
-             content = excluded.content,
-             urgent = excluded.urgent,
-             type = excluded.type,
-             recipient_ids = excluded.recipient_ids,
-             recipient_names = excluded.recipient_names
+        UPDATE message_draft
+        SET
+            account_id = :accountId,
+            title = :title,
+            content = :content,
+            urgent = :urgent,
+            type = :type,
+            recipient_ids = :recipientIds,
+            recipient_names = :recipientNames
+        WHERE id = :id
         """.trimIndent()
     ).bindKotlin(draft)
         .bind("id", id)
         .bind("accountId", accountId)
-        .execute()
-}
+        .updateExactlyOne()
 
 fun Database.Transaction.deleteDraft(accountId: MessageAccountId, draftId: MessageDraftId) {
     this.createUpdate("DELETE FROM message_draft WHERE id = :id AND account_id = :accountId")

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -193,12 +193,12 @@ class MessageController(
         user: AuthenticatedUser,
         @PathVariable accountId: MessageAccountId,
         @PathVariable draftId: MessageDraftId,
-        @RequestBody content: UpsertableDraftContent,
+        @RequestBody content: UpdatableDraftContent,
     ) {
         Audit.MessagingUpdateDraft.log(accountId, draftId)
         return db.connect { dbc ->
             requireMessageAccountAccess(dbc, user, accountId)
-            dbc.transaction { it.upsertDraft(accountId, draftId, content) }
+            dbc.transaction { it.updateDraft(accountId, draftId, content) }
         }
     }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This is a workaround for some E2E test flakiness caused by draft updates happening *after* a draft has been deleted.