### PR TITLE
Do not show absence category selection if only one option is possible

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-diary-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-diary-page.ts
@@ -2,7 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { AbsenceType } from 'lib-common/generated/api-types/daycare'
+import {
+  AbsenceCategory,
+  AbsenceType
+} from 'lib-common/generated/api-types/daycare'
+import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
 import { waitUntilEqual } from '../../../utils'
@@ -23,7 +27,10 @@ export class UnitDiaryPage {
   #groupSelector = new Select(
     this.page.find('[data-qa="attendances-group-select"]')
   )
-  #childRows = this.page.findAll('[data-qa="absence-child-row"]')
+  #absenceCell = (childId: UUID, date: LocalDate) =>
+    new AbsenceCell(
+      this.page.findByDataQa(`absence-cell-${childId}-${date.formatIso()}`)
+    )
 
   #staffAttendanceCells = this.page.findAll('[data-qa="staff-attendance-cell"]')
   #addAbsencesButton = this.page.find('[data-qa="add-absences-button"]')
@@ -36,31 +43,50 @@ export class UnitDiaryPage {
     await waitUntilEqual(() => this.#groupSelector.selectedOption, groupId)
   }
 
-  async addAbsenceToChild(n: number, type: AbsenceType | 'NO_ABSENCE') {
-    const childRow = new DiaryChildRow(this.#childRows.nth(n))
-    await childRow.selectDay(0)
+  async addAbsenceToChild(
+    childId: UUID,
+    date: LocalDate,
+    type: AbsenceType | 'NO_ABSENCE',
+    categories: AbsenceCategory[] = []
+  ) {
+    await this.#absenceCell(childId, date).select()
     await this.#addAbsencesButton.click()
 
     const modal = new AbsenceModal(this.page.find('[data-qa="absence-modal"]'))
     await modal.selectAbsenceType(type)
-    await modal.selectBillableCaretype()
+    for (const category of categories) {
+      await modal.selectAbsenceCategory(category)
+    }
     await modal.submit()
   }
 
-  async childHasAbsence(n: number, type: AbsenceType) {
-    const childRow = new DiaryChildRow(this.#childRows.nth(n))
-    await childRow.assertAbsenceType(0, type)
+  async childHasAbsence(
+    childId: UUID,
+    date: LocalDate,
+    type: AbsenceType,
+    category: AbsenceCategory
+  ) {
+    await this.#absenceCell(childId, date).assertAbsenceType(type, category)
   }
 
-  async assertTooltipContains(n: number, expectedTexts: string[]) {
-    const childRow = new DiaryChildRow(this.#childRows.nth(n))
-    const tooltipText = await childRow.hoverAndGetTooltip(n)
+  async assertTooltipContains(
+    childId: UUID,
+    date: LocalDate,
+    expectedTexts: string[]
+  ) {
+    const tooltipText = await this.#absenceCell(
+      childId,
+      date
+    ).hoverAndGetTooltip()
     return expectedTexts.every((text) => tooltipText.includes(text))
   }
 
-  async childHasNoAbsence(n: number) {
-    const childRow = new DiaryChildRow(this.#childRows.nth(n))
-    await childRow.assertNoAbsence(0)
+  async childHasNoAbsence(
+    childId: UUID,
+    date: LocalDate,
+    category: AbsenceCategory
+  ) {
+    await this.#absenceCell(childId, date).assertNoAbsence(category)
   }
 
   async fillStaffAttendance(n: number, staffCount: number) {
@@ -77,46 +103,49 @@ export class UnitDiaryPage {
   }
 }
 
-export class DiaryChildRow extends Element {
-  #absenceCells = this.findAll('[data-qa="absence-cell"]')
-
-  async selectDay(n: number) {
-    await this.#absenceCells.nth(n).click()
+export class AbsenceCell extends Element {
+  constructor(private cell: Element) {
+    super(cell)
   }
 
-  async assertAbsenceType(n: number, type: AbsenceType) {
-    await this.#absenceCells
-      .nth(n)
-      .find(`.absence-cell-right-${type}`)
+  async select() {
+    await this.locator.click()
+  }
+
+  async assertAbsenceType(
+    type: AbsenceType | 'empty',
+    category: AbsenceCategory
+  ) {
+    await this.cell
+      .find(
+        `.absence-cell-${category === 'BILLABLE' ? 'right' : 'left'}-${type}`
+      )
       .waitUntilVisible()
   }
 
-  async assertNoAbsence(n: number) {
-    await this.#absenceCells
-      .nth(n)
-      .find(`.absence-cell-right-empty`)
-      .waitUntilVisible()
+  async assertNoAbsence(category: AbsenceCategory) {
+    await this.assertAbsenceType('empty', category)
   }
 
-  async hoverAndGetTooltip(n: number): Promise<string> {
-    const cell = this.#absenceCells.nth(n)
-    await cell.hover()
-    return (await cell.findByDataQa('absence-cell-tooltip').textContent) || ''
+  async hoverAndGetTooltip(): Promise<string> {
+    await this.cell.hover()
+    return (
+      (await this.cell.findByDataQa('absence-cell-tooltip').textContent) || ''
+    )
   }
 }
 
 export class AbsenceModal extends Modal {
   #absenceTypeRadio = (type: AbsenceType | 'NO_ABSENCE') =>
     new Radio(this.find(`[data-qa="absence-type-${type}"]`))
-  #checkboxBillable = new Checkbox(
-    this.find('[data-qa="absences-select-BILLABLE"]')
-  )
+  #categoryCheckbox = (category: AbsenceCategory) =>
+    new Checkbox(this.findByDataQa(`absences-select-${category}`))
 
   async selectAbsenceType(type: AbsenceType | 'NO_ABSENCE') {
     await this.#absenceTypeRadio(type).check()
   }
 
-  async selectBillableCaretype() {
-    await this.#checkboxBillable.check()
+  async selectAbsenceCategory(category: AbsenceCategory) {
+    await this.#categoryCheckbox(category).check()
   }
 }

--- a/frontend/src/employee-frontend/components/absences/AbsenceModal.tsx
+++ b/frontend/src/employee-frontend/components/absences/AbsenceModal.tsx
@@ -24,6 +24,7 @@ export default React.memo(function AbsenceModal({
   onCancel,
   selectedAbsenceType,
   setSelectedAbsenceType,
+  showCategorySelection,
   selectedCategories,
   updateCategories
 }: {
@@ -32,6 +33,7 @@ export default React.memo(function AbsenceModal({
   onCancel: () => void
   selectedAbsenceType: AbsenceType | null
   setSelectedAbsenceType: (value: AbsenceType | null) => void
+  showCategorySelection: boolean
   selectedCategories: AbsenceCategory[]
   updateCategories: (value: AbsenceCategory) => void
 }) {
@@ -68,18 +70,22 @@ export default React.memo(function AbsenceModal({
           />
         </FixedSpaceColumn>
 
-        <Label>{i18n.absences.modal.placementSectionLabel}</Label>
-        <FixedSpaceColumn spacing="xs">
-          {absenceCategories.map((category, index) => (
-            <Checkbox
-              key={index}
-              label={i18n.absences.absenceCategories[category]}
-              checked={selectedCategories.includes(category)}
-              onChange={() => updateCategories(category)}
-              data-qa={`absences-select-${category}`}
-            />
-          ))}
-        </FixedSpaceColumn>
+        {showCategorySelection && (
+          <>
+            <Label>{i18n.absences.modal.placementSectionLabel}</Label>
+            <FixedSpaceColumn spacing="xs">
+              {absenceCategories.map((category, index) => (
+                <Checkbox
+                  key={index}
+                  label={i18n.absences.absenceCategories[category]}
+                  checked={selectedCategories.includes(category)}
+                  onChange={() => updateCategories(category)}
+                  data-qa={`absences-select-${category}`}
+                />
+              ))}
+            </FixedSpaceColumn>
+          </>
+        )}
       </FixedSpaceColumn>
     </FormModal>
   )

--- a/frontend/src/employee-frontend/components/absences/AbsenceTable.tsx
+++ b/frontend/src/employee-frontend/components/absences/AbsenceTable.tsx
@@ -110,7 +110,7 @@ const AbsenceTableRow = React.memo(function AbsenceTableRow({
             className={`${
               date.isToday() ? 'absence-cell-today' : ''
             } hover-highlight absence-cell-wrapper`}
-            data-qa="absence-cell"
+            data-qa={`absence-cell-${child.id}-${date.formatIso()}`}
           >
             <AbsenceCell
               selectedCells={selectedCells}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
If every selected cell in the absence table only has one possible absence category, hide the category selection from the absence modal and use the only possible value.

