### PR TITLE
Fix child income statement flaky e2e

### DIFF
--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-income-statement.spec.ts
@@ -91,6 +91,6 @@ describe('Child Income statements', () => {
 
     // Delete
     await child1ISList.deleteChildIncomeStatement(0)
-    await child1ISList.assertChildIncomeStatementRowCount(0)
+    await child1ISList.assertIncomeStatementMissingWarningIsShown()
   })
 })


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

When there are no rows, the table is replaced with a warning – thus, no table element exists when there are 0 rows.