### PR TITLE
Only parse request body when it's actually needed

### DIFF
--- a/apigw/src/enduser/app.ts
+++ b/apigw/src/enduser/app.ts
@@ -54,7 +54,6 @@ app.get('/health', (_, res) => {
     : res.status(200).json({ status: 'UP' })
 })
 app.use(tracing)
-app.use(express.json())
 app.use(cookieParser())
 app.use(session('enduser', redisClient))
 app.use(touchSessionMaxAge)

--- a/apigw/src/internal/app.ts
+++ b/apigw/src/internal/app.ts
@@ -69,7 +69,6 @@ app.get('/health', (_, res) => {
     : res.status(200).json({ status: 'UP' })
 })
 app.use(tracing)
-app.use(express.json({ limit: '8mb' }))
 app.use(session('employee', redisClient))
 app.use(touchSessionMaxAge)
 app.use(cookieParser(cookieSecret))
@@ -135,7 +134,7 @@ function internalApiRouter() {
     router.get('/auth/mobile-e2e-signup', devApiE2ESignup)
   }
 
-  router.post('/auth/mobile', mobileDeviceSession)
+  router.post('/auth/mobile', express.json(), mobileDeviceSession)
 
   router.use(checkMobileEmployeeIdToken(new AsyncRedisClient(redisClient)))
 
@@ -154,10 +153,12 @@ function internalApiRouter() {
   router.use(csrf)
   router.post(
     '/auth/pin-login',
+    express.json(),
     pinLoginRequestHandler(new AsyncRedisClient(redisClient))
   )
   router.post(
     '/auth/pin-logout',
+    express.json(),
     pinLogoutRequestHandler(new AsyncRedisClient(redisClient))
   )
   router.post(

--- a/apigw/src/shared/routes/auth/saml/index.ts
+++ b/apigw/src/shared/routes/auth/saml/index.ts
@@ -39,7 +39,7 @@ function getDefaultPageUrl(req: express.Request): string {
 }
 
 function getRedirectUrl(req: express.Request): string {
-  const relayState = req.body.RelayState || req.query.RelayState
+  const relayState = req.body?.RelayState || req.query.RelayState
 
   if (typeof relayState === 'string' && path.isAbsolute(relayState)) {
     if (evakaBaseUrl === 'local') {


### PR DESCRIPTION
#### Summary

This should solve unexpected occurences of `PayloadTooLargeError`, as well as enhance performance of proxied requests a bit.
