### PR TITLE
Fix AsyncButton double-submissions

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkDepartedPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkDepartedPage.tsx
@@ -54,7 +54,9 @@ export default React.memo(function StaffMarkDepartedPage() {
   }>()
 
   const { unitInfoResponse, reloadUnitInfo } = useContext(UnitContext)
-  useEffect(reloadUnitInfo, [reloadUnitInfo])
+  useEffect(() => {
+    reloadUnitInfo()
+  }, [reloadUnitInfo])
 
   const { staffAttendanceResponse, reloadStaffAttendance } = useContext(
     StaffAttendanceContext

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -212,6 +212,7 @@ export interface ExternalStaffDepartureRequest {
 export interface ExternalStaffMember {
   arrived: HelsinkiDateTime
   groupId: UUID
+  hasFutureAttendances: boolean
   id: UUID
   name: string
 }
@@ -324,6 +325,7 @@ export interface StaffMember {
   employeeId: UUID
   firstName: string
   groupIds: UUID[]
+  hasFutureAttendances: boolean
   lastName: string
   latestCurrentDayAttendance: StaffMemberAttendance | null
   plannedAttendances: PlannedStaffAttendance[]

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -106,7 +106,7 @@ function AsyncButton<T>({
       if (preventDefault) e.preventDefault()
 
       if (!mountedRef.current) return
-      if (isInProgress) return
+      if (isInProgress || isSuccess) return
 
       const maybePromise = onClick()
       if (maybePromise === undefined) {
@@ -114,8 +114,7 @@ function AsyncButton<T>({
       } else {
         setButtonState(inProgress)
         maybePromise
-          .then(async (result) => {
-            await new Promise((r) => setTimeout(r, 1000))
+          .then((result) => {
             if (!mountedRef.current) return
             if (result.isSuccess) {
               handleSuccess(result.value)
@@ -148,7 +147,14 @@ function AsyncButton<T>({
           })
       }
     },
-    [preventDefault, isInProgress, onClick, handleSuccess, handleFailure]
+    [
+      preventDefault,
+      isInProgress,
+      onClick,
+      handleSuccess,
+      handleFailure,
+      isSuccess
+    ]
   )
 
   useEffect(() => {

--- a/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
+++ b/frontend/src/lib-customizations/espoo/employee-mobile-frontend/assets/i18n/fi.ts
@@ -238,7 +238,9 @@ export const fi = {
       differenceReason: 'Kirjaa syy',
       differenceInfo:
         'Saavut työvuorostasi poikkeavaan aikaan. Valitse syykoodi.',
-      differenceInfoToggle: 'Poikkeaa työvuorostasi'
+      differenceInfoToggle: 'Poikkeaa työvuorostasi',
+      hasFutureAttendance:
+        'Sinulla on tulevaisuuteen merkittu läsnäolo, joten et voi kirjautua läsnäolevaksi.'
     }
   },
   childInfo: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceQueriesTest.kt
@@ -116,7 +116,7 @@ class RealtimeStaffAttendanceQueriesTest : PureJdbiTest(resetDbBeforeEach = true
             }
             tx.markExternalStaffArrival(ExternalStaffArrival("Foo Present", group1.id, now.minusDays(1), occupancyCoefficientSeven))
         }
-        val externalAttendances = db.read { it.getExternalStaffAttendances(testDaycare.id) }
+        val externalAttendances = db.read { it.getExternalStaffAttendances(testDaycare.id, now) }
 
         assertEquals(1, externalAttendances.size)
         assertEquals("Foo Present", externalAttendances[0].name)

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
@@ -45,7 +45,7 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
             dbc.read {
                 CurrentDayStaffAttendanceResponse(
                     staff = it.getStaffAttendances(unitId, evakaClock.now()),
-                    extraAttendances = it.getExternalStaffAttendances(unitId)
+                    extraAttendances = it.getExternalStaffAttendances(unitId, evakaClock.now())
                 )
             }
         }
@@ -185,7 +185,7 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
 
         db.connect { dbc ->
             // todo: convert to action auth
-            val attendance = dbc.read { it.getExternalStaffAttendance(body.attendanceId) }
+            val attendance = dbc.read { it.getExternalStaffAttendance(body.attendanceId, evakaClock.now()) }
                 ?: throw NotFound("attendance not found")
             ac.requirePermissionFor(user, Action.Group.MARK_EXTERNAL_DEPARTURE, attendance.groupId)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
@@ -45,6 +45,7 @@ data class ExternalStaffMember(
     val name: String,
     val groupId: GroupId,
     val arrived: HelsinkiDateTime,
+    val hasFutureAttendances: Boolean
 )
 
 data class StaffMember(
@@ -57,7 +58,8 @@ data class StaffMember(
     @Json
     val attendances: List<StaffMemberAttendance>,
     @Json
-    val plannedAttendances: List<PlannedStaffAttendance>
+    val plannedAttendances: List<PlannedStaffAttendance>,
+    val hasFutureAttendances: Boolean
 ) {
     val present: GroupId?
         get() = latestCurrentDayAttendance?.takeIf { it.departed == null && it.type.presentInGroup() }?.groupId


### PR DESCRIPTION
#### Summary
- **Remove debugging delay** that was accidentally merged, which delayed all AsyncButton successes by 1 second
- Prevent another request from being sent when the success state is visible, as it is possible the onSuccess handler will prevent the user from redoing the same action (e.g., via redirection)
- Show a warning for future staff attendances that will prevent the staff member from logging in

<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

