### PR TITLE
Flaky E2E fix: make sure the correct group is selected

### DIFF
--- a/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
@@ -213,6 +213,7 @@ describe('Child message thread', () => {
     await citizenSendsMessageToGroup()
     await userSeesNewMessagesIndicator()
     await employeeLoginsToMessagesPage()
+    await nav.selectGroup(daycareGroupId)
     await waitUntilTrue(() => messagesPage.messagesExist())
   })
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Fixes E2E test flakiness caused by asserting messages on the wrong group page