### PR TITLE
EVAKA-4590 Update assistance need decision

### DIFF
--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-page.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-page.spec.ts
@@ -769,9 +769,7 @@ describe('Citizen assistance need decision page', () => {
     )
     await waitUntilEqual(
       () => assistanceNeedDecisionPage.preparedBy1,
-      `${serviceWorker.firstName} ${serviceWorker.lastName}, teacher\n${
-        serviceWorker.email ?? ''
-      }\n010202020202`
+      `${serviceWorker.firstName} ${serviceWorker.lastName}, teacher\n010202020202`
     )
     await waitUntilEqual(
       () => assistanceNeedDecisionPage.decisionMaker,

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
@@ -170,7 +170,9 @@ describe('Assistance Need Decisions - Language', () => {
   })
 
   test('Change language to swedish', async () => {
-    await assistanceNeedDecisionEditPage.assertPageTitle('Päätös tuesta')
+    await assistanceNeedDecisionEditPage.assertPageTitle(
+      'Päätös tuesta varhaiskasvatuksessa'
+    )
     await assistanceNeedDecisionEditPage.selectLanguage('Ruotsi')
     await assistanceNeedDecisionEditPage.assertPageTitle('Beslut om stöd')
     await assistanceNeedDecisionEditPage.waitUntilSaved()
@@ -268,9 +270,7 @@ describe('Assistance Need Decisions - Preview page', () => {
     )
     await waitUntilEqual(
       () => assistanceNeedDecisionPreviewPage.preparedBy1,
-      `${serviceWorker.firstName} ${serviceWorker.lastName}, teacher\n${
-        serviceWorker.email ?? ''
-      }\n010202020202`
+      `${serviceWorker.firstName} ${serviceWorker.lastName}, teacher\n010202020202`
     )
     await waitUntilEqual(
       () => assistanceNeedDecisionPreviewPage.decisionMaker,

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
@@ -501,20 +501,20 @@ export default React.memo(function AssistanceNeedDecisionForm({
       <FixedSpaceColumn spacing={defaultMargins.s}>
         <Label>{t.futureLevelOfAssistance}</Label>
         {renderAssistanceLevelMultiCheckbox(
-          'ASSISTANCE_ENDS',
-          t.assistanceLevel.assistanceEnds
-        )}
-        {renderAssistanceLevelMultiCheckbox(
-          'ASSISTANCE_SERVICES_FOR_TIME',
-          t.assistanceLevel.assistanceServicesForTime
+          'SPECIAL_ASSISTANCE',
+          t.assistanceLevel.specialAssistance
         )}
         {renderAssistanceLevelMultiCheckbox(
           'ENHANCED_ASSISTANCE',
           t.assistanceLevel.enhancedAssistance
         )}
         {renderAssistanceLevelMultiCheckbox(
-          'SPECIAL_ASSISTANCE',
-          t.assistanceLevel.specialAssistance
+          'ASSISTANCE_SERVICES_FOR_TIME',
+          t.assistanceLevel.assistanceServicesForTime
+        )}
+        {renderAssistanceLevelMultiCheckbox(
+          'ASSISTANCE_ENDS',
+          t.assistanceLevel.assistanceEnds
         )}
       </FixedSpaceColumn>
 
@@ -596,6 +596,9 @@ export default React.memo(function AssistanceNeedDecisionForm({
           info={fieldInfos.motivationForDecision}
         />
       </FixedSpaceColumn>
+
+      <H2>{t.jurisdiction}</H2>
+      <P noMargin>{t.jurisdictionText}</P>
 
       <H2>{t.personsResponsible}</H2>
       {renderResult(employees, (employees) => (

--- a/frontend/src/lib-common/generated/api-types/assistanceneed.ts
+++ b/frontend/src/lib-common/generated/api-types/assistanceneed.ts
@@ -122,7 +122,6 @@ export interface AssistanceNeedDecisionCitizenListItem {
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionEmployee
 */
 export interface AssistanceNeedDecisionEmployee {
-  email: string | null
   employeeId: UUID | null
   name: string | null
   phoneNumber: string | null

--- a/frontend/src/lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly.tsx
+++ b/frontend/src/lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly.tsx
@@ -75,6 +75,8 @@ export interface AssistanceNeedDecisionTexts {
   lawReference: string
   appealInstructionsTitle: string
   appealInstructions: JSX.Element
+  jurisdiction: string
+  jurisdictionText: string
 }
 
 const List = styled.ul`
@@ -339,6 +341,9 @@ export default React.memo(function AssistanceNeedDecisionReadOnly({
             />
           </div>
 
+          <H2>{t.jurisdiction}</H2>
+          <P noMargin>{t.jurisdictionText}</P>
+
           <H2>{t.personsResponsible}</H2>
 
           <div>
@@ -350,7 +355,6 @@ export default React.memo(function AssistanceNeedDecisionReadOnly({
                     <div>
                       {decision.preparedBy1.name}, {decision.preparedBy1.title}
                     </div>
-                    <div>{decision.preparedBy1.email}</div>
                     <div>{decision.preparedBy1.phoneNumber}</div>
                   </LabelContainer>
                 )
@@ -366,7 +370,6 @@ export default React.memo(function AssistanceNeedDecisionReadOnly({
                     <div>
                       {decision.preparedBy2.name}, {decision.preparedBy2.title}
                     </div>
-                    <div>{decision.preparedBy2.email}</div>
                     <div>{decision.preparedBy2.phoneNumber}</div>
                   </LabelContainer>
                 )

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -1922,7 +1922,7 @@ export default {
       title: 'Tuen tarve',
       unreadCount: 'lukematonta',
       decisions: {
-        title: 'Tuen päätökset',
+        title: 'Päätökset tuesta varhaiskasvatuksessa',
         form: 'Lomake',
         assistanceLevel: 'Tuen taso',
         validityPeriod: 'Voimassa',
@@ -1931,7 +1931,7 @@ export default {
         status: 'Tila',
         openDecision: 'Avaa päätös',
         decision: {
-          pageTitle: 'Päätös tuesta',
+          pageTitle: 'Päätös tuesta varhaiskasvatuksessa',
           neededTypesOfAssistance: 'Lapsen tarvitsemat tuen muodot',
           pedagogicalMotivation: 'Pedagogiset tuen muodot ja perustelut',
           structuralMotivation: 'Rakenteelliset tuen muodot ja perustelut',
@@ -1975,11 +1975,14 @@ export default {
           unitMayChange:
             'Loma-aikoina tuen järjestämispaikka ja -tapa saattavat muuttua.',
           motivationForDecision: 'Perustelut lapsen tuen tasolle',
+          jurisdiction: 'Toimivalta',
+          jurisdictionText:
+            'Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 3 kohta',
           personsResponsible: 'Vastuuhenkilöt',
           preparator: 'Päätöksen valmistelija',
-          decisionMaker: 'Päättäjä',
+          decisionMaker: 'Päätöksen tekijä',
           disclaimer:
-            'Varhaiskasvatuslain 15 e § :n mukainen päätös voidaan panna täytäntöön muutoksenhausta huolimatta.',
+            'Varhaiskasvatuslain 15 e §:n mukaan tämä päätös voidaan panna täytäntöön muutoksenhausta huolimatta.',
           decisionNumber: 'Päätösnumero',
           statuses: {
             DRAFT: 'Luonnos',
@@ -1987,8 +1990,8 @@ export default {
             ACCEPTED: 'Hyväksytty',
             REJECTED: 'Hylätty'
           },
-          confidential: 'Salassapidettävä',
-          lawReference: 'Varhaiskasvatuslaki 15 §',
+          confidential: 'Salassa pidettävä',
+          lawReference: 'Varhaiskasvatuslaki 40 §',
           appealInstructionsTitle: 'Oikaisuvaatimusohje',
           appealInstructions: (
             <>

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -2005,6 +2005,9 @@ const sv: Translations = {
           selectedUnit: 'Enheten där stödet ges',
           unitMayChange: 'Enheten kan ändras under semestertider',
           motivationForDecision: 'Motivering av beslut',
+          jurisdiction: 'Befogenhet',
+          jurisdictionText:
+            'Delegationsbeslut om beslutanderätten för tjänsteinnehavarna av personalen vid den finskspråkiga småbarnspedagogiken och tillväxt- och lärandegrenen A del 3 § 3 pkt',
           personsResponsible: 'Ansvarspersoner',
           preparator: 'Beredare av beslutet',
           decisionMaker: 'Beslutsfattare',
@@ -2018,7 +2021,7 @@ const sv: Translations = {
             REJECTED: 'Avvisat'
           },
           confidential: 'Konfidentiellt',
-          lawReference: 'Lagen om småbarnspedagogik 15 §',
+          lawReference: 'Lagen om småbarnspedagogik 40 §',
           appealInstructionsTitle: 'Anvisningar för begäran om omprövning',
           appealInstructions: (
             <>

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -40,7 +40,7 @@ export const fi = {
     welcomePage: 'Tervetuloa eVakaan',
     vasuPage: 'Vasu 2021',
     vasuTemplates: 'Vasu-pohjat',
-    assistanceNeedDecision: 'Päätös tuesta'
+    assistanceNeedDecision: 'Päätös tuesta varhaiskasvatuksessa'
   },
   common: {
     yes: 'Kyllä',
@@ -693,15 +693,15 @@ export const fi = {
       }
     },
     assistanceNeedDecision: {
-      pageTitle: 'Päätös tuesta',
-      sectionTitle: 'Tuen päätökset',
+      pageTitle: 'Päätös tuesta varhaiskasvatuksessa',
+      sectionTitle: 'Päätökset tuesta varhaiskasvatuksessa',
       description:
         'Hyväksytyt ja hylätyt päätökset tuesta näkyvät huoltajalle eVakassa.',
       table: {
         form: 'Lomake',
         inEffect: 'Voimassa',
         unit: 'Yksikkö',
-        sentToDecisionMaker: 'Lähetetty päättäjälle',
+        sentToDecisionMaker: 'Lähetetty päätöksen tekijälle',
         decisionMadeOn: 'Päätös tehty',
         status: 'Tila'
       },
@@ -783,12 +783,15 @@ export const fi = {
       unitMayChange:
         'Loma-aikoina tuen järjestämispaikka ja -tapa saattavat muuttua.',
       motivationForDecision: 'Perustelut lapsen tuen tasolle',
+      jurisdiction: 'Toimivalta',
+      jurisdictionText:
+        'Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 3 kohta',
       personsResponsible: 'Vastuuhenkilöt',
       preparator: 'Päätöksen valmistelija',
-      decisionMaker: 'Päättäjä',
+      decisionMaker: 'Päätöksen tekijä',
       title: 'Titteli',
       disclaimer:
-        'Varhaiskasvatuslain 15 e § :n mukainen päätös voidaan panna täytäntöön muutoksenhausta huolimatta.',
+        'Varhaiskasvatuslain 15 e §:n mukaan tämä päätös voidaan panna täytäntöön muutoksenhausta huolimatta.',
       decisionNumber: 'Päätösnumero',
       statuses: {
         DRAFT: 'Luonnos',
@@ -796,14 +799,14 @@ export const fi = {
         ACCEPTED: 'Hyväksytty',
         REJECTED: 'Hylätty'
       },
-      confidential: 'Salassapidettävä',
-      lawReference: 'Varhaiskasvatuslaki 15 §',
+      confidential: 'Salassa pidettävä',
+      lawReference: 'Varhaiskasvatuslaki 40 §',
       noRecord: 'Ei merkintää',
       leavePage: 'Poistu',
       preview: 'Esikatsele',
       modifyDecision: 'Muokkaa',
-      sendToDecisionMaker: 'Lähetä päättäjälle',
-      sentToDecisionMaker: 'Lähetetty päättäjälle',
+      sendToDecisionMaker: 'Lähetä päätöksen tekijälle',
+      sentToDecisionMaker: 'Lähetetty päätöksen tekijälle',
       appealInstructionsTitle: 'Oikaisuvaatimusohje',
       appealInstructions: (
         <>
@@ -2702,8 +2705,8 @@ export const fi = {
     },
     assistanceNeedDecisions: {
       title: 'Tuen päätökset',
-      description: 'Päättäjälle lähetetyt tuen päätökset.',
-      sentToDecisionMaker: 'Lähetetty päättäjälle',
+      description: 'Päätöksen tekijälle lähetetyt tuen päätökset.',
+      sentToDecisionMaker: 'Lähetetty päätöksen tekijälle',
       decisionMade: 'Päätös tehty',
       status: 'Tila',
       returnForEditModal: {

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/sv.tsx
@@ -77,6 +77,9 @@ export const sv = {
       selectedUnit: 'Enheten där stödet ges',
       unitMayChange: 'Enheten kan ändras under semestertider',
       motivationForDecision: 'Motivering av beslut',
+      jurisdiction: 'Befogenhet',
+      jurisdictionText:
+        'Delegationsbeslut om beslutanderätten för tjänsteinnehavarna av personalen vid den finskspråkiga småbarnspedagogiken och tillväxt- och lärandegrenen A del 3 § 3 pkt',
       personsResponsible: 'Ansvarspersoner',
       preparator: 'Beredare av beslutet',
       decisionMaker: 'Beslutsfattare',
@@ -91,7 +94,7 @@ export const sv = {
         REJECTED: 'Avvisat'
       },
       confidential: 'Konfidentiellt',
-      lawReference: 'Lagen om småbarnspedagogik 15 §',
+      lawReference: 'Lagen om småbarnspedagogik 40 §',
       noRecord: 'Ingen anmärkning',
       leavePage: 'Stäng',
       modifyDecision: 'Redigera',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
@@ -139,7 +139,6 @@ class AssistanceNeedDecisionIntegrationTest : FullApplicationTest(resetDbBeforeE
         assertEquals(testDecision.preparedBy1?.title, assistanceNeedDecision.preparedBy1?.title)
         assertEquals(testDecision.preparedBy1?.phoneNumber, assistanceNeedDecision.preparedBy1?.phoneNumber)
         assertEquals(assistanceNeedDecision.preparedBy1?.name, "${testDecisionMaker_1.firstName} ${testDecisionMaker_1.lastName}")
-        assertEquals(assistanceNeedDecision.preparedBy1?.email, testDecisionMaker_1.email)
         assertEquals(assistanceNeedDecision.preparedBy2, null)
         assertEquals(testDecision.decisionMaker?.employeeId, assistanceNeedDecision.decisionMaker?.employeeId)
         assertEquals(testDecision.decisionMaker?.title, assistanceNeedDecision.decisionMaker?.title)

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecision.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecision.kt
@@ -149,7 +149,6 @@ data class AssistanceNeedDecisionEmployee(
     val employeeId: EmployeeId?,
     val title: String?,
     val name: String? = null,
-    val email: String? = null,
     val phoneNumber: String?
 ) {
     fun toForm() = AssistanceNeedDecisionEmployeeForm(employeeId, title, phoneNumber)

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
@@ -143,8 +143,8 @@ fun Database.Read.getAssistanceNeedDecisionById(id: AssistanceNeedDecisionId): A
           expert_responsibilities, guardians_heard_on, view_of_guardians, other_representative_heard, other_representative_details, 
           assistance_levels, motivation_for_decision,
           decision_maker_employee_id, decision_maker_title, concat(dm.first_name, ' ', dm.last_name) decision_maker_name,
-          preparer_1_employee_id, preparer_1_title, concat(p1.first_name, ' ', p1.last_name) preparer_1_name, p1.email preparer_1_email, preparer_1_phone_number,
-          preparer_2_employee_id, preparer_2_title, concat(p2.first_name, ' ', p2.last_name) preparer_2_name, p2.email preparer_2_email, preparer_2_phone_number,
+          preparer_1_employee_id, preparer_1_title, concat(p1.first_name, ' ', p1.last_name) preparer_1_name, preparer_1_phone_number,
+          preparer_2_employee_id, preparer_2_title, concat(p2.first_name, ' ', p2.last_name) preparer_2_name, preparer_2_phone_number,
           coalesce(jsonb_agg(jsonb_build_object(
             'id', dg.id,
             'personId', dg.person_id,

--- a/service/src/main/resources/WEB-INF/templates/assistance-need/decision.html
+++ b/service/src/main/resources/WEB-INF/templates/assistance-need/decision.html
@@ -221,6 +221,11 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         </div>
 
         <div class="decision-details-container">
+          <h2 th:text="#{jurisdiction}"></h2>
+          <p th:text="#{jurisdictionText}"></p>
+        </div>
+
+        <div class="decision-details-container">
           <h2 th:text="#{personsResponsible}"></h2>
           <div class="decision-details" th:if="${decision.preparedBy1} != null">
             <h3 th:text="#{preparator}"></h3>
@@ -229,7 +234,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
                 <span th:text="${decision.preparedBy1.name}"></span>,
                 <span th:text="${decision.preparedBy1.title}"></span>
               </div>
-              <div th:text="${decision.preparedBy1.email}"></div>
               <div th:text="${decision.preparedBy1.phoneNumber}"></div>
             </div>
           </div>
@@ -240,7 +244,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
                 <span th:text="${decision.preparedBy2.name}"></span>,
                 <span th:text="${decision.preparedBy2.title}"></span>
               </div>
-              <div th:text="${decision.preparedBy2.email}"></div>
               <div th:text="${decision.preparedBy2.phoneNumber}"></div>
             </div>
           </div>

--- a/service/src/main/resources/WEB-INF/templates/assistance-need/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/assistance-need/decision.properties
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: 2017-2021 City of Espoo
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
-header.1=PÄÄTÖS tuesta
-header.2=<strong>Salassapidettävä</strong><br />Varhaiskasvatuslaki 15 §
+header.1=PÄÄTÖS tuesta varhaiskasvatuksessa
+header.2=<strong>Salassa pidettävä</strong><br />Varhaiskasvatuslaki 40 §
 
-decision.title=PÄÄTÖS TUESTA
+decision.title=PÄÄTÖS TUESTA VARHAISKASVATUKSESSA
 
 decision.details.child.prefix=Lapsellenne
 decision.details.child={0} (s. {1})
-decision.details.date=<strong>on tehty päätös tuesta ajalle</strong>
+decision.details.date=<strong>on tehty päätös tuesta varhaiskasvatuksessa ajalle</strong>
 
 neededTypesOfAssistance=Lapsen tarvitsemat tuen muodot
 pedagogicalMotivation=Pedagogiset tuen muodot ja perustelut
@@ -43,14 +43,16 @@ selectedUnit=Päätökselle valittu varhaiskasvatusyksikkö
 motivationForDecision=Perustelut päätökselle
 personsResponsible=Vastuuhenkilöt
 preparator=Päätöksen valmistelija
-decisionMaker=Päättäjä
+decisionMaker=Päätöksen tekijä
 title=Titteli
-disclaimer=Varhaiskasvatuslain 15 e § :n mukainen päätös voidaan panna täytäntöön muutoksenhausta huolimatta.
+disclaimer=Varhaiskasvatuslain 15 e §:n mukaan tämä päätös voidaan panna täytäntöön muutoksenhausta huolimatta.
 statuses.ACCEPTED=hyväksytty
 statuses.REJECTED=hylätty
 decisionStatus=Päätös on
 decisionMadeOn=Päätetty
 unitMayChange=Loma-aikoina tuen järjestämispaikka ja -tapa saattavat muuttua.
+jurisdiction=Toimivalta
+jurisdictionText=Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 3 kohta
 
 appealInstructionTitle=Oikaisuvaatimusohje
 appealInstructions=\

--- a/service/src/main/resources/WEB-INF/templates/assistance-need/decision_sv.properties
+++ b/service/src/main/resources/WEB-INF/templates/assistance-need/decision_sv.properties
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 header.1=BESLUT om stöd
-header.2=<strong>Konfidentiellt</strong><br />Lagen om småbarnspedagogik 15 §
+header.2=<strong>Konfidentiellt</strong><br />Lagen om småbarnspedagogik 40 §
 
 decision.title=BESLUT OM STÖD
 
@@ -52,6 +52,8 @@ statuses.ACCEPTED=godkänt
 statuses.REJECTED=avvisat
 decisionStatus=Beslutet är
 decisionMadeOn=Beslut fattat den
+jurisdiction=Befogenhet
+jurisdictionText=Delegationsbeslut om beslutanderätten för tjänsteinnehavarna av personalen vid den finskspråkiga småbarnspedagogiken och tillväxt- och lärandegrenen A del 3 § 3 pkt
 
 appealInstructionTitle=Anvisningar för begäran om omprövning
 appealInstructions=\


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- Remove emails from preparators
- Reorder assistance levels
- "Päätös tuesta" -> "Päätös tuesta varhaiskasvatuksessa"
- Add new jurisdiction text
- Update law clauses