### PR TITLE
Fix flaky application decision e2e test

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -728,6 +728,7 @@ INSERT INTO guardian (guardian_id, child_id) VALUES (:guardianId, :childId) ON C
     @PostMapping("/applications/{applicationId}/actions/{action}")
     fun simpleAction(
         db: Database,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId,
         @PathVariable action: String
     ) {
@@ -748,6 +749,7 @@ INSERT INTO guardian (guardian_id, child_id) VALUES (:guardianId, :childId) ON C
                 actionFn.invoke(tx, fakeAdmin, applicationId)
             }
         }
+        runAllAsyncJobs(clock)
     }
 
     @PostMapping("/applications/{applicationId}/actions/create-placement-plan")


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The test `Decision is not sent automatically to the other guardian if the first guardian has restricted details enabled` used to be flaky because evaka-service would be running a family initialization async job at the same time with a guardian VTJ-query causing the one of the processes to fail because of a deadlock. I added a `runAllAsyncJobs` call to the end of the application actions endpoint in dev api to make sure that all the async jobs have been run before doing the next step in e2e test data initialization. But it turned out that `runAllAsyncJobs` was not reliable and it would sometimes return even though there were some async jobs still waiting to be run. I've now fixed it, but I'm not sure if my fix is bulletproof. There haven't been any issues with `runAllAsyncJobs` in ~100 tests that I ran. Previously ~1/20 of the tests would fail.

