### PR TITLE
Remove messages access from early childhood education secretary

### DIFF
--- a/service/src/main/resources/db/migration/R__message_account_access_view.sql
+++ b/service/src/main/resources/db/migration/R__message_account_access_view.sql
@@ -11,7 +11,7 @@ CREATE VIEW message_account_access_view(employee_id, account_id) AS (
     SELECT acl.employee_id, acc.id as account_id
     FROM message_account acc
         JOIN daycare_group dg ON acc.daycare_group_id = dg.id
-        JOIN daycare_acl acl ON acl.daycare_id = dg.daycare_id AND (acl.role = 'UNIT_SUPERVISOR' OR acl.role = 'SPECIAL_EDUCATION_TEACHER' OR acl.role = 'EARLY_CHILDHOOD_EDUCATION_SECRETARY')
+        JOIN daycare_acl acl ON acl.daycare_id = dg.daycare_id AND (acl.role = 'UNIT_SUPERVISOR' OR acl.role = 'SPECIAL_EDUCATION_TEACHER')
     WHERE acc.active = TRUE
 
     UNION


### PR DESCRIPTION
Secretary should be able send to every daycare group without having
access to them, but shouldn't see other staff messages like unit
supervisor. This commit breaks former and fixes latter.

We should discuss how to implement this later..
