### PR TITLE
Fix apigw test regression: post SAML data in tests using urlencoded format

### DIFF
--- a/apigw/src/shared/__tests__/saml-slo.ts
+++ b/apigw/src/shared/__tests__/saml-slo.ts
@@ -204,7 +204,7 @@ async function callSLOEndpointAndAssertResult(
   )
   const res = await tester.client.post(
     SP_LOGOUT_CALLBACK_ENDPOINT,
-    { SAMLRequest: idpInitiatedLogoutRequest },
+    new URLSearchParams({ SAMLRequest: idpInitiatedLogoutRequest }),
     {
       maxRedirects: 0,
       validateStatus: () => true

--- a/apigw/src/shared/test/gateway-tester.ts
+++ b/apigw/src/shared/test/gateway-tester.ts
@@ -94,7 +94,7 @@ export class GatewayTester {
       this.nockScope.post('/system/employee-login').reply(200, user)
       await this.client.post(
         '/api/internal/auth/saml/login/callback',
-        postData,
+        new URLSearchParams(postData),
         {
           maxRedirects: 0,
           validateStatus: (status) => status >= 200 && status <= 302
@@ -105,7 +105,7 @@ export class GatewayTester {
       this.nockScope.post('/system/citizen-login').reply(200, user)
       await this.client.post(
         '/api/application/auth/saml/login/callback',
-        postData,
+        new URLSearchParams(postData),
         {
           maxRedirects: 0,
           validateStatus: (status) => status >= 200 && status <= 302


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Previously JSON worked fine, since we had a global JSON parsing middleware installed. Now that the global middleware no longer exists, we *could* install the same middleware to the SAML endpoints, but in real SAML flows the data is not posted as JSON but in urlencoded format.

So, post data in tests using that format since we don't even need to support JSON.