### PR TITLE
Fix flakiness in E2E messaging tests: make sure reply has actually been sent

### DIFF
--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -88,6 +88,8 @@ export default class CitizenMessagesPage {
     await this.#openReplyEditorButton.click()
     await this.#messageReplyContent.fill(content)
     await this.#sendReplyButton.click()
+    // the content is cleared and the button is disabled once the reply has been sent
+    await waitUntilTrue(() => this.#sendReplyButton.disabled)
   }
 
   async sendNewMessage(title: string, content: string, receivers: string[]) {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Clicking the button does not mean the reply has already been sent, and in the tests we generally don't refresh in a loop until we see data. This leads to race conditions where we might load the inbox on the receiving side before the server has actually processed the click.