### PR TITLE
Fix realtime occupancy graph tooltip

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/ChartTooltip.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/ChartTooltip.tsx
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { TooltipModel } from 'chart.js'
-import React from 'react'
+import React, { ReactNode } from 'react'
 import styled from 'styled-components'
 
 import colors from 'lib-customizations/common'
@@ -13,65 +12,65 @@ type Position = {
   y: number
 }
 
-export type ChartTooltipData = {
-  tooltip?: TooltipModel<'line'>
-  children: JSX.Element
+export interface ChartTooltipProps {
+  position?: {
+    x: number
+    y: number
+    xAlign: string
+    yAlign: string
+    caretX: number
+    caretY: number
+  }
+  content: ReactNode
+  visible: boolean
 }
 
 export const ChartTooltip = React.memo(function ChartTooltip({
-  data: { tooltip, children },
+  position,
+  content,
   visible
-}: {
-  data: ChartTooltipData
-  visible: boolean
-}) {
-  if (tooltip === undefined) {
+}: ChartTooltipProps) {
+  if (position === undefined) {
     return null
   }
 
   const align =
-    tooltip.xAlign !== 'center'
-      ? tooltip.xAlign
-      : tooltip.yAlign !== 'center'
-      ? tooltip.yAlign
+    position.xAlign !== 'center'
+      ? position.xAlign
+      : position.yAlign !== 'center'
+      ? position.yAlign
       : 'left'
   const pos =
     align === 'left'
       ? {
-          x: tooltip.caretX + caretSize,
-          y: tooltip.y
+          x: position.caretX + caretSize,
+          y: position.y
         }
       : align === 'right'
       ? {
-          x: tooltip.caretX - caretSize - tooltipWidth,
-          y: tooltip.y
+          x: position.caretX - caretSize - tooltipWidth,
+          y: position.y
         }
       : align === 'bottom'
       ? {
-          x: tooltip.x,
-          y: tooltip.caretY - caretSize - tooltipHeight
+          x: position.x,
+          y: position.caretY - caretSize - tooltipHeight
         }
       : {
           // top
-          x: tooltip.x - tooltipWidth / 2,
-          y: tooltip.caretY + caretSize
+          x: position.x - tooltipWidth / 2,
+          y: position.caretY + caretSize
         }
 
-  // make sure the tooltip fits inside the chart width
-  const rect = tooltip.chart.canvas.getBoundingClientRect()
-  if (pos.x + tooltipWidth > rect.right) {
-    pos.x = pos.x - (tooltipWidth - (rect.right - pos.x)) - 16
-  }
-
   const caretPos = {
-    x: tooltip.caretX - caretSize,
-    y: tooltip.caretY - caretSize
+    x: position.caretX - caretSize,
+    y: position.caretY - caretSize
   }
   return (
     <>
       <Caret pos={caretPos} className={align} opacity={visible ? 1 : 0} />
       <PositionedDiv pos={pos} opacity={visible ? 1 : 0} className={align}>
-        <TooltipBody>{children}</TooltipBody>
+        <TooltipBody>{content}</TooltipBody>
       </PositionedDiv>
     </>
   )

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -230,13 +230,21 @@ function graphData(
   const lastStaffAttendance = staffData[staffData.length - 1]
   const lastChildAttendance = childData[childData.length - 1]
 
-  // If staff is still present, extend the graph up to current time
+  // If staff are still present, extend the staff graph up to current time
   if (
     lastStaffAttendance &&
     lastStaffAttendance.y > 0 &&
     isBefore(lastStaffAttendance.x, now.toSystemTzDate())
   ) {
     staffData.push({ ...lastStaffAttendance, x: now.toSystemTzDate() })
+  }
+
+  // If children are still present, extend the child graph up to current time
+  if (
+    lastChildAttendance &&
+    lastChildAttendance.y > 0 &&
+    isBefore(lastChildAttendance.x, now.toSystemTzDate())
+  ) {
     childData.push({ ...lastChildAttendance, x: now.toSystemTzDate() })
   }
 

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraph.tsx
@@ -45,7 +45,8 @@ export default React.memo(function OccupancyDayGraph({
   shiftCareUnit
 }: Props) {
   const { i18n } = useTranslation()
-  return occupancy.occupancySeries.length === 0 ? (
+  return occupancy.occupancySeries.length === 0 ||
+    queryDate.isAfter(LocalDate.todayInHelsinkiTz()) ? (
     <GraphPlaceholder data-qa="no-data-placeholder">
       {i18n.unit.occupancy.realtime.noData}
     </GraphPlaceholder>
@@ -200,13 +201,6 @@ const Graph = React.memo(function Graph({
       ) : null,
     [i18n, tooltipParams.data]
   )
-
-  if (data.datasets.length === 0)
-    return (
-      <GraphPlaceholder data-qa="no-data-placeholder">
-        {i18n.unit.occupancy.realtime.noData}
-      </GraphPlaceholder>
-    )
 
   return (
     <div onMouseOver={showTooltip} onMouseOut={hideTooltip}>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
* Fix the realtime occupancy graph's tooltip crashing the page when there's no data for the day by checking that a datapoint exists in the tooltip handler.
* Fix the tooltip causing recurring state update loops every time it's rendered.
* Extend the graph if children are currently present and it's past the graph's normal upper limit.
* Hide the graph on future dates since there is no data for those dates yet anyway.

