### PR TITLE
Upgrade react-day-picker

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
     "react-chartjs-2": "^4.3.1",
     "react-csv": "^2.2.2",
     "react-datepicker": "^4.8.0",
-    "react-day-picker": "7.4.10",
+    "react-day-picker": "^8.3.5",
     "react-dom": "^17.0.2",
     "react-focus-lock": "2.9.1",
     "react-image-crop": "^9.1.1",

--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
@@ -9,19 +9,21 @@ import styled from 'styled-components'
 import LocalDate from 'lib-common/local-date'
 
 import { InputInfo } from '../../atoms/form/InputField'
+import { fontWeights } from '../../typography'
 import { defaultMargins } from '../../white-space'
 
 import DatePickerDay from './DatePickerDay'
 import DatePickerInput from './DatePickerInput'
 
 const inputWidth = 120
+
 const DatePickerWrapper = styled.div`
   position: relative;
   display: inline-block;
   width: ${inputWidth}px;
 `
 const minMargin = 16
-const overflow = 70
+const overflow = 100
 
 const DayPickerPositioner = styled.div<{ openAbove?: boolean }>`
   position: absolute;
@@ -43,8 +45,37 @@ const DayPickerDiv = styled.div`
   display: flex;
   justify-content: center;
 
-  p:not(:last-child) {
-    margin-bottom: 8px;
+  .rdp-caption_label {
+    font-weight: ${fontWeights.medium};
+  }
+
+  .rdp-head_cell {
+    text-transform: none;
+    font-size: 1em;
+    font-weight: ${fontWeights.normal};
+  }
+
+  .rdp-day_today {
+    color: ${(p) => p.theme.colors.accents.a2orangeDark};
+  }
+
+  .rdp-button:not([disabled]) {
+    &:hover {
+      color: ${(p) => p.theme.colors.grayscale.g100};
+      background-color: ${(p) => p.theme.colors.accents.a8lightBlue};
+    }
+
+    &:active,
+    &:focus {
+      color: ${(p) => p.theme.colors.grayscale.g100};
+      background-color: ${(p) => p.theme.colors.grayscale.g0};
+      border: 2px solid ${(p) => p.theme.colors.main.m2Active};
+    }
+  }
+
+  .rdp-day_selected:not([disabled]) {
+    color: ${(p) => p.theme.colors.grayscale.g0};
+    background-color: ${(p) => p.theme.colors.main.m2Active};
   }
 `
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5975,7 +5975,7 @@ __metadata:
     react-chartjs-2: ^4.3.1
     react-csv: ^2.2.2
     react-datepicker: ^4.8.0
-    react-day-picker: 7.4.10
+    react-day-picker: ^8.3.5
     react-dom: ^17.0.2
     react-focus-lock: 2.9.1
     react-image-crop: ^9.1.1
@@ -9823,14 +9823,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-day-picker@npm:7.4.10":
-  version: 7.4.10
-  resolution: "react-day-picker@npm:7.4.10"
-  dependencies:
-    prop-types: ^15.6.2
+"react-day-picker@npm:^8.3.5":
+  version: 8.3.5
+  resolution: "react-day-picker@npm:8.3.5"
   peerDependencies:
-    react: ~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 33a4614bb4d457a3e72462d092fa131d3d7ec1ba858ac7e70d65b59e464606ffc039afdd226db37ead1326e248ca9a103007ee0bb829b277cd7297e5f5807ad1
+    date-fns: ^2.28.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: ecd8bed29e7cb649eb397bed88f8e2bbca2e037a8f8d6a51f24f7bb3d57339292b004d0c038276d8c932e4f7adde471b1368e395d964b56b0dfb8441363339ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Summary

The built-in styles in the new version are minimal. I tried to make it look mostly like the old one but with eVaka colors.

**Old:**

<img width="274" alt="Screenshot 2022-08-22 at 14 40 07" src="https://user-images.githubusercontent.com/70927/186080711-cd5c5a25-b9be-4abe-ad3e-e425c86f6935.png">

**New:**

<img width="337" alt="Screenshot 2022-08-23 at 8 58 07" src="https://user-images.githubusercontent.com/70927/186081294-8575ad54-53a3-47fe-bab6-10b2c2766b6a.png">