### PR TITLE
Use content-disposition header with inline attachments

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/s3/DocumentServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/s3/DocumentServiceIntegrationTest.kt
@@ -94,12 +94,12 @@ class DocumentServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = f
     fun `responseInline works`() {
         documentClient.upload(bucketEnv.data, Document("test", byteArrayOf(0x12, 0x34, 0x56), "text/plain"))
 
-        val response = documentClient.responseInline(bucketEnv.data, "test")
+        val response = documentClient.responseInline(bucketEnv.data, "test", "overridden-filename.txt")
         val s3Url = responseEntityToS3URL(response)
         val (_, s3response, s3data) = http.get(s3Url).response()
 
         assertEquals("text/plain", s3response.headers["Content-Type"].first())
-        assertEquals(listOf(), s3response.headers["Content-Disposition"])
+        assertEquals(listOf("inline; filename=\"overridden-filename.txt\""), s3response.headers["Content-Disposition"])
         assertContentEquals(byteArrayOf(0x12, 0x34, 0x56), s3data.get())
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentsController.kt
@@ -276,7 +276,7 @@ class AttachmentsController(
 
         if (requestedFilename != attachment.name) throw BadRequest("Requested file name doesn't match actual file name for $attachmentId")
 
-        return documentClient.responseInline(filesBucket, "$attachmentId")
+        return documentClient.responseInline(filesBucket, "$attachmentId", attachment.name)
     }
 
     @DeleteMapping(value = ["/{attachmentId}", "/citizen/{attachmentId}"])


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Spring by default adds a `Content-Disposition: inline; filename="f.txt"` header if it's missing which breaks at least PDF files on some browsers.


