### PR TITLE
Fix employee login when external id changes

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
@@ -75,6 +75,12 @@ RETURNING id, first_name, last_name, email, external_id, created, updated, roles
     .mapTo<Employee>()
     .asSequence().first()
 
+fun Database.Transaction.updateExternalIdByEmployeeNumber(employeeNumber: String, externalId: ExternalId) =
+    createUpdate("UPDATE employee SET external_id = :externalId WHERE employee_number = :employeeNumber AND external_id != :externalId")
+        .bind("employeeNumber", employeeNumber)
+        .bind("externalId", externalId)
+        .updateNoneOrOne()
+
 fun Database.Transaction.loginEmployee(employee: NewEmployee): Employee = createUpdate(
     // language=SQL
     """

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
@@ -65,6 +65,9 @@ class SystemController(private val personService: PersonService, private val acc
     ): EmployeeUser {
         return db.connect { dbc ->
             dbc.transaction {
+                if (request.employeeNumber != null) {
+                    it.updateExternalIdByEmployeeNumber(request.employeeNumber, request.externalId)
+                }
                 val inserted = it.loginEmployee(request.toNewEmployee())
                 val roles = it.getEmployeeRoles(inserted.id)
                 val employee = EmployeeUser(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
@@ -241,6 +241,12 @@ class Database(private val jdbi: Jdbi) {
             if (rows == 0) throw NotFound(notFoundMsg)
             if (rows > 1) throw Error(foundMultipleMsg)
         }
+
+        fun updateNoneOrOne(foundMultipleMsg: String = "Found multiple"): Int {
+            val rows = this.execute()
+            if (rows > 1) throw Error(foundMultipleMsg)
+            return rows
+        }
     }
 
     class PreparedBatch internal constructor(override val raw: org.jdbi.v3.core.statement.PreparedBatch) : SqlStatement<PreparedBatch>() {


### PR DESCRIPTION
#### Summary

When employee gets a new contract or comes back to work
(or whatever) it gets a new external id in SSO for some reason but
employee number (should) stays the same.

Bad thing about this is (unline external id which seems uuid and
probably generated by system) employee number is set by human, so
there is possibility for human error to set same or wrong employee
number to employee.