### PR TITLE
Add configurable amount of days when the citizen calendar opens

### DIFF
--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -324,3 +324,58 @@ describe('Citizen calendar child visibility', () => {
     await dayView.assertNoActivePlacementsMsgVisible()
   })
 })
+
+describe('Citizen calendar visibility', () => {
+  let page: Page
+  const today = LocalDate.todayInSystemTz()
+  let child: PersonDetail
+  let daycareId: string
+
+  beforeEach(async () => {
+    await resetDatabase()
+    const fixtures = await initializeAreaAndPersonData()
+    child = fixtures.enduserChildFixtureJari
+    daycareId = fixtures.daycareFixture.id
+  })
+
+  test('Child is visible when placement starts within 2 weeks', async () => {
+    await insertDaycarePlacementFixtures([
+      createDaycarePlacementFixture(
+        uuidv4(),
+        child.id,
+        daycareId,
+        today.addDays(13).formatIso(),
+        today.addYears(1).formatIso()
+      )
+    ])
+
+    page = await Page.open({
+      mockedTime: today.toSystemTzDate()
+    })
+    await enduserLogin(page)
+
+    await page.find('[data-qa="nav-calendar"]').waitUntilVisible()
+  })
+
+  test('Child is not visible when placement starts later than 2 weeks', async () => {
+    await insertDaycarePlacementFixtures([
+      createDaycarePlacementFixture(
+        uuidv4(),
+        child.id,
+        daycareId,
+        today.addDays(15).formatIso(),
+        today.addYears(1).formatIso()
+      )
+    ])
+
+    page = await Page.open({
+      mockedTime: today.toSystemTzDate()
+    })
+
+    await enduserLogin(page)
+
+    // Ensure page has loaded
+    await page.find('[data-qa="nav-children"]').waitUntilVisible()
+    await page.find('[data-qa="nav-calendar"]').waitUntilHidden()
+  })
+})

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -518,6 +518,18 @@ data class OphEnv(
     }
 }
 
+data class CitizenCalendarEnv(
+    val calendarOpenBeforePlacementDays: Int
+) {
+    companion object {
+        fun fromEnvironment(env: Environment): CitizenCalendarEnv {
+            return CitizenCalendarEnv(
+                calendarOpenBeforePlacementDays = env.lookup("evaka.citizen.calendar.calendar_open_before_placement_days") ?: 14
+            )
+        }
+    }
+}
+
 data class Sensitive<T>(val value: T) {
     override fun toString(): String = "**REDACTED**"
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/EnvConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/EnvConfig.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.shared.config
 
 import fi.espoo.evaka.BucketEnv
+import fi.espoo.evaka.CitizenCalendarEnv
 import fi.espoo.evaka.DatabaseEnv
 import fi.espoo.evaka.DvvModificationsEnv
 import fi.espoo.evaka.EmailEnv
@@ -67,6 +68,9 @@ class EnvConfig {
 
     @Bean
     fun ophEnv(env: Environment): OphEnv? = OphEnv.fromEnvironment(env)
+
+    @Bean
+    fun citizenCalendarEnv(env: Environment): CitizenCalendarEnv? = CitizenCalendarEnv.fromEnvironment(env)
 
     @Bean
     fun sfiEnv(evakaEnv: EvakaEnv, env: Environment): SfiEnv? = when (evakaEnv.sfiEnabled) {


### PR DESCRIPTION
#### Summary
- Calendar UI used to open on the day that first placement starts. Add a configurable number of days when the calendar opens prior to the first placement

