### PR TITLE
EVAKA-4596 Remove gaps in occupancy graph for overnight attendances

### DIFF
--- a/frontend/src/lib-common/generated/api-types/occupancy.ts
+++ b/frontend/src/lib-common/generated/api-types/occupancy.ts
@@ -23,6 +23,7 @@ export interface ChildCapacityPoint {
 export interface ChildOccupancyAttendance {
   arrived: HelsinkiDateTime
   capacity: number
+  childId: UUID
   departed: HelsinkiDateTime | null
 }
 


### PR DESCRIPTION
#### Summary

Overnight attendances are marked as ending on 23:59 on day 1 and
starting 00:00 on day 2, which caused the occupancy graph to drop down
to zero in the minute between 23:59 and 00:00.

This change removes the zero data point between 23:59 and 00:00, and
thus it is no longer rendered in the graph.
