### PR TITLE
Fix overflowing citizen calendar

### DIFF
--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -123,6 +123,8 @@ const NoReservationNote = styled.span`
 `
 
 const GroupedElementText = styled.div`
+  word-break: break-word;
+
   &.missing-reservation {
     color: ${(p) => p.theme.colors.accents.a2orangeDark};
   }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

When English was selected, the calendar page would overflow on certain window sizes because the word "attendance" required too much space.