### PR TITLE
Trim external emplyee's names

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/MarkExternalStaffMemberArrivalPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/MarkExternalStaffMemberArrivalPage.tsx
@@ -58,7 +58,7 @@ export default function MarkExternalStaffMemberArrivalPage() {
         ? postExternalStaffArrival({
             arrived: LocalTime.parse(form.arrived, 'HH:mm'),
             groupId: form.group.id,
-            name: form.name
+            name: form.name.trim()
           })
         : undefined,
     [form.arrived, form.group, form.name]

--- a/service/src/main/resources/db/migration/V266__trim_external_staff_names.sql
+++ b/service/src/main/resources/db/migration/V266__trim_external_staff_names.sql
@@ -1,0 +1,1 @@
+UPDATE staff_attendance_external SET name = TRIM(BOTH FROM name)

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -263,3 +263,4 @@ V262__child_consent_on_delete_cascade.sql
 V263__child_absences_function.sql
 V264__fridge_partner_self_foreign_key.sql
 V265__finance_decisions_partner_constraint.sql
+V266__trim_external_staff_names.sql


### PR DESCRIPTION
#### Summary
In case of substitute workers coming in, make sure to trim away any
whitespace from their names to avoid duplicates and hard to sort/find
persons.
