### PR TITLE
Fix ordering in income statements query

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementQueries.kt
@@ -515,7 +515,7 @@ WHERE handler_id IS NULL
 AND (cardinality(:areas) = 0 OR ca.short_name = ANY(:areas))
 AND (cardinality(:providerTypes) = 0 OR d.provider_type = ANY(:providerTypes::unit_provider_type[]))
 AND daterange(:sentStartDate, :sentEndDate, '[]') @> i.created::date
-ORDER BY i.created, i.start_date, i.id, a.id, person.last_name, person.first_name  -- order by area to get the same result each time
+ORDER BY i.created, i.start_date, i.id, ca.id, person.last_name, person.first_name  -- order by area to get the same result each time
 """
 
 fun Database.Read.fetchIncomeStatementsAwaitingHandler(


### PR DESCRIPTION
#### Summary

The comment says `order by area ...` but this was not true because `a` is application and `ca` is area.