### PR TITLE
Improve async job runner behaviour when shutting down (e.g. SIGTERM from Docker)

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -142,7 +142,7 @@ class AsyncJobRunner<T : AsyncJobPayload>(val payloadType: KClass<T>, private va
                     }
                     remaining -= 1
                     config.throttleInterval?.toMillis()?.run { Thread.sleep(this) }
-                } while (job != null && remaining > 0)
+                } while (job != null && remaining > 0 && !executor.isTerminating)
             } finally {
                 activeWorkerCount.decrementAndGet()
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -190,7 +190,9 @@ class AsyncJobRunner<T : AsyncJobPayload>(val payloadType: KClass<T>, private va
 
     override fun close() {
         this.executor.shutdown()
-        this.executor.awaitTermination(10, TimeUnit.SECONDS)
+        if (!this.executor.awaitTermination(10, TimeUnit.SECONDS)) {
+            logger.error { "Some async jobs did not terminate in time during shutdown" }
+        }
         this.executor.shutdownNow()
     }
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- We already handle shutdown gracefully if there are very few or no jobs. However, if a lot of pending jobs exist in the database, `runPendingJobs` kept claiming new ones even if we were trying to shut down. Detect this scenario and stop claiming jobs so the scheduled task can shut down in time
- Log an error if we ended up shutting down even if some job didn't terminate correctly
