### PR TITLE
Send null paattymis_pvm to varda

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUnits.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUnits.kt
@@ -228,6 +228,7 @@ data class VardaUnitRequest(
     val sahkopostiosoite: String?,
     val varhaiskasvatuspaikat: Int,
     val alkamis_pvm: String?,
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     val paattymis_pvm: String?,
     val kunta_koodi: String?,
     val lahdejarjestelma: String?,


### PR DESCRIPTION
#### Summary
When unit was accidentally marked a closing date which was sent to varda, then the date was removed, it was not sent to varda because null value fields were dropped from the request payload. Allow sending null paattymis_pvm.

