### PR TITLE
Don't show children in between placements as reservable in the citizen calendar

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -38,6 +38,7 @@ import DayView from './DayView'
 import ReservationModal from './ReservationModal'
 import { getCalendarEvents, getReservations } from './api'
 import FixedPeriodSelectionModal from './holiday-modal/FixedPeriodSelectionModal'
+import { getEarliestReservableDate } from './utils'
 
 async function getReservationsDefaultRange(): Promise<
   Result<ReservationsResponse>
@@ -113,14 +114,10 @@ const CalendarPage = React.memo(function CalendarPage() {
 
   const firstReservableDate: LocalDate = useMemo(() => {
     if (data.isSuccess) {
-      const earliestReservableDate =
-        data.value.reservableDays &&
-        data.value.reservableDays.length > 0 &&
-        data.value.reservableDays[0].start.isEqualOrAfter(
-          LocalDate.todayInSystemTz()
-        )
-          ? data.value.reservableDays[0].start
-          : LocalDate.todayInSystemTz()
+      const earliestReservableDate = getEarliestReservableDate(
+        data.value.children,
+        data.value.reservableDays
+      )
       // First reservable day that has no reservations
       const firstReservableEmptyDate = data.value.dailyData.find(
         (day) =>

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -57,6 +57,7 @@ import { CalendarModalBackground, CalendarModalSection } from './CalendarModal'
 import { RoundChildImage } from './RoundChildImages'
 import TimeRangeInput, { TimeRangeWithErrors } from './TimeRangeInput'
 import { postReservations } from './api'
+import { isDayReservableForSomeone } from './utils'
 
 interface Props {
   date: LocalDate
@@ -88,10 +89,8 @@ function getChildrenWithReservations(
   if (!dailyData) return []
 
   return reservationsResponse.children
-    .filter(
-      (child) =>
-        child.placementMinStart.isEqualOrBefore(date) &&
-        child.placementMaxEnd.isEqualOrAfter(date)
+    .filter((child) =>
+      child.placements.some((pl) => date.isBetween(pl.start, pl.end))
     )
     .map((child) => {
       const childReservations = dailyData?.children.find(
@@ -508,7 +507,7 @@ const emptyReservation: TimeRangeWithErrors = {
 function useEditState(
   date: LocalDate,
   childrenWithReservations: ChildWithReservations[],
-  reservableDays: FiniteDateRange[],
+  reservableDays: Record<string, FiniteDateRange[]>,
   reloadData: () => void
 ) {
   const today = LocalDate.todayInSystemTz()
@@ -522,7 +521,7 @@ function useEditState(
   )
 
   const editable = useMemo(
-    () => anyChildReservable && reservableDays.some((r) => r.includes(date)),
+    () => anyChildReservable && isDayReservableForSomeone(date, reservableDays),
     [anyChildReservable, reservableDays, date]
   )
 

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
+import { Failure } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import {
   DailyReservationData,
@@ -25,6 +26,7 @@ import Button from 'lib-components/atoms/buttons/Button'
 import Select from 'lib-components/atoms/dropdowns/Select'
 import { FixedSpaceFlexWrap } from 'lib-components/layout/flex-helpers'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
+import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 import DateRangePicker from 'lib-components/molecules/date-picker/DateRangePicker'
 import {
   ModalHeader,
@@ -154,6 +156,17 @@ export default React.memo(function ReservationModal({
         )
     )
   }, [availableChildren, selectedRange])
+
+  const [saveError, setSaveError] = useState<string | undefined>()
+  const showSaveError = useCallback(
+    (reason: Failure<void>) => {
+      reason.errorCode === 'NON_RESERVABLE_DAYS' &&
+        setSaveError(
+          i18n.calendar.reservationModal.saveErrors.NON_RESERVABLE_DAYS
+        )
+    },
+    [i18n, setSaveError]
+  )
 
   return (
     <ModalAccessibilityWrapper>
@@ -290,6 +303,15 @@ export default React.memo(function ReservationModal({
                 )}
               </CalendarModalSection>
             </div>
+            <Gap size="m" />
+            {saveError !== undefined && (
+              <AlertBox
+                title={i18n.calendar.reservationModal.saveErrors.failure}
+                message={saveError}
+                wide
+                noMargin
+              />
+            )}
             <CalendarModalButtons>
               <Button
                 onClick={onClose}
@@ -311,6 +333,9 @@ export default React.memo(function ReservationModal({
                 onSuccess={() => {
                   onReload()
                   onClose()
+                }}
+                onFailure={(reason) => {
+                  showSaveError(reason)
                 }}
                 data-qa="modal-okBtn"
               />

--- a/frontend/src/citizen-frontend/calendar/api.ts
+++ b/frontend/src/citizen-frontend/calendar/api.ts
@@ -36,15 +36,14 @@ export async function getReservations(
         })),
         children: res.data.children.map((child) => ({
           ...child,
-          placementMinStart: LocalDate.parseIso(child.placementMinStart),
-          placementMaxEnd: LocalDate.parseIso(child.placementMaxEnd)
+          placements: child.placements.map((r) => FiniteDateRange.parseJson(r))
         })),
-        // TODO Array.isArray is only for backward compatibility – remove ternaries when this is in production
-        reservableDays: Array.isArray(res.data.reservableDays)
-          ? res.data.reservableDays.map((r) => FiniteDateRange.parseJson(r))
-          : res.data.reservableDays
-          ? [FiniteDateRange.parseJson(res.data.reservableDays)]
-          : []
+        reservableDays: Object.entries(res.data.reservableDays).reduce<
+          Record<string, FiniteDateRange[]>
+        >((acc, [childId, ranges]) => {
+          acc[childId] = ranges.map((r) => FiniteDateRange.parseJson(r))
+          return acc
+        }, {})
       })
     )
     .catch((e) => Failure.fromError(e))

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -139,7 +139,9 @@ const groupChildren = (
     groupBy(
       allChildren
         .filter((childInfo) =>
-          date.isBetween(childInfo.placementMinStart, childInfo.placementMaxEnd)
+          childInfo.placements.some((placement) =>
+            date.isBetween(placement.start, placement.end)
+          )
         )
         .map<DailyChildGroupElement>((childInfo) => {
           const child = reservedChildren.find(

--- a/frontend/src/citizen-frontend/calendar/utils.ts
+++ b/frontend/src/citizen-frontend/calendar/utils.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import FiniteDateRange from 'lib-common/finite-date-range'
+import { ReservationChild } from 'lib-common/generated/api-types/reservations'
+import LocalDate from 'lib-common/local-date'
+
+export const getEarliestReservableDate = (
+  childInfo: ReservationChild[],
+  reservableDays: Record<string, FiniteDateRange[]>
+) => {
+  const earliestReservableDateByChild = childInfo.map((c) =>
+    reservableDays[c.id].reduce(
+      (acc, cur) => (cur.start.isBefore(acc) ? cur.start : acc),
+      LocalDate.todayInSystemTz()
+    )
+  )
+  const earliestReservableDate = earliestReservableDateByChild.reduce(
+    (acc, cur) => (cur.isBefore(acc) ? cur : acc),
+    LocalDate.todayInSystemTz()
+  )
+  return earliestReservableDate
+}
+
+export const getLatestReservableDate = (
+  childInfo: ReservationChild[],
+  reservableDays: Record<string, FiniteDateRange[]>
+) => {
+  const earliestReservableDateByChild = childInfo.map((c) =>
+    reservableDays[c.id].reduce(
+      (acc, cur) => (cur.end.isAfter(acc) ? cur.end : acc),
+      LocalDate.todayInSystemTz()
+    )
+  )
+  const earliestReservableDate = earliestReservableDateByChild.reduce(
+    (acc, cur) => (cur.isAfter(acc) ? cur : acc),
+    LocalDate.todayInSystemTz()
+  )
+  return earliestReservableDate
+}
+
+export const isDayReservableForSomeone = (
+  date: LocalDate,
+  reservableDays: Record<string, FiniteDateRange[]>
+) =>
+  Object.entries(reservableDays).some(([_childId, ranges]) =>
+    ranges.some((r) => r.includes(date))
+  )

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -285,18 +285,30 @@ describe('Citizen calendar child visibility', () => {
   let header: CitizenHeader
   let calendarPage: CitizenCalendarPage
   const today = LocalDate.of(2022, 1, 5)
+  const placement1start = today
+  const placement1end = today.addMonths(6)
+  const placement2start = today.addMonths(8)
+  const placement2end = today.addMonths(12)
 
   beforeEach(async () => {
     await resetDatabase()
     const fixtures = await initializeAreaAndPersonData()
     const child = fixtures.enduserChildFixtureJari
+
     await insertDaycarePlacementFixtures([
       createDaycarePlacementFixture(
         uuidv4(),
         child.id,
         fixtures.daycareFixture.id,
-        today.formatIso(),
-        today.addYears(1).formatIso()
+        placement1start.formatIso(),
+        placement1end.formatIso()
+      ),
+      createDaycarePlacementFixture(
+        uuidv4(),
+        child.id,
+        fixtures.daycareFixture.id,
+        placement2start.formatIso(),
+        placement2end.formatIso()
       )
     ])
 
@@ -310,10 +322,16 @@ describe('Citizen calendar child visibility', () => {
   })
 
   test('Child visible only while placement is active', async () => {
-    await calendarPage.assertChildCountOnDay(today.subDays(1), 0)
-    await calendarPage.assertChildCountOnDay(today, 1)
-    await calendarPage.assertChildCountOnDay(today.addYears(1), 1)
-    await calendarPage.assertChildCountOnDay(today.addYears(1).addDays(1), 0)
+    await calendarPage.assertChildCountOnDay(placement1start.subDays(1), 0)
+    await calendarPage.assertChildCountOnDay(placement1start, 1)
+    await calendarPage.assertChildCountOnDay(placement1end, 1)
+    await calendarPage.assertChildCountOnDay(placement1end.addDays(1), 0)
+
+    await calendarPage.assertChildCountOnDay(placement2start.subDays(1), 0)
+    await calendarPage.assertChildCountOnDay(placement2start, 1)
+    await calendarPage.assertChildCountOnDay(placement2start.addDays(1), 1)
+    await calendarPage.assertChildCountOnDay(placement2end, 1)
+    await calendarPage.assertChildCountOnDay(placement2end.addDays(1), 0)
   })
 
   test('Day popup contains message if no children placements on that date', async () => {

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
@@ -92,8 +92,8 @@ export default React.memo(function ReservationModalSingleChild({
 
   const [showAllErrors, setShowAllErrors] = useState(false)
   const validationResult = useMemo(
-    () => validateForm([reservableDates], formData),
-    [formData]
+    () => validateForm({ [child.id]: [reservableDates] }, formData),
+    [child.id, formData]
   )
 
   const shiftCareRange = useMemo(() => {

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -68,8 +68,7 @@ export interface ReservationChild {
   inShiftCareUnit: boolean
   lastName: string
   maxOperationalDays: number[]
-  placementMaxEnd: LocalDate
-  placementMinStart: LocalDate
+  placements: FiniteDateRange[]
   preferredName: string | null
 }
 
@@ -80,7 +79,7 @@ export interface ReservationsResponse {
   children: ReservationChild[]
   dailyData: DailyReservationData[]
   includesWeekends: boolean
-  reservableDays: FiniteDateRange[]
+  reservableDays: Record<string, FiniteDateRange[]>
 }
 
 /**

--- a/frontend/src/lib-common/reservations.ts
+++ b/frontend/src/lib-common/reservations.ts
@@ -57,7 +57,7 @@ export type ReservationFormDataForValidation = Omit<
 > & { endDate: LocalDate | null; startDate: LocalDate | null }
 
 export function validateForm(
-  reservableDays: FiniteDateRange[],
+  reservableDays: Record<string, FiniteDateRange[]>,
   { startDate, endDate, ...formData }: ReservationFormDataForValidation
 ): ValidationResult {
   const errors: ReservationErrors = {}
@@ -68,13 +68,21 @@ export function validateForm(
 
   if (startDate === null) {
     errors['startDate'] = 'required'
-  } else if (!reservableDays.some((r) => r.includes(startDate))) {
+  } else if (
+    !formData.selectedChildren.some((childId) =>
+      reservableDays[childId].some((r) => r.includes(startDate))
+    )
+  ) {
     errors['startDate'] = 'validDate'
   }
 
   if (endDate === null) {
     errors['endDate'] = 'required'
-  } else if (!reservableDays.some((r) => r.includes(endDate))) {
+  } else if (
+    !formData.selectedChildren.some((childId) =>
+      reservableDays[childId].some((r) => r.includes(endDate))
+    )
+  ) {
     errors['endDate'] = 'validDate'
   } else if (startDate && endDate.isBefore(startDate)) {
     errors['endDate'] = 'dateTooEarly'

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -295,7 +295,11 @@ const en: Translations = {
       start: 'Start',
       end: 'End',
       absent: 'Absent',
-      dayOff: 'Day off'
+      dayOff: 'Day off',
+      saveErrors: {
+        failure: 'Could not save',
+        NON_RESERVABLE_DAYS: 'Some of the selected days cannot be reserved'
+      }
     },
     absenceModal: {
       title: 'Report absence',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -292,7 +292,11 @@ export default {
       start: 'Alkaa',
       end: 'Päättyy',
       absent: 'Poissa',
-      dayOff: 'Vapaapäivä'
+      dayOff: 'Vapaapäivä',
+      saveErrors: {
+        failure: 'Tallennus epäonnistui',
+        NON_RESERVABLE_DAYS: 'Joitain valittuja päiviä ei voida varata'
+      }
     },
     absenceModal: {
       title: 'Ilmoita poissaolo',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -292,7 +292,11 @@ const sv: Translations = {
       start: 'Börjar',
       end: 'Slutar',
       absent: 'Frånvarande',
-      dayOff: 'Ledighet'
+      dayOff: 'Ledighet',
+      saveErrors: {
+        failure: 'Kunde inte spara',
+        NON_RESERVABLE_DAYS: 'Alla valda dagar kan inte reserveras.'
+      }
     },
     absenceModal: {
       title: 'Anmäl frånvaro',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationCitizenControllerTest.kt
@@ -98,26 +98,24 @@ class ReservationCitizenControllerTest : FullApplicationTest(resetDbBeforeEach =
             listOf(
                 // Sorted by date of birth, oldest child first
                 ReservationChild(
-                    testChild_2.id,
-                    testChild_2.firstName,
-                    testChild_2.lastName,
-                    "",
-                    null,
-                    testDate,
-                    testDate.plusDays(1),
-                    setOf(1, 2, 3, 4, 5),
-                    false
+                    id = testChild_2.id,
+                    firstName = testChild_2.firstName,
+                    lastName = testChild_2.lastName,
+                    preferredName = "",
+                    imageId = null,
+                    placements = listOf(FiniteDateRange(testDate, testDate.plusDays(1))),
+                    maxOperationalDays = setOf(1, 2, 3, 4, 5),
+                    inShiftCareUnit = false
                 ),
                 ReservationChild(
-                    testChild_1.id,
-                    testChild_1.firstName,
-                    testChild_2.lastName,
-                    "",
-                    null,
-                    testDate,
-                    testDate.plusDays(1),
-                    setOf(1, 2, 3, 4, 5),
-                    false
+                    id = testChild_1.id,
+                    firstName = testChild_1.firstName,
+                    lastName = testChild_1.lastName,
+                    preferredName = "",
+                    imageId = null,
+                    placements = listOf(FiniteDateRange(testDate, testDate.plusDays(1))),
+                    maxOperationalDays = setOf(1, 2, 3, 4, 5),
+                    inShiftCareUnit = false
                 ),
             ),
             res.children


### PR DESCRIPTION
Children who had a placement, which ended and are waiting for the next placement to start were wrongly shown in the calendar. This change allows gaps in placements to be rendered correctly.

Also added an error message if the citizen tries to store a reservation that overlaps with non reservable days.