### PR TITLE
Use EvakaClock as much as possible in the backend

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -55,7 +55,6 @@ import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.shared.security.upsertCitizenUser
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -47,10 +47,10 @@ import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.BadRequest
-import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snPreschoolDaycare45
 import fi.espoo.evaka.testAdult_1
@@ -110,6 +110,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
 
     private val today: LocalDate = LocalDate.of(2020, 2, 16)
     private val now: HelsinkiDateTime = HelsinkiDateTime.of(today, LocalTime.of(12, 0, 0))
+    private val clock = MockEvakaClock(now)
 
     @BeforeEach
     private fun beforeEach() {
@@ -237,7 +238,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
 
         db.transaction { tx ->
             // when
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
 
         db.read {
@@ -262,7 +263,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         }
         db.transaction { tx ->
             // when
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         db.read {
             // then
@@ -296,7 +297,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         }
         db.transaction { tx ->
             // when
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         // then
         assertDueDate(applicationId, null) // missing attachment
@@ -348,7 +349,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         }
         db.transaction { tx ->
             // when
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         // then
         assertDueDate(applicationId, now.plusDays(14 + 3).toLocalDate()) // attachments received after application sent
@@ -375,7 +376,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         }
         db.transaction { tx ->
             // when
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         db.read {
             // then
@@ -407,7 +408,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         }
         db.transaction { tx ->
             // when
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         db.read {
             // then
@@ -438,7 +439,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
 
         db.transaction { tx ->
             // when
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
 
         db.read {
@@ -471,7 +472,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
 
         db.transaction { tx ->
             // when
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
 
         db.read {
@@ -491,11 +492,11 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.read {
             // then
@@ -514,11 +515,11 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.read {
             // then
@@ -536,11 +537,11 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -561,11 +562,11 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 preferredStartDate = LocalDate.of(2020, 8, 1),
                 guardianEmail = ""
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -584,11 +585,11 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 hasAdditionalInfo = true,
                 applicationId = applicationId
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -607,12 +608,12 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
-            service.setVerified(tx, serviceWorker, applicationId)
+            service.setVerified(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -622,7 +623,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         }
         db.transaction { tx ->
             // when
-            service.setUnverified(tx, serviceWorker, applicationId)
+            service.setUnverified(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -637,11 +638,11 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         db.transaction { tx ->
             // given
             tx.insertApplication(applicationId = applicationId, preferredStartDate = LocalDate.of(2020, 8, 1))
-            service.sendApplication(tx, serviceWorker, applicationId, today)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
-            service.cancelApplication(tx, serviceWorker, applicationId)
+            service.cancelApplication(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -655,12 +656,12 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         db.transaction { tx ->
             // given
             tx.insertApplication(applicationId = applicationId, preferredStartDate = LocalDate.of(2020, 8, 1))
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
-            service.cancelApplication(tx, serviceWorker, applicationId)
+            service.cancelApplication(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -674,12 +675,12 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         db.transaction { tx ->
             // given
             tx.insertApplication(applicationId = applicationId, preferredStartDate = LocalDate.of(2020, 8, 1))
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
-            service.returnToSent(tx, serviceWorker, applicationId)
+            service.returnToSent(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -697,8 +698,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -755,8 +756,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -813,8 +814,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 13)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -887,8 +888,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
@@ -962,8 +963,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
             service.createPlacementPlan(
                 tx,
                 serviceWorker,
@@ -977,7 +978,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         }
         db.transaction { tx ->
             // when
-            service.cancelPlacementPlan(tx, serviceWorker, applicationId)
+            service.cancelPlacementPlan(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -1044,7 +1045,6 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         )
 
     private fun sendDecisionsWithoutProposalTest(
-        clock: EvakaClock = RealEvakaClock(),
         child: DevPerson,
         applier: DevPerson,
         secondDecisionTo: DevPerson?,
@@ -1059,8 +1059,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 13)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
             service.createPlacementPlan(
                 tx,
                 serviceWorker,
@@ -1071,7 +1071,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
 
         // when
         db.transaction { tx ->
-            service.sendDecisionsWithoutProposal(tx, serviceWorker, applicationId)
+            service.sendDecisionsWithoutProposal(tx, serviceWorker, clock, applicationId)
         }
         asyncJobRunner.runPendingJobsSync(clock)
         asyncJobRunner.runPendingJobsSync(clock)
@@ -1122,8 +1122,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
             service.createPlacementPlan(
                 tx,
                 serviceWorker,
@@ -1135,7 +1135,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 )
             )
             // when
-            service.sendPlacementProposal(tx, serviceWorker, applicationId)
+            service.sendPlacementProposal(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -1156,8 +1156,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
             service.createPlacementPlan(
                 tx,
                 serviceWorker,
@@ -1168,11 +1168,11 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                     preschoolDaycarePeriod = connectedPeriod
                 )
             )
-            service.sendPlacementProposal(tx, serviceWorker, applicationId)
+            service.sendPlacementProposal(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
-            service.withdrawPlacementProposal(tx, serviceWorker, applicationId)
+            service.withdrawPlacementProposal(tx, serviceWorker, clock, applicationId)
         }
         db.read { tx ->
             // then
@@ -1195,8 +1195,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
             service.createPlacementPlan(
                 tx,
                 serviceWorker,
@@ -1207,17 +1207,18 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                     preschoolDaycarePeriod = connectedPeriod
                 )
             )
-            service.sendPlacementProposal(tx, serviceWorker, applicationId)
+            service.sendPlacementProposal(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
             service.respondToPlacementProposal(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 PlacementPlanConfirmationStatus.ACCEPTED
             )
-            service.confirmPlacementProposalChanges(tx, serviceWorker, testDaycare.id)
+            service.confirmPlacementProposalChanges(tx, serviceWorker, clock, testDaycare.id)
         }
         val clock = RealEvakaClock()
         asyncJobRunner.runPendingJobsSync(clock)
@@ -1251,8 +1252,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 guardian = testAdult_1, applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1)
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
             service.createPlacementPlan(
                 tx,
                 serviceWorker,
@@ -1272,17 +1273,18 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                     planned = false
                 )
             }.let { updates -> decisionDraftService.updateDecisionDrafts(tx, applicationId, updates) }
-            service.sendPlacementProposal(tx, serviceWorker, applicationId)
+            service.sendPlacementProposal(tx, serviceWorker, clock, applicationId)
         }
         db.transaction { tx ->
             // when
             service.respondToPlacementProposal(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 PlacementPlanConfirmationStatus.ACCEPTED
             )
-            service.confirmPlacementProposalChanges(tx, serviceWorker, testDaycare.id)
+            service.confirmPlacementProposalChanges(tx, serviceWorker, clock, testDaycare.id)
         }
         val clock = RealEvakaClock()
         asyncJobRunner.runPendingJobsSync(clock)
@@ -1320,6 +1322,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.rejectDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id
             )
@@ -1354,6 +1357,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1361,6 +1365,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.rejectDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL_DAYCARE).id
             )
@@ -1400,6 +1405,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1439,6 +1445,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1479,6 +1486,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1519,6 +1527,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1559,6 +1568,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1601,6 +1611,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1641,6 +1652,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1679,6 +1691,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1718,6 +1731,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1758,6 +1772,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1799,6 +1814,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1839,6 +1855,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1879,6 +1896,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1919,6 +1937,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1959,6 +1978,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -1987,6 +2007,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 user,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start,
@@ -1994,6 +2015,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.rejectDecision(
                 tx,
                 user,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL_DAYCARE).id,
             )
@@ -2016,6 +2038,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 service.acceptDecision(
                     tx,
                     user,
+                    clock,
                     applicationId,
                     getDecision(tx, DecisionType.PRESCHOOL).id,
                     mainPeriod.start,
@@ -2036,6 +2059,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 service.rejectDecision(
                     tx,
                     user,
+                    clock,
                     applicationId,
                     getDecision(tx, DecisionType.PRESCHOOL).id,
                 )
@@ -2053,6 +2077,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -2060,6 +2085,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL_DAYCARE).id,
                 connectedPeriod.start
@@ -2104,6 +2130,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -2129,6 +2156,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -2154,6 +2182,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 service.acceptDecision(
                     tx,
                     serviceWorker,
+                    clock,
                     applicationId,
                     getDecision(tx, DecisionType.PRESCHOOL_DAYCARE).id,
                     mainPeriod.start
@@ -2170,6 +2199,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -2181,6 +2211,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 service.acceptDecision(
                     tx,
                     serviceWorker,
+                    clock,
                     applicationId,
                     getDecision(tx, DecisionType.PRESCHOOL).id,
                     mainPeriod.start
@@ -2197,6 +2228,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.rejectDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id
             )
@@ -2207,6 +2239,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 service.acceptDecision(
                     tx,
                     serviceWorker,
+                    clock,
                     applicationId,
                     getDecision(tx, DecisionType.PRESCHOOL).id,
                     mainPeriod.start
@@ -2223,6 +2256,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.acceptDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id,
                 mainPeriod.start
@@ -2234,6 +2268,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 service.rejectDecision(
                     tx,
                     serviceWorker,
+                    clock,
                     applicationId,
                     getDecision(tx, DecisionType.PRESCHOOL).id
                 )
@@ -2249,6 +2284,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.rejectDecision(
                 tx,
                 serviceWorker,
+                clock,
                 applicationId,
                 getDecision(tx, DecisionType.PRESCHOOL).id
             )
@@ -2259,6 +2295,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 service.rejectDecision(
                     tx,
                     serviceWorker,
+                    clock,
                     applicationId,
                     getDecision(tx, DecisionType.PRESCHOOL).id
                 )
@@ -2279,8 +2316,8 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 preferredStartDate = preferredStartDate,
                 serviceNeedOption = serviceNeedOption
             )
-            service.sendApplication(tx, serviceWorker, applicationId, today)
-            service.moveToWaitingPlacement(tx, serviceWorker, applicationId)
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
             service.createPlacementPlan(
                 tx,
                 serviceWorker,
@@ -2291,7 +2328,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                     preschoolDaycarePeriod = connectedPeriod
                 )
             )
-            service.sendDecisionsWithoutProposal(tx, serviceWorker, applicationId)
+            service.sendDecisionsWithoutProposal(tx, serviceWorker, clock, applicationId)
         }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -51,7 +51,6 @@ import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.MockEvakaClock
-import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snPreschoolDaycare45
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_4
@@ -1220,7 +1219,6 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             )
             service.confirmPlacementProposalChanges(tx, serviceWorker, clock, testDaycare.id)
         }
-        val clock = RealEvakaClock()
         asyncJobRunner.runPendingJobsSync(clock)
         asyncJobRunner.runPendingJobsSync(clock)
         sfiAsyncJobRunner.runPendingJobsSync(clock)
@@ -1286,7 +1284,6 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             )
             service.confirmPlacementProposalChanges(tx, serviceWorker, clock, testDaycare.id)
         }
-        val clock = RealEvakaClock()
         asyncJobRunner.runPendingJobsSync(clock)
         asyncJobRunner.runPendingJobsSync(clock)
         sfiAsyncJobRunner.runPendingJobsSync(clock)
@@ -1436,7 +1433,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.minusDays(10),
                 validTo = null
             )
-            tx.upsertIncome(mapper, earlierIndefinite, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, earlierIndefinite, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1477,7 +1474,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.minusDays(10),
                 validTo = mainPeriod.start.plusMonths(5)
             )
-            tx.upsertIncome(mapper, earlierIncome, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, earlierIncome, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1518,7 +1515,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.plusMonths(5),
                 validTo = null
             )
-            tx.upsertIncome(mapper, laterIndefiniteIncome, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, laterIndefiniteIncome, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1559,7 +1556,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.minusMonths(7),
                 validTo = mainPeriod.start.minusMonths(5)
             )
-            tx.upsertIncome(mapper, earlierIncome, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, earlierIncome, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1602,7 +1599,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.plusMonths(5),
                 validTo = mainPeriod.start.plusMonths(6)
             )
-            tx.upsertIncome(mapper, laterIncome, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, laterIncome, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1643,7 +1640,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.minusDays(10),
                 validTo = null
             )
-            tx.upsertIncome(mapper, earlierIndefinite, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, earlierIndefinite, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions(preferredStartDate = null)
 
@@ -1682,7 +1679,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start,
                 validTo = null
             )
-            tx.upsertIncome(mapper, sameDayIncomeIndefinite, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, sameDayIncomeIndefinite, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1722,7 +1719,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start,
                 validTo = mainPeriod.start.plusMonths(5)
             )
-            tx.upsertIncome(mapper, sameDayIncome, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, sameDayIncome, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1763,7 +1760,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.minusDays(1),
                 validTo = null
             )
-            tx.upsertIncome(mapper, dayBeforeIncomeIndefinite, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, dayBeforeIncomeIndefinite, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1805,7 +1802,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.plusDays(1),
                 validTo = null
             )
-            tx.upsertIncome(mapper, nextDayIncomeIndefinite, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, nextDayIncomeIndefinite, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1846,7 +1843,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.minusDays(1),
                 validTo = mainPeriod.start.plusMonths(5)
             )
-            tx.upsertIncome(mapper, incomeDayBefore, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, incomeDayBefore, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1887,7 +1884,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.minusMonths(2),
                 validTo = mainPeriod.start
             )
-            tx.upsertIncome(mapper, earlierIncomeEndingOnSameDay, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, earlierIncomeEndingOnSameDay, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1928,7 +1925,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.minusMonths(2),
                 validTo = mainPeriod.start.plusDays(1)
             )
-            tx.upsertIncome(mapper, earlierIncomeEndingOnNextDay, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, earlierIncomeEndingOnNextDay, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 
@@ -1969,7 +1966,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 validFrom = mainPeriod.start.minusMonths(2),
                 validTo = mainPeriod.start.minusDays(1)
             )
-            tx.upsertIncome(mapper, earlierIncomeEndingOnDayBefore, financeUser.evakaUserId)
+            tx.upsertIncome(clock, mapper, earlierIncomeEndingOnDayBefore, financeUser.evakaUserId)
         }
         workflowForPreschoolDaycareDecisions()
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/GetApplicationIntegrationTests.kt
@@ -26,6 +26,7 @@ import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.job.ScheduledJobs
 import fi.espoo.evaka.test.validDaycareApplication
 import fi.espoo.evaka.testAdult_1
@@ -228,7 +229,7 @@ class GetApplicationIntegrationTests : FullApplicationTest(resetDbBeforeEach = t
             assertEquals(3, data.size)
         }
 
-        scheduledJobs.removeOldDraftApplications(db)
+        scheduledJobs.removeOldDraftApplications(db, RealEvakaClock())
 
         db.transaction { tx ->
             val data =

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PendingDecisionEmailServiceIntegrationTest.kt
@@ -178,7 +178,7 @@ class PendingDecisionEmailServiceIntegrationTest : FullApplicationTest(resetDbBe
     }
 
     private fun runPendingDecisionEmailAsyncJobs(clock: EvakaClock = RealEvakaClock()): Int {
-        scheduledJobs.sendPendingDecisionReminderEmails(db)
+        scheduledJobs.sendPendingDecisionReminderEmails(db, clock)
         val jobCount = asyncJobRunner.getPendingJobCount()
         asyncJobRunner.runPendingJobsSync(clock)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
@@ -502,6 +502,7 @@ class AssistanceNeedDecisionIntegrationTest : FullApplicationTest(resetDbBeforeE
     @Test
     fun `Decision PDF generation is successful`() {
         val pdf = assistanceNeedDecisionService.generatePdf(
+            sentDate = LocalDate.now(),
             AssistanceNeedDecision(
                 validityPeriod = DateRange(LocalDate.of(2022, 1, 1), LocalDate.of(2023, 1, 1)),
                 status = AssistanceNeedDecisionStatus.ACCEPTED,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceUpkeepIntegrationTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.dev.insertTestBackUpCare
 import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.job.ScheduledJobs
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
@@ -48,7 +49,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             )
         }
 
-        scheduledJobs.endOfDayAttendanceUpkeep(db)
+        scheduledJobs.endOfDayAttendanceUpkeep(db, RealEvakaClock())
 
         val attendanceEndTimes = getAttendanceEndTimes()
         assertEquals(1, attendanceEndTimes.size)
@@ -74,7 +75,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             )
         }
 
-        scheduledJobs.endOfDayAttendanceUpkeep(db)
+        scheduledJobs.endOfDayAttendanceUpkeep(db, RealEvakaClock())
 
         val attendanceEndTimes = getAttendanceEndTimes()
         assertEquals(1, attendanceEndTimes.size)
@@ -109,7 +110,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             )
         }
 
-        scheduledJobs.endOfDayAttendanceUpkeep(db)
+        scheduledJobs.endOfDayAttendanceUpkeep(db, RealEvakaClock())
 
         val attendanceEndTimes = getAttendanceEndTimes()
         assertEquals(1, attendanceEndTimes.size)
@@ -143,7 +144,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             )
         }
 
-        scheduledJobs.endOfDayAttendanceUpkeep(db)
+        scheduledJobs.endOfDayAttendanceUpkeep(db, RealEvakaClock())
 
         val attendanceEndTimes = getAttendanceEndTimes()
         assertEquals(1, attendanceEndTimes.size)
@@ -184,7 +185,7 @@ class AttendanceUpkeepIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             )
         }
 
-        scheduledJobs.endOfDayAttendanceUpkeep(db)
+        scheduledJobs.endOfDayAttendanceUpkeep(db, RealEvakaClock())
 
         val attendanceEndTimes = getAttendanceEndTimes()
         assertEquals(1, attendanceEndTimes.size)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventServiceIntegrationTest.kt
@@ -72,6 +72,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
     // a monday
     private val today = LocalDate.of(2021, 6, 5)
     private val now = HelsinkiDateTime.of(today, LocalTime.of(12, 0, 0))
+    private val clock = MockEvakaClock(now)
 
     private final val groupId = GroupId(UUID.randomUUID())
     private final val groupId2 = GroupId(UUID.randomUUID())
@@ -143,7 +144,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "uwe",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(3))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         val event = this.calendarEventController.getUnitCalendarEvents(
             dbInstance(), admin, testDaycare.id,
@@ -167,7 +168,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "gwe",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         val event = this.calendarEventController.getUnitCalendarEvents(
             dbInstance(), admin, testDaycare.id,
@@ -191,7 +192,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         val event = this.calendarEventController.getUnitCalendarEvents(
             dbInstance(), admin, testDaycare.id,
@@ -215,7 +216,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         this.calendarEventController.modifyCalendarEvent(
             dbInstance(),
@@ -245,7 +246,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         this.calendarEventController.deleteCalendarEvent(
             dbInstance(),
@@ -273,7 +274,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         val form2 = CalendarEventForm(
             unitId = testDaycare.id,
@@ -282,7 +283,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "uw",
             period = FiniteDateRange(today.plusDays(1), today.plusDays(1))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form2)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form2)
 
         val form3 = CalendarEventForm(
             unitId = testDaycare.id,
@@ -291,7 +292,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "gw",
             period = FiniteDateRange(today.plusDays(1), today.plusDays(1))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form3)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form3)
 
         val guardianEvents = this.calendarEventController.getCitizenCalendarEvents(
             dbInstance(),
@@ -352,7 +353,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "ge",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         val event = this.calendarEventController.getCitizenCalendarEvents(
             dbInstance(),
@@ -389,7 +390,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "ie",
             period = FiniteDateRange(today.minusDays(1), today.plusDays(2))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         assert(
             this.calendarEventController.getCitizenCalendarEvents(
@@ -410,7 +411,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "ge",
             period = FiniteDateRange(today.minusDays(1), today.plusDays(2))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         assert(
             this.calendarEventController.getCitizenCalendarEvents(
@@ -431,7 +432,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "uw",
             period = FiniteDateRange(today.minusDays(1), today.plusDays(2))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         assert(
             this.calendarEventController.getCitizenCalendarEvents(
@@ -452,7 +453,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "ge",
             period = FiniteDateRange(placementStart.minusDays(10), placementStart.minusDays(8))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         val form2 = CalendarEventForm(
             unitId = testDaycare.id,
@@ -461,7 +462,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "uw",
             period = FiniteDateRange(placementStart.minusDays(20), placementStart.minusDays(20))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form2)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form2)
 
         assert(
             this.calendarEventController.getCitizenCalendarEvents(
@@ -482,7 +483,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "u1_g",
             period = FiniteDateRange(placementStart, placementStart.plusDays(30))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         val form2 = CalendarEventForm(
             unitId = testDaycare2.id,
@@ -491,7 +492,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "u1_u",
             period = FiniteDateRange(placementStart, placementStart.plusDays(30))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form2)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form2)
 
         this.backupCareController.createForChild(
             dbInstance(),
@@ -553,7 +554,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementController.deletePlacement(dbInstance(), admin, placementId)
         assert(
             this.calendarEventController.getUnitCalendarEvents(
@@ -573,7 +574,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementController.updatePlacementById(
             dbInstance(),
             admin,
@@ -598,7 +599,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementController.updatePlacementById(
             dbInstance(), admin,
             placementId,
@@ -622,7 +623,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementController.deleteGroupPlacement(
             dbInstance(), admin,
             groupPlacementId
@@ -645,7 +646,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementController.transferGroupPlacement(
             dbInstance(), admin,
             groupPlacementId,
@@ -669,7 +670,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementController.transferGroupPlacement(
             dbInstance(), admin,
             groupPlacementId,
@@ -692,7 +693,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
@@ -717,7 +718,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
@@ -741,7 +742,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
@@ -772,7 +773,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
@@ -812,6 +813,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.calendarEventController.createCalendarEvent(
             dbInstance(),
             admin,
+            clock,
             form
         )
         this.backupCareController.update(
@@ -847,7 +849,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.backupCareController.update(
             dbInstance(),
             admin,
@@ -879,7 +881,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.backupCareController.delete(
             dbInstance(),
             admin,
@@ -904,11 +906,11 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             description = "cse",
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
-        this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+        this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementControllerCitizen.postPlacementTermination(
             dbInstance(),
             guardian,
-            MockEvakaClock(now),
+            clock,
             testChild_1.id,
             PlacementControllerCitizen.PlacementTerminationRequestBody(
                 type = TerminatablePlacementType.DAYCARE,
@@ -937,7 +939,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         )
 
         assertThrows<BadRequest> {
-            this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+            this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         }
     }
 
@@ -963,7 +965,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         )
 
         assertThrows<BadRequest> {
-            this.calendarEventController.createCalendarEvent(dbInstance(), admin, form)
+            this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventServiceIntegrationTest.kt
@@ -147,7 +147,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         val event = this.calendarEventController.getUnitCalendarEvents(
-            dbInstance(), admin, testDaycare.id,
+            dbInstance(), admin, clock, testDaycare.id,
             today, today.plusDays(4)
         )[0]
 
@@ -171,7 +171,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         val event = this.calendarEventController.getUnitCalendarEvents(
-            dbInstance(), admin, testDaycare.id,
+            dbInstance(), admin, clock, testDaycare.id,
             today, today.plusDays(5)
         )[0]
 
@@ -195,7 +195,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
         val event = this.calendarEventController.getUnitCalendarEvents(
-            dbInstance(), admin, testDaycare.id,
+            dbInstance(), admin, clock, testDaycare.id,
             today, today.plusDays(5)
         )[0]
 
@@ -221,15 +221,16 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.calendarEventController.modifyCalendarEvent(
             dbInstance(),
             admin,
+            clock,
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(4)
             )[0].id,
             CalendarEventUpdateForm(title = "Updated title", description = "desc, updated")
         )
 
         val event = this.calendarEventController.getUnitCalendarEvents(
-            dbInstance(), admin, testDaycare.id,
+            dbInstance(), admin, clock, testDaycare.id,
             today, today.plusDays(4)
         )[0]
 
@@ -251,15 +252,16 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.calendarEventController.deleteCalendarEvent(
             dbInstance(),
             admin,
+            clock,
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(4)
             )[0].id
         )
 
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(4)
             ).isEmpty()
         )
@@ -297,6 +299,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val guardianEvents = this.calendarEventController.getCitizenCalendarEvents(
             dbInstance(),
             guardian,
+            clock,
             today,
             today.plusDays(10)
         )
@@ -358,6 +361,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val event = this.calendarEventController.getCitizenCalendarEvents(
             dbInstance(),
             guardian,
+            clock,
             today,
             today.plusDays(10)
         ).first()
@@ -396,6 +400,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             this.calendarEventController.getCitizenCalendarEvents(
                 dbInstance(),
                 guardian,
+                clock,
                 today.minusDays(10),
                 today.plusDays(10)
             ).isEmpty()
@@ -417,6 +422,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             this.calendarEventController.getCitizenCalendarEvents(
                 dbInstance(),
                 guardian,
+                clock,
                 today.minusDays(10),
                 today.plusDays(10)
             ).isEmpty()
@@ -438,6 +444,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             this.calendarEventController.getCitizenCalendarEvents(
                 dbInstance(),
                 guardian,
+                clock,
                 today.minusDays(10),
                 today.plusDays(10)
             ).isEmpty()
@@ -468,6 +475,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             this.calendarEventController.getCitizenCalendarEvents(
                 dbInstance(),
                 guardian,
+                clock,
                 placementStart.minusDays(50),
                 placementStart.plusDays(50)
             ).isEmpty()
@@ -497,12 +505,13 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
+            clock,
             testChild_1.id,
             NewBackupCare(testDaycare2.id, null, FiniteDateRange(placementStart.plusDays(10), placementStart.plusDays(20)))
         )
 
         val guardianEvents = this.calendarEventController.getCitizenCalendarEvents(
-            dbInstance(), guardian,
+            dbInstance(), guardian, clock,
             placementStart, placementStart.plusDays(50)
         )
 
@@ -555,10 +564,10 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             period = FiniteDateRange(today.plusDays(3), today.plusDays(4))
         )
         this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
-        this.placementController.deletePlacement(dbInstance(), admin, placementId)
+        this.placementController.deletePlacement(dbInstance(), admin, clock, placementId)
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isEmpty()
         )
@@ -578,12 +587,13 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.placementController.updatePlacementById(
             dbInstance(),
             admin,
+            clock,
             placementId,
             PlacementUpdateRequestBody(startDate = today.plusDays(10), endDate = placementEnd)
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isEmpty()
         )
@@ -601,13 +611,13 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         )
         this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementController.updatePlacementById(
-            dbInstance(), admin,
+            dbInstance(), admin, clock,
             placementId,
             PlacementUpdateRequestBody(startDate = placementStart, endDate = today.minusDays(1))
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isEmpty()
         )
@@ -625,12 +635,12 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         )
         this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementController.deleteGroupPlacement(
-            dbInstance(), admin,
+            dbInstance(), admin, clock,
             groupPlacementId
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isEmpty()
         )
@@ -648,13 +658,13 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         )
         this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementController.transferGroupPlacement(
-            dbInstance(), admin,
+            dbInstance(), admin, clock,
             groupPlacementId,
             GroupTransferRequestBody(groupId = groupId2, startDate = today),
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isEmpty()
         )
@@ -672,13 +682,13 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         )
         this.calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
         this.placementController.transferGroupPlacement(
-            dbInstance(), admin,
+            dbInstance(), admin, clock,
             groupPlacementId,
             GroupTransferRequestBody(groupId = groupId2, startDate = today.plusDays(5))
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isNotEmpty()
         )
@@ -697,12 +707,13 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
+            clock,
             testChild_1.id,
             NewBackupCare(unitId = testDaycare2.id, groupId = null, period = FiniteDateRange(today, today.plusDays(10)))
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isEmpty()
         )
@@ -722,12 +733,13 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
+            clock,
             testChild_1.id,
             NewBackupCare(unitId = testDaycare2.id, groupId = null, period = FiniteDateRange(today.minusDays(10), today))
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isNotEmpty()
         )
@@ -746,18 +758,20 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
+            clock,
             testChild_1.id,
             NewBackupCare(unitId = testDaycare2.id, groupId = null, period = FiniteDateRange(today.plusDays(10), today.plusDays(20)))
         )
         this.backupCareController.update(
             dbInstance(),
             admin,
+            clock,
             db.transaction { tx -> tx.getBackupCaresForChild(testChild_1.id).first().id },
             BackupCareUpdateRequest(FiniteDateRange(today, today.plusDays(20)), null)
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isEmpty()
         )
@@ -777,18 +791,20 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
+            clock,
             testChild_1.id,
             NewBackupCare(unitId = testDaycare2.id, groupId = null, period = FiniteDateRange(today.minusDays(10), today))
         )
         this.backupCareController.update(
             dbInstance(),
             admin,
+            clock,
             db.transaction { tx -> tx.getBackupCaresForChild(testChild_1.id).first().id },
             BackupCareUpdateRequest(FiniteDateRange(today.minusDays(10), today.plusDays(20)), null)
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isEmpty()
         )
@@ -800,6 +816,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
+            clock,
             testChild_1.id,
             NewBackupCare(unitId = testDaycare2.id, groupId = unit2GroupId, period = FiniteDateRange(today, today.plusDays(10)))
         )
@@ -819,6 +836,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.update(
             dbInstance(),
             admin,
+            clock,
             db.transaction { tx -> tx.getBackupCaresForChild(testChild_1.id).first().id },
             BackupCareUpdateRequest(FiniteDateRange(today.plusDays(8), today.plusDays(10)), null)
         )
@@ -826,6 +844,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             this.calendarEventController.getUnitCalendarEvents(
                 dbInstance(),
                 admin,
+                clock,
                 testDaycare2.id,
                 today,
                 today.plusDays(5)
@@ -839,6 +858,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
+            clock,
             testChild_1.id,
             NewBackupCare(unitId = testDaycare2.id, groupId = unit2GroupId, period = FiniteDateRange(today, today.plusDays(10)))
         )
@@ -853,12 +873,13 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.update(
             dbInstance(),
             admin,
+            clock,
             db.transaction { tx -> tx.getBackupCaresForChild(testChild_1.id).first().id },
             BackupCareUpdateRequest(FiniteDateRange(today, today.plusDays(1)), null)
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare2.id,
+                dbInstance(), admin, clock, testDaycare2.id,
                 today,
                 today.plusDays(5)
             ).isEmpty()
@@ -871,6 +892,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.createForChild(
             dbInstance(),
             admin,
+            clock,
             testChild_1.id,
             NewBackupCare(unitId = testDaycare2.id, groupId = unit2GroupId, period = FiniteDateRange(today, today.plusDays(10)))
         )
@@ -885,11 +907,12 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         this.backupCareController.delete(
             dbInstance(),
             admin,
+            clock,
             db.transaction { tx -> tx.getBackupCaresForChild(testChild_1.id).first().id }
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare2.id,
+                dbInstance(), admin, clock, testDaycare2.id,
                 today,
                 today.plusDays(5)
             ).isEmpty()
@@ -921,7 +944,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         )
         assert(
             this.calendarEventController.getUnitCalendarEvents(
-                dbInstance(), admin, testDaycare.id,
+                dbInstance(), admin, clock, testDaycare.id,
                 today, today.plusDays(5)
             ).isEmpty()
         )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/ChildrenControllerIntegrationTest.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Forbidden
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -58,7 +59,7 @@ class ChildrenControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     }
 
     fun getAdditionalInfo(user: AuthenticatedUser) {
-        val body = childController.getAdditionalInfo(Database(jdbi), user, childId)
+        val body = childController.getAdditionalInfo(Database(jdbi), user, RealEvakaClock(), childId)
 
         assertEquals(child.additionalInformation.diet, body.diet)
         assertEquals(child.additionalInformation.additionalInfo, body.additionalInfo)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/service/AbsenceServiceIntegrationTest.kt
@@ -35,6 +35,7 @@ import fi.espoo.evaka.shared.dev.insertTestReservation
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.domain.TimeRange
 import fi.espoo.evaka.testArea
 import fi.espoo.evaka.testChild_1
@@ -212,7 +213,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         val initialAbsenceList = listOf(initialAbsence)
 
         val result = db.transaction { tx ->
-            tx.upsertAbsences(initialAbsenceList, EvakaUserId(testUserId.raw))
+            tx.upsertAbsences(RealEvakaClock(), initialAbsenceList, EvakaUserId(testUserId.raw))
             absenceService.getAbsencesByMonth(tx, groupId, absenceDate.year, absenceDate.monthValue)
         }
         val absence = result.children[0].absences.getValue(absenceDate)[0]
@@ -243,7 +244,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         val initialAbsenceList = listOf(initialAbsence)
 
         val result = db.transaction { tx ->
-            tx.upsertAbsences(initialAbsenceList, EvakaUserId(testUserId.raw))
+            tx.upsertAbsences(RealEvakaClock(), initialAbsenceList, EvakaUserId(testUserId.raw))
             absenceService.getAbsencesByMonth(tx, groupId, absenceDate.year, absenceDate.monthValue)
         }
         val absence = result.children[0].absences.getValue(absenceDate)[0]
@@ -264,7 +265,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         val initialAbsenceList = listOf(initialAbsence, initialAbsence2)
 
         val result = db.transaction { tx ->
-            tx.upsertAbsences(initialAbsenceList, EvakaUserId(testUserId.raw))
+            tx.upsertAbsences(RealEvakaClock(), initialAbsenceList, EvakaUserId(testUserId.raw))
             absenceService.getAbsencesByMonth(tx, groupId, absenceDate.year, absenceDate.monthValue)
         }
         val absences = result.children[0].absences.getValue(absenceDate)
@@ -282,7 +283,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         val initialAbsenceList = listOf(initialAbsence, initialAbsence2)
 
         val result = db.transaction { tx ->
-            tx.upsertAbsences(initialAbsenceList, EvakaUserId(testUserId.raw))
+            tx.upsertAbsences(RealEvakaClock(), initialAbsenceList, EvakaUserId(testUserId.raw))
             absenceService.getAbsencesByMonth(tx, groupId, absenceDate.year, absenceDate.monthValue)
         }
         val absences = result.children[0].absences.getValue(absenceDate)
@@ -299,7 +300,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         val initialAbsenceList = listOf(initialAbsence)
 
         var result = db.transaction { tx ->
-            tx.upsertAbsences(initialAbsenceList, EvakaUserId(testUserId.raw))
+            tx.upsertAbsences(RealEvakaClock(), initialAbsenceList, EvakaUserId(testUserId.raw))
             absenceService.getAbsencesByMonth(tx, groupId, absenceDate.year, absenceDate.monthValue)
         }
         val absence = result.children[0].absences.getValue(absenceDate)[0]
@@ -313,7 +314,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         )
 
         result = db.transaction { tx ->
-            tx.upsertAbsences(listOf(updatedAbsence), EvakaUserId(testUserId.raw))
+            tx.upsertAbsences(RealEvakaClock(), listOf(updatedAbsence), EvakaUserId(testUserId.raw))
             absenceService.getAbsencesByMonth(tx, groupId, absenceDate.year, absenceDate.monthValue)
         }
         val absences = result.children[0].absences.getValue(absenceDate)
@@ -333,7 +334,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         val initialAbsenceList = listOf(initialAbsence, initialAbsence2)
 
         val absences = db.transaction { tx ->
-            tx.upsertAbsences(initialAbsenceList, EvakaUserId(testUserId.raw))
+            tx.upsertAbsences(RealEvakaClock(), initialAbsenceList, EvakaUserId(testUserId.raw))
             absenceService.getAbsencesByChild(tx, childId, absenceDate.year, absenceDate.monthValue)
         }
         assertEquals(initialAbsenceList.size, absences.size)
@@ -354,7 +355,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         val initialAbsenceList = listOf(initialAbsence, initialAbsence2)
 
         val absences = db.transaction { tx ->
-            tx.upsertAbsences(initialAbsenceList, EvakaUserId(testUserId.raw))
+            tx.upsertAbsences(RealEvakaClock(), initialAbsenceList, EvakaUserId(testUserId.raw))
             absenceService.getAbsencesByChild(tx, childId2, absenceDate.year, absenceDate.monthValue)
         }
         assertEquals(0, absences.size)
@@ -370,7 +371,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         val initialAbsenceList = listOf(initialAbsence, initialAbsence2)
 
         val absences = db.transaction { tx ->
-            tx.upsertAbsences(initialAbsenceList, EvakaUserId(testUserId.raw))
+            tx.upsertAbsences(RealEvakaClock(), initialAbsenceList, EvakaUserId(testUserId.raw))
             absenceService.getAbsencesByChild(tx, childId, 2019, 9)
         }
         assertEquals(1, absences.size)
@@ -662,7 +663,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                 AbsenceType.OTHER_ABSENCE,
                 placementStart.plusDays(1)
             )
-            it.upsertAbsences(listOf(absence), EvakaUserId(testUserId.raw))
+            it.upsertAbsences(RealEvakaClock(), listOf(absence), EvakaUserId(testUserId.raw))
         }
 
         val result = db.read { absenceService.getAbsencesByMonth(it, groupId, 2019, 8) }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -39,7 +39,7 @@ import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
-import fi.espoo.evaka.shared.domain.RealEvakaClock
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testAdult_3
@@ -525,7 +525,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
             .asUser(serviceWorker)
             .responseObject<List<DaycarePlacementWithDetails>>(jsonMapper)
 
-        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+        asyncJobRunner.runPendingJobsSync(MockEvakaClock(now))
 
         return data.get().first().id
     }
@@ -552,7 +552,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 assertEquals(200, res.statusCode)
             }
 
-        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+        asyncJobRunner.runPendingJobsSync(MockEvakaClock(now))
     }
 
     private fun updatePlacement(id: PlacementId, startDate: LocalDate, endDate: LocalDate) {
@@ -569,7 +569,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 assertEquals(200, res.statusCode)
             }
 
-        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+        asyncJobRunner.runPendingJobsSync(MockEvakaClock(now))
     }
 
     private fun deletePlacement(id: PlacementId) {
@@ -580,7 +580,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 assertEquals(200, res.statusCode)
             }
 
-        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+        asyncJobRunner.runPendingJobsSync(MockEvakaClock(now))
     }
 
     private fun changeHeadOfFamily(child: DevPerson, headOfFamilyId: PersonId) {
@@ -598,7 +598,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
             .objectBody(body, mapper = jsonMapper)
             .response()
 
-        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+        asyncJobRunner.runPendingJobsSync(MockEvakaClock(now))
     }
 
     private fun searchValueDecisions(status: String, searchTerms: String = "", distinctionsString: String = "[]"): Paged<VoucherValueDecisionSummary> {
@@ -635,7 +635,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 }
             }
 
-        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+        asyncJobRunner.runPendingJobsSync(MockEvakaClock(now))
         return decisionIds
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.config.defaultJsonMapper
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snDaycareFullDay35
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
@@ -230,6 +231,7 @@ class FeeDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
     private fun searchAndAssert(searchTerms: String, expectedChildLastName: String) {
         val result = db.read { tx ->
             tx.searchFeeDecisions(
+                clock = RealEvakaClock(),
                 searchTerms = searchTerms,
                 page = 0,
                 pageSize = 100,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.config.defaultJsonMapper
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snDaycareFullDay35
 import fi.espoo.evaka.testAdult_1
@@ -33,7 +34,6 @@ import fi.espoo.evaka.testDecisionMaker_2
 import fi.espoo.evaka.toFeeDecisionServiceNeed
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -112,7 +112,7 @@ class FeeDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         db.transaction { tx ->
             val draft = testDecisions.find { it.status == FeeDecisionStatus.DRAFT }!!
             tx.upsertFeeDecisions(listOf(draft))
-            tx.approveFeeDecisionDraftsForSending(listOf(draft.id), testDecisionMaker_1.id, approvedAt = Instant.now(), false, false)
+            tx.approveFeeDecisionDraftsForSending(listOf(draft.id), testDecisionMaker_1.id, approvedAt = HelsinkiDateTime.now(), false, false)
 
             val result = tx.getFeeDecision(testDecisions[0].id)!!
             assertEquals(FeeDecisionStatus.WAITING_FOR_SENDING, result.status)
@@ -165,7 +165,7 @@ class FeeDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 )
 
             tx.upsertFeeDecisions(listOf(draft))
-            tx.approveFeeDecisionDraftsForSending(listOf(draft.id), testDecisionMaker_1.id, approvedAt = Instant.now(), true, forceUseDaycareHandler)
+            tx.approveFeeDecisionDraftsForSending(listOf(draft.id), testDecisionMaker_1.id, approvedAt = HelsinkiDateTime.now(), true, forceUseDaycareHandler)
 
             tx.getFeeDecision(draft.id)!!
         }
@@ -183,7 +183,7 @@ class FeeDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             )
             tx.upsertFeeDecisions(decisions)
 
-            tx.approveFeeDecisionDraftsForSending(decisions.map { it.id }, testDecisionMaker_1.id, approvedAt = Instant.now(), false, false)
+            tx.approveFeeDecisionDraftsForSending(decisions.map { it.id }, testDecisionMaker_1.id, approvedAt = HelsinkiDateTime.now(), false, false)
 
             val result = tx.getFeeDecisionsByIds(decisions.map { it.id }).sortedBy { it.decisionNumber }
             with(result[0]) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
@@ -25,6 +25,7 @@ import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.dev.DevInvoiceCorrection
 import fi.espoo.evaka.shared.dev.insertTestInvoiceCorrection
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testArea
 import fi.espoo.evaka.testChild_1
@@ -43,6 +44,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
     private val generator: InvoiceGenerator = InvoiceGenerator(draftInvoiceGenerator)
     private val invoiceService =
         InvoiceService(InvoiceIntegrationClient.MockClient(defaultJsonMapper()), TestInvoiceProductProvider(), featureConfig)
+    private val clock = RealEvakaClock()
 
     @BeforeEach
     fun beforeEach() {
@@ -78,6 +80,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
             invoiceService.sendInvoices(
                 it,
                 AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)),
+                clock,
                 invoices.map { it.id },
                 null,
                 null
@@ -100,6 +103,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
             invoiceService.sendInvoices(
                 it,
                 AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)),
+                clock,
                 invoices.map { it.id },
                 null,
                 null
@@ -125,6 +129,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
             invoiceService.sendInvoices(
                 it,
                 AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)),
+                clock,
                 invoices.map { it.id },
                 null,
                 null
@@ -147,6 +152,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
             invoiceService.sendInvoices(
                 it,
                 AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)),
+                clock,
                 invoices.map { it.id },
                 null,
                 null
@@ -390,6 +396,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
             invoiceService.sendInvoices(
                 it,
                 AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)),
+                clock,
                 invoices.map { it.id },
                 null,
                 null
@@ -418,6 +425,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
             invoiceService.sendInvoices(
                 it,
                 AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN)),
+                clock,
                 invoices.map { it.id },
                 null,
                 null

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -45,6 +45,7 @@ import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.snDaycareContractDays10
 import fi.espoo.evaka.snDaycareContractDays15
 import fi.espoo.evaka.snDaycareFullDay35
@@ -4808,6 +4809,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     private fun insertAbsences(childId: ChildId, absenceDays: List<Pair<LocalDate, AbsenceType>>) {
         db.transaction { tx ->
             tx.upsertAbsences(
+                RealEvakaClock(),
                 absenceDays.map { (date, type) ->
                     AbsenceUpsert(
                         absenceType = type,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.security.PilotFeature
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -157,7 +158,7 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
 
             val contentId = tx.insertMessageContent("content", employeeAccount)
             val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false)
-            val messageId = tx.insertMessage(contentId, threadId, employeeAccount, allAccounts.map { it.name })
+            val messageId = tx.insertMessage(RealEvakaClock(), contentId, threadId, employeeAccount, allAccounts.map { it.name })
             tx.insertRecipients(allAccounts.map { it.id }.toSet(), messageId)
         }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -33,6 +33,7 @@ import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.testArea
 import fi.espoo.evaka.testChild_1
@@ -128,7 +129,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals("Newest thread", thread.title)
 
         // when the thread is marked read for person 1
-        db.transaction { it.markThreadRead(person1Account, thread1Id) }
+        db.transaction { it.markThreadRead(RealEvakaClock(), person1Account, thread1Id) }
 
         // then the message has correct readAt
         val person1Threads = db.read {
@@ -156,6 +157,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             val recipients = listOf(employee1Account)
             val contentId = it.insertMessageContent(content = "Just replying here", sender = person1Account)
             val messageId = it.insertMessage(
+                RealEvakaClock(),
                 contentId = contentId,
                 threadId = thread2Id,
                 sender = person1Account,
@@ -308,6 +310,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         val participants2 = db.transaction { tx ->
             val contentId = tx.insertMessageContent("foo", person2Account)
             val messageId = tx.insertMessage(
+                RealEvakaClock(),
                 contentId = contentId,
                 threadId = threadId,
                 sender = person2Account,
@@ -470,7 +473,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, db.read { it.getUnreadMessagesCounts(setOf(person2Account)).first().unreadCount })
 
         // when employee reads the message
-        db.transaction { it.markThreadRead(employee1Account, thread1) }
+        db.transaction { it.markThreadRead(RealEvakaClock(), employee1Account, thread1) }
 
         // then the thread does not count towards unread messages
         assertEquals(0, db.read { it.getUnreadMessagesCounts(setOf(person1Account)).first().unreadCount })
@@ -486,7 +489,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(2, db.read { it.getUnreadMessagesCounts(setOf(person2Account)).first().unreadCount })
 
         // when person two reads a thread
-        db.transaction { it.markThreadRead(person2Account, thread2) }
+        db.transaction { it.markThreadRead(RealEvakaClock(), person2Account, thread2) }
 
         // then unread count goes down by one
         assertEquals(0, db.read { it.getUnreadMessagesCounts(setOf(employee1Account)).first().unreadCount })
@@ -505,6 +508,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             val threadId = tx.insertThread(MessageType.MESSAGE, title, urgent = false)
             val messageId =
                 tx.insertMessage(
+                    RealEvakaClock(),
                     contentId = contentId,
                     threadId = threadId,
                     sender = sender,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
@@ -32,6 +32,7 @@ import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testArea
@@ -259,7 +260,7 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
 
             val contentId = tx.insertMessageContent("content", employeeAccount)
             val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false)
-            val messageId = tx.insertMessage(contentId, threadId, employeeAccount, listOf("recipient name"))
+            val messageId = tx.insertMessage(RealEvakaClock(), contentId, threadId, employeeAccount, listOf("recipient name"))
             tx.insertRecipients(setOf(personAccount), messageId)
         }
 
@@ -278,7 +279,7 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
 
             val contentId = tx.insertMessageContent("content", personAccount)
             val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false)
-            val messageId = tx.insertMessage(contentId, threadId, personAccount, listOf("employee name"))
+            val messageId = tx.insertMessage(RealEvakaClock(), contentId, threadId, personAccount, listOf("employee name"))
             tx.insertRecipients(setOf(employeeAccount), messageId)
         }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.util.UUID
@@ -60,7 +61,7 @@ class EmployeeControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         val responseCreate = employeeController.createEmployee(Database(jdbi), user, requestFromEmployee(employee1))
         assertEquals(1, employeeController.getEmployees(Database(jdbi), user).size)
 
-        val responseGet = employeeController.getEmployee(Database(jdbi), user, responseCreate.id)
+        val responseGet = employeeController.getEmployee(Database(jdbi), user, RealEvakaClock(), responseCreate.id)
         assertEquals(1, employeeController.getEmployees(Database(jdbi), user).size)
         assertEquals(responseCreate.id, responseGet.id)
     }
@@ -70,7 +71,7 @@ class EmployeeControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
         val body = employeeController.createEmployee(Database(jdbi), user, requestFromEmployee(employee1))
 
-        employeeController.deleteEmployee(Database(jdbi), user, body.id)
+        employeeController.deleteEmployee(Database(jdbi), user, RealEvakaClock(), body.id)
 
         assertEquals(0, employeeController.getEmployees(Database(jdbi), user).size)
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerIntegrationTest.kt
@@ -25,17 +25,19 @@ class EmployeeControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     @Autowired
     lateinit var employeeController: EmployeeController
 
+    private val clock = RealEvakaClock()
+
     @Test
     fun `no employees return empty list`() {
         val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
-        val employees = employeeController.getEmployees(Database(jdbi), user)
+        val employees = employeeController.getEmployees(Database(jdbi), user, clock)
         assertEquals(listOf(), employees)
     }
 
     @Test
     fun `admin can add employee`() {
         val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
-        val emp = employeeController.createEmployee(Database(jdbi), user, requestFromEmployee(employee1))
+        val emp = employeeController.createEmployee(Database(jdbi), user, clock, requestFromEmployee(employee1))
         assertEquals(employee1.firstName, emp.firstName)
         assertEquals(employee1.lastName, emp.lastName)
         assertEquals(employee1.email, emp.email)
@@ -45,9 +47,9 @@ class EmployeeControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     @Test
     fun `admin gets all employees`() {
         val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
-        employeeController.createEmployee(Database(jdbi), user, requestFromEmployee(employee1))
-        employeeController.createEmployee(Database(jdbi), user, requestFromEmployee(employee2))
-        val employees = employeeController.getEmployees(Database(jdbi), user)
+        employeeController.createEmployee(Database(jdbi), user, clock, requestFromEmployee(employee1))
+        employeeController.createEmployee(Database(jdbi), user, clock, requestFromEmployee(employee2))
+        val employees = employeeController.getEmployees(Database(jdbi), user, clock)
         assertEquals(2, employees.size)
         assertEquals(employee1.email, employees[0].email)
         assertEquals(employee2.email, employees[1].email)
@@ -56,24 +58,24 @@ class EmployeeControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     @Test
     fun `admin can first create, then get employee`() {
         val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
-        assertEquals(0, employeeController.getEmployees(Database(jdbi), user).size)
+        assertEquals(0, employeeController.getEmployees(Database(jdbi), user, clock).size)
 
-        val responseCreate = employeeController.createEmployee(Database(jdbi), user, requestFromEmployee(employee1))
-        assertEquals(1, employeeController.getEmployees(Database(jdbi), user).size)
+        val responseCreate = employeeController.createEmployee(Database(jdbi), user, clock, requestFromEmployee(employee1))
+        assertEquals(1, employeeController.getEmployees(Database(jdbi), user, clock).size)
 
-        val responseGet = employeeController.getEmployee(Database(jdbi), user, RealEvakaClock(), responseCreate.id)
-        assertEquals(1, employeeController.getEmployees(Database(jdbi), user).size)
+        val responseGet = employeeController.getEmployee(Database(jdbi), user, clock, responseCreate.id)
+        assertEquals(1, employeeController.getEmployees(Database(jdbi), user, clock).size)
         assertEquals(responseCreate.id, responseGet.id)
     }
 
     @Test
     fun `admin can delete employee`() {
         val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
-        val body = employeeController.createEmployee(Database(jdbi), user, requestFromEmployee(employee1))
+        val body = employeeController.createEmployee(Database(jdbi), user, clock, requestFromEmployee(employee1))
 
-        employeeController.deleteEmployee(Database(jdbi), user, RealEvakaClock(), body.id)
+        employeeController.deleteEmployee(Database(jdbi), user, clock, body.id)
 
-        assertEquals(0, employeeController.getEmployees(Database(jdbi), user).size)
+        assertEquals(0, employeeController.getEmployees(Database(jdbi), user, clock).size)
     }
 
     fun requestFromEmployee(employee: Employee) = NewEmployee(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerSearchIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/EmployeeControllerSearchIntegrationTest.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1
 import fi.espoo.evaka.unitSupervisorOfTestDaycare
@@ -38,7 +39,7 @@ class EmployeeControllerSearchIntegrationTest : FullApplicationTest(resetDbBefor
     @Test
     fun `admin searches employees`() {
         val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
-        val body = controller.searchEmployees(Database(jdbi), user, SearchEmployeeRequest(page = 1, pageSize = 4, searchTerm = null))
+        val body = controller.searchEmployees(Database(jdbi), user, RealEvakaClock(), SearchEmployeeRequest(page = 1, pageSize = 4, searchTerm = null))
 
         assertEquals(4, body.total)
         assertEquals(1, body.pages)
@@ -58,7 +59,7 @@ class EmployeeControllerSearchIntegrationTest : FullApplicationTest(resetDbBefor
     @Test
     fun `admin searches employees with free text`() {
         val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
-        val body = controller.searchEmployees(Database(jdbi), user, SearchEmployeeRequest(page = 1, pageSize = 10, searchTerm = "super"))
+        val body = controller.searchEmployees(Database(jdbi), user, RealEvakaClock(), SearchEmployeeRequest(page = 1, pageSize = 10, searchTerm = "super"))
         assertEquals(1, body.data.size)
         assertEquals("Sammy", body.data[0].firstName)
         assertEquals("Supervisor", body.data[0].lastName)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/ParentshipControllerIntegrationTest.kt
@@ -84,7 +84,7 @@ class ParentshipControllerIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val endDate = startDate.plusDays(200)
         val reqBody =
             ParentshipController.ParentshipRequest(parent.id, child.id, startDate, endDate)
-        controller.createParentship(Database(jdbi), user, reqBody)
+        controller.createParentship(Database(jdbi), user, clock, reqBody)
 
         val getResponse = controller.getParentships(Database(jdbi), user, clock, headOfChildId = parent.id)
         with(getResponse.first().data) {
@@ -108,7 +108,7 @@ class ParentshipControllerIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val endDate = startDate.plusDays(200)
         val reqBody =
             ParentshipController.ParentshipRequest(parent.id, sibling.id, startDate, endDate)
-        controller.createParentship(Database(jdbi), user, reqBody)
+        controller.createParentship(Database(jdbi), user, clock, reqBody)
 
         val getResponse = controller.getParentships(Database(jdbi), user, clock, headOfChildId = parent.id)
         assertEquals(2, getResponse.size)
@@ -150,10 +150,10 @@ class ParentshipControllerIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val newStartDate = child.dateOfBirth.plusDays(100)
         val newEndDate = child.dateOfBirth.plusDays(300)
         val requestBody = ParentshipController.ParentshipUpdateRequest(newStartDate, newEndDate)
-        controller.updateParentship(Database(jdbi), user, parentship.id, requestBody)
+        controller.updateParentship(Database(jdbi), user, clock, parentship.id, requestBody)
 
         // child1 should have new dates
-        val fetched1 = controller.getParentship(Database(jdbi), user, parentship.id)
+        val fetched1 = controller.getParentship(Database(jdbi), user, clock, parentship.id)
         assertEquals(newStartDate, fetched1.startDate)
         assertEquals(newEndDate, fetched1.endDate)
     }
@@ -186,7 +186,7 @@ class ParentshipControllerIntegrationTest : FullApplicationTest(resetDbBeforeEac
             }
         }
 
-        controller.deleteParentship(Database(jdbi), user, parentship.id)
+        controller.deleteParentship(Database(jdbi), user, clock, parentship.id)
         db.read { r ->
             assertEquals(1, r.getParentships(headOfChildId = parent.id, childId = null).size)
         }
@@ -204,7 +204,7 @@ class ParentshipControllerIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 assertEquals(2, tx.getParentships(headOfChildId = parent.id, childId = null).size)
             }
         }
-        assertThrows<Forbidden> { controller.deleteParentship(Database(jdbi), user, parentship.id) }
+        assertThrows<Forbidden> { controller.deleteParentship(Database(jdbi), user, clock, parentship.id) }
     }
 
     @Test
@@ -225,7 +225,7 @@ class ParentshipControllerIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val newStartDate = child.dateOfBirth.plusDays(100)
         val newEndDate = child.dateOfBirth.plusDays(300)
         val requestBody = ParentshipController.ParentshipUpdateRequest(newStartDate, newEndDate)
-        assertThrows<Forbidden> { controller.updateParentship(Database(jdbi), user, parentship.id, requestBody) }
+        assertThrows<Forbidden> { controller.updateParentship(Database(jdbi), user, clock, parentship.id, requestBody) }
     }
 
     @Test
@@ -234,7 +234,7 @@ class ParentshipControllerIntegrationTest : FullApplicationTest(resetDbBeforeEac
         val parentship = db.transaction { tx ->
             tx.createParentship(child.id, parent.id, child.dateOfBirth, child.dateOfBirth.plusDays(200))
         }
-        assertThrows<Forbidden> { controller.deleteParentship(Database(jdbi), user, parentship.id) }
+        assertThrows<Forbidden> { controller.deleteParentship(Database(jdbi), user, clock, parentship.id) }
     }
 
     @Test
@@ -246,7 +246,7 @@ class ParentshipControllerIntegrationTest : FullApplicationTest(resetDbBeforeEac
             child.dateOfBirth.minusDays(1),
             child.dateOfBirth.plusYears(1)
         )
-        assertThrows<BadRequest> { controller.createParentship(Database(jdbi), user, request) }
+        assertThrows<BadRequest> { controller.createParentship(Database(jdbi), user, clock, request) }
     }
 
     @Test
@@ -258,6 +258,6 @@ class ParentshipControllerIntegrationTest : FullApplicationTest(resetDbBeforeEac
             child.dateOfBirth,
             child.dateOfBirth.plusYears(18)
         )
-        assertThrows<BadRequest> { controller.createParentship(Database(jdbi), user, request) }
+        assertThrows<BadRequest> { controller.createParentship(Database(jdbi), user, clock, request) }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -18,8 +18,11 @@ import fi.espoo.evaka.shared.dev.DevGuardianBlocklistEntry
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestGuardianBlocklistEntry
 import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.test.assertEquals
 
@@ -29,6 +32,8 @@ class PersonControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     @Autowired
     lateinit var controller: PersonController
 
+    private val clock = MockEvakaClock(HelsinkiDateTime.of(LocalDateTime.of(2022, 1, 1, 12, 0)))
+
     @Test
     fun `Search finds person by first and last name`() {
         val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.SERVICE_WORKER))
@@ -37,6 +42,7 @@ class PersonControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
         val response = controller.findBySearchTerms(
             Database(jdbi),
             user,
+            clock,
             SearchPersonBody(
                 searchTerm = "${person.firstName} ${person.lastName}",
                 orderBy = "first_name",
@@ -55,6 +61,7 @@ class PersonControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
         val response = controller.findBySearchTerms(
             Database(jdbi),
             user,
+            clock,
             SearchPersonBody(
                 searchTerm = "${person.firstName}\t${person.lastName}",
                 orderBy = "first_name",
@@ -73,6 +80,7 @@ class PersonControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
         val response = controller.findBySearchTerms(
             Database(jdbi),
             user,
+            clock,
             SearchPersonBody(
                 searchTerm = "${person.firstName}\u00A0${person.lastName}",
                 orderBy = "first_name",
@@ -93,6 +101,7 @@ class PersonControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
         val response = controller.findBySearchTerms(
             Database(jdbi),
             user,
+            clock,
             SearchPersonBody(
                 searchTerm = "${person.firstName}\u3000${person.lastName}",
                 orderBy = "first_name",

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonControllerIntegrationTest.kt
@@ -124,7 +124,7 @@ class PersonControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             )
         }
 
-        val dependants = controller.getPersonDependants(Database(jdbi), admin, guardianId)
+        val dependants = controller.getPersonDependants(Database(jdbi), admin, clock, guardianId)
         assertEquals(3, dependants.size)
 
         val blockedDependant = dependants.find { it.socialSecurityNumber == "070714A9126" }!!
@@ -134,7 +134,7 @@ class PersonControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             tx.execute("UPDATE person SET vtj_guardians_queried = NULL, vtj_dependants_queried = NULL")
         }
 
-        assertEquals(2, controller.getPersonDependants(Database(jdbi), admin, guardianId).size)
+        assertEquals(2, controller.getPersonDependants(Database(jdbi), admin, clock, guardianId).size)
     }
 
     @Test
@@ -149,7 +149,7 @@ class PersonControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             )
         }
 
-        val guardians = controller.getPersonGuardians(Database(jdbi), admin, childId)
+        val guardians = controller.getPersonGuardians(Database(jdbi), admin, clock, childId)
         assertEquals(2, guardians.size)
 
         val blockedGuardian = guardians.find { it.socialSecurityNumber == "070644-937X" }!!
@@ -159,7 +159,7 @@ class PersonControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             tx.execute("UPDATE person SET vtj_guardians_queried = NULL, vtj_dependants_queried = NULL")
         }
 
-        assertEquals(1, controller.getPersonGuardians(Database(jdbi), admin, childId).size)
+        assertEquals(1, controller.getPersonGuardians(Database(jdbi), admin, clock, childId).size)
     }
 
     private fun createPerson(): PersonDTO {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -34,6 +34,7 @@ import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.security.upsertCitizenUser
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1
@@ -140,7 +141,7 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, countBefore)
 
         db.transaction {
-            mergeService.mergePeople(it, adultId, adultIdDuplicate)
+            mergeService.mergePeople(it, RealEvakaClock(), adultId, adultIdDuplicate)
         }
 
         val countAfter = db.read {
@@ -187,7 +188,7 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals(1, countBefore)
 
         db.transaction {
-            mergeService.mergePeople(it, childId, childIdDuplicate)
+            mergeService.mergePeople(it, RealEvakaClock(), childId, childIdDuplicate)
         }
 
         val countAfter = db.read {
@@ -218,6 +219,7 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         db.transaction { tx ->
             messageService.createMessageThreadsForRecipientGroups(
                 tx,
+                RealEvakaClock(),
                 title = "Juhannus",
                 content = "Juhannus tulee kohta",
                 type = MessageType.MESSAGE,
@@ -233,7 +235,7 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         db.transaction {
-            mergeService.mergePeople(it, senderId, senderIdDuplicate)
+            mergeService.mergePeople(it, RealEvakaClock(), senderId, senderIdDuplicate)
             mergeService.deleteEmptyPerson(it, senderIdDuplicate)
         }
 
@@ -266,6 +268,7 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         db.transaction { tx ->
             messageService.createMessageThreadsForRecipientGroups(
                 tx,
+                RealEvakaClock(),
                 title = "Juhannus",
                 content = "Juhannus tulee kohta",
                 type = MessageType.MESSAGE,
@@ -281,7 +284,7 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         db.transaction {
-            mergeService.mergePeople(it, receiverId, receiverIdDuplicate)
+            mergeService.mergePeople(it, RealEvakaClock(), receiverId, receiverIdDuplicate)
             mergeService.deleteEmptyPerson(it, receiverIdDuplicate)
         }
 
@@ -327,7 +330,7 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         }
 
         db.transaction {
-            mergeService.mergePeople(it, childId, childIdDuplicate)
+            mergeService.mergePeople(it, RealEvakaClock(), childId, childIdDuplicate)
         }
 
         verify(asyncJobRunnerMock).plan(
@@ -360,7 +363,7 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         }
 
         db.transaction {
-            mergeService.mergePeople(it, person.id, duplicate.id)
+            mergeService.mergePeople(it, RealEvakaClock(), person.id, duplicate.id)
             mergeService.deleteEmptyPerson(it, duplicate.id)
         }
         db.read {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/ParentshipServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/ParentshipServiceIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.pis.getParentships
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
@@ -30,12 +31,12 @@ class ParentshipServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach =
         val endDate1 = startDate1.plusDays(50)
 
         db.transaction { tx ->
-            parentshipService.createParentship(tx, child.id, parent1.id, startDate1, endDate1)
+            parentshipService.createParentship(tx, RealEvakaClock(), child.id, parent1.id, startDate1, endDate1)
 
             val startDate2 = endDate1.plusDays(1)
             val endDate2 = startDate2.plusDays(50)
 
-            parentshipService.createParentship(tx, child.id, parent2.id, startDate2, endDate2)
+            parentshipService.createParentship(tx, RealEvakaClock(), child.id, parent2.id, startDate2, endDate2)
 
             val headsByChild = tx.getParentships(headOfChildId = null, childId = child.id)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/VTJBatchRefreshServiceIntegrationTest.kt
@@ -94,6 +94,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest(resetDbBeforeE
         service.doVTJRefresh(db, RealEvakaClock(), AsyncJob.VTJRefresh(testAdult_1.id))
         verify(parentshipService).createParentship(
             any(),
+            any(),
             eq(testChild_1.id),
             eq(testAdult_1.id),
             eq(LocalDate.now()),
@@ -152,6 +153,7 @@ class VTJBatchRefreshServiceIntegrationTest : FullApplicationTest(resetDbBeforeE
 
         service.doVTJRefresh(db, RealEvakaClock(), AsyncJob.VTJRefresh(testAdult_1.id))
         verify(parentshipService).createParentship(
+            any(),
             any(),
             eq(testChild_1.id),
             eq(testAdult_1.id),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationUpkeepIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationUpkeepIntegrationTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.dev.DevReservation
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestReservation
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.job.ScheduledJobs
 import fi.espoo.evaka.shared.security.upsertCitizenUser
 import fi.espoo.evaka.testAdult_1
@@ -89,7 +90,7 @@ class ReservationUpkeepIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             )
         }
 
-        scheduledJobs.endOfDayReservationUpkeep(db)
+        scheduledJobs.endOfDayReservationUpkeep(db, RealEvakaClock())
 
         val reservations = db.read { tx ->
             tx.createQuery("""SELECT id FROM attendance_reservation""").mapTo<AttendanceReservationId>().toSet()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -38,6 +38,8 @@ import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestMobileDevice
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import fi.espoo.evaka.shared.security.actionrule.DefaultActionRuleMapping
@@ -47,6 +49,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -65,6 +68,8 @@ class AclIntegrationTest : PureJdbiTest(resetDbBeforeEach = false) {
 
     private lateinit var acl: AccessControlList
     private lateinit var accessControl: AccessControl
+
+    private val clock = MockEvakaClock(HelsinkiDateTime.of(LocalDateTime.of(2022, 1, 1, 12, 0)))
 
     @BeforeAll
     fun before() {
@@ -110,8 +115,8 @@ class AclIntegrationTest : PureJdbiTest(resetDbBeforeEach = false) {
 
         assertEquals(aclAuth, acl.getAuthorizedUnits(user))
 
-        assertTrue(accessControl.hasPermissionFor(user, Action.Person.READ, fridgeParentId))
-        assertTrue(accessControl.hasPermissionFor(user, Action.Person.READ, guardianId))
+        assertTrue(accessControl.hasPermissionFor(user, clock, Action.Person.READ, fridgeParentId))
+        assertTrue(accessControl.hasPermissionFor(user, clock, Action.Person.READ, guardianId))
     }
 
     @ParameterizedTest(name = "{0}")
@@ -122,14 +127,14 @@ class AclIntegrationTest : PureJdbiTest(resetDbBeforeEach = false) {
         val positiveAclAuth = AclAuthorization.Subset(setOf(daycareId))
 
         assertEquals(negativeAclAuth, acl.getAuthorizedUnits(user))
-        assertFalse(accessControl.hasPermissionFor(user, Action.Person.READ, fridgeParentId))
-        assertFalse(accessControl.hasPermissionFor(user, Action.Person.READ, guardianId))
+        assertFalse(accessControl.hasPermissionFor(user, clock, Action.Person.READ, fridgeParentId))
+        assertFalse(accessControl.hasPermissionFor(user, clock, Action.Person.READ, guardianId))
 
         db.transaction { it.insertDaycareAclRow(daycareId, employeeId, role) }
 
         assertEquals(positiveAclAuth, acl.getAuthorizedUnits(user))
-        assertTrue(accessControl.hasPermissionFor(user, Action.Person.READ, fridgeParentId))
-        assertTrue(accessControl.hasPermissionFor(user, Action.Person.READ, guardianId))
+        assertTrue(accessControl.hasPermissionFor(user, clock, Action.Person.READ, fridgeParentId))
+        assertTrue(accessControl.hasPermissionFor(user, clock, Action.Person.READ, guardianId))
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -34,6 +34,7 @@ import fi.espoo.evaka.shared.dev.insertTestApplicationForm
 import fi.espoo.evaka.shared.dev.insertTestBackupCare
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.test.validDaycareApplication
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_5
@@ -294,7 +295,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
                     FiniteDateRange(preferredStartDate, preferredStartDate.plusMonths(1))
                 )
             )
-            applicationStateService.sendDecisionsWithoutProposal(it, serviceWorker, applicationId)
+            applicationStateService.sendDecisionsWithoutProposal(it, serviceWorker, RealEvakaClock(), applicationId)
         }
 
         scheduledJobs.cancelOutdatedTransferApplications(db)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -93,7 +93,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
             assertEquals(1, it.getApplicationAttachments(id_not_to_be_deleted).size)
         }
 
-        scheduledJobs.removeOldDraftApplications(db)
+        scheduledJobs.removeOldDraftApplications(db, RealEvakaClock())
 
         db.read {
             assertNull(it.fetchApplicationDetails(id_to_be_deleted))
@@ -116,7 +116,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val preferredStartDate = LocalDate.now().plusMonths(1)
         val applicationId = createTransferApplication(ApplicationType.DAYCARE, preferredStartDate)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.CANCELLED, applicationStatus)
@@ -127,7 +127,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val preferredStartDate = LocalDate.now().plusMonths(1)
         val applicationId = createNormalApplication(ApplicationType.DAYCARE, preferredStartDate)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.SENT, applicationStatus)
@@ -140,7 +140,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate, preferredStartDate.plusMonths(1))
         createPlacement(PlacementType.DAYCARE, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.SENT, applicationStatus)
@@ -153,7 +153,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate, preferredStartDate.plusMonths(1))
         createPlacement(PlacementType.DAYCARE_FIVE_YEAR_OLDS, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.SENT, applicationStatus)
@@ -166,7 +166,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate.plusMonths(1), preferredStartDate.plusMonths(2))
         createPlacement(PlacementType.DAYCARE, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.SENT, applicationStatus)
@@ -179,7 +179,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate, preferredStartDate.plusMonths(1))
         createPlacement(PlacementType.PRESCHOOL, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.CANCELLED, applicationStatus)
@@ -192,7 +192,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate.minusMonths(1), LocalDate.now().minusMonths(1))
         createPlacement(PlacementType.DAYCARE, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.CANCELLED, applicationStatus)
@@ -205,7 +205,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate.minusMonths(1), LocalDate.now())
         createPlacement(PlacementType.DAYCARE, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.SENT, applicationStatus)
@@ -218,7 +218,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate.minusMonths(1), LocalDate.now().minusDays(2))
         createPlacement(PlacementType.DAYCARE, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.CANCELLED, applicationStatus)
@@ -231,7 +231,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate.minusMonths(1), LocalDate.now().plusMonths(1))
         createPlacement(PlacementType.PRESCHOOL, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.SENT, applicationStatus)
@@ -245,7 +245,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate.minusMonths(1), LocalDate.now().plusMonths(1))
         createPlacement(PlacementType.PRESCHOOL, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.SENT, applicationStatus)
@@ -258,7 +258,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate.minusMonths(1), LocalDate.now().plusMonths(1))
         createPlacement(PlacementType.PREPARATORY, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.SENT, applicationStatus)
@@ -271,7 +271,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
         val dateRange = FiniteDateRange(preferredStartDate.minusMonths(1), LocalDate.now().plusMonths(1))
         createPlacement(PlacementType.PRESCHOOL_DAYCARE, dateRange)
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.SENT, applicationStatus)
@@ -298,7 +298,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
             applicationStateService.sendDecisionsWithoutProposal(it, serviceWorker, RealEvakaClock(), applicationId)
         }
 
-        scheduledJobs.cancelOutdatedTransferApplications(db)
+        scheduledJobs.cancelOutdatedTransferApplications(db, RealEvakaClock())
 
         val applicationStatus = getApplicationStatus(applicationId)
         assertEquals(ApplicationStatus.WAITING_CONFIRMATION, applicationStatus)
@@ -331,7 +331,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
             val notesBeforeCleanup = it.getChildStickyNotesForChild(testChild_1.id)
             assertEquals(2, notesBeforeCleanup.size)
         }
-        scheduledJobs.removeExpiredNotes(db)
+        scheduledJobs.removeExpiredNotes(db, RealEvakaClock())
 
         db.read {
             val notesAfterCleanup = it.getChildStickyNotesForChild(testChild_1.id)
@@ -366,7 +366,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
             )
         }
 
-        scheduledJobs.removeExpiredNotes(db)
+        scheduledJobs.removeExpiredNotes(db, RealEvakaClock())
 
         db.read {
             val note1AfterCleanup = it.getChildDailyNote(testChild_1.id)
@@ -435,7 +435,7 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
             )
         }
 
-        scheduledJobs.removeExpiredNotes(db)
+        scheduledJobs.removeExpiredNotes(db, RealEvakaClock())
 
         db.read {
             val note1AfterCleanup = it.getChildDailyNote(testChild_1.id)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/ApplicationAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/ApplicationAccessControlTest.kt
@@ -24,11 +24,14 @@ import fi.espoo.evaka.shared.dev.insertTestCareArea
 import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacementPlan
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.security.actionrule.HasUnitRole
 import fi.espoo.evaka.shared.security.actionrule.IsCitizen
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -37,6 +40,8 @@ class ApplicationAccessControlTest : AccessControlTest() {
     private lateinit var childId: ChildId
     private lateinit var applicationId: ApplicationId
     private lateinit var daycareId: DaycareId
+
+    private val clock = MockEvakaClock(HelsinkiDateTime.of(LocalDateTime.of(2022, 1, 1, 12, 0)))
 
     @BeforeEach
     private fun beforeEach() {
@@ -68,8 +73,8 @@ class ApplicationAccessControlTest : AccessControlTest() {
         rules.add(action, IsCitizen(allowWeakLogin = false).ownerOfApplication())
         val otherCitizen = createTestCitizen(CitizenAuthLevel.STRONG)
 
-        assertTrue(accessControl.hasPermissionFor(creatorCitizen, action, applicationId))
-        assertFalse(accessControl.hasPermissionFor(otherCitizen, action, applicationId))
+        assertTrue(accessControl.hasPermissionFor(creatorCitizen, clock, action, applicationId))
+        assertFalse(accessControl.hasPermissionFor(otherCitizen, clock, action, applicationId))
     }
 
     @Test
@@ -78,8 +83,8 @@ class ApplicationAccessControlTest : AccessControlTest() {
         rules.add(action, HasUnitRole(UserRole.UNIT_SUPERVISOR).inPreferredUnitOfApplication())
         val unitSupervisor = createTestEmployee(globalRoles = emptySet(), unitRoles = mapOf(daycareId to UserRole.UNIT_SUPERVISOR))
         val otherEmployee = createTestEmployee(globalRoles = emptySet(), unitRoles = mapOf(daycareId to UserRole.STAFF))
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, action, applicationId))
-        assertFalse(accessControl.hasPermissionFor(otherEmployee, action, applicationId))
+        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, applicationId))
+        assertFalse(accessControl.hasPermissionFor(otherEmployee, clock, action, applicationId))
     }
 
     @Test
@@ -93,7 +98,7 @@ class ApplicationAccessControlTest : AccessControlTest() {
         }
         val unitSupervisor = createTestEmployee(globalRoles = emptySet(), unitRoles = mapOf(daycareId to UserRole.UNIT_SUPERVISOR))
         val otherEmployee = createTestEmployee(globalRoles = emptySet(), unitRoles = mapOf(daycareId to UserRole.STAFF))
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, action, applicationId))
-        assertFalse(accessControl.hasPermissionFor(otherEmployee, action, applicationId))
+        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, applicationId))
+        assertFalse(accessControl.hasPermissionFor(otherEmployee, clock, action, applicationId))
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AssistanceNeedDecisionAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AssistanceNeedDecisionAccessControlTest.kt
@@ -24,10 +24,13 @@ import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.security.actionrule.HasUnitRole
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -35,6 +38,8 @@ import kotlin.test.assertTrue
 class AssistanceNeedDecisionAccessControlTest : AccessControlTest() {
     private lateinit var childId: ChildId
     private lateinit var assistanceNeedDecisionId: AssistanceNeedDecisionId
+
+    private val clock = MockEvakaClock(HelsinkiDateTime.of(LocalDateTime.of(2022, 1, 1, 12, 0)))
 
     @BeforeEach
     private fun beforeEach() {
@@ -99,9 +104,9 @@ class AssistanceNeedDecisionAccessControlTest : AccessControlTest() {
             daycareId
         }
         val unitSupervisor = createTestEmployee(emptySet(), mapOf(daycareId to UserRole.UNIT_SUPERVISOR))
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, action, assistanceNeedDecisionId))
+        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, assistanceNeedDecisionId))
 
         val staff = createTestEmployee(emptySet(), mapOf(daycareId to UserRole.STAFF))
-        assertFalse(accessControl.hasPermissionFor(staff, action, assistanceNeedDecisionId))
+        assertFalse(accessControl.hasPermissionFor(staff, clock, action, assistanceNeedDecisionId))
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/ChildAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/ChildAccessControlTest.kt
@@ -18,17 +18,22 @@ import fi.espoo.evaka.shared.dev.insertTestChild
 import fi.espoo.evaka.shared.dev.insertTestDaycare
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.security.actionrule.HasUnitRole
 import fi.espoo.evaka.shared.security.actionrule.IsCitizen
 import fi.espoo.evaka.shared.security.actionrule.IsMobile
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ChildAccessControlTest : AccessControlTest() {
     private lateinit var childId: ChildId
+
+    private val clock = MockEvakaClock(HelsinkiDateTime.of(LocalDateTime.of(2022, 1, 1, 12, 0)))
 
     @BeforeEach
     private fun beforeEach() {
@@ -47,9 +52,9 @@ class ChildAccessControlTest : AccessControlTest() {
         }
         val otherCitizen = createTestCitizen(CitizenAuthLevel.STRONG)
 
-        assertTrue(accessControl.hasPermissionFor(guardianCitizen, action, childId))
-        assertFalse(accessControl.hasPermissionFor(otherCitizen, action, childId))
-        assertFalse(accessControl.hasPermissionFor(guardianCitizen.copy(authLevel = CitizenAuthLevel.WEAK), action, childId))
+        assertTrue(accessControl.hasPermissionFor(guardianCitizen, clock, action, childId))
+        assertFalse(accessControl.hasPermissionFor(otherCitizen, clock, action, childId))
+        assertFalse(accessControl.hasPermissionFor(guardianCitizen.copy(authLevel = CitizenAuthLevel.WEAK), clock, action, childId))
     }
 
     @Test
@@ -63,10 +68,10 @@ class ChildAccessControlTest : AccessControlTest() {
             daycareId
         }
         val unitSupervisor = createTestEmployee(emptySet(), mapOf(daycareId to UserRole.UNIT_SUPERVISOR))
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, action, childId))
+        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, childId))
 
         val staff = createTestEmployee(emptySet(), mapOf(daycareId to UserRole.STAFF))
-        assertFalse(accessControl.hasPermissionFor(staff, action, childId))
+        assertFalse(accessControl.hasPermissionFor(staff, clock, action, childId))
     }
 
     @Test
@@ -81,9 +86,9 @@ class ChildAccessControlTest : AccessControlTest() {
             Pair(daycareId, otherDaycareId)
         }
         val unitMobile = createTestMobile(daycareId)
-        assertTrue(accessControl.hasPermissionFor(unitMobile, action, childId))
+        assertTrue(accessControl.hasPermissionFor(unitMobile, clock, action, childId))
 
         val otherMobile = createTestMobile(otherDaycareId)
-        assertFalse(accessControl.hasPermissionFor(otherMobile, action, childId))
+        assertFalse(accessControl.hasPermissionFor(otherMobile, clock, action, childId))
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/IsCitizenTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/IsCitizenTest.kt
@@ -8,8 +8,11 @@ import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.security.actionrule.IsCitizen
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -19,30 +22,32 @@ class IsCitizenTest : AccessControlTest() {
     private val weakCitizen = AuthenticatedUser.Citizen(PersonId(UUID.randomUUID()), CitizenAuthLevel.WEAK)
     private val employee = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), emptySet())
 
+    private val clock = MockEvakaClock(HelsinkiDateTime.of(LocalDateTime.of(2022, 1, 1, 12, 0)))
+
     @Test
     fun `permits only strongly authenticated citizen if allowWeakLogin = false`() {
         val action = Action.Global.READ_HOLIDAY_PERIODS
         rules.add(action, IsCitizen(allowWeakLogin = false).any())
-        assertTrue(accessControl.hasPermissionFor(strongCitizen, action))
-        assertFalse(accessControl.hasPermissionFor(weakCitizen, action))
-        assertFalse(accessControl.hasPermissionFor(employee, action))
+        assertTrue(accessControl.hasPermissionFor(strongCitizen, clock, action))
+        assertFalse(accessControl.hasPermissionFor(weakCitizen, clock, action))
+        assertFalse(accessControl.hasPermissionFor(employee, clock, action))
     }
 
     @Test
     fun `permits any citizen if allowWeakLogin = true`() {
         val action = Action.Global.READ_HOLIDAY_PERIODS
         rules.add(action, IsCitizen(allowWeakLogin = true).any())
-        assertTrue(accessControl.hasPermissionFor(strongCitizen, action))
-        assertTrue(accessControl.hasPermissionFor(weakCitizen, action))
-        assertFalse(accessControl.hasPermissionFor(employee, action))
+        assertTrue(accessControl.hasPermissionFor(strongCitizen, clock, action))
+        assertTrue(accessControl.hasPermissionFor(weakCitizen, clock, action))
+        assertFalse(accessControl.hasPermissionFor(employee, clock, action))
     }
 
     @Test
     fun `self() permits only if the target is the same citizen user doing the action`() {
         val action = Action.Person.READ
         rules.add(action, IsCitizen(allowWeakLogin = false).self())
-        assertTrue(accessControl.hasPermissionFor(strongCitizen, action, strongCitizen.id))
-        assertFalse(accessControl.hasPermissionFor(strongCitizen, action, weakCitizen.id))
-        assertFalse(accessControl.hasPermissionFor(weakCitizen, action, weakCitizen.id))
+        assertTrue(accessControl.hasPermissionFor(strongCitizen, clock, action, strongCitizen.id))
+        assertFalse(accessControl.hasPermissionFor(strongCitizen, clock, action, weakCitizen.id))
+        assertFalse(accessControl.hasPermissionFor(weakCitizen, clock, action, weakCitizen.id))
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/UnitAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/UnitAccessControlTest.kt
@@ -55,8 +55,8 @@ class UnitAccessControlTest : AccessControlTest() {
         rules.add(action, HasUnitRole(UserRole.UNIT_SUPERVISOR).withUnitFeatures(unitFeature).inAnyUnit())
         val deniedSupervisor = createTestEmployee(globalRoles = emptySet(), unitRoles = mapOf(daycareId to UserRole.UNIT_SUPERVISOR, featureDaycareId to UserRole.STAFF))
         val permittedSupervisor = createTestEmployee(globalRoles = emptySet(), unitRoles = mapOf(daycareId to UserRole.STAFF, featureDaycareId to UserRole.UNIT_SUPERVISOR))
-        assertFalse(accessControl.hasPermissionFor(deniedSupervisor, action))
-        assertTrue(accessControl.hasPermissionFor(permittedSupervisor, action))
+        assertFalse(accessControl.hasPermissionFor(deniedSupervisor, clock, action))
+        assertTrue(accessControl.hasPermissionFor(permittedSupervisor, clock, action))
     }
 
     @Test
@@ -65,8 +65,8 @@ class UnitAccessControlTest : AccessControlTest() {
         rules.add(action, HasUnitRole(UserRole.UNIT_SUPERVISOR).inUnit())
         val unitSupervisor = createTestEmployee(globalRoles = emptySet(), unitRoles = mapOf(daycareId to UserRole.UNIT_SUPERVISOR))
         val otherEmployee = createTestEmployee(globalRoles = emptySet(), unitRoles = mapOf(daycareId to UserRole.STAFF))
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, action, daycareId))
-        assertFalse(accessControl.hasPermissionFor(otherEmployee, action, daycareId))
+        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, daycareId))
+        assertFalse(accessControl.hasPermissionFor(otherEmployee, clock, action, daycareId))
     }
 
     @Test
@@ -75,10 +75,10 @@ class UnitAccessControlTest : AccessControlTest() {
         rules.add(action, HasUnitRole(UserRole.UNIT_SUPERVISOR).withUnitFeatures(unitFeature).inUnit())
         val unitSupervisor = createTestEmployee(globalRoles = emptySet(), unitRoles = mapOf(daycareId to UserRole.UNIT_SUPERVISOR, featureDaycareId to UserRole.UNIT_SUPERVISOR))
         val otherEmployee = createTestEmployee(globalRoles = emptySet(), unitRoles = mapOf(daycareId to UserRole.STAFF, featureDaycareId to UserRole.STAFF))
-        assertFalse(accessControl.hasPermissionFor(unitSupervisor, action, daycareId))
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, action, featureDaycareId))
-        assertFalse(accessControl.hasPermissionFor(otherEmployee, action, daycareId))
-        assertFalse(accessControl.hasPermissionFor(otherEmployee, action, featureDaycareId))
+        assertFalse(accessControl.hasPermissionFor(unitSupervisor, clock, action, daycareId))
+        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, featureDaycareId))
+        assertFalse(accessControl.hasPermissionFor(otherEmployee, clock, action, daycareId))
+        assertFalse(accessControl.hasPermissionFor(otherEmployee, clock, action, featureDaycareId))
     }
 
     @Test
@@ -90,8 +90,8 @@ class UnitAccessControlTest : AccessControlTest() {
             tx.insertTestDaycare(DevDaycare(areaId = areaId))
         }
         val otherMobile = createTestMobile(otherDaycareId)
-        assertTrue(accessControl.hasPermissionFor(unitMobile, action, daycareId))
-        assertFalse(accessControl.hasPermissionFor(otherMobile, action, daycareId))
+        assertTrue(accessControl.hasPermissionFor(unitMobile, clock, action, daycareId))
+        assertFalse(accessControl.hasPermissionFor(otherMobile, clock, action, daycareId))
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.insertTestCareArea
 import fi.espoo.evaka.shared.dev.insertTestDaycare
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.testArea
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDaycare2
@@ -123,7 +124,7 @@ class VardaUnitIntegrationTest : VardaIntegrationTest(resetDbBeforeEach = true) 
 
     private fun updateUnits() {
         val ophMunicipalOrganizerIdUrl = "${vardaEnv.url}/v1/vakajarjestajat/${ophEnv.organizerId}/"
-        updateUnits(db, vardaClient, ophEnv.municipalityCode, ophMunicipalOrganizerIdUrl)
+        updateUnits(db, RealEvakaClock(), vardaClient, ophEnv.municipalityCode, ophMunicipalOrganizerIdUrl)
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
@@ -49,10 +49,11 @@ class ApplicationControllerCitizen(
     @GetMapping("/applications/by-guardian")
     fun getGuardianApplications(
         db: Database,
-        user: AuthenticatedUser.Citizen
+        user: AuthenticatedUser.Citizen,
+        clock: EvakaClock
     ): List<ApplicationsOfChild> {
         Audit.ApplicationRead.log(targetId = user.id)
-        accessControl.requirePermissionFor(user, Action.Citizen.Person.READ_APPLICATIONS, user.id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Person.READ_APPLICATIONS, user.id)
         return db.connect { dbc ->
             dbc.read { tx ->
                 val existingApplicationsByChild = tx.fetchApplicationSummariesForCitizen(user.id)
@@ -78,10 +79,11 @@ class ApplicationControllerCitizen(
     fun getApplication(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId
     ): ApplicationDetails {
         Audit.ApplicationRead.log(targetId = user.id, objectId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Citizen.Application.READ, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Application.READ, applicationId)
 
         val application = db.connect { dbc ->
             dbc.transaction { tx ->
@@ -99,11 +101,11 @@ class ApplicationControllerCitizen(
     fun createApplication(
         db: Database,
         user: AuthenticatedUser.Citizen,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestBody body: CreateApplicationBody
     ): ApplicationId {
         Audit.ApplicationCreate.log(targetId = user.id, objectId = body)
-        accessControl.requirePermissionFor(user, Action.Citizen.Child.CREATE_APPLICATION, body.childId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Child.CREATE_APPLICATION, body.childId)
 
         return db.connect { dbc ->
             dbc.transaction { tx ->
@@ -126,7 +128,7 @@ class ApplicationControllerCitizen(
                     childId = body.childId,
                     origin = ApplicationOrigin.ELECTRONIC
                 ).also {
-                    applicationStateService.initializeApplicationForm(tx, user, evakaClock.today(), it, body.type, guardian, child)
+                    applicationStateService.initializeApplicationForm(tx, user, clock.today(), it, body.type, guardian, child)
                 }
             }
         }
@@ -136,10 +138,11 @@ class ApplicationControllerCitizen(
     fun getChildDuplicateApplications(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable childId: ChildId
     ): Map<ApplicationType, Boolean> {
         Audit.ApplicationReadDuplicates.log(targetId = user.id, objectId = childId)
-        accessControl.requirePermissionFor(user, Action.Citizen.Child.READ_DUPLICATE_APPLICATIONS, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Child.READ_DUPLICATE_APPLICATIONS, childId)
 
         return db.connect { dbc ->
             dbc.read { tx ->
@@ -159,17 +162,17 @@ class ApplicationControllerCitizen(
     fun getChildPlacementStatusByApplicationType(
         db: Database,
         user: AuthenticatedUser.Citizen,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable childId: ChildId
     ): Map<ApplicationType, Boolean> {
         Audit.ApplicationReadActivePlacementsByType.log(targetId = user.id, objectId = childId)
-        accessControl.requirePermissionFor(user, Action.Citizen.Child.READ_PLACEMENT_STATUS_BY_APPLICATION_TYPE, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Child.READ_PLACEMENT_STATUS_BY_APPLICATION_TYPE, childId)
 
         return db.connect { dbc ->
             dbc.read { tx ->
                 ApplicationType.values()
                     .map { type ->
-                        type to tx.activePlacementExists(childId = childId, type = type, today = evakaClock.today())
+                        type to tx.activePlacementExists(childId = childId, type = type, today = clock.today())
                     }
                     .toMap()
             }
@@ -180,12 +183,12 @@ class ApplicationControllerCitizen(
     fun updateApplication(
         db: Database,
         user: AuthenticatedUser.Citizen,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId,
         @RequestBody applicationForm: ApplicationFormUpdate
     ) {
         Audit.ApplicationUpdate.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Citizen.Application.UPDATE, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Application.UPDATE, applicationId)
 
         db.connect { dbc ->
             dbc.transaction {
@@ -194,7 +197,7 @@ class ApplicationControllerCitizen(
                     user,
                     applicationId,
                     applicationForm,
-                    evakaClock.today()
+                    clock.today()
                 )
             }
         }
@@ -204,12 +207,12 @@ class ApplicationControllerCitizen(
     fun saveApplicationAsDraft(
         db: Database,
         user: AuthenticatedUser.Citizen,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId,
         @RequestBody applicationForm: ApplicationFormUpdate
     ) {
         Audit.ApplicationUpdate.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Citizen.Application.UPDATE, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Application.UPDATE, applicationId)
 
         db.connect { dbc ->
             dbc.transaction {
@@ -218,7 +221,7 @@ class ApplicationControllerCitizen(
                     user,
                     applicationId,
                     applicationForm,
-                    evakaClock.today(),
+                    clock.today(),
                     asDraft = true
                 )
             }
@@ -229,10 +232,11 @@ class ApplicationControllerCitizen(
     fun deleteUnprocessedApplication(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId
     ) {
         Audit.ApplicationDelete.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Citizen.Application.DELETE, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Application.DELETE, applicationId)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -251,16 +255,16 @@ class ApplicationControllerCitizen(
     fun sendApplication(
         db: Database,
         user: AuthenticatedUser.Citizen,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId
     ) {
-        db.connect { dbc -> dbc.transaction { applicationStateService.sendApplication(it, user, applicationId, evakaClock.today()) } }
+        db.connect { dbc -> dbc.transaction { applicationStateService.sendApplication(it, user, clock, applicationId) } }
     }
 
     @GetMapping("/decisions")
-    fun getDecisions(db: Database, user: AuthenticatedUser.Citizen): List<ApplicationDecisions> {
+    fun getDecisions(db: Database, user: AuthenticatedUser.Citizen, clock: EvakaClock): List<ApplicationDecisions> {
         Audit.DecisionRead.log(targetId = user.id)
-        accessControl.requirePermissionFor(user, Action.Citizen.Person.READ_DECISIONS, user.id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Person.READ_DECISIONS, user.id)
         return db.connect { dbc -> dbc.read { it.getOwnDecisions(user.id) } }
     }
 
@@ -268,10 +272,11 @@ class ApplicationControllerCitizen(
     fun getApplicationDecisions(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId
     ): List<Decision> {
         Audit.DecisionReadByApplication.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Citizen.Application.READ_DECISIONS, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Application.READ_DECISIONS, applicationId)
 
         return db.connect { dbc ->
             dbc.read { tx ->
@@ -285,6 +290,7 @@ class ApplicationControllerCitizen(
     fun acceptDecision(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId,
         @RequestBody body: AcceptDecisionRequest
     ) {
@@ -294,6 +300,7 @@ class ApplicationControllerCitizen(
                 applicationStateService.acceptDecision(
                     it,
                     user,
+                    clock,
                     applicationId,
                     body.decisionId,
                     body.requestedStartDate,
@@ -306,13 +313,14 @@ class ApplicationControllerCitizen(
     fun rejectDecision(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId,
         @RequestBody body: RejectDecisionRequest
     ) {
         // note: applicationStateService handles logging and authorization
         db.connect { dbc ->
             dbc.transaction {
-                applicationStateService.rejectDecision(it, user, applicationId, body.decisionId)
+                applicationStateService.rejectDecision(it, user, clock, applicationId, body.decisionId)
             }
         }
     }
@@ -321,10 +329,11 @@ class ApplicationControllerCitizen(
     fun downloadDecisionPdf(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable id: DecisionId
     ): ResponseEntity<Any> {
         Audit.DecisionDownloadPdf.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Citizen.Decision.DOWNLOAD_PDF, id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Decision.DOWNLOAD_PDF, id)
 
         return db.connect { dbc ->
             val decision = dbc.transaction { tx -> tx.getDecision(id) } ?: throw NotFound("Decision $id does not exist")
@@ -335,10 +344,11 @@ class ApplicationControllerCitizen(
     @GetMapping("/applications/by-guardian/notifications")
     fun getGuardianApplicationNotifications(
         db: Database,
-        user: AuthenticatedUser.Citizen
+        user: AuthenticatedUser.Citizen,
+        clock: EvakaClock
     ): Int {
         Audit.ApplicationReadNotifications.log(targetId = user.id)
-        accessControl.requirePermissionFor(user, Action.Citizen.Person.READ_APPLICATION_NOTIFICATIONS, user.id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Person.READ_APPLICATION_NOTIFICATIONS, user.id)
         return db.connect { dbc ->
             dbc.read { tx ->
                 tx.fetchApplicationNotificationCountForCitizen(user.id)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -299,7 +299,7 @@ class ApplicationControllerV2(
                         .map { personDTO -> PersonJSON.from(personDTO) }
 
                 val attachments = tx.getApplicationAttachments(applicationId).let { allAttachments ->
-                    val permissions = accessControl.checkPermissionFor(tx, user, Action.Attachment.READ_APPLICATION_ATTACHMENT, allAttachments.map { it.id })
+                    val permissions = accessControl.checkPermissionFor(tx, user, clock, Action.Attachment.READ_APPLICATION_ATTACHMENT, allAttachments.map { it.id })
                     allAttachments.filter { attachment -> permissions[attachment.id]?.isPermitted() ?: false }
                 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -132,11 +132,11 @@ class ApplicationControllerV2(
     fun createPaperApplication(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestBody body: PaperApplicationCreateRequest
     ): ApplicationId {
         Audit.ApplicationCreate.log(targetId = body.guardianId, objectId = body.childId)
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_PAPER_APPLICATION)
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_PAPER_APPLICATION)
 
         return db.connect { dbc ->
             dbc.transaction { tx ->
@@ -174,7 +174,7 @@ class ApplicationControllerV2(
                 applicationStateService.initializeApplicationForm(
                     tx,
                     user,
-                    evakaClock.today(),
+                    clock.today(),
                     id,
                     body.type,
                     guardian,
@@ -250,10 +250,11 @@ class ApplicationControllerV2(
     fun getGuardianApplicationSummaries(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable(value = "guardianId") guardianId: PersonId
     ): List<PersonApplicationSummary> {
         Audit.ApplicationRead.log(targetId = guardianId)
-        accessControl.requirePermissionFor(user, Action.Global.READ_PERSON_APPLICATION)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_PERSON_APPLICATION)
 
         return db.connect { dbc -> dbc.read { it.fetchApplicationSummariesForGuardian(guardianId) } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -274,6 +274,7 @@ class ApplicationControllerV2(
     fun getApplicationDetails(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable(value = "applicationId") applicationId: ApplicationId
     ): ApplicationResponse {
         Audit.ApplicationRead.log(targetId = applicationId)
@@ -302,7 +303,7 @@ class ApplicationControllerV2(
                     allAttachments.filter { attachment -> permissions[attachment.id]?.isPermitted() ?: false }
                 }
 
-                val permittedActions = accessControl.getPermittedActions<ApplicationId, Action.Application>(tx, user, applicationId)
+                val permittedActions = accessControl.getPermittedActions<ApplicationId, Action.Application>(tx, user, clock, applicationId)
 
                 ApplicationResponse(
                     application = application.copy(attachments = attachments),

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -189,7 +189,7 @@ class ApplicationControllerV2(
     fun getApplicationSummaries(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestBody body: SearchApplicationRequest
     ): Paged<ApplicationSummary> {
         Audit.ApplicationSearch.log()
@@ -213,12 +213,12 @@ class ApplicationControllerV2(
         }
 
         val canReadServiceWorkerNotes =
-            accessControl.hasPermissionFor(user, Action.Global.READ_SERVICE_WORKER_APPLICATION_NOTES)
+            accessControl.hasPermissionFor(user, clock, Action.Global.READ_SERVICE_WORKER_APPLICATION_NOTES)
 
         return db.connect { dbc ->
             dbc.read { tx ->
                 tx.fetchApplicationSummaries(
-                    today = evakaClock.today(),
+                    today = clock.today(),
                     page = body.page ?: 1,
                     pageSize = body.pageSize ?: 100,
                     sortBy = body.sortBy ?: ApplicationSortColumn.CHILD_NAME,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -29,7 +29,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.freeTextSearchQuery
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.db.mapJsonColumn
-import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.mapToPaged
 import mu.KotlinLogging
 import org.jdbi.v3.core.result.RowView
@@ -925,7 +925,7 @@ fun Database.Transaction.removeOldDrafts(deleteAttachment: (db: Database.Transac
     }
 }
 
-fun Database.Transaction.cancelOutdatedSentTransferApplications(): List<ApplicationId> = createUpdate(
+fun Database.Transaction.cancelOutdatedSentTransferApplications(clock: EvakaClock): List<ApplicationId> = createUpdate(
     // only include applications that don't have decisions
     // placement type checks are doing in inverse so that the addition and accidental omission of new placement types
     // does not cause the cancellation of applications that shouldn't be cancelled
@@ -952,7 +952,7 @@ RETURNING id
 """
 )
     .bind("cancelled", ApplicationStatus.CANCELLED)
-    .bind("yesterday", HelsinkiDateTime.now().toLocalDate().minusDays(1))
+    .bind("yesterday", clock.today().minusDays(1))
     .bind(
         "notDaycarePlacements",
         arrayOf(

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -882,12 +882,13 @@ fun Database.Transaction.deleteApplication(id: ApplicationId) {
     createUpdate(sql).bind("id", id).execute()
 }
 
-fun Database.Transaction.removeOldDrafts(deleteAttachment: (db: Database.Transaction, id: AttachmentId) -> Unit) {
+fun Database.Transaction.removeOldDrafts(clock: EvakaClock, deleteAttachment: (db: Database.Transaction, id: AttachmentId) -> Unit) {
     val thresholdDays = 31
 
     // language=SQL
     val applicationIds =
-        createQuery("""SELECT id FROM application WHERE status = 'CREATED' AND created < current_date - :thresholdDays""")
+        createQuery("""SELECT id FROM application WHERE status = 'CREATED' AND created < :today - :thresholdDays""")
+            .bind("today", clock.today())
             .bind("thresholdDays", thresholdDays)
             .mapTo<ApplicationId>()
             .toList()

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -73,6 +73,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
@@ -194,12 +195,13 @@ class ApplicationStateService(
     fun sendApplication(
         tx: Database.Transaction,
         user: AuthenticatedUser,
-        applicationId: ApplicationId,
-        currentDate: LocalDate,
+        clock: EvakaClock,
+        applicationId: ApplicationId
     ) {
         Audit.ApplicationSend.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.SEND, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.SEND, applicationId)
 
+        val currentDate = clock.today()
         val application = getApplication(tx, applicationId)
         verifyStatus(application, CREATED)
         validateApplication(tx, application.type, application.form, currentDate, strict = user is AuthenticatedUser.Citizen)
@@ -248,9 +250,9 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, SENT)
     }
 
-    fun moveToWaitingPlacement(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
+    fun moveToWaitingPlacement(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId) {
         Audit.ApplicationVerify.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.MOVE_TO_WAITING_PLACEMENT, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.MOVE_TO_WAITING_PLACEMENT, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, SENT)
@@ -271,36 +273,36 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, WAITING_PLACEMENT)
     }
 
-    fun returnToSent(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
+    fun returnToSent(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId) {
         Audit.ApplicationReturnToSent.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.RETURN_TO_SENT, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.RETURN_TO_SENT, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_PLACEMENT)
         tx.updateApplicationStatus(application.id, SENT)
     }
 
-    fun cancelApplication(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
+    fun cancelApplication(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId) {
         Audit.ApplicationCancel.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.CANCEL, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.CANCEL, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, setOf(SENT, WAITING_PLACEMENT))
         tx.updateApplicationStatus(application.id, CANCELLED)
     }
 
-    fun setVerified(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
+    fun setVerified(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId) {
         Audit.ApplicationAdminDetailsUpdate.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.VERIFY, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.VERIFY, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_PLACEMENT)
         tx.setApplicationVerified(applicationId, true)
     }
 
-    fun setUnverified(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
+    fun setUnverified(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId) {
         Audit.ApplicationAdminDetailsUpdate.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.VERIFY, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.VERIFY, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_PLACEMENT)
@@ -326,9 +328,9 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, WAITING_DECISION)
     }
 
-    fun cancelPlacementPlan(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
+    fun cancelPlacementPlan(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId) {
         Audit.ApplicationReturnToWaitingPlacement.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.CANCEL_PLACEMENT_PLAN, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.CANCEL_PLACEMENT_PLAN, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_DECISION)
@@ -337,27 +339,27 @@ class ApplicationStateService(
         tx.updateApplicationStatus(application.id, WAITING_PLACEMENT)
     }
 
-    fun sendDecisionsWithoutProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
+    fun sendDecisionsWithoutProposal(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId) {
         Audit.DecisionCreate.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.SEND_DECISIONS_WITHOUT_PROPOSAL, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.SEND_DECISIONS_WITHOUT_PROPOSAL, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_DECISION)
         finalizeDecisions(tx, user, application)
     }
 
-    fun sendPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
+    fun sendPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId) {
         Audit.PlacementProposalCreate.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.SEND_PLACEMENT_PROPOSAL, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.SEND_PLACEMENT_PROPOSAL, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_DECISION)
         tx.updateApplicationStatus(application.id, WAITING_UNIT_CONFIRMATION)
     }
 
-    fun withdrawPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
+    fun withdrawPlacementProposal(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId) {
         Audit.ApplicationReturnToWaitingDecision.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.WITHDRAW_PLACEMENT_PROPOSAL, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.WITHDRAW_PLACEMENT_PROPOSAL, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_UNIT_CONFIRMATION)
@@ -367,13 +369,14 @@ class ApplicationStateService(
     fun respondToPlacementProposal(
         tx: Database.Transaction,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         applicationId: ApplicationId,
         status: PlacementPlanConfirmationStatus,
         rejectReason: PlacementPlanRejectReason? = null,
         rejectOtherReason: String? = null
     ) {
         Audit.PlacementPlanRespond.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.RESPOND_TO_PLACEMENT_PROPOSAL, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.RESPOND_TO_PLACEMENT_PROPOSAL, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_UNIT_CONFIRMATION)
@@ -390,9 +393,9 @@ class ApplicationStateService(
         }
     }
 
-    fun confirmPlacementProposalChanges(tx: Database.Transaction, user: AuthenticatedUser, unitId: DaycareId) {
+    fun confirmPlacementProposalChanges(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, unitId: DaycareId) {
         Audit.PlacementProposalAccept.log(targetId = unitId)
-        accessControl.requirePermissionFor(user, Action.Unit.ACCEPT_PLACEMENT_PROPOSAL, unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.ACCEPT_PLACEMENT_PROPOSAL, unitId)
 
         // language=sql
         val rejectSQL =
@@ -428,18 +431,18 @@ class ApplicationStateService(
         validIds.map { getApplication(tx, it) }.forEach { finalizeDecisions(tx, user, it) }
     }
 
-    fun confirmDecisionMailed(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId) {
+    fun confirmDecisionMailed(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId) {
         Audit.DecisionConfirmMailed.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.CONFIRM_DECISIONS_MAILED, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.CONFIRM_DECISIONS_MAILED, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_MAILING)
         tx.updateApplicationStatus(application.id, WAITING_CONFIRMATION)
     }
 
-    fun acceptDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId, decisionId: DecisionId, requestedStartDate: LocalDate) {
+    fun acceptDecision(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId, decisionId: DecisionId, requestedStartDate: LocalDate) {
         Audit.DecisionAccept.log(targetId = decisionId)
-        accessControl.requirePermissionFor(user, Action.Application.ACCEPT_DECISION, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.ACCEPT_DECISION, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, setOf(WAITING_CONFIRMATION, ACTIVE))
@@ -502,9 +505,9 @@ class ApplicationStateService(
         }
     }
 
-    fun rejectDecision(tx: Database.Transaction, user: AuthenticatedUser, applicationId: ApplicationId, decisionId: DecisionId) {
+    fun rejectDecision(tx: Database.Transaction, user: AuthenticatedUser, clock: EvakaClock, applicationId: ApplicationId, decisionId: DecisionId) {
         Audit.DecisionReject.log(targetId = decisionId)
-        accessControl.requirePermissionFor(user, Action.Application.REJECT_DECISION, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.REJECT_DECISION, applicationId)
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, setOf(WAITING_CONFIRMATION, ACTIVE, REJECTED))

--- a/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/DecisionMessageProcessor.kt
@@ -33,14 +33,14 @@ class DecisionMessageProcessor(
         logger.info { "Successfully created decision pdf(s) for decision (id: $decisionId)." }
         if (msg.sendAsMessage) {
             logger.info { "Sending decision pdf(s) for decision (id: $decisionId)." }
-            asyncJobRunner.plan(tx, listOf(AsyncJob.SendDecision(decisionId)))
+            asyncJobRunner.plan(tx, listOf(AsyncJob.SendDecision(decisionId)), runAt = clock.now())
         }
     }
 
     fun runSendJob(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.SendDecision) = db.transaction { tx ->
         val decisionId = msg.decisionId
 
-        decisionService.deliverDecisionToGuardians(tx, decisionId)
+        decisionService.deliverDecisionToGuardians(tx, clock, decisionId)
         logger.info { "Successfully sent decision(s) pdf for decision (id: $decisionId)." }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
@@ -35,7 +35,7 @@ class NoteController(private val accessControl: AccessControl) {
         @PathVariable applicationId: ApplicationId
     ): List<ApplicationNoteResponse> {
         Audit.NoteRead.log(targetId = applicationId)
-        val notesQuery: (Database.Read) -> List<ApplicationNote> = if (accessControl.hasPermissionFor(user, Action.Application.READ_NOTES, applicationId)) {
+        val notesQuery: (Database.Read) -> List<ApplicationNote> = if (accessControl.hasPermissionFor(user, clock, Action.Application.READ_NOTES, applicationId)) {
             { tx: Database.Read -> tx.getApplicationNotes(applicationId) }
         } else {
             accessControl

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
@@ -117,11 +117,12 @@ class NoteController(private val accessControl: AccessControl) {
     fun updateServiceWorkerNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId,
         @RequestBody note: NoteRequest
     ) {
         Audit.ServiceWorkerNoteUpdate.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Global.WRITE_SERVICE_WORKER_APPLICATION_NOTES)
+        accessControl.requirePermissionFor(user, clock, Action.Global.WRITE_SERVICE_WORKER_APPLICATION_NOTES)
 
         db.connect { dbc ->
             dbc.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
@@ -39,7 +39,7 @@ class NoteController(private val accessControl: AccessControl) {
             { tx: Database.Read -> tx.getApplicationNotes(applicationId) }
         } else {
             accessControl
-                .requirePermissionFor(user, Action.Application.READ_SPECIAL_EDUCATION_TEACHER_NOTES, applicationId)
+                .requirePermissionFor(user, clock, Action.Application.READ_SPECIAL_EDUCATION_TEACHER_NOTES, applicationId)
                 .let {
                     { tx: Database.Read -> tx.getApplicationSpecialEducationTeacherNotes(applicationId) }
                 }
@@ -65,11 +65,12 @@ class NoteController(private val accessControl: AccessControl) {
     fun createNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") applicationId: ApplicationId,
         @RequestBody note: NoteRequest
     ): ApplicationNote {
         Audit.NoteCreate.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.CREATE_NOTE, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.CREATE_NOTE, applicationId)
 
         return db.connect { dbc ->
             dbc.transaction {
@@ -82,11 +83,12 @@ class NoteController(private val accessControl: AccessControl) {
     fun updateNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("noteId") noteId: ApplicationNoteId,
         @RequestBody note: NoteRequest
     ) {
         Audit.NoteUpdate.log(targetId = noteId)
-        accessControl.requirePermissionFor(user, Action.ApplicationNote.UPDATE, noteId)
+        accessControl.requirePermissionFor(user, clock, Action.ApplicationNote.UPDATE, noteId)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -99,10 +101,11 @@ class NoteController(private val accessControl: AccessControl) {
     fun deleteNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("noteId") noteId: ApplicationNoteId
     ) {
         Audit.NoteDelete.log(targetId = noteId)
-        accessControl.requirePermissionFor(user, Action.ApplicationNote.DELETE, noteId)
+        accessControl.requirePermissionFor(user, clock, Action.ApplicationNote.DELETE, noteId)
         db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.deleteApplicationNote(noteId)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/NoteController.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.ApplicationNoteId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -30,6 +31,7 @@ class NoteController(private val accessControl: AccessControl) {
     fun getNotes(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable applicationId: ApplicationId
     ): List<ApplicationNoteResponse> {
         Audit.NoteRead.log(targetId = applicationId)
@@ -47,7 +49,7 @@ class NoteController(private val accessControl: AccessControl) {
             dbc.read { tx ->
                 val notes = notesQuery(tx)
                 val permittedActions = accessControl
-                    .getPermittedActions<ApplicationNoteId, Action.ApplicationNote>(tx, user, notes.map { it.id })
+                    .getPermittedActions<ApplicationNoteId, Action.ApplicationNote>(tx, user, clock, notes.map { it.id })
 
                 notes.map {
                     ApplicationNoteResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -31,11 +31,12 @@ class AssistanceActionController(
     fun createAssistanceAction(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @RequestBody body: AssistanceActionRequest
     ): AssistanceAction {
         Audit.ChildAssistanceActionCreate.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.CREATE_ASSISTANCE_ACTION, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_ASSISTANCE_ACTION, childId)
         return db.connect { dbc ->
             assistanceActionService.createAssistanceAction(
                 dbc,
@@ -54,7 +55,7 @@ class AssistanceActionController(
         @PathVariable childId: ChildId
     ): List<AssistanceActionResponse> {
         Audit.ChildAssistanceActionRead.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_ASSISTANCE_ACTION, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_ASSISTANCE_ACTION, childId)
         return db.connect { dbc ->
             val relevantPreschoolPlacements = dbc.read { tx ->
                 tx.getPlacementsForChild(childId).filter {
@@ -83,11 +84,12 @@ class AssistanceActionController(
     fun updateAssistanceAction(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") assistanceActionId: AssistanceActionId,
         @RequestBody body: AssistanceActionRequest
     ): AssistanceAction {
         Audit.ChildAssistanceActionUpdate.log(targetId = assistanceActionId)
-        accessControl.requirePermissionFor(user, Action.AssistanceAction.UPDATE, assistanceActionId)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceAction.UPDATE, assistanceActionId)
         return db.connect { dbc ->
             assistanceActionService.updateAssistanceAction(
                 dbc,
@@ -102,10 +104,11 @@ class AssistanceActionController(
     fun deleteAssistanceAction(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") assistanceActionId: AssistanceActionId
     ) {
         Audit.ChildAssistanceActionDelete.log(targetId = assistanceActionId)
-        accessControl.requirePermissionFor(user, Action.AssistanceAction.DELETE, assistanceActionId)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceAction.DELETE, assistanceActionId)
         db.connect { dbc -> assistanceActionService.deleteAssistanceAction(dbc, assistanceActionId) }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -73,7 +73,7 @@ class AssistanceActionController(
             }
             val assistanceActionIds = assistanceActions.map { it.id }
             val permittedActions = dbc.read { tx ->
-                accessControl.getPermittedActions<AssistanceActionId, Action.AssistanceAction>(tx, user, assistanceActionIds)
+                accessControl.getPermittedActions<AssistanceActionId, Action.AssistanceAction>(tx, user, clock, assistanceActionIds)
             }
             assistanceActions.map { AssistanceActionResponse(it, permittedActions[it.id] ?: emptySet()) }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -68,7 +68,7 @@ class AssistanceActionController(
                         placement.startDate.isBefore(it.startDate) || placement.startDate == it.startDate
                     }
                 }
-                val decisions = accessControl.checkPermissionFor(dbc, user, Action.AssistanceAction.READ_PRE_PRESCHOOL_ASSISTANCE_ACTION, prePreschool.map { it.id })
+                val decisions = dbc.read { tx -> accessControl.checkPermissionFor(tx, user, clock, Action.AssistanceAction.READ_PRE_PRESCHOOL_ASSISTANCE_ACTION, prePreschool.map { it.id }) }
                 allAssistanceActions.filter { decisions[it.id]?.isPermitted() ?: true }
             }
             val assistanceActionIds = assistanceActions.map { it.id }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -113,8 +113,8 @@ class AssistanceActionController(
     }
 
     @GetMapping("/assistance-action-options")
-    fun getAssistanceActionOptions(db: Database, user: AuthenticatedUser): List<AssistanceActionOption> {
-        accessControl.requirePermissionFor(user, Action.Global.READ_ASSISTANCE_ACTION_OPTIONS)
+    fun getAssistanceActionOptions(db: Database, user: AuthenticatedUser, clock: EvakaClock): List<AssistanceActionOption> {
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_ASSISTANCE_ACTION_OPTIONS)
         return db.connect { dbc -> assistanceActionService.getAssistanceActionOptions(dbc) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -113,8 +113,8 @@ class AssistanceNeedController(
     }
 
     @GetMapping("/assistance-basis-options")
-    fun getAssistanceBasisOptions(db: Database, user: AuthenticatedUser): List<AssistanceBasisOption> {
-        accessControl.requirePermissionFor(user, Action.Global.READ_ASSISTANCE_BASIS_OPTIONS)
+    fun getAssistanceBasisOptions(db: Database, user: AuthenticatedUser, clock: EvakaClock): List<AssistanceBasisOption> {
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_ASSISTANCE_BASIS_OPTIONS)
         return db.connect { dbc -> assistanceNeedService.getAssistanceBasisOptions(dbc) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -40,7 +40,8 @@ class AssistanceNeedController(
         return db.connect { dbc ->
             assistanceNeedService.createAssistanceNeed(
                 dbc,
-                user = user,
+                user,
+                clock,
                 childId = childId,
                 data = body
             )
@@ -93,7 +94,8 @@ class AssistanceNeedController(
         return db.connect { dbc ->
             assistanceNeedService.updateAssistanceNeed(
                 dbc,
-                user = user,
+                user,
+                clock,
                 id = assistanceNeedId,
                 data = body
             )
@@ -109,7 +111,7 @@ class AssistanceNeedController(
     ) {
         Audit.ChildAssistanceNeedDelete.log(targetId = assistanceNeedId)
         accessControl.requirePermissionFor(user, clock, Action.AssistanceNeed.DELETE, assistanceNeedId)
-        db.connect { dbc -> assistanceNeedService.deleteAssistanceNeed(dbc, assistanceNeedId) }
+        db.connect { dbc -> assistanceNeedService.deleteAssistanceNeed(dbc, clock, assistanceNeedId) }
     }
 
     @GetMapping("/assistance-basis-options")

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -68,7 +68,7 @@ class AssistanceNeedController(
                         placement.startDate.isBefore(it.startDate) || placement.startDate == it.startDate
                     }
                 }
-                val decisions = accessControl.checkPermissionFor(dbc, user, Action.AssistanceNeed.READ_PRE_PRESCHOOL_ASSISTANCE_NEED, prePreschool.map { it.id })
+                val decisions = dbc.read { tx -> accessControl.checkPermissionFor(tx, user, clock, Action.AssistanceNeed.READ_PRE_PRESCHOOL_ASSISTANCE_NEED, prePreschool.map { it.id }) }
                 allAssistanceNeeds.filter { decisions[it.id]?.isPermitted() ?: true }
             }
             val assistanceNeedIds = assistanceNeeds.map { it.id }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -31,11 +31,12 @@ class AssistanceNeedController(
     fun createAssistanceNeed(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @RequestBody body: AssistanceNeedRequest
     ): AssistanceNeed {
         Audit.ChildAssistanceNeedCreate.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.CREATE_ASSISTANCE_NEED, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_ASSISTANCE_NEED, childId)
         return db.connect { dbc ->
             assistanceNeedService.createAssistanceNeed(
                 dbc,
@@ -54,7 +55,7 @@ class AssistanceNeedController(
         @PathVariable childId: ChildId
     ): List<AssistanceNeedResponse> {
         Audit.ChildAssistanceNeedRead.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_ASSISTANCE_NEED, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_ASSISTANCE_NEED, childId)
         return db.connect { dbc ->
             val relevantPreschoolPlacements = dbc.read { tx ->
                 tx.getPlacementsForChild(childId).filter {
@@ -83,11 +84,12 @@ class AssistanceNeedController(
     fun updateAssistanceNeed(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") assistanceNeedId: AssistanceNeedId,
         @RequestBody body: AssistanceNeedRequest
     ): AssistanceNeed {
         Audit.ChildAssistanceNeedUpdate.log(targetId = assistanceNeedId)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeed.UPDATE, assistanceNeedId)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeed.UPDATE, assistanceNeedId)
         return db.connect { dbc ->
             assistanceNeedService.updateAssistanceNeed(
                 dbc,
@@ -102,10 +104,11 @@ class AssistanceNeedController(
     fun deleteAssistanceNeed(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") assistanceNeedId: AssistanceNeedId
     ) {
         Audit.ChildAssistanceNeedDelete.log(targetId = assistanceNeedId)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeed.DELETE, assistanceNeedId)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeed.DELETE, assistanceNeedId)
         db.connect { dbc -> assistanceNeedService.deleteAssistanceNeed(dbc, assistanceNeedId) }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -73,7 +73,7 @@ class AssistanceNeedController(
             }
             val assistanceNeedIds = assistanceNeeds.map { it.id }
             val permittedActions = dbc.read { tx ->
-                accessControl.getPermittedActions<AssistanceNeedId, Action.AssistanceNeed>(tx, user, assistanceNeedIds)
+                accessControl.getPermittedActions<AssistanceNeedId, Action.AssistanceNeed>(tx, user, clock, assistanceNeedIds)
             }
             assistanceNeeds.map { AssistanceNeedResponse(it, permittedActions[it.id] ?: emptySet()) }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionCitizenController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionCitizenController.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.AssistanceNeedDecisionId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -29,10 +30,11 @@ class AssistanceNeedDecisionCitizenController(
     fun getChildAssistanceNeedDecisions(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<AssistanceNeedDecisionCitizenListItem> {
         Audit.ChildAssistanceNeedDecisionsListCitizen.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Citizen.Child.READ_ASSISTANCE_NEED_DECISIONS, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Child.READ_ASSISTANCE_NEED_DECISIONS, childId)
 
         return db.connect { dbc ->
             dbc.transaction { tx ->
@@ -44,10 +46,11 @@ class AssistanceNeedDecisionCitizenController(
     @GetMapping("/assistance-need-decisions")
     fun getAssistanceNeedDecisions(
         db: Database,
-        user: AuthenticatedUser.Citizen
+        user: AuthenticatedUser.Citizen,
+        clock: EvakaClock
     ): List<AssistanceNeedDecisionCitizenListItem> {
         Audit.AssistanceNeedDecisionsListCitizen.log(targetId = user.id)
-        accessControl.requirePermissionFor(user, Action.Citizen.Person.READ_ASSISTANCE_NEED_DECISIONS, user.id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Person.READ_ASSISTANCE_NEED_DECISIONS, user.id)
 
         return db.connect { dbc -> dbc.transaction { tx -> tx.getAssistanceNeedDecisionsForCitizen(user.id) } }
     }
@@ -56,10 +59,11 @@ class AssistanceNeedDecisionCitizenController(
     fun getAssistanceNeedDecision(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ): AssistanceNeedDecision {
         Audit.ChildAssistanceNeedDecisionReadCitizen.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Citizen.AssistanceNeedDecision.READ, id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.AssistanceNeedDecision.READ, id)
         return db.connect { dbc ->
             dbc.read { tx ->
                 val decision = tx.getAssistanceNeedDecisionById(id)
@@ -77,10 +81,11 @@ class AssistanceNeedDecisionCitizenController(
     fun getAssistanceNeedDecisionPdf(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ): ResponseEntity<Any> {
         Audit.ChildAssistanceNeedDecisionDownloadCitizen.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Citizen.AssistanceNeedDecision.DOWNLOAD, id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.AssistanceNeedDecision.DOWNLOAD, id)
         return db.connect { assistanceNeedDecisionService.getDecisionPdfResponse(it, id) }
     }
 
@@ -88,10 +93,11 @@ class AssistanceNeedDecisionCitizenController(
     fun markAssistanceNeedDecisionAsRead(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ) {
         Audit.ChildAssistanceNeedDecisionMarkReadCitizen.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Citizen.AssistanceNeedDecision.MARK_AS_READ, id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.AssistanceNeedDecision.MARK_AS_READ, id)
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.markAssistanceNeedDecisionAsReadByGuardian(id, user.id)
@@ -102,10 +108,11 @@ class AssistanceNeedDecisionCitizenController(
     @GetMapping("/children/assistance-need-decisions/unread-counts")
     fun getAssistanceNeedDecisionUnreadCount(
         db: Database,
-        user: AuthenticatedUser.Citizen
+        user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
     ): List<UnreadAssistanceNeedDecisionItem> {
         Audit.ChildAssistanceNeedDecisionGetUnreadCountCitizen.log(targetId = user.id)
-        accessControl.requirePermissionFor(user, Action.Citizen.Person.READ_UNREAD_ASSISTANCE_NEED_DECISION_COUNT, user.id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Person.READ_UNREAD_ASSISTANCE_NEED_DECISION_COUNT, user.id)
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.getAssistanceNeedDecisionsUnreadCountsForCitizen(user.id)

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
@@ -261,7 +261,8 @@ class AssistanceNeedDecisionController(
                             AsyncJob.SendAssistanceNeedDecisionEmail(id),
                             AsyncJob.CreateAssistanceNeedDecisionPdf(id),
                             AsyncJob.SendAssistanceNeedDecisionSfiMessage(id)
-                        )
+                        ),
+                        runAt = clock.now()
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
@@ -74,6 +74,7 @@ class AssistanceNeedDecisionController(
     fun getAssistanceNeedDecision(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ): AssistanceNeedDecisionResponse {
         Audit.ChildAssistanceNeedDecisionRead.log(targetId = id)
@@ -84,7 +85,7 @@ class AssistanceNeedDecisionController(
 
                 AssistanceNeedDecisionResponse(
                     decision,
-                    permittedActions = accessControl.getPermittedActions(tx, user, id),
+                    permittedActions = accessControl.getPermittedActions(tx, user, clock, id),
                     hasMissingFields = hasMissingFields(decision)
                 )
             }
@@ -169,6 +170,7 @@ class AssistanceNeedDecisionController(
     fun getAssistanceNeedDecisions(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<AssistanceNeedDecisionBasicsResponse> {
         Audit.ChildAssistanceNeedDecisionsList.log(targetId = childId)
@@ -179,6 +181,7 @@ class AssistanceNeedDecisionController(
                 val permittedActions = accessControl.getPermittedActions<AssistanceNeedDecisionId, Action.AssistanceNeedDecision>(
                     tx,
                     user,
+                    clock,
                     decisions.map { it.id }
                 )
                 decisions.map {

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
@@ -39,11 +39,12 @@ class AssistanceNeedDecisionController(
     fun createAssistanceNeedDecision(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @RequestBody body: AssistanceNeedDecisionRequest
     ): AssistanceNeedDecision {
         Audit.ChildAssistanceNeedDecisionCreate.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.CREATE_ASSISTANCE_NEED_DECISION, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_ASSISTANCE_NEED_DECISION, childId)
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 var decision: AssistanceNeedDecisionForm = body.decision.copy(
@@ -78,7 +79,7 @@ class AssistanceNeedDecisionController(
         @PathVariable id: AssistanceNeedDecisionId
     ): AssistanceNeedDecisionResponse {
         Audit.ChildAssistanceNeedDecisionRead.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeedDecision.READ, id)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.READ, id)
         return db.connect { dbc ->
             dbc.read { tx ->
                 val decision = tx.getAssistanceNeedDecisionById(id)
@@ -96,11 +97,12 @@ class AssistanceNeedDecisionController(
     fun updateAssistanceNeedDecision(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId,
         @RequestBody body: AssistanceNeedDecisionRequest
     ) {
         Audit.ChildAssistanceNeedDecisionUpdate.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeedDecision.UPDATE, id)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.UPDATE, id)
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 val decision = tx.getAssistanceNeedDecisionById(id)
@@ -135,7 +137,7 @@ class AssistanceNeedDecisionController(
         @PathVariable id: AssistanceNeedDecisionId
     ) {
         Audit.ChildAssistanceNeedDecisionSend.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeedDecision.SEND, id)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.SEND, id)
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 val decision = tx.getAssistanceNeedDecisionById(id)
@@ -174,7 +176,7 @@ class AssistanceNeedDecisionController(
         @PathVariable childId: ChildId
     ): List<AssistanceNeedDecisionBasicsResponse> {
         Audit.ChildAssistanceNeedDecisionsList.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_ASSISTANCE_NEED_DECISIONS, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_ASSISTANCE_NEED_DECISIONS, childId)
         return db.connect { dbc ->
             dbc.read { tx ->
                 val decisions = tx.getAssistanceNeedDecisionsByChildId(childId)
@@ -195,10 +197,11 @@ class AssistanceNeedDecisionController(
     fun deleteAssistanceNeedDecision(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ) {
         Audit.ChildAssistanceNeedDecisionDelete.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeedDecision.DELETE, id)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.DELETE, id)
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 if (!tx.deleteAssistanceNeedDecision(id)) {
@@ -217,7 +220,7 @@ class AssistanceNeedDecisionController(
         @RequestBody body: DecideAssistanceNeedDecisionRequest
     ) {
         Audit.ChildAssistanceNeedDecisionDecide.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeedDecision.DECIDE, id)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.DECIDE, id)
 
         if (body.status == AssistanceNeedDecisionStatus.DRAFT) {
             throw BadRequest("Assistance need decisions cannot be decided to be a draft")
@@ -269,10 +272,11 @@ class AssistanceNeedDecisionController(
     fun markAssistanceNeedDecisionAsOpened(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ) {
         Audit.ChildAssistanceNeedDecisionOpened.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeedDecision.MARK_AS_OPENED, id)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.MARK_AS_OPENED, id)
 
         return db.connect { dbc ->
             dbc.transaction { tx ->
@@ -285,11 +289,12 @@ class AssistanceNeedDecisionController(
     fun updateAssistanceNeedDecisionDecisionMaker(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId,
         @RequestBody body: UpdateDecisionMakerForAssistanceNeedDecisionRequest
     ) {
         Audit.ChildAssistanceNeedDecisionUpdateDecisionMaker.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeedDecision.UPDATE_DECISION_MAKER, id)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.UPDATE_DECISION_MAKER, id)
 
         return db.connect { dbc ->
             dbc.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.NotFound
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.time.LocalDate
 
 fun Database.Transaction.insertAssistanceNeedDecision(

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientController.kt
@@ -58,7 +58,7 @@ class AssistanceNeedVoucherCoefficientController(
                 tx.getAssistanceNeedVoucherCoefficientsForChild(childId).map {
                     AssistanceNeedVoucherCoefficientResponse(
                         voucherCoefficient = it,
-                        permittedActions = accessControl.getPermittedActions(tx, user, it.id)
+                        permittedActions = accessControl.getPermittedActions(tx, user, clock, it.id)
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientController.kt
@@ -30,11 +30,12 @@ class AssistanceNeedVoucherCoefficientController(
     fun createAssistanceNeedVoucherCoefficient(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @RequestBody body: AssistanceNeedVoucherCoefficientRequest
     ): AssistanceNeedVoucherCoefficient {
         Audit.ChildAssistanceNeedVoucherCoefficientCreate.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.CREATE_ASSISTANCE_NEED_VOUCHER_COEFFICIENT, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_ASSISTANCE_NEED_VOUCHER_COEFFICIENT, childId)
 
         return db.connect { dbc ->
             dbc.transaction { tx ->
@@ -52,7 +53,7 @@ class AssistanceNeedVoucherCoefficientController(
         @PathVariable childId: ChildId
     ): List<AssistanceNeedVoucherCoefficientResponse> {
         Audit.ChildAssistanceNeedVoucherCoefficientRead.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_ASSISTANCE_NEED_VOUCHER_COEFFICIENTS, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_ASSISTANCE_NEED_VOUCHER_COEFFICIENTS, childId)
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.getAssistanceNeedVoucherCoefficientsForChild(childId).map {
@@ -69,11 +70,12 @@ class AssistanceNeedVoucherCoefficientController(
     fun updateAssistanceNeedVoucherCoefficient(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") assistanceNeedVoucherCoefficientId: AssistanceNeedVoucherCoefficientId,
         @RequestBody body: AssistanceNeedVoucherCoefficientRequest
     ): AssistanceNeedVoucherCoefficient {
         Audit.ChildAssistanceNeedVoucherCoefficientUpdate.log(targetId = assistanceNeedVoucherCoefficientId)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeedVoucherCoefficient.UPDATE, assistanceNeedVoucherCoefficientId)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedVoucherCoefficient.UPDATE, assistanceNeedVoucherCoefficientId)
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 adjustExistingCoefficients(
@@ -94,10 +96,11 @@ class AssistanceNeedVoucherCoefficientController(
     fun deleteAssistanceNeedVoucherCoefficient(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") assistanceNeedVoucherCoefficientId: AssistanceNeedVoucherCoefficientId
     ) {
         Audit.ChildAssistanceNeedVoucherCoefficientDelete.log(targetId = assistanceNeedVoucherCoefficientId)
-        accessControl.requirePermissionFor(user, Action.AssistanceNeedVoucherCoefficient.DELETE, assistanceNeedVoucherCoefficientId)
+        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedVoucherCoefficient.DELETE, assistanceNeedVoucherCoefficientId)
         db.connect { dbc ->
             dbc.transaction { tx ->
                 if (!tx.deleteAssistanceNeedVoucherCoefficient(assistanceNeedVoucherCoefficientId)) {

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientQueries.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.NotFound
-import org.jdbi.v3.core.kotlin.bindKotlin
 
 fun Database.Transaction.insertAssistanceNeedVoucherCoefficient(
     childId: ChildId,

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/AttachmentQueries.kt
@@ -17,7 +17,6 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.BadRequest
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.lang.IllegalArgumentException
 
 fun Database.Transaction.insertAttachment(

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
@@ -31,16 +31,16 @@ class MobileUnitController(private val accessControl: AccessControl) {
     fun getUnitInfo(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable unitId: DaycareId,
     ): UnitInfo {
         Audit.UnitRead.log(targetId = unitId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_MOBILE_INFO, unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_MOBILE_INFO, unitId)
         return db.connect { dbc ->
             dbc.read { tx ->
                 tx.fetchUnitInfo(
                     unitId,
-                    evakaClock.today(),
+                    clock.today(),
                 )
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
@@ -50,16 +50,16 @@ class MobileUnitController(private val accessControl: AccessControl) {
     fun getUnitStats(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestParam unitIds: List<DaycareId>
     ): List<UnitStats> {
         Audit.UnitRead.log(targetId = unitIds)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_MOBILE_STATS, unitIds)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_MOBILE_STATS, unitIds)
         return db.connect { dbc ->
             dbc.read { tx ->
                 tx.fetchUnitStats(
                     unitIds,
-                    evakaClock.today(),
+                    clock.today(),
                 )
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
@@ -15,7 +15,6 @@ import fi.espoo.evaka.shared.db.mapRow
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.HelsinkiDateTimeRange
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalTime

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficientController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficientController.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,10 +27,11 @@ class StaffOccupancyCoefficientController(
     fun getOccupancyCoefficients(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam unitId: DaycareId,
     ): List<StaffOccupancyCoefficient> {
         Audit.StaffOccupancyCoefficientRead.log(unitId)
-        ac.requirePermissionFor(user, Action.Unit.READ_STAFF_OCCUPANCY_COEFFICIENTS, unitId)
+        ac.requirePermissionFor(user, clock, Action.Unit.READ_STAFF_OCCUPANCY_COEFFICIENTS, unitId)
         return db.connect { dbc -> dbc.read { it.getOccupancyCoefficientsByUnit(unitId) } }
     }
 
@@ -37,10 +39,11 @@ class StaffOccupancyCoefficientController(
     fun upsertOccupancyCoefficient(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: OccupancyCoefficientUpsert,
     ) {
         Audit.StaffOccupancyCoefficientUpsert.log(body.unitId, body.employeeId)
-        ac.requirePermissionFor(user, Action.Unit.UPSERT_STAFF_OCCUPANCY_COEFFICIENTS, body.unitId)
+        ac.requirePermissionFor(user, clock, Action.Unit.UPSERT_STAFF_OCCUPANCY_COEFFICIENTS, body.unitId)
         db.connect { dbc -> dbc.transaction { it.upsertOccupancyCoefficient(body) } }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficientQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficientQueries.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.math.BigDecimal
 
 fun Database.Read.getOccupancyCoefficientForEmployee(employeeId: EmployeeId, groupId: GroupId): BigDecimal? =

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -41,7 +41,7 @@ class BackupCareController(private val accessControl: AccessControl) {
         @PathVariable("childId") childId: ChildId
     ): ChildBackupCaresResponse {
         Audit.ChildBackupCareRead.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_BACKUP_CARE, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_BACKUP_CARE, childId)
         return ChildBackupCaresResponse(
             db.connect { dbc ->
                 dbc.read { tx ->
@@ -58,11 +58,12 @@ class BackupCareController(private val accessControl: AccessControl) {
     fun createForChild(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("childId") childId: ChildId,
         @RequestBody body: NewBackupCare
     ): BackupCareCreateResponse {
         Audit.ChildBackupCareCreate.log(targetId = childId, objectId = body.unitId)
-        accessControl.requirePermissionFor(user, Action.Child.CREATE_BACKUP_CARE, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_BACKUP_CARE, childId)
         try {
             val id = db.connect {
                     dbc ->
@@ -86,11 +87,12 @@ class BackupCareController(private val accessControl: AccessControl) {
     fun update(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") backupCareId: BackupCareId,
         @RequestBody body: BackupCareUpdateRequest
     ) {
         Audit.BackupCareUpdate.log(targetId = backupCareId, objectId = body.groupId)
-        accessControl.requirePermissionFor(user, Action.BackupCare.UPDATE, backupCareId)
+        accessControl.requirePermissionFor(user, clock, Action.BackupCare.UPDATE, backupCareId)
         try {
             db.connect { dbc ->
                 dbc.transaction { tx ->
@@ -154,10 +156,11 @@ class BackupCareController(private val accessControl: AccessControl) {
     fun delete(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") backupCareId: BackupCareId
     ) {
         Audit.BackupCareDelete.log(targetId = backupCareId)
-        accessControl.requirePermissionFor(user, Action.BackupCare.DELETE, backupCareId)
+        accessControl.requirePermissionFor(user, clock, Action.BackupCare.DELETE, backupCareId)
         db.connect { dbc ->
             dbc.transaction { tx ->
                 val backupCare = tx.getBackupCare(backupCareId)
@@ -173,12 +176,13 @@ class BackupCareController(private val accessControl: AccessControl) {
     fun getForDaycare(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("daycareId") daycareId: DaycareId,
         @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
         @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
     ): UnitBackupCaresResponse {
         Audit.DaycareBackupCareRead.log(targetId = daycareId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_BACKUP_CARE, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_BACKUP_CARE, daycareId)
         val backupCares = db.connect { dbc -> dbc.read { it.getBackupCaresForDaycare(daycareId, FiniteDateRange(startDate, endDate)) } }
         return UnitBackupCaresResponse(backupCares)
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -36,6 +37,7 @@ class BackupCareController(private val accessControl: AccessControl) {
     fun getForChild(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("childId") childId: ChildId
     ): ChildBackupCaresResponse {
         Audit.ChildBackupCareRead.log(targetId = childId)
@@ -45,7 +47,7 @@ class BackupCareController(private val accessControl: AccessControl) {
                 dbc.read { tx ->
                     val backupCares = tx.getBackupCaresForChild(childId)
                     val backupCareIds = backupCares.map { bc -> bc.id }
-                    val permittedActions = accessControl.getPermittedActions<BackupCareId, Action.BackupCare>(tx, user, backupCareIds)
+                    val permittedActions = accessControl.getPermittedActions<BackupCareId, Action.BackupCare>(tx, user, clock, backupCareIds)
                     backupCares.map { bc -> ChildBackupCareResponse(bc, permittedActions[bc.id] ?: emptySet()) }
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/backuppickup/BackupPickupController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backuppickup/BackupPickupController.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.BackupPickupId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -25,11 +26,12 @@ class BackupPickupController(private val accessControl: AccessControl) {
     fun createForChild(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("childId") childId: ChildId,
         @RequestBody body: ChildBackupPickupContent
     ): ChildBackupPickupCreateResponse {
         Audit.ChildBackupPickupCreate.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.CREATE_BACKUP_PICKUP, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_BACKUP_PICKUP, childId)
         return ChildBackupPickupCreateResponse(db.connect { dbc -> dbc.transaction { tx -> tx.createBackupPickup(childId, body) } })
     }
 
@@ -37,10 +39,11 @@ class BackupPickupController(private val accessControl: AccessControl) {
     fun getForChild(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("childId") childId: ChildId
     ): List<ChildBackupPickup> {
         Audit.ChildBackupPickupRead.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_BACKUP_PICKUP, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_BACKUP_PICKUP, childId)
         return db.connect { dbc -> dbc.transaction { tx -> tx.getBackupPickupsForChild(childId) } }
     }
 
@@ -48,11 +51,12 @@ class BackupPickupController(private val accessControl: AccessControl) {
     fun update(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") id: BackupPickupId,
         @RequestBody body: ChildBackupPickupContent
     ) {
         Audit.ChildBackupPickupUpdate.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.BackupPickup.UPDATE, id)
+        accessControl.requirePermissionFor(user, clock, Action.BackupPickup.UPDATE, id)
         db.connect { dbc -> dbc.transaction { tx -> tx.updateBackupPickup(id, body) } }
     }
 
@@ -60,10 +64,11 @@ class BackupPickupController(private val accessControl: AccessControl) {
     fun delete(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") id: BackupPickupId
     ) {
         Audit.ChildBackupPickupDelete.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.BackupPickup.DELETE, id)
+        accessControl.requirePermissionFor(user, clock, Action.BackupPickup.DELETE, id)
         db.connect { dbc -> dbc.transaction { tx -> tx.deleteBackupPickup(id) } }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventController.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -59,6 +60,7 @@ class CalendarEventController(private val accessControl: AccessControl) {
     fun createCalendarEvent(
         db: Database,
         user: AuthenticatedUser.Employee,
+        clock: EvakaClock,
         @RequestBody body: CalendarEventForm
     ) {
         Audit.CalendarEventCreate.log(targetId = body.unitId)
@@ -68,7 +70,7 @@ class CalendarEventController(private val accessControl: AccessControl) {
                 accessControl.requirePermissionFor(user, Action.Unit.CREATE_CALENDAR_EVENT, body.unitId)
 
                 if (body.tree != null) {
-                    accessControl.requirePermissionFor(user, Action.Group.CREATE_CALENDAR_EVENT, body.tree.keys)
+                    accessControl.requirePermissionFor(user, clock, Action.Group.CREATE_CALENDAR_EVENT, body.tree.keys)
 
                     val unitGroupIds = tx.getDaycareGroups(body.unitId, body.period.start, body.period.end)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/children/ChildControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/children/ChildControllerCitizen.kt
@@ -20,7 +20,7 @@ class ChildControllerCitizen(private val accessControl: AccessControl) {
     @GetMapping
     fun getChildren(db: Database, user: AuthenticatedUser.Citizen, clock: EvakaClock): List<Child> {
         Audit.CitizenChildrenRead.log()
-        accessControl.requirePermissionFor(user, Action.Citizen.Person.READ_CHILDREN, user.id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Person.READ_CHILDREN, user.id)
         return db.connect { dbc -> dbc.read { it.getChildrenByGuardian(user.id, clock.today()) } }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/children/consent/ChildConsentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/children/consent/ChildConsentController.kt
@@ -79,7 +79,7 @@ class ChildConsentController(
                     if (consent.given == null) {
                         tx.deleteChildConsentEmployee(childId, consent.type)
                     } else {
-                        tx.upsertChildConsentEmployee(childId, consent.type, consent.given, user.id, clock.now())
+                        tx.upsertChildConsentEmployee(clock, childId, consent.type, consent.given, user.id, clock.now())
                     }
                 }
             }
@@ -99,7 +99,7 @@ class ChildConsentController(
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 body.filter { featureConfig.enabledChildConsentTypes.contains(it.type) }.forEach { consent ->
-                    if (consent.given == null || !tx.insertChildConsentCitizen(childId, consent.type, consent.given, user.id)) {
+                    if (consent.given == null || !tx.insertChildConsentCitizen(clock, childId, consent.type, consent.given, user.id)) {
                         throw Forbidden("Citizens may not modify consent that has already been given.")
                     }
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimes.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimes.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.shared.DailyServiceTimesId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.TimeRange
-import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.mapper.PropagateNull
 import java.time.DayOfWeek
 import java.time.LocalDate

--- a/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesCitizenController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesCitizenController.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.DailyServiceTimeNotificationId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.GetMapping
@@ -36,10 +37,11 @@ class DailyServiceTimesCitizenController(private val accessControl: AccessContro
     fun dismissDailyServiceTimeNotification(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @RequestBody body: List<DailyServiceTimeNotificationId>
     ) {
         Audit.ChildDailyServiceTimeNotificationsDismiss.log(targetId = body)
-        accessControl.requirePermissionFor(user, Action.Citizen.DailyServiceTimeNotification.DISMISS, body)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.DailyServiceTimeNotification.DISMISS, body)
 
         db.connect { dbc -> dbc.transaction { tx -> tx.deleteDailyServiceTimesNotifications(body) } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesCitizenController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesCitizenController.kt
@@ -25,10 +25,11 @@ class DailyServiceTimesCitizenController(private val accessControl: AccessContro
     @GetMapping("/daily-service-time-notifications")
     fun getDailyServiceTimeNotifications(
         db: Database,
-        user: AuthenticatedUser.Citizen
+        user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
     ): List<DailyServiceTimeNotification> {
         Audit.ChildDailyServiceTimeNotificationsRead.log(targetId = user.id)
-        accessControl.requirePermissionFor(user, Action.Citizen.Person.READ_DAILY_SERVICE_TIME_NOTIFICATIONS, user.id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Person.READ_DAILY_SERVICE_TIME_NOTIFICATIONS, user.id)
 
         return db.connect { dbc -> dbc.transaction { tx -> tx.getDailyServiceTimesNotifications(user.id) } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesController.kt
@@ -41,7 +41,7 @@ class DailyServiceTimesController(
         @PathVariable childId: ChildId
     ): List<DailyServiceTimesResponse> {
         Audit.ChildDailyServiceTimesRead.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_DAILY_SERVICE_TIMES, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_DAILY_SERVICE_TIMES, childId)
         return db.connect { dbc ->
             dbc.read { tx ->
                 tx.getChildDailyServiceTimes(childId).map {
@@ -59,22 +59,22 @@ class DailyServiceTimesController(
     @PostMapping("/children/{childId}/daily-service-times")
     fun postDailyServiceTimes(
         db: Database,
-        evakaClock: EvakaClock,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @RequestBody body: DailyServiceTimes
     ) {
         Audit.ChildDailyServiceTimesEdit.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.CREATE_DAILY_SERVICE_TIME, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_DAILY_SERVICE_TIME, childId)
 
-        if (body.validityPeriod.start.isBefore(evakaClock.today())) {
+        if (body.validityPeriod.start.isBefore(clock.today())) {
             throw BadRequest("New daily service times cannot be added in the past")
         }
 
         db.connect { dbc ->
             dbc.transaction { tx ->
                 this.checkOverlappingDailyServiceTimes(tx, childId, body.validityPeriod)
-                this.deleteCollidingReservationsAndNotify(tx, tx.createChildDailyServiceTimes(childId, body), evakaClock)
+                this.deleteCollidingReservationsAndNotify(tx, tx.createChildDailyServiceTimes(childId, body), clock)
             }
         }
     }
@@ -82,18 +82,18 @@ class DailyServiceTimesController(
     @PutMapping("/daily-service-times/{id}")
     fun putDailyServiceTimes(
         db: Database,
-        evakaClock: EvakaClock,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: DailyServiceTimesId,
         @RequestBody body: DailyServiceTimes
     ) {
         Audit.ChildDailyServiceTimesEdit.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.DailyServiceTime.UPDATE, id)
+        accessControl.requirePermissionFor(user, clock, Action.DailyServiceTime.UPDATE, id)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.updateChildDailyServiceTimes(id, body)
-                this.deleteCollidingReservationsAndNotify(tx, id, evakaClock)
+                this.deleteCollidingReservationsAndNotify(tx, id, clock)
             }
         }
     }
@@ -102,10 +102,11 @@ class DailyServiceTimesController(
     fun deleteDailyServiceTimes(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: DailyServiceTimesId
     ) {
         Audit.ChildDailyServiceTimesDelete.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.DailyServiceTime.DELETE, id)
+        accessControl.requirePermissionFor(user, clock, Action.DailyServiceTime.DELETE, id)
 
         db.connect { dbc -> dbc.transaction { it.deleteChildDailyServiceTimes(id) } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesController.kt
@@ -37,6 +37,7 @@ class DailyServiceTimesController(
     fun getDailyServiceTimes(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<DailyServiceTimesResponse> {
         Audit.ChildDailyServiceTimesRead.log(targetId = childId)
@@ -47,7 +48,7 @@ class DailyServiceTimesController(
                     DailyServiceTimesResponse(
                         it,
                         permittedActions = accessControl.getPermittedActions(
-                            tx, user, it.id
+                            tx, user, clock, it.id
                         )
                     )
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
@@ -21,7 +21,6 @@ import fi.espoo.evaka.shared.domain.Coordinate
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.PilotFeature
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.time.LocalDate
 
 data class DaycareFields(

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
@@ -50,12 +50,13 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
     fun upsertAbsences(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody absences: List<AbsenceUpsert>,
         @PathVariable groupId: GroupId
     ) {
         Audit.AbsenceUpdate.log(targetId = groupId)
         accessControl.requirePermissionFor(user, Action.Group.CREATE_ABSENCES, groupId)
-        accessControl.requirePermissionFor(user, Action.Child.CREATE_ABSENCE, absences.map { it.childId })
+        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_ABSENCE, absences.map { it.childId })
 
         db.connect { dbc -> dbc.transaction { it.upsertAbsences(absences, user.evakaUserId) } }
     }
@@ -64,12 +65,13 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
     fun deleteAbsences(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody deletions: List<AbsenceDelete>,
         @PathVariable groupId: GroupId
     ) {
         Audit.AbsenceUpdate.log(targetId = groupId)
         accessControl.requirePermissionFor(user, Action.Group.DELETE_ABSENCES, groupId)
-        accessControl.requirePermissionFor(user, Action.Child.DELETE_ABSENCE, deletions.map { it.childId })
+        accessControl.requirePermissionFor(user, clock, Action.Child.DELETE_ABSENCE, deletions.map { it.childId })
 
         db.connect { dbc -> dbc.transaction { it.batchDeleteAbsences(deletions) } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceController.kt
@@ -59,7 +59,7 @@ class AbsenceController(private val absenceService: AbsenceService, private val 
         accessControl.requirePermissionFor(user, clock, Action.Group.CREATE_ABSENCES, groupId)
         accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_ABSENCE, absences.map { it.childId })
 
-        db.connect { dbc -> dbc.transaction { it.upsertAbsences(absences, user.evakaUserId) } }
+        db.connect { dbc -> dbc.transaction { it.upsertAbsences(clock, absences, user.evakaUserId) } }
     }
 
     @PostMapping("/{groupId}/delete")

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -29,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class ChildController(private val accessControl: AccessControl, private val featureConfig: FeatureConfig) {
     @GetMapping("/children/{childId}")
-    fun getChild(db: Database, user: AuthenticatedUser, @PathVariable childId: ChildId): ChildResponse {
+    fun getChild(db: Database, user: AuthenticatedUser, clock: EvakaClock, @PathVariable childId: ChildId): ChildResponse {
         Audit.PersonDetailsRead.log(targetId = childId)
         accessControl.requirePermissionFor(user, Action.Child.READ, childId)
         return db.connect { dbc ->
@@ -46,8 +47,8 @@ class ChildController(private val accessControl: AccessControl, private val feat
                     ?: throw NotFound("Child $childId not found")
                 ChildResponse(
                     person = PersonJSON.from(child),
-                    permittedActions = accessControl.getPermittedActions(tx, user, childId),
-                    permittedPersonActions = accessControl.getPermittedActions(tx, user, childId),
+                    permittedActions = accessControl.getPermittedActions(tx, user, clock, childId),
+                    permittedPersonActions = accessControl.getPermittedActions(tx, user, clock, childId),
                     assistanceNeedVoucherCoefficientsEnabled = !featureConfig.valueDecisionCapacityFactorEnabled
                 )
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
@@ -32,7 +32,7 @@ class ChildController(private val accessControl: AccessControl, private val feat
     @GetMapping("/children/{childId}")
     fun getChild(db: Database, user: AuthenticatedUser, clock: EvakaClock, @PathVariable childId: ChildId): ChildResponse {
         Audit.PersonDetailsRead.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ, childId)
         return db.connect { dbc ->
             dbc.read { tx ->
                 val child = tx.getPersonById(childId)
@@ -57,9 +57,9 @@ class ChildController(private val accessControl: AccessControl, private val feat
     }
 
     @GetMapping("/children/{childId}/additional-information")
-    fun getAdditionalInfo(db: Database, user: AuthenticatedUser, @PathVariable childId: ChildId): AdditionalInformation {
+    fun getAdditionalInfo(db: Database, user: AuthenticatedUser, clock: EvakaClock, @PathVariable childId: ChildId): AdditionalInformation {
         Audit.ChildAdditionalInformationRead.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_ADDITIONAL_INFO, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_ADDITIONAL_INFO, childId)
         return db.connect { dbc -> dbc.read { it.getAdditionalInformation(childId) } }
     }
 
@@ -67,11 +67,12 @@ class ChildController(private val accessControl: AccessControl, private val feat
     fun updateAdditionalInfo(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @RequestBody data: AdditionalInformation
     ) {
         Audit.ChildAdditionalInformationUpdate.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.UPDATE_ADDITIONAL_INFO, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.UPDATE_ADDITIONAL_INFO, childId)
         db.connect { dbc -> dbc.transaction { it.upsertAdditionalInformation(childId, data) } }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
@@ -39,10 +39,11 @@ class ChildController(private val accessControl: AccessControl, private val feat
                     ?.hideNonPermittedPersonData(
                         includeInvoiceAddress = accessControl.hasPermissionFor(
                             user,
+                            clock,
                             Action.Person.READ_INVOICE_ADDRESS,
                             childId
                         ),
-                        includeOphOid = accessControl.hasPermissionFor(user, Action.Person.READ_OPH_OID, childId)
+                        includeOphOid = accessControl.hasPermissionFor(user, clock, Action.Person.READ_OPH_OID, childId)
                     )
                     ?: throw NotFound("Child $childId not found")
                 ChildResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -106,7 +106,7 @@ class DaycareController(
         @PathVariable daycareId: DaycareId
     ): DaycareResponse {
         Audit.UnitRead.log(targetId = daycareId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ, daycareId)
         return db.connect { dbc ->
             dbc.read { tx ->
                 tx.getDaycare(daycareId)?.let { daycare ->
@@ -133,12 +133,13 @@ class DaycareController(
     fun getGroups(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate? = null,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate? = null
     ): List<DaycareGroup> {
         Audit.UnitGroupsSearch.log(targetId = daycareId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_GROUPS, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_GROUPS, daycareId)
         return db.connect { dbc -> dbc.read { daycareService.getDaycareGroups(it, daycareId, from, to) } }
     }
 
@@ -146,11 +147,12 @@ class DaycareController(
     fun createGroup(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @RequestBody body: CreateGroupRequest
     ): DaycareGroup {
         Audit.UnitGroupsCreate.log(targetId = daycareId)
-        accessControl.requirePermissionFor(user, Action.Unit.CREATE_GROUP, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.CREATE_GROUP, daycareId)
 
         return db.connect { dbc -> dbc.transaction { daycareService.createGroup(it, daycareId, body.name, body.startDate, body.initialCaretakers) } }
     }
@@ -164,12 +166,13 @@ class DaycareController(
     fun updateGroup(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId,
         @RequestBody body: GroupUpdateRequest
     ) {
         Audit.UnitGroupsUpdate.log(targetId = groupId)
-        accessControl.requirePermissionFor(user, Action.Group.UPDATE, groupId)
+        accessControl.requirePermissionFor(user, clock, Action.Group.UPDATE, groupId)
 
         db.connect { dbc -> dbc.transaction { it.updateGroup(groupId, body.name, body.startDate, body.endDate) } }
     }
@@ -178,11 +181,12 @@ class DaycareController(
     fun deleteGroup(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId
     ) {
         Audit.UnitGroupsDelete.log(targetId = groupId)
-        accessControl.requirePermissionFor(user, Action.Group.DELETE, groupId)
+        accessControl.requirePermissionFor(user, clock, Action.Group.DELETE, groupId)
 
         db.connect { dbc -> dbc.transaction { daycareService.deleteGroup(it, groupId) } }
     }
@@ -191,11 +195,12 @@ class DaycareController(
     fun getCaretakers(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId
     ): CaretakersResponse {
         Audit.UnitGroupsCaretakersRead.log(targetId = groupId)
-        accessControl.requirePermissionFor(user, Action.Group.READ_CARETAKERS, groupId)
+        accessControl.requirePermissionFor(user, clock, Action.Group.READ_CARETAKERS, groupId)
 
         return db.connect { dbc ->
             dbc.read {
@@ -212,12 +217,13 @@ class DaycareController(
     fun createCaretakers(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId,
         @RequestBody body: CaretakerRequest
     ) {
         Audit.UnitGroupsCaretakersCreate.log(targetId = groupId)
-        accessControl.requirePermissionFor(user, Action.Group.CREATE_CARETAKERS, groupId)
+        accessControl.requirePermissionFor(user, clock, Action.Group.CREATE_CARETAKERS, groupId)
 
         db.connect { dbc ->
             dbc.transaction {
@@ -236,13 +242,14 @@ class DaycareController(
     fun updateCaretakers(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId,
         @PathVariable id: DaycareCaretakerId,
         @RequestBody body: CaretakerRequest
     ) {
         Audit.UnitGroupsCaretakersUpdate.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Group.UPDATE_CARETAKERS, groupId)
+        accessControl.requirePermissionFor(user, clock, Action.Group.UPDATE_CARETAKERS, groupId)
 
         db.connect { dbc ->
             dbc.transaction {
@@ -262,12 +269,13 @@ class DaycareController(
     fun removeCaretakers(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable groupId: GroupId,
         @PathVariable id: DaycareCaretakerId
     ) {
         Audit.UnitGroupsCaretakersDelete.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Group.DELETE_CARETAKERS, groupId)
+        accessControl.requirePermissionFor(user, clock, Action.Group.DELETE_CARETAKERS, groupId)
 
         db.connect { dbc ->
             dbc.transaction {
@@ -284,11 +292,12 @@ class DaycareController(
     fun updateDaycare(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @RequestBody fields: DaycareFields
     ): Daycare {
         Audit.UnitUpdate.log(targetId = daycareId)
-        accessControl.requirePermissionFor(user, Action.Unit.UPDATE, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.UPDATE, daycareId)
         fields.validate()
         return db.connect { dbc ->
             dbc.transaction {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -81,10 +81,11 @@ class DaycareController(
     fun postUnitFeatures(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody request: UpdateFeaturesRequest
     ) {
         Audit.UnitFeaturesUpdate.log(targetId = request.unitIds)
-        accessControl.requirePermissionFor(user, Action.Unit.UPDATE_FEATURES, request.unitIds)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.UPDATE_FEATURES, request.unitIds)
 
         db.connect { dbc ->
             dbc.transaction {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -101,6 +101,7 @@ class DaycareController(
     fun getDaycare(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId
     ): DaycareResponse {
         Audit.UnitRead.log(targetId = daycareId)
@@ -109,7 +110,7 @@ class DaycareController(
             dbc.read { tx ->
                 tx.getDaycare(daycareId)?.let { daycare ->
                     val groups = tx.getDaycareGroupSummaries(daycareId)
-                    val permittedActions = accessControl.getPermittedActions<GroupId, Action.Group>(tx, user, groups.map { it.id })
+                    val permittedActions = accessControl.getPermittedActions<GroupId, Action.Group>(tx, user, clock, groups.map { it.id })
                     DaycareResponse(
                         daycare,
                         groups.map {
@@ -120,7 +121,7 @@ class DaycareController(
                                 permittedActions = permittedActions[it.id]!!
                             )
                         },
-                        accessControl.getPermittedActions(tx, user, daycareId)
+                        accessControl.getPermittedActions(tx, user, clock, daycareId)
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -70,10 +70,11 @@ class DaycareController(
     @GetMapping("/features")
     fun getFeatures(
         db: Database,
-        user: AuthenticatedUser
+        user: AuthenticatedUser,
+        clock: EvakaClock
     ): List<UnitFeatures> {
         Audit.UnitFeaturesRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_UNIT_FEATURES)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_UNIT_FEATURES)
         return db.connect { dbc -> dbc.read { it.getUnitFeatures() } }
     }
 
@@ -312,10 +313,11 @@ class DaycareController(
     fun createDaycare(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody fields: DaycareFields
     ): CreateDaycareResponse {
         Audit.UnitCreate.log()
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_UNIT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_UNIT)
         fields.validate()
         return CreateDaycareResponse(
             db.connect { dbc ->

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
@@ -36,24 +36,25 @@ class StaffAttendanceController(
     fun getAttendancesByUnit(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable unitId: DaycareId
     ): UnitStaffAttendance {
         Audit.UnitStaffAttendanceRead.log(targetId = unitId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_STAFF_ATTENDANCES, unitId)
-        return db.connect { dbc -> staffAttendanceService.getUnitAttendancesForDate(dbc, unitId, evakaClock.today()) }
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_STAFF_ATTENDANCES, unitId)
+        return db.connect { dbc -> staffAttendanceService.getUnitAttendancesForDate(dbc, unitId, clock.today()) }
     }
 
     @GetMapping("/group/{groupId}")
     fun getAttendancesByGroup(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam year: Int,
         @RequestParam month: Int,
         @PathVariable groupId: GroupId
     ): Wrapper<StaffAttendanceForDates> {
         Audit.StaffAttendanceRead.log(targetId = groupId)
-        accessControl.requirePermissionFor(user, Action.Group.READ_STAFF_ATTENDANCES, groupId)
+        accessControl.requirePermissionFor(user, clock, Action.Group.READ_STAFF_ATTENDANCES, groupId)
         val result = db.connect { dbc -> staffAttendanceService.getGroupAttendancesByMonth(dbc, year, month, groupId) }
         return Wrapper(result)
     }
@@ -62,11 +63,12 @@ class StaffAttendanceController(
     fun upsertStaffAttendance(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody staffAttendance: StaffAttendanceUpdate,
         @PathVariable groupId: GroupId
     ) {
         Audit.StaffAttendanceUpdate.log(targetId = groupId)
-        accessControl.requirePermissionFor(user, Action.Group.UPDATE_STAFF_ATTENDANCES, groupId)
+        accessControl.requirePermissionFor(user, clock, Action.Group.UPDATE_STAFF_ATTENDANCES, groupId)
         if (staffAttendance.count == null) {
             throw BadRequest("Count can't be null")
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
@@ -22,6 +22,7 @@ import fi.espoo.evaka.shared.auth.DaycareAclRow
 import fi.espoo.evaka.shared.auth.clearDaycareGroupAcl
 import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -37,10 +38,11 @@ class UnitAclController(private val accessControl: AccessControl) {
     fun getAcl(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId
     ): DaycareAclResponse {
         Audit.UnitAclRead.log()
-        accessControl.requirePermissionFor(user, Action.Unit.READ_ACL, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_ACL, daycareId)
         return DaycareAclResponse(db.connect { dbc -> getDaycareAclRows(dbc, daycareId) })
     }
 
@@ -48,11 +50,12 @@ class UnitAclController(private val accessControl: AccessControl) {
     fun insertUnitSupervisor(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
-        accessControl.requirePermissionFor(user, Action.Unit.INSERT_ACL_UNIT_SUPERVISOR, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.INSERT_ACL_UNIT_SUPERVISOR, daycareId)
         db.connect { dbc -> addUnitSupervisor(dbc, daycareId, employeeId) }
     }
 
@@ -60,11 +63,12 @@ class UnitAclController(private val accessControl: AccessControl) {
     fun deleteUnitSupervisor(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
-        accessControl.requirePermissionFor(user, Action.Unit.DELETE_ACL_UNIT_SUPERVISOR, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.DELETE_ACL_UNIT_SUPERVISOR, daycareId)
         db.connect { dbc -> removeUnitSupervisor(dbc, daycareId, employeeId) }
     }
 
@@ -72,11 +76,12 @@ class UnitAclController(private val accessControl: AccessControl) {
     fun insertSpecialEducationTeacher(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
-        accessControl.requirePermissionFor(user, Action.Unit.INSERT_ACL_SPECIAL_EDUCATION_TEACHER, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.INSERT_ACL_SPECIAL_EDUCATION_TEACHER, daycareId)
         db.connect { dbc -> addSpecialEducationTeacher(dbc, daycareId, employeeId) }
     }
 
@@ -84,11 +89,12 @@ class UnitAclController(private val accessControl: AccessControl) {
     fun deleteSpecialEducationTeacher(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
-        accessControl.requirePermissionFor(user, Action.Unit.DELETE_ACL_SPECIAL_EDUCATION_TEACHER, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.DELETE_ACL_SPECIAL_EDUCATION_TEACHER, daycareId)
         db.connect { dbc -> removeSpecialEducationTeacher(dbc, daycareId, employeeId) }
     }
 
@@ -96,11 +102,12 @@ class UnitAclController(private val accessControl: AccessControl) {
     fun insertEarlyChildhoodEducationSecretary(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
-        accessControl.requirePermissionFor(user, Action.Unit.INSERT_ACL_EARLY_CHILDHOOD_EDUCATION_SECRETARY, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.INSERT_ACL_EARLY_CHILDHOOD_EDUCATION_SECRETARY, daycareId)
         db.connect { dbc -> addEarlyChildhoodEducationSecretary(dbc, daycareId, employeeId) }
     }
 
@@ -108,11 +115,12 @@ class UnitAclController(private val accessControl: AccessControl) {
     fun deleteEarlyChildhoodEducationSecretary(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
-        accessControl.requirePermissionFor(user, Action.Unit.DELETE_ACL_EARLY_CHILDHOOD_EDUCATION_SECRETARY, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.DELETE_ACL_EARLY_CHILDHOOD_EDUCATION_SECRETARY, daycareId)
         db.connect { dbc -> removeEarlyChildhoodEducationSecretary(dbc, daycareId, employeeId) }
     }
 
@@ -120,11 +128,12 @@ class UnitAclController(private val accessControl: AccessControl) {
     fun insertStaff(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
-        accessControl.requirePermissionFor(user, Action.Unit.INSERT_ACL_STAFF, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.INSERT_ACL_STAFF, daycareId)
         db.connect { dbc -> addStaffMember(dbc, daycareId, employeeId) }
     }
 
@@ -132,11 +141,12 @@ class UnitAclController(private val accessControl: AccessControl) {
     fun deleteStaff(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
-        accessControl.requirePermissionFor(user, Action.Unit.DELETE_ACL_STAFF, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.DELETE_ACL_STAFF, daycareId)
         db.connect { dbc -> removeStaffMember(dbc, daycareId, employeeId) }
     }
 
@@ -144,12 +154,13 @@ class UnitAclController(private val accessControl: AccessControl) {
     fun updateStaffGroupAcl(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId,
         @RequestBody update: GroupAclUpdate
     ) {
         Audit.UnitGroupAclUpdate.log(targetId = daycareId, objectId = employeeId)
-        accessControl.requirePermissionFor(user, Action.Unit.UPDATE_STAFF_GROUP_ACL, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.UPDATE_STAFF_GROUP_ACL, daycareId)
 
         db.connect { dbc ->
             dbc.transaction {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -28,7 +28,6 @@ import fi.espoo.evaka.shared.domain.HelsinkiDateTimeRange
 import fi.espoo.evaka.shared.domain.getHolidays
 import fi.espoo.evaka.shared.domain.operationalDates
 import fi.espoo.evaka.user.EvakaUserType
-import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.mapper.Nested
 import org.springframework.stereotype.Service
 import java.math.BigDecimal

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -37,10 +38,11 @@ class DecisionController(
     fun getDecisionsByGuardian(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("id") guardianId: PersonId
     ): DecisionListResponse {
         Audit.DecisionRead.log(targetId = guardianId)
-        accessControl.requirePermissionFor(user, Action.Person.READ_DECISIONS, guardianId)
+        accessControl.requirePermissionFor(user, clock, Action.Person.READ_DECISIONS, guardianId)
         val decisions = db.connect { dbc -> dbc.read { it.getDecisionsByGuardian(guardianId, acl.getAuthorizedUnits(user)) } }
         return DecisionListResponse(decisions)
     }
@@ -49,10 +51,11 @@ class DecisionController(
     fun getDecisionsByChild(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("id") childId: ChildId
     ): DecisionListResponse {
         Audit.DecisionRead.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_DECISIONS, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_DECISIONS, childId)
         val decisions = db.connect { dbc -> dbc.read { it.getDecisionsByChild(childId, acl.getAuthorizedUnits(user)) } }
         return DecisionListResponse(decisions)
     }
@@ -61,10 +64,11 @@ class DecisionController(
     fun getDecisionsByApplication(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("id") applicationId: ApplicationId
     ): DecisionListResponse {
         Audit.DecisionRead.log(targetId = applicationId)
-        accessControl.requirePermissionFor(user, Action.Application.READ_DECISIONS, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.READ_DECISIONS, applicationId)
         val decisions = db.connect { dbc -> dbc.read { it.getDecisionsByApplication(applicationId, acl.getAuthorizedUnits(user)) } }
 
         return DecisionListResponse(decisions)
@@ -81,10 +85,11 @@ class DecisionController(
     fun downloadDecisionPdf(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("id") decisionId: DecisionId
     ): ResponseEntity<Any> {
         Audit.DecisionDownloadPdf.log(targetId = decisionId)
-        accessControl.requirePermissionFor(user, Action.Decision.DOWNLOAD_PDF, decisionId)
+        accessControl.requirePermissionFor(user, clock, Action.Decision.DOWNLOAD_PDF, decisionId)
 
         return db.connect { dbc ->
             val decision = dbc.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionController.kt
@@ -75,9 +75,9 @@ class DecisionController(
     }
 
     @GetMapping("/units")
-    fun getDecisionUnits(db: Database, user: AuthenticatedUser): List<DecisionUnit> {
+    fun getDecisionUnits(db: Database, user: AuthenticatedUser, clock: EvakaClock): List<DecisionUnit> {
         Audit.UnitRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_DECISION_UNITS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_DECISION_UNITS)
         return db.connect { dbc -> dbc.read { decisionDraftService.getDecisionUnits(it) } }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/dvv/DvvModificationsBatchRefreshService.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
-import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -30,7 +29,7 @@ class DvvModificationsBatchRefreshService(
         logger.info("DvvModificationsRefresh: finished processing $modificationCount DVV person modifications for ${msg.ssns.size} ssns")
     }
 
-    fun scheduleBatch(db: Database.Connection): Int {
+    fun scheduleBatch(db: Database.Connection, clock: EvakaClock): Int {
         val jobCount = db.transaction { tx ->
             tx.deleteOldJobs()
 
@@ -44,7 +43,7 @@ class DvvModificationsBatchRefreshService(
                         requestingUserId = UUID.fromString("00000000-0000-0000-0000-000000000000")
                     )
                 ),
-                runAt = HelsinkiDateTime.now(),
+                runAt = clock.now(),
                 retryCount = 10
             )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodController.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.HolidayPeriodId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -28,9 +29,10 @@ class HolidayPeriodController(private val accessControl: AccessControl) {
     fun getHolidayPeriods(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock
     ): List<HolidayPeriod> {
         Audit.HolidayPeriodsList.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_HOLIDAY_PERIODS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_HOLIDAY_PERIODS)
         return db.connect { dbc -> dbc.read { it.getHolidayPeriods() } }
     }
 
@@ -38,10 +40,11 @@ class HolidayPeriodController(private val accessControl: AccessControl) {
     fun getHolidayPeriod(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: HolidayPeriodId,
     ): HolidayPeriod {
         Audit.HolidayPeriodRead.log(id)
-        accessControl.requirePermissionFor(user, Action.Global.READ_HOLIDAY_PERIOD)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_HOLIDAY_PERIOD)
         return db.connect { dbc -> dbc.read { it.getHolidayPeriod(id) } } ?: throw NotFound()
     }
 
@@ -49,10 +52,11 @@ class HolidayPeriodController(private val accessControl: AccessControl) {
     fun createHolidayPeriod(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: HolidayPeriodBody
     ): HolidayPeriod {
         Audit.HolidayPeriodCreate.log()
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_HOLIDAY_PERIOD)
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_HOLIDAY_PERIOD)
         return db.connect { dbc ->
             dbc.transaction {
                 try {
@@ -68,11 +72,12 @@ class HolidayPeriodController(private val accessControl: AccessControl) {
     fun updateHolidayPeriod(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: HolidayPeriodId,
         @RequestBody body: HolidayPeriodBody
     ) {
         Audit.HolidayPeriodUpdate.log(id)
-        accessControl.requirePermissionFor(user, Action.Global.UPDATE_HOLIDAY_PERIOD)
+        accessControl.requirePermissionFor(user, clock, Action.Global.UPDATE_HOLIDAY_PERIOD)
         db.connect { dbc ->
             dbc.transaction {
                 try {
@@ -88,10 +93,11 @@ class HolidayPeriodController(private val accessControl: AccessControl) {
     fun deleteHolidayPeriod(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: HolidayPeriodId
     ) {
         Audit.HolidayPeriodDelete.log(id)
-        accessControl.requirePermissionFor(user, Action.Global.DELETE_HOLIDAY_PERIOD)
+        accessControl.requirePermissionFor(user, clock, Action.Global.DELETE_HOLIDAY_PERIOD)
         db.connect { dbc -> dbc.transaction { it.deleteHolidayPeriod(id) } }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -40,9 +40,10 @@ class HolidayPeriodControllerCitizen(private val accessControl: AccessControl) {
     fun getHolidayPeriods(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
     ): List<HolidayPeriod> {
         Audit.HolidayPeriodsList.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_HOLIDAY_PERIODS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_HOLIDAY_PERIODS)
         return db.connect { dbc -> dbc.read { it.getHolidayPeriods() } }
     }
 
@@ -50,13 +51,13 @@ class HolidayPeriodControllerCitizen(private val accessControl: AccessControl) {
     fun getActiveQuestionnaires(
         db: Database,
         user: AuthenticatedUser.Citizen,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
     ): List<ActiveQuestionnaire> {
         Audit.HolidayPeriodsList.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_ACTIVE_HOLIDAY_QUESTIONNAIRES)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_ACTIVE_HOLIDAY_QUESTIONNAIRES)
         return db.connect { dbc ->
             dbc.read { tx ->
-                val activeQuestionnaire = tx.getActiveFixedPeriodQuestionnaire(evakaClock.today()) ?: return@read listOf()
+                val activeQuestionnaire = tx.getActiveFixedPeriodQuestionnaire(clock.today()) ?: return@read listOf()
 
                 val continuousPlacementPeriod = activeQuestionnaire.conditions.continuousPlacement
                 val eligibleChildren = if (continuousPlacementPeriod != null) {

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodQueries.kt
@@ -6,7 +6,6 @@ package fi.espoo.evaka.holidayperiod
 
 import fi.espoo.evaka.shared.HolidayPeriodId
 import fi.espoo.evaka.shared.db.Database
-import org.jdbi.v3.core.kotlin.bindKotlin
 
 fun Database.Read.getHolidayPeriodDeadlines(): List<HolidayPeriodDeadline> =
     this.createQuery("SELECT id, period, reservation_deadline FROM holiday_period WHERE reservation_deadline IS NOT NULL")

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaireController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaireController.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.HolidayQuestionnaireId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -28,9 +29,10 @@ class HolidayQuestionnaireController(private val accessControl: AccessControl) {
     fun getQuestionnaires(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock
     ): List<FixedPeriodQuestionnaire> {
         Audit.HolidayQuestionnairesList.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_HOLIDAY_QUESTIONNAIRES)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_HOLIDAY_QUESTIONNAIRES)
         return db.connect { dbc -> dbc.read { it.getHolidayQuestionnaires() } }
     }
 
@@ -38,10 +40,11 @@ class HolidayQuestionnaireController(private val accessControl: AccessControl) {
     fun getQuestionnaire(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: HolidayQuestionnaireId
     ): FixedPeriodQuestionnaire {
         Audit.HolidayQuestionnaireRead.log(id)
-        accessControl.requirePermissionFor(user, Action.Global.READ_HOLIDAY_QUESTIONNAIRE)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_HOLIDAY_QUESTIONNAIRE)
         return db.connect { dbc -> dbc.read { it.getFixedPeriodQuestionnaire(id) ?: throw NotFound() } }
     }
 
@@ -49,10 +52,11 @@ class HolidayQuestionnaireController(private val accessControl: AccessControl) {
     fun createHolidayQuestionnaire(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: FixedPeriodQuestionnaireBody
     ) {
         Audit.HolidayQuestionnaireCreate.log()
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_HOLIDAY_QUESTIONNAIRE)
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_HOLIDAY_QUESTIONNAIRE)
         return db.connect { dbc ->
             dbc.transaction {
                 try {
@@ -68,11 +72,12 @@ class HolidayQuestionnaireController(private val accessControl: AccessControl) {
     fun updateHolidayQuestionnaire(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: HolidayQuestionnaireId,
         @RequestBody body: FixedPeriodQuestionnaireBody
     ) {
         Audit.HolidayQuestionnaireUpdate.log(id)
-        accessControl.requirePermissionFor(user, Action.Global.UPDATE_HOLIDAY_QUESTIONNAIRE)
+        accessControl.requirePermissionFor(user, clock, Action.Global.UPDATE_HOLIDAY_QUESTIONNAIRE)
         return db.connect { dbc ->
             dbc.transaction {
                 try {
@@ -88,10 +93,11 @@ class HolidayQuestionnaireController(private val accessControl: AccessControl) {
     fun deleteHolidayQuestionnaire(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: HolidayQuestionnaireId
     ) {
         Audit.HolidayQuestionnaireDelete.log(id)
-        accessControl.requirePermissionFor(user, Action.Global.DELETE_HOLIDAY_QUESTIONNAIRE)
+        accessControl.requirePermissionFor(user, clock, Action.Global.DELETE_HOLIDAY_QUESTIONNAIRE)
         db.connect { dbc -> dbc.transaction { it.deleteHolidayQuestionnaire(id) } }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaireQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaireQueries.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.shared.HolidayQuestionnaireId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.time.LocalDate
 
 private val questionnaireSelect = """

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
@@ -121,10 +121,11 @@ class IncomeStatementController(
     fun getIncomeStatementsAwaitingHandler(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: SearchIncomeStatementsRequest
     ): Paged<IncomeStatementAwaitingHandler> {
         Audit.IncomeStatementsAwaitingHandler.log()
-        accessControl.requirePermissionFor(user, Action.Global.FETCH_INCOME_STATEMENTS_AWAITING_HANDLER)
+        accessControl.requirePermissionFor(user, clock, Action.Global.FETCH_INCOME_STATEMENTS_AWAITING_HANDLER)
         return db.connect { dbc ->
             dbc.read {
                 it.fetchIncomeStatementsAwaitingHandler(

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
@@ -34,12 +35,13 @@ class IncomeStatementController(
     fun getIncomeStatements(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable personId: PersonId,
         @RequestParam page: Int,
         @RequestParam pageSize: Int
     ): Paged<IncomeStatement> {
         Audit.IncomeStatementsOfPerson.log(personId)
-        accessControl.requirePermissionFor(user, Action.Person.READ_INCOME_STATEMENTS, personId)
+        accessControl.requirePermissionFor(user, clock, Action.Person.READ_INCOME_STATEMENTS, personId)
         return db.connect { dbc ->
             dbc.read {
                 it.readIncomeStatementsForPerson(
@@ -56,12 +58,13 @@ class IncomeStatementController(
     fun getChildIncomeStatements(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @RequestParam page: Int,
         @RequestParam pageSize: Int
     ): Paged<IncomeStatement> {
         Audit.IncomeStatementsOfChild.log(user.id, childId)
-        accessControl.requirePermissionFor(user, Action.Person.READ_INCOME_STATEMENTS, PersonId(childId.raw))
+        accessControl.requirePermissionFor(user, clock, Action.Person.READ_INCOME_STATEMENTS, PersonId(childId.raw))
 
         return db.connect { dbc ->
             dbc.read { tx ->
@@ -74,11 +77,12 @@ class IncomeStatementController(
     fun getIncomeStatement(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable personId: PersonId,
         @PathVariable incomeStatementId: IncomeStatementId,
     ): IncomeStatement {
         Audit.IncomeStatementReadOfPerson.log(incomeStatementId, personId)
-        accessControl.requirePermissionFor(user, Action.Person.READ_INCOME_STATEMENTS, personId)
+        accessControl.requirePermissionFor(user, clock, Action.Person.READ_INCOME_STATEMENTS, personId)
         return db.connect { dbc ->
             dbc.read {
                 it.readIncomeStatementForPerson(
@@ -96,11 +100,12 @@ class IncomeStatementController(
     fun setHandled(
         db: Database,
         user: AuthenticatedUser.Employee,
+        clock: EvakaClock,
         @PathVariable incomeStatementId: IncomeStatementId,
         @RequestBody body: SetIncomeStatementHandledBody
     ) {
         Audit.IncomeStatementUpdateHandled.log(incomeStatementId)
-        accessControl.requirePermissionFor(user, Action.IncomeStatement.UPDATE_HANDLED, incomeStatementId)
+        accessControl.requirePermissionFor(user, clock, Action.IncomeStatement.UPDATE_HANDLED, incomeStatementId)
         db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.updateIncomeStatementHandled(
@@ -139,10 +144,11 @@ class IncomeStatementController(
     fun getIncomeStatementChildren(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable guardianId: PersonId
     ): List<ChildBasicInfo> {
         Audit.IncomeStatementsOfChild.log()
-        accessControl.requirePermissionFor(user, Action.Person.READ_INCOME_STATEMENTS, guardianId)
+        accessControl.requirePermissionFor(user, clock, Action.Person.READ_INCOME_STATEMENTS, guardianId)
         return db.connect { dbc ->
             dbc.read {
                 it.getIncomeStatementChildrenByGuardian(guardianId)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -126,7 +126,7 @@ class FeeDecisionController(
                     clock.now(),
                     featureConfig.alwaysUseDaycareFinanceDecisionHandler
                 )
-                asyncJobRunner.plan(tx, confirmedDecisions.map { AsyncJob.NotifyFeeDecisionApproved(it) })
+                asyncJobRunner.plan(tx, confirmedDecisions.map { AsyncJob.NotifyFeeDecisionApproved(it) }, runAt = clock.now())
             }
         }
     }
@@ -135,7 +135,7 @@ class FeeDecisionController(
     fun setSent(db: Database, user: AuthenticatedUser, clock: EvakaClock, @RequestBody feeDecisionIds: List<FeeDecisionId>) {
         Audit.FeeDecisionMarkSent.log(targetId = feeDecisionIds)
         accessControl.requirePermissionFor(user, clock, Action.FeeDecision.UPDATE, feeDecisionIds)
-        db.connect { dbc -> dbc.transaction { service.setSent(it, feeDecisionIds) } }
+        db.connect { dbc -> dbc.transaction { service.setSent(it, clock, feeDecisionIds) } }
     }
 
     @GetMapping("/pdf/{decisionId}")

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -81,7 +81,7 @@ class FeeDecisionController(
         @RequestBody body: SearchFeeDecisionRequest
     ): Paged<FeeDecisionSummary> {
         Audit.FeeDecisionSearch.log()
-        accessControl.requirePermissionFor(user, Action.Global.SEARCH_FEE_DECISIONS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.SEARCH_FEE_DECISIONS)
         val maxPageSize = 5000
         if (body.pageSize > maxPageSize) throw BadRequest("Maximum page size is $maxPageSize")
         if (body.startDate != null && body.endDate != null && body.endDate < body.startDate)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -77,6 +77,7 @@ class FeeDecisionController(
     fun search(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: SearchFeeDecisionRequest
     ): Paged<FeeDecisionSummary> {
         Audit.FeeDecisionSearch.log()
@@ -88,6 +89,7 @@ class FeeDecisionController(
         return db.connect { dbc ->
             dbc.read { tx ->
                 tx.searchFeeDecisions(
+                    clock,
                     body.page,
                     body.pageSize,
                     body.sortBy ?: FeeDecisionSortParam.STATUS,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -112,18 +112,18 @@ class FeeDecisionController(
     fun confirmDrafts(
         db: Database,
         user: AuthenticatedUser.Employee,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestBody feeDecisionIds: List<FeeDecisionId>
     ) {
         Audit.FeeDecisionConfirm.log(targetId = feeDecisionIds)
-        accessControl.requirePermissionFor(user, Action.FeeDecision.UPDATE, feeDecisionIds)
+        accessControl.requirePermissionFor(user, clock, Action.FeeDecision.UPDATE, feeDecisionIds)
         db.connect { dbc ->
             dbc.transaction { tx ->
                 val confirmedDecisions = service.confirmDrafts(
                     tx,
                     user,
                     feeDecisionIds,
-                    evakaClock.now(),
+                    clock.now(),
                     featureConfig.alwaysUseDaycareFinanceDecisionHandler
                 )
                 asyncJobRunner.plan(tx, confirmedDecisions.map { AsyncJob.NotifyFeeDecisionApproved(it) })
@@ -132,9 +132,9 @@ class FeeDecisionController(
     }
 
     @PostMapping("/mark-sent")
-    fun setSent(db: Database, user: AuthenticatedUser, @RequestBody feeDecisionIds: List<FeeDecisionId>) {
+    fun setSent(db: Database, user: AuthenticatedUser, clock: EvakaClock, @RequestBody feeDecisionIds: List<FeeDecisionId>) {
         Audit.FeeDecisionMarkSent.log(targetId = feeDecisionIds)
-        accessControl.requirePermissionFor(user, Action.FeeDecision.UPDATE, feeDecisionIds)
+        accessControl.requirePermissionFor(user, clock, Action.FeeDecision.UPDATE, feeDecisionIds)
         db.connect { dbc -> dbc.transaction { service.setSent(it, feeDecisionIds) } }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.PostMapping
@@ -33,9 +34,9 @@ class FeeDecisionGeneratorController(
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     @PostMapping("/generate")
-    fun generateDecisions(db: Database, user: AuthenticatedUser, @RequestBody data: GenerateDecisionsBody) {
+    fun generateDecisions(db: Database, user: AuthenticatedUser, clock: EvakaClock, @RequestBody data: GenerateDecisionsBody) {
         Audit.FeeDecisionGenerate.log(targetId = data.targetHeads)
-        accessControl.requirePermissionFor(user, Action.Global.GENERATE_FEE_DECISIONS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.GENERATE_FEE_DECISIONS)
         db.connect { dbc ->
             generateAllStartingFrom(
                 dbc,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionGeneratorController.kt
@@ -40,13 +40,14 @@ class FeeDecisionGeneratorController(
         db.connect { dbc ->
             generateAllStartingFrom(
                 dbc,
+                clock,
                 LocalDate.parse(data.starting, DateTimeFormatter.ISO_DATE),
                 data.targetHeads.filterNotNull().distinct()
             )
         }
     }
 
-    private fun generateAllStartingFrom(db: Database.Connection, starting: LocalDate, targetHeads: List<PersonId>) {
-        db.transaction { planFinanceDecisionGeneration(it, asyncJobRunner, DateRange(starting, null), targetHeads) }
+    private fun generateAllStartingFrom(db: Database.Connection, clock: EvakaClock, starting: LocalDate, targetHeads: List<PersonId>) {
+        db.transaction { planFinanceDecisionGeneration(it, clock, asyncJobRunner, DateRange(starting, null), targetHeads) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
@@ -72,7 +72,7 @@ class FinanceBasicsController(
                 }
 
                 mapConstraintExceptions { tx.insertNewFeeThresholds(body) }
-                asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyFeeThresholdsUpdated(body.validDuring)))
+                asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyFeeThresholdsUpdated(body.validDuring)), runAt = clock.now())
             }
         }
     }
@@ -92,7 +92,7 @@ class FinanceBasicsController(
         db.connect { dbc ->
             dbc.transaction { tx ->
                 mapConstraintExceptions { tx.updateFeeThresholds(id, thresholds) }
-                asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyFeeThresholdsUpdated(thresholds.validDuring)))
+                asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyFeeThresholdsUpdated(thresholds.validDuring)), runAt = clock.now())
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
@@ -18,7 +18,6 @@ import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.jdbi.v3.core.JdbiException
-import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.mapper.Nested
 import org.postgresql.util.PSQLState
 import org.springframework.web.bind.annotation.GetMapping

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.psqlCause
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.jdbi.v3.core.JdbiException
@@ -79,11 +80,12 @@ class FinanceBasicsController(
     fun updateFeeThresholds(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: FeeThresholdsId,
         @RequestBody thresholds: FeeThresholds
     ) {
         Audit.FinanceBasicsFeeThresholdsUpdate.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.FeeThresholds.UPDATE, id)
+        accessControl.requirePermissionFor(user, clock, Action.FeeThresholds.UPDATE, id)
 
         validateFeeThresholds(thresholds)
         db.connect { dbc ->

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
@@ -38,9 +38,9 @@ class FinanceBasicsController(
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     @GetMapping("/fee-thresholds")
-    fun getFeeThresholds(db: Database, user: AuthenticatedUser): List<FeeThresholdsWithId> {
+    fun getFeeThresholds(db: Database, user: AuthenticatedUser, clock: EvakaClock): List<FeeThresholdsWithId> {
         Audit.FinanceBasicsFeeThresholdsRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_FEE_THRESHOLDS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_FEE_THRESHOLDS)
 
         return db.connect { dbc -> dbc.read { tx -> tx.getFeeThresholds().sortedByDescending { it.thresholds.validDuring.start } } }
     }
@@ -49,10 +49,11 @@ class FinanceBasicsController(
     fun createFeeThresholds(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: FeeThresholds
     ) {
         Audit.FinanceBasicsFeeThresholdsCreate.log()
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_FEE_THRESHOLDS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_FEE_THRESHOLDS)
 
         validateFeeThresholds(body)
         db.connect { dbc ->

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -144,8 +144,8 @@ class IncomeController(
     }
 
     @GetMapping("/types")
-    fun getTypes(user: AuthenticatedUser): Map<String, IncomeType> {
-        accessControl.requirePermissionFor(user, Action.Global.READ_INCOME_TYPES)
+    fun getTypes(user: AuthenticatedUser, clock: EvakaClock): Map<String, IncomeType> {
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_INCOME_TYPES)
         return incomeTypesProvider.get()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
@@ -65,10 +65,11 @@ class InvoiceController(
     fun searchInvoices(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: SearchInvoicesRequest
     ): Paged<InvoiceSummary> {
         Audit.InvoicesSearch.log()
-        accessControl.requirePermissionFor(user, Action.Global.SEARCH_INVOICES)
+        accessControl.requirePermissionFor(user, clock, Action.Global.SEARCH_INVOICES)
         val maxPageSize = 5000
         if (body.pageSize > maxPageSize) throw BadRequest("Maximum page size is $maxPageSize")
         return db.connect { dbc ->
@@ -92,9 +93,9 @@ class InvoiceController(
     }
 
     @PostMapping("/create-drafts")
-    fun createDraftInvoices(db: Database, user: AuthenticatedUser) {
+    fun createDraftInvoices(db: Database, user: AuthenticatedUser, clock: EvakaClock) {
         Audit.InvoicesCreate.log()
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_DRAFT_INVOICES)
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_DRAFT_INVOICES)
         db.connect { dbc -> dbc.transaction { generator.createAndStoreAllDraftInvoices(it) } }
     }
 
@@ -184,8 +185,8 @@ class InvoiceController(
     }
 
     @GetMapping("/codes")
-    fun getInvoiceCodes(db: Database, user: AuthenticatedUser): Wrapper<InvoiceCodes> {
-        accessControl.requirePermissionFor(user, Action.Global.READ_INVOICE_CODES)
+    fun getInvoiceCodes(db: Database, user: AuthenticatedUser, clock: EvakaClock): Wrapper<InvoiceCodes> {
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_INVOICE_CODES)
         return Wrapper(db.connect { dbc -> dbc.read { service.getInvoiceCodes(it) } })
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
@@ -150,9 +150,9 @@ class InvoiceController(
     }
 
     @GetMapping("/{id}")
-    fun getInvoice(db: Database, user: AuthenticatedUser, @PathVariable id: InvoiceId): Wrapper<InvoiceDetailed> {
+    fun getInvoice(db: Database, user: AuthenticatedUser, clock: EvakaClock, @PathVariable id: InvoiceId): Wrapper<InvoiceDetailed> {
         Audit.InvoicesRead.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Invoice.READ, id)
+        accessControl.requirePermissionFor(user, clock, Action.Invoice.READ, id)
         val res = db.connect { dbc -> dbc.read { it.getDetailedInvoice(id) } }
             ?: throw NotFound("No invoice found with given ID ($id)")
         return Wrapper(res)
@@ -162,10 +162,11 @@ class InvoiceController(
     fun getHeadOfFamilyInvoices(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable uuid: PersonId
     ): Wrapper<List<Invoice>> {
         Audit.InvoicesRead.log(targetId = uuid)
-        accessControl.requirePermissionFor(user, Action.Person.READ_INVOICES, uuid)
+        accessControl.requirePermissionFor(user, clock, Action.Person.READ_INVOICES, uuid)
         return Wrapper(db.connect { dbc -> dbc.read { it.getHeadOfFamilyInvoices(uuid) } })
     }
 
@@ -173,11 +174,12 @@ class InvoiceController(
     fun putInvoice(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: InvoiceId,
         @RequestBody invoice: Invoice
     ) {
         Audit.InvoicesUpdate.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Invoice.UPDATE, id)
+        accessControl.requirePermissionFor(user, clock, Action.Invoice.UPDATE, id)
         db.connect { dbc -> dbc.transaction { service.updateInvoice(it, id, invoice) } }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
@@ -121,7 +121,7 @@ class InvoiceController(
         accessControl.requirePermissionFor(user, clock, Action.Invoice.SEND, invoiceIds)
         db.connect { dbc ->
             dbc.transaction {
-                service.sendInvoices(it, user, invoiceIds, invoiceDate, dueDate)
+                service.sendInvoices(it, user, clock, invoiceIds, invoiceDate, dueDate)
             }
         }
     }
@@ -138,7 +138,7 @@ class InvoiceController(
             dbc.transaction { tx ->
                 val invoiceIds = service.getInvoiceIds(tx, payload.from, payload.to, payload.areas)
                 accessControl.requirePermissionFor(user, clock, Action.Invoice.SEND, invoiceIds)
-                service.sendInvoices(tx, user, invoiceIds, payload.invoiceDate, payload.dueDate)
+                service.sendInvoices(tx, user, clock, invoiceIds, payload.invoiceDate, payload.dueDate)
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceCorrectionsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceCorrectionsController.kt
@@ -20,7 +20,6 @@ import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.jdbi.v3.core.JdbiException
-import org.jdbi.v3.core.kotlin.bindKotlin
 import org.postgresql.util.PSQLState
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/PaymentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/PaymentController.kt
@@ -57,7 +57,7 @@ class PaymentController(private val accessControl: AccessControl, private val pa
         @RequestBody body: SendPaymentsRequest,
     ) {
         Audit.PaymentsSend.log(targetId = body.paymentIds)
-        accessControl.requirePermissionFor(user, Action.Payment.SEND, body.paymentIds)
+        accessControl.requirePermissionFor(user, clock, Action.Payment.SEND, body.paymentIds)
         db.connect { dbc ->
             dbc.transaction { tx ->
                 paymentService.sendPayments(tx, clock.now(), user, body.paymentIds, body.paymentDate, body.dueDate)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/PaymentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/PaymentController.kt
@@ -39,7 +39,7 @@ class PaymentController(private val accessControl: AccessControl, private val pa
     @PostMapping("/create-drafts")
     fun createDrafts(db: Database, user: AuthenticatedUser, clock: EvakaClock) {
         Audit.PaymentsCreate.log()
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_DRAFT_PAYMENTS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_DRAFT_PAYMENTS)
         db.connect { dbc -> dbc.transaction { tx -> createPaymentDrafts(tx) } }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -108,10 +108,11 @@ class VoucherValueDecisionController(
     fun getDecision(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: VoucherValueDecisionId
     ): Wrapper<VoucherValueDecisionDetailed> {
         Audit.VoucherValueDecisionRead.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.VoucherValueDecision.READ, id)
+        accessControl.requirePermissionFor(user, clock, Action.VoucherValueDecision.READ, id)
         val res = db.connect { dbc -> dbc.read { it.getVoucherValueDecision(id) } }
             ?: throw NotFound("No voucher value decision found with given ID ($id)")
         return Wrapper(res)
@@ -121,10 +122,11 @@ class VoucherValueDecisionController(
     fun getHeadOfFamilyDecisions(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable headOfFamilyId: PersonId
     ): List<VoucherValueDecisionSummary> {
         Audit.VoucherValueDecisionHeadOfFamilyRead.log(targetId = headOfFamilyId)
-        accessControl.requirePermissionFor(user, Action.Person.READ_VOUCHER_VALUE_DECISIONS, headOfFamilyId)
+        accessControl.requirePermissionFor(user, clock, Action.Person.READ_VOUCHER_VALUE_DECISIONS, headOfFamilyId)
         return db.connect { dbc -> dbc.read { it.getHeadOfFamilyVoucherValueDecisions(headOfFamilyId) } }
     }
 
@@ -175,10 +177,11 @@ class VoucherValueDecisionController(
     fun getDecisionPdf(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable decisionId: VoucherValueDecisionId
     ): ResponseEntity<Any> {
         Audit.FeeDecisionPdfRead.log(targetId = decisionId)
-        accessControl.requirePermissionFor(user, Action.VoucherValueDecision.READ, decisionId)
+        accessControl.requirePermissionFor(user, clock, Action.VoucherValueDecision.READ, decisionId)
 
         return db.connect { dbc ->
             dbc.read { tx ->
@@ -205,11 +208,12 @@ class VoucherValueDecisionController(
     fun setType(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable uuid: VoucherValueDecisionId,
         @RequestBody request: VoucherValueDecisionTypeRequest
     ) {
         Audit.VoucherValueDecisionSetType.log(targetId = uuid)
-        accessControl.requirePermissionFor(user, Action.VoucherValueDecision.UPDATE, uuid)
+        accessControl.requirePermissionFor(user, clock, Action.VoucherValueDecision.UPDATE, uuid)
         db.connect { dbc -> dbc.transaction { valueDecisionService.setType(it, uuid, request.type) } }
     }
 
@@ -222,7 +226,7 @@ class VoucherValueDecisionController(
         @RequestBody body: CreateRetroactiveFeeDecisionsBody
     ) {
         Audit.VoucherValueDecisionHeadOfFamilyCreateRetroactive.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Person.GENERATE_RETROACTIVE_VOUCHER_VALUE_DECISIONS, id)
+        accessControl.requirePermissionFor(user, clock, Action.Person.GENERATE_RETROACTIVE_VOUCHER_VALUE_DECISIONS, id)
         db.connect { dbc -> dbc.transaction { generator.createRetroactiveValueDecisions(it, clock, id, body.from) } }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -74,18 +74,18 @@ class VoucherValueDecisionController(
     fun search(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: SearchVoucherValueDecisionRequest,
-        evakaClock: EvakaClock
     ): Paged<VoucherValueDecisionSummary> {
         Audit.VoucherValueDecisionSearch.log()
-        accessControl.requirePermissionFor(user, Action.Global.SEARCH_VOUCHER_VALUE_DECISIONS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.SEARCH_VOUCHER_VALUE_DECISIONS)
         val maxPageSize = 5000
         if (body.pageSize > maxPageSize) throw BadRequest("Maximum page size is $maxPageSize")
         return db.connect { dbc ->
             dbc
                 .read { tx ->
                     tx.searchValueDecisions(
-                        evakaClock,
+                        clock,
                         body.page,
                         body.pageSize,
                         body.sortBy ?: VoucherValueDecisionSortParam.STATUS,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -285,7 +285,7 @@ fun sendVoucherValueDecisions(
     tx.deleteValueDecisions(emptyDecisions.map { it.id })
     val validIds = validDecisions.map { it.id }
     tx.approveValueDecisionDraftsForSending(validIds, user.id, now, alwaysUseDaycareFinanceDecisionHandler)
-    asyncJobRunner.plan(tx, validIds.map { AsyncJob.NotifyVoucherValueDecisionApproved(it) })
+    asyncJobRunner.plan(tx, validIds.map { AsyncJob.NotifyVoucherValueDecisionApproved(it) }, runAt = now)
 }
 
 enum class VoucherValueDecisionSortParam {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeAlterationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeAlterationQueries.kt
@@ -9,9 +9,10 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.FeeAlterationId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import java.time.LocalDate
 
-fun Database.Transaction.upsertFeeAlteration(feeAlteration: FeeAlteration) {
+fun Database.Transaction.upsertFeeAlteration(clock: EvakaClock, feeAlteration: FeeAlteration) {
     val sql =
         """
             INSERT INTO fee_alteration (
@@ -35,7 +36,7 @@ fun Database.Transaction.upsertFeeAlteration(feeAlteration: FeeAlteration) {
                 :valid_to,
                 :notes,
                 :updated_by,
-                now()
+                :now
             ) ON CONFLICT (id) DO UPDATE SET
                 type = :type::fee_alteration_type,
                 amount = :amount,
@@ -44,10 +45,11 @@ fun Database.Transaction.upsertFeeAlteration(feeAlteration: FeeAlteration) {
                 valid_to = :valid_to,
                 notes = :notes,
                 updated_by = :updated_by,
-                updated_at = now()
+                updated_at = :now
         """
 
     val update = createUpdate(sql)
+        .bind("now", clock.now())
         .bind("id", feeAlteration.id)
         .bind("person_id", feeAlteration.personId)
         .bind("type", feeAlteration.type.toString())

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
@@ -26,9 +26,9 @@ import fi.espoo.evaka.shared.db.disjointNumberQuery
 import fi.espoo.evaka.shared.db.freeTextSearchQuery
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.mapToPaged
 import fi.espoo.evaka.shared.utils.splitSearchText
-import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
@@ -505,7 +505,7 @@ fun Database.Read.findFeeDecisionsForHeadOfFamily(
 fun Database.Transaction.approveFeeDecisionDraftsForSending(
     ids: List<FeeDecisionId>,
     approvedBy: EmployeeId,
-    approvedAt: Instant,
+    approvedAt: HelsinkiDateTime,
     isRetroactive: Boolean = false,
     alwaysUseDaycareFinanceDecisionHandler: Boolean
 ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
@@ -25,6 +25,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.disjointNumberQuery
 import fi.espoo.evaka.shared.db.freeTextSearchQuery
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.mapToPaged
 import fi.espoo.evaka.shared.utils.splitSearchText
 import java.time.Instant
@@ -261,6 +262,7 @@ fun Database.Transaction.deleteFeeDecisions(ids: List<FeeDecisionId>) {
 }
 
 fun Database.Read.searchFeeDecisions(
+    clock: EvakaClock,
     page: Int,
     pageSize: Int,
     sortBy: FeeDecisionSortParam,
@@ -295,7 +297,7 @@ fun Database.Read.searchFeeDecisions(
         Binding.of("start_date", startDate),
         Binding.of("end_date", endDate),
         Binding.of("finance_decision_handler", financeDecisionHandlerId),
-        Binding.of("firstPlacementStartDate", LocalDate.now().withDayOfMonth(1)),
+        Binding.of("firstPlacementStartDate", clock.today().withDayOfMonth(1)),
     )
 
     val numberParamsRaw = splitSearchText(searchTerms).filter(decisionNumberRegex::matches)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
@@ -19,7 +19,6 @@ import fi.espoo.evaka.shared.db.mapJsonColumn
 import fi.espoo.evaka.shared.domain.DateRange
 import org.jdbi.v3.core.result.RowView
 import org.postgresql.util.PGobject
-import java.time.Instant
 import java.time.LocalDate
 
 fun Database.Transaction.upsertIncome(mapper: JsonMapper, income: Income, updatedBy: EvakaUserId) {
@@ -203,8 +202,8 @@ fun toIncome(mapper: JsonMapper, incomeTypes: Map<String, IncomeType>) = { rv: R
         validFrom = rv.mapColumn("valid_from"),
         validTo = rv.mapColumn("valid_to"),
         notes = rv.mapColumn("notes"),
-        updatedAt = rv.mapColumn<Instant>("updated_at"),
-        updatedBy = rv.mapColumn<String>("updated_by_name"),
+        updatedAt = rv.mapColumn("updated_at"),
+        updatedBy = rv.mapColumn("updated_by_name"),
         applicationId = rv.mapColumn("application_id"),
         attachments = rv.mapJsonColumn("attachments")
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
@@ -17,11 +17,12 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.db.mapJsonColumn
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import org.jdbi.v3.core.result.RowView
 import org.postgresql.util.PGobject
 import java.time.LocalDate
 
-fun Database.Transaction.upsertIncome(mapper: JsonMapper, income: Income, updatedBy: EvakaUserId) {
+fun Database.Transaction.upsertIncome(clock: EvakaClock, mapper: JsonMapper, income: Income, updatedBy: EvakaUserId) {
     val sql =
         """
         INSERT INTO income (
@@ -47,7 +48,7 @@ fun Database.Transaction.upsertIncome(mapper: JsonMapper, income: Income, update
             :valid_from,
             :valid_to,
             :notes,
-            now(),
+            :now,
             :updated_by,
             :application_id
         ) ON CONFLICT (id) DO UPDATE SET
@@ -58,12 +59,13 @@ fun Database.Transaction.upsertIncome(mapper: JsonMapper, income: Income, update
             valid_from = :valid_from,
             valid_to = :valid_to,
             notes = :notes,
-            updated_at = now(),
+            updated_at = :now,
             updated_by = :updated_by,
             application_id = :application_id
     """
 
     val update = createUpdate(sql)
+        .bind("now", clock.now())
         .bind("id", income.id)
         .bind("person_id", income.personId)
         .bind("effect", income.effect.toString())

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
@@ -29,7 +29,6 @@ import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.mapToPaged
-import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.result.RowView
 import java.time.LocalDate
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
@@ -27,6 +27,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.freeTextSearchQuery
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.mapToPaged
 import org.jdbi.v3.core.result.RowView
@@ -370,7 +371,7 @@ fun Database.Transaction.deleteDraftInvoices(draftIds: List<InvoiceId>) {
         .execute()
 }
 
-fun Database.Transaction.setDraftsSent(invoices: List<InvoiceDetailed>, sentBy: EvakaUserId) {
+fun Database.Transaction.setDraftsSent(clock: EvakaClock, invoices: List<InvoiceDetailed>, sentBy: EvakaUserId) {
     if (invoices.isEmpty()) return
 
     val batch = prepareBatch(
@@ -380,7 +381,7 @@ SET
     number = :number,
     invoice_date = :invoiceDate,
     due_date = :dueDate,
-    sent_at = now(),
+    sent_at = :now,
     sent_by = :sentBy,
     status = :status::invoice_status
 WHERE id = :id
@@ -389,6 +390,7 @@ WHERE id = :id
     invoices.forEach {
         batch
             .bind("id", it.id)
+            .bind("now", clock.now())
             .bind("invoiceDate", it.invoiceDate)
             .bind("dueDate", it.dueDate)
             .bind("number", it.number)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
@@ -11,10 +11,10 @@ import fi.espoo.evaka.attachment.IncomeAttachment
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.jdbi.v3.json.Json
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.time.Instant
 import java.time.LocalDate
 
 @ExcludeCodeGen
@@ -29,7 +29,7 @@ data class Income(
     val validFrom: LocalDate,
     val validTo: LocalDate?,
     val notes: String,
-    val updatedAt: Instant? = null,
+    val updatedAt: HelsinkiDateTime? = null,
     val updatedBy: String? = null,
     val applicationId: ApplicationId? = null,
     @Json

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/FeeDecisionGenerationJobProcessor.kt
@@ -28,7 +28,7 @@ class FeeDecisionGenerationJobProcessor(
 
     fun runJob(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.NotifyFeeThresholdsUpdated) {
         logger.info { "Handling fee thresholds update event for date range (id: ${msg.dateRange})" }
-        db.transaction { planFinanceDecisionGeneration(it, asyncJobRunner, msg.dateRange, listOf()) }
+        db.transaction { planFinanceDecisionGeneration(it, clock, asyncJobRunner, msg.dateRange, listOf()) }
     }
 
     fun runJob(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.GenerateFinanceDecisions) {
@@ -46,6 +46,7 @@ class FeeDecisionGenerationJobProcessor(
 
 fun planFinanceDecisionGeneration(
     tx: Database.Transaction,
+    clock: EvakaClock,
     asyncJobRunner: AsyncJobRunner<AsyncJob>,
     dateRange: DateRange,
     targetHeadsOfFamily: List<PersonId>
@@ -59,5 +60,5 @@ fun planFinanceDecisionGeneration(
             .list()
     }
 
-    asyncJobRunner.plan(tx, heads.distinct().map { AsyncJob.GenerateFinanceDecisions.forAdult(it, dateRange) })
+    asyncJobRunner.plan(tx, heads.distinct().map { AsyncJob.GenerateFinanceDecisions.forAdult(it, dateRange) }, runAt = clock.now())
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/messaging/InvoicingAsyncJobs.kt
@@ -32,12 +32,12 @@ class InvoicingAsyncJobs(
         val decisionId = msg.decisionId
         feeService.createFeeDecisionPdf(tx, decisionId)
         logger.info { "Successfully created fee decision pdf (id: $decisionId)." }
-        asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyFeeDecisionPdfGenerated(decisionId)))
+        asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyFeeDecisionPdfGenerated(decisionId)), runAt = clock.now())
     }
 
     fun runSendFeeDecisionPdf(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.NotifyFeeDecisionPdfGenerated) = db.transaction { tx ->
         val decisionId = msg.decisionId
-        feeService.sendDecision(tx, decisionId).let { sent ->
+        feeService.sendDecision(tx, clock, decisionId).let { sent ->
             logger.info {
                 if (sent) "Successfully sent fee decision msg to suomi.fi (id: $decisionId)."
                 else "Marked fee decision as requiring manual sending (id: $decisionId)."
@@ -49,12 +49,12 @@ class InvoicingAsyncJobs(
         val decisionId = msg.decisionId
         valueDecisionService.createDecisionPdf(tx, decisionId)
         logger.info { "Successfully created voucher value decision pdf (id: $decisionId)." }
-        asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyVoucherValueDecisionPdfGenerated(decisionId)))
+        asyncJobRunner.plan(tx, listOf(AsyncJob.NotifyVoucherValueDecisionPdfGenerated(decisionId)), runAt = clock.now())
     }
 
     fun runSendVoucherValueDecisionPdf(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.NotifyVoucherValueDecisionPdfGenerated) = db.transaction { tx ->
         val decisionId = msg.decisionId
-        valueDecisionService.sendDecision(tx, decisionId).let { sent ->
+        valueDecisionService.sendDecision(tx, clock, decisionId).let { sent ->
             logger.info {
                 if (sent) "Successfully sent voucher value decision msg to suomi.fi (id: $decisionId)."
                 else "Marked voucher value decision as requiring manual sending (id: $decisionId)."

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
@@ -79,7 +79,7 @@ class FeeDecisionService(
             throw BadRequest("Some fee decisions were not drafts")
         }
         val today = confirmDateTime.toLocalDate()
-        val approvedAt = confirmDateTime.toInstant()
+        val approvedAt = confirmDateTime
         val lastPossibleDecisionValidFromDate = today.plusDays(env.nrOfDaysFeeDecisionCanBeSentInAdvance)
         val decisionsNotValidForConfirmation = decisions.filter {
             it.validFrom > lastPossibleDecisionValidFromDate

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiQueries.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.KoskiStudyRightId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.time.LocalDate
 
 data class KoskiStudyRightKey(val childId: ChildId, val unitId: DaycareId, val type: OpiskeluoikeudenTyyppiKoodi)

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
@@ -35,7 +35,7 @@ class KoskiUpdateService(
             db.transaction { tx ->
                 val requests = tx.getPendingStudyRights(clock.today(), params)
                 logger.info { "Scheduling ${requests.size} Koski upload requests" }
-                asyncJobRunner.plan(tx, requests.map { AsyncJob.UploadToKoski(it) }, retryCount = 1)
+                asyncJobRunner.plan(tx, requests.map { AsyncJob.UploadToKoski(it) }, retryCount = 1, runAt = clock.now())
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/ChildRecipientsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/ChildRecipientsController.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.GetMapping
@@ -24,10 +25,11 @@ class ChildRecipientsController(private val accessControl: AccessControl) {
     fun getRecipients(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<Recipient> {
         Audit.MessagingBlocklistRead.log(childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_CHILD_RECIPIENTS, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_CHILD_RECIPIENTS, childId)
 
         return db.connect { dbc -> dbc.read { it.fetchRecipients(childId) } }
     }
@@ -39,12 +41,13 @@ class ChildRecipientsController(private val accessControl: AccessControl) {
     fun editRecipient(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @PathVariable personId: PersonId,
         @RequestBody body: EditRecipientRequest
     ) {
         Audit.MessagingBlocklistEdit.log(childId)
-        accessControl.requirePermissionFor(user, Action.Child.UPDATE_CHILD_RECIPIENT, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.UPDATE_CHILD_RECIPIENT, childId)
 
         db.connect { dbc ->
             dbc.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -158,6 +158,7 @@ class MessageController(
             dbc.transaction { tx ->
                 messageService.createMessageThreadsForRecipientGroups(
                     tx,
+                    clock,
                     title = body.title,
                     content = body.content,
                     sender = accountId,
@@ -247,6 +248,7 @@ class MessageController(
 
             messageService.replyToThread(
                 db = dbc,
+                clock = clock,
                 replyToMessageId = messageId,
                 senderAccount = accountId,
                 recipientAccountIds = body.recipientAccountIds,
@@ -266,7 +268,7 @@ class MessageController(
         Audit.MessagingMarkMessagesReadWrite.log(accountId, threadId)
         return db.connect { dbc ->
             requireMessageAccountAccess(dbc, user, clock, accountId)
-            dbc.transaction { it.markThreadRead(accountId, threadId) }
+            dbc.transaction { it.markThreadRead(clock, accountId, threadId) }
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/note/NotesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/NotesController.kt
@@ -34,17 +34,17 @@ class NotesController(
     fun getNotesByGroup(
         user: AuthenticatedUser,
         db: Database,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable groupId: GroupId
     ): NotesByGroupResponse {
         Audit.NotesByGroupRead.log(groupId)
-        ac.requirePermissionFor(user, Action.Group.READ_NOTES, groupId)
+        ac.requirePermissionFor(user, clock, Action.Group.READ_NOTES, groupId)
 
         return db.connect { dbc ->
             dbc.read {
                 NotesByGroupResponse(
-                    childDailyNotes = it.getChildDailyNotesInGroup(groupId, evakaClock.today()),
-                    childStickyNotes = it.getChildStickyNotesForGroup(groupId, evakaClock.today()),
+                    childDailyNotes = it.getChildDailyNotesInGroup(groupId, clock.today()),
+                    childStickyNotes = it.getChildStickyNotesForGroup(groupId, clock.today()),
                     groupNotes = it.getGroupNotesForGroup(groupId)
                 )
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteController.kt
@@ -60,7 +60,7 @@ class ChildDailyNoteController(
         Audit.ChildDailyNoteUpdate.log(noteId, noteId)
         ac.requirePermissionFor(user, clock, Action.ChildDailyNote.UPDATE, noteId)
 
-        return db.connect { dbc -> dbc.transaction { it.updateChildDailyNote(noteId, body) } }
+        return db.connect { dbc -> dbc.transaction { it.updateChildDailyNote(clock, noteId, body) } }
     }
 
     @DeleteMapping("/child-daily-notes/{noteId}")

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteController.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
 import fi.espoo.evaka.shared.domain.Conflict
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import mu.KotlinLogging
@@ -31,11 +32,12 @@ class ChildDailyNoteController(
     fun createChildDailyNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @RequestBody body: ChildDailyNoteBody
     ): ChildDailyNoteId {
         Audit.ChildDailyNoteCreate.log(childId)
-        ac.requirePermissionFor(user, Action.Child.CREATE_DAILY_NOTE, childId)
+        ac.requirePermissionFor(user, clock, Action.Child.CREATE_DAILY_NOTE, childId)
 
         try {
             return db.connect { dbc -> dbc.transaction { it.createChildDailyNote(childId, body) } }
@@ -51,11 +53,12 @@ class ChildDailyNoteController(
     fun updateChildDailyNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable noteId: ChildDailyNoteId,
         @RequestBody body: ChildDailyNoteBody
     ): ChildDailyNote {
         Audit.ChildDailyNoteUpdate.log(noteId, noteId)
-        ac.requirePermissionFor(user, Action.ChildDailyNote.UPDATE, noteId)
+        ac.requirePermissionFor(user, clock, Action.ChildDailyNote.UPDATE, noteId)
 
         return db.connect { dbc -> dbc.transaction { it.updateChildDailyNote(noteId, body) } }
     }
@@ -64,10 +67,11 @@ class ChildDailyNoteController(
     fun deleteChildDailyNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable noteId: ChildDailyNoteId
     ) {
         Audit.ChildDailyNoteDelete.log(noteId)
-        ac.requirePermissionFor(user, Action.ChildDailyNote.DELETE, noteId)
+        ac.requirePermissionFor(user, clock, Action.ChildDailyNote.DELETE, noteId)
 
         return db.connect { dbc -> dbc.transaction { it.deleteChildDailyNote(noteId) } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteQueries.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.time.LocalDate
 
 fun Database.Read.getChildDailyNote(childId: ChildId): ChildDailyNote? {

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteQueries.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
 
@@ -74,7 +75,7 @@ RETURNING id
         .one()
 }
 
-fun Database.Transaction.updateChildDailyNote(id: ChildDailyNoteId, note: ChildDailyNoteBody): ChildDailyNote {
+fun Database.Transaction.updateChildDailyNote(clock: EvakaClock, id: ChildDailyNoteId, note: ChildDailyNoteBody): ChildDailyNote {
     return createUpdate(
         """
 UPDATE child_daily_note SET
@@ -84,12 +85,13 @@ UPDATE child_daily_note SET
     sleeping_minutes = :sleepingMinutes,
     reminders = :reminders::child_daily_note_reminder[],
     reminder_note = :reminderNote,
-    modified_at = now()
+    modified_at = :now
 WHERE id = :id
 RETURNING *
         """.trimIndent()
     )
         .bind("id", id)
+        .bind("now", clock.now())
         .bindKotlin(note)
         .executeAndReturnGeneratedKeys()
         .mapTo<ChildDailyNote>()

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/sticky/ChildStickyNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/sticky/ChildStickyNoteController.kt
@@ -55,7 +55,7 @@ class ChildStickyNoteController(
 
         validateExpiration(clock, body.expires)
 
-        return db.connect { dbc -> dbc.transaction { it.updateChildStickyNote(noteId, body) } }
+        return db.connect { dbc -> dbc.transaction { it.updateChildStickyNote(clock, noteId, body) } }
     }
 
     @DeleteMapping("/child-sticky-notes/{noteId}")

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/sticky/ChildStickyNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/sticky/ChildStickyNoteController.kt
@@ -30,14 +30,14 @@ class ChildStickyNoteController(
     fun createChildStickyNote(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @RequestBody body: ChildStickyNoteBody
     ): ChildStickyNoteId {
         Audit.ChildStickyNoteCreate.log(childId)
-        ac.requirePermissionFor(user, Action.Child.CREATE_STICKY_NOTE, childId)
+        ac.requirePermissionFor(user, clock, Action.Child.CREATE_STICKY_NOTE, childId)
 
-        validateExpiration(evakaClock, body.expires)
+        validateExpiration(clock, body.expires)
 
         return db.connect { dbc -> dbc.transaction { it.createChildStickyNote(childId, body) } }
     }
@@ -46,14 +46,14 @@ class ChildStickyNoteController(
     fun updateChildStickyNote(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable noteId: ChildStickyNoteId,
         @RequestBody body: ChildStickyNoteBody
     ): ChildStickyNote {
         Audit.ChildStickyNoteUpdate.log(noteId, noteId)
-        ac.requirePermissionFor(user, Action.ChildStickyNote.UPDATE, noteId)
+        ac.requirePermissionFor(user, clock, Action.ChildStickyNote.UPDATE, noteId)
 
-        validateExpiration(evakaClock, body.expires)
+        validateExpiration(clock, body.expires)
 
         return db.connect { dbc -> dbc.transaction { it.updateChildStickyNote(noteId, body) } }
     }
@@ -62,10 +62,11 @@ class ChildStickyNoteController(
     fun deleteChildStickyNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable noteId: ChildStickyNoteId
     ) {
         Audit.ChildStickyNoteDelete.log(noteId)
-        ac.requirePermissionFor(user, Action.ChildStickyNote.DELETE, noteId)
+        ac.requirePermissionFor(user, clock, Action.ChildStickyNote.DELETE, noteId)
 
         return db.connect { dbc -> dbc.transaction { it.deleteChildStickyNote(noteId) } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/sticky/ChildStickyNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/sticky/ChildStickyNoteQueries.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.ChildStickyNoteId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import java.time.LocalDate
 
 fun Database.Read.getChildStickyNotesForChild(childId: ChildId): List<ChildStickyNote> = createQuery(
@@ -73,18 +74,19 @@ RETURNING id
         .one()
 }
 
-fun Database.Transaction.updateChildStickyNote(id: ChildStickyNoteId, note: ChildStickyNoteBody): ChildStickyNote {
+fun Database.Transaction.updateChildStickyNote(clock: EvakaClock, id: ChildStickyNoteId, note: ChildStickyNoteBody): ChildStickyNote {
     return createUpdate(
         """
 UPDATE child_sticky_note SET
     note = :note,
     expires = :expires,
-    modified_at = now()
+    modified_at = :now
 WHERE id = :id
 RETURNING *
         """.trimIndent()
     )
         .bind("id", id)
+        .bind("now", clock.now())
         .bindKotlin(note)
         .executeAndReturnGeneratedKeys()
         .mapTo<ChildStickyNote>()

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/sticky/ChildStickyNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/sticky/ChildStickyNoteQueries.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.shared.ChildStickyNoteId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.time.LocalDate
 
 fun Database.Read.getChildStickyNotesForChild(childId: ChildId): List<ChildStickyNote> = createQuery(

--- a/service/src/main/kotlin/fi/espoo/evaka/note/group/GroupNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/group/GroupNoteController.kt
@@ -48,7 +48,7 @@ class GroupNoteController(
         Audit.GroupNoteUpdate.log(noteId, noteId)
         ac.requirePermissionFor(user, clock, Action.GroupNote.UPDATE, noteId)
 
-        return db.connect { dbc -> dbc.transaction { it.updateGroupNote(noteId, body) } }
+        return db.connect { dbc -> dbc.transaction { it.updateGroupNote(clock, noteId, body) } }
     }
 
     @DeleteMapping("/group-notes/{noteId}")

--- a/service/src/main/kotlin/fi/espoo/evaka/note/group/GroupNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/group/GroupNoteController.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupNoteId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -26,11 +27,12 @@ class GroupNoteController(
     fun createGroupNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable groupId: GroupId,
         @RequestBody body: GroupNoteBody
     ): GroupNoteId {
         Audit.GroupNoteCreate.log(groupId)
-        ac.requirePermissionFor(user, Action.Group.CREATE_NOTE, groupId)
+        ac.requirePermissionFor(user, clock, Action.Group.CREATE_NOTE, groupId)
 
         return db.connect { dbc -> dbc.transaction { it.createGroupNote(groupId, body) } }
     }
@@ -39,11 +41,12 @@ class GroupNoteController(
     fun updateGroupNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable noteId: GroupNoteId,
         @RequestBody body: GroupNoteBody
     ): GroupNote {
         Audit.GroupNoteUpdate.log(noteId, noteId)
-        ac.requirePermissionFor(user, Action.GroupNote.UPDATE, noteId)
+        ac.requirePermissionFor(user, clock, Action.GroupNote.UPDATE, noteId)
 
         return db.connect { dbc -> dbc.transaction { it.updateGroupNote(noteId, body) } }
     }
@@ -52,10 +55,11 @@ class GroupNoteController(
     fun deleteGroupNote(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable noteId: GroupNoteId
     ) {
         Audit.GroupNoteDelete.log(noteId)
-        ac.requirePermissionFor(user, Action.GroupNote.DELETE, noteId)
+        ac.requirePermissionFor(user, clock, Action.GroupNote.DELETE, noteId)
 
         return db.connect { dbc -> dbc.transaction { it.deleteGroupNote(noteId) } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/note/group/GroupNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/group/GroupNoteQueries.kt
@@ -8,7 +8,6 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupNoteId
 import fi.espoo.evaka.shared.db.Database
-import org.jdbi.v3.core.kotlin.bindKotlin
 
 fun Database.Read.getGroupNotesForGroup(groupId: GroupId): List<GroupNote> {
     return getGroupNotesForGroups(listOf(groupId))

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
@@ -41,18 +41,18 @@ class OccupancyController(
     fun getOccupancyPeriods(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable unitId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
         @RequestParam type: OccupancyType
     ): OccupancyResponse {
         Audit.OccupancyRead.log(targetId = unitId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_OCCUPANCIES, unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_OCCUPANCIES, unitId)
 
         val occupancies = db.connect { dbc ->
             dbc.read {
-                it.calculateOccupancyPeriods(evakaClock.today(), unitId, FiniteDateRange(from, to), type, acl.getAuthorizedUnits(user))
+                it.calculateOccupancyPeriods(clock.today(), unitId, FiniteDateRange(from, to), type, acl.getAuthorizedUnits(user))
             }
         }
 
@@ -67,7 +67,7 @@ class OccupancyController(
     fun getOccupancyPeriodsSpeculated(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable unitId: DaycareId,
         @PathVariable applicationId: ApplicationId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
@@ -76,8 +76,8 @@ class OccupancyController(
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) preschoolDaycareTo: LocalDate?,
     ): OccupancyResponseSpeculated {
         Audit.OccupancySpeculatedRead.log(targetId = Pair(unitId, applicationId))
-        accessControl.requirePermissionFor(user, Action.Unit.READ_OCCUPANCIES, unitId)
-        accessControl.requirePermissionFor(user, Action.Application.READ, applicationId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_OCCUPANCIES, unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Application.READ, applicationId)
 
         val period = FiniteDateRange(from, to)
         val preschoolDaycarePeriod = if (preschoolDaycareFrom != null && preschoolDaycareTo != null) {
@@ -112,7 +112,7 @@ class OccupancyController(
 
                 val (threeMonths, sixMonths) = calculateSpeculatedMaxOccupancies(
                     tx,
-                    evakaClock.today(),
+                    clock.today(),
                     acl.getAuthorizedUnits(user),
                     unitId,
                     speculatedPlacements,
@@ -133,19 +133,19 @@ class OccupancyController(
     fun getOccupancyPeriodsOnGroups(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable unitId: DaycareId,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
         @RequestParam type: OccupancyType
     ): List<OccupancyResponseGroupLevel> {
         Audit.OccupancyRead.log(targetId = unitId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_OCCUPANCIES, unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_OCCUPANCIES, unitId)
 
         val occupancies = db.connect { dbc ->
             dbc.read {
                 it.calculateOccupancyPeriodsGroupLevel(
-                    evakaClock.today(),
+                    clock.today(),
                     unitId,
                     FiniteDateRange(from, to),
                     type,

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
@@ -95,13 +95,14 @@ class MobileDevicesController(private val accessControl: AccessControl) {
     fun pinLogin(
         db: Database,
         user: AuthenticatedUser.MobileDevice,
+        clock: EvakaClock,
         @RequestBody params: PinLoginRequest
     ): PinLoginResponse {
         Audit.PinLogin.log(targetId = params.employeeId)
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 if (tx.employeePinIsCorrect(params.employeeId, params.pin)) {
-                    tx.markEmployeeLastLogin(params.employeeId)
+                    tx.markEmployeeLastLogin(clock, params.employeeId)
                     tx.resetEmployeePinFailureCount(params.employeeId)
                     tx.getEmployeeUser(params.employeeId)
                         ?.let { PinLoginResponse(PinLoginStatus.SUCCESS, Employee(it.firstName, it.lastName)) }

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -32,10 +33,11 @@ class MobileDevicesController(private val accessControl: AccessControl) {
     fun getMobileDevices(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam unitId: DaycareId
     ): List<MobileDevice> {
         Audit.MobileDevicesList.log(targetId = unitId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_MOBILE_DEVICES, unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_MOBILE_DEVICES, unitId)
         return db.connect { dbc -> dbc.read { it.listSharedDevices(unitId) } }
     }
 
@@ -67,11 +69,12 @@ class MobileDevicesController(private val accessControl: AccessControl) {
     fun putMobileDeviceName(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: MobileDeviceId,
         @RequestBody body: RenameRequest
     ) {
         Audit.MobileDevicesRename.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.MobileDevice.UPDATE_NAME, id)
+        accessControl.requirePermissionFor(user, clock, Action.MobileDevice.UPDATE_NAME, id)
         db.connect { dbc -> dbc.transaction { it.renameDevice(id, body.name) } }
     }
 
@@ -79,10 +82,11 @@ class MobileDevicesController(private val accessControl: AccessControl) {
     fun deleteMobileDevice(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: MobileDeviceId
     ) {
         Audit.MobileDevicesDelete.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.MobileDevice.DELETE, id)
+        accessControl.requirePermissionFor(user, clock, Action.MobileDevice.DELETE, id)
         db.connect { dbc -> dbc.transaction { it.deleteDevice(id) } }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
@@ -45,9 +45,10 @@ class MobileDevicesController(private val accessControl: AccessControl) {
     fun getMobileDevices(
         db: Database,
         user: AuthenticatedUser.Employee,
+        clock: EvakaClock
     ): List<MobileDevice> {
         Audit.MobileDevicesList.log(targetId = user.id)
-        accessControl.requirePermissionFor(user, Action.Global.READ_PERSONAL_MOBILE_DEVICES)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_PERSONAL_MOBILE_DEVICES)
         return db.connect { dbc -> dbc.read { it.listPersonalDevices(user.id) } }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -55,7 +55,7 @@ class PairingsController(
             is PostPairingReq.Unit ->
                 accessControl.requirePermissionFor(user, clock, Action.Unit.CREATE_MOBILE_DEVICE_PAIRING, body.unitId)
             is PostPairingReq.Employee -> {
-                accessControl.requirePermissionFor(user, Action.Global.CREATE_PERSONAL_MOBILE_DEVICE_PAIRING)
+                accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_PERSONAL_MOBILE_DEVICE_PAIRING)
                 if (user.id != body.employeeId) throw Forbidden()
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -53,7 +53,7 @@ class PairingsController(
         Audit.PairingInit.log(targetId = body.id)
         when (body) {
             is PostPairingReq.Unit ->
-                accessControl.requirePermissionFor(user, Action.Unit.CREATE_MOBILE_DEVICE_PAIRING, body.unitId)
+                accessControl.requirePermissionFor(user, clock, Action.Unit.CREATE_MOBILE_DEVICE_PAIRING, body.unitId)
             is PostPairingReq.Employee -> {
                 accessControl.requirePermissionFor(user, Action.Global.CREATE_PERSONAL_MOBILE_DEVICE_PAIRING)
                 if (user.id != body.employeeId) throw Forbidden()
@@ -112,6 +112,7 @@ class PairingsController(
     fun postPairingResponse(
         db: Database,
         user: AuthenticatedUser.Employee,
+        clock: EvakaClock,
         @PathVariable id: PairingId,
         @RequestBody body: PostPairingResponseReq
     ): Pairing {
@@ -120,7 +121,7 @@ class PairingsController(
             val (unitId, employeeId) = dbc.read { it.fetchPairingReferenceIds(id) }
             try {
                 when {
-                    unitId != null -> accessControl.requirePermissionFor(user, Action.Pairing.POST_RESPONSE, id)
+                    unitId != null -> accessControl.requirePermissionFor(user, clock, Action.Pairing.POST_RESPONSE, id)
                     employeeId != null ->
                         if (user.id != employeeId) throw Forbidden()
                     else -> error("Pairing unitId and employeeId were null")

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
@@ -46,10 +47,10 @@ class PairingsController(
     fun postPairing(
         db: Database,
         user: AuthenticatedUser.Employee,
+        clock: EvakaClock,
         @RequestBody body: PostPairingReq
     ): Pairing {
         Audit.PairingInit.log(targetId = body.id)
-        @Suppress("DEPRECATION")
         when (body) {
             is PostPairingReq.Unit ->
                 accessControl.requirePermissionFor(user, Action.Unit.CREATE_MOBILE_DEVICE_PAIRING, body.unitId)
@@ -62,8 +63,8 @@ class PairingsController(
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 when (body) {
-                    is PostPairingReq.Unit -> tx.initPairing(unitId = body.unitId)
-                    is PostPairingReq.Employee -> tx.initPairing(employeeId = body.employeeId)
+                    is PostPairingReq.Unit -> tx.initPairing(clock, unitId = body.unitId)
+                    is PostPairingReq.Employee -> tx.initPairing(clock, employeeId = body.employeeId)
                 }.also {
                     asyncJobRunner.plan(
                         tx = tx,
@@ -89,10 +90,11 @@ class PairingsController(
     @PostMapping("/public/pairings/challenge")
     fun postPairingChallenge(
         db: Database,
+        clock: EvakaClock,
         @RequestBody body: PostPairingChallengeReq
     ): Pairing {
         Audit.PairingChallenge.log(targetId = body.challengeKey)
-        return db.connect { dbc -> dbc.transaction { it.challengePairing(body.challengeKey) } }
+        return db.connect { dbc -> dbc.transaction { it.challengePairing(clock, body.challengeKey) } }
     }
 
     /**

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.PedagogicalDocumentId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -33,10 +34,11 @@ class PedagogicalDocumentController(
     fun createPedagogicalDocument(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: PedagogicalDocumentPostBody
     ): PedagogicalDocument {
         Audit.PedagogicalDocumentUpdate.log(body.childId)
-        accessControl.requirePermissionFor(user, Action.Child.CREATE_PEDAGOGICAL_DOCUMENT, body.childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_PEDAGOGICAL_DOCUMENT, body.childId)
         return db.connect {
             it.transaction { tx ->
                 tx.createDocument(user, body).also {
@@ -50,11 +52,12 @@ class PedagogicalDocumentController(
     fun updatePedagogicalDocument(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable documentId: PedagogicalDocumentId,
         @RequestBody body: PedagogicalDocumentPostBody
     ): PedagogicalDocument {
         Audit.PedagogicalDocumentUpdate.log(documentId)
-        accessControl.requirePermissionFor(user, Action.PedagogicalDocument.UPDATE, documentId)
+        accessControl.requirePermissionFor(user, clock, Action.PedagogicalDocument.UPDATE, documentId)
         return db.connect {
             it.transaction { tx ->
                 tx.updateDocument(user, body, documentId).also {
@@ -68,10 +71,11 @@ class PedagogicalDocumentController(
     fun getChildPedagogicalDocuments(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<PedagogicalDocument> {
         Audit.PedagogicalDocumentRead.log(childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_PEDAGOGICAL_DOCUMENTS, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_PEDAGOGICAL_DOCUMENTS, childId)
         return db.connect { dbc ->
             dbc.read {
                 it.findPedagogicalDocumentsByChild(childId)
@@ -83,10 +87,11 @@ class PedagogicalDocumentController(
     fun deletePedagogicalDocument(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable documentId: PedagogicalDocumentId
     ) {
         Audit.PedagogicalDocumentUpdate.log(documentId)
-        accessControl.requirePermissionFor(user, Action.PedagogicalDocument.DELETE, documentId)
+        accessControl.requirePermissionFor(user, clock, Action.PedagogicalDocument.DELETE, documentId)
         return db.connect { dbc ->
             dbc.transaction {
                 it.deleteDocument(documentId)

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentControllerCitizen.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.GetMapping
@@ -51,10 +52,11 @@ class PedagogicalDocumentControllerCitizen(
     fun markPedagogicalDocumentRead(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable documentId: PedagogicalDocumentId
     ) {
         Audit.PedagogicalDocumentUpdate.log(documentId, user.id)
-        accessControl.requirePermissionFor(user, Action.Citizen.PedagogicalDocument.READ, documentId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.PedagogicalDocument.READ, documentId)
         return db.connect { dbc ->
             dbc.transaction { it.markDocumentReadByGuardian(documentId, user.id) }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
@@ -16,7 +16,6 @@ import fi.espoo.evaka.shared.db.freeTextSearchQueryForColumns
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.mapToPaged
-import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.json.Json
 
 data class NewEmployee(

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Binding
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.freeTextSearchQueryForColumns
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.mapToPaged
@@ -81,16 +82,17 @@ fun Database.Transaction.updateExternalIdByEmployeeNumber(employeeNumber: String
         .bind("externalId", externalId)
         .updateNoneOrOne()
 
-fun Database.Transaction.loginEmployee(employee: NewEmployee): Employee = createUpdate(
+fun Database.Transaction.loginEmployee(clock: EvakaClock, employee: NewEmployee): Employee = createUpdate(
     // language=SQL
     """
 INSERT INTO employee (first_name, last_name, email, external_id, employee_number, roles, last_login)
-VALUES (:employee.firstName, :employee.lastName, :employee.email, :employee.externalId, :employee.employeeNumber, :employee.roles::user_role[], now())
+VALUES (:employee.firstName, :employee.lastName, :employee.email, :employee.externalId, :employee.employeeNumber, :employee.roles::user_role[], :now)
 ON CONFLICT (external_id) DO UPDATE
-SET last_login = now(), first_name = EXCLUDED.first_name, last_name = EXCLUDED.last_name, email = EXCLUDED.email, employee_number = EXCLUDED.employee_number
+SET last_login = :now, first_name = EXCLUDED.first_name, last_name = EXCLUDED.last_name, email = EXCLUDED.email, employee_number = EXCLUDED.employee_number
 RETURNING id, first_name, last_name, email, external_id, created, updated, roles
     """.trimIndent()
 ).bindKotlin("employee", employee)
+    .bind("now", clock.now())
     .executeAndReturnGeneratedKeys()
     .mapTo<Employee>()
     .first()
@@ -155,13 +157,14 @@ $where
 """
 )
 
-fun Database.Transaction.markEmployeeLastLogin(id: EmployeeId) = createUpdate(
+fun Database.Transaction.markEmployeeLastLogin(clock: EvakaClock, id: EmployeeId) = createUpdate(
     """
 UPDATE employee 
-SET last_login = now()
+SET last_login = :now
 WHERE id = :id
     """.trimIndent()
 ).bind("id", id)
+    .bind("now", clock.now())
     .execute()
 
 fun Database.Read.getEmployeeUser(id: EmployeeId): EmployeeUser? = createEmployeeUserQuery("WHERE id = :id")

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonQueries.kt
@@ -383,13 +383,14 @@ private val toPersonDTO: (RowView) -> PersonDTO = { row ->
     )
 }
 
-fun Database.Transaction.markPersonLastLogin(id: PersonId) = createUpdate(
+fun Database.Transaction.markPersonLastLogin(clock: EvakaClock, id: PersonId) = createUpdate(
     """
 UPDATE person 
-SET last_login = now()
+SET last_login = :now
 WHERE id = :id
     """.trimIndent()
 ).bind("id", id)
+    .bind("now", clock.now())
     .execute()
 
 data class PersonReference(

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
@@ -38,6 +38,7 @@ class SystemController(private val personService: PersonService, private val acc
     fun citizenLogin(
         db: Database,
         user: AuthenticatedUser.SystemInternalUser,
+        clock: EvakaClock,
         @RequestBody request: CitizenLoginRequest
     ): CitizenUser {
         return db.connect { dbc ->
@@ -49,7 +50,7 @@ class SystemController(private val personService: PersonService, private val acc
                         ExternalIdentifier.SSN.getInstance(request.socialSecurityNumber)
                     )?.let { CitizenUser(it.id) }
                     ?: error("No person found with ssn")
-                tx.markPersonLastLogin(citizen.id)
+                tx.markPersonLastLogin(clock, citizen.id)
                 tx.upsertCitizenUser(citizen.id)
                 citizen
             }
@@ -62,6 +63,7 @@ class SystemController(private val personService: PersonService, private val acc
     fun employeeLogin(
         db: Database,
         user: AuthenticatedUser.SystemInternalUser,
+        clock: EvakaClock,
         @RequestBody request: EmployeeLoginRequest
     ): EmployeeUser {
         return db.connect { dbc ->
@@ -69,7 +71,7 @@ class SystemController(private val personService: PersonService, private val acc
                 if (request.employeeNumber != null) {
                     it.updateExternalIdByEmployeeNumber(request.employeeNumber, request.externalId)
                 }
-                val inserted = it.loginEmployee(request.toNewEmployee())
+                val inserted = it.loginEmployee(clock, request.toNewEmployee())
                 val roles = it.getEmployeeRoles(inserted.id)
                 val employee = EmployeeUser(
                     id = inserted.id,

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
@@ -104,7 +104,7 @@ class SystemController(private val personService: PersonService, private val acc
                         lastName = employeeUser.lastName,
                         globalRoles = employeeUser.globalRoles,
                         allScopedRoles = employeeUser.allScopedRoles,
-                        accessibleFeatures = accessControl.getPermittedFeatures(tx, AuthenticatedUser.Employee(employeeUser)),
+                        accessibleFeatures = accessControl.getPermittedFeatures(tx, AuthenticatedUser.Employee(employeeUser), clock),
                         permittedGlobalActions = accessControl.getPermittedGlobalActions(tx, AuthenticatedUser.Employee(employeeUser), clock)
                     )
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -54,9 +55,9 @@ class EmployeeController(private val accessControl: AccessControl) {
     }
 
     @GetMapping("/{id}")
-    fun getEmployee(db: Database, user: AuthenticatedUser.Employee, @PathVariable(value = "id") id: EmployeeId): Employee {
+    fun getEmployee(db: Database, user: AuthenticatedUser.Employee, clock: EvakaClock, @PathVariable(value = "id") id: EmployeeId): Employee {
         Audit.EmployeeRead.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Employee.READ, id)
+        accessControl.requirePermissionFor(user, clock, Action.Employee.READ, id)
         return db.connect { dbc -> dbc.read { it.getEmployee(id) } } ?: throw NotFound()
     }
 
@@ -67,11 +68,12 @@ class EmployeeController(private val accessControl: AccessControl) {
     fun updateEmployee(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable(value = "id") id: EmployeeId,
         @RequestBody body: EmployeeUpdate
     ) {
         Audit.EmployeeUpdate.log(targetId = id, objectId = body.globalRoles)
-        accessControl.requirePermissionFor(user, Action.Employee.UPDATE, id)
+        accessControl.requirePermissionFor(user, clock, Action.Employee.UPDATE, id)
 
         db.connect { dbc ->
             dbc.transaction {
@@ -87,10 +89,11 @@ class EmployeeController(private val accessControl: AccessControl) {
     fun getEmployeeDetails(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable(value = "id") id: EmployeeId
     ): EmployeeWithDaycareRoles {
         Audit.EmployeeRead.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Employee.READ_DETAILS, id)
+        accessControl.requirePermissionFor(user, clock, Action.Employee.READ_DETAILS, id)
 
         return db.connect { dbc -> dbc.read { it.getEmployeeWithRoles(id) } }
             ?: throw NotFound("employee $id not found")
@@ -104,9 +107,9 @@ class EmployeeController(private val accessControl: AccessControl) {
     }
 
     @DeleteMapping("/{id}")
-    fun deleteEmployee(db: Database, user: AuthenticatedUser, @PathVariable(value = "id") id: EmployeeId) {
+    fun deleteEmployee(db: Database, user: AuthenticatedUser, clock: EvakaClock, @PathVariable(value = "id") id: EmployeeId) {
         Audit.EmployeeDelete.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.Employee.DELETE, id)
+        accessControl.requirePermissionFor(user, clock, Action.Employee.DELETE, id)
         db.connect { dbc -> dbc.transaction { it.deleteEmployee(id) } }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
@@ -41,11 +41,12 @@ class FamilyController(
     fun getFamilyByPerson(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable(value = "id") id: PersonId
     ): FamilyOverview {
         Audit.PisFamilyRead.log(targetId = id)
         accessControl.requirePermissionFor(user, Action.Person.READ_FAMILY_OVERVIEW, id)
-        val includeIncome = accessControl.hasPermissionFor(user, Action.Person.READ_INCOME, id)
+        val includeIncome = accessControl.hasPermissionFor(user, clock, Action.Person.READ_INCOME, id)
 
         return db.connect { dbc ->
             dbc.read {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
@@ -50,7 +50,7 @@ class FamilyController(
 
         return db.connect { dbc ->
             dbc.read {
-                val overview = familyOverviewService.getFamilyByAdult(it, id)
+                val overview = familyOverviewService.getFamilyByAdult(it, clock, id)
                 if (includeIncome) overview
                 else overview?.copy(
                     headOfFamily = overview.headOfFamily.copy(income = null),

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -57,6 +58,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
     fun getParentships(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam(value = "headOfChildId", required = false) headOfChildId: PersonId? = null,
         @RequestParam(value = "childId", required = false) childId: PersonId? = null
     ): List<ParentshipWithPermittedActions> {
@@ -78,7 +80,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
                     childId = childId,
                     includeConflicts = true
                 )
-                val permittedActions = accessControl.getPermittedActions<ParentshipId, Action.Parentship>(tx, user, parentships.map { it.id })
+                val permittedActions = accessControl.getPermittedActions<ParentshipId, Action.Parentship>(tx, user, clock, parentships.map { it.id })
                 parentships.map { ParentshipWithPermittedActions(it, permittedActions[it.id] ?: emptySet()) }
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/ParentshipController.kt
@@ -46,6 +46,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
             dbc.transaction {
                 parentshipService.createParentship(
                     it,
+                    clock,
                     body.childId,
                     body.headOfChildId,
                     body.startDate,
@@ -114,7 +115,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
 
         return db.connect { dbc ->
             dbc.transaction {
-                parentshipService.updateParentshipDuration(it, id, body.startDate, body.endDate)
+                parentshipService.updateParentshipDuration(it, clock, id, body.startDate, body.endDate)
             }
         }
     }
@@ -129,7 +130,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
         Audit.ParentShipsRetry.log(targetId = parentshipId)
         accessControl.requirePermissionFor(user, clock, Action.Parentship.RETRY, parentshipId)
 
-        db.connect { dbc -> dbc.transaction { parentshipService.retryParentship(it, parentshipId) } }
+        db.connect { dbc -> dbc.transaction { parentshipService.retryParentship(it, clock, parentshipId) } }
     }
 
     @DeleteMapping("/{id}")
@@ -150,7 +151,7 @@ class ParentshipController(private val parentshipService: ParentshipService, pri
                 accessControl.requirePermissionFor(user, clock, Action.Parentship.DELETE_CONFLICTED_PARENTSHIP, id)
             }
 
-            dbc.transaction { parentshipService.deleteParentship(it, id) }
+            dbc.transaction { parentshipService.deleteParentship(it, clock, id) }
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
@@ -65,7 +65,8 @@ class PartnershipsController(
                                 body.person1Id,
                                 DateRange(body.startDate, body.endDate)
                             )
-                        )
+                        ),
+                        runAt = clock.now()
                     )
                 }
         }
@@ -121,7 +122,8 @@ class PartnershipsController(
                                 partnership.partners.first().id,
                                 DateRange(partnership.startDate, partnership.endDate)
                             )
-                        )
+                        ),
+                        runAt = clock.now()
                     )
                 }
         }
@@ -147,7 +149,8 @@ class PartnershipsController(
                                 it.partners.first().id,
                                 DateRange(it.startDate, it.endDate)
                             )
-                        )
+                        ),
+                        runAt = clock.now()
                     )
                 }
             }
@@ -174,7 +177,8 @@ class PartnershipsController(
                                 it.id,
                                 DateRange(partnership.startDate, partnership.endDate)
                             )
-                        }
+                        },
+                        runAt = clock.now()
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PartnershipsController.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -41,10 +42,11 @@ class PartnershipsController(
     fun createPartnership(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: PartnershipRequest
     ) {
         Audit.PartnerShipsCreate.log(targetId = body.person1Id)
-        accessControl.requirePermissionFor(user, Action.Person.CREATE_PARTNERSHIP, body.person1Id)
+        accessControl.requirePermissionFor(user, clock, Action.Person.CREATE_PARTNERSHIP, body.person1Id)
 
         db.connect { dbc ->
             dbc
@@ -73,10 +75,11 @@ class PartnershipsController(
     fun getPartnerships(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam personId: PersonId
     ): List<Partnership> {
         Audit.PartnerShipsRead.log(targetId = personId)
-        accessControl.requirePermissionFor(user, Action.Person.READ_PARTNERSHIPS, personId)
+        accessControl.requirePermissionFor(user, clock, Action.Person.READ_PARTNERSHIPS, personId)
 
         return db.connect { dbc -> dbc.read { it.getPartnershipsForPerson(personId, includeConflicts = true) } }
     }
@@ -85,10 +88,11 @@ class PartnershipsController(
     fun getPartnership(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable partnershipId: PartnershipId
     ): Partnership {
         Audit.PartnerShipsRead.log(targetId = partnershipId)
-        accessControl.requirePermissionFor(user, Action.Partnership.READ, partnershipId)
+        accessControl.requirePermissionFor(user, clock, Action.Partnership.READ, partnershipId)
 
         return db.connect { dbc -> dbc.read { it.getPartnership(partnershipId) } }
             ?: throw NotFound()
@@ -98,11 +102,12 @@ class PartnershipsController(
     fun updatePartnership(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable partnershipId: PartnershipId,
         @RequestBody body: PartnershipUpdateRequest
     ) {
         Audit.PartnerShipsUpdate.log(targetId = partnershipId)
-        accessControl.requirePermissionFor(user, Action.Partnership.UPDATE, partnershipId)
+        accessControl.requirePermissionFor(user, clock, Action.Partnership.UPDATE, partnershipId)
 
         return db.connect { dbc ->
             dbc
@@ -126,10 +131,11 @@ class PartnershipsController(
     fun retryPartnership(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable partnershipId: PartnershipId
     ) {
         Audit.PartnerShipsRetry.log(targetId = partnershipId)
-        accessControl.requirePermissionFor(user, Action.Partnership.RETRY, partnershipId)
+        accessControl.requirePermissionFor(user, clock, Action.Partnership.RETRY, partnershipId)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -152,10 +158,11 @@ class PartnershipsController(
     fun deletePartnership(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable partnershipId: PartnershipId
     ) {
         Audit.PartnerShipsDelete.log(targetId = partnershipId)
-        accessControl.requirePermissionFor(user, Action.Partnership.DELETE, partnershipId)
+        accessControl.requirePermissionFor(user, clock, Action.Partnership.DELETE, partnershipId)
 
         db.connect { dbc ->
             dbc.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -49,10 +49,10 @@ class PersonController(
     private val fridgeFamilyService: FridgeFamilyService
 ) {
     @PostMapping
-    fun createEmpty(db: Database, user: AuthenticatedUser, evakaClock: EvakaClock): PersonIdentityResponseJSON {
+    fun createEmpty(db: Database, user: AuthenticatedUser, clock: EvakaClock): PersonIdentityResponseJSON {
         Audit.PersonCreate.log()
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_PERSON)
-        return db.connect { dbc -> dbc.transaction { createEmptyPerson(it, evakaClock) } }
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_PERSON)
+        return db.connect { dbc -> dbc.transaction { createEmptyPerson(it, clock) } }
             .let { PersonIdentityResponseJSON.from(it) }
     }
 
@@ -134,7 +134,7 @@ class PersonController(
         @RequestBody body: SearchPersonBody
     ): List<PersonSummary> {
         Audit.PersonDetailsSearch.log()
-        accessControl.requirePermissionFor(user, Action.Global.SEARCH_PEOPLE)
+        accessControl.requirePermissionFor(user, clock, Action.Global.SEARCH_PEOPLE)
         return db.connect { dbc ->
             dbc.read {
                 it.searchPeople(
@@ -241,10 +241,11 @@ class PersonController(
     fun getOrCreatePersonBySsn(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: GetOrCreatePersonBySsnRequest
     ): PersonJSON {
         Audit.PersonDetailsRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_PERSON_FROM_VTJ)
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_PERSON_FROM_VTJ)
 
         if (!isValidSSN(body.ssn)) throw BadRequest("Invalid SSN")
 
@@ -282,10 +283,11 @@ class PersonController(
     fun createPerson(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: CreatePersonBody
     ): PersonId {
         Audit.PersonCreate.log()
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_PERSON)
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_PERSON)
         return db.connect { dbc -> dbc.transaction { createPerson(it, body) } }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -60,6 +60,7 @@ class PersonController(
     fun getPerson(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable personId: PersonId
     ): PersonResponse {
         Audit.PersonDetailsRead.log(targetId = personId)
@@ -69,7 +70,7 @@ class PersonController(
                 tx.getPersonById(personId)?.let {
                     PersonResponse(
                         PersonJSON.from(it),
-                        accessControl.getPermittedActions(tx, user, personId)
+                        accessControl.getPermittedActions(tx, user, clock, personId)
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -274,7 +274,7 @@ class PersonController(
         accessControl.requirePermissionFor(user, clock, Action.Person.MERGE, setOf(body.master, body.duplicate))
         db.connect { dbc ->
             dbc.transaction { tx ->
-                mergeService.mergePeople(tx, master = body.master, duplicate = body.duplicate)
+                mergeService.mergePeople(tx, clock, master = body.master, duplicate = body.duplicate)
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import fi.espoo.evaka.shared.utils.EMAIL_PATTERN
@@ -22,9 +23,9 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/citizen/personal-data")
 class PersonalDataControllerCitizen(private val accessControl: AccessControl) {
     @PutMapping
-    fun updatePersonalData(db: Database, user: AuthenticatedUser.Citizen, @RequestBody body: PersonalDataUpdate) {
+    fun updatePersonalData(db: Database, user: AuthenticatedUser.Citizen, clock: EvakaClock, @RequestBody body: PersonalDataUpdate) {
         Audit.PersonalDataUpdate.log(targetId = user.id)
-        accessControl.requirePermissionFor(user, Action.Citizen.Person.UPDATE_PERSONAL_DATA, user.id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Person.UPDATE_PERSONAL_DATA, user.id)
 
         db.connect { dbc ->
             dbc.transaction {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import fi.espoo.evaka.shared.utils.EMAIL_PATTERN
 import fi.espoo.evaka.shared.utils.PHONE_PATTERN
-import org.jdbi.v3.core.kotlin.bindKotlin
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
@@ -26,7 +26,7 @@ class FridgeFamilyService(
         updatePersonAndFamilyFromVtj(db, AuthenticatedUser.SystemInternalUser, clock, msg.personId)
     }
 
-    fun updatePersonAndFamilyFromVtj(db: Database.Connection, user: AuthenticatedUser, evakaClock: EvakaClock, personId: PersonId) {
+    fun updatePersonAndFamilyFromVtj(db: Database.Connection, user: AuthenticatedUser, clock: EvakaClock, personId: PersonId) {
         logger.info("Refreshing $personId from VTJ")
         val head = db.transaction {
             personService.getPersonWithChildren(
@@ -39,7 +39,7 @@ class FridgeFamilyService(
         if (head != null) {
             logger.info("Person to refresh has ${head.children.size} children")
 
-            val partner = db.read { getPartnerId(it, personId) }
+            val partner = db.read { getPartnerId(it, clock, personId) }
                 ?.also { logger.info("Person has fridge partner $it") }
                 ?.let { partnerId ->
                     db.transaction {
@@ -56,14 +56,14 @@ class FridgeFamilyService(
 
             val children = head.children + (partner?.children ?: emptyList())
 
-            val currentFridgeChildren = db.read { getCurrentFridgeChildren(it, personId) }
+            val currentFridgeChildren = db.read { getCurrentFridgeChildren(it, clock, personId) }
             logger.info("Currently person has ${currentFridgeChildren.size} fridge children in evaka")
 
             val newChildrenInSameAddress = children
                 .asSequence()
                 .distinct()
                 .filter { child -> !child.socialSecurityNumber.isNullOrBlank() }
-                .filter { child -> child.dateOfBirth.isAfter(evakaClock.today().minusYears(18)) }
+                .filter { child -> child.dateOfBirth.isAfter(clock.today().minusYears(18)) }
                 .filter { livesInSameAddress(it.address, head.address) }
                 .filter { !currentFridgeChildren.contains(it.id) }
                 .toList()
@@ -72,9 +72,9 @@ class FridgeFamilyService(
             newChildrenInSameAddress.forEach { child ->
                 try {
                     val startDate =
-                        if (childShouldBeAddedToFamilyStartingFromBirthday(evakaClock.today(), child.dateOfBirth))
+                        if (childShouldBeAddedToFamilyStartingFromBirthday(clock.today(), child.dateOfBirth))
                             child.dateOfBirth
-                        else evakaClock.today()
+                        else clock.today()
                     db.transaction { tx ->
                         parentshipService.createParentship(
                             tx,
@@ -93,27 +93,27 @@ class FridgeFamilyService(
         }
     }
 
-    fun getPartnerId(tx: Database.Read, personId: PersonId): PersonId? {
+    fun getPartnerId(tx: Database.Read, clock: EvakaClock, personId: PersonId): PersonId? {
         // language=sql
         val sql =
             """
             SELECT p2.person_id AS partner_id
             FROM fridge_partner p1
             LEFT OUTER JOIN fridge_partner p2 ON p1.partnership_id = p2.partnership_id AND p1.person_id != p2.person_id
-            WHERE p1.person_id = :personId AND daterange(p1.start_date, p1.end_date, '[]') @> current_date AND p1.conflict = false AND p2.conflict = false
+            WHERE p1.person_id = :personId AND daterange(p1.start_date, p1.end_date, '[]') @> :today AND p1.conflict = false AND p2.conflict = false
             """.trimIndent()
 
-        return tx.createQuery(sql).bind("personId", personId).mapTo<PersonId>().firstOrNull()
+        return tx.createQuery(sql).bind("today", clock.today()).bind("personId", personId).mapTo<PersonId>().firstOrNull()
     }
 
-    private fun getCurrentFridgeChildren(tx: Database.Read, personId: PersonId): Set<ChildId> {
+    private fun getCurrentFridgeChildren(tx: Database.Read, clock: EvakaClock, personId: PersonId): Set<ChildId> {
         // language=sql
         val sql =
             """
             SELECT child_id FROM fridge_child 
-            WHERE head_of_child = :personId AND daterange(start_date, end_date, '[]') @> current_date AND conflict = false
+            WHERE head_of_child = :personId AND daterange(start_date, end_date, '[]') @> :today AND conflict = false
             """.trimIndent()
-        return tx.createQuery(sql).bind("personId", personId).mapTo<ChildId>().list().toHashSet()
+        return tx.createQuery(sql).bind("today", clock.today()).bind("personId", personId).mapTo<ChildId>().list().toHashSet()
     }
 
     private fun livesInSameAddress(address1: PersonAddressDTO, address2: PersonAddressDTO): Boolean {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/FridgeFamilyService.kt
@@ -78,6 +78,7 @@ class FridgeFamilyService(
                     db.transaction { tx ->
                         parentshipService.createParentship(
                             tx,
+                            clock,
                             childId = child.id,
                             headOfChildId = personId,
                             startDate = startDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -140,7 +140,8 @@ class PlacementController(
 
                 asyncJobRunner.plan(
                     tx,
-                    listOf(AsyncJob.GenerateFinanceDecisions.forChild(body.childId, DateRange(body.startDate, body.endDate)))
+                    listOf(AsyncJob.GenerateFinanceDecisions.forChild(body.childId, DateRange(body.startDate, body.endDate))),
+                    runAt = clock.now()
                 )
             }
         }
@@ -171,7 +172,8 @@ class PlacementController(
                                 maxOf(body.endDate, oldPlacement.endDate)
                             )
                         )
-                    )
+                    ),
+                    runAt = clock.now()
                 )
             }
         }
@@ -196,7 +198,8 @@ class PlacementController(
                                 it.childId,
                                 DateRange(it.startDate, it.endDate)
                             )
-                        )
+                        ),
+                        runAt = clock.now()
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -25,6 +25,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
@@ -53,6 +54,7 @@ class PlacementController(
     fun getPlacements(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam(value = "daycareId", required = false) daycareId: DaycareId? = null,
         @RequestParam(value = "childId", required = false) childId: ChildId? = null,
         @RequestParam(
@@ -66,8 +68,8 @@ class PlacementController(
     ): Set<DaycarePlacementWithDetails> {
         Audit.PlacementSearch.log(targetId = daycareId ?: childId)
         when {
-            daycareId != null -> accessControl.requirePermissionFor(user, Action.Unit.READ_PLACEMENT, daycareId)
-            childId != null -> accessControl.requirePermissionFor(user, Action.Child.READ_PLACEMENT, childId)
+            daycareId != null -> accessControl.requirePermissionFor(user, clock, Action.Unit.READ_PLACEMENT, daycareId)
+            childId != null -> accessControl.requirePermissionFor(user, clock, Action.Child.READ_PLACEMENT, childId)
             else -> throw BadRequest("daycareId or childId is required")
         }
 
@@ -90,6 +92,7 @@ class PlacementController(
     fun getPlacementPlans(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam(value = "daycareId", required = true) daycareId: DaycareId,
         @RequestParam(
             value = "from",
@@ -98,7 +101,7 @@ class PlacementController(
         @RequestParam(value = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
     ): List<PlacementPlanDetails> {
         Audit.PlacementPlanSearch.log(targetId = daycareId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_PLACEMENT_PLAN, daycareId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_PLACEMENT_PLAN, daycareId)
 
         return db.connect { dbc -> dbc.read { it.getPlacementPlans(HelsinkiDateTime.now().toLocalDate(), daycareId, startDate, endDate) } }
     }
@@ -107,10 +110,11 @@ class PlacementController(
     fun createPlacement(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: PlacementCreateRequestBody
     ) {
         Audit.PlacementCreate.log(targetId = body.childId, objectId = body.unitId)
-        accessControl.requirePermissionFor(user, Action.Unit.CREATE_PLACEMENT, body.unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.CREATE_PLACEMENT, body.unitId)
 
         if (body.startDate > body.endDate) throw BadRequest("Placement start date cannot be after the end date")
 
@@ -146,11 +150,12 @@ class PlacementController(
     fun updatePlacementById(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("placementId") placementId: PlacementId,
         @RequestBody body: PlacementUpdateRequestBody
     ) {
         Audit.PlacementUpdate.log(targetId = placementId)
-        accessControl.requirePermissionFor(user, Action.Placement.UPDATE, placementId)
+        accessControl.requirePermissionFor(user, clock, Action.Placement.UPDATE, placementId)
 
         val aclAuth = acl.getAuthorizedUnits(user)
         db.connect { dbc ->
@@ -176,9 +181,10 @@ class PlacementController(
     fun deletePlacement(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("placementId") placementId: PlacementId
     ) {
-        accessControl.requirePermissionFor(user, Action.Placement.DELETE, placementId)
+        accessControl.requirePermissionFor(user, clock, Action.Placement.DELETE, placementId)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -203,11 +209,12 @@ class PlacementController(
     fun createGroupPlacement(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("placementId") placementId: PlacementId,
         @RequestBody body: GroupPlacementRequestBody
     ): GroupPlacementId {
         Audit.DaycareGroupPlacementCreate.log(targetId = placementId, objectId = body.groupId)
-        accessControl.requirePermissionFor(user, Action.Placement.CREATE_GROUP_PLACEMENT, placementId)
+        accessControl.requirePermissionFor(user, clock, Action.Placement.CREATE_GROUP_PLACEMENT, placementId)
 
         return db.connect { dbc ->
             dbc.transaction { tx ->
@@ -225,10 +232,11 @@ class PlacementController(
     fun deleteGroupPlacement(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("groupPlacementId") groupPlacementId: GroupPlacementId
     ) {
         Audit.DaycareGroupPlacementDelete.log(targetId = groupPlacementId)
-        accessControl.requirePermissionFor(user, Action.GroupPlacement.DELETE, groupPlacementId)
+        accessControl.requirePermissionFor(user, clock, Action.GroupPlacement.DELETE, groupPlacementId)
 
         db.connect { dbc -> dbc.transaction { it.deleteGroupPlacement(groupPlacementId) } }
     }
@@ -237,11 +245,12 @@ class PlacementController(
     fun transferGroupPlacement(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable("groupPlacementId") groupPlacementId: GroupPlacementId,
         @RequestBody body: GroupTransferRequestBody
     ) {
         Audit.DaycareGroupPlacementTransfer.log(targetId = groupPlacementId)
-        accessControl.requirePermissionFor(user, Action.GroupPlacement.UPDATE, groupPlacementId)
+        accessControl.requirePermissionFor(user, clock, Action.GroupPlacement.UPDATE, groupPlacementId)
 
         db.connect { dbc ->
             dbc.transaction {
@@ -254,10 +263,11 @@ class PlacementController(
     fun getChildPlacementPeriods(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable adultId: PersonId
     ): List<FiniteDateRange> {
         Audit.PlacementChildPlacementPeriodsRead.log(targetId = adultId)
-        accessControl.requirePermissionFor(user, Action.Person.READ_CHILD_PLACEMENT_PERIODS, adultId)
+        accessControl.requirePermissionFor(user, clock, Action.Person.READ_CHILD_PLACEMENT_PERIODS, adultId)
 
         return db.connect { dbc ->
             dbc.read { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
@@ -87,7 +87,7 @@ class PlacementControllerCitizen(
             }
             val terminatablePlacementGroup = dbc.read { it.getCitizenChildPlacements(clock.today(), childId) }
                 .also { placements ->
-                    accessControl.requirePermissionFor(user, Action.Citizen.Placement.TERMINATE, placements.map { it.id })
+                    accessControl.requirePermissionFor(user, clock, Action.Citizen.Placement.TERMINATE, placements.map { it.id })
                 }
                 .let { mapToTerminatablePlacements(it, clock.today()) }
                 .find { it.unitId == body.unitId && it.type == body.type }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
@@ -42,22 +42,22 @@ class PlacementControllerCitizen(
     fun getPlacements(
         db: Database,
         user: AuthenticatedUser.Citizen,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
     ): ChildPlacementResponse {
         Audit.PlacementSearch.log(targetId = childId)
-        accessControl.requirePermissionFor(user, Action.Citizen.Child.READ_PLACEMENT, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Child.READ_PLACEMENT, childId)
 
         return db.connect { dbc ->
             ChildPlacementResponse(
                 placements = mapToTerminatablePlacements(
                     dbc.read {
                         it.getCitizenChildPlacements(
-                            evakaClock.today(),
+                            clock.today(),
                             childId
                         )
                     },
-                    evakaClock.today()
+                    clock.today()
                 )
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
@@ -113,7 +113,7 @@ class PlacementControllerCitizen(
                 }
 
                 tx.cancelAllActiveTransferApplicationsAfterDate(childId, terminationDate)
-                asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forChild(childId, DateRange(terminationDate, null))))
+                asyncJobRunner.plan(tx, listOf(AsyncJob.GenerateFinanceDecisions.forChild(childId, DateRange(terminationDate, null))), runAt = clock.now())
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -22,6 +22,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Conflict
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.NotFound
 import mu.KotlinLogging
@@ -187,6 +188,7 @@ class PlacementPlanService(
 
     fun applyPlacementPlan(
         tx: Database.Transaction,
+        clock: EvakaClock,
         application: ApplicationDetails,
         unitId: DaycareId,
         type: PlacementType,
@@ -214,7 +216,8 @@ class PlacementPlanService(
             tx,
             timeline.ranges().map {
                 AsyncJob.GenerateFinanceDecisions.forChild(childId, it.asDateRange())
-            }.asIterable()
+            }.asIterable(),
+            runAt = clock.now()
         )
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.format.annotation.DateTimeFormat
@@ -26,11 +27,12 @@ class ApplicationsReportController(private val accessControl: AccessControl, pri
     fun getApplicationsReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): List<ApplicationsReportRow> {
         Audit.ApplicationsReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_APPLICATIONS_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_APPLICATIONS_REPORT)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
 
         return db.connect { dbc ->

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedDecisionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedDecisionsReport.kt
@@ -46,10 +46,11 @@ class AssistanceNeedDecisionsReport(private val accessControl: AccessControl, pr
     @GetMapping("/reports/assistance-need-decisions/unread-count")
     fun getAssistanceNeedDecisionUnreadCount(
         db: Database,
-        user: AuthenticatedUser
+        user: AuthenticatedUser,
+        clock: EvakaClock,
     ): Int {
         Audit.AssistanceNeedDecisionsReportUnreadCount.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_ASSISTANCE_NEED_DECISIONS_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_ASSISTANCE_NEED_DECISIONS_REPORT)
 
         return db.connect { dbc ->
             dbc.read {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReport.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.jdbi.v3.json.Json
@@ -32,10 +33,11 @@ class AssistanceNeedsAndActionsReportController(private val acl: AccessControlLi
     fun getAssistanceNeedReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): AssistanceNeedsAndActionsReport {
         Audit.AssistanceNeedsReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_ASSISTANCE_NEEDS_AND_ACTIONS_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_ASSISTANCE_NEEDS_AND_ACTIONS_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -30,10 +31,11 @@ class AttendanceReservationReportController(private val accessControl: AccessCon
         @PathVariable unitId: DaycareId,
         @RequestParam(required = false) groupIds: List<GroupId>?,
         db: Database,
-        user: AuthenticatedUser
+        user: AuthenticatedUser,
+        clock: EvakaClock
     ): List<AttendanceReservationReportRow> {
         Audit.AttendanceReservationReportRead.log(targetId = unitId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_ATTENDANCE_RESERVATION_REPORT, unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_ATTENDANCE_RESERVATION_REPORT, unitId)
         return db.connect { dbc ->
             dbc.read { tx ->
                 tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.format.annotation.DateTimeFormat
@@ -25,10 +26,11 @@ class ChildAgeLanguageReportController(private val acl: AccessControlList, priva
     fun getChildAgeLanguageReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): List<ChildAgeLanguageReportRow> {
         Audit.ChildAgeLanguageReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_CHILD_AGE_AND_LANGUAGE_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_CHILD_AGE_AND_LANGUAGE_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
@@ -34,13 +34,13 @@ class ChildrenInDifferentAddressReportController(
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
-                it.getChildrenInDifferentAddressRows(acl.getAuthorizedUnits(user))
+                it.getChildrenInDifferentAddressRows(acl.getAuthorizedUnits(user), clock)
             }
         }
     }
 }
 
-private fun Database.Read.getChildrenInDifferentAddressRows(authorizedUnits: AclAuthorization): List<ChildrenInDifferentAddressReportRow> {
+private fun Database.Read.getChildrenInDifferentAddressRows(authorizedUnits: AclAuthorization, clock: EvakaClock): List<ChildrenInDifferentAddressReportRow> {
     val units = authorizedUnits.ids
     // language=sql
     val sql =
@@ -61,13 +61,13 @@ private fun Database.Read.getChildrenInDifferentAddressRows(authorizedUnits: Acl
         JOIN person p ON p.id = fc.head_of_child
         JOIN person ch ON ch.id = fc.child_id
         JOIN placement pl ON pl.child_id = fc.child_id
-          AND daterange(pl.start_date, pl.end_date, '[]') @> current_date
+          AND daterange(pl.start_date, pl.end_date, '[]') @> :today
           AND pl.type != 'CLUB'::placement_type
         JOIN daycare u ON u.id = pl.unit_id
         JOIN care_area ca ON ca.id = u.care_area_id
         WHERE
             (:units::uuid[] IS NULL OR u.id = ANY(:units)) AND
-            daterange(fc.start_date, fc.end_date, '[]') @> current_date AND
+            daterange(fc.start_date, fc.end_date, '[]') @> :today AND
             fc.conflict = false AND
             p.residence_code <> ch.residence_code AND
             p.residence_code IS NOT NULL AND
@@ -83,6 +83,7 @@ private fun Database.Read.getChildrenInDifferentAddressRows(authorizedUnits: Acl
         ORDER BY u.name, p.last_name, p.first_name, ch.last_name, ch.first_name;
         """.trimIndent()
     return createQuery(sql)
+        .bind("today", clock.today())
         .bind("units", units)
         .mapTo<ChildrenInDifferentAddressReportRow>()
         .toList()

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.GetMapping
@@ -25,10 +26,11 @@ class ChildrenInDifferentAddressReportController(
     @GetMapping("/reports/children-in-different-address")
     fun getChildrenInDifferentAddressReport(
         db: Database,
-        user: AuthenticatedUser
+        user: AuthenticatedUser,
+        clock: EvakaClock
     ): List<ChildrenInDifferentAddressReportRow> {
         Audit.ChildrenInDifferentAddressReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_CHILD_IN_DIFFERENT_ADDRESS_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_CHILD_IN_DIFFERENT_ADDRESS_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DecisionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DecisionsReport.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -25,11 +26,12 @@ class DecisionsReportController(private val accessControl: AccessControl) {
     fun getDecisionsReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): List<DecisionsReportRow> {
         Audit.DecisionsReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_DECISIONS_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_DECISIONS_REPORT)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
 
         return db.connect { dbc ->

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.pis.getTransferablePersonReferences
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.jdbi.v3.json.Json
@@ -19,9 +20,9 @@ import java.time.LocalDate
 @RestController
 class DuplicatePeopleReportController(private val accessControl: AccessControl) {
     @GetMapping("/reports/duplicate-people")
-    fun getDuplicatePeopleReport(db: Database, user: AuthenticatedUser): List<DuplicatePeopleReportRow> {
+    fun getDuplicatePeopleReport(db: Database, user: AuthenticatedUser, clock: EvakaClock): List<DuplicatePeopleReportRow> {
         Audit.DuplicatePeopleReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_DUPLICATE_PEOPLE_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_DUPLICATE_PEOPLE_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,11 +22,12 @@ class EndedPlacementsReportController(private val accessControl: AccessControl) 
     fun getEndedPlacementsReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam year: Int,
         @RequestParam month: Int
     ): List<EndedPlacementsReportRow> {
         Audit.EndedPlacementsReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_ENDED_PLACEMENTS_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_ENDED_PLACEMENTS_REPORT)
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,9 +20,9 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class FamilyConflictReportController(private val acl: AccessControlList, private val accessControl: AccessControl) {
     @GetMapping("/reports/family-conflicts")
-    fun getFamilyConflictsReport(db: Database, user: AuthenticatedUser): List<FamilyConflictReportRow> {
+    fun getFamilyConflictsReport(db: Database, user: AuthenticatedUser, clock: EvakaClock): List<FamilyConflictReportRow> {
         Audit.FamilyConflictReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_FAMILY_CONFLICT_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_FAMILY_CONFLICT_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
@@ -26,15 +26,15 @@ class FamilyContactReportController(private val accessControl: AccessControl) {
     fun getFamilyContactsReport(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestParam unitId: DaycareId
     ): List<FamilyContactReportRow> {
         Audit.FamilyContactReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Unit.READ_FAMILY_CONTACT_REPORT, unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_FAMILY_CONTACT_REPORT, unitId)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
-                it.getFamilyContacts(evakaClock.today(), unitId)
+                it.getFamilyContacts(clock.today(), unitId)
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.invoicing.domain.addressUsable
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.format.annotation.DateTimeFormat
@@ -33,10 +34,11 @@ class InvoiceReportController(private val accessControl: AccessControl) {
     fun getInvoiceReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): InvoiceReport {
         Audit.InvoicesReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_INVOICE_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_INVOICE_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.format.annotation.DateTimeFormat
@@ -25,11 +26,12 @@ class MissingHeadOfFamilyReportController(private val acl: AccessControlList, pr
     fun getMissingHeadOfFamilyReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?
     ): List<MissingHeadOfFamilyReportRow> {
         Audit.MissingHeadOfFamilyReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_MISSING_HEAD_OF_FAMILY_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_MISSING_HEAD_OF_FAMILY_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.format.annotation.DateTimeFormat
@@ -26,11 +27,12 @@ class MissingServiceNeedReportController(private val acl: AccessControlList, pri
     fun getMissingServiceNeedReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?
     ): List<MissingServiceNeedReportRow> {
         Audit.MissingServiceNeedReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_MISSING_SERVICE_NEED_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_MISSING_SERVICE_NEED_REPORT)
         if (to != null && to.isBefore(from)) throw BadRequest("Invalid time range")
 
         return db.connect { dbc ->

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -34,7 +34,7 @@ class OccupancyReportController(private val accessControl: AccessControl, privat
     fun getOccupancyUnitReport(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestParam type: OccupancyType,
         @RequestParam(required = false) careAreaId: AreaId?,
         @RequestParam(required = false) providerType: ProviderType?,
@@ -43,7 +43,7 @@ class OccupancyReportController(private val accessControl: AccessControl, privat
         @RequestParam month: Int
     ): List<OccupancyUnitReportResultRow> {
         Audit.OccupancyReportRead.log(targetId = careAreaId)
-        accessControl.requirePermissionFor(user, Action.Global.READ_OCCUPANCY_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_OCCUPANCY_REPORT)
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 
@@ -51,7 +51,7 @@ class OccupancyReportController(private val accessControl: AccessControl, privat
             dbc.read { tx ->
                 tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                 tx.calculateUnitOccupancyReport(
-                    evakaClock.today(),
+                    clock.today(),
                     careAreaId,
                     providerType,
                     unitTypes,
@@ -67,7 +67,7 @@ class OccupancyReportController(private val accessControl: AccessControl, privat
     fun getOccupancyGroupReport(
         db: Database,
         user: AuthenticatedUser,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestParam type: OccupancyType,
         @RequestParam(required = false) careAreaId: AreaId?,
         @RequestParam(required = false) providerType: ProviderType?,
@@ -76,14 +76,14 @@ class OccupancyReportController(private val accessControl: AccessControl, privat
         @RequestParam month: Int
     ): List<OccupancyGroupReportResultRow> {
         Audit.OccupancyReportRead.log(targetId = careAreaId)
-        accessControl.requirePermissionFor(user, Action.Global.READ_OCCUPANCY_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_OCCUPANCY_REPORT)
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 
         return db.connect { dbc ->
             dbc.read { tx ->
                 tx.calculateGroupOccupancyReport(
-                    evakaClock.today(),
+                    clock.today(),
                     careAreaId,
                     providerType,
                     unitTypes,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.GetMapping
@@ -24,10 +25,11 @@ class PartnersInDifferentAddressReportController(
     @GetMapping("/reports/partners-in-different-address")
     fun getPartnersInDifferentAddressReport(
         db: Database,
-        user: AuthenticatedUser
+        user: AuthenticatedUser,
+        clock: EvakaClock
     ): List<PartnersInDifferentAddressReportRow> {
         Audit.PartnersInDifferentAddressReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_PARTNERS_IN_DIFFERENT_ADDRESS_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_PARTNERS_IN_DIFFERENT_ADDRESS_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.format.annotation.DateTimeFormat
@@ -24,11 +25,12 @@ class PlacementSketchingReportController(private val accessControl: AccessContro
     fun getPlacementSketchingReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("placementStartDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) placementStartDate: LocalDate,
         @RequestParam("earliestPreferredStartDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) earliestPreferredStartDate: LocalDate?
     ): List<PlacementSketchingReportRow> {
         Audit.PlacementSketchingReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_PLACEMENT_SKETCHING_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_PLACEMENT_SKETCHING_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.format.annotation.DateTimeFormat
@@ -25,11 +26,12 @@ class PresenceReportController(private val accessControl: AccessControl) {
     fun getPresenceReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): List<PresenceReportRow> {
         Audit.PresenceReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_PRESENCE_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_PRESENCE_REPORT)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
         if (to.isAfter(from.plusDays(MAX_NUMBER_OF_DAYS.toLong()))) throw BadRequest("Period is too long. Use maximum of $MAX_NUMBER_OF_DAYS days")
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.format.annotation.DateTimeFormat
@@ -29,11 +30,12 @@ class RawReportController(private val accessControl: AccessControl) {
     fun getRawReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): List<RawReportRow> {
         Audit.RawReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_RAW_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_RAW_REPORT)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
         if (to.isAfter(from.plusDays(7))) throw BadRequest("Time range too long")
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AclAuthorization
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.format.annotation.DateTimeFormat
@@ -24,10 +25,11 @@ class ServiceNeedReport(private val acl: AccessControlList, private val accessCo
     fun getServiceNeedReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): List<ServiceNeedReportRow> {
         Audit.ServiceNeedReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_SERVICE_NEED_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_SERVICE_NEED_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
@@ -62,11 +63,12 @@ class ServiceVoucherValueReportController(
     fun getServiceVoucherValuesForUnit(
         db: Database,
         user: AuthenticatedUser.Employee,
+        clock: EvakaClock,
         @PathVariable unitId: DaycareId,
         @RequestParam year: Int,
         @RequestParam month: Int
     ): ServiceVoucherUnitReport {
-        accessControl.requirePermissionFor(user, Action.Unit.READ_SERVICE_VOUCHER_VALUES_REPORT, unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_SERVICE_VOUCHER_VALUES_REPORT, unitId)
 
         return db.connect { dbc ->
             dbc.read { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -41,11 +41,12 @@ class ServiceVoucherValueReportController(
     fun getServiceVoucherValuesForAllUnits(
         db: Database,
         user: AuthenticatedUser.Employee,
+        clock: EvakaClock,
         @RequestParam year: Int,
         @RequestParam month: Int,
         @RequestParam(required = false) areaId: AreaId?
     ): ServiceVoucherReport {
-        accessControl.requirePermissionFor(user, Action.Global.READ_SERVICE_VOUCHER_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_SERVICE_VOUCHER_REPORT)
         val authorization = acl.getAuthorizedUnits(user, setOf(UserRole.UNIT_SUPERVISOR))
 
         return db.connect { dbc ->

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/SextetReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/SextetReport.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.GetMapping
@@ -22,11 +23,12 @@ class SextetReportController(private val accessControl: AccessControl) {
     fun getApplicationsReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam year: Int,
         @RequestParam placementType: PlacementType
     ): List<SextetReportRow> {
         Audit.SextetReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_SEXTET_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_SEXTET_REPORT)
 
         return db.connect { dbc ->
             dbc.read {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -23,11 +24,12 @@ class StartingPlacementsReportController(private val accessControl: AccessContro
     fun getStartingPlacementsReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("year") year: Int,
         @RequestParam("month") month: Int
     ): List<StartingPlacementsRow> {
         Audit.StartingPlacementsReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_STARTING_PLACEMENTS_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_STARTING_PLACEMENTS_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -20,10 +21,11 @@ class VardaErrorReport(private val accessControl: AccessControl) {
     @GetMapping("/reports/varda-errors")
     fun getVardaErrors(
         db: Database,
-        user: AuthenticatedUser
+        user: AuthenticatedUser,
+        clock: EvakaClock
     ): List<VardaErrorReportRow> {
         Audit.VardaReportRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_VARDA_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_VARDA_REPORT)
         return db.connect { dbc ->
             dbc.read {
                 it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/patu/PatuReportingController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/patu/PatuReportingController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -31,11 +32,12 @@ class PatuReportingController(private val asyncJobRunner: AsyncJobRunner<AsyncJo
     fun sendPatuReport(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ) {
         Audit.PatuReportSend.log()
-        accessControl.requirePermissionFor(user, Action.Global.SEND_PATU_REPORT)
+        accessControl.requirePermissionFor(user, clock, Action.Global.SEND_PATU_REPORT)
         db.connect { dbc ->
             dbc.transaction { tx ->
                 val range = DateRange(from, to)

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -39,12 +39,12 @@ class ReservationControllerCitizen(
     fun getReservations(
         db: Database,
         user: AuthenticatedUser.Citizen,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
     ): ReservationsResponse {
         Audit.AttendanceReservationCitizenRead.log(targetId = user.id)
-        accessControl.requirePermissionFor(user, Action.Citizen.Person.READ_RESERVATIONS, user.id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Person.READ_RESERVATIONS, user.id)
 
         val range = try {
             FiniteDateRange(from, to)
@@ -61,7 +61,7 @@ class ReservationControllerCitizen(
                 val reservations = tx.getReservationsCitizen(user.id, range, includeWeekends)
                 val deadlines = tx.getHolidayPeriodDeadlines()
                 val reservableDayRanges =
-                    getReservableDays(evakaClock.now(), featureConfig.citizenReservationThresholdHours, deadlines)
+                    getReservableDays(clock.now(), featureConfig.citizenReservationThresholdHours, deadlines)
                 val reservableDays = children.associate { child ->
                     Pair(
                         child.id,

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -86,17 +86,17 @@ class ReservationControllerCitizen(
     fun postReservations(
         db: Database,
         user: AuthenticatedUser.Citizen,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestBody body: List<DailyReservationRequest>
     ) {
         Audit.AttendanceReservationCitizenCreate.log(targetId = body.map { it.childId }.toSet().joinToString())
-        accessControl.requirePermissionFor(user, Action.Citizen.Child.CREATE_RESERVATION, body.map { it.childId })
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Child.CREATE_RESERVATION, body.map { it.childId })
 
         db.connect { dbc ->
             dbc.transaction { tx ->
                 val deadlines = tx.getHolidayPeriodDeadlines()
                 val reservableDays =
-                    getReservableDays(evakaClock.now(), featureConfig.citizenReservationThresholdHours, deadlines)
+                    getReservableDays(clock.now(), featureConfig.citizenReservationThresholdHours, deadlines)
                 createReservations(tx, user.evakaUserId, body.validate(reservableDays), user.id)
             }
         }
@@ -106,13 +106,13 @@ class ReservationControllerCitizen(
     fun postAbsences(
         db: Database,
         user: AuthenticatedUser.Citizen,
-        evakaClock: EvakaClock,
+        clock: EvakaClock,
         @RequestBody body: AbsenceRequest
     ) {
         Audit.AbsenceCitizenCreate.log(targetId = body.childIds.toSet().joinToString())
-        accessControl.requirePermissionFor(user, Action.Citizen.Child.CREATE_ABSENCE, body.childIds)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Child.CREATE_ABSENCE, body.childIds)
 
-        if (body.dateRange.start.isBefore(evakaClock.today()))
+        if (body.dateRange.start.isBefore(clock.today()))
             throw BadRequest("Cannot mark absences for past days")
 
         if (!listOf(OTHER_ABSENCE, PLANNED_ABSENCE, SICKLEAVE).contains(body.absenceType))

--- a/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInfoController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInfoController.kt
@@ -32,6 +32,6 @@ class ChildSensitiveInfoController(
 
         ac.requirePermissionFor(user, clock, Action.Child.READ_SENSITIVE_INFO, childId)
 
-        return db.connect { dbc -> dbc.read { it.getChildSensitiveInfo(childId) ?: throw NotFound("Child not found") } }
+        return db.connect { dbc -> dbc.read { it.getChildSensitiveInfo(clock, childId) ?: throw NotFound("Child not found") } }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInfoController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInfoController.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -24,11 +25,12 @@ class ChildSensitiveInfoController(
     fun getSensitiveInfo(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
     ): ChildSensitiveInformation {
         Audit.ChildSensitiveInfoRead.log(targetId = childId)
 
-        ac.requirePermissionFor(user, Action.Child.READ_SENSITIVE_INFO, childId)
+        ac.requirePermissionFor(user, clock, Action.Child.READ_SENSITIVE_INFO, childId)
 
         return db.connect { dbc -> dbc.read { it.getChildSensitiveInfo(childId) ?: throw NotFound("Child not found") } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/sensitive/GetChildSensitiveInfoQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sensitive/GetChildSensitiveInfoQueries.kt
@@ -12,14 +12,15 @@ import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.placement.getCurrentPlacementForChild
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 
-fun Database.Read.getChildSensitiveInfo(childId: ChildId): ChildSensitiveInformation? {
+fun Database.Read.getChildSensitiveInfo(clock: EvakaClock, childId: ChildId): ChildSensitiveInformation? {
     val person = getPersonById(childId) ?: return null
 
-    val placementType = getCurrentPlacementForChild(childId)?.let { it.type }
+    val placementType = getCurrentPlacementForChild(clock, childId)?.let { it.type }
     val child = getChild(childId)
     val backupPickups = getBackupPickupsForChild(childId)
-    val familyContacts = fetchFamilyContacts(childId)
+    val familyContacts = fetchFamilyContacts(clock, childId)
 
     return ChildSensitiveInformation(
         id = person.id,

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeed.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.jdbi.v3.core.mapper.Nested
@@ -233,9 +234,10 @@ fun clearServiceNeedsFromPeriod(tx: Database.Transaction, placementId: Placement
     }
 }
 
-fun notifyServiceNeedUpdated(tx: Database.Transaction, asyncJobRunner: AsyncJobRunner<AsyncJob>, childRange: ServiceNeedChildRange) {
+fun notifyServiceNeedUpdated(tx: Database.Transaction, clock: EvakaClock, asyncJobRunner: AsyncJobRunner<AsyncJob>, childRange: ServiceNeedChildRange) {
     asyncJobRunner.plan(
         tx,
-        listOf(AsyncJob.GenerateFinanceDecisions.forChild(childRange.childId, childRange.dateRange.asDateRange()))
+        listOf(AsyncJob.GenerateFinanceDecisions.forChild(childRange.childId, childRange.dateRange.asDateRange())),
+        runAt = clock.now()
     )
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -138,10 +138,11 @@ class ServiceNeedController(
     @GetMapping("/service-needs/options")
     fun getServiceNeedOptions(
         db: Database,
-        user: AuthenticatedUser
+        user: AuthenticatedUser,
+        clock: EvakaClock
     ): List<ServiceNeedOption> {
         Audit.ServiceNeedOptionsRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_SERVICE_NEED_OPTIONS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_SERVICE_NEED_OPTIONS)
 
         return db.connect { dbc -> dbc.read { it.getServiceNeedOptions() } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -65,7 +65,7 @@ class ServiceNeedController(
                     confirmedAt = HelsinkiDateTime.now()
                 )
                     .let { id -> tx.getServiceNeedChildRange(id) }
-                    .let { notifyServiceNeedUpdated(tx, asyncJobRunner, it) }
+                    .let { notifyServiceNeedUpdated(tx, clock, asyncJobRunner, it) }
             }
         }
     }
@@ -103,6 +103,7 @@ class ServiceNeedController(
                 )
                 notifyServiceNeedUpdated(
                     tx,
+                    clock,
                     asyncJobRunner,
                     ServiceNeedChildRange(
                         childId = oldRange.childId,
@@ -130,7 +131,7 @@ class ServiceNeedController(
             dbc.transaction { tx ->
                 val childRange = tx.getServiceNeedChildRange(id)
                 tx.deleteServiceNeed(id)
-                notifyServiceNeedUpdated(tx, asyncJobRunner, childRange)
+                notifyServiceNeedUpdated(tx, clock, asyncJobRunner, childRange)
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
@@ -45,10 +46,11 @@ class ServiceNeedController(
     fun postServiceNeed(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: ServiceNeedCreateRequest
     ) {
         Audit.PlacementServiceNeedCreate.log(targetId = body.placementId)
-        accessControl.requirePermissionFor(user, Action.Placement.CREATE_SERVICE_NEED, body.placementId)
+        accessControl.requirePermissionFor(user, clock, Action.Placement.CREATE_SERVICE_NEED, body.placementId)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -79,11 +81,12 @@ class ServiceNeedController(
     fun putServiceNeed(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: ServiceNeedId,
         @RequestBody body: ServiceNeedUpdateRequest
     ) {
         Audit.PlacementServiceNeedUpdate.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.ServiceNeed.UPDATE, id)
+        accessControl.requirePermissionFor(user, clock, Action.ServiceNeed.UPDATE, id)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -117,10 +120,11 @@ class ServiceNeedController(
     fun deleteServiceNeed(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: ServiceNeedId
     ) {
         Audit.PlacementServiceNeedDelete.log(targetId = id)
-        accessControl.requirePermissionFor(user, Action.ServiceNeed.DELETE, id)
+        accessControl.requirePermissionFor(user, clock, Action.ServiceNeed.DELETE, id)
 
         db.connect { dbc ->
             dbc.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/setting/SettingController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/setting/SettingController.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.setting
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.springframework.web.bind.annotation.GetMapping
@@ -20,16 +21,16 @@ import org.springframework.web.bind.annotation.RestController
 class SettingController(private val accessControl: AccessControl) {
 
     @GetMapping
-    fun getSettings(db: Database, user: AuthenticatedUser): Map<SettingType, String> {
+    fun getSettings(db: Database, user: AuthenticatedUser, clock: EvakaClock): Map<SettingType, String> {
         Audit.SettingsRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.UPDATE_SETTINGS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.UPDATE_SETTINGS)
         return db.connect { dbc -> dbc.read { tx -> tx.getSettings() } }
     }
 
     @PutMapping
-    fun setSettings(db: Database, user: AuthenticatedUser, @RequestBody settings: Map<SettingType, String>) {
+    fun setSettings(db: Database, user: AuthenticatedUser, clock: EvakaClock, @RequestBody settings: Map<SettingType, String>) {
         Audit.SettingsUpdate.log()
-        accessControl.requirePermissionFor(user, Action.Global.UPDATE_SETTINGS)
+        accessControl.requirePermissionFor(user, clock, Action.Global.UPDATE_SETTINGS)
         return db.connect { dbc -> dbc.transaction { tx -> tx.setSettings(settings) } }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueries.kt
@@ -51,7 +51,7 @@ fun <T : AsyncJobPayload> Database.Transaction.claimJob(now: HelsinkiDateTime, j
 WITH claimed_job AS (
   SELECT id
   FROM async_job
-  WHERE run_at < :now
+  WHERE run_at <= :now
   AND retry_count > 0
   AND completed_at IS NULL
   AND type = ANY(:jobTypes)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledJobTriggerController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledJobTriggerController.kt
@@ -71,7 +71,7 @@ class ScheduledJobTriggerController(
 
         db.connect { dbc ->
             dbc.transaction { tx ->
-                asyncJobRunner.plan(tx, listOf(AsyncJob.RunScheduledJob(body.type)), retryCount = 1)
+                asyncJobRunner.plan(tx, listOf(AsyncJob.RunScheduledJob(body.type)), retryCount = 1, runAt = clock.now())
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledJobTriggerController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ScheduledJobTriggerController.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.job.ScheduledJob
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -24,8 +25,8 @@ class ScheduledJobTriggerController(
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     @GetMapping(produces = ["text/html"])
-    fun form(user: AuthenticatedUser): String {
-        accessControl.requirePermissionFor(user, Action.Global.TRIGGER_SCHEDULED_JOBS)
+    fun form(user: AuthenticatedUser, clock: EvakaClock): String {
+        accessControl.requirePermissionFor(user, clock, Action.Global.TRIGGER_SCHEDULED_JOBS)
 
         // language=html
         return """
@@ -65,8 +66,8 @@ class ScheduledJobTriggerController(
     }
 
     @PostMapping
-    fun trigger(user: AuthenticatedUser, db: Database, @RequestBody body: TriggerBody) {
-        accessControl.requirePermissionFor(user, Action.Global.TRIGGER_SCHEDULED_JOBS)
+    fun trigger(user: AuthenticatedUser, db: Database, clock: EvakaClock, @RequestBody body: TriggerBody) {
+        accessControl.requirePermissionFor(user, clock, Action.Global.TRIGGER_SCHEDULED_JOBS)
 
         db.connect { dbc ->
             dbc.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -73,7 +73,6 @@ import fi.espoo.evaka.user.EvakaUser
 import fi.espoo.evaka.varda.VardaServiceNeed
 import mu.KotlinLogging
 import org.intellij.lang.annotations.Language
-import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.json.Json
 import org.postgresql.util.PGobject
 import org.springframework.core.io.ClassPathResource

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -520,7 +520,7 @@ data class DevIncome(
     val effect: IncomeEffect = IncomeEffect.MAX_FEE_ACCEPTED,
     val isEntrepreneur: Boolean = false,
     val worksAtEcha: Boolean = false,
-    val updatedAt: Instant = Instant.now(),
+    val updatedAt: HelsinkiDateTime = HelsinkiDateTime.now(),
     val updatedBy: EvakaUserId
 )
 
@@ -564,7 +564,7 @@ data class DevFeeAlteration(
     val validTo: LocalDate?,
     val notes: String = "",
     val updatedBy: EvakaUserId,
-    val updatedAt: Instant = Instant.now()
+    val updatedAt: HelsinkiDateTime = HelsinkiDateTime.now()
 )
 
 fun Database.Transaction.insertTestFeeAlteration(feeAlteration: DevFeeAlteration) {
@@ -634,7 +634,7 @@ fun Database.Transaction.insertTestPlacementPlan(
     endDate: LocalDate = LocalDate.of(2019, 12, 31),
     preschoolDaycareStartDate: LocalDate? = null,
     preschoolDaycareEndDate: LocalDate? = null,
-    updated: Instant = Instant.now(),
+    updated: HelsinkiDateTime = HelsinkiDateTime.now(),
     deleted: Boolean? = false
 ): PlacementPlanId {
     createUpdate(
@@ -668,9 +668,9 @@ data class TestDecision(
     val status: DecisionStatus = DecisionStatus.PENDING,
     val requestedStartDate: LocalDate? = null,
     val resolvedBy: UUID? = null,
-    val resolved: Instant? = resolvedBy?.let { Instant.ofEpochSecond(1546300800) }, // 2019-01-01 midnight
+    val resolved: HelsinkiDateTime? = resolvedBy?.let { HelsinkiDateTime.from(Instant.ofEpochSecond(1546300800)) }, // 2019-01-01 midnight
     val pendingDecisionEmailsSentCount: Int? = 0,
-    val pendingDecisionEmailSent: Instant? = null
+    val pendingDecisionEmailSent: HelsinkiDateTime? = null
 )
 
 fun Database.Transaction.insertTestDecision(decision: TestDecision) = insertTestDataRow(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -178,7 +178,6 @@ import java.math.BigDecimal
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
-import java.time.OffsetDateTime
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
@@ -1703,8 +1702,8 @@ data class PlacementPlan(
 data class DevApplicationWithForm(
     val id: ApplicationId,
     val type: ApplicationType,
-    val createdDate: OffsetDateTime?,
-    val modifiedDate: OffsetDateTime?,
+    val createdDate: HelsinkiDateTime?,
+    val modifiedDate: HelsinkiDateTime?,
     var sentDate: LocalDate?,
     var dueDate: LocalDate?,
     val status: ApplicationStatus,
@@ -1721,10 +1720,10 @@ data class DevApplicationWithForm(
 data class DevApplicationForm(
     val id: UUID? = UUID.randomUUID(),
     val applicationId: ApplicationId,
-    val createdDate: OffsetDateTime? = OffsetDateTime.now(),
+    val createdDate: HelsinkiDateTime? = HelsinkiDateTime.now(),
     val revision: Int,
     val document: DaycareFormV0,
-    val updated: OffsetDateTime? = OffsetDateTime.now()
+    val updated: HelsinkiDateTime? = HelsinkiDateTime.now()
 )
 
 data class DevDaycareGroupAcl(val groupId: GroupId, val employeeId: EmployeeId)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -792,9 +792,10 @@ INSERT INTO guardian (guardian_id, child_id) VALUES (:guardianId, :childId) ON C
     @PostMapping("/mobile/pairings/challenge")
     fun postPairingChallenge(
         db: Database,
+        clock: EvakaClock,
         @RequestBody body: PairingsController.PostPairingChallengeReq
     ): Pairing {
-        return db.connect { dbc -> dbc.transaction { it.challengePairing(body.challengeKey) } }
+        return db.connect { dbc -> dbc.transaction { it.challengePairing(clock, body.challengeKey) } }
     }
 
     @PostMapping("/mobile/pairings/{id}/response")
@@ -812,13 +813,14 @@ INSERT INTO guardian (guardian_id, child_id) VALUES (:guardianId, :childId) ON C
     @PostMapping("/mobile/pairings")
     fun postPairing(
         db: Database,
+        clock: EvakaClock,
         @RequestBody body: PairingsController.PostPairingReq
     ): Pairing {
         return db.connect { dbc ->
             dbc.transaction {
                 when (body) {
-                    is PairingsController.PostPairingReq.Unit -> it.initPairing(unitId = body.unitId)
-                    is PairingsController.PostPairingReq.Employee -> it.initPairing(employeeId = body.employeeId)
+                    is PairingsController.PostPairingReq.Unit -> it.initPairing(clock, unitId = body.unitId)
+                    is PairingsController.PostPairingReq.Employee -> it.initPairing(clock, employeeId = body.employeeId)
                 }
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -390,6 +390,7 @@ class DevApi(
     @PostMapping("/decisions/{id}/actions/reject-by-citizen")
     fun rejectDecisionByCitizen(
         db: Database,
+        clock: EvakaClock,
         @PathVariable id: DecisionId,
     ) {
         db.connect { dbc ->
@@ -400,6 +401,7 @@ class DevApi(
                 applicationStateService.rejectDecision(
                     tx,
                     AuthenticatedUser.Citizen(application.guardianId, CitizenAuthLevel.STRONG),
+                    clock,
                     application.id,
                     id,
                 )
@@ -748,7 +750,7 @@ INSERT INTO guardian (guardian_id, child_id) VALUES (:guardianId, :childId) ON C
         db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.ensureFakeAdminExists()
-                actionFn.invoke(tx, fakeAdmin, applicationId)
+                actionFn.invoke(tx, fakeAdmin, clock, applicationId)
             }
         }
         runAllAsyncJobs(clock)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1065,21 +1065,21 @@ INSERT INTO guardian (guardian_id, child_id) VALUES (:guardianId, :childId) ON C
     }
 
     @PostMapping("/vasu/doc")
-    fun createVasuDocument(db: Database, @RequestBody body: PostVasuDocBody): VasuDocumentId {
+    fun createVasuDocument(db: Database, clock: EvakaClock, @RequestBody body: PostVasuDocBody): VasuDocumentId {
         return db.connect { dbc ->
             dbc.transaction { tx ->
                 val template = tx.getVasuTemplate(body.templateId)
                     ?: throw NotFound("Template with id ${body.templateId} not found")
-                tx.insertVasuDocument(body.childId, template)
+                tx.insertVasuDocument(clock, body.childId, template)
             }
         }
     }
 
     @PostMapping("/vasu/doc/publish/{documentId}")
-    fun publishVasuDocument(db: Database, @PathVariable documentId: VasuDocumentId) {
+    fun publishVasuDocument(db: Database, clock: EvakaClock, @PathVariable documentId: VasuDocumentId) {
         return db.connect { dbc ->
             dbc.transaction { tx ->
-                tx.publishVasuDocument(documentId)
+                tx.publishVasuDocument(clock, documentId)
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunner.kt
@@ -10,6 +10,7 @@ import com.github.kagkarlsson.scheduler.task.helper.Tasks
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.voltti.logging.loggers.info
 import mu.KotlinLogging
 import org.jdbi.v3.core.Jdbi
@@ -56,7 +57,7 @@ class ScheduledJobRunner(
         val logMeta = mapOf("jobName" to job.name)
         logger.info(logMeta) { "Planning scheduled job ${job.name}" }
         db.transaction { tx ->
-            asyncJobRunner.plan(tx, listOf(AsyncJob.RunScheduledJob(job)), retryCount = retryCount)
+            asyncJobRunner.plan(tx, listOf(AsyncJob.RunScheduledJob(job)), retryCount = retryCount, runAt = HelsinkiDateTime.now())
         }
         asyncJobRunner.wakeUp()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -118,7 +118,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun dvvUpdate(db: Database.Connection, clock: EvakaClock) {
-        dvvModificationsBatchRefreshService.scheduleBatch(db)
+        dvvModificationsBatchRefreshService.scheduleBatch(db, clock)
     }
 
     fun koskiUpdate(db: Database.Connection, clock: EvakaClock) {
@@ -130,7 +130,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun vardaReset(db: Database.Connection, clock: EvakaClock) {
-        vardaResetService.planVardaReset(db, addNewChildren = true)
+        vardaResetService.planVardaReset(db, clock, addNewChildren = true)
     }
 
     fun removeOldDraftApplications(db: Database.Connection, clock: EvakaClock) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -10,7 +10,6 @@ import fi.espoo.evaka.application.removeOldDrafts
 import fi.espoo.evaka.attachment.AttachmentsController
 import fi.espoo.evaka.attendance.addMissingStaffAttendanceDepartures
 import fi.espoo.evaka.dvv.DvvModificationsBatchRefreshService
-import fi.espoo.evaka.invoicing.service.VoucherValueDecisionService
 import fi.espoo.evaka.koski.KoskiSearchParams
 import fi.espoo.evaka.koski.KoskiUpdateService
 import fi.espoo.evaka.note.child.daily.deleteExpiredNotes
@@ -55,7 +54,6 @@ class ScheduledJobs(
     private val dvvModificationsBatchRefreshService: DvvModificationsBatchRefreshService,
     private val attachmentsController: AttachmentsController,
     private val pendingDecisionEmailService: PendingDecisionEmailService,
-    private val voucherValueDecisionService: VoucherValueDecisionService,
     private val koskiUpdateService: KoskiUpdateService,
     asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -126,7 +126,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun vardaUpdate(db: Database.Connection, clock: EvakaClock) {
-        vardaUpdateService.startVardaUpdate(db)
+        vardaUpdateService.startVardaUpdate(db, clock)
     }
 
     fun vardaReset(db: Database.Connection, clock: EvakaClock) {
@@ -134,7 +134,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun removeOldDraftApplications(db: Database.Connection, clock: EvakaClock) {
-        db.transaction { it.removeOldDrafts(attachmentsController::deleteAttachment) }
+        db.transaction { it.removeOldDrafts(clock, attachmentsController::deleteAttachment) }
     }
 
     fun cancelOutdatedTransferApplications(db: Database.Connection, clock: EvakaClock) {
@@ -148,7 +148,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun sendPendingDecisionReminderEmails(db: Database.Connection, clock: EvakaClock) {
-        pendingDecisionEmailService.scheduleSendPendingDecisionsEmails(db)
+        pendingDecisionEmailService.scheduleSendPendingDecisionsEmails(db, clock)
     }
 
     fun freezeVoucherValueReports(db: Database.Connection, clock: EvakaClock) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -145,7 +145,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
 
     fun cancelOutdatedTransferApplications(db: Database.Connection) {
         val canceledApplications = db.transaction {
-            val applicationIds = it.cancelOutdatedSentTransferApplications()
+            val applicationIds = it.cancelOutdatedSentTransferApplications(RealEvakaClock())
             applicationIds
         }
         logger.info {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
@@ -45,8 +45,8 @@ class AccessControl(
         )
     }
 
-    fun requirePermissionFor(user: AuthenticatedUser, action: Action.UnscopedAction) = Database(jdbi).connect { dbc ->
-        dbc.read { tx -> checkPermissionFor(tx, user, RealEvakaClock(), action) }.assert()
+    fun requirePermissionFor(user: AuthenticatedUser, clock: EvakaClock, action: Action.UnscopedAction) = Database(jdbi).connect { dbc ->
+        dbc.read { tx -> checkPermissionFor(tx, user, clock, action) }.assert()
     }
 
     fun hasPermissionFor(user: AuthenticatedUser, clock: EvakaClock, action: Action.UnscopedAction): Boolean = Database(jdbi).connect { dbc ->

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
@@ -24,8 +24,7 @@ class AccessControl(
     private val actionRuleMapping: ActionRuleMapping,
     private val jdbi: Jdbi
 ) {
-    fun getPermittedFeatures(tx: Database.Read, user: AuthenticatedUser.Employee): EmployeeFeatures {
-        val clock = RealEvakaClock()
+    fun getPermittedFeatures(tx: Database.Read, user: AuthenticatedUser.Employee, clock: EvakaClock): EmployeeFeatures {
         return EmployeeFeatures(
             applications = checkPermissionFor(tx, user, clock, Action.Global.APPLICATIONS_PAGE).isPermitted(),
             employees = checkPermissionFor(tx, user, clock, Action.Global.EMPLOYEES_PAGE).isPermitted(),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
@@ -50,8 +50,8 @@ class AccessControl(
         dbc.read { tx -> checkPermissionFor(tx, user, RealEvakaClock(), action) }.assert()
     }
 
-    fun hasPermissionFor(user: AuthenticatedUser, action: Action.UnscopedAction): Boolean = Database(jdbi).connect { dbc ->
-        dbc.read { tx -> checkPermissionFor(tx, user, RealEvakaClock(), action) }.isPermitted()
+    fun hasPermissionFor(user: AuthenticatedUser, clock: EvakaClock, action: Action.UnscopedAction): Boolean = Database(jdbi).connect { dbc ->
+        dbc.read { tx -> checkPermissionFor(tx, user, clock, action) }.isPermitted()
     }
 
     fun checkPermissionFor(tx: Database.Read, user: AuthenticatedUser, clock: EvakaClock, action: Action.UnscopedAction, allowedToAdmin: Boolean = true): AccessControlDecision {
@@ -100,11 +100,11 @@ class AccessControl(
         }
     }
 
-    fun <T> hasPermissionFor(user: AuthenticatedUser, action: Action.ScopedAction<T>, target: T): Boolean =
-        hasPermissionFor(user, action, listOf(target))
-    fun <T> hasPermissionFor(user: AuthenticatedUser, action: Action.ScopedAction<T>, targets: Iterable<T>): Boolean = Database(jdbi).connect { dbc ->
+    fun <T> hasPermissionFor(user: AuthenticatedUser, clock: EvakaClock, action: Action.ScopedAction<T>, target: T): Boolean =
+        hasPermissionFor(user, clock, action, listOf(target))
+    fun <T> hasPermissionFor(user: AuthenticatedUser, clock: EvakaClock, action: Action.ScopedAction<T>, targets: Iterable<T>): Boolean = Database(jdbi).connect { dbc ->
         dbc.read { tx ->
-            checkPermissionFor(tx, user, RealEvakaClock(), action, targets).values.all { it.isPermitted() }
+            checkPermissionFor(tx, user, clock, action, targets).values.all { it.isPermitted() }
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
@@ -93,10 +93,10 @@ class AccessControl(
     }
 
     fun <T> requirePermissionFor(user: AuthenticatedUser, action: Action.ScopedAction<T>, target: T) =
-        requirePermissionFor(user, action, listOf(target))
-    fun <T> requirePermissionFor(user: AuthenticatedUser, action: Action.ScopedAction<T>, targets: Iterable<T>) = Database(jdbi).connect { dbc ->
+        requirePermissionFor(user, RealEvakaClock(), action, listOf(target))
+    fun <T> requirePermissionFor(user: AuthenticatedUser, clock: EvakaClock, action: Action.ScopedAction<T>, targets: Iterable<T>) = Database(jdbi).connect { dbc ->
         dbc.read { tx ->
-            checkPermissionFor(tx, user, RealEvakaClock(), action, targets).values.forEach { it.assert() }
+            checkPermissionFor(tx, user, clock, action, targets).values.forEach { it.assert() }
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
@@ -197,13 +197,15 @@ class AccessControl(
     inline fun <T, reified A> getPermittedActions(
         tx: Database.Read,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         target: T
-    ) where A : Action.ScopedAction<T>, A : Enum<A> = getPermittedActions(tx, user, RealEvakaClock(), A::class.java, setOf(target)).values.first()
+    ) where A : Action.ScopedAction<T>, A : Enum<A> = getPermittedActions(tx, user, clock, A::class.java, setOf(target)).values.first()
     inline fun <T, reified A> getPermittedActions(
         tx: Database.Read,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         targets: Iterable<T>
-    ) where A : Action.ScopedAction<T>, A : Enum<A> = getPermittedActions(tx, user, RealEvakaClock(), A::class.java, targets.toSet())
+    ) where A : Action.ScopedAction<T>, A : Enum<A> = getPermittedActions(tx, user, clock, A::class.java, targets.toSet())
 
     fun <T, A> getPermittedActions(
         tx: Database.Read,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.Forbidden
-import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.security.actionrule.AccessControlFilter
 import fi.espoo.evaka.shared.security.actionrule.ActionRuleMapping
 import fi.espoo.evaka.shared.security.actionrule.DatabaseActionRule
@@ -92,8 +91,8 @@ class AccessControl(
         return permittedActions
     }
 
-    fun <T> requirePermissionFor(user: AuthenticatedUser, action: Action.ScopedAction<T>, target: T) =
-        requirePermissionFor(user, RealEvakaClock(), action, listOf(target))
+    fun <T> requirePermissionFor(user: AuthenticatedUser, clock: EvakaClock, action: Action.ScopedAction<T>, target: T) =
+        requirePermissionFor(user, clock, action, listOf(target))
     fun <T> requirePermissionFor(user: AuthenticatedUser, clock: EvakaClock, action: Action.ScopedAction<T>, targets: Iterable<T>) = Database(jdbi).connect { dbc ->
         dbc.read { tx ->
             checkPermissionFor(tx, user, clock, action, targets).values.forEach { it.assert() }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
@@ -466,7 +466,7 @@ FROM daily_service_time dst
 JOIN employee_child_daycare_acl(:today) acl USING (child_id)
 JOIN daycare ON acl.daycare_id = daycare.id
 WHERE employee_id = :userId
-  AND lower(dst.validity_period) > current_date
+  AND lower(dst.validity_period) > :today
             """.trimIndent()
         )
             .bind("today", now.toLocalDate())

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -76,7 +76,7 @@ class UnitsView(private val accessControl: AccessControl, private val acl: Acces
         ) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): UnitDataResponse {
         Audit.UnitView.log(targetId = unitId)
-        accessControl.requirePermissionFor(user, Action.Unit.READ_BASIC, unitId)
+        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_BASIC, unitId)
 
         val period = FiniteDateRange(from, to)
         return db.connect { dbc ->

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -86,12 +86,14 @@ class UnitsView(private val accessControl: AccessControl, private val acl: Acces
                 val backupCares = tx.getBackupCaresForDaycare(unitId, period)
                 val missingGroupPlacements = if (accessControl.hasPermissionFor(
                         user,
+                        clock,
                         Action.Unit.READ_MISSING_GROUP_PLACEMENTS,
                         unitId
                     )
                 ) getMissingGroupPlacements(tx, unitId) else emptyList()
                 val recentlyTerminatedPlacements = if (accessControl.hasPermissionFor(
                         user,
+                        clock,
                         Action.Unit.READ_TERMINATED_PLACEMENTS,
                         unitId
                     )
@@ -119,7 +121,7 @@ class UnitsView(private val accessControl: AccessControl, private val acl: Acces
                     }.toSet()
 
                 val capacities =
-                    if (accessControl.hasPermissionFor(user, Action.Unit.READ_CHILD_CAPACITY_FACTORS, unitId))
+                    if (accessControl.hasPermissionFor(user, clock, Action.Unit.READ_CHILD_CAPACITY_FACTORS, unitId))
                         tx.getUnitChildrenCapacities(unitId, from)
                     else listOf()
 
@@ -143,7 +145,7 @@ class UnitsView(private val accessControl: AccessControl, private val acl: Acces
                     unitChildrenCapacityFactors = capacities
                 )
 
-                if (accessControl.hasPermissionFor(user, Action.Unit.READ_DETAILED, unitId)) {
+                if (accessControl.hasPermissionFor(user, clock, Action.Unit.READ_DETAILED, unitId)) {
                     val unitOccupancies = getUnitOccupancies(tx, clock.now(), unitId, period, acl.getAuthorizedUnits(user))
                     val groupOccupancies = getGroupOccupancies(tx, clock.today(), unitId, period, acl.getAuthorizedUnits(user))
                     val placementProposals = tx.getPlacementPlans(

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaController.kt
@@ -30,19 +30,21 @@ class VardaController(
     @PostMapping("/reset-children")
     fun resetChildren(
         db: Database,
+        clock: EvakaClock,
         @RequestParam(defaultValue = "true") addNewChildren: Boolean,
         @RequestParam(defaultValue = "1000") limit: Int,
     ) {
-        db.connect { dbc -> vardaResetService.planVardaReset(dbc, addNewChildren = addNewChildren, maxChildren = limit) }
+        db.connect { dbc -> vardaResetService.planVardaReset(dbc, clock, addNewChildren = addNewChildren, maxChildren = limit) }
     }
 
     @PostMapping("/reset-by-report/{organizerId}")
     fun resetChildrenByReport(
         db: Database,
+        clock: EvakaClock,
         @PathVariable organizerId: Long,
         @RequestParam(defaultValue = "1000") limit: Int,
     ) {
-        db.connect { dbc -> vardaResetService.planResetByVardaChildrenErrorReport(dbc, organizerId = organizerId, limit = limit) }
+        db.connect { dbc -> vardaResetService.planResetByVardaChildrenErrorReport(dbc, clock, organizerId = organizerId, limit = limit) }
     }
 
     @PostMapping("/mark-child-for-reset/{childId}")

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaController.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.varda
 
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -20,9 +21,10 @@ class VardaController(
 ) {
     @PostMapping("/run-update-all")
     fun runFullVardaUpdate(
-        db: Database
+        db: Database,
+        clock: EvakaClock
     ) {
-        db.connect { dbc -> vardaUpdateService.startVardaUpdate(dbc) }
+        db.connect { dbc -> vardaUpdateService.startVardaUpdate(dbc, clock) }
     }
 
     @PostMapping("/reset-children")

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaQueries.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.NotFound
 import mu.KotlinLogging
-import org.jdbi.v3.core.kotlin.bindKotlin
 import java.time.Instant
 import java.time.LocalDate
 

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaQueries.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import mu.KotlinLogging
 import java.time.Instant
@@ -105,7 +106,7 @@ WHERE evaka_service_need_id = :serviceNeedId
     .bind("errors", errors)
     .execute()
 
-fun Database.Read.getEvakaServiceNeedChanges(feeDecisionMinDate: LocalDate): List<ChangedChildServiceNeed> =
+fun Database.Read.getEvakaServiceNeedChanges(clock: EvakaClock, feeDecisionMinDate: LocalDate): List<ChangedChildServiceNeed> =
     createQuery(
         """
 WITH potential_missing_varda_service_needs AS (
@@ -126,7 +127,7 @@ WITH potential_missing_varda_service_needs AS (
         AND d.upload_children_to_varda = true
         AND sno.daycare_hours_per_week >= 1
         AND (vsn.evaka_service_need_updated IS NULL OR sn.updated > vsn.evaka_service_need_updated)
-        AND sn.start_date <= current_date
+        AND sn.start_date <= :today
         AND vrc.reset_timestamp IS NOT NULL
 ), service_need_fee_decision AS (
     SELECT
@@ -188,6 +189,7 @@ FROM varda_service_need vsn
 WHERE update_failed = true       
         """.trimIndent()
     )
+        .bind("today", clock.today())
         .bind("vardaPlacementTypes", vardaPlacementTypes)
         .bind("feeDecisionMinDate", feeDecisionMinDate)
         .mapTo<ChangedChildServiceNeed>()
@@ -369,6 +371,7 @@ fun Database.Read.serviceNeedIsInvoicedByMunicipality(serviceNeedId: ServiceNeed
     .list().isNotEmpty()
 
 fun Database.Read.getServiceNeedsForVardaByChild(
+    clock: EvakaClock,
     childId: ChildId
 ): List<ServiceNeedId> {
     // language=SQL
@@ -383,10 +386,11 @@ fun Database.Read.getServiceNeedsForVardaByChild(
         AND pl.type = ANY(:vardaPlacementTypes::placement_type[])
         AND d.upload_children_to_varda = true
         AND sno.daycare_hours_per_week >= 1
-        AND sn.start_date <= current_date
+        AND sn.start_date <= :today
         """.trimIndent()
 
     return createQuery(sql)
+        .bind("today", clock.today())
         .bind("childId", childId)
         .bind("vardaPlacementTypes", vardaPlacementTypes)
         .mapTo<ServiceNeedId>()
@@ -463,7 +467,7 @@ fun Database.Transaction.getVardaChildrenToReset(limit: Int, addNewChildren: Boo
         .list()
 }
 
-fun Database.Read.calculateDeletedChildServiceNeeds(): Map<ChildId, List<ServiceNeedId>> =
+fun Database.Read.calculateDeletedChildServiceNeeds(clock: EvakaClock): Map<ChildId, List<ServiceNeedId>> =
     this.createQuery(
         """
 SELECT evaka_child_id AS child_id, array_agg(evaka_service_need_id::uuid) AS service_need_ids
@@ -481,11 +485,12 @@ WHERE
   p.type = ANY(:vardaPlacementTypes::placement_type[])
   AND d.upload_children_to_varda = true
   AND sno.daycare_hours_per_week >= 1
-  AND sn.start_date <= current_date
+  AND sn.start_date <= :today
 )
 GROUP BY evaka_child_id
         """.trimIndent()
     )
+        .bind("today", clock.today())
         .bind("vardaPlacementTypes", vardaPlacementTypes)
         .map { row -> row.mapColumn<ChildId>("child_id") to row.mapColumn<List<ServiceNeedId>>("service_need_ids") }
         .toMap()

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaResetService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaResetService.kt
@@ -60,7 +60,7 @@ class VardaResetService(
 
     fun resetVardaChildByAsyncJob(db: Database.Connection, clock: EvakaClock, msg: VardaAsyncJob.ResetVardaChild) {
         logger.info("VardaUpdate: starting to reset child ${msg.childId}")
-        resetVardaChild(db, client, msg.childId, feeDecisionMinDate, municipalOrganizerOid)
+        resetVardaChild(db, clock, client, msg.childId, feeDecisionMinDate, municipalOrganizerOid)
     }
 
     fun deleteVardaChildByAsyncJob(db: Database.Connection, clock: EvakaClock, msg: VardaAsyncJob.DeleteVardaChild) {
@@ -95,10 +95,10 @@ class VardaResetService(
     }
 }
 
-private fun resetVardaChild(db: Database.Connection, client: VardaClient, childId: ChildId, feeDecisionMinDate: LocalDate, municipalOrganizerOid: String) {
+private fun resetVardaChild(db: Database.Connection, clock: EvakaClock, client: VardaClient, childId: ChildId, feeDecisionMinDate: LocalDate, municipalOrganizerOid: String) {
     if (deleteChildDataFromVardaAndDb(db, client, childId)) {
         try {
-            val childServiceNeeds = db.read { it.getServiceNeedsForVardaByChild(childId) }
+            val childServiceNeeds = db.read { it.getServiceNeedsForVardaByChild(clock, childId) }
             logger.info("VardaUpdate: found ${childServiceNeeds.size} service needs for child $childId to be sent")
             childServiceNeeds.forEachIndexed { idx, serviceNeedId ->
                 logger.info("VardaUpdate: sending service need $serviceNeedId for child $childId (${idx + 1}/${childServiceNeeds.size})")

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -61,7 +61,7 @@ class VardaUpdateService(
 
         logger.info("VardaUpdate: starting update process")
 
-        updateUnits(db, client, ophMunicipalityCode, ophMunicipalOrganizerIdUrl)
+        updateUnits(db, clock, client, ophMunicipalityCode, ophMunicipalOrganizerIdUrl)
 
         planVardaChildrenUpdate(db, clock)
     }
@@ -83,6 +83,7 @@ class VardaUpdateService(
                 serviceNeedDiffsByChild.values.map {
                     VardaAsyncJob.UpdateVardaChild(it)
                 },
+                runAt = clock.now(),
                 retryCount = 2,
                 retryInterval = Duration.ofMinutes(10)
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -56,14 +56,14 @@ class VardaUpdateService(
 
     val client = VardaClient(tokenProvider, fuel, mapper, vardaEnv)
 
-    fun startVardaUpdate(db: Database.Connection) {
+    fun startVardaUpdate(db: Database.Connection, clock: EvakaClock) {
         val client = VardaClient(tokenProvider, fuel, mapper, vardaEnv)
 
         logger.info("VardaUpdate: starting update process")
 
         updateUnits(db, client, ophMunicipalityCode, ophMunicipalOrganizerIdUrl)
 
-        planVardaChildrenUpdate(db)
+        planVardaChildrenUpdate(db, clock)
     }
 
     /*
@@ -72,8 +72,8 @@ class VardaUpdateService(
             - For each new service need, IF related fee data exists, add all related data to varda
             - For each modified service need, delete old related data from varda and add new
      */
-    fun planVardaChildrenUpdate(db: Database.Connection) {
-        val serviceNeedDiffsByChild = getChildrenToUpdate(db, feeDecisionMinDate)
+    fun planVardaChildrenUpdate(db: Database.Connection, clock: EvakaClock) {
+        val serviceNeedDiffsByChild = getChildrenToUpdate(db, clock, feeDecisionMinDate)
 
         logger.info("VardaUpdate: will update ${serviceNeedDiffsByChild.entries.size} children")
 
@@ -96,9 +96,9 @@ class VardaUpdateService(
     }
 }
 
-fun getChildrenToUpdate(db: Database.Connection, feeDecisionMinDate: LocalDate): Map<ChildId, VardaChildCalculatedServiceNeedChanges> {
+fun getChildrenToUpdate(db: Database.Connection, clock: EvakaClock, feeDecisionMinDate: LocalDate): Map<ChildId, VardaChildCalculatedServiceNeedChanges> {
     val includedChildIds = db.read { it.getSuccessfullyVardaResetEvakaChildIds() }
-    val serviceNeedDiffsByChild = calculateEvakaVsVardaServiceNeedChangesByChild(db, feeDecisionMinDate)
+    val serviceNeedDiffsByChild = calculateEvakaVsVardaServiceNeedChangesByChild(db, clock, feeDecisionMinDate)
         .filter { includedChildIds.contains(it.key) }
     return serviceNeedDiffsByChild
 }
@@ -387,10 +387,10 @@ private fun calculateVardaFeeDataStartDate(fdStartDate: LocalDate, serviceNeedDa
     return if (serviceNeedDates.includes(fdStartDate)) fdStartDate else serviceNeedDates.start
 }
 
-fun calculateEvakaVsVardaServiceNeedChangesByChild(db: Database.Connection, feeDecisionMinDate: LocalDate): Map<ChildId, VardaChildCalculatedServiceNeedChanges> {
-    val evakaServiceNeedDeletionsByChild = db.read { it.calculateDeletedChildServiceNeeds() }
+fun calculateEvakaVsVardaServiceNeedChangesByChild(db: Database.Connection, clock: EvakaClock, feeDecisionMinDate: LocalDate): Map<ChildId, VardaChildCalculatedServiceNeedChanges> {
+    val evakaServiceNeedDeletionsByChild = db.read { it.calculateDeletedChildServiceNeeds(clock) }
 
-    val evakaServiceNeedChangesByChild = db.read { it.getEvakaServiceNeedChanges(feeDecisionMinDate) }
+    val evakaServiceNeedChangesByChild = db.read { it.getEvakaServiceNeedChanges(clock, feeDecisionMinDate) }
         .groupBy { it.evakaChildId }
 
     val additionsAndChangesToVardaByChild = evakaServiceNeedChangesByChild.entries.associate { evakaServiceNeedChangesForChild ->

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
@@ -33,7 +34,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
 
 @RestController
 class VasuController(
@@ -134,6 +134,7 @@ class VasuController(
     fun putDocument(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: VasuDocumentId,
         @RequestBody body: UpdateDocumentRequest
     ) {
@@ -175,7 +176,7 @@ class VasuController(
                                             storedEntry.edited
                                         else
                                             FollowupEntryEditDetails(
-                                                editedAt = LocalDate.now(),
+                                                editedAt = clock.today(),
                                                 editorId = EmployeeId(user.rawId()),
                                                 editorName = null
                                             ),

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
@@ -49,11 +49,12 @@ class VasuController(
     fun createDocument(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId,
         @RequestBody body: CreateDocumentRequest
     ): VasuDocumentId {
         Audit.VasuDocumentCreate.log(childId)
-        accessControl.requirePermissionFor(user, Action.Child.CREATE_VASU_DOCUMENT, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_VASU_DOCUMENT, childId)
 
         return db.connect { dbc ->
             dbc.transaction { tx ->
@@ -77,10 +78,11 @@ class VasuController(
     fun getVasuSummariesByChild(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<VasuDocumentSummary> {
         Audit.ChildVasuDocumentsRead.log(childId)
-        accessControl.requirePermissionFor(user, Action.Child.READ_VASU_DOCUMENT, childId)
+        accessControl.requirePermissionFor(user, clock, Action.Child.READ_VASU_DOCUMENT, childId)
 
         return db.connect { dbc -> dbc.read { tx -> tx.getVasuDocumentSummaries(childId) } }
     }
@@ -93,10 +95,11 @@ class VasuController(
     fun getDocument(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: VasuDocumentId
     ): VasuDocument {
         Audit.VasuDocumentRead.log(id)
-        accessControl.requirePermissionFor(user, Action.VasuDocument.READ, id)
+        accessControl.requirePermissionFor(user, clock, Action.VasuDocument.READ, id)
 
         return db.connect { dbc ->
             dbc.read { tx ->
@@ -139,7 +142,7 @@ class VasuController(
         @RequestBody body: UpdateDocumentRequest
     ) {
         Audit.VasuDocumentUpdate.log(id)
-        accessControl.requirePermissionFor(user, Action.VasuDocument.UPDATE, id)
+        accessControl.requirePermissionFor(user, clock, Action.VasuDocument.UPDATE, id)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -216,6 +219,7 @@ class VasuController(
     fun updateDocumentState(
         db: Database,
         user: AuthenticatedUser.Employee,
+        clock: EvakaClock,
         @PathVariable id: VasuDocumentId,
         @RequestBody body: ChangeDocumentStateRequest
     ) {
@@ -229,12 +233,12 @@ class VasuController(
 
         events.forEach { eventType ->
             when (eventType) {
-                PUBLISHED -> accessControl.requirePermissionFor(user, Action.VasuDocument.EVENT_PUBLISHED, id)
-                MOVED_TO_READY -> accessControl.requirePermissionFor(user, Action.VasuDocument.EVENT_MOVED_TO_READY, id)
-                RETURNED_TO_READY -> accessControl.requirePermissionFor(user, Action.VasuDocument.EVENT_RETURNED_TO_READY, id)
-                MOVED_TO_REVIEWED -> accessControl.requirePermissionFor(user, Action.VasuDocument.EVENT_MOVED_TO_REVIEWED, id)
-                RETURNED_TO_REVIEWED -> accessControl.requirePermissionFor(user, Action.VasuDocument.EVENT_RETURNED_TO_REVIEWED, id)
-                MOVED_TO_CLOSED -> accessControl.requirePermissionFor(user, Action.VasuDocument.EVENT_MOVED_TO_CLOSED, id)
+                PUBLISHED -> accessControl.requirePermissionFor(user, clock, Action.VasuDocument.EVENT_PUBLISHED, id)
+                MOVED_TO_READY -> accessControl.requirePermissionFor(user, clock, Action.VasuDocument.EVENT_MOVED_TO_READY, id)
+                RETURNED_TO_READY -> accessControl.requirePermissionFor(user, clock, Action.VasuDocument.EVENT_RETURNED_TO_READY, id)
+                MOVED_TO_REVIEWED -> accessControl.requirePermissionFor(user, clock, Action.VasuDocument.EVENT_MOVED_TO_REVIEWED, id)
+                RETURNED_TO_REVIEWED -> accessControl.requirePermissionFor(user, clock, Action.VasuDocument.EVENT_RETURNED_TO_REVIEWED, id)
+                MOVED_TO_CLOSED -> accessControl.requirePermissionFor(user, clock, Action.VasuDocument.EVENT_MOVED_TO_CLOSED, id)
             }.exhaust()
         }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuController.kt
@@ -69,7 +69,7 @@ class VasuController(
                     throw BadRequest("Template is not currently valid")
                 }
 
-                tx.insertVasuDocument(childId, template)
+                tx.insertVasuDocument(clock, childId, template)
             }
         }
     }
@@ -194,7 +194,7 @@ class VasuController(
                     }
                 )
 
-                tx.updateVasuDocumentMaster(id, transformedFollowupsVasu.content, body.childLanguage)
+                tx.updateVasuDocumentMaster(clock, id, transformedFollowupsVasu.content, body.childLanguage)
                 tx.revokeVasuGuardianHasGivenPermissionToShare(id)
             }
         }
@@ -249,7 +249,7 @@ class VasuController(
                 validateStateTransition(eventType = body.eventType, currentState = currentState)
 
                 if (events.contains(PUBLISHED)) {
-                    tx.publishVasuDocument(id)
+                    tx.publishVasuDocument(clock, id)
                 }
 
                 if (events.contains(MOVED_TO_CLOSED)) {

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuControllerCitizen.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.VasuDocumentId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -88,10 +89,11 @@ class VasuControllerCitizen(
     fun getDocument(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: VasuDocumentId
     ): CitizenGetVasuDocumentResponse {
         Audit.VasuDocumentReadByGuardian.log(id, user.rawId())
-        accessControl.requirePermissionFor(user, Action.Citizen.VasuDocument.READ, id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.VasuDocument.READ, id)
 
         return db.connect { dbc ->
             dbc.read { tx ->
@@ -109,10 +111,11 @@ class VasuControllerCitizen(
     fun givePermissionToShare(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: VasuDocumentId
     ) {
         Audit.VasuDocumentGivePermissionToShareByGuardian.log(id, user.rawId())
-        accessControl.requirePermissionFor(user, Action.Citizen.VasuDocument.GIVE_PERMISSION_TO_SHARE, id)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.VasuDocument.GIVE_PERMISSION_TO_SHARE, id)
 
         return db.connect { dbc ->
             dbc.transaction { it.setVasuGuardianHasGivenPermissionToShare(id, PersonId(user.rawId())) }

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuTemplateController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuTemplateController.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.VasuTemplateId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Conflict
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
@@ -61,11 +62,12 @@ class VasuTemplateController(
     fun editTemplate(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: VasuTemplateId,
         @RequestBody body: VasuTemplateUpdate
     ) {
         Audit.VasuTemplateEdit.log()
-        accessControl.requirePermissionFor(user, Action.VasuTemplate.UPDATE, id)
+        accessControl.requirePermissionFor(user, clock, Action.VasuTemplate.UPDATE, id)
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -85,11 +87,12 @@ class VasuTemplateController(
     fun copyTemplate(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: VasuTemplateId,
         @RequestBody body: CopyTemplateRequest
     ): VasuTemplateId {
         Audit.VasuTemplateCopy.log(id)
-        accessControl.requirePermissionFor(user, Action.VasuTemplate.COPY, id)
+        accessControl.requirePermissionFor(user, clock, Action.VasuTemplate.COPY, id)
 
         return db.connect { dbc ->
             dbc.transaction {
@@ -121,10 +124,11 @@ class VasuTemplateController(
     fun getTemplate(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: VasuTemplateId
     ): VasuTemplate {
         Audit.VasuTemplateRead.log(id)
-        accessControl.requirePermissionFor(user, Action.VasuTemplate.READ, id)
+        accessControl.requirePermissionFor(user, clock, Action.VasuTemplate.READ, id)
 
         return db.connect { dbc -> dbc.read { tx -> tx.getVasuTemplate(id) } } ?: throw NotFound("template $id not found")
     }
@@ -133,10 +137,11 @@ class VasuTemplateController(
     fun deleteTemplate(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: VasuTemplateId
     ) {
         Audit.VasuTemplateDelete.log(id)
-        accessControl.requirePermissionFor(user, Action.VasuTemplate.DELETE, id)
+        accessControl.requirePermissionFor(user, clock, Action.VasuTemplate.DELETE, id)
 
         db.connect { dbc -> dbc.transaction { it.deleteUnusedVasuTemplate(id) } }
     }
@@ -145,11 +150,12 @@ class VasuTemplateController(
     fun putTemplateContent(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @PathVariable id: VasuTemplateId,
         @RequestBody content: VasuContent
     ) {
         Audit.VasuTemplateUpdate.log(id)
-        accessControl.requirePermissionFor(user, Action.VasuTemplate.UPDATE, id)
+        accessControl.requirePermissionFor(user, clock, Action.VasuTemplate.UPDATE, id)
 
         db.connect { dbc ->
             dbc.transaction { tx ->

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuTemplateController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuTemplateController.kt
@@ -119,7 +119,7 @@ class VasuTemplateController(
         Audit.VasuTemplateRead.log()
         accessControl.requirePermissionFor(user, clock, Action.Global.READ_VASU_TEMPLATE)
 
-        return db.connect { dbc -> dbc.read { tx -> tx.getVasuTemplates(validOnly) } }
+        return db.connect { dbc -> dbc.read { tx -> tx.getVasuTemplates(clock, validOnly) } }
     }
 
     @GetMapping("/{id}")

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuTemplateController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuTemplateController.kt
@@ -40,10 +40,11 @@ class VasuTemplateController(
     fun postTemplate(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestBody body: CreateTemplateRequest
     ): VasuTemplateId {
         Audit.VasuTemplateCreate.log()
-        accessControl.requirePermissionFor(user, Action.Global.CREATE_VASU_TEMPLATE)
+        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_VASU_TEMPLATE)
 
         return db.connect { dbc ->
             dbc.transaction {
@@ -112,10 +113,11 @@ class VasuTemplateController(
     fun getTemplates(
         db: Database,
         user: AuthenticatedUser,
+        clock: EvakaClock,
         @RequestParam(required = false) validOnly: Boolean = false
     ): List<VasuTemplateSummary> {
         Audit.VasuTemplateRead.log()
-        accessControl.requirePermissionFor(user, Action.Global.READ_VASU_TEMPLATE)
+        accessControl.requirePermissionFor(user, clock, Action.Global.READ_VASU_TEMPLATE)
 
         return db.connect { dbc -> dbc.read { tx -> tx.getVasuTemplates(validOnly) } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -55,7 +55,7 @@ class VtjController(
                 val (userDetails, ssn, children) = when (person.identity) {
                     is ExternalIdentifier.NoID ->
                         Triple(
-                            CitizenUserDetails.from(person, accessControlCitizen.getPermittedFeatures(tx, user)),
+                            CitizenUserDetails.from(person, accessControlCitizen.getPermittedFeatures(tx, user, clock)),
                             (person.identity as? ExternalIdentifier.SSN)?.ssn ?: "",
                             emptyList()
                         )
@@ -63,7 +63,7 @@ class VtjController(
                         personService.getPersonWithChildren(tx, user, personId)
                             ?.let {
                                 Triple(
-                                    CitizenUserDetails.from(it, accessControlCitizen.getPermittedFeatures(tx, user)),
+                                    CitizenUserDetails.from(it, accessControlCitizen.getPermittedFeatures(tx, user, clock)),
                                     it.socialSecurityNumber!!,
                                     it.children.map { Child.from(it) }
                                 )

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/controllers/VtjController.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.AccessControlCitizen
@@ -38,10 +39,11 @@ class VtjController(
     internal fun getDetails(
         db: Database,
         user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
         @PathVariable(value = "personId") personId: PersonId
     ): UserDetailsResponse {
         Audit.VtjRequest.log(targetId = personId)
-        accessControl.requirePermissionFor(user, Action.Citizen.Person.READ_VTJ_DETAILS, personId)
+        accessControl.requirePermissionFor(user, clock, Action.Citizen.Person.READ_VTJ_DETAILS, personId)
         val notFound = { throw NotFound("Person not found") }
         if (user.id != personId) {
             notFound()


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- pass EvakaClock to (almost) every function that depends on time. This adds boilerplate, but makes things more explicit and *simpler* because dependency on time is not hidden. It's much easier to reduce boilerplate than try to reliably test a large call stack of functions where some functions may call `HelsinkiDateTime.now()` or some similar thing, and some functions use EvakaClock. The solution is to use EvakaClock as much as possible and find other ways to fight boilerplate than magically conjuring current time (= an uncontrolled side effect) in random functions
- replace SQL `current_date`/`clock_timestamp`/`now` with bind parameters
- replace Instant with HelsinkiDateTime
- replace `LocalDate.now()` with EvakaClock. Note that `Localdate.now()` without parameters always returns current date *according to server timezone (= probably UTC)*, which can be wrong
- there are some remaining `HelsinkiDateTime.now` and `LocalDate.now` calls which still need to be replaced, but this pull request is already a bit too big
- in many cases a function is actually just interested in today/now and doesn't need the whole clock. I didn't want to spend time thinking on every single case in this pull request, so these can be refactored and simplified later

This pull request doesn't yet guarantee reliable tests, because it just makes it possible to use mocked clock and have it work (mostly) correctly. The next step is to (usually) replace `RealEvakaClock` in integration tests, and (usually) pass a mocked time in E2E tests.