### PR TITLE
Remove wrong info text for now

### DIFF
--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -1194,7 +1194,7 @@ export const fi = {
     },
     transitions: {
       guardiansWillBeNotified:
-        'Huoltajalle/huoltajille lähetetään sähköpostiin viesti, että eVakaan on julkaistu uusi dokumentti.',
+        'Suunnitelma julkaistaan huoltajien nähtäväksi eVakassa.',
       vasuIsPublishedToGuardians: 'Suunnitelma julkaistaan huoltajille',
       PUBLISHED: {
         buttonText: 'Julkaise suunnitelma',


### PR DESCRIPTION
#### Summary
- The vasu email notification seems to be missing functionality. Remove related info text until the functionality really exists
<img width="525" alt="Screenshot 2022-09-09 at 8 51 04" src="https://user-images.githubusercontent.com/158767/189280635-c9b67d68-e15a-4b8c-ac19-93d7e9297ca1.png">
