### PR TITLE
Vasu followup enhancements

### DIFF
--- a/frontend/src/citizen-frontend/children/sections/vasu-and-leops/vasu/components/FollowupQuestion.tsx
+++ b/frontend/src/citizen-frontend/children/sections/vasu-and-leops/vasu/components/FollowupQuestion.tsx
@@ -20,6 +20,7 @@ export default React.memo(function FollowupQuestion({
   translations,
   questionNumber
 }: FollowupQuestionProps) {
+  const nonEmptyEntries = value.filter((entry) => entry.text.trim() !== '')
   return (
     <FollowupQuestionContainer data-qa="vasu-followup-question">
       <H2>{title}</H2>
@@ -28,9 +29,9 @@ export default React.memo(function FollowupQuestion({
       }${name}`}</Label>
 
       <div>
-        {value.length > 0 ? (
+        {nonEmptyEntries.length > 0 ? (
           <ul>
-            {value.map((entry, ix) => (
+            {nonEmptyEntries.map((entry, ix) => (
               <li key={ix}>
                 {entry.date.format()}: {entry.text}
               </li>

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
@@ -99,6 +99,10 @@ export class VasuEditPage extends VasuPageCommon {
     }
   }
 
+  #followupAddBtn = this.page
+    .findByDataQa('vasu-followup-question')
+    .findByDataQa('followup-add-btn')
+
   readonly #vasuPreviewBtn = this.page.find('[data-qa="vasu-preview-btn"]')
   readonly #vasuContainer = this.page.find('[data-qa="vasu-container"]')
 
@@ -117,6 +121,10 @@ export class VasuEditPage extends VasuPageCommon {
 
   async setMultiSelectQuestionOptionText(key: string, text: string) {
     await this.#multiSelectQuestionOptionTextInput(key).fill(text)
+  }
+
+  async addFollowup() {
+    await this.#followupAddBtn.click()
   }
 
   async inputFollowupWithDateComment(

--- a/frontend/src/e2e-test/specs/5_employee/vasu.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/vasu.spec.ts
@@ -438,12 +438,15 @@ describe('Vasu document page', () => {
 
       test('Adding a followup comment renders it on the page', async () => {
         const vasuEditPage = await editDocument()
+        await vasuEditPage.addFollowup()
         await vasuEditPage.inputFollowupWithDateComment(
           'This is a followup',
           '01.04.2020',
           0,
           0
         )
+
+        await vasuEditPage.addFollowup()
         await vasuEditPage.inputFollowupWithDateComment(
           'A second one',
           '09.10.2021',

--- a/frontend/src/employee-frontend/components/vasu/components/FollowupQuestion.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/FollowupQuestion.tsx
@@ -206,11 +206,15 @@ export default React.memo(function FollowupQuestion({
           ))
         ) : (
           <ul>
-            {value.map((entry, ix) => (
-              <li key={ix} data-qa="follow-up-entry">
-                {entry.date.format()}: {entry.text}
-              </li>
-            ))}
+            {/* Render items with non-empty text. It's not allowed to remove an item
+            to retain the creator/editor info. */}
+            {value
+              .filter((entry) => entry.text.trim() !== '')
+              .map((entry, ix) => (
+                <li key={ix} data-qa="follow-up-entry">
+                  {entry.date.format()}: {entry.text}
+                </li>
+              ))}
           </ul>
         )}
       </div>


### PR DESCRIPTION
#### Summary

Before this change, an empty followup entry was created automatically to the end of the list. This change adds a button you have to click to add a new entry:
<img width="880" alt="Screenshot 2022-09-09 at 8 44 38" src="https://user-images.githubusercontent.com/70927/189280829-a97a6690-f29a-48b0-969c-4c8b51defd7a.png">

Also, followup entries with an empty text are not rendered anymore.