### PR TITLE
Add assistance decision maker options

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionEditPage.tsx
@@ -12,7 +12,9 @@ import styled from 'styled-components'
 import { renderResult } from 'employee-frontend/components/async-rendering'
 import AutosaveStatusIndicator from 'employee-frontend/components/common/AutosaveStatusIndicator'
 import { I18nContext, Lang, useTranslation } from 'employee-frontend/state/i18n'
-import { Failure } from 'lib-common/api'
+import { Employee } from 'employee-frontend/types/employee'
+import { AutosaveStatus } from 'employee-frontend/utils/use-autosave'
+import { Failure, Result } from 'lib-common/api'
 import {
   AssistanceNeedDecisionForm,
   AssistanceNeedDecisionLanguage
@@ -90,7 +92,7 @@ export default React.memo(function AssistanceNeedDecisionEditPage() {
 
   const { i18n } = useTranslation()
 
-  const { formState, setFormState, status, forceSave } =
+  const { decisionMakerOptions, formState, setFormState, status, forceSave } =
     useAssistanceNeedDecision(id)
 
   const navigate = useNavigate()
@@ -264,6 +266,8 @@ export default React.memo(function AssistanceNeedDecisionEditPage() {
               )}
               <I18nContext.Provider value={formLanguageState}>
                 <DecisionContents
+                  status={status}
+                  decisionMakerOptions={decisionMakerOptions}
                   child={child}
                   formState={formState}
                   setFormState={setFormState}
@@ -381,12 +385,16 @@ const FlexGap = styled.div`
 `
 
 const DecisionContents = React.memo(function DecisionContents({
+  status,
+  decisionMakerOptions,
   child,
   formState,
   setFormState,
   fieldInfos,
   onStartDateMissing
 }: {
+  status: AutosaveStatus
+  decisionMakerOptions: Result<Employee[]>
   child: PersonJSON
   formState?: AssistanceNeedDecisionForm
   setFormState: React.Dispatch<
@@ -420,6 +428,8 @@ const DecisionContents = React.memo(function DecisionContents({
       </FixedSpaceRow>
       {formState && (
         <AssistanceNeededDecisionForm
+          status={status}
+          decisionMakerOptions={decisionMakerOptions}
           formState={formState}
           setFormState={setFormState}
           fieldInfos={fieldInfos}

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/api.ts
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/api.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { Employee } from 'employee-frontend/types/employee'
 import { Failure, Result, Success } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import {
@@ -146,5 +147,23 @@ export function updateAssistanceNeedDecisionDecisionMaker(
   return client
     .post(`/assistance-need-decision/${id}/update-decision-maker`, { title })
     .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
+}
+
+export function getAssistanceDecisionMakerOptions(
+  id: UUID
+): Promise<Result<Employee[]>> {
+  return client
+    .get<JsonOf<Employee[]>>(
+      `/assistance-need-decision/${id}/decision-maker-option`
+    )
+    .then((res) =>
+      res.data.map((data) => ({
+        ...data,
+        created: HelsinkiDateTime.parseIso(data.created),
+        updated: HelsinkiDateTime.parseIso(data.updated)
+      }))
+    )
+    .then((v) => Success.of(v))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/lib-common/generated/action.d.ts
+++ b/frontend/src/lib-common/generated/action.d.ts
@@ -143,6 +143,7 @@ export type AssistanceNeedDecision =
   | 'DELETE'
   | 'MARK_AS_OPENED'
   | 'READ'
+  | 'READ_DECISION_MAKER_OPTIONS'
   | 'SEND'
   | 'UPDATE'
   | 'UPDATE_DECISION_MAKER'

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -70,6 +70,7 @@ enum class Audit(
     ChildAssistanceNeedDecisionGetUnreadCountCitizen("evaka.citizen.child.assistance-need-decision.get-unread-count"),
     ChildAssistanceNeedDecisionMarkReadCitizen("evaka.citizen.child.assistance-need-decision.mark-as-read"),
     ChildAssistanceNeedDecisionRead("evaka.child.assistance-need-decision.read"),
+    ChildAssistanceNeedDecisionReadDecisionMakerOptions("evaka.child.assistance-need-decision.read-decision-maker-options"),
     ChildAssistanceNeedDecisionReadCitizen("evaka.citizen.child.assistance-need-decision.read"),
     ChildAssistanceNeedDecisionUpdate("evaka.child.assistance-need-decision.update"),
     ChildAssistanceNeedDecisionsList("evaka.child.assistance-need-decision.list"),

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
@@ -11,6 +11,9 @@ import fi.espoo.evaka.decision.getSendAddress
 import fi.espoo.evaka.emailclient.IEmailClient
 import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.identity.ExternalIdentifier
+import fi.espoo.evaka.pis.Employee
+import fi.espoo.evaka.pis.getEmployees
+import fi.espoo.evaka.pis.getEmployeesByRoles
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.getChildGuardians
@@ -21,6 +24,7 @@ import fi.espoo.evaka.sficlient.SfiMessagesClient
 import fi.espoo.evaka.shared.AssistanceNeedDecisionId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
@@ -204,6 +208,19 @@ class AssistanceNeedDecisionService(
                     setVariable("hasAssistanceServices", decision.assistanceLevels.contains(AssistanceLevel.ASSISTANCE_SERVICES_FOR_TIME))
                 }
             )
+        )
+    }
+
+    fun getDecisionMakerOptions(tx: Database.Read, id: AssistanceNeedDecisionId, roles: Set<UserRole>): List<Employee> {
+        val assistanceDecision = tx.getAssistanceNeedDecisionById(id)
+        // original implementation
+        if (roles.isEmpty()) {
+            return tx.getEmployees().sortedBy { it.email }
+        }
+        return tx.getEmployeesByRoles(
+            globalRoles = roles.filter { it.isGlobalRole() },
+            unitScopedRoles = roles.filter { it.isUnitScopedRole() },
+            unitId = assistanceDecision.selectedUnit?.id
         )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.shared
 
 import fi.espoo.evaka.children.consent.ChildConsentType
+import fi.espoo.evaka.shared.auth.UserRole
 
 data class FeatureConfig(
     /** Does capacity factor affect voucher value decisions?
@@ -86,6 +87,12 @@ data class FeatureConfig(
 
     /** Controls whether permission to share is required for curriculum documents */
     val curriculumDocumentPermissionToShareRequired: Boolean,
+
+    /** Employees with given user roles to show as options for assistance decision makers.
+     *
+     * May contain global and unit scoped roles (empty = all roles are visible).
+     */
+    val assistanceDecisionMakerRoles: Set<UserRole> = emptySet(),
 
     /** The number of days citizens can move daycare start forward */
     val requestedStartUpperLimit: Int

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -355,6 +355,10 @@ sealed interface Action {
         override fun toString(): String = "${javaClass.name}.$name"
     }
     enum class AssistanceNeedDecision(override vararg val defaultRules: ScopedActionRule<in AssistanceNeedDecisionId>) : ScopedAction<AssistanceNeedDecisionId> {
+        READ_DECISION_MAKER_OPTIONS(
+            HasGlobalRole(SERVICE_WORKER),
+            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER).inPlacementUnitOfChildOfAssistanceNeedDecision()
+        ),
         UPDATE(HasGlobalRole(SERVICE_WORKER), HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER).inPlacementUnitOfChildOfAssistanceNeedDecision()),
         DELETE(HasGlobalRole(SERVICE_WORKER), HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER).inPlacementUnitOfChildOfAssistanceNeedDecision()),
         READ(


### PR DESCRIPTION
#### Summary

Currently assistance decision edit shows all employees as options for decision maker. In Tampere only directors and unit supervisors can be decision maker -> show only them with following customization feature config:

```
assistanceDecisionMakerRoles = setOf(UserRole.DIRECTOR, UserRole.UNIT_SUPERVISOR)
```

Default config behaves like before.