### PR TITLE
Move participant selection widget higher to give more space for list

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
@@ -575,6 +575,18 @@ const CreateEventModal = React.memo(function CreateEventModal({
       rejectAction={() => onClose(false)}
       rejectLabel={i18n.common.cancel}
     >
+      <Label>{i18n.unit.calendar.events.create.attendees}</Label>
+      <Gap size="xs" />
+      <TreeDropdown
+        tree={form.attendees}
+        onChange={(tree) => updateForm('attendees', tree)}
+        data-qa="attendees"
+        labels={i18n.common.treeDropdown}
+        placeholder={i18n.common.treeDropdown.placeholder}
+      />
+
+      <Gap size="s" />
+
       <Label>{i18n.unit.calendar.events.create.eventTitle}</Label>
       <InputField
         value={form.title}
@@ -599,18 +611,6 @@ const CreateEventModal = React.memo(function CreateEventModal({
         errorTexts={i18n.validationErrors}
         locale={lang}
         required={true}
-      />
-
-      <Gap size="s" />
-
-      <Label>{i18n.unit.calendar.events.create.attendees}</Label>
-      <Gap size="xs" />
-      <TreeDropdown
-        tree={form.attendees}
-        onChange={(tree) => updateForm('attendees', tree)}
-        data-qa="attendees"
-        labels={i18n.common.treeDropdown}
-        placeholder={i18n.common.treeDropdown.placeholder}
       />
 
       {childrenWithMissingPlacement.length > 0 && (


### PR DESCRIPTION
#### Summary
Some employees have a really limited height screens on which the event calendar participant selection list does not fit. It is also difficult to scroll without a roll button mouse. This change gives more space for the list to make so much room that everything that needs to fit on screen hopefully fits (needs to be tested by the employees to get confirmation)

