### PR TITLE
EVAKA-4420 show unit supervisor group messages to staff

### DIFF
--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -8,7 +8,8 @@ import {
   TextInput,
   Page,
   Checkbox,
-  MultiSelect
+  MultiSelect,
+  Combobox
 } from '../../../utils/page'
 
 export default class MessagesPage {
@@ -20,6 +21,7 @@ export default class MessagesPage {
     '[data-qa="close-message-editor-btn"]'
   )
   #discardMessageButton = this.page.find('[data-qa="discard-draft-btn"]')
+  #senderSelection = new Combobox(this.page.findByDataQa('select-sender'))
   #receiverSelection = new MultiSelect(
     this.page.find('[data-qa="select-receiver"]')
   )
@@ -27,12 +29,10 @@ export default class MessagesPage {
   #inputContent = new TextInput(this.page.find('[data-qa="input-content"]'))
   #fileUpload = this.page.find('[data-qa="upload-message-attachment"]')
   #personalAccount = this.page.find('[data-qa="personal-account"]')
-  #firstSentMessagesBoxRow = this.page
-    .findAll('[data-qa="message-box-row-SENT"]')
-    .first()
   #draftMessagesBoxRow = new TextInput(
     this.#personalAccount.find('[data-qa="message-box-row-DRAFTS"]')
   )
+  #messageCopiesInbox = this.page.findByDataQa('message-box-row-COPIES')
   #receivedMessage = this.page.find('[data-qa="received-message-row"]')
   #draftMessage = this.page.find('[data-qa="draft-message-row"]')
   #messageContent = (index = 0) =>
@@ -46,6 +46,7 @@ export default class MessagesPage {
     this.page.find('[data-qa="message-reply-content"]')
   )
   #urgent = new Checkbox(this.page.findByDataQa('checkbox-urgent'))
+  #emptyInboxText = this.page.findByDataQa('empty-inbox-text')
 
   async getReceivedMessageCount() {
     return await this.page.findAll('[data-qa="received-message-row"]').count()
@@ -60,6 +61,7 @@ export default class MessagesPage {
   }
 
   async assertMessageIsSentForParticipants(nth: number, participants: string) {
+    await this.page.findAll('[data-qa="message-box-row-SENT"]').first().click()
     await waitUntilEqual(
       () =>
         this.page
@@ -100,6 +102,7 @@ export default class MessagesPage {
     content: string
     urgent?: boolean
     attachmentCount?: number
+    sender?: string
     receiver?: string
   }) {
     const attachmentCount = message.attachmentCount ?? 0
@@ -109,6 +112,9 @@ export default class MessagesPage {
     await this.#inputTitle.fill(message.title)
     await this.#inputContent.fill(message.content)
 
+    if (message.sender) {
+      await this.#senderSelection.fillAndSelectFirst(message.sender)
+    }
     if (message.receiver) {
       await this.#receiverSelection.fillAndSelectFirst(message.receiver)
     } else {
@@ -132,9 +138,6 @@ export default class MessagesPage {
     }
     await this.#sendMessageButton.click()
     await waitUntilEqual(() => this.isEditorVisible(), false)
-
-    await this.#firstSentMessagesBoxRow.click()
-    await waitUntilTrue(() => this.existsSentMessage())
   }
 
   async addAttachment() {
@@ -199,5 +202,22 @@ export default class MessagesPage {
   async assertNoDrafts() {
     await this.#draftMessagesBoxRow.click()
     await this.#draftMessage.waitUntilHidden()
+  }
+
+  async assertCopyContent(title: string, content: string) {
+    await this.#messageCopiesInbox.click()
+    await waitUntilEqual(
+      () => this.page.findByDataQa('thread-list-item-title').innerText,
+      title
+    )
+    await waitUntilEqual(
+      () => this.page.findByDataQa('thread-list-item-content').innerText,
+      content
+    )
+  }
+
+  async assertNoCopies() {
+    await this.#messageCopiesInbox.click()
+    await this.#emptyInboxText.waitUntilVisible()
   }
 }

--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -201,7 +201,7 @@ export default class MessagesPage {
 
   async assertNoDrafts() {
     await this.#draftMessagesBoxRow.click()
-    await this.#draftMessage.waitUntilHidden()
+    await this.#emptyInboxText.waitUntilVisible()
   }
 
   async assertCopyContent(title: string, content: string) {

--- a/frontend/src/employee-frontend/components/Header.tsx
+++ b/frontend/src/employee-frontend/components/Header.tsx
@@ -203,9 +203,16 @@ export default React.memo(function Header() {
             isGroupMessageAccount
           )
           return (personal.length > 0 ? personal : group).reduce(
-            (sum, { account: { id: accountId } }) =>
-              sum +
-              (counts.find((c) => c.accountId === accountId)?.unreadCount || 0),
+            (sum, { account: { id: accountId } }) => {
+              const accountCounts = counts.find(
+                (c) => c.accountId === accountId
+              )
+              return (
+                sum +
+                (accountCounts?.unreadCount ?? 0) +
+                (accountCounts?.unreadCopyCount ?? 0)
+              )
+            },
             0
           )
         })

--- a/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
+++ b/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
@@ -14,7 +14,7 @@ import { faChevronDown, faChevronUp } from 'lib-icons'
 
 import MessageBox, { MessageBoxRow } from './MessageBox'
 import { MessageContext } from './MessageContext'
-import { AccountView, messageBoxes } from './types-view'
+import { AccountView, groupMessageBoxes } from './types-view'
 
 const AccountContainer = styled.div`
   margin: 12px 0;
@@ -88,7 +88,7 @@ export default function GroupMessageAccountList({
           startCollapsed={startCollapsed(acc, i)}
           title={acc.daycareGroup.name}
         >
-          {messageBoxes.map((view) => (
+          {groupMessageBoxes.map((view) => (
             <MessageBox
               key={view}
               view={view}

--- a/frontend/src/employee-frontend/components/messages/MessageBox.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageBox.tsx
@@ -45,12 +45,24 @@ export default function MessageBox({
   const { i18n } = useTranslation()
   const { unreadCountsByAccount } = useContext(MessageContext)
   const active = view == activeView?.view && account.id == activeView.account.id
-  const unreadCount =
-    (unreadCountsByAccount.isSuccess
-      ? unreadCountsByAccount.value.find(
-          ({ accountId }) => accountId === account.id
-        )?.unreadCount
-      : null) || 0
+  const unreadCount = unreadCountsByAccount
+    .map((unreadCounts) => {
+      if (view === 'RECEIVED') {
+        return (
+          unreadCounts.find(({ accountId }) => accountId === account.id)
+            ?.unreadCount ?? 0
+        )
+      }
+      if (view === 'COPIES') {
+        return (
+          unreadCounts.find(({ accountId }) => accountId === account.id)
+            ?.unreadCopyCount ?? 0
+        )
+      }
+
+      return 0
+    })
+    .getOrElse(0)
   return (
     <MessageBoxRow
       onClick={() => setView({ account: account, view: view })}
@@ -58,9 +70,7 @@ export default function MessageBox({
       data-qa={`message-box-row-${view}`}
     >
       {i18n.messages.messageBoxes.names[view]}{' '}
-      {view === 'RECEIVED' && unreadCount > 0 && (
-        <UnreadCount>{unreadCount}</UnreadCount>
-      )}
+      {unreadCount > 0 && <UnreadCount>{unreadCount}</UnreadCount>}
     </MessageBoxRow>
   )
 }

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -130,11 +130,7 @@ export default React.memo(function MessagesPage() {
           showEditor={() => setShowEditor(true)}
           setSelectedReceivers={setSelectedReceivers}
         />
-        {(selectedAccount?.view === 'RECEIVED' ||
-          selectedAccount?.view === 'SENT' ||
-          selectedAccount?.view === 'DRAFTS') && (
-          <MessageList {...selectedAccount} />
-        )}
+        {selectedAccount?.view && <MessageList {...selectedAccount} />}
         {showEditor &&
           accounts.isSuccess &&
           selectedReceivers &&

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -30,7 +30,7 @@ import GroupMessageAccountList from './GroupMessageAccountList'
 import MessageBox from './MessageBox'
 import { MessageContext } from './MessageContext'
 import { getReceivers } from './api'
-import { messageBoxes } from './types-view'
+import { personalMessageBoxes } from './types-view'
 
 const Container = styled.div`
   flex: 0 1 260px;
@@ -148,7 +148,7 @@ function Accounts({ accounts, setSelectedReceivers }: AccountsProps) {
       {personalAccount && (
         <AccountSection data-qa="personal-account">
           <AccountHeader>{i18n.messages.sidePanel.ownMessages}</AccountHeader>
-          {messageBoxes.map((view) => (
+          {personalMessageBoxes.map((view) => (
             <MessageBox
               key={view}
               view={view}

--- a/frontend/src/employee-frontend/components/messages/api.ts
+++ b/frontend/src/employee-frontend/components/messages/api.ts
@@ -4,14 +4,16 @@
 
 import { Failure, Paged, Result, Success } from 'lib-common/api'
 import {
+  deserializeMessageCopy,
   deserializeMessageThread,
   deserializeReplyResponse
 } from 'lib-common/api-types/messaging/message'
 import {
+  AuthorizedMessageAccount,
   DraftContent,
+  MessageCopy,
   MessageReceiversResponse,
   MessageThread,
-  AuthorizedMessageAccount,
   PostMessageBody,
   ReplyToMessageBody,
   SentMessage,
@@ -79,6 +81,21 @@ export async function getReceivedMessages(
         ...data,
         data: data.data.map((d) => deserializeMessageThread(d))
       })
+    )
+    .catch((e) => Failure.fromError(e))
+}
+
+export async function getMessageCopies(
+  accountId: UUID,
+  page: number,
+  pageSize: number
+): Promise<Result<Paged<MessageCopy>>> {
+  return client
+    .get<JsonOf<Paged<MessageCopy>>>(`/messages/${accountId}/copies`, {
+      params: { page, pageSize }
+    })
+    .then(({ data }) =>
+      Success.of({ ...data, data: data.data.map(deserializeMessageCopy) })
     )
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-frontend/components/messages/types-view.ts
+++ b/frontend/src/employee-frontend/components/messages/types-view.ts
@@ -4,11 +4,17 @@
 
 import { MessageAccount } from 'lib-common/generated/api-types/messaging'
 
-export type View = 'RECEIVED' | 'SENT' | 'DRAFTS'
+export type View = 'RECEIVED' | 'SENT' | 'DRAFTS' | 'COPIES'
 
 export interface AccountView {
   account: MessageAccount
   view: View
 }
 
-export const messageBoxes: View[] = ['RECEIVED', 'SENT', 'DRAFTS']
+export const personalMessageBoxes: View[] = ['RECEIVED', 'SENT', 'DRAFTS']
+export const groupMessageBoxes: View[] = [
+  'RECEIVED',
+  'SENT',
+  'DRAFTS',
+  'COPIES'
+]

--- a/frontend/src/lib-common/api-types/messaging/message.ts
+++ b/frontend/src/lib-common/api-types/messaging/message.ts
@@ -5,6 +5,7 @@
 import {
   Message,
   MessageAccount,
+  MessageCopy,
   MessageThread,
   ThreadReply
 } from '../../generated/api-types/messaging'
@@ -49,4 +50,12 @@ export const deserializeReplyResponse = (
 ): ThreadReply => ({
   threadId: responseData.threadId,
   message: deserializeMessage(responseData.message, staffAnnotation)
+})
+
+export const deserializeMessageCopy = (
+  json: JsonOf<MessageCopy>
+): MessageCopy => ({
+  ...json,
+  sentAt: HelsinkiDateTime.parseIso(json.sentAt),
+  readAt: json.readAt ? HelsinkiDateTime.parseIso(json.readAt) : null
 })

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -98,16 +98,6 @@ export interface MessageReceiver {
   childFirstName: string
   childId: UUID
   childLastName: string
-  receiverPersons: MessageReceiverPerson[]
-}
-
-/**
-* Generated from fi.espoo.evaka.messaging.MessageReceiverPerson
-*/
-export interface MessageReceiverPerson {
-  accountId: UUID
-  receiverFirstName: string
-  receiverLastName: string
 }
 
 /**
@@ -118,6 +108,22 @@ export interface MessageReceiversResponse {
   groupName: string
   receivers: MessageReceiver[]
 }
+
+/**
+* Generated from fi.espoo.evaka.messaging.MessageRecipient
+*/
+export interface MessageRecipient {
+  id: UUID
+  type: MessageRecipientType
+}
+
+/**
+* Generated from fi.espoo.evaka.messaging.MessageRecipientType
+*/
+export type MessageRecipientType =
+  | 'UNIT'
+  | 'GROUP'
+  | 'CHILD'
 
 /**
 * Generated from fi.espoo.evaka.messaging.MessageThread
@@ -144,8 +150,8 @@ export interface PostMessageBody {
   attachmentIds: UUID[]
   content: string
   draftId: UUID | null
-  recipientAccountIds: UUID[]
   recipientNames: string[]
+  recipients: MessageRecipient[]
   title: string
   type: MessageType
   urgent: boolean

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -91,6 +91,28 @@ export interface MessageAccount {
 }
 
 /**
+* Generated from fi.espoo.evaka.messaging.MessageCopy
+*/
+export interface MessageCopy {
+  attachments: MessageAttachment[]
+  content: string
+  messageId: UUID
+  readAt: HelsinkiDateTime | null
+  recipientAccountType: AccountType
+  recipientId: UUID
+  recipientName: string
+  recipientNames: string[]
+  senderAccountType: AccountType
+  senderId: UUID
+  senderName: string
+  sentAt: HelsinkiDateTime
+  threadId: UUID
+  title: string
+  type: MessageType
+  urgent: boolean
+}
+
+/**
 * Generated from fi.espoo.evaka.messaging.MessageReceiver
 */
 export interface MessageReceiver {
@@ -203,6 +225,7 @@ export interface ThreadReply {
 */
 export interface UnreadCountByAccount {
   accountId: UUID
+  unreadCopyCount: number
   unreadCount: number
 }
 
@@ -212,6 +235,7 @@ export interface UnreadCountByAccount {
 export interface UnreadCountByAccountAndGroup {
   accountId: UUID
   groupId: UUID
+  unreadCopyCount: number
   unreadCount: number
 }
 

--- a/frontend/src/lib-components/employee/messages/EmptyMessageFolder.tsx
+++ b/frontend/src/lib-components/employee/messages/EmptyMessageFolder.tsx
@@ -28,7 +28,7 @@ export default React.memo(function EmptyMessagesFolder({
       ) : (
         <>
           <FontAwesomeIcon icon={faFolderOpen} size="7x" color={iconColor} />
-          <H3>{text}</H3>
+          <H3 data-qa="empty-inbox-text">{text}</H3>
         </>
       )}
     </EmptyThreadViewContainer>

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -3327,7 +3327,8 @@ export const fi = {
       names: {
         RECEIVED: 'Saapuneet',
         SENT: 'Lähetetyt',
-        DRAFTS: 'Luonnokset'
+        DRAFTS: 'Luonnokset',
+        COPIES: 'Johtajan/kaupungin tiedotteet'
       },
       receivers: 'Vastaanottajat',
       newMessage: 'Uusi viesti'
@@ -3336,7 +3337,8 @@ export const fi = {
       titles: {
         RECEIVED: 'Saapuneet viestit',
         SENT: 'Lähetetyt viestit',
-        DRAFTS: 'Luonnokset'
+        DRAFTS: 'Luonnokset',
+        COPIES: 'Johtajan/kaupungin tiedotteet'
       }
     },
     types: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -157,7 +157,7 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                     .list()
 
             val contentId = tx.insertMessageContent("content", employeeAccount)
-            val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false)
+            val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false, isCopy = false)
             val messageId = tx.insertMessage(RealEvakaClock().now(), contentId, threadId, employeeAccount, allAccounts.map { it.name })
             tx.insertRecipients(allAccounts.map { it.id }.toSet(), messageId)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -104,15 +104,10 @@ class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest(reset
     @Test
     fun `notifications are sent to citizens`() {
         val employeeAccount = db.read { it.getEmployeeMessageAccountIds(employeeId).first() }
-        val personAccounts = db.read { tx ->
-            testPersons.map {
-                tx.getCitizenMessageAccount(it.id)
-            }
-        }
 
         postNewThread(
             sender = employeeAccount,
-            recipients = personAccounts,
+            recipients = listOf(MessageRecipient(MessageRecipientType.CHILD, testChild_1.id)),
             user = employee,
         )
         asyncJobRunner.runPendingJobsSync(RealEvakaClock())
@@ -128,7 +123,7 @@ class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest(reset
 
     private fun postNewThread(
         sender: MessageAccountId,
-        recipients: List<MessageAccountId>,
+        recipients: List<MessageRecipient>,
         user: AuthenticatedUser.Employee,
     ) {
         val (_, response) = http.post("/messages/$sender")
@@ -138,7 +133,7 @@ class MessageNotificationEmailServiceIntegrationTest : FullApplicationTest(reset
                         title = "Juhannus",
                         content = "Juhannus tulee pian",
                         type = MessageType.MESSAGE,
-                        recipientAccountIds = recipients.toSet(),
+                        recipients = recipients.toSet(),
                         recipientNames = listOf(),
                         urgent = false
                     )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -301,6 +301,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             ThreadWithParticipants(
                 threadId = threadId,
                 type = MessageType.MESSAGE,
+                isCopy = false,
                 senders = setOf(employee1Account),
                 recipients = setOf(person1Account, person2Account)
             ),
@@ -323,6 +324,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             ThreadWithParticipants(
                 threadId = threadId,
                 type = MessageType.MESSAGE,
+                isCopy = false,
                 senders = setOf(employee1Account, person2Account),
                 recipients = setOf(person1Account, person2Account, employee1Account)
             ),
@@ -505,7 +507,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
     ) =
         db.transaction { tx ->
             val contentId = tx.insertMessageContent(content, sender)
-            val threadId = tx.insertThread(MessageType.MESSAGE, title, urgent = false)
+            val threadId = tx.insertThread(MessageType.MESSAGE, title, urgent = false, isCopy = false)
             val messageId =
                 tx.insertMessage(
                     RealEvakaClock().now(),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
@@ -259,7 +259,7 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
             val personAccount = tx.createPersonMessageAccount(testAdult_1.id)
 
             val contentId = tx.insertMessageContent("content", employeeAccount)
-            val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false)
+            val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false, isCopy = false)
             val messageId = tx.insertMessage(RealEvakaClock().now(), contentId, threadId, employeeAccount, listOf("recipient name"))
             tx.insertRecipients(setOf(personAccount), messageId)
         }
@@ -278,7 +278,7 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
             val personAccount = tx.createPersonMessageAccount(testAdult_1.id)
 
             val contentId = tx.insertMessageContent("content", personAccount)
-            val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false)
+            val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false, isCopy = false)
             val messageId = tx.insertMessage(RealEvakaClock().now(), contentId, threadId, personAccount, listOf("employee name"))
             tx.insertRecipients(setOf(employeeAccount), messageId)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -226,7 +226,8 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                 urgent = false,
                 sender = senderDuplicateAccount,
                 recipientGroups = setOf(setOf(receiverAccount)),
-                recipientNames = listOf()
+                recipientNames = listOf(),
+                staffCopyRecipients = setOf()
             )
         }
         assertEquals(
@@ -275,7 +276,8 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                 urgent = false,
                 sender = senderAccount,
                 recipientGroups = setOf(setOf(receiverDuplicateAccount)),
-                recipientNames = listOf()
+                recipientNames = listOf(),
+                staffCopyRecipients = setOf()
             )
         }
         assertEquals(

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/DraftContent.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/DraftContent.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.messaging
 
 import fi.espoo.evaka.attachment.MessageAttachment
-import fi.espoo.evaka.shared.MessageAccountId
+import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.MessageDraftId
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.jdbi.v3.json.Json
@@ -17,7 +17,7 @@ data class DraftContent(
     val title: String,
     val content: String,
     val urgent: Boolean,
-    val recipientIds: Set<MessageAccountId>,
+    val recipientIds: Set<Id<*>>,
     val recipientNames: List<String>,
     @Json
     val attachments: List<MessageAttachment>,
@@ -28,6 +28,6 @@ data class UpdatableDraftContent(
     val title: String,
     val content: String,
     val urgent: Boolean,
-    val recipientIds: Set<MessageAccountId>,
+    val recipientIds: Set<Id<*>>,
     val recipientNames: List<String>,
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.attachment.MessageAttachment
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.MessageAccountId
 import fi.espoo.evaka.shared.MessageContentId
 import fi.espoo.evaka.shared.MessageId
@@ -67,8 +68,7 @@ data class MessageReceiver(
     val childId: ChildId,
     val childFirstName: String,
     val childLastName: String,
-    val childDateOfBirth: LocalDate,
-    val receiverPersons: List<MessageReceiverPerson>
+    val childDateOfBirth: LocalDate
 )
 
 enum class AccountType {
@@ -98,8 +98,10 @@ data class AuthorizedMessageAccount(
     val daycareGroup: Group?
 )
 
-data class MessageReceiverPerson(
-    val accountId: MessageAccountId,
-    val receiverFirstName: String,
-    val receiverLastName: String
-)
+enum class MessageRecipientType {
+    UNIT,
+    GROUP,
+    CHILD
+}
+
+data class MessageRecipient(val type: MessageRecipientType, val id: Id<*>)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -151,7 +151,7 @@ class MessageControllerCitizen(
             if (allReceiversValid) {
                 dbc.transaction { tx ->
                     val contentId = tx.insertMessageContent(body.content, accountId)
-                    val threadId = tx.insertThread(MessageType.MESSAGE, body.title, urgent = false)
+                    val threadId = tx.insertThread(MessageType.MESSAGE, body.title, urgent = false, isCopy = false)
                     val messageId =
                         tx.insertMessage(
                             now = clock.now(),

--- a/service/src/main/resources/db/migration/V269__message_thread_is_copy.sql
+++ b/service/src/main/resources/db/migration/V269__message_thread_is_copy.sql
@@ -1,0 +1,3 @@
+ALTER TABLE message_thread ADD COLUMN is_copy BOOLEAN;
+UPDATE message_thread SET is_copy = false;
+ALTER TABLE message_thread ALTER COLUMN is_copy SET NOT NULL;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -266,3 +266,4 @@ V265__finance_decisions_partner_constraint.sql
 V266__trim_external_staff_names.sql
 V267__calendar_events.sql
 V268__employee_preferred_first_name.sql
+V269__message_thread_is_copy.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Employee frontend's message receivers is refactored. Instead of picking the message accounts of all the final recipients (or guardians) in the frontend, the same selection that is shown in the UI is picked and the backend queries the final recipients. This is so that the backend knows when a message is send to the whole unit or group.