### PR TITLE
As sent_at is part of message thread identity ensure it stays the same

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -158,7 +158,7 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
 
             val contentId = tx.insertMessageContent("content", employeeAccount)
             val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false)
-            val messageId = tx.insertMessage(RealEvakaClock(), contentId, threadId, employeeAccount, allAccounts.map { it.name })
+            val messageId = tx.insertMessage(RealEvakaClock().now(), contentId, threadId, employeeAccount, allAccounts.map { it.name })
             tx.insertRecipients(allAccounts.map { it.id }.toSet(), messageId)
         }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -157,7 +157,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             val recipients = listOf(employee1Account)
             val contentId = it.insertMessageContent(content = "Just replying here", sender = person1Account)
             val messageId = it.insertMessage(
-                RealEvakaClock(),
+                RealEvakaClock().now(),
                 contentId = contentId,
                 threadId = thread2Id,
                 sender = person1Account,
@@ -310,7 +310,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         val participants2 = db.transaction { tx ->
             val contentId = tx.insertMessageContent("foo", person2Account)
             val messageId = tx.insertMessage(
-                RealEvakaClock(),
+                RealEvakaClock().now(),
                 contentId = contentId,
                 threadId = threadId,
                 sender = person2Account,
@@ -508,7 +508,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             val threadId = tx.insertThread(MessageType.MESSAGE, title, urgent = false)
             val messageId =
                 tx.insertMessage(
-                    RealEvakaClock(),
+                    RealEvakaClock().now(),
                     contentId = contentId,
                     threadId = threadId,
                     sender = sender,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
@@ -260,7 +260,7 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
 
             val contentId = tx.insertMessageContent("content", employeeAccount)
             val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false)
-            val messageId = tx.insertMessage(RealEvakaClock(), contentId, threadId, employeeAccount, listOf("recipient name"))
+            val messageId = tx.insertMessage(RealEvakaClock().now(), contentId, threadId, employeeAccount, listOf("recipient name"))
             tx.insertRecipients(setOf(personAccount), messageId)
         }
 
@@ -279,7 +279,7 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
 
             val contentId = tx.insertMessageContent("content", personAccount)
             val threadId = tx.insertThread(MessageType.MESSAGE, "title", urgent = false)
-            val messageId = tx.insertMessage(RealEvakaClock(), contentId, threadId, personAccount, listOf("employee name"))
+            val messageId = tx.insertMessage(RealEvakaClock().now(), contentId, threadId, personAccount, listOf("employee name"))
             tx.insertRecipients(setOf(employeeAccount), messageId)
         }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -154,7 +154,7 @@ class MessageControllerCitizen(
                     val threadId = tx.insertThread(MessageType.MESSAGE, body.title, urgent = false)
                     val messageId =
                         tx.insertMessage(
-                            clock = clock,
+                            now = clock.now(),
                             contentId = contentId,
                             threadId = threadId,
                             sender = accountId,

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -81,7 +81,7 @@ WHERE rec.message_id = msg.id
 }
 
 fun Database.Transaction.insertMessage(
-    clock: EvakaClock,
+    now: HelsinkiDateTime,
     contentId: MessageContentId,
     threadId: MessageThreadId,
     sender: MessageAccountId,
@@ -97,7 +97,7 @@ fun Database.Transaction.insertMessage(
         RETURNING id
     """.trimIndent()
     return createQuery(insertMessageSql)
-        .bind("now", clock.now())
+        .bind("now", now)
         .bind("contentId", contentId)
         .bind("threadId", threadId)
         .bind("repliesToId", repliesToMessageId)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
@@ -32,11 +32,12 @@ class MessageService(
         tx.insertMessageContent(content, sender)
             .also { contentId -> tx.reAssociateMessageAttachments(attachmentIds, contentId) }
             .let { contentId ->
+                val now = clock.now()
                 recipientGroups.map {
                     val threadId = tx.insertThread(type, title, urgent)
                     val messageId =
                         tx.insertMessage(
-                            clock = clock,
+                            now = now,
                             contentId = contentId,
                             threadId = threadId,
                             sender = sender,
@@ -70,7 +71,7 @@ class MessageService(
         val message = db.transaction { tx ->
             val recipientNames = tx.getAccountNames(recipientAccountIds)
             val contentId = tx.insertMessageContent(content, senderAccount)
-            val messageId = tx.insertMessage(clock, contentId, threadId, senderAccount, repliesToMessageId = replyToMessageId, recipientNames = recipientNames)
+            val messageId = tx.insertMessage(clock.now(), contentId, threadId, senderAccount, repliesToMessageId = replyToMessageId, recipientNames = recipientNames)
             tx.insertRecipients(recipientAccountIds, messageId)
             notificationEmailService.scheduleSendingMessageNotifications(tx, messageId)
             tx.getMessage(messageId)


### PR DESCRIPTION
#### Summary
When message is sent to multiple recipients, a message_thread is created to sender. The sent_at timestamp is part of the identity of the thread, so it must stay the same for each created message in order to avoid creating a thread per recipient

