### PR TITLE
Send financial decision sfi messages to restricted info recipient

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
@@ -187,12 +187,15 @@ data class FeeDecisionDetailed(
 
     val requiresManualSending
         get(): Boolean {
+            if (decisionType !== FeeDecisionType.NORMAL || headOfFamily.forceManualFeeDecisions) {
+                return true
+            }
+
             // Restricted will be sent to allow fast receiving via suomi.fi e-channel.
             if (headOfFamily.restrictedDetailsEnabled) {
                 return false
-            } else if (decisionType !== FeeDecisionType.NORMAL || headOfFamily.forceManualFeeDecisions) {
-                return true
             }
+
             return headOfFamily.let {
                 listOf(
                     it.ssn,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
@@ -187,7 +187,10 @@ data class FeeDecisionDetailed(
 
     val requiresManualSending
         get(): Boolean {
-            if (decisionType !== FeeDecisionType.NORMAL || headOfFamily.forceManualFeeDecisions) {
+            // Restricted will be sent to allow fast receiving via suomi.fi e-channel.
+            if (headOfFamily.restrictedDetailsEnabled) {
+                return false
+            } else if (decisionType !== FeeDecisionType.NORMAL || headOfFamily.forceManualFeeDecisions) {
                 return true
             }
             return headOfFamily.let {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/VoucherValueDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/VoucherValueDecisions.kt
@@ -227,7 +227,10 @@ data class VoucherValueDecisionDetailed(
 
     val requiresManualSending
         get(): Boolean {
-            if (decisionType !== VoucherValueDecisionType.NORMAL || headOfFamily.forceManualFeeDecisions) {
+            // Restricted will be sent to allow fast receiving via suomi.fi e-channel.
+            if (headOfFamily.restrictedDetailsEnabled) {
+                return false
+            } else if (decisionType !== VoucherValueDecisionType.NORMAL || headOfFamily.forceManualFeeDecisions) {
                 return true
             }
             return this.headOfFamily.let {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/VoucherValueDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/VoucherValueDecisions.kt
@@ -227,12 +227,15 @@ data class VoucherValueDecisionDetailed(
 
     val requiresManualSending
         get(): Boolean {
+            if (decisionType !== VoucherValueDecisionType.NORMAL || headOfFamily.forceManualFeeDecisions) {
+                return true
+            }
+
             // Restricted will be sent to allow fast receiving via suomi.fi e-channel.
             if (headOfFamily.restrictedDetailsEnabled) {
                 return false
-            } else if (decisionType !== VoucherValueDecisionType.NORMAL || headOfFamily.forceManualFeeDecisions) {
-                return true
             }
+
             return this.headOfFamily.let {
                 listOf(it.ssn, it.streetAddress, it.postalCode, it.postOffice).any { item -> item.isNullOrBlank() }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
@@ -197,10 +197,7 @@ class FeeDecisionService(
             error("Cannot send fee decision ${decision.id} - missing document key")
         }
 
-        // If receiver has restricted details enabled, still send the message via sfi so
-        // that if the receiver has the electric channel enabled he can receive the message that way,
-        // if not, the paper channel message is sent to financial handlers
-        if (!decision.headOfFamily.restrictedDetailsEnabled && decision.requiresManualSending) {
+        if (decision.requiresManualSending) {
             tx.setFeeDecisionWaitingForManualSending(decision.id)
             return false
         }
@@ -210,8 +207,8 @@ class FeeDecisionService(
 
         // If address is missing (restricted info enabled), use the financial handling address instead
         val sendAddress = DecisionSendAddress.fromPerson(recipient) ?: when (lang) {
-            "sv" -> messageProvider.getDefaultFeeDecisionAddress(MessageLanguage.SV)
-            else -> messageProvider.getDefaultFeeDecisionAddress(MessageLanguage.FI)
+            "sv" -> messageProvider.getDefaultFinancialDecisionAddress(MessageLanguage.SV)
+            else -> messageProvider.getDefaultFinancialDecisionAddress(MessageLanguage.FI)
         }
 
         val feeDecisionDisplayName =

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/PdfService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/PdfService.kt
@@ -130,8 +130,8 @@ class PDFService(
                 (decision.partnerIncome != null && decision.partnerIncome.effect != IncomeEffect.INCOME)
 
         val sendAddress = DecisionSendAddress.fromPerson(decision.headOfFamily) ?: when (lang.name) {
-            "sv" -> messageProvider.getDefaultFeeDecisionAddress(MessageLanguage.SV)
-            else -> messageProvider.getDefaultFeeDecisionAddress(MessageLanguage.FI)
+            "sv" -> messageProvider.getDefaultFinancialDecisionAddress(MessageLanguage.SV)
+            else -> messageProvider.getDefaultFinancialDecisionAddress(MessageLanguage.FI)
         }
 
         val isReliefDecision = decision.decisionType !== VoucherValueDecisionType.NORMAL
@@ -220,8 +220,8 @@ class PDFService(
         val totalIncome = listOfNotNull(decision.headOfFamilyIncome?.total, decision.partnerIncome?.total).sum()
 
         val sendAddress = DecisionSendAddress.fromPerson(decision.headOfFamily) ?: when (lang) {
-            "sv" -> messageProvider.getDefaultFeeDecisionAddress(MessageLanguage.SV)
-            else -> messageProvider.getDefaultFeeDecisionAddress(MessageLanguage.FI)
+            "sv" -> messageProvider.getDefaultFinancialDecisionAddress(MessageLanguage.SV)
+            else -> messageProvider.getDefaultFinancialDecisionAddress(MessageLanguage.FI)
         }
 
         val hideTotalIncome =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageProvider.kt
@@ -119,7 +119,7 @@ Klientavgiften för småbarnspedagogik gäller tills vidare och familjen är sky
         )
     }
 
-    override fun getDefaultFeeDecisionAddress(lang: MessageLanguage): DecisionSendAddress = when (lang) {
+    override fun getDefaultFinancialDecisionAddress(lang: MessageLanguage): DecisionSendAddress = when (lang) {
         MessageLanguage.FI -> DecisionSendAddress(
             "",
             "02700",

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/message/MessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/message/MessageProvider.kt
@@ -24,7 +24,7 @@ interface IMessageProvider {
     /**
      * Returns address used for fee decisions when person is missing address.
      */
-    fun getDefaultFeeDecisionAddress(lang: MessageLanguage): DecisionSendAddress
+    fun getDefaultFinancialDecisionAddress(lang: MessageLanguage): DecisionSendAddress
 }
 
 enum class MessageLanguage {


### PR DESCRIPTION
#### Summary
If financial decision recipient has restricted info enabled, send the message via suomi.fi. If the recipient has the sfi e-channel enabled he will receive the message immediately. If instead the paper channel is enabled, the decision is sent to financial handers who will then manually send it to the proper address
