### PR TITLE
Make ImageEditor buttons+disclaimer sticky

### DIFF
--- a/frontend/src/employee-mobile-frontend/components/attendances/child-info/ImageEditor.tsx
+++ b/frontend/src/employee-mobile-frontend/components/attendances/child-info/ImageEditor.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components'
 import { Failure, Result } from 'lib-common/api'
 import AsyncButton from 'lib-components/atoms/buttons/AsyncButton'
 import Button from 'lib-components/atoms/buttons/Button'
+import StickyFooter from 'lib-components/layout/StickyFooter'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { InformationText } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -141,55 +142,63 @@ export default React.memo(function ImageEditor({
   }, [imageElem, completedCrop])
 
   return (
-    <Container>
-      <CropWrapper>
-        <ReactCrop
-          src={image}
-          crop={crop}
-          onImageLoaded={setImageElem}
-          onChange={(c) => setCrop(c)}
-          onComplete={setCompletedCrop}
-          circularCrop
-        />
-        <canvas
-          ref={previewCanvasRef}
-          style={{
-            width: 256,
-            height: 256,
-            display: 'none'
-          }}
-        />
-      </CropWrapper>
-
+    <div>
+      <CropContainer>
+        <CropWrapper>
+          <ReactCrop
+            src={image}
+            crop={crop}
+            onImageLoaded={setImageElem}
+            onChange={(c) => setCrop(c)}
+            onComplete={setCompletedCrop}
+            circularCrop
+          />
+          <canvas
+            ref={previewCanvasRef}
+            style={{
+              width: 256,
+              height: 256,
+              display: 'none'
+            }}
+          />
+        </CropWrapper>
+      </CropContainer>
       <Gap />
+      <StickyFooter>
+        <FooterContainer>
+          <InformationText centered>
+            {i18n.childInfo.image.modalMenu.disclaimer}
+          </InformationText>
 
-      <InformationText centered>
-        {i18n.childInfo.image.modalMenu.disclaimer}
-      </InformationText>
-
-      <ButtonRow>
-        <Button
-          text={i18n.common.cancel}
-          onClick={onReturn}
-          disabled={submitting}
-        />
-        <AsyncButton
-          text={i18n.common.save}
-          primary
-          disabled={!completedCrop}
-          onClick={onSave}
-          onSuccess={onSuccess}
-        />
-      </ButtonRow>
-    </Container>
+          <ButtonRow>
+            <Button
+              text={i18n.common.cancel}
+              onClick={onReturn}
+              disabled={submitting}
+            />
+            <AsyncButton
+              text={i18n.common.save}
+              primary
+              disabled={!completedCrop}
+              onClick={onSave}
+              onSuccess={onSuccess}
+            />
+          </ButtonRow>
+        </FooterContainer>
+      </StickyFooter>
+    </div>
   )
 })
 
-const Container = styled.div`
+const CropContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: stretch;
+  margin: ${defaultMargins.m};
+`
+
+const FooterContainer = styled.div`
   margin: ${defaultMargins.m};
 `
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

If the edited image had an unfortunate aspect ratio and did not fit the screen, these things were not visible. It's possible to scroll the page, but it's unintuitive.

Before:

![Screenshot from 2022-09-22 11-38-33](https://user-images.githubusercontent.com/94033/191709437-8411cefa-f8e7-4eb6-ad1d-e0b7389e66dc.png)

After:

![Screenshot from 2022-09-22 11-38-14](https://user-images.githubusercontent.com/94033/191709394-42602fdc-2436-4418-b4f5-adfe6fb7a775.png)
