### PR TITLE
Citizen scroll page to top on navigation

### DIFF
--- a/frontend/src/citizen-frontend/AccessibilityStatement.tsx
+++ b/frontend/src/citizen-frontend/AccessibilityStatement.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import Main from 'lib-components/atoms/Main'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
@@ -11,18 +11,8 @@ import Container, { ContentArea } from 'lib-components/layout/Container'
 import Footer from './Footer'
 import { useTranslation } from './localization'
 
-export interface Props {
-  scrollToTop: () => void
-}
-
-export default React.memo(function AccessibilityStatement({
-  scrollToTop
-}: Props) {
+export default React.memo(function AccessibilityStatement() {
   const t = useTranslation()
-
-  // Scroll the main content area to top on first mount
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => scrollToTop(), [])
 
   return (
     <>

--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -3,12 +3,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { ErrorBoundary } from '@sentry/react'
-import React, { ReactNode, useCallback, useContext, useRef } from 'react'
+import React, { ReactNode, useCallback, useContext } from 'react'
 import { Route, BrowserRouter, Navigate, Routes } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import styled from 'styled-components'
 
-import { scrollElementToPos } from 'lib-common/utils/scrolling'
 import SkipToContent from 'lib-components/atoms/buttons/SkipToContent'
 import ErrorPage from 'lib-components/molecules/ErrorPage'
 import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
@@ -18,6 +17,7 @@ import AccessibilityStatement from './AccessibilityStatement'
 import CitizenReloadNotification from './CitizenReloadNotification'
 import LoginPage from './LoginPage'
 import RequireAuth from './RequireAuth'
+import ScrollToTop from './ScrollToTop'
 import ApplicationCreation from './applications/ApplicationCreation'
 import Applications from './applications/Applications'
 import ApplicationEditor from './applications/editor/ApplicationEditor'
@@ -94,38 +94,44 @@ const Content = React.memo(function Content() {
 
   const { modalOpen } = useContext(OverlayContext)
 
-  const mainRef = useRef<HTMLDivElement>(null)
-  const scrollMainToTop = useCallback(
-    () =>
-      scrollElementToPos(mainRef.current, {
-        top: 0,
-        left: 0,
-        behavior: 'auto'
-      }),
-    []
-  )
-
   return (
     <FullPageContainer>
       <SkipToContent target="main">{t.skipLinks.mainContent}</SkipToContent>
       <Header ariaHidden={modalOpen} />
       <CitizenReloadNotification />
-      <MainContainer ariaHidden={modalOpen} ref={mainRef}>
+      <MainContainer ariaHidden={modalOpen}>
         <Routes>
-          <Route path="/login" element={<LoginPage />} />
+          <Route
+            path="/login"
+            element={
+              <ScrollToTop>
+                <LoginPage />
+              </ScrollToTop>
+            }
+          />
           <Route
             path="/map"
-            element={<MapPage scrollToTop={scrollMainToTop} />}
+            element={
+              <ScrollToTop>
+                <MapPage />
+              </ScrollToTop>
+            }
           />
           <Route
             path="/accessibility"
-            element={<AccessibilityStatement scrollToTop={scrollMainToTop} />}
+            element={
+              <ScrollToTop>
+                <AccessibilityStatement />
+              </ScrollToTop>
+            }
           />
           <Route
             path="/applications"
             element={
               <RequireAuth>
-                <Applications />
+                <ScrollToTop>
+                  <Applications />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -133,7 +139,9 @@ const Content = React.memo(function Content() {
             path="/applications/new/:childId"
             element={
               <RequireAuth>
-                <ApplicationCreation />
+                <ScrollToTop>
+                  <ApplicationCreation />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -141,7 +149,9 @@ const Content = React.memo(function Content() {
             path="/applications/:applicationId"
             element={
               <RequireAuth>
-                <ApplicationReadView />
+                <ScrollToTop>
+                  <ApplicationReadView />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -149,7 +159,9 @@ const Content = React.memo(function Content() {
             path="/applications/:applicationId/edit"
             element={
               <RequireAuth>
-                <ApplicationEditor />
+                <ScrollToTop>
+                  <ApplicationEditor />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -157,7 +169,9 @@ const Content = React.memo(function Content() {
             path="/personal-details"
             element={
               <RequireAuth strength="WEAK">
-                <PersonalDetails />
+                <ScrollToTop>
+                  <PersonalDetails />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -165,7 +179,9 @@ const Content = React.memo(function Content() {
             path="/income"
             element={
               <RequireAuth>
-                <IncomeStatements />
+                <ScrollToTop>
+                  <IncomeStatements />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -173,7 +189,9 @@ const Content = React.memo(function Content() {
             path="/income/:incomeStatementId/edit"
             element={
               <RequireAuth>
-                <IncomeStatementEditor />
+                <ScrollToTop>
+                  <IncomeStatementEditor />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -181,7 +199,9 @@ const Content = React.memo(function Content() {
             path="/income/:incomeStatementId"
             element={
               <RequireAuth>
-                <IncomeStatementView />
+                <ScrollToTop>
+                  <IncomeStatementView />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -189,7 +209,9 @@ const Content = React.memo(function Content() {
             path="/child-income/:childId/:incomeStatementId/edit"
             element={
               <RequireAuth>
-                <ChildIncomeStatementEditor />
+                <ScrollToTop>
+                  <ChildIncomeStatementEditor />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -197,7 +219,9 @@ const Content = React.memo(function Content() {
             path="/child-income/:childId/:incomeStatementId"
             element={
               <RequireAuth>
-                <ChildIncomeStatementView />
+                <ScrollToTop>
+                  <ChildIncomeStatementView />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -205,7 +229,9 @@ const Content = React.memo(function Content() {
             path="/children/:childId"
             element={
               <RequireAuth>
-                <ChildPage />
+                <ScrollToTop>
+                  <ChildPage />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -213,7 +239,9 @@ const Content = React.memo(function Content() {
             path="/decisions"
             element={
               <RequireAuth>
-                <Decisions />
+                <ScrollToTop>
+                  <Decisions />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -221,7 +249,9 @@ const Content = React.memo(function Content() {
             path="/decisions/by-application/:applicationId"
             element={
               <RequireAuth>
-                <DecisionResponseList />
+                <ScrollToTop>
+                  <DecisionResponseList />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -229,7 +259,9 @@ const Content = React.memo(function Content() {
             path="/decisions/assistance/:id"
             element={
               <RequireAuth>
-                <AssistanceDecisionPage />
+                <ScrollToTop>
+                  <AssistanceDecisionPage />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -245,7 +277,9 @@ const Content = React.memo(function Content() {
             path="/messages"
             element={
               <RequireAuth strength="WEAK">
-                <MessagesPage />
+                <ScrollToTop>
+                  <MessagesPage />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -253,7 +287,9 @@ const Content = React.memo(function Content() {
             path="/calendar"
             element={
               <RequireAuth strength="WEAK">
-                <CalendarPage />
+                <ScrollToTop>
+                  <CalendarPage />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -261,7 +297,9 @@ const Content = React.memo(function Content() {
             path="/vasu/:id"
             element={
               <RequireAuth>
-                <VasuPage />
+                <ScrollToTop>
+                  <VasuPage />
+                </ScrollToTop>
               </RequireAuth>
             }
           />
@@ -273,27 +311,21 @@ const Content = React.memo(function Content() {
   )
 })
 
-// eslint-disable-next-line react/display-name
-const MainContainer = React.memo(
-  React.forwardRef(function MainContainer(
-    {
-      ariaHidden,
-      children
-    }: {
-      ariaHidden: boolean
-      children: ReactNode
-    },
-    ref: React.ForwardedRef<HTMLDivElement>
-  ) {
-    const { user } = useContext(AuthContext)
-    const render = useCallback(() => <>{children}</>, [children])
-    return (
-      <ScrollableMain aria-hidden={ariaHidden} ref={ref}>
-        <UnwrapResult result={user}>{render}</UnwrapResult>
-      </ScrollableMain>
-    )
-  })
-)
+const MainContainer = React.memo(function MainContainer({
+  ariaHidden,
+  children
+}: {
+  ariaHidden: boolean
+  children: ReactNode
+}) {
+  const { user } = useContext(AuthContext)
+  const render = useCallback(() => <>{children}</>, [children])
+  return (
+    <ScrollableMain aria-hidden={ariaHidden}>
+      <UnwrapResult result={user}>{render}</UnwrapResult>
+    </ScrollableMain>
+  )
+})
 
 function HandleRedirection() {
   const user = useUser()

--- a/frontend/src/citizen-frontend/ScrollToTop.tsx
+++ b/frontend/src/citizen-frontend/ScrollToTop.tsx
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React, { ReactChild, ReactChildren, useLayoutEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+import { scrollToPos } from 'lib-common/utils/scrolling'
+
+export default React.memo(function ScrollToTop({
+  children
+}: {
+  children: ReactChild | ReactChildren
+}) {
+  const location = useLocation()
+
+  useLayoutEffect(() => {
+    scrollToPos({ top: 0, left: 0, behavior: 'auto' })
+  }, [location.pathname])
+
+  return <>{children}</>
+})

--- a/frontend/src/citizen-frontend/children/ChildPage.tsx
+++ b/frontend/src/citizen-frontend/children/ChildPage.tsx
@@ -9,13 +9,11 @@ import { Failure, Success } from 'lib-common/api'
 import { Child } from 'lib-common/generated/api-types/children'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
 import Main from 'lib-components/atoms/Main'
-import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { Gap } from 'lib-components/white-space'
 
 import Footer from '../Footer'
 import { renderResult } from '../async-rendering'
-import { useTranslation } from '../localization'
 
 import ChildHeader from './ChildHeader'
 import ChildConsentsSection from './sections/consents/ChildConsentsSection'
@@ -25,7 +23,6 @@ import VasuAndLeopsSection from './sections/vasu-and-leops/VasuAndLeopsSection'
 import { ChildrenContext } from './state'
 
 export default React.memo(function ChildPage() {
-  const t = useTranslation()
   const { childId } = useNonNullableParams<{ childId: string }>()
   const { children } = useContext(ChildrenContext)
   const child = children.chain<Child>((children) => {
@@ -39,8 +36,6 @@ export default React.memo(function ChildPage() {
     <>
       <Main>
         <Container>
-          <Gap size="s" />
-          <ReturnButton label={t.common.return} />
           <Gap size="s" />
           {renderResult(child, (child) => (
             <>

--- a/frontend/src/citizen-frontend/map/MapPage.tsx
+++ b/frontend/src/citizen-frontend/map/MapPage.tsx
@@ -8,14 +8,10 @@ import Main from 'lib-components/atoms/Main'
 
 import MapView from './MapView'
 
-interface Props {
-  scrollToTop: () => void
-}
-
-export default React.memo(function MapPage({ scrollToTop }: Props) {
+export default React.memo(function MapPage() {
   return (
     <Main>
-      <MapView scrollToTop={scrollToTop} />
+      <MapView />
     </Main>
   )
 })

--- a/frontend/src/citizen-frontend/map/MapView.tsx
+++ b/frontend/src/citizen-frontend/map/MapView.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import sortBy from 'lodash/sortBy'
-import React, { ReactNode, useEffect, useMemo, useState } from 'react'
+import React, { ReactNode, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { Result, Success } from 'lib-common/api'
@@ -87,11 +87,7 @@ async function fetchUnitsWithDistances(
   }
 }
 
-export interface Props {
-  scrollToTop: () => void
-}
-
-export default React.memo(function MapView({ scrollToTop }: Props) {
+export default React.memo(function MapView() {
   const t = useTranslation()
   const [mobileMode, setMobileMode] = useState<MobileMode>('map')
   const user = useUser()
@@ -105,10 +101,6 @@ export default React.memo(function MapView({ scrollToTop }: Props) {
   const [languages, setLanguages] = useState<Language[]>([])
   const [providerTypes, setProviderTypes] = useState<ProviderTypeOption[]>([])
   const [shiftCare, setShiftCare] = useState<boolean>(false)
-
-  // Scroll the main content area to top on first mount
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => scrollToTop(), [])
 
   const [allUnits] = useApiState(() => fetchUnits(careType), [careType])
 

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -85,7 +85,7 @@ const MessageContent = styled.div`
 `
 
 const ReplyToThreadButton = styled(InlineButton)`
-  padding-left: 28px;
+  margin-left: 28px;
 `
 
 const SingleMessage = React.memo(function SingleMessage({


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
In citizen frontend scroll every page to the top on navigation. Navigating back behaves similarly because there's no simple way to make it work like in a traditional web page.

Also:
- Fix messages reply button focus outline
- Remove back button in child page

