### PR TITLE
Disable SQL null coalescing for primitive types

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -447,8 +447,8 @@ fun Database.Read.fetchApplicationSummariesForGuardian(guardianId: PersonId): Li
             a.preferredStartDate, a.sentDate, a.type,
             a.childId, a.childName, a.childSsn,
             a.guardianId, concat(p.last_name, ' ', p.first_name) as guardianName,
-            a.connecteddaycare,
-            a.preparatoryeducation,
+            coalesce(a.connecteddaycare, false) AS connectedDaycare,
+            coalesce(a.preparatoryeducation, false) AS preparatoryEducation,
             d.name AS preferredUnitName,
             a.status
         FROM application_view a

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
@@ -338,7 +338,7 @@ fun Database.Read.getAssistanceNeedDecisionsForCitizen(
         """
         SELECT ad.id, ad.child_id, validity_period, status, decision_made, assistance_levels,
             selected_unit AS selected_unit_id, unit.name AS selected_unit_name,
-            (:guardianId = ANY(unread_guardian_ids)) AS is_unread
+            coalesce(:guardianId = ANY(unread_guardian_ids), false) AS is_unread
         FROM guardian g
         JOIN assistance_need_decision ad ON ad.child_id = g.child_id
         LEFT JOIN daycare unit ON unit.id = selected_unit

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
@@ -132,8 +132,8 @@ private fun Database.Read.getAttendanceReservationReport(
           count(*) FILTER (WHERE r.age < 3) AS child_count_under_3,
           count(*) FILTER (WHERE r.age >= 3) AS child_count_over_3,
           count(*) FILTER (WHERE r.age IS NOT NULL) AS child_count,
-          sum(r.service_need_factor * r.assistance_need_factor) AS capacity_factor,
-          round(sum(r.service_need_factor * r.assistance_need_factor) / 7, 1) AS staff_count_required
+          coalesce(sum(r.service_need_factor * r.assistance_need_factor), 0) AS capacity_factor,
+          coalesce(round(sum(r.service_need_factor * r.assistance_need_factor) / 7, 1), 0) AS staff_count_required
         FROM generate_series(:start, :end + interval '1 day' - interval '1 second', interval '30 minutes') dateTime
         CROSS JOIN groups g
         LEFT JOIN reservations r ON

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -20,6 +20,7 @@ import org.jdbi.v3.core.generic.GenericTypes
 import org.jdbi.v3.core.kotlin.KotlinPlugin
 import org.jdbi.v3.core.mapper.ColumnMapper
 import org.jdbi.v3.core.mapper.ColumnMapperFactory
+import org.jdbi.v3.core.mapper.ColumnMappers
 import org.jdbi.v3.core.mapper.RowMapperFactory
 import org.jdbi.v3.core.mapper.SingleColumnMapper
 import org.jdbi.v3.core.result.RowView
@@ -79,6 +80,7 @@ fun configureJdbi(jdbi: Jdbi): Jdbi {
         .installPlugin(PostgresPlugin())
         .installPlugin(Jackson2Plugin())
     jdbi.getConfig(Jackson2Config::class.java).mapper = jsonMapper
+    jdbi.getConfig(ColumnMappers::class.java).coalesceNullPrimitivesToDefaults = false
     jdbi.registerArgument(finiteDateRangeArgumentFactory)
     jdbi.registerArgument(dateRangeArgumentFactory)
     jdbi.registerArgument(timeRangeArgumentFactory)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

In our codebase it's always a bug to return NULL for a non-nullable type, even if the type is primitive.