### PR TITLE
Fix citizen calendar events query breaking sometimes

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
@@ -168,7 +168,7 @@ SELECT ce.id, cp.child_id, ce.period * daterange(dgp.start_date, dgp.end_date, '
          ELSE 'unit' END
 ) type, dg.id group_id, dg.name group_name, unit.id unit_id, unit.name unit_name
 FROM child_placement cp
-LEFT JOIN daycare_group_placement dgp ON dgp.daycare_placement_id = cp.id
+LEFT JOIN daycare_group_placement dgp ON cp.backup_group_id IS NULL AND dgp.daycare_placement_id = cp.id
 LEFT JOIN calendar_event_attendee cea
     ON cea.unit_id = cp.unit_id
     AND (cea.child_id IS NULL OR cea.child_id = cp.child_id)
@@ -178,8 +178,8 @@ LEFT JOIN daycare_group dg ON dg.id = cea.group_id
 LEFT JOIN daycare unit ON unit.id = cea.unit_id
 WHERE cp.period && ce.period
   AND ce.period && :range
-  -- dgp start date can be null when the child is in backup care; this is accounted in ce.period
-  AND (dgp.start_date IS NULL OR daterange(dgp.start_date, dgp.end_date, '[]') && ce.period)
+  AND daterange(dgp.start_date, dgp.end_date, '[]') && ce.period
+  AND daterange(dgp.start_date, dgp.end_date, '[]') && cp.period
         """.trimIndent()
     )
         .bind("guardianId", guardianId)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The query would sometimes break when backup placements would split the original placement in multiple parts because the group placement join had no check that it overlaps with the computed placements resulting in the intersection `ce.period * daterange(dgp.start_date, dgp.end_date, '[]') * cp.period` being empty. Also joins `group_placement` only if the `child_placement` is not a backup placement.