### PR TITLE
HOTFIX: Avoid fetching data twice on component mount

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildReservationsTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildReservationsTable.tsx
@@ -4,7 +4,7 @@
 
 import classNames from 'classnames'
 import sortBy from 'lodash/sortBy'
-import React, { useEffect, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 
 import {
@@ -43,6 +43,13 @@ interface Props {
 }
 
 export default React.memo(function ChildReservationsTable(props: Props) {
+  const { selectedDate } = props
+
+  // Reset edit state when the selected date changes
+  return <ChildReservations key={selectedDate.formatIso()} {...props} />
+})
+
+const ChildReservations = React.memo(function ChildReservations(props: Props) {
   const { operationalDays, onMakeReservationForChild, selectedDate } = props
   const { i18n } = useTranslation()
   const { editState, stopEditing, startEditing, ...editCallbacks } =
@@ -51,8 +58,6 @@ export default React.memo(function ChildReservationsTable(props: Props) {
       props.reloadReservations,
       props.unitId
     )
-
-  useEffect(stopEditing, [stopEditing, selectedDate])
 
   const allDayRows = useMemo(
     () =>


### PR DESCRIPTION
#### Summary

The `ChildReservationsTable` component (indirectly) called `reloadReservations` on mount. This caused useless database load, because the endpoint in question does heavy computations.

Fix by resetting component state properly.
