### PR TITLE
Hide header/footer from vasu print view

### DIFF
--- a/frontend/src/citizen-frontend/navigation/Header.tsx
+++ b/frontend/src/citizen-frontend/navigation/Header.tsx
@@ -109,6 +109,9 @@ const HeaderContainer = styled.header`
     max-width: 1344px;
     width: 1344px;
   }
+  @media print {
+    display: none;
+  }
 `
 
 const MobileOnly = styled.div`

--- a/frontend/src/citizen-frontend/navigation/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/MobileNav.tsx
@@ -150,6 +150,10 @@ const BottomBar = styled.nav`
   @media (min-width: ${desktopMin}) {
     display: none;
   }
+
+  @media print {
+    display: none;
+  }
 `
 
 const BottomBarLink = React.memo(function BottomBarLink({


### PR DESCRIPTION
#### Summary
Before fix: 
<img width="520" alt="Screenshot 2022-10-03 at 9 17 25" src="https://user-images.githubusercontent.com/158767/193512386-cdaca91f-4a5b-4e91-89a6-df5987a7dc67.png">
<img width="512" alt="Screenshot 2022-10-03 at 9 25 57" src="https://user-images.githubusercontent.com/158767/193513847-d24c7c40-b9de-4688-bf8c-5d9d871174f8.png">


After fix:
<img width="514" alt="Screenshot 2022-10-03 at 9 16 57" src="https://user-images.githubusercontent.com/158767/193512406-0cd04ff8-78ba-40e7-99ff-49ac71ceba2e.png">

<img width="491" alt="Screenshot 2022-10-03 at 9 26 55" src="https://user-images.githubusercontent.com/158767/193513864-0f7da262-7f73-4a33-8f72-a99559dc7e64.png">
