### PR TITLE
Fix keycloak fonts

### DIFF
--- a/keycloak/theme/evaka/login/theme.properties
+++ b/keycloak/theme/evaka/login/theme.properties
@@ -2,7 +2,7 @@ parent=keycloak
 import=common/keycloak
 locales=fi,sv,en
 # Inherit styles from parent and use custom css files
-styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css lib/zocial/zocial.css css/login.css css/shared.css css/hs-login.css
+styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css css/login.css css/shared.css css/hs-login.css
 
 # Add custom JS hooks
 scripts=js/customRegistrationValidation.js js/inputReset.js

--- a/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -149,7 +149,7 @@ server {
   add_header Report-To '{"group","csp-endpoint","max_age":31536000,"endpoints":[{"url":"https://$host/api/csp"}]}';
 
   set $loadFailedInlineScript "'sha256-z1vaAvxob9VDuw7klCB049Y2Xr6lf7KjhDrsLvsvcPU='"; # SHA256 calculated from the script contents
-  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
+  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' https://fonts.gstatic.com data:; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
   add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' ${loadFailedInlineScript}; frame-ancestors 'none'; form-action 'self';";
 
   # Tracing
@@ -341,7 +341,7 @@ server {
 
     limit_req  zone=req_zone burst=100 nodelay;
 
-    add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com data:; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; frame-ancestors 'self'; form-action 'self' ${formActionUrl}";
+    add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'; form-action 'self' ${formActionUrl}";
 
     proxy_ssl_verify off;
 

--- a/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -149,7 +149,7 @@ server {
   add_header Report-To '{"group","csp-endpoint","max_age":31536000,"endpoints":[{"url":"https://$host/api/csp"}]}';
 
   set $loadFailedInlineScript "'sha256-z1vaAvxob9VDuw7klCB049Y2Xr6lf7KjhDrsLvsvcPU='"; # SHA256 calculated from the script contents
-  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
+  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' https://fonts.gstatic.com data:; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
   add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' ${loadFailedInlineScript}; frame-ancestors 'none'; form-action 'self';";
 
   # Tracing

--- a/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -149,7 +149,7 @@ server {
   add_header Report-To '{"group","csp-endpoint","max_age":31536000,"endpoints":[{"url":"https://$host/api/csp"}]}';
 
   set $loadFailedInlineScript "'sha256-z1vaAvxob9VDuw7klCB049Y2Xr6lf7KjhDrsLvsvcPU='"; # SHA256 calculated from the script contents
-  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' https://fonts.gstatic.com data:; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
+  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
   add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' ${loadFailedInlineScript}; frame-ancestors 'none'; form-action 'self';";
 
   # Tracing
@@ -341,7 +341,7 @@ server {
 
     limit_req  zone=req_zone burst=100 nodelay;
 
-    add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'; form-action 'self' ${formActionUrl}";
+    add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com data:; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; frame-ancestors 'self'; form-action 'self' ${formActionUrl}";
 
     proxy_ssl_verify off;
 


### PR DESCRIPTION
#### Summary

Fixed error "Refused to load the stylesheet 'https://fonts.googleapis.com/css?family=Montserrat:200,300,400,700|Open+Sans:300,400,600,700' because it violates the following Content Security Policy directive".

Also fixes CSS file 404 error.