### PR TITLE
Attendance reservations speedup

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/AttendanceReservationsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/AttendanceReservationsControllerIntegrationTest.kt
@@ -1,0 +1,502 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.reservations
+
+import com.github.kittinunf.fuel.jackson.responseObject
+import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.dailyservicetimes.DailyServiceTimes
+import fi.espoo.evaka.dailyservicetimes.DailyServiceTimesType
+import fi.espoo.evaka.daycare.service.AbsenceCategory
+import fi.espoo.evaka.daycare.service.AbsenceType
+import fi.espoo.evaka.insertGeneralTestFixtures
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.EvakaUserId
+import fi.espoo.evaka.shared.Timeline
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.auth.insertDaycareAclRow
+import fi.espoo.evaka.shared.dev.DevDailyServiceTimes
+import fi.espoo.evaka.shared.dev.DevDaycareGroup
+import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.DevReservation
+import fi.espoo.evaka.shared.dev.insertTestAbsence
+import fi.espoo.evaka.shared.dev.insertTestBackUpCare
+import fi.espoo.evaka.shared.dev.insertTestChildAttendance
+import fi.espoo.evaka.shared.dev.insertTestDailyServiceTimes
+import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
+import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
+import fi.espoo.evaka.shared.dev.insertTestEmployee
+import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.insertTestReservation
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.TimeRange
+import fi.espoo.evaka.testChild_1
+import fi.espoo.evaka.testChild_4
+import fi.espoo.evaka.testChild_5
+import fi.espoo.evaka.testChild_6
+import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.testDaycare2
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class AttendanceReservationsControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
+    private val employeeId = EmployeeId(UUID.randomUUID())
+
+    private val mon = LocalDate.of(2021, 3, 1)
+    private val tue = LocalDate.of(2021, 3, 2)
+    private val wed = LocalDate.of(2021, 3, 3)
+    private val thu = LocalDate.of(2021, 3, 4)
+    private val fri = LocalDate.of(2021, 3, 5)
+    private val monFri = FiniteDateRange(mon, fri)
+
+    private val unitOperationalDays = monFri.dates().map {
+        UnitAttendanceReservations.OperationalDay(it, isHoliday = false)
+    }.toList()
+
+    private val testGroup1 = DevDaycareGroup(daycareId = testDaycare.id, name = "Test group 1")
+    private val testGroup2 = DevDaycareGroup(daycareId = testDaycare.id, name = "Test group 2")
+
+    @BeforeEach
+    fun beforeEach() {
+        db.transaction {
+            it.insertGeneralTestFixtures()
+            it.insertTestDaycareGroup(testGroup1)
+            it.insertTestDaycareGroup(testGroup2)
+
+            it.insertTestEmployee(DevEmployee(employeeId))
+            it.insertDaycareAclRow(testDaycare.id, employeeId, UserRole.STAFF)
+        }
+    }
+
+    @Test
+    fun `generates the correct result in all cases`() {
+        db.transaction {
+            val child1PlacementId = it.insertTestPlacement(
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                startDate = mon,
+                endDate = fri,
+            )
+            it.insertTestDaycareGroupPlacement(
+                daycarePlacementId = child1PlacementId,
+                groupId = testGroup1.id,
+                startDate = mon,
+                endDate = wed,
+            )
+            it.insertTestDaycareGroupPlacement(
+                daycarePlacementId = child1PlacementId,
+                groupId = testGroup2.id,
+                startDate = thu,
+                endDate = fri,
+            )
+            it.insertTestReservation(
+                DevReservation(
+                    childId = testChild_1.id,
+                    date = mon,
+                    startTime = LocalTime.of(8, 0),
+                    endTime = LocalTime.of(16, 0),
+                    createdBy = EvakaUserId(employeeId.raw),
+                )
+            )
+            it.insertTestChildAttendance(
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                arrived = HelsinkiDateTime.of(mon, LocalTime.of(8, 15)),
+                departed = HelsinkiDateTime.of(mon, LocalTime.of(16, 5)),
+            )
+            it.insertTestAbsence(
+                childId = testChild_1.id,
+                date = tue,
+                category = AbsenceCategory.BILLABLE,
+                absenceType = AbsenceType.OTHER_ABSENCE,
+                modifiedBy = EvakaUserId(employeeId.raw),
+            )
+
+            // No group placement -> ungrouped
+            // Placement doesn't cover the whole period
+            it.insertTestPlacement(
+                childId = testChild_4.id,
+                unitId = testDaycare.id,
+                startDate = wed,
+                endDate = fri,
+            )
+
+            // Placement in other unit, backup in this unit's group 2
+            it.insertTestPlacement(
+                childId = testChild_5.id,
+                unitId = testDaycare2.id,
+                startDate = mon,
+                endDate = fri,
+            )
+            it.insertTestBackUpCare(
+                childId = testChild_5.id,
+                unitId = testDaycare.id,
+                groupId = testGroup2.id,
+                startDate = fri,
+                endDate = fri,
+            )
+            it.insertTestDailyServiceTimes(
+                DevDailyServiceTimes(
+                    childId = testChild_5.id,
+                    validityPeriod = monFri.asDateRange(),
+                    type = DailyServiceTimesType.REGULAR,
+                    regularTimes = TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0)),
+                )
+            )
+
+            // Placed to this unit's group 1...
+            val child6PlacementId = it.insertTestPlacement(
+                childId = testChild_6.id,
+                unitId = testDaycare.id,
+                startDate = wed,
+                endDate = fri,
+            )
+            it.insertTestDaycareGroupPlacement(
+                daycarePlacementId = child6PlacementId,
+                groupId = testGroup1.id,
+                startDate = wed,
+                endDate = fri,
+            )
+            // ... and has a backup in another group in this unit
+            it.insertTestBackUpCare(
+                childId = testChild_6.id,
+                unitId = testDaycare.id,
+                groupId = testGroup2.id,
+                startDate = thu,
+                endDate = thu,
+            )
+            // ... and has a backup in another unit
+            it.insertTestBackUpCare(
+                childId = testChild_6.id,
+                unitId = testDaycare2.id,
+                startDate = fri,
+                endDate = fri,
+            )
+            // Reservation is shown in the result because the child is in this unit
+            it.insertTestReservation(
+                DevReservation(
+                    childId = testChild_6.id,
+                    date = thu,
+                    startTime = LocalTime.of(9, 0),
+                    endTime = LocalTime.of(15, 0),
+                    createdBy = EvakaUserId(employeeId.raw),
+                )
+            )
+            // Reservation is NOT shown in the result because the child is in another unit
+            it.insertTestReservation(
+                DevReservation(
+                    childId = testChild_6.id,
+                    date = fri,
+                    startTime = LocalTime.of(7, 0),
+                    endTime = LocalTime.of(17, 0),
+                    createdBy = EvakaUserId(employeeId.raw),
+                )
+            )
+        }
+
+        val attendanceReservations = getAttendanceReservations()
+        assertEquals(testDaycare.name, attendanceReservations.unit)
+        assertEquals(unitOperationalDays, attendanceReservations.operationalDays)
+
+        val group1 = attendanceReservations.groups.find { it.group.id == testGroup1.id }!!
+        assertEquals(
+            listOf(
+                UnitAttendanceReservations.ChildDailyRecords(
+                    UnitAttendanceReservations.Child(
+                        testChild_1.id,
+                        testChild_1.firstName,
+                        testChild_1.lastName,
+                        testChild_1.dateOfBirth
+                    ),
+                    listOf(
+                        mapOf(
+                            mon to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = UnitAttendanceReservations.ReservationTimes("08:00", "16:00"),
+                                attendance = UnitAttendanceReservations.AttendanceTimes("08:15", "16:05"),
+                                absence = null,
+                                dailyServiceTimes = null,
+                                inOtherUnit = false,
+                            ),
+                            tue to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = null,
+                                attendance = null,
+                                absence = UnitAttendanceReservations.Absence(AbsenceType.OTHER_ABSENCE),
+                                dailyServiceTimes = null,
+                                inOtherUnit = false,
+                            ),
+                            wed to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = null,
+                                attendance = null,
+                                absence = null,
+                                dailyServiceTimes = null,
+                                inOtherUnit = false,
+                            ),
+                        )
+                    )
+                ),
+                UnitAttendanceReservations.ChildDailyRecords(
+                    UnitAttendanceReservations.Child(
+                        testChild_6.id,
+                        testChild_6.firstName,
+                        testChild_6.lastName,
+                        testChild_6.dateOfBirth
+                    ),
+                    listOf(
+                        mapOf(
+                            wed to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = null,
+                                attendance = null,
+                                absence = null,
+                                dailyServiceTimes = null,
+                                inOtherUnit = false,
+                            ),
+                            // Backup in group 2 => thu is missing
+                            // Backup in another unit
+                            fri to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = null,
+                                attendance = null,
+                                absence = null,
+                                dailyServiceTimes = null,
+                                inOtherUnit = true,
+                            ),
+                        )
+                    )
+                )
+            ),
+            group1.children.sortedBy { it.child.lastName }
+        )
+
+        val group2 = attendanceReservations.groups.find { it.group.id == testGroup2.id }!!
+        assertEquals(
+            listOf(
+                UnitAttendanceReservations.ChildDailyRecords(
+                    UnitAttendanceReservations.Child(
+                        testChild_1.id,
+                        testChild_1.firstName,
+                        testChild_1.lastName,
+                        testChild_1.dateOfBirth
+                    ),
+                    listOf(emptyChildRecords(FiniteDateRange(thu, fri)))
+                ),
+                UnitAttendanceReservations.ChildDailyRecords(
+                    UnitAttendanceReservations.Child(
+                        testChild_6.id,
+                        testChild_6.firstName,
+                        testChild_6.lastName,
+                        testChild_6.dateOfBirth
+                    ),
+                    listOf(
+                        mapOf(
+                            // Backup in group 2
+                            thu to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = UnitAttendanceReservations.ReservationTimes("09:00", "15:00"),
+                                attendance = null,
+                                absence = null,
+                                dailyServiceTimes = null,
+                                inOtherUnit = false
+                            ),
+                        )
+                    )
+                ),
+                UnitAttendanceReservations.ChildDailyRecords(
+                    UnitAttendanceReservations.Child(
+                        testChild_5.id,
+                        testChild_5.firstName,
+                        testChild_5.lastName,
+                        testChild_5.dateOfBirth
+                    ),
+                    listOf(
+                        mapOf(
+                            // Normally in another unit, backup in group 2
+                            fri to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = null,
+                                attendance = null,
+                                absence = null,
+                                dailyServiceTimes = DailyServiceTimes.RegularTimes(
+                                    TimeRange(
+                                        LocalTime.of(8, 0),
+                                        LocalTime.of(16, 0)
+                                    ),
+                                    monFri.asDateRange(),
+                                ),
+                                inOtherUnit = false
+                            ),
+                        )
+                    )
+                ),
+            ),
+            group2.children.sortedBy { it.child.lastName },
+        )
+
+        // Ungrouped
+        assertEquals(
+            listOf(
+                UnitAttendanceReservations.ChildDailyRecords(
+                    UnitAttendanceReservations.Child(
+                        testChild_4.id,
+                        testChild_4.firstName,
+                        testChild_4.lastName,
+                        testChild_4.dateOfBirth
+                    ),
+                    listOf(emptyChildRecords(FiniteDateRange(wed, fri)))
+                ),
+            ),
+            attendanceReservations.ungrouped.sortedBy { it.child.lastName }
+        )
+    }
+
+    @Test
+    fun `two reservations or attendances in the same day`() {
+        db.transaction { tx ->
+            val child1PlacementId = tx.insertTestPlacement(
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                startDate = mon,
+                endDate = fri,
+            )
+            tx.insertTestDaycareGroupPlacement(
+                daycarePlacementId = child1PlacementId,
+                groupId = testGroup1.id,
+                startDate = mon,
+                endDate = fri,
+            )
+            listOf(
+                DevReservation(
+                    childId = testChild_1.id,
+                    date = mon,
+                    startTime = LocalTime.of(19, 0),
+                    endTime = LocalTime.of(23, 59),
+                    createdBy = EvakaUserId(employeeId.raw),
+                ),
+                DevReservation(
+                    childId = testChild_1.id,
+                    date = tue,
+                    startTime = LocalTime.of(0, 0),
+                    endTime = LocalTime.of(8, 0),
+                    createdBy = EvakaUserId(employeeId.raw),
+                ),
+                DevReservation(
+                    childId = testChild_1.id,
+                    date = tue,
+                    startTime = LocalTime.of(17, 30),
+                    endTime = LocalTime.of(23, 59),
+                    createdBy = EvakaUserId(employeeId.raw),
+                ),
+                DevReservation(
+                    childId = testChild_1.id,
+                    date = wed,
+                    startTime = LocalTime.of(0, 0),
+                    endTime = LocalTime.of(9, 30),
+                    createdBy = EvakaUserId(employeeId.raw),
+                ),
+            ).forEach { tx.insertTestReservation(it) }
+
+            listOf(
+                Pair(
+                    HelsinkiDateTime.of(mon, LocalTime.of(19, 10)),
+                    HelsinkiDateTime.of(mon, LocalTime.of(23, 59))
+                ),
+                Pair(
+                    HelsinkiDateTime.of(tue, LocalTime.of(0, 0)),
+                    HelsinkiDateTime.of(tue, LocalTime.of(10, 30))
+                ),
+                Pair(
+                    HelsinkiDateTime.of(tue, LocalTime.of(17, 0)),
+                    null,
+                ),
+            ).forEach {
+                tx.insertTestChildAttendance(
+                    childId = testChild_1.id,
+                    unitId = testDaycare.id,
+                    arrived = it.first,
+                    departed = it.second,
+                )
+            }
+        }
+
+        val attendanceReservations = getAttendanceReservations()
+
+        val group1 = attendanceReservations.groups.find { it.group.id == testGroup1.id }!!
+        assertEquals(
+            listOf(
+                UnitAttendanceReservations.ChildDailyRecords(
+                    UnitAttendanceReservations.Child(
+                        testChild_1.id,
+                        testChild_1.firstName,
+                        testChild_1.lastName,
+                        testChild_1.dateOfBirth
+                    ),
+                    listOf(
+                        emptyChildRecords(monFri) + mapOf(
+                            mon to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = UnitAttendanceReservations.ReservationTimes("19:00", "23:59"),
+                                attendance = UnitAttendanceReservations.AttendanceTimes("19:10", "23:59"),
+                                absence = null,
+                                dailyServiceTimes = null,
+                                inOtherUnit = false,
+                            ),
+                            tue to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = UnitAttendanceReservations.ReservationTimes("00:00", "08:00"),
+                                attendance = UnitAttendanceReservations.AttendanceTimes("00:00", "10:30"),
+                                absence = null,
+                                dailyServiceTimes = null,
+                                inOtherUnit = false,
+                            ),
+                            wed to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = UnitAttendanceReservations.ReservationTimes("00:00", "09:30"),
+                                attendance = null,
+                                absence = null,
+                                dailyServiceTimes = null,
+                                inOtherUnit = false,
+                            ),
+                        ),
+
+                        // Second daily entries go to another map
+                        emptyChildRecords(monFri) + mapOf(
+                            tue to UnitAttendanceReservations.ChildRecordOfDay(
+                                reservation = UnitAttendanceReservations.ReservationTimes("17:30", "23:59"),
+                                attendance = UnitAttendanceReservations.AttendanceTimes("17:00", null),
+                                absence = null,
+                                dailyServiceTimes = null,
+                                inOtherUnit = false,
+                            ),
+                        )
+                    )
+                ),
+            ),
+            group1.children.sortedBy { it.child.lastName }
+        )
+
+        assertEquals(emptyList(), attendanceReservations.ungrouped)
+    }
+
+    private fun emptyChildRecords(timeline: Timeline): Map<LocalDate, UnitAttendanceReservations.ChildRecordOfDay> =
+        timeline.ranges().fold(emptyMap()) { acc, range -> acc + emptyChildRecords(range) }
+
+    private fun emptyChildRecords(period: FiniteDateRange): Map<LocalDate, UnitAttendanceReservations.ChildRecordOfDay> =
+        period.dates().map {
+            it to UnitAttendanceReservations.ChildRecordOfDay(
+                reservation = null,
+                attendance = null,
+                absence = null,
+                dailyServiceTimes = null,
+                inOtherUnit = false
+            )
+        }.toMap()
+
+    private fun getAttendanceReservations(): UnitAttendanceReservations {
+        val (_, response, body) = http.get("/attendance-reservations?unitId=${testDaycare.id}&from=$mon&to=$fri")
+            .asUser(AuthenticatedUser.Employee(employeeId, setOf(UserRole.STAFF)))
+            .responseObject<UnitAttendanceReservations>(jsonMapper)
+        assertEquals(200, response.statusCode)
+        return body.get()
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
+import fi.espoo.evaka.shared.db.mapJsonColumn
 import fi.espoo.evaka.shared.db.mapRow
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.EvakaClock
@@ -25,7 +26,6 @@ import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import org.jdbi.v3.core.mapper.Nested
 import org.jdbi.v3.core.mapper.PropagateNull
-import org.jdbi.v3.json.Json
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -49,34 +49,52 @@ class AttendanceReservationController(private val ac: AccessControl) {
     ): UnitAttendanceReservations {
         ac.requirePermissionFor(user, clock, Action.Unit.READ_ATTENDANCE_RESERVATIONS, unitId)
         if (to < from || from.plusMonths(1) < to) throw BadRequest("Invalid query dates")
-        val dateRange = FiniteDateRange(from, to)
+        val period = FiniteDateRange(from, to)
+
         return db.connect { dbc ->
             dbc.read { tx ->
                 val unitName = tx.getDaycare(unitId)?.name ?: throw NotFound("Unit $unitId not found")
-                val operationalDays = tx.getUnitOperationalDays(unitId, dateRange)
-                tx
-                    .getAttendanceReservationData(unitId, dateRange)
-                    .groupBy { it.group }
-                    .let { groupedReservations ->
-                        val ungroupedRows = groupedReservations[null]
+                val operationalDays = tx.getUnitOperationalDays(unitId, period)
 
-                        val childIds = groupedReservations.values.flatten().map { it.child.id }.toSet()
-                        val serviceTimes = tx.getDailyServiceTimes(childIds)
+                val effectiveGroupPlacements = tx.getEffectiveGroupPlacementsInRange(unitId, period)
 
-                        UnitAttendanceReservations(
-                            unit = unitName,
-                            operationalDays = operationalDays,
-                            groups = groupedReservations.entries.mapNotNull { (group, rows) ->
-                                if (group == null) null
-                                else UnitAttendanceReservations.GroupAttendanceReservations(
-                                    group = group,
-                                    children = toChildDayRows(rows, serviceTimes)
-                                )
-                            },
-                            ungrouped = ungroupedRows?.let { toChildDayRows(it, serviceTimes) }
-                                ?: emptyList()
+                val flatData = period.dates().flatMap { date ->
+                    effectiveGroupPlacements
+                        .filter { it.period.includes(date) }
+                        .groupBy { it.childId }
+                        // Find the correct placement status for each child on this date.
+                        // Precedence: Backup > Group placement > Placement
+                        .map { (childId, rows) ->
+                            val backup = rows.find { it.isBackup }
+                            val groupInOwnUnit = rows.find { it.group != null }?.group
+                            val group = if (backup != null && !backup.inOtherUnit) backup.group else groupInOwnUnit
+                            ChildPlacementStatus(
+                                date = date,
+                                childId = childId,
+                                group = group,
+                                inOtherUnit = backup?.inOtherUnit ?: false
+                            )
+                        }
+                }.toList()
+
+                val childIds = flatData.map { it.childId }.toSet()
+                val serviceTimes = tx.getDailyServiceTimes(childIds)
+                val childData = tx.getChildData(childIds, period)
+
+                val byGroup = flatData.groupBy { it.group }
+
+                UnitAttendanceReservations(
+                    unit = unitName,
+                    operationalDays = operationalDays,
+                    groups = byGroup.entries.mapNotNull { (group, rows) ->
+                        if (group == null) null
+                        else UnitAttendanceReservations.GroupAttendanceReservations(
+                            group = group,
+                            children = toChildDayRows(rows, serviceTimes, childData)
                         )
-                    }
+                    },
+                    ungrouped = byGroup[null]?.let { toChildDayRows(it, serviceTimes, childData) } ?: emptyList()
+                )
             }
         }.also {
             Audit.UnitAttendanceReservationsRead.log(
@@ -151,13 +169,11 @@ data class UnitAttendanceReservations(
     )
 
     data class AttendanceTimes(
-        @PropagateNull
         val startTime: String,
         val endTime: String?
     )
 
     data class Absence(
-        @PropagateNull
         val type: AbsenceType
     )
 
@@ -166,21 +182,6 @@ data class UnitAttendanceReservations(
         val firstName: String,
         val lastName: String,
         val dateOfBirth: LocalDate
-    )
-
-    data class QueryRow(
-        val date: LocalDate,
-        @Nested("group")
-        val group: ReservationGroup?,
-        @Nested
-        val child: Child,
-        @Json
-        val reservations: List<ReservationTimes>,
-        @Json
-        val attendances: List<AttendanceTimes>,
-        @Nested("absence")
-        val absence: Absence?,
-        val inOtherUnit: Boolean
     )
 }
 
@@ -198,74 +199,86 @@ private fun Database.Read.getUnitOperationalDays(unitId: DaycareId, dateRange: F
     .mapTo<UnitAttendanceReservations.OperationalDay>()
     .toList()
 
-private fun Database.Read.getAttendanceReservationData(unitId: DaycareId, dateRange: FiniteDateRange): List<UnitAttendanceReservations.QueryRow> {
-    val inOtherUnit = "rp.placement_unit_id <> rp.unit_id AND rp.placement_unit_id = :unitId"
+private data class ChildPlacementStatus(
+    val date: LocalDate,
+    val childId: ChildId,
+    val group: UnitAttendanceReservations.ReservationGroup?,
+    val inOtherUnit: Boolean,
+)
+
+private data class EffectiveGroupPlacementPeriod(
+    val period: FiniteDateRange,
+    val childId: ChildId,
+    @Nested("group")
+    val group: UnitAttendanceReservations.ReservationGroup?,
+    val isBackup: Boolean,
+    val inOtherUnit: Boolean,
+)
+
+private fun Database.Read.getEffectiveGroupPlacementsInRange(
+    unitId: DaycareId,
+    dateRange: FiniteDateRange
+): List<EffectiveGroupPlacementPeriod> {
     return createQuery(
         """
-        SELECT 
-            t::date AS date,
-            dg.id AS group_id,
-            dg.name AS group_name,
-            p.id,
-            p.first_name,
-            p.last_name,
-            p.date_of_birth,
-            (CASE WHEN ($inOtherUnit)
-                THEN '[]'
-                ELSE coalesce(res.reservations, '[]') END
-            ) AS reservations,
-            (CASE WHEN ($inOtherUnit)
-                THEN '[]'
-                ELSE coalesce(attendances.attendances, '[]') END
-            ) AS attendances,
-            ab.absence_type,
-            $inOtherUnit AS in_other_unit
-        FROM generate_series(:start, :end, '1 day') t
-        JOIN realized_placement_one(t::date) rp ON true
-        JOIN person p ON rp.child_id = p.id
-        LEFT JOIN daycare_group dg ON dg.id = (CASE WHEN ($inOtherUnit)
-            THEN rp.placement_group_id
-            ELSE rp.group_id END
-        )
-        LEFT JOIN LATERAL (
-            SELECT
-                jsonb_agg(
-                    jsonb_build_object(
-                        'startTime', to_char(att.start_time, 'HH24:MI'),
-                        'endTime', to_char(att.end_time, 'HH24:MI')
-                    ) ORDER BY att.start_time ASC
-                ) AS attendances
-            FROM child_attendance att WHERE att.child_id = p.id AND att.date = t::date
-        ) attendances ON true
-        LEFT JOIN LATERAL (
-            SELECT
-                jsonb_agg(
-                    jsonb_build_object(
-                        'startTime', to_char(ar.start_time, 'HH24:MI'),
-                        'endTime', to_char(ar.end_time, 'HH24:MI')
-                    ) ORDER BY ar.start_time ASC
-                ) AS reservations
-            FROM attendance_reservation ar WHERE ar.child_id = p.id AND ar.date = t::date
-        ) res ON true
-        LEFT JOIN LATERAL (
-            SELECT absence_type
-            FROM absence
-            WHERE absence.date = t::date AND absence.child_id = p.id
-            LIMIT 1
-        ) ab ON true
-        WHERE rp.unit_id = :unitId OR rp.placement_unit_id = :unitId
-        """.trimIndent()
+-- Placement without group
+SELECT
+    daterange(p.start_date, p.end_date, '[]') * :dateRange AS period,
+    p.child_id,
+    NULL AS group_id,
+    NULL AS group_name,
+    FALSE AS is_backup,
+    FALSE AS in_other_unit
+FROM placement p
+WHERE p.unit_id = :unitId AND daterange(p.start_date, p.end_date, '[]') && :dateRange
+
+UNION ALL
+
+-- Group placement
+SELECT
+    daterange(dgp.start_date, dgp.end_date, '[]') * :dateRange AS period,
+    p.child_id,
+    dgp.daycare_group_id AS group_id,
+    dg.name AS group_name,
+    FALSE AS is_backup,
+    FALSE AS in_other_unit
+FROM daycare_group_placement dgp
+JOIN placement p ON p.id = dgp.daycare_placement_id
+JOIN daycare_group dg ON dg.id = dgp.daycare_group_id
+WHERE p.unit_id = :unitId AND daterange(dgp.start_date, dgp.end_date, '[]') && :dateRange
+
+UNION ALL
+
+/*
+Backup placement
+- in own unit => use the backup group
+- in other unit => use no group, so the group is taken from own group placement
+*/
+SELECT
+    daterange(bc.start_date, bc.end_date, '[]') * :dateRange AS period,
+    bc.child_id,
+    CASE WHEN bc.unit_id <> :unitId THEN NULL ELSE bc.group_id END AS group_id,
+    CASE WHEN bc.unit_id <> :unitId THEN NULL ELSE dg.name END AS group_name,
+    TRUE AS is_backup,
+    bc.unit_id <> :unitId AS in_other_unit
+FROM placement p
+JOIN backup_care bc ON bc.child_id = p.child_id
+LEFT JOIN daycare_group dg ON dg.id = bc.group_id
+WHERE
+    (p.unit_id = :unitId OR bc.unit_id = :unitId) AND
+    daterange(p.start_date, p.end_date, '[]') && :dateRange AND
+    daterange(bc.start_date, bc.end_date, '[]') && :dateRange
+"""
     )
         .bind("unitId", unitId)
-        .bind("start", dateRange.start)
-        .bind("end", dateRange.end)
-        .mapTo<UnitAttendanceReservations.QueryRow>()
+        .bind("dateRange", dateRange)
+        .mapTo<EffectiveGroupPlacementPeriod>()
         .toList()
 }
 
-// currently queried separately to be able to use existing mapper
-private fun Database.Read.getDailyServiceTimes(childIds: Set<ChildId>) = createQuery(
-    """
+private fun Database.Read.getDailyServiceTimes(childIds: Set<ChildId>): Map<ChildId, List<DailyServiceTimes>> =
+    createQuery(
+        """
 SELECT
     id,
     child_id,
@@ -281,46 +294,152 @@ SELECT
     validity_period
 FROM daily_service_time
 WHERE child_id = ANY(:childIds)
-    """.trimIndent()
-)
-    .bind("childIds", childIds)
-    .map { row -> row.mapColumn<ChildId>("child_id") to toDailyServiceTimes(row.mapRow()).times }
-    .toList()
-    .groupBy { it.first }
-    .mapValues { it.value.map { it.second } }
+        """.trimIndent()
+    )
+        .bind("childIds", childIds)
+        .map { row -> row.mapColumn<ChildId>("child_id") to toDailyServiceTimes(row.mapRow()).times }
+        .toList()
+        .groupBy({ it.first }, { it.second })
 
-private fun toChildDayRows(rows: List<UnitAttendanceReservations.QueryRow>, serviceTimes: Map<ChildId, List<DailyServiceTimes>>): List<UnitAttendanceReservations.ChildDailyRecords> {
+private data class ChildData(
+    val child: UnitAttendanceReservations.Child,
+    val reservations: Map<LocalDate, List<UnitAttendanceReservations.ReservationTimes>>,
+    val attendances: Map<LocalDate, List<UnitAttendanceReservations.AttendanceTimes>>,
+    val absences: Map<LocalDate, UnitAttendanceReservations.Absence>,
+)
+
+private data class ReservationTimesForDate(
+    val date: LocalDate,
+    val startTime: String,
+    val endTime: String
+) {
+    fun toReservationTimes() = UnitAttendanceReservations.ReservationTimes(startTime, endTime)
+}
+
+private data class AttendanceTimesForDate(
+    val date: LocalDate,
+    val startTime: String,
+    val endTime: String?
+) {
+    fun toAttendanceTimes() = UnitAttendanceReservations.AttendanceTimes(startTime, endTime)
+}
+
+private data class AbsenceForDate(
+    val date: LocalDate,
+    val type: AbsenceType
+) {
+    fun toAbsence() = UnitAttendanceReservations.Absence(type)
+}
+
+private fun Database.Read.getChildData(childIds: Set<ChildId>, dateRange: FiniteDateRange): Map<ChildId, ChildData> {
+    return createQuery(
+        """
+SELECT            
+    p.id,
+    p.first_name,
+    p.last_name,
+    p.date_of_birth,
+    coalesce((
+        SELECT jsonb_agg(jsonb_build_object(
+            'date', to_char(ar.date, 'YYYY-MM-DD'),
+            'startTime', to_char(ar.start_time, 'HH24:MI'),
+            'endTime', to_char(ar.end_time, 'HH24:MI')
+        ) ORDER BY ar.date, ar.start_time)
+        FROM attendance_reservation ar WHERE ar.child_id = p.id AND between_start_and_end(:dateRange, ar.date)
+    ), '[]'::jsonb) AS reservations,
+    coalesce((
+        SELECT jsonb_agg(jsonb_build_object(
+            'date', to_char(att.date, 'YYYY-MM-DD'),
+            'startTime', to_char(att.start_time, 'HH24:MI'),
+            'endTime', to_char(att.end_time, 'HH24:MI')
+        ) ORDER BY att.date, att.start_time)
+        FROM child_attendance att WHERE att.child_id = p.id AND between_start_and_end(:dateRange, att.date)
+    ), '[]'::jsonb) AS attendances,
+    coalesce((
+        SELECT jsonb_agg(json_build_object(
+            'date', to_char(a.date, 'YYYY-MM-DD'),
+            'type', a.absence_type
+        ) ORDER BY a.date)
+        FROM absence a
+        WHERE a.child_id = p.id AND between_start_and_end(:dateRange, a.date)
+    ), '[]'::jsonb) AS absences
+FROM person p
+WHERE p.id = ANY(:childIds)
+"""
+    )
+        .bind("dateRange", dateRange)
+        .bind("childIds", childIds)
+        .map { row ->
+            ChildData(
+                child = UnitAttendanceReservations.Child(
+                    id = row.mapColumn("id"),
+                    firstName = row.mapColumn("first_name"),
+                    lastName = row.mapColumn("last_name"),
+                    dateOfBirth = row.mapColumn("date_of_birth"),
+                ),
+                reservations = row.mapJsonColumn<List<ReservationTimesForDate>>("reservations")
+                    .groupBy({ it.date }, { it.toReservationTimes() }),
+                attendances = row.mapJsonColumn<List<AttendanceTimesForDate>>("attendances")
+                    .groupBy({ it.date }, { it.toAttendanceTimes() }),
+                // The SQL query can return multiple absences for the same date, but here we only take one
+                absences = row.mapJsonColumn<List<AbsenceForDate>>("absences")
+                    .associateBy({ it.date }, { it.toAbsence() }),
+            )
+        }
+        .associateBy { it.child.id }
+}
+
+private fun toChildDayRows(
+    rows: List<ChildPlacementStatus>,
+    serviceTimes: Map<ChildId, List<DailyServiceTimes>>,
+    childData: Map<ChildId, ChildData>,
+): List<UnitAttendanceReservations.ChildDailyRecords> {
     return rows
-        .groupBy { it.child }
-        .map { (child, dailyData) ->
+        .groupBy { it.childId }
+        .map { (childId, dailyData) ->
+            val child = childData[childId] ?: throw IllegalStateException("Child data not found for child $childId")
+            val hasMultipleRecordsOnSomeDay = dailyData.any { placementStatus ->
+                val date = placementStatus.date
+                !placementStatus.inOtherUnit && (
+                    (child.reservations[date] ?: listOf()).size > 1 ||
+                        (child.attendances[date] ?: listOf()).size > 1
+                    )
+            }
             UnitAttendanceReservations.ChildDailyRecords(
-                child = child,
+                child = child.child,
                 dailyData = listOfNotNull(
                     dailyData.associateBy(
-                        keySelector = { it.date },
-                        valueTransform = { day ->
-                            UnitAttendanceReservations.ChildRecordOfDay(
-                                reservation = day.reservations.getOrNull(0),
-                                attendance = day.attendances.getOrNull(0),
-                                absence = day.absence,
-                                dailyServiceTimes = serviceTimes[child.id]?.find { it.validityPeriod.includes(day.date) },
-                                inOtherUnit = day.inOtherUnit
-                            )
-                        }
+                        { it.date },
+                        { dailyRecord(it, 0, child, serviceTimes[childId]) }
                     ),
-                    if (dailyData.any { it.reservations.size > 1 || it.attendances.size > 1 }) dailyData.associateBy(
-                        keySelector = { it.date },
-                        valueTransform = { day ->
-                            UnitAttendanceReservations.ChildRecordOfDay(
-                                reservation = day.reservations.getOrNull(1),
-                                attendance = day.attendances.getOrNull(1),
-                                absence = day.absence,
-                                dailyServiceTimes = serviceTimes[child.id]?.find { it.validityPeriod.includes(day.date) },
-                                inOtherUnit = day.inOtherUnit
-                            )
-                        }
-                    ) else null
+                    if (hasMultipleRecordsOnSomeDay) {
+                        dailyData.associateBy(
+                            { it.date },
+                            { dailyRecord(it, 1, child, serviceTimes[childId]) }
+                        )
+                    } else null
                 )
             )
         }
+}
+
+private fun dailyRecord(
+    placementStatus: ChildPlacementStatus,
+    rowIndex: Int,
+    childData: ChildData,
+    serviceTimes: List<DailyServiceTimes>?
+): UnitAttendanceReservations.ChildRecordOfDay {
+    val date = placementStatus.date
+    val inOtherUnit = placementStatus.inOtherUnit
+
+    val reservation = if (inOtherUnit) null else childData.reservations[date]?.getOrNull(rowIndex)
+    val attendance = if (inOtherUnit) null else childData.attendances[date]?.getOrNull(rowIndex)
+
+    return UnitAttendanceReservations.ChildRecordOfDay(
+        reservation = reservation,
+        attendance = attendance,
+        absence = childData.absences[date],
+        dailyServiceTimes = serviceTimes?.find { dst -> dst.validityPeriod.includes(date) },
+        inOtherUnit = inOtherUnit
+    )
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -1259,3 +1259,13 @@ VALUES (:id, :calendarEventId, :unitId, :groupId, :childId)
 RETURNING id
 """
 )
+
+fun Database.Transaction.insertTestDailyServiceTimes(dailyServiceTimes: DevDailyServiceTimes) =
+    createUpdate(
+        """
+INSERT INTO daily_service_time (id, child_id, type, validity_period, regular_times, monday_times, tuesday_times, wednesday_times, thursday_times, friday_times, saturday_times, sunday_times)
+VALUES (:id, :childId, :type, :validityPeriod, :regularTimes, :mondayTimes, :tuesdayTimes, :wednesdayTimes, :thursdayTimes, :fridayTimes, :saturdayTimes, :sundayTimes)
+"""
+    )
+        .bindKotlin(dailyServiceTimes)
+        .execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -180,6 +180,7 @@ import java.math.BigDecimal
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
@@ -1250,17 +1251,10 @@ INSERT INTO guardian (guardian_id, child_id) VALUES (:guardianId, :childId) ON C
         }
 
     @PostMapping("/daily-service-time")
-    fun addDailyServiceTime(db: Database, @RequestBody body: DevDailyServiceTime) =
+    fun addDailyServiceTime(db: Database, @RequestBody body: DevDailyServiceTimes) =
         db.connect { dbc ->
             dbc.transaction {
-                it.createUpdate(
-                    """
-                    INSERT INTO daily_service_time (id, child_id, type, validity_period, regular_times, monday_times, tuesday_times, wednesday_times, thursday_times, friday_times, saturday_times, sunday_times)
-                    VALUES (:id, :childId, :type, :validityPeriod, :regularTimes, :mondayTimes, :tuesdayTimes, :wednesdayTimes, :thursdayTimes, :fridayTimes, :saturdayTimes, :sundayTimes)
-                    """.trimIndent()
-                )
-                    .bindKotlin(body)
-                    .execute()
+                it.insertTestDailyServiceTimes(body)
             }
         }
 
@@ -1789,19 +1783,19 @@ data class DevStaffAttendance(
     val occupancyCoefficient: BigDecimal,
     val type: StaffAttendanceType
 )
-data class DevDailyServiceTime(
-    val id: DailyServiceTimesId,
+data class DevDailyServiceTimes(
+    val id: DailyServiceTimesId = DailyServiceTimesId(UUID.randomUUID()),
     val childId: ChildId,
-    val type: DailyServiceTimesType,
+    val type: DailyServiceTimesType = DailyServiceTimesType.REGULAR,
     val validityPeriod: DateRange,
-    val regularTimes: TimeRange?,
-    val mondayTimes: TimeRange?,
-    val tuesdayTimes: TimeRange?,
-    val wednesdayTimes: TimeRange?,
-    val thursdayTimes: TimeRange?,
-    val fridayTimes: TimeRange?,
-    val saturdayTimes: TimeRange?,
-    val sundayTimes: TimeRange?
+    val regularTimes: TimeRange = TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0)),
+    val mondayTimes: TimeRange? = null,
+    val tuesdayTimes: TimeRange? = null,
+    val wednesdayTimes: TimeRange? = null,
+    val thursdayTimes: TimeRange? = null,
+    val fridayTimes: TimeRange? = null,
+    val saturdayTimes: TimeRange? = null,
+    val sundayTimes: TimeRange? = null,
 )
 
 data class DevDailyServiceTimeNotification(


### PR DESCRIPTION
#### Summary

Replace the dreadful `generate_series` + `realized_placement_one` combo with more CPU-friendly reads from DB and data mangling in the Kotlin side.

Add integration tests for `AttendanceReservationsController`.