### PR TITLE
Simplify and speed up reading of a sent message

### DIFF
--- a/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
@@ -135,6 +135,7 @@ export default React.memo(function ThreadListContainer({
         messages: [
           {
             id: message.contentId,
+            threadId: message.contentId,
             sender: { ...account },
             sentAt: message.sentAt,
             recipients: message.recipients,
@@ -157,6 +158,7 @@ export default React.memo(function ThreadListContainer({
         messages: [
           {
             id: message.messageId,
+            threadId: message.threadId,
             sender: {
               id: message.senderId,
               name: message.senderName,

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -88,6 +88,7 @@ export interface Message {
   recipients: MessageAccount[]
   sender: MessageAccount
   sentAt: HelsinkiDateTime
+  threadId: UUID
 }
 
 /**

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
@@ -21,6 +21,7 @@ import java.time.LocalDate
 
 data class Message(
     val id: MessageId,
+    val threadId: MessageThreadId,
     @Json
     val sender: MessageAccount,
     @Json

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
@@ -99,7 +99,7 @@ class MessageService(
             val messageId = tx.insertMessage(now, contentId, threadId, senderAccount, repliesToMessageId = replyToMessageId, recipientNames = recipientNames)
             tx.insertRecipients(recipientAccountIds, messageId)
             notificationEmailService.scheduleSendingMessageNotifications(tx, messageId)
-            tx.getMessage(messageId)
+            tx.getSentMessage(senderAccount, messageId)
         }
         return ThreadReply(threadId, message)
     }


### PR DESCRIPTION
#### Summary

Aggregate the data in the database. Use a single `Message` type instead of multiple intermediate types. 

The SQL query in `getSentMessage()` is now almost identical with `getThreadMessages().`
