### PR TITLE
Fix children not being invoiced when they are split between parents

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementQueries.kt
@@ -587,6 +587,6 @@ ORDER BY p.date_of_birth, p.last_name, p.first_name, p.id
     )
         .bind("today", HelsinkiDateTime.now().toLocalDate())
         .bind("guardianId", guardianId)
-        .bind("invoicedPlacementTypes", PlacementType.invoiced())
+        .bind("invoicedPlacementTypes", PlacementType.invoiced)
         .mapTo<ChildBasicInfo>()
         .list()

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementType.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementType.kt
@@ -49,6 +49,7 @@ enum class PlacementType : DatabaseEnum {
     override val sqlType: String = "placement_type"
 
     companion object {
-        fun invoiced() = values().filter { it.isInvoiced() }
+        val temporary = listOf(TEMPORARY_DAYCARE, TEMPORARY_DAYCARE_PART_DAY)
+        val invoiced = values().filter { it.isInvoiced() }.filterNot { temporary.contains(it) }
     }
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Invoice generation assumed that families with children that are split between two fridge parents would still have two fee decisions, one for each parent. This caused some of the children not getting an invoice if their parent was not the head of family on a fee decision.

