### PR TITLE
Add partial absence thresholds feature config

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -205,4 +205,5 @@ val testFeatureConfig = FeatureConfig(
     curriculumDocumentPermissionToShareRequired = true,
     assistanceDecisionMakerRoles = null,
     requestedStartUpperLimit = 14,
+    partialAbsenceThresholdsEnabled = true,
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -132,6 +132,7 @@ class EspooConfig {
         curriculumDocumentPermissionToShareRequired = true,
         assistanceDecisionMakerRoles = null,
         requestedStartUpperLimit = 14,
+        partialAbsenceThresholdsEnabled = true,
     )
 
     @Bean

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -95,5 +95,8 @@ data class FeatureConfig(
     val assistanceDecisionMakerRoles: Set<UserRole>?,
 
     /** The number of days citizens can move daycare start forward */
-    val requestedStartUpperLimit: Int
+    val requestedStartUpperLimit: Int,
+
+    /** Control whether to use partial absence thresholds in child attendance departure **/
+    val partialAbsenceThresholdsEnabled: Boolean,
 )


### PR DESCRIPTION
#### Summary

This adds new feature config to disable "partial absence thresholds" functionality which seems pretty Espoo-specific with many hard coded arrival/departure times etc.