### PR TITLE
Fix employee mobile inputs staying behind Samsung on screen keyboard

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -253,7 +253,7 @@ function employeeMobile(flags) {
       fingerprints: !flags.isDevelopment,
       ios: true,
       name: 'eVaka',
-      display: 'fullscreen',
+      display: 'standalone',
       start_url: '/employee/mobile',
       background_color: '#ffffff',
       theme_color: '#3273c9',


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
With `display: 'fullscreen'` on Samsung phones the PWA browser window does not resize properly when the on screen keyboard is shown. That means that any inputs that are at the bottom of the screen are hidden behind the keyboard when focused.

