### PR TITLE
Do not sort by area

### DIFF
--- a/frontend/src/employee-frontend/components/reports/VoucherServiceProviders.tsx
+++ b/frontend/src/employee-frontend/components/reports/VoucherServiceProviders.tsx
@@ -152,12 +152,7 @@ export default React.memo(function VoucherServiceProviders() {
           childCount: childCount,
           sum: formatCents(monthlyPaymentSum, true)
         }))
-        .sort((l, r) =>
-          `${l.areaName}-${l.unitName}`.localeCompare(
-            `${r.areaName}-${r.unitName}`,
-            'fi'
-          )
-        )
+        .sort((l, r) => `${l.unitName}`.localeCompare(`${r.unitName}`, 'fi'))
     )
     .getOrElse(undefined)
 

--- a/frontend/src/employee-frontend/components/reports/VoucherServiceProviders.tsx
+++ b/frontend/src/employee-frontend/components/reports/VoucherServiceProviders.tsx
@@ -152,7 +152,7 @@ export default React.memo(function VoucherServiceProviders() {
           childCount: childCount,
           sum: formatCents(monthlyPaymentSum, true)
         }))
-        .sort((l, r) => `${l.unitName}`.localeCompare(`${r.unitName}`, 'fi'))
+        .sort((l, r) => l.unitName.localeCompare(r.unitName, 'fi'))
     )
     .getOrElse(undefined)
 


### PR DESCRIPTION
#### Summary
Consider three units in voucher service providers unit report: Area A Unit A, Area B Unit B and Area A unit C. Currently if there is no area filter selected the units are grouped by area and then sorted (ACB). Instead it should be ordered by name only when there is no area filter. Thus the correct order of units should then be ABC

