### PR TITLE
Hide decisions waiting mailing from citizen

### DIFF
--- a/frontend/src/citizen-frontend/decisions/api.ts
+++ b/frontend/src/citizen-frontend/decisions/api.ts
@@ -50,7 +50,7 @@ export async function getApplicationDecisions(
           ...decision,
           startDate: LocalDate.parseIso(decision.startDate),
           endDate: LocalDate.parseIso(decision.endDate),
-          sentDate: LocalDate.parseIso(decision.sentDate),
+          sentDate: LocalDate.parseNullableIso(decision.sentDate),
           requestedStartDate: LocalDate.parseNullableIso(
             decision.requestedStartDate
           ),

--- a/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
+++ b/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
@@ -154,7 +154,7 @@ export default React.memo(function DecisionResponse({
           {startDate.format()} - {endDate.format()}
         </span>
         <Label>{t.decisions.applicationDecisions.sentDate}</Label>
-        <span data-qa="decision-sent-date">{sentDate.format()}</span>
+        <span data-qa="decision-sent-date">{sentDate?.format() ?? ''}</span>
         <Label>{t.decisions.applicationDecisions.statusLabel}</Label>
         <Status data-qa="decision-status">
           <RoundIcon

--- a/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponseList.tsx
+++ b/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponseList.tsx
@@ -151,7 +151,7 @@ const sortDecisions = (
 ): DecisionWithValidStartDatePeriod[] =>
   orderBy(
     decisions,
-    ({ decision: { sentDate } }) => sentDate.toSystemTzDate(),
+    ({ decision: { sentDate } }) => sentDate?.toSystemTzDate(),
     'desc'
   )
 

--- a/frontend/src/employee-frontend/api/applications.ts
+++ b/frontend/src/employee-frontend/api/applications.ts
@@ -51,7 +51,7 @@ export async function getApplication(
         ...decision,
         startDate: LocalDate.parseIso(decision.startDate),
         endDate: LocalDate.parseIso(decision.endDate),
-        sentDate: LocalDate.parseIso(decision.sentDate),
+        sentDate: LocalDate.parseNullableIso(decision.sentDate),
         requestedStartDate: LocalDate.parseNullableIso(
           decision.requestedStartDate
         ),

--- a/frontend/src/employee-frontend/api/person.ts
+++ b/frontend/src/employee-frontend/api/person.ts
@@ -233,7 +233,7 @@ export async function getGuardianDecisions(
         ...data,
         startDate: LocalDate.parseIso(data.startDate),
         endDate: LocalDate.parseIso(data.endDate),
-        sentDate: LocalDate.parseIso(data.sentDate),
+        sentDate: LocalDate.parseNullableIso(data.sentDate),
         requestedStartDate: LocalDate.parseNullableIso(data.requestedStartDate),
         resolved: LocalDate.parseNullableIso(data.resolved)
       }))

--- a/frontend/src/employee-frontend/components/person-profile/PersonDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonDecisions.tsx
@@ -75,7 +75,7 @@ const PersonDecisions = React.memo(function PersonDecisions({
                       {decision.startDate.format()}
                     </DateTd>
                     <DateTd data-qa="decision-sent-date">
-                      {decision.sentDate.format()}
+                      {decision.sentDate?.format() ?? ''}
                     </DateTd>
                     <Td data-qa="decision-type">
                       {i18n.personProfile.application.types[decision.type]}

--- a/frontend/src/lib-common/generated/api-types/decision.ts
+++ b/frontend/src/lib-common/generated/api-types/decision.ts
@@ -24,7 +24,7 @@ export interface Decision {
   otherGuardianDocumentKey: string | null
   requestedStartDate: LocalDate | null
   resolved: LocalDate | null
-  sentDate: LocalDate
+  sentDate: LocalDate | null
   startDate: LocalDate
   status: DecisionStatus
   type: DecisionType

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.decision.DecisionStatus
 import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.decision.fetchDecisionDrafts
 import fi.espoo.evaka.decision.getDecisionsByApplication
+import fi.espoo.evaka.decision.getSentDecisionsByApplication
 import fi.espoo.evaka.insertApplication
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.data.getIncomesForPerson
@@ -1097,7 +1098,9 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             val decisionsByApplication = it.getDecisionsByApplication(applicationId, AclAuthorization.All)
             assertEquals(1, decisionsByApplication.size)
             val decision = decisionsByApplication.first()
-            assertNotNull(decision.sentDate)
+            if (!manualMailing) {
+                assertNotNull(decision.sentDate)
+            }
             assertNotNull(decision.documentKey)
 
             if (secondDecisionTo == null) {
@@ -1150,7 +1153,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_UNIT_CONFIRMATION, application.status)
 
-            val decisions = tx.getDecisionsByApplication(applicationId, AclAuthorization.All)
+            val decisions = tx.getSentDecisionsByApplication(applicationId, AclAuthorization.All)
             assertEquals(0, decisions.size)
         }
     }
@@ -1187,7 +1190,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_DECISION, application.status)
 
-            val decisions = tx.getDecisionsByApplication(applicationId, AclAuthorization.All)
+            val decisions = tx.getSentDecisionsByApplication(applicationId, AclAuthorization.All)
             assertEquals(0, decisions.size)
         }
     }
@@ -1303,7 +1306,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             val decisionDrafts = tx.fetchDecisionDrafts(applicationId)
             assertEquals(2, decisionDrafts.size)
 
-            val decisionsByApplication = tx.getDecisionsByApplication(applicationId, AclAuthorization.All)
+            val decisionsByApplication = tx.getSentDecisionsByApplication(applicationId, AclAuthorization.All)
             assertEquals(0, decisionsByApplication.size)
 
             val messages = MockSfiMessagesClient.getMessages()

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
@@ -9,9 +9,9 @@ import fi.espoo.evaka.decision.Decision
 import fi.espoo.evaka.decision.DecisionService
 import fi.espoo.evaka.decision.DecisionStatus
 import fi.espoo.evaka.decision.DecisionType
-import fi.espoo.evaka.decision.getDecision
-import fi.espoo.evaka.decision.getDecisionsByApplication
 import fi.espoo.evaka.decision.getOwnDecisions
+import fi.espoo.evaka.decision.getSentDecision
+import fi.espoo.evaka.decision.getSentDecisionsByApplication
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.ApplicationId
@@ -308,7 +308,7 @@ class ApplicationControllerCitizen(
         return db.connect { dbc ->
             dbc.read { tx ->
                 tx.fetchApplicationDetails(applicationId) ?: throw NotFound("Application not found")
-                tx.getDecisionsByApplication(applicationId, AclAuthorization.All).map {
+                tx.getSentDecisionsByApplication(applicationId, AclAuthorization.All).map {
                     DecisionWithValidStartDatePeriod(it, it.validRequestedStartDatePeriod(featureConfig))
                 }
             }
@@ -366,7 +366,7 @@ class ApplicationControllerCitizen(
         accessControl.requirePermissionFor(user, clock, Action.Citizen.Decision.DOWNLOAD_PDF, id)
 
         return db.connect { dbc ->
-            val decision = dbc.transaction { tx -> tx.getDecision(id) } ?: throw NotFound("Decision $id does not exist")
+            val decision = dbc.transaction { tx -> tx.getSentDecision(id) } ?: throw NotFound("Decision $id does not exist")
             decisionService.getDecisionPdf(dbc, decision)
         }.also {
             Audit.DecisionDownloadPdf.log(targetId = id)

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -35,6 +35,7 @@ import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.decision.clearDecisionDrafts
 import fi.espoo.evaka.decision.fetchDecisionDrafts
 import fi.espoo.evaka.decision.getDecisionsByApplication
+import fi.espoo.evaka.decision.markApplicationDecisionsSent
 import fi.espoo.evaka.decision.markDecisionAccepted
 import fi.espoo.evaka.decision.markDecisionRejected
 import fi.espoo.evaka.identity.ExternalIdentifier
@@ -441,6 +442,7 @@ class ApplicationStateService(
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_MAILING)
         tx.updateApplicationStatus(application.id, WAITING_CONFIRMATION)
+        tx.markApplicationDecisionsSent(application.id, clock.today())
         Audit.ApplicationConfirmDecisionsMailed.log(targetId = applicationId)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/Decision.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/Decision.kt
@@ -26,7 +26,7 @@ data class Decision(
     val documentKey: String?,
     val otherGuardianDocumentKey: String?,
     val decisionNumber: Long,
-    val sentDate: LocalDate,
+    val sentDate: LocalDate?,
     val status: DecisionStatus,
     val requestedStartDate: LocalDate?,
     val resolved: LocalDate?

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -216,6 +216,7 @@ class DecisionService(
                 logger.warn("Skipping sending decision $decisionId to application other guardian ${application.otherGuardianId} - not a current VTJ guardian")
             }
         }
+        tx.markDecisionSent(decisionId, clock.today())
     }
 
     fun deliverDecisionToGuardian(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Citizens would previously see decisions waiting mailing in their decisions page. Accepting or rejecting those decisions would still fail. Hide them until they are marked as sent.

