### PR TITLE
EVAKA-HOTFIX support applications for foster children without a SSN

### DIFF
--- a/frontend/src/citizen-frontend/applications/api.ts
+++ b/frontend/src/citizen-frontend/applications/api.ts
@@ -143,7 +143,13 @@ const deserializeApplicationsOfChild = (
 export const getApplicationChildren = (): Promise<Result<CitizenChildren[]>> =>
   client
     .get<JsonOf<CitizenChildren[]>>('/citizen/applications/children')
-    .then((res) => Success.of(res.data))
+    .then(({ data }) =>
+      data.map((child) => ({
+        ...child,
+        dateOfBirth: LocalDate.parseIso(child.dateOfBirth)
+      }))
+    )
+    .then((data) => Success.of(data))
     .catch((e) => Failure.fromError(e))
 
 export async function createApplication(

--- a/frontend/src/lib-common/api-types/application/ApplicationFormData.ts
+++ b/frontend/src/lib-common/api-types/application/ApplicationFormData.ts
@@ -114,15 +114,23 @@ export function apiDataToFormData(
   children: CitizenChildren[]
 ): ApplicationFormData {
   const vtjSiblings: VtjSibling[] = children
-    .filter(
-      (vtjChild) =>
-        vtjChild.socialSecurityNumber !==
-        application.form.child.person.socialSecurityNumber
+    .map(
+      ({ firstName, lastName, socialSecurityNumber }): VtjSibling | undefined =>
+        socialSecurityNumber
+          ? {
+              firstName,
+              lastName,
+              socialSecurityNumber,
+              selected: false
+            }
+          : undefined
     )
-    .map((child) => ({
-      ...child,
-      selected: false
-    }))
+    .filter(
+      (vtjChild): vtjChild is VtjSibling =>
+        !!vtjChild &&
+        vtjChild.socialSecurityNumber !==
+          application.form.child.person.socialSecurityNumber
+    )
 
   const vtjSiblingsSiblingBasis = vtjSiblings.map((sibling) => ({
     ...sibling,

--- a/frontend/src/lib-common/generated/api-types/application.ts
+++ b/frontend/src/lib-common/generated/api-types/application.ts
@@ -340,10 +340,11 @@ export interface CitizenApplicationSummary {
 * Generated from fi.espoo.evaka.application.CitizenChildren
 */
 export interface CitizenChildren {
+  dateOfBirth: LocalDate
   firstName: string
   id: UUID
   lastName: string
-  socialSecurityNumber: string
+  socialSecurityNumber: string | null
 }
 
 /**

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -522,19 +522,19 @@ fun Database.Read.fetchApplicationSummariesForCitizen(citizenId: PersonId): List
         .toList()
 }
 
-data class CitizenChildren(val id: ChildId, val firstName: String, val lastName: String, val socialSecurityNumber: String)
+data class CitizenChildren(val id: ChildId, val firstName: String, val lastName: String, val dateOfBirth: LocalDate, val socialSecurityNumber: String?)
 
 fun Database.Read.getCitizenChildren(today: LocalDate, citizenId: PersonId): List<CitizenChildren> {
     //language=sql
     val sql =
         """
-        SELECT child.id, first_name, last_name, social_security_number
+        SELECT child.id, first_name, last_name, date_of_birth, social_security_number
         FROM guardian LEFT JOIN person child ON guardian.child_id = child.id
         WHERE guardian_id = :citizenId
 
         UNION
 
-        SELECT child.id, first_name, last_name, social_security_number
+        SELECT child.id, first_name, last_name, date_of_birth, social_security_number
         FROM foster_parent JOIN person child ON foster_parent.child_id = child.id
         WHERE parent_id = :citizenId AND valid_during @> :today
         """.trimIndent()


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Applications page does not work at all if a parent has a foster child without a SSN. Previously citizens could make applications only for their own dependants who always had a SSN.

