### PR TITLE
Hide mobile message input when message is a copy

### DIFF
--- a/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
@@ -130,6 +130,7 @@ export default React.memo(function ThreadListContainer({
         type: message.type,
         title: message.threadTitle,
         urgent: message.urgent,
+        isCopy: false,
         participants: message.recipientNames,
         children: [],
         messages: [
@@ -153,6 +154,7 @@ export default React.memo(function ThreadListContainer({
       value.map((message) => ({
         ...message,
         id: message.threadId,
+        isCopy: true,
         participants: [message.recipientName],
         children: [],
         messages: [

--- a/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
+++ b/frontend/src/employee-mobile-frontend/components/messages/ThreadView.tsx
@@ -44,7 +44,7 @@ const getAccountsInThread = (
 }
 
 export const ThreadView = React.memo(function ThreadView({
-  thread: { id: threadId, messages, title },
+  thread: { id: threadId, messages, title, isCopy },
   onBack,
   senderAccountId
 }: ThreadViewProps) {
@@ -92,26 +92,28 @@ export const ThreadView = React.memo(function ThreadView({
         />
       ))}
       <div ref={endOfMessagesRef} />
-      <ThreadViewReplyContainer>
-        <ThreadViewReply>
-          <div className="thread-view-input-wrapper">
-            <TextArea
-              value={replyContent}
-              onChange={onUpdateContent}
-              className="thread-view-input"
-              placeholder={i18n.messages.inputPlaceholder}
-              data-qa="thread-reply-input"
-            />
-          </div>
-          <RoundIconButton
-            onClick={onSubmitReply}
-            disabled={replyContent.length === 0}
-            data-qa="thread-reply-button"
-          >
-            <FontAwesomeIcon icon={faArrowRight} />
-          </RoundIconButton>
-        </ThreadViewReply>
-      </ThreadViewReplyContainer>
+      {!isCopy && (
+        <ThreadViewReplyContainer>
+          <ThreadViewReply>
+            <div className="thread-view-input-wrapper">
+              <TextArea
+                value={replyContent}
+                onChange={onUpdateContent}
+                className="thread-view-input"
+                placeholder={i18n.messages.inputPlaceholder}
+                data-qa="thread-reply-input"
+              />
+            </div>
+            <RoundIconButton
+              onClick={onSubmitReply}
+              disabled={replyContent.length === 0}
+              data-qa="thread-reply-button"
+            >
+              <FontAwesomeIcon icon={faArrowRight} />
+            </RoundIconButton>
+          </ThreadViewReply>
+        </ThreadViewReplyContainer>
+      )}
     </ThreadViewMobile>
   )
 })

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -173,6 +173,7 @@ export type MessageRecipientType =
 export interface MessageThread {
   children: MessageChild[]
   id: UUID
+  isCopy: boolean
   messages: Message[]
   title: string
   type: MessageType

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
@@ -39,6 +39,7 @@ data class MessageThread(
     val type: MessageType,
     val title: String,
     val urgent: Boolean,
+    val isCopy: Boolean,
     val children: List<MessageChild>,
     @Json
     val messages: List<Message>,

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -226,6 +226,7 @@ private data class ReceivedThread(
     val title: String,
     val type: MessageType,
     val urgent: Boolean,
+    val isCopy: Boolean,
     @Json
     val children: List<MessageChild>,
 )
@@ -240,6 +241,7 @@ SELECT
     t.title,
     t.message_type AS type,
     t.urgent,
+    t.is_copy,
     coalesce((
         SELECT jsonb_agg(jsonb_build_object(
             'childId', mtc.child_id,
@@ -277,6 +279,7 @@ SELECT
     t.title,
     t.message_type AS type,
     t.urgent,
+    t.is_copy,
     coalesce((
         SELECT jsonb_agg(jsonb_build_object(
             'childId', mtc.child_id,
@@ -364,6 +367,7 @@ private fun combineThreadsAndMessages(accountId: MessageAccountId, threads: Page
                     type = thread.type,
                     title = thread.title,
                     urgent = thread.urgent,
+                    isCopy = thread.isCopy,
                     children = thread.children,
                     messages = messages,
                 )


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Message copies cannot be replied to anyway so hide the message reply input.

