### PR TITLE
Fix pedagogical document attachment access control check for foster parents

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -396,7 +396,8 @@ sealed interface Action {
         READ_MESSAGE_DRAFT_ATTACHMENT(IsEmployee.hasPermissionForAttachmentThroughMessageDraft()),
         READ_PEDAGOGICAL_DOCUMENT_ATTACHMENT(
             HasUnitRole(UNIT_SUPERVISOR, STAFF, SPECIAL_EDUCATION_TEACHER).withUnitFeatures(PilotFeature.VASU_AND_PEDADOC).inPlacementUnitOfChildOfPedagogicalDocumentOfAttachment(),
-            IsCitizen(allowWeakLogin = false).guardianOfChildOfPedagogicalDocumentOfAttachment()
+            IsCitizen(allowWeakLogin = false).guardianOfChildOfPedagogicalDocumentOfAttachment(),
+            IsCitizen(allowWeakLogin = false).fosterParentOfChildOfPedagogicalDocumentOfAttachment()
         ),
         DELETE_APPLICATION_ATTACHMENT(HasGlobalRole(SERVICE_WORKER).andAttachmentWasUploadedByAnyEmployee(), IsCitizen(allowWeakLogin = false).uploaderOfAttachment()),
         DELETE_INCOME_STATEMENT_ATTACHMENT(HasGlobalRole(FINANCE_ADMIN).andAttachmentWasUploadedByAnyEmployee(), IsCitizen(allowWeakLogin = false).uploaderOfAttachment()),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsCitizen.kt
@@ -208,6 +208,20 @@ WHERE g.guardian_id = :guardianId
             .bind("guardianId", guardianId)
     }
 
+    fun fosterParentOfChildOfPedagogicalDocumentOfAttachment() = rule { userId, now ->
+        QueryFragment<AttachmentId>(
+            """
+SELECT a.id
+FROM attachment a
+JOIN pedagogical_document pd ON a.pedagogical_document_id = pd.id
+JOIN foster_parent fp ON pd.child_id = fp.child_id
+WHERE fp.parent_id = :userId AND fp.valid_during @> :today
+            """.trimIndent()
+        )
+            .bind("today", now.toLocalDate())
+            .bind("userId", userId)
+    }
+
     fun guardianOfChildOfVasu() = rule { citizenId, _ ->
         QueryFragment<VasuDocumentId>(
             """


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
`READ_PEDAGOGICAL_DOCUMENT_ATTACHMENT` action was missing a condition for foster parents.

