### PR TITLE
EVAKA-HOTFIX placement termination in mobile

### DIFF
--- a/frontend/src/citizen-frontend/children/ResponsiveWholePageCollapsible.tsx
+++ b/frontend/src/citizen-frontend/children/ResponsiveWholePageCollapsible.tsx
@@ -166,7 +166,7 @@ const ResponsiveCollapsibleContainer = styled.div<{ open: boolean }>`
     bottom: 0;
     left: 0;
     right: 0;
-    z-index: 100;
+    z-index: 29;
     background-color: ${(p) => p.theme.colors.grayscale.g0};
     margin-top: 0;
     display: ${(props) => (props.open ? 'flex' : 'none')};
@@ -175,7 +175,7 @@ const ResponsiveCollapsibleContainer = styled.div<{ open: boolean }>`
 `
 
 const ResponsiveCollapsibleTitle = styled.div`
-  z-index: 105;
+  z-index: 30;
   top: 0;
   width: 100%;
   background-color: ${(p) => p.theme.colors.grayscale.g0};

--- a/frontend/src/citizen-frontend/children/sections/pedagogical-documents/PedagogicalDocumentsSection.tsx
+++ b/frontend/src/citizen-frontend/children/sections/pedagogical-documents/PedagogicalDocumentsSection.tsx
@@ -31,7 +31,7 @@ import {
   TabletAndDesktop
 } from 'lib-components/layout/responsive-layout'
 import FileDownloadButton from 'lib-components/molecules/FileDownloadButton'
-import { fontWeights } from 'lib-components/typography'
+import { Dimmed, fontWeights } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import {
   faArrowDown,
@@ -212,7 +212,12 @@ const PedagogicalDocumentsDisplay = React.memo(
     items: PedagogicalDocumentCitizen[]
     onRead: (doc: PedagogicalDocumentCitizen) => void
   }) {
-    return (
+    const t = useTranslation()
+    return items.length === 0 ? (
+      <NoDocumentsContainer>
+        <Dimmed>{t.children.pedagogicalDocuments.noDocuments}</Dimmed>
+      </NoDocumentsContainer>
+    ) : (
       <>
         <MobileOnly>
           <PedagogicalDocumentsList items={items} onRead={onRead} />
@@ -489,4 +494,9 @@ const ExpandableText = styled.span<ExpandableTextProps>`
   -webkit-box-orient: vertical;
   -webkit-line-clamp: ${(props) =>
     props.expanded ? 'none' : props.clampLines};
+`
+
+const NoDocumentsContainer = styled.div`
+  padding: ${defaultMargins.s};
+  padding-bottom: 0;
 `

--- a/frontend/src/citizen-frontend/children/sections/vasu-and-leops/VasuAndLeopsSection.tsx
+++ b/frontend/src/citizen-frontend/children/sections/vasu-and-leops/VasuAndLeopsSection.tsx
@@ -175,24 +175,6 @@ export default React.memo(function VasuAndLeopsSection({
       data-qa="collapsible-vasu"
       contentPadding="zero"
     >
-      <PaddingBox>
-        <P>
-          {i18n.children.vasu.givePermissionToShareInfoVasu}
-          <ParagraphInfoButton
-            aria-label={i18n.common.openExpandingInfo}
-            onClick={() => setInfoOpen(!infoOpen)}
-            open={infoOpen}
-          />
-        </P>
-        {infoOpen && (
-          <ExpandingInfoBox
-            close={() => setInfoOpen(false)}
-            info={i18n.children.vasu.givePermissionToShareInfoVasuInfoText}
-            width="full"
-            closeLabel=""
-          />
-        )}
-      </PaddingBox>
       {renderResult(vasus, ({ data: items, permissionToShareRequired }) =>
         items.length === 0 ? (
           <PaddingBox>
@@ -201,6 +183,26 @@ export default React.memo(function VasuAndLeopsSection({
           </PaddingBox>
         ) : (
           <>
+            <PaddingBox>
+              <P>
+                {i18n.children.vasu.givePermissionToShareInfoVasu}
+                <ParagraphInfoButton
+                  aria-label={i18n.common.openExpandingInfo}
+                  onClick={() => setInfoOpen(!infoOpen)}
+                  open={infoOpen}
+                />
+              </P>
+              {infoOpen && (
+                <ExpandingInfoBox
+                  close={() => setInfoOpen(false)}
+                  info={
+                    i18n.children.vasu.givePermissionToShareInfoVasuInfoText
+                  }
+                  width="full"
+                  closeLabel=""
+                />
+              )}
+            </PaddingBox>
             <MobileAndTablet>
               {items.map((vasu) => (
                 <MobileRowContainer key={vasu.id}>

--- a/frontend/src/lib-components/molecules/modals/BaseModal.tsx
+++ b/frontend/src/lib-components/molecules/modals/BaseModal.tsx
@@ -39,7 +39,7 @@ interface Props extends ModalBaseProps {
 
 export default React.memo(function BaseModal(props: Props) {
   return (
-    <ModalBackground>
+    <ModalBackground zIndex={props.zIndex}>
       <ModalWrapper
         className={props.className}
         zIndex={props.zIndex}

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -1991,6 +1991,7 @@ const en: Translations = {
     },
     pedagogicalDocuments: {
       title: 'Growth and learning',
+      noDocuments: 'No documents',
       table: {
         date: 'Date',
         child: 'Child',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -2065,6 +2065,7 @@ export default {
     },
     pedagogicalDocuments: {
       title: 'Lapsen arkeen liittyviä dokumentteja',
+      noDocuments: 'Ei dokumentteja',
       table: {
         date: 'Päivämäärä',
         child: 'Lapsi',

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -2095,6 +2095,7 @@ const sv: Translations = {
     },
     pedagogicalDocuments: {
       title: 'Tillväxt och inlärning',
+      noDocuments: 'Inga dokument',
       table: {
         date: 'Datum',
         child: 'Barn',


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The placement termination modal had a lower z-index than the modal for the placement termination section so the `ResponsiveWholePageCollapsible` component's z-index is lowered.

Also, show a text indicating that a child has no pedagogical documents and show the curriculum sharing info only if a child has curriculums.

Before:
<img width="378" alt="Screenshot 2022-10-14 at 15 28 41" src="https://user-images.githubusercontent.com/4426547/195847906-9792903f-245f-45b4-b9e6-3d8ba104a840.png">

After:
<img width="380" alt="Screenshot 2022-10-14 at 15 28 25" src="https://user-images.githubusercontent.com/4426547/195847926-9f8e0adf-eb90-405c-a8d9-ead286d7289c.png">

Before:
<img width="379" alt="Screenshot 2022-10-14 at 15 32 11" src="https://user-images.githubusercontent.com/4426547/195847936-1ac4c2e5-4f4f-4391-bc09-792969a6bfdd.png">

After:
<img width="379" alt="Screenshot 2022-10-14 at 15 31 56" src="https://user-images.githubusercontent.com/4426547/195847958-7ce35c95-5e20-48f7-987c-325a255e0e8b.png">


