### PR TITLE
Access control cleanup - part 1

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AccessControlTest.kt
@@ -28,7 +28,7 @@ abstract class AccessControlTest : PureJdbiTest(resetDbBeforeEach = true) {
     @BeforeEach
     fun prepareRules() {
         rules = TestActionRuleMapping()
-        accessControl = AccessControl(rules, jdbi)
+        accessControl = AccessControl(rules)
     }
 
     class TestActionRuleMapping : ActionRuleMapping {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/ApplicationAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/ApplicationAccessControlTest.kt
@@ -74,8 +74,14 @@ class ApplicationAccessControlTest : AccessControlTest() {
         rules.add(action, IsCitizen(allowWeakLogin = false).ownerOfApplication())
         val otherCitizen = createTestCitizen(CitizenAuthLevel.STRONG)
 
-        assertTrue(accessControl.hasPermissionFor(creatorCitizen, clock, action, applicationId))
-        assertFalse(accessControl.hasPermissionFor(otherCitizen, clock, action, applicationId))
+        db.read { tx ->
+            assertTrue(
+                accessControl.hasPermissionFor(tx, creatorCitizen, clock, action, applicationId)
+            )
+            assertFalse(
+                accessControl.hasPermissionFor(tx, otherCitizen, clock, action, applicationId)
+            )
+        }
     }
 
     @Test
@@ -92,8 +98,14 @@ class ApplicationAccessControlTest : AccessControlTest() {
                 globalRoles = emptySet(),
                 unitRoles = mapOf(daycareId to UserRole.STAFF)
             )
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, applicationId))
-        assertFalse(accessControl.hasPermissionFor(otherEmployee, clock, action, applicationId))
+        db.read { tx ->
+            assertTrue(
+                accessControl.hasPermissionFor(tx, unitSupervisor, clock, action, applicationId)
+            )
+            assertFalse(
+                accessControl.hasPermissionFor(tx, otherEmployee, clock, action, applicationId)
+            )
+        }
     }
 
     @Test
@@ -116,7 +128,13 @@ class ApplicationAccessControlTest : AccessControlTest() {
                 globalRoles = emptySet(),
                 unitRoles = mapOf(daycareId to UserRole.STAFF)
             )
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, applicationId))
-        assertFalse(accessControl.hasPermissionFor(otherEmployee, clock, action, applicationId))
+        db.read { tx ->
+            assertTrue(
+                accessControl.hasPermissionFor(tx, unitSupervisor, clock, action, applicationId)
+            )
+            assertFalse(
+                accessControl.hasPermissionFor(tx, otherEmployee, clock, action, applicationId)
+            )
+        }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AssistanceNeedDecisionAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AssistanceNeedDecisionAccessControlTest.kt
@@ -119,11 +119,23 @@ class AssistanceNeedDecisionAccessControlTest : AccessControlTest() {
             }
         val unitSupervisor =
             createTestEmployee(emptySet(), mapOf(daycareId to UserRole.UNIT_SUPERVISOR))
-        assertTrue(
-            accessControl.hasPermissionFor(unitSupervisor, clock, action, assistanceNeedDecisionId)
-        )
+        db.read { tx ->
+            assertTrue(
+                accessControl.hasPermissionFor(
+                    tx,
+                    unitSupervisor,
+                    clock,
+                    action,
+                    assistanceNeedDecisionId
+                )
+            )
+        }
 
         val staff = createTestEmployee(emptySet(), mapOf(daycareId to UserRole.STAFF))
-        assertFalse(accessControl.hasPermissionFor(staff, clock, action, assistanceNeedDecisionId))
+        db.read { tx ->
+            assertFalse(
+                accessControl.hasPermissionFor(tx, staff, clock, action, assistanceNeedDecisionId)
+            )
+        }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AttachmentAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AttachmentAccessControlTest.kt
@@ -39,18 +39,40 @@ class AttachmentAccessControlTest : AccessControlTest() {
 
         val uploaderEmployee = createTestEmployee(emptySet())
         val employeeAttachmentId = insertApplicationAttachment(uploaderEmployee)
-        assertTrue(
-            accessControl.hasPermissionFor(permittedEmployee, clock, action, employeeAttachmentId)
-        )
-        assertFalse(
-            accessControl.hasPermissionFor(deniedEmployee, clock, action, employeeAttachmentId)
-        )
+        db.read { tx ->
+            assertTrue(
+                accessControl.hasPermissionFor(
+                    tx,
+                    permittedEmployee,
+                    clock,
+                    action,
+                    employeeAttachmentId
+                )
+            )
+            assertFalse(
+                accessControl.hasPermissionFor(
+                    tx,
+                    deniedEmployee,
+                    clock,
+                    action,
+                    employeeAttachmentId
+                )
+            )
+        }
 
         val uploaderCitizen = createTestCitizen(CitizenAuthLevel.STRONG)
         val citizenAttachmentId = insertApplicationAttachment(uploaderCitizen)
-        assertFalse(
-            accessControl.hasPermissionFor(permittedEmployee, clock, action, citizenAttachmentId)
-        )
+        db.read { tx ->
+            assertFalse(
+                accessControl.hasPermissionFor(
+                    tx,
+                    permittedEmployee,
+                    clock,
+                    action,
+                    citizenAttachmentId
+                )
+            )
+        }
     }
 
     @Test
@@ -61,16 +83,23 @@ class AttachmentAccessControlTest : AccessControlTest() {
         val otherCitizen = createTestCitizen(CitizenAuthLevel.STRONG)
 
         val attachmentId = insertApplicationAttachment(uploaderCitizen)
-        assertTrue(accessControl.hasPermissionFor(uploaderCitizen, clock, action, attachmentId))
-        assertFalse(accessControl.hasPermissionFor(otherCitizen, clock, action, attachmentId))
-        assertFalse(
-            accessControl.hasPermissionFor(
-                uploaderCitizen.copy(authLevel = CitizenAuthLevel.WEAK),
-                clock,
-                action,
-                attachmentId
+        db.read { tx ->
+            assertTrue(
+                accessControl.hasPermissionFor(tx, uploaderCitizen, clock, action, attachmentId)
             )
-        )
+            assertFalse(
+                accessControl.hasPermissionFor(tx, otherCitizen, clock, action, attachmentId)
+            )
+            assertFalse(
+                accessControl.hasPermissionFor(
+                    tx,
+                    uploaderCitizen.copy(authLevel = CitizenAuthLevel.WEAK),
+                    clock,
+                    action,
+                    attachmentId
+                )
+            )
+        }
     }
 
     private fun insertApplicationAttachment(user: AuthenticatedUser) =

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/ChildAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/ChildAccessControlTest.kt
@@ -51,16 +51,19 @@ class ChildAccessControlTest : AccessControlTest() {
         db.transaction { tx -> tx.insertGuardian(guardianCitizen.id, childId) }
         val otherCitizen = createTestCitizen(CitizenAuthLevel.STRONG)
 
-        assertTrue(accessControl.hasPermissionFor(guardianCitizen, clock, action, childId))
-        assertFalse(accessControl.hasPermissionFor(otherCitizen, clock, action, childId))
-        assertFalse(
-            accessControl.hasPermissionFor(
-                guardianCitizen.copy(authLevel = CitizenAuthLevel.WEAK),
-                clock,
-                action,
-                childId
+        db.read { tx ->
+            assertTrue(accessControl.hasPermissionFor(tx, guardianCitizen, clock, action, childId))
+            assertFalse(accessControl.hasPermissionFor(tx, otherCitizen, clock, action, childId))
+            assertFalse(
+                accessControl.hasPermissionFor(
+                    tx,
+                    guardianCitizen.copy(authLevel = CitizenAuthLevel.WEAK),
+                    clock,
+                    action,
+                    childId
+                )
             )
-        )
+        }
     }
 
     @Test
@@ -82,10 +85,14 @@ class ChildAccessControlTest : AccessControlTest() {
             }
         val unitSupervisor =
             createTestEmployee(emptySet(), mapOf(daycareId to UserRole.UNIT_SUPERVISOR))
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, childId))
+        db.read { tx ->
+            assertTrue(accessControl.hasPermissionFor(tx, unitSupervisor, clock, action, childId))
+        }
 
         val staff = createTestEmployee(emptySet(), mapOf(daycareId to UserRole.STAFF))
-        assertFalse(accessControl.hasPermissionFor(staff, clock, action, childId))
+        db.read { tx ->
+            assertFalse(accessControl.hasPermissionFor(tx, staff, clock, action, childId))
+        }
     }
 
     @Test
@@ -107,9 +114,13 @@ class ChildAccessControlTest : AccessControlTest() {
                 Pair(daycareId, otherDaycareId)
             }
         val unitMobile = createTestMobile(daycareId)
-        assertTrue(accessControl.hasPermissionFor(unitMobile, clock, action, childId))
+        db.read { tx ->
+            assertTrue(accessControl.hasPermissionFor(tx, unitMobile, clock, action, childId))
+        }
 
         val otherMobile = createTestMobile(otherDaycareId)
-        assertFalse(accessControl.hasPermissionFor(otherMobile, clock, action, childId))
+        db.read { tx ->
+            assertFalse(accessControl.hasPermissionFor(tx, otherMobile, clock, action, childId))
+        }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/IsCitizenTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/IsCitizenTest.kt
@@ -30,26 +30,38 @@ class IsCitizenTest : AccessControlTest() {
     fun `permits only strongly authenticated citizen if allowWeakLogin = false`() {
         val action = Action.Global.READ_HOLIDAY_PERIODS
         rules.add(action, IsCitizen(allowWeakLogin = false).any())
-        assertTrue(accessControl.hasPermissionFor(strongCitizen, clock, action))
-        assertFalse(accessControl.hasPermissionFor(weakCitizen, clock, action))
-        assertFalse(accessControl.hasPermissionFor(employee, clock, action))
+        db.read { tx ->
+            assertTrue(accessControl.hasPermissionFor(tx, strongCitizen, clock, action))
+            assertFalse(accessControl.hasPermissionFor(tx, weakCitizen, clock, action))
+            assertFalse(accessControl.hasPermissionFor(tx, employee, clock, action))
+        }
     }
 
     @Test
     fun `permits any citizen if allowWeakLogin = true`() {
         val action = Action.Global.READ_HOLIDAY_PERIODS
         rules.add(action, IsCitizen(allowWeakLogin = true).any())
-        assertTrue(accessControl.hasPermissionFor(strongCitizen, clock, action))
-        assertTrue(accessControl.hasPermissionFor(weakCitizen, clock, action))
-        assertFalse(accessControl.hasPermissionFor(employee, clock, action))
+        db.read { tx ->
+            assertTrue(accessControl.hasPermissionFor(tx, strongCitizen, clock, action))
+            assertTrue(accessControl.hasPermissionFor(tx, weakCitizen, clock, action))
+            assertFalse(accessControl.hasPermissionFor(tx, employee, clock, action))
+        }
     }
 
     @Test
     fun `self() permits only if the target is the same citizen user doing the action`() {
         val action = Action.Person.READ
         rules.add(action, IsCitizen(allowWeakLogin = false).self())
-        assertTrue(accessControl.hasPermissionFor(strongCitizen, clock, action, strongCitizen.id))
-        assertFalse(accessControl.hasPermissionFor(strongCitizen, clock, action, weakCitizen.id))
-        assertFalse(accessControl.hasPermissionFor(weakCitizen, clock, action, weakCitizen.id))
+        db.read { tx ->
+            assertTrue(
+                accessControl.hasPermissionFor(tx, strongCitizen, clock, action, strongCitizen.id)
+            )
+            assertFalse(
+                accessControl.hasPermissionFor(tx, strongCitizen, clock, action, weakCitizen.id)
+            )
+            assertFalse(
+                accessControl.hasPermissionFor(tx, weakCitizen, clock, action, weakCitizen.id)
+            )
+        }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/StaticActionRuleTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/StaticActionRuleTest.kt
@@ -32,18 +32,22 @@ class StaticActionRuleTest : AccessControlTest() {
     fun `IsCitizen permits only strongly authenticated citizen if allowWeakLogin = false`() {
         val action = Action.Global.READ_HOLIDAY_PERIODS
         rules.add(action, IsCitizen(allowWeakLogin = false).any())
-        assertTrue(accessControl.hasPermissionFor(strongCitizen, clock, action))
-        assertFalse(accessControl.hasPermissionFor(weakCitizen, clock, action))
-        assertFalse(accessControl.hasPermissionFor(employee, clock, action))
+        db.read { tx ->
+            assertTrue(accessControl.hasPermissionFor(tx, strongCitizen, clock, action))
+            assertFalse(accessControl.hasPermissionFor(tx, weakCitizen, clock, action))
+            assertFalse(accessControl.hasPermissionFor(tx, employee, clock, action))
+        }
     }
 
     @Test
     fun `IsCitizen permits any citizen if allowWeakLogin = true`() {
         val action = Action.Global.READ_HOLIDAY_PERIODS
         rules.add(action, IsCitizen(allowWeakLogin = true).any())
-        assertTrue(accessControl.hasPermissionFor(strongCitizen, clock, action))
-        assertTrue(accessControl.hasPermissionFor(weakCitizen, clock, action))
-        assertFalse(accessControl.hasPermissionFor(employee, clock, action))
+        db.read { tx ->
+            assertTrue(accessControl.hasPermissionFor(tx, strongCitizen, clock, action))
+            assertTrue(accessControl.hasPermissionFor(tx, weakCitizen, clock, action))
+            assertFalse(accessControl.hasPermissionFor(tx, employee, clock, action))
+        }
     }
 
     @Test
@@ -58,7 +62,9 @@ class StaticActionRuleTest : AccessControlTest() {
         val deniedEmployee =
             AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.DIRECTOR))
 
-        assertTrue(accessControl.hasPermissionFor(permittedEmployee, clock, action))
-        assertFalse(accessControl.hasPermissionFor(deniedEmployee, clock, action))
+        db.read { tx ->
+            assertTrue(accessControl.hasPermissionFor(tx, permittedEmployee, clock, action))
+            assertFalse(accessControl.hasPermissionFor(tx, deniedEmployee, clock, action))
+        }
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/UnitAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/UnitAccessControlTest.kt
@@ -70,8 +70,10 @@ class UnitAccessControlTest : AccessControlTest() {
                 unitRoles =
                     mapOf(daycareId to UserRole.STAFF, featureDaycareId to UserRole.UNIT_SUPERVISOR)
             )
-        assertFalse(accessControl.hasPermissionFor(deniedSupervisor, clock, action))
-        assertTrue(accessControl.hasPermissionFor(permittedSupervisor, clock, action))
+        db.read { tx ->
+            assertFalse(accessControl.hasPermissionFor(tx, deniedSupervisor, clock, action))
+            assertTrue(accessControl.hasPermissionFor(tx, permittedSupervisor, clock, action))
+        }
     }
 
     @Test
@@ -88,8 +90,10 @@ class UnitAccessControlTest : AccessControlTest() {
                 globalRoles = emptySet(),
                 unitRoles = mapOf(daycareId to UserRole.STAFF)
             )
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, daycareId))
-        assertFalse(accessControl.hasPermissionFor(otherEmployee, clock, action, daycareId))
+        db.read { tx ->
+            assertTrue(accessControl.hasPermissionFor(tx, unitSupervisor, clock, action, daycareId))
+            assertFalse(accessControl.hasPermissionFor(tx, otherEmployee, clock, action, daycareId))
+        }
     }
 
     @Test
@@ -113,10 +117,18 @@ class UnitAccessControlTest : AccessControlTest() {
                 globalRoles = emptySet(),
                 unitRoles = mapOf(daycareId to UserRole.STAFF, featureDaycareId to UserRole.STAFF)
             )
-        assertFalse(accessControl.hasPermissionFor(unitSupervisor, clock, action, daycareId))
-        assertTrue(accessControl.hasPermissionFor(unitSupervisor, clock, action, featureDaycareId))
-        assertFalse(accessControl.hasPermissionFor(otherEmployee, clock, action, daycareId))
-        assertFalse(accessControl.hasPermissionFor(otherEmployee, clock, action, featureDaycareId))
+        db.read { tx ->
+            assertFalse(
+                accessControl.hasPermissionFor(tx, unitSupervisor, clock, action, daycareId)
+            )
+            assertTrue(
+                accessControl.hasPermissionFor(tx, unitSupervisor, clock, action, featureDaycareId)
+            )
+            assertFalse(accessControl.hasPermissionFor(tx, otherEmployee, clock, action, daycareId))
+            assertFalse(
+                accessControl.hasPermissionFor(tx, otherEmployee, clock, action, featureDaycareId)
+            )
+        }
     }
 
     @Test
@@ -127,8 +139,10 @@ class UnitAccessControlTest : AccessControlTest() {
         val otherDaycareId =
             db.transaction { tx -> tx.insertTestDaycare(DevDaycare(areaId = areaId)) }
         val otherMobile = createTestMobile(otherDaycareId)
-        assertTrue(accessControl.hasPermissionFor(unitMobile, clock, action, daycareId))
-        assertFalse(accessControl.hasPermissionFor(otherMobile, clock, action, daycareId))
+        db.read { tx ->
+            assertTrue(accessControl.hasPermissionFor(tx, unitMobile, clock, action, daycareId))
+            assertFalse(accessControl.hasPermissionFor(tx, otherMobile, clock, action, daycareId))
+        }
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -225,7 +225,7 @@ class ApplicationStateService(
         clock: EvakaClock,
         applicationId: ApplicationId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Application.SEND, applicationId)
+        accessControl.requirePermissionFor(tx, user, clock, Action.Application.SEND, applicationId)
 
         val currentDate = clock.today()
         val application = getApplication(tx, applicationId)
@@ -323,6 +323,7 @@ class ApplicationStateService(
         applicationId: ApplicationId
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Application.MOVE_TO_WAITING_PLACEMENT,
@@ -361,6 +362,7 @@ class ApplicationStateService(
         applicationId: ApplicationId
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Application.RETURN_TO_SENT,
@@ -379,7 +381,13 @@ class ApplicationStateService(
         clock: EvakaClock,
         applicationId: ApplicationId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Application.CANCEL, applicationId)
+        accessControl.requirePermissionFor(
+            tx,
+            user,
+            clock,
+            Action.Application.CANCEL,
+            applicationId
+        )
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, setOf(SENT, WAITING_PLACEMENT))
@@ -393,7 +401,13 @@ class ApplicationStateService(
         clock: EvakaClock,
         applicationId: ApplicationId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Application.VERIFY, applicationId)
+        accessControl.requirePermissionFor(
+            tx,
+            user,
+            clock,
+            Action.Application.VERIFY,
+            applicationId
+        )
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_PLACEMENT)
@@ -407,7 +421,13 @@ class ApplicationStateService(
         clock: EvakaClock,
         applicationId: ApplicationId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Application.VERIFY, applicationId)
+        accessControl.requirePermissionFor(
+            tx,
+            user,
+            clock,
+            Action.Application.VERIFY,
+            applicationId
+        )
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_PLACEMENT)
@@ -451,6 +471,7 @@ class ApplicationStateService(
         applicationId: ApplicationId
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Application.CANCEL_PLACEMENT_PLAN,
@@ -472,6 +493,7 @@ class ApplicationStateService(
         applicationId: ApplicationId
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Application.SEND_DECISIONS_WITHOUT_PROPOSAL,
@@ -494,6 +516,7 @@ class ApplicationStateService(
         applicationId: ApplicationId
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Application.SEND_PLACEMENT_PROPOSAL,
@@ -513,6 +536,7 @@ class ApplicationStateService(
         applicationId: ApplicationId
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Application.WITHDRAW_PLACEMENT_PROPOSAL,
@@ -535,6 +559,7 @@ class ApplicationStateService(
         rejectOtherReason: String? = null
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Application.RESPOND_TO_PLACEMENT_PROPOSAL,
@@ -576,6 +601,7 @@ class ApplicationStateService(
         unitId: DaycareId
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Unit.ACCEPT_PLACEMENT_PROPOSAL,
@@ -622,6 +648,7 @@ class ApplicationStateService(
         applicationId: ApplicationId
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Application.CONFIRM_DECISIONS_MAILED,
@@ -644,6 +671,7 @@ class ApplicationStateService(
         requestedStartDate: LocalDate
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Application.ACCEPT_DECISION,
@@ -741,6 +769,7 @@ class ApplicationStateService(
         decisionId: DecisionId
     ) {
         accessControl.requirePermissionFor(
+            tx,
             user,
             clock,
             Action.Application.REJECT_DECISION,

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionController.kt
@@ -35,13 +35,16 @@ class AssistanceActionController(
         @PathVariable childId: ChildId,
         @RequestBody body: AssistanceActionRequest
     ): AssistanceAction {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Child.CREATE_ASSISTANCE_ACTION,
-            childId
-        )
         return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Child.CREATE_ASSISTANCE_ACTION,
+                        childId
+                    )
+                }
                 assistanceActionService.createAssistanceAction(
                     dbc,
                     user = user,
@@ -64,13 +67,16 @@ class AssistanceActionController(
         clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<AssistanceActionResponse> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Child.READ_ASSISTANCE_ACTION,
-            childId
-        )
         return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Child.READ_ASSISTANCE_ACTION,
+                        childId
+                    )
+                }
                 val relevantPreschoolPlacements =
                     dbc.read { tx ->
                         tx.getPlacementsForChild(childId).filter {
@@ -134,13 +140,16 @@ class AssistanceActionController(
         @PathVariable("id") assistanceActionId: AssistanceActionId,
         @RequestBody body: AssistanceActionRequest
     ): AssistanceAction {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.AssistanceAction.UPDATE,
-            assistanceActionId
-        )
         return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.AssistanceAction.UPDATE,
+                        assistanceActionId
+                    )
+                }
                 assistanceActionService.updateAssistanceAction(
                     dbc,
                     user = user,
@@ -158,13 +167,16 @@ class AssistanceActionController(
         clock: EvakaClock,
         @PathVariable("id") assistanceActionId: AssistanceActionId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.AssistanceAction.DELETE,
-            assistanceActionId
-        )
         db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.AssistanceAction.DELETE,
+                    assistanceActionId
+                )
+            }
             assistanceActionService.deleteAssistanceAction(dbc, assistanceActionId)
         }
         Audit.ChildAssistanceActionDelete.log(targetId = assistanceActionId)
@@ -176,11 +188,16 @@ class AssistanceActionController(
         user: AuthenticatedUser,
         clock: EvakaClock
     ): List<AssistanceActionOption> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.READ_ASSISTANCE_ACTION_OPTIONS
-        )
-        return db.connect { dbc -> assistanceActionService.getAssistanceActionOptions(dbc) }
+        return db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Global.READ_ASSISTANCE_ACTION_OPTIONS
+                )
+            }
+            assistanceActionService.getAssistanceActionOptions(dbc)
+        }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedController.kt
@@ -35,13 +35,16 @@ class AssistanceNeedController(
         @PathVariable childId: ChildId,
         @RequestBody body: AssistanceNeedRequest
     ): AssistanceNeed {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Child.CREATE_ASSISTANCE_NEED,
-            childId
-        )
         return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Child.CREATE_ASSISTANCE_NEED,
+                        childId
+                    )
+                }
                 assistanceNeedService.createAssistanceNeed(
                     dbc,
                     user,
@@ -65,8 +68,16 @@ class AssistanceNeedController(
         clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<AssistanceNeedResponse> {
-        accessControl.requirePermissionFor(user, clock, Action.Child.READ_ASSISTANCE_NEED, childId)
         return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Child.READ_ASSISTANCE_NEED,
+                        childId
+                    )
+                }
                 val relevantPreschoolPlacements =
                     dbc.read { tx ->
                         tx.getPlacementsForChild(childId).filter {
@@ -128,13 +139,16 @@ class AssistanceNeedController(
         @PathVariable("id") assistanceNeedId: AssistanceNeedId,
         @RequestBody body: AssistanceNeedRequest
     ): AssistanceNeed {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.AssistanceNeed.UPDATE,
-            assistanceNeedId
-        )
         return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.AssistanceNeed.UPDATE,
+                        assistanceNeedId
+                    )
+                }
                 assistanceNeedService.updateAssistanceNeed(
                     dbc,
                     user,
@@ -153,13 +167,16 @@ class AssistanceNeedController(
         clock: EvakaClock,
         @PathVariable("id") assistanceNeedId: AssistanceNeedId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.AssistanceNeed.DELETE,
-            assistanceNeedId
-        )
         db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.AssistanceNeed.DELETE,
+                    assistanceNeedId
+                )
+            }
             assistanceNeedService.deleteAssistanceNeed(dbc, clock, assistanceNeedId)
         }
         Audit.ChildAssistanceNeedDelete.log(targetId = assistanceNeedId)
@@ -171,7 +188,16 @@ class AssistanceNeedController(
         user: AuthenticatedUser,
         clock: EvakaClock
     ): List<AssistanceBasisOption> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_ASSISTANCE_BASIS_OPTIONS)
-        return db.connect { dbc -> assistanceNeedService.getAssistanceBasisOptions(dbc) }
+        return db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Global.READ_ASSISTANCE_BASIS_OPTIONS
+                )
+            }
+            assistanceNeedService.getAssistanceBasisOptions(dbc)
+        }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionCitizenController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionCitizenController.kt
@@ -30,15 +30,16 @@ class AssistanceNeedDecisionCitizenController(
         user: AuthenticatedUser.Citizen,
         clock: EvakaClock
     ): List<AssistanceNeedDecisionCitizenListItem> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.READ_ASSISTANCE_NEED_DECISIONS,
-            user.id
-        )
-
         return db.connect { dbc ->
-                dbc.transaction { tx ->
+                dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.Person.READ_ASSISTANCE_NEED_DECISIONS,
+                        user.id
+                    )
+
                     tx.getAssistanceNeedDecisionsForCitizen(clock.today(), user.id)
                 }
             }
@@ -52,14 +53,15 @@ class AssistanceNeedDecisionCitizenController(
         clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ): AssistanceNeedDecision {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.AssistanceNeedDecision.READ,
-            id
-        )
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.AssistanceNeedDecision.READ,
+                        id
+                    )
                     val decision = tx.getAssistanceNeedDecisionById(id)
 
                     if (
@@ -84,13 +86,18 @@ class AssistanceNeedDecisionCitizenController(
         clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ): ResponseEntity<Any> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.AssistanceNeedDecision.DOWNLOAD,
-            id
-        )
-        return db.connect { assistanceNeedDecisionService.getDecisionPdfResponse(it, id) }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Citizen.AssistanceNeedDecision.DOWNLOAD,
+                        id
+                    )
+                }
+                assistanceNeedDecisionService.getDecisionPdfResponse(dbc, id)
+            }
             .also { Audit.ChildAssistanceNeedDecisionDownloadCitizen.log(targetId = id) }
     }
 
@@ -101,14 +108,17 @@ class AssistanceNeedDecisionCitizenController(
         clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.AssistanceNeedDecision.MARK_AS_READ,
-            id
-        )
         return db.connect { dbc ->
-                dbc.transaction { tx -> tx.markAssistanceNeedDecisionAsReadByGuardian(id, user.id) }
+                dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.AssistanceNeedDecision.MARK_AS_READ,
+                        id
+                    )
+                    tx.markAssistanceNeedDecisionAsReadByGuardian(id, user.id)
+                }
             }
             .also { Audit.ChildAssistanceNeedDecisionMarkReadCitizen.log(targetId = id) }
     }
@@ -119,14 +129,15 @@ class AssistanceNeedDecisionCitizenController(
         user: AuthenticatedUser.Citizen,
         clock: EvakaClock
     ): List<UnreadAssistanceNeedDecisionItem> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.READ_UNREAD_ASSISTANCE_NEED_DECISION_COUNT,
-            user.id
-        )
         return db.connect { dbc ->
-                dbc.transaction { tx ->
+                dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.Person.READ_UNREAD_ASSISTANCE_NEED_DECISION_COUNT,
+                        user.id
+                    )
                     tx.getAssistanceNeedDecisionsUnreadCountsForCitizen(clock.today(), user.id)
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
@@ -45,14 +45,15 @@ class AssistanceNeedDecisionController(
         @PathVariable childId: ChildId,
         @RequestBody body: AssistanceNeedDecisionRequest
     ): AssistanceNeedDecision {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Child.CREATE_ASSISTANCE_NEED_DECISION,
-            childId
-        )
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Child.CREATE_ASSISTANCE_NEED_DECISION,
+                        childId
+                    )
                     var decision: AssistanceNeedDecisionForm =
                         body.decision.copy(
                             status = AssistanceNeedDecisionStatus.DRAFT,
@@ -95,9 +96,15 @@ class AssistanceNeedDecisionController(
         clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ): AssistanceNeedDecisionResponse {
-        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.READ, id)
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.AssistanceNeedDecision.READ,
+                        id
+                    )
                     val decision = tx.getAssistanceNeedDecisionById(id)
 
                     AssistanceNeedDecisionResponse(
@@ -118,9 +125,15 @@ class AssistanceNeedDecisionController(
         @PathVariable id: AssistanceNeedDecisionId,
         @RequestBody body: AssistanceNeedDecisionRequest
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.UPDATE, id)
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.AssistanceNeedDecision.UPDATE,
+                        id
+                    )
                     val decision = tx.getAssistanceNeedDecisionById(id)
 
                     if (
@@ -163,9 +176,15 @@ class AssistanceNeedDecisionController(
         clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.SEND, id)
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.AssistanceNeedDecision.SEND,
+                        id
+                    )
                     val decision = tx.getAssistanceNeedDecisionById(id)
 
                     if (
@@ -209,14 +228,15 @@ class AssistanceNeedDecisionController(
         clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<AssistanceNeedDecisionBasicsResponse> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Child.READ_ASSISTANCE_NEED_DECISIONS,
-            childId
-        )
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Child.READ_ASSISTANCE_NEED_DECISIONS,
+                        childId
+                    )
                     val decisions = tx.getAssistanceNeedDecisionsByChildId(childId)
                     val permittedActions =
                         accessControl.getPermittedActions<
@@ -250,9 +270,15 @@ class AssistanceNeedDecisionController(
         clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.DELETE, id)
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.AssistanceNeedDecision.DELETE,
+                        id
+                    )
                     if (!tx.deleteAssistanceNeedDecision(id)) {
                         throw NotFound(
                             "Assistance need decision $id cannot found or cannot be deleted",
@@ -272,14 +298,20 @@ class AssistanceNeedDecisionController(
         @PathVariable id: AssistanceNeedDecisionId,
         @RequestBody body: DecideAssistanceNeedDecisionRequest
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.AssistanceNeedDecision.DECIDE, id)
-
         if (body.status == AssistanceNeedDecisionStatus.DRAFT) {
             throw BadRequest("Assistance need decisions cannot be decided to be a draft")
         }
 
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.AssistanceNeedDecision.DECIDE,
+                        id
+                    )
+
                     val decision = tx.getAssistanceNeedDecisionById(id)
 
                     if (
@@ -343,15 +375,17 @@ class AssistanceNeedDecisionController(
         clock: EvakaClock,
         @PathVariable id: AssistanceNeedDecisionId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.AssistanceNeedDecision.MARK_AS_OPENED,
-            id
-        )
-
         return db.connect { dbc ->
-                dbc.transaction { tx -> tx.markAssistanceNeedDecisionAsOpened(id) }
+                dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.AssistanceNeedDecision.MARK_AS_OPENED,
+                        id
+                    )
+                    tx.markAssistanceNeedDecisionAsOpened(id)
+                }
             }
             .also { Audit.ChildAssistanceNeedDecisionOpened.log(targetId = id) }
     }
@@ -364,15 +398,15 @@ class AssistanceNeedDecisionController(
         @PathVariable id: AssistanceNeedDecisionId,
         @RequestBody body: UpdateDecisionMakerForAssistanceNeedDecisionRequest
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.AssistanceNeedDecision.UPDATE_DECISION_MAKER,
-            id
-        )
-
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.AssistanceNeedDecision.UPDATE_DECISION_MAKER,
+                        id
+                    )
                     val decision = tx.getAssistanceNeedDecisionById(id)
 
                     if (
@@ -410,14 +444,15 @@ class AssistanceNeedDecisionController(
         user: AuthenticatedUser,
         db: Database
     ): List<Employee> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.AssistanceNeedDecision.READ_DECISION_MAKER_OPTIONS,
-            id
-        )
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.AssistanceNeedDecision.READ_DECISION_MAKER_OPTIONS,
+                        id
+                    )
                     assistanceNeedDecisionService.getDecisionMakerOptions(
                         tx,
                         id,

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientController.kt
@@ -32,15 +32,15 @@ class AssistanceNeedVoucherCoefficientController(private val accessControl: Acce
         @PathVariable childId: ChildId,
         @RequestBody body: AssistanceNeedVoucherCoefficientRequest
     ): AssistanceNeedVoucherCoefficient {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Child.CREATE_ASSISTANCE_NEED_VOUCHER_COEFFICIENT,
-            childId
-        )
-
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Child.CREATE_ASSISTANCE_NEED_VOUCHER_COEFFICIENT,
+                        childId
+                    )
                     adjustExistingCoefficients(tx, childId, body.validityPeriod, null)
                     tx.insertAssistanceNeedVoucherCoefficient(childId, body)
                 }
@@ -60,14 +60,15 @@ class AssistanceNeedVoucherCoefficientController(private val accessControl: Acce
         clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<AssistanceNeedVoucherCoefficientResponse> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Child.READ_ASSISTANCE_NEED_VOUCHER_COEFFICIENTS,
-            childId
-        )
         return db.connect { dbc ->
-                dbc.transaction { tx ->
+                dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Child.READ_ASSISTANCE_NEED_VOUCHER_COEFFICIENTS,
+                        childId
+                    )
                     tx.getAssistanceNeedVoucherCoefficientsForChild(childId).map {
                         AssistanceNeedVoucherCoefficientResponse(
                             voucherCoefficient = it,
@@ -93,14 +94,15 @@ class AssistanceNeedVoucherCoefficientController(private val accessControl: Acce
         @PathVariable("id") assistanceNeedVoucherCoefficientId: AssistanceNeedVoucherCoefficientId,
         @RequestBody body: AssistanceNeedVoucherCoefficientRequest
     ): AssistanceNeedVoucherCoefficient {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.AssistanceNeedVoucherCoefficient.UPDATE,
-            assistanceNeedVoucherCoefficientId
-        )
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.AssistanceNeedVoucherCoefficient.UPDATE,
+                        assistanceNeedVoucherCoefficientId
+                    )
                     adjustExistingCoefficients(
                         tx,
                         tx.getAssistanceNeedVoucherCoefficientById(
@@ -130,14 +132,15 @@ class AssistanceNeedVoucherCoefficientController(private val accessControl: Acce
         clock: EvakaClock,
         @PathVariable("id") assistanceNeedVoucherCoefficientId: AssistanceNeedVoucherCoefficientId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.AssistanceNeedVoucherCoefficient.DELETE,
-            assistanceNeedVoucherCoefficientId
-        )
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.AssistanceNeedVoucherCoefficient.DELETE,
+                    assistanceNeedVoucherCoefficientId
+                )
                 if (
                     !tx.deleteAssistanceNeedVoucherCoefficient(assistanceNeedVoucherCoefficientId)
                 ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -70,9 +70,19 @@ class ChildAttendanceController(
         clock: EvakaClock,
         @PathVariable unitId: DaycareId
     ): AttendanceResponse {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_CHILD_ATTENDANCES, unitId)
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Unit.READ_CHILD_ATTENDANCES,
+                        unitId
+                    )
 
-        return db.connect { dbc -> dbc.read { it.getAttendancesResponse(unitId, clock.now()) } }
+                    it.getAttendancesResponse(unitId, clock.now())
+                }
+            }
             .also {
                 Audit.ChildAttendancesRead.log(
                     targetId = unitId,
@@ -101,15 +111,15 @@ class ChildAttendanceController(
         @PathVariable childId: ChildId,
         @RequestBody body: AttendancesRequest
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.UPDATE_CHILD_ATTENDANCES,
-            unitId
-        )
-
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Unit.UPDATE_CHILD_ATTENDANCES,
+                    unitId
+                )
                 tx.deleteAbsencesByDate(childId, clock.today())
                 tx.deleteAttendancesByDate(childId, body.date)
                 try {
@@ -143,17 +153,16 @@ class ChildAttendanceController(
         @PathVariable childId: ChildId,
         @RequestBody body: ArrivalRequest
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.UPDATE_CHILD_ATTENDANCES,
-            unitId
-        )
-
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Unit.UPDATE_CHILD_ATTENDANCES,
+                    unitId
+                )
                 tx.fetchChildPlacementBasics(childId, unitId, clock.today())
-
                 tx.deleteAbsencesByDate(childId, clock.today())
                 try {
                     tx.insertAttendance(
@@ -178,15 +187,15 @@ class ChildAttendanceController(
         @PathVariable unitId: DaycareId,
         @PathVariable childId: ChildId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.UPDATE_CHILD_ATTENDANCES,
-            unitId
-        )
-
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Unit.UPDATE_CHILD_ATTENDANCES,
+                    unitId
+                )
                 tx.fetchChildPlacementBasics(childId, unitId, clock.today())
                 tx.deleteAbsencesByDate(childId, clock.today())
 
@@ -205,10 +214,15 @@ class ChildAttendanceController(
         @PathVariable unitId: DaycareId,
         @PathVariable childId: ChildId
     ): List<AbsenceThreshold> {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_CHILD_ATTENDANCES, unitId)
-
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Unit.READ_CHILD_ATTENDANCES,
+                        unitId
+                    )
                     val attendance = getChildOngoingAttendance(tx, childId, unitId)
                     getPartialAbsenceThresholds(tx, clock, childId, unitId, attendance)
                 }
@@ -236,15 +250,15 @@ class ChildAttendanceController(
         @PathVariable childId: ChildId,
         @RequestBody body: DepartureRequest
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.UPDATE_CHILD_ATTENDANCES,
-            unitId
-        )
-
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Unit.UPDATE_CHILD_ATTENDANCES,
+                    unitId
+                )
                 val now = clock.now()
                 val today = clock.today()
 
@@ -310,15 +324,15 @@ class ChildAttendanceController(
         @PathVariable unitId: DaycareId,
         @PathVariable childId: ChildId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.UPDATE_CHILD_ATTENDANCES,
-            unitId
-        )
-
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Unit.UPDATE_CHILD_ATTENDANCES,
+                    unitId
+                )
                 tx.fetchChildPlacementBasics(childId, unitId, clock.today())
                 tx.deleteAbsencesByDate(childId, clock.today())
 
@@ -341,18 +355,18 @@ class ChildAttendanceController(
         @PathVariable childId: ChildId,
         @RequestBody body: FullDayAbsenceRequest
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.UPDATE_CHILD_ATTENDANCES,
-            unitId
-        )
-
         val now = clock.now()
         val today = now.toLocalDate()
 
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Unit.UPDATE_CHILD_ATTENDANCES,
+                    unitId
+                )
                 val placementBasics = tx.fetchChildPlacementBasics(childId, unitId, clock.today())
 
                 val attendance = tx.getChildAttendance(childId, unitId, clock.now())
@@ -390,16 +404,16 @@ class ChildAttendanceController(
         @PathVariable childId: ChildId,
         @RequestBody body: AbsenceRangeRequest
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.UPDATE_CHILD_ATTENDANCES,
-            unitId
-        )
-
         val now = clock.now()
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Unit.UPDATE_CHILD_ATTENDANCES,
+                    unitId
+                )
                 val typeOnDates =
                     tx.fetchChildPlacementTypeDates(childId, unitId, body.startDate, body.endDate)
 
@@ -429,10 +443,16 @@ class ChildAttendanceController(
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Child.DELETE_ABSENCE_RANGE, childId)
         val deleted =
             db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Child.DELETE_ABSENCE_RANGE,
+                        childId
+                    )
                     tx.deleteAbsencesByFiniteDateRange(childId, FiniteDateRange(from, to))
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
@@ -34,8 +34,18 @@ class MobileUnitController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable unitId: DaycareId
     ): UnitInfo {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_MOBILE_INFO, unitId)
-        return db.connect { dbc -> dbc.read { tx -> tx.fetchUnitInfo(unitId, clock.today()) } }
+        return db.connect { dbc ->
+                dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Unit.READ_MOBILE_INFO,
+                        unitId
+                    )
+                    tx.fetchUnitInfo(unitId, clock.today())
+                }
+            }
             .also { Audit.UnitRead.log(targetId = unitId) }
     }
 
@@ -46,8 +56,18 @@ class MobileUnitController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @RequestParam unitIds: List<DaycareId>
     ): List<UnitStats> {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_MOBILE_STATS, unitIds)
-        return db.connect { dbc -> dbc.read { tx -> tx.fetchUnitStats(unitIds, clock.today()) } }
+        return db.connect { dbc ->
+                dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Unit.READ_MOBILE_STATS,
+                        unitIds
+                    )
+                    tx.fetchUnitStats(unitIds, clock.today())
+                }
+            }
             .also { Audit.UnitRead.log(targetId = unitIds) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -40,10 +40,16 @@ class BackupCareController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable("childId") childId: ChildId
     ): ChildBackupCaresResponse {
-        accessControl.requirePermissionFor(user, clock, Action.Child.READ_BACKUP_CARE, childId)
         return ChildBackupCaresResponse(
             db.connect { dbc ->
                     dbc.read { tx ->
+                        accessControl.requirePermissionFor(
+                            tx,
+                            user,
+                            clock,
+                            Action.Child.READ_BACKUP_CARE,
+                            childId
+                        )
                         val backupCares = tx.getBackupCaresForChild(childId)
                         val backupCareIds = backupCares.map { bc -> bc.id }
                         val permittedActions =
@@ -75,11 +81,17 @@ class BackupCareController(private val accessControl: AccessControl) {
         @PathVariable("childId") childId: ChildId,
         @RequestBody body: NewBackupCare
     ): BackupCareCreateResponse {
-        accessControl.requirePermissionFor(user, clock, Action.Child.CREATE_BACKUP_CARE, childId)
         try {
             val id =
                 db.connect { dbc ->
                     dbc.transaction { tx ->
+                        accessControl.requirePermissionFor(
+                            tx,
+                            user,
+                            clock,
+                            Action.Child.CREATE_BACKUP_CARE,
+                            childId
+                        )
                         if (!tx.childPlacementsHasConsecutiveRange(childId, body.period)) {
                             throw BadRequest(
                                 "The new backup care period is not contained within a placement"
@@ -111,10 +123,16 @@ class BackupCareController(private val accessControl: AccessControl) {
         @PathVariable("id") backupCareId: BackupCareId,
         @RequestBody body: BackupCareUpdateRequest
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.BackupCare.UPDATE, backupCareId)
         try {
             db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.BackupCare.UPDATE,
+                        backupCareId
+                    )
                     if (
                         !tx.childPlacementsHasConsecutiveRange(
                             tx.getBackupCareChildId(backupCareId),
@@ -207,9 +225,15 @@ class BackupCareController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable("id") backupCareId: BackupCareId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.BackupCare.DELETE, backupCareId)
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.BackupCare.DELETE,
+                    backupCareId
+                )
                 val backupCare = tx.getBackupCare(backupCareId)
                 if (backupCare != null) {
                     tx.clearCalendarEventAttendees(
@@ -235,10 +259,16 @@ class BackupCareController(private val accessControl: AccessControl) {
         startDate: LocalDate,
         @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
     ): UnitBackupCaresResponse {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_BACKUP_CARE, daycareId)
         val backupCares =
             db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Unit.READ_BACKUP_CARE,
+                        daycareId
+                    )
                     it.getBackupCaresForDaycare(daycareId, FiniteDateRange(startDate, endDate))
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/children/consent/ChildConsentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/children/consent/ChildConsentController.kt
@@ -31,9 +31,15 @@ class ChildConsentController(
         clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<ChildConsent> {
-        accessControl.requirePermissionFor(user, clock, Action.Child.READ_CHILD_CONSENTS, childId)
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Child.READ_CHILD_CONSENTS,
+                        childId
+                    )
                     val consents = tx.getChildConsentsByChild(childId)
                     featureConfig.enabledChildConsentTypes.map { type ->
                         consents.find { it.type == type }
@@ -52,14 +58,15 @@ class ChildConsentController(
         user: AuthenticatedUser.Citizen,
         clock: EvakaClock
     ): Map<ChildId, List<CitizenChildConsent>> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.READ_CHILD_CONSENTS,
-            user.id
-        )
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.Person.READ_CHILD_CONSENTS,
+                        user.id
+                    )
                     tx.getCitizenChildConsentsForGuardian(user.id, clock.today()).mapValues {
                         consent ->
                         featureConfig.enabledChildConsentTypes.map { type ->
@@ -88,9 +95,15 @@ class ChildConsentController(
         @PathVariable childId: ChildId,
         @RequestBody body: List<UpdateChildConsentRequest>
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Child.UPSERT_CHILD_CONSENT, childId)
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Child.UPSERT_CHILD_CONSENT,
+                        childId
+                    )
                     body
                         .filter { featureConfig.enabledChildConsentTypes.contains(it.type) }
                         .forEach { consent ->
@@ -120,14 +133,15 @@ class ChildConsentController(
         @PathVariable childId: ChildId,
         @RequestBody body: List<CitizenChildConsent>
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Child.INSERT_CHILD_CONSENTS,
-            childId
-        )
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.Child.INSERT_CHILD_CONSENTS,
+                        childId
+                    )
                     body
                         .filter { featureConfig.enabledChildConsentTypes.contains(it.type) }
                         .forEach { consent ->
@@ -157,14 +171,15 @@ class ChildConsentController(
         user: AuthenticatedUser.Citizen,
         clock: EvakaClock
     ): Map<ChildId, Int> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.READ_CHILD_CONSENT_NOTIFICATIONS,
-            user.id
-        )
         return db.connect { dbc ->
-                dbc.transaction { tx ->
+                dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.Person.READ_CHILD_CONSENT_NOTIFICATIONS,
+                        user.id
+                    )
                     tx.getCitizenConsentedChildConsentTypes(user.id, clock.today())
                         .map { (child, knownConsentTypes) ->
                             child to

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/StaffAttendanceController.kt
@@ -39,8 +39,16 @@ class StaffAttendanceController(
         clock: EvakaClock,
         @PathVariable unitId: DaycareId
     ): UnitStaffAttendance {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_STAFF_ATTENDANCES, unitId)
         return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Unit.READ_STAFF_ATTENDANCES,
+                        unitId
+                    )
+                }
                 staffAttendanceService.getUnitAttendancesForDate(dbc, unitId, clock.today())
             }
             .also { Audit.UnitStaffAttendanceRead.log(targetId = unitId) }
@@ -55,14 +63,17 @@ class StaffAttendanceController(
         @RequestParam month: Int,
         @PathVariable groupId: GroupId
     ): Wrapper<StaffAttendanceForDates> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Group.READ_STAFF_ATTENDANCES,
-            groupId
-        )
         val result =
             db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Group.READ_STAFF_ATTENDANCES,
+                        groupId
+                    )
+                }
                 staffAttendanceService.getGroupAttendancesByMonth(dbc, year, month, groupId)
             }
         Audit.StaffAttendanceRead.log(targetId = groupId)
@@ -77,16 +88,19 @@ class StaffAttendanceController(
         @RequestBody staffAttendance: StaffAttendanceUpdate,
         @PathVariable groupId: GroupId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Group.UPDATE_STAFF_ATTENDANCES,
-            groupId
-        )
         if (staffAttendance.count == null) {
             throw BadRequest("Count can't be null")
         }
         db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Group.UPDATE_STAFF_ATTENDANCES,
+                    groupId
+                )
+            }
             staffAttendanceService.upsertStaffAttendance(
                 dbc,
                 staffAttendance.copy(groupId = groupId)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclController.kt
@@ -41,9 +41,19 @@ class UnitAclController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable daycareId: DaycareId
     ): DaycareAclResponse {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_ACL, daycareId)
         return DaycareAclResponse(
-            db.connect { dbc -> getDaycareAclRows(dbc, daycareId) }
+            db.connect { dbc ->
+                    dbc.read {
+                        accessControl.requirePermissionFor(
+                            it,
+                            user,
+                            clock,
+                            Action.Unit.READ_ACL,
+                            daycareId
+                        )
+                    }
+                    getDaycareAclRows(dbc, daycareId)
+                }
                 .also {
                     Audit.UnitAclRead.log(targetId = daycareId, args = mapOf("count" to it.size))
                 }
@@ -58,13 +68,18 @@ class UnitAclController(private val accessControl: AccessControl) {
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.INSERT_ACL_UNIT_SUPERVISOR,
-            daycareId
-        )
-        db.connect { dbc -> addUnitSupervisor(dbc, daycareId, employeeId) }
+        db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Unit.INSERT_ACL_UNIT_SUPERVISOR,
+                    daycareId
+                )
+            }
+            addUnitSupervisor(dbc, daycareId, employeeId)
+        }
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
     }
 
@@ -76,13 +91,18 @@ class UnitAclController(private val accessControl: AccessControl) {
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.DELETE_ACL_UNIT_SUPERVISOR,
-            daycareId
-        )
-        db.connect { dbc -> removeUnitSupervisor(dbc, daycareId, employeeId) }
+        db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Unit.DELETE_ACL_UNIT_SUPERVISOR,
+                    daycareId
+                )
+            }
+            removeUnitSupervisor(dbc, daycareId, employeeId)
+        }
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
     }
 
@@ -94,13 +114,18 @@ class UnitAclController(private val accessControl: AccessControl) {
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.INSERT_ACL_SPECIAL_EDUCATION_TEACHER,
-            daycareId
-        )
-        db.connect { dbc -> addSpecialEducationTeacher(dbc, daycareId, employeeId) }
+        db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Unit.INSERT_ACL_SPECIAL_EDUCATION_TEACHER,
+                    daycareId
+                )
+            }
+            addSpecialEducationTeacher(dbc, daycareId, employeeId)
+        }
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
     }
 
@@ -112,13 +137,18 @@ class UnitAclController(private val accessControl: AccessControl) {
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.DELETE_ACL_SPECIAL_EDUCATION_TEACHER,
-            daycareId
-        )
-        db.connect { dbc -> removeSpecialEducationTeacher(dbc, daycareId, employeeId) }
+        db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Unit.DELETE_ACL_SPECIAL_EDUCATION_TEACHER,
+                    daycareId
+                )
+            }
+            removeSpecialEducationTeacher(dbc, daycareId, employeeId)
+        }
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
     }
 
@@ -130,13 +160,18 @@ class UnitAclController(private val accessControl: AccessControl) {
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.INSERT_ACL_EARLY_CHILDHOOD_EDUCATION_SECRETARY,
-            daycareId
-        )
-        db.connect { dbc -> addEarlyChildhoodEducationSecretary(dbc, daycareId, employeeId) }
+        db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Unit.INSERT_ACL_EARLY_CHILDHOOD_EDUCATION_SECRETARY,
+                    daycareId
+                )
+            }
+            addEarlyChildhoodEducationSecretary(dbc, daycareId, employeeId)
+        }
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
     }
 
@@ -148,13 +183,18 @@ class UnitAclController(private val accessControl: AccessControl) {
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.DELETE_ACL_EARLY_CHILDHOOD_EDUCATION_SECRETARY,
-            daycareId
-        )
-        db.connect { dbc -> removeEarlyChildhoodEducationSecretary(dbc, daycareId, employeeId) }
+        db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Unit.DELETE_ACL_EARLY_CHILDHOOD_EDUCATION_SECRETARY,
+                    daycareId
+                )
+            }
+            removeEarlyChildhoodEducationSecretary(dbc, daycareId, employeeId)
+        }
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
     }
 
@@ -166,8 +206,18 @@ class UnitAclController(private val accessControl: AccessControl) {
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.INSERT_ACL_STAFF, daycareId)
-        db.connect { dbc -> addStaffMember(dbc, daycareId, employeeId) }
+        db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Unit.INSERT_ACL_STAFF,
+                    daycareId
+                )
+            }
+            addStaffMember(dbc, daycareId, employeeId)
+        }
         Audit.UnitAclCreate.log(targetId = daycareId, objectId = employeeId)
     }
 
@@ -179,8 +229,18 @@ class UnitAclController(private val accessControl: AccessControl) {
         @PathVariable daycareId: DaycareId,
         @PathVariable employeeId: EmployeeId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.DELETE_ACL_STAFF, daycareId)
-        db.connect { dbc -> removeStaffMember(dbc, daycareId, employeeId) }
+        db.connect { dbc ->
+            dbc.read {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Unit.DELETE_ACL_STAFF,
+                    daycareId
+                )
+            }
+            removeStaffMember(dbc, daycareId, employeeId)
+        }
         Audit.UnitAclDelete.log(targetId = daycareId, objectId = employeeId)
     }
 
@@ -193,15 +253,15 @@ class UnitAclController(private val accessControl: AccessControl) {
         @PathVariable employeeId: EmployeeId,
         @RequestBody update: GroupAclUpdate
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.UPDATE_STAFF_GROUP_ACL,
-            daycareId
-        )
-
         db.connect { dbc ->
             dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Unit.UPDATE_STAFF_GROUP_ACL,
+                    daycareId
+                )
                 it.clearDaycareGroupAcl(daycareId, employeeId)
                 it.insertDaycareGroupAcl(daycareId, employeeId, update.groupIds)
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodController.kt
@@ -31,8 +31,17 @@ class HolidayPeriodController(private val accessControl: AccessControl) {
         user: AuthenticatedUser,
         clock: EvakaClock
     ): List<HolidayPeriod> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_HOLIDAY_PERIODS)
-        return db.connect { dbc -> dbc.read { it.getHolidayPeriods() } }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_HOLIDAY_PERIODS
+                    )
+                    it.getHolidayPeriods()
+                }
+            }
             .also { Audit.HolidayPeriodsList.log(args = mapOf("count" to it.size)) }
     }
 
@@ -43,8 +52,18 @@ class HolidayPeriodController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable id: HolidayPeriodId
     ): HolidayPeriod {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_HOLIDAY_PERIOD)
-        return db.connect { dbc -> dbc.read { it.getHolidayPeriod(id) } ?: throw NotFound() }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_HOLIDAY_PERIOD
+                    )
+                    it.getHolidayPeriod(id)
+                }
+                    ?: throw NotFound()
+            }
             .also { Audit.HolidayPeriodRead.log(targetId = id) }
     }
 
@@ -55,9 +74,14 @@ class HolidayPeriodController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @RequestBody body: HolidayPeriodBody
     ): HolidayPeriod {
-        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_HOLIDAY_PERIOD)
         return db.connect { dbc ->
                 dbc.transaction {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.CREATE_HOLIDAY_PERIOD
+                    )
                     try {
                         it.createHolidayPeriod(body)
                     } catch (e: Exception) {
@@ -76,9 +100,14 @@ class HolidayPeriodController(private val accessControl: AccessControl) {
         @PathVariable id: HolidayPeriodId,
         @RequestBody body: HolidayPeriodBody
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Global.UPDATE_HOLIDAY_PERIOD)
         db.connect { dbc ->
             dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Global.UPDATE_HOLIDAY_PERIOD
+                )
                 try {
                     it.updateHolidayPeriod(id, body)
                 } catch (e: Exception) {
@@ -96,8 +125,17 @@ class HolidayPeriodController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable id: HolidayPeriodId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Global.DELETE_HOLIDAY_PERIOD)
-        db.connect { dbc -> dbc.transaction { it.deleteHolidayPeriod(id) } }
+        db.connect { dbc ->
+            dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Global.DELETE_HOLIDAY_PERIOD
+                )
+                it.deleteHolidayPeriod(id)
+            }
+        }
         Audit.HolidayPeriodDelete.log(targetId = id)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaireController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaireController.kt
@@ -31,8 +31,17 @@ class HolidayQuestionnaireController(private val accessControl: AccessControl) {
         user: AuthenticatedUser,
         clock: EvakaClock
     ): List<FixedPeriodQuestionnaire> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_HOLIDAY_QUESTIONNAIRES)
-        return db.connect { dbc -> dbc.read { it.getHolidayQuestionnaires() } }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_HOLIDAY_QUESTIONNAIRES
+                    )
+                    it.getHolidayQuestionnaires()
+                }
+            }
             .also { Audit.HolidayQuestionnairesList.log(args = mapOf("count" to it.size)) }
     }
 
@@ -43,9 +52,16 @@ class HolidayQuestionnaireController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable id: HolidayQuestionnaireId
     ): FixedPeriodQuestionnaire {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_HOLIDAY_QUESTIONNAIRE)
         return db.connect { dbc ->
-                dbc.read { it.getFixedPeriodQuestionnaire(id) ?: throw NotFound() }
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_HOLIDAY_QUESTIONNAIRE
+                    )
+                    it.getFixedPeriodQuestionnaire(id) ?: throw NotFound()
+                }
             }
             .also { Audit.HolidayQuestionnaireRead.log(targetId = id) }
     }
@@ -57,10 +73,15 @@ class HolidayQuestionnaireController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @RequestBody body: FixedPeriodQuestionnaireBody
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Global.CREATE_HOLIDAY_QUESTIONNAIRE)
         val id =
             db.connect { dbc ->
                 dbc.transaction {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.CREATE_HOLIDAY_QUESTIONNAIRE
+                    )
                     try {
                         it.createFixedPeriodQuestionnaire(body)
                     } catch (e: Exception) {
@@ -79,9 +100,14 @@ class HolidayQuestionnaireController(private val accessControl: AccessControl) {
         @PathVariable id: HolidayQuestionnaireId,
         @RequestBody body: FixedPeriodQuestionnaireBody
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Global.UPDATE_HOLIDAY_QUESTIONNAIRE)
         db.connect { dbc ->
             dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Global.UPDATE_HOLIDAY_QUESTIONNAIRE
+                )
                 try {
                     it.updateFixedPeriodQuestionnaire(id, body)
                 } catch (e: Exception) {
@@ -99,8 +125,17 @@ class HolidayQuestionnaireController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable id: HolidayQuestionnaireId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Global.DELETE_HOLIDAY_QUESTIONNAIRE)
-        db.connect { dbc -> dbc.transaction { it.deleteHolidayQuestionnaire(id) } }
+        db.connect { dbc ->
+            dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Global.DELETE_HOLIDAY_QUESTIONNAIRE
+                )
+                it.deleteHolidayQuestionnaire(id)
+            }
+        }
         Audit.HolidayQuestionnaireDelete.log(targetId = id)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
@@ -38,14 +38,15 @@ class IncomeStatementController(private val accessControl: AccessControl) {
         @RequestParam page: Int,
         @RequestParam pageSize: Int
     ): Paged<IncomeStatement> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Person.READ_INCOME_STATEMENTS,
-            personId
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Person.READ_INCOME_STATEMENTS,
+                        personId
+                    )
                     it.readIncomeStatementsForPerson(
                         personId = personId,
                         includeEmployeeContent = true,
@@ -71,15 +72,15 @@ class IncomeStatementController(private val accessControl: AccessControl) {
         @RequestParam page: Int,
         @RequestParam pageSize: Int
     ): Paged<IncomeStatement> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Person.READ_INCOME_STATEMENTS,
-            PersonId(childId.raw)
-        )
-
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Person.READ_INCOME_STATEMENTS,
+                        PersonId(childId.raw)
+                    )
                     tx.readIncomeStatementsForPerson(
                         PersonId(childId.raw),
                         includeEmployeeContent = true,
@@ -104,14 +105,15 @@ class IncomeStatementController(private val accessControl: AccessControl) {
         @PathVariable personId: PersonId,
         @PathVariable incomeStatementId: IncomeStatementId
     ): IncomeStatement {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Person.READ_INCOME_STATEMENTS,
-            personId
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Person.READ_INCOME_STATEMENTS,
+                        personId
+                    )
                     it.readIncomeStatementForPerson(
                         personId,
                         incomeStatementId,
@@ -133,14 +135,15 @@ class IncomeStatementController(private val accessControl: AccessControl) {
         @PathVariable incomeStatementId: IncomeStatementId,
         @RequestBody body: SetIncomeStatementHandledBody
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.IncomeStatement.UPDATE_HANDLED,
-            incomeStatementId
-        )
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.IncomeStatement.UPDATE_HANDLED,
+                    incomeStatementId
+                )
                 tx.updateIncomeStatementHandled(
                     incomeStatementId,
                     body.handlerNote,
@@ -158,13 +161,14 @@ class IncomeStatementController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @RequestBody body: SearchIncomeStatementsRequest
     ): Paged<IncomeStatementAwaitingHandler> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.FETCH_INCOME_STATEMENTS_AWAITING_HANDLER
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.FETCH_INCOME_STATEMENTS_AWAITING_HANDLER
+                    )
                     it.fetchIncomeStatementsAwaitingHandler(
                         clock.now().toLocalDate(),
                         body.areas ?: emptyList(),
@@ -189,14 +193,17 @@ class IncomeStatementController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable guardianId: PersonId
     ): List<ChildBasicInfo> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Person.READ_INCOME_STATEMENTS,
-            guardianId
-        )
         return db.connect { dbc ->
-                dbc.read { it.getIncomeStatementChildrenByGuardian(guardianId) }
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Person.READ_INCOME_STATEMENTS,
+                        guardianId
+                    )
+                    it.getIncomeStatementChildrenByGuardian(guardianId)
+                }
             }
             .also {
                 Audit.GuardianChildrenRead.log(targetId = guardianId, mapOf("count" to it.size))

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizen.kt
@@ -41,15 +41,15 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         @RequestParam page: Int,
         @RequestParam pageSize: Int
     ): Paged<IncomeStatement> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.READ_INCOME_STATEMENTS,
-            user.id
-        )
-
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.Person.READ_INCOME_STATEMENTS,
+                        user.id
+                    )
                     tx.readIncomeStatementsForPerson(
                         user.id,
                         includeEmployeeContent = false,
@@ -75,15 +75,15 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         @RequestParam page: Int,
         @RequestParam pageSize: Int
     ): Paged<IncomeStatement> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Child.READ_INCOME_STATEMENTS,
-            childId
-        )
-
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.Child.READ_INCOME_STATEMENTS,
+                        childId
+                    )
                     tx.readIncomeStatementsForPerson(
                         childId,
                         includeEmployeeContent = false,
@@ -107,14 +107,18 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<LocalDate> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Child.READ_INCOME_STATEMENTS,
-            childId
-        )
-
-        return db.connect { dbc -> dbc.read { it.readIncomeStatementStartDates(childId) } }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Citizen.Child.READ_INCOME_STATEMENTS,
+                        childId
+                    )
+                    it.readIncomeStatementStartDates(childId)
+                }
+            }
             .also {
                 Audit.IncomeStatementStartDatesOfChild.log(
                     targetId = childId,
@@ -129,13 +133,18 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         user: AuthenticatedUser.Citizen,
         clock: EvakaClock
     ): List<LocalDate> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.READ_INCOME_STATEMENTS,
-            user.id
-        )
-        return db.connect { dbc -> dbc.read { it.readIncomeStatementStartDates(user.id) } }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Citizen.Person.READ_INCOME_STATEMENTS,
+                        user.id
+                    )
+                    it.readIncomeStatementStartDates(user.id)
+                }
+            }
             .also {
                 Audit.IncomeStatementStartDates.log(
                     targetId = user.id,
@@ -151,15 +160,15 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         clock: EvakaClock,
         @PathVariable incomeStatementId: IncomeStatementId
     ): IncomeStatement {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.IncomeStatement.READ,
-            incomeStatementId
-        )
-
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.IncomeStatement.READ,
+                        incomeStatementId
+                    )
                     tx.readIncomeStatementForPerson(
                         user.id,
                         incomeStatementId,
@@ -179,15 +188,15 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         @PathVariable childId: ChildId,
         @PathVariable incomeStatementId: IncomeStatementId
     ): IncomeStatement {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.IncomeStatement.READ,
-            incomeStatementId
-        )
-
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.IncomeStatement.READ,
+                        incomeStatementId
+                    )
                     tx.readIncomeStatementForPerson(
                         PersonId(childId.raw),
                         incomeStatementId,
@@ -206,13 +215,19 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         clock: EvakaClock,
         @RequestBody body: IncomeStatementBody
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.CREATE_INCOME_STATEMENT,
-            user.id
-        )
-        val id = db.connect { createIncomeStatement(it, user.id, user.id, body) }
+        val id =
+            db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Citizen.Person.CREATE_INCOME_STATEMENT,
+                        user.id
+                    )
+                }
+                createIncomeStatement(dbc, user.id, user.id, body)
+            }
         Audit.IncomeStatementCreate.log(targetId = user.id, objectId = id)
     }
 
@@ -224,13 +239,19 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         @PathVariable childId: ChildId,
         @RequestBody body: IncomeStatementBody
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Child.CREATE_INCOME_STATEMENT,
-            childId
-        )
-        val id = db.connect { createIncomeStatement(it, childId, user.id, body) }
+        val id =
+            db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Citizen.Child.CREATE_INCOME_STATEMENT,
+                        childId
+                    )
+                }
+                createIncomeStatement(dbc, childId, user.id, body)
+            }
         Audit.IncomeStatementCreateForChild.log(user.id, objectId = id)
     }
 
@@ -242,16 +263,16 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         @PathVariable incomeStatementId: IncomeStatementId,
         @RequestBody body: IncomeStatementBody
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.IncomeStatement.UPDATE,
-            incomeStatementId
-        )
-
         if (!validateIncomeStatementBody(body)) throw BadRequest("Invalid income statement body")
         db.connect { dbc ->
             dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.IncomeStatement.UPDATE,
+                        incomeStatementId
+                    )
                     verifyIncomeStatementModificationsAllowed(tx, user.id, incomeStatementId)
                     tx.updateIncomeStatement(incomeStatementId, body).also { success ->
                         if (success) {
@@ -282,18 +303,18 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         @PathVariable incomeStatementId: IncomeStatementId,
         @RequestBody body: IncomeStatementBody
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.IncomeStatement.UPDATE,
-            incomeStatementId
-        )
-
         if (!validateIncomeStatementBody(body))
             throw BadRequest("Invalid child income statement body")
 
         db.connect { dbc ->
             dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.IncomeStatement.UPDATE,
+                        incomeStatementId
+                    )
                     verifyIncomeStatementModificationsAllowed(
                         tx,
                         PersonId(childId.raw),
@@ -326,9 +347,15 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         clock: EvakaClock,
         @PathVariable id: IncomeStatementId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Citizen.IncomeStatement.DELETE, id)
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Citizen.IncomeStatement.DELETE,
+                    id
+                )
                 verifyIncomeStatementModificationsAllowed(tx, user.id, id)
                 tx.removeIncomeStatement(id)
             }
@@ -344,10 +371,15 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         @PathVariable childId: ChildId,
         @PathVariable id: IncomeStatementId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Citizen.IncomeStatement.DELETE, id)
-
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Citizen.IncomeStatement.DELETE,
+                    id
+                )
                 verifyIncomeStatementModificationsAllowed(tx, childId, id)
                 tx.removeIncomeStatement(id)
             }
@@ -362,13 +394,18 @@ class IncomeStatementControllerCitizen(private val accessControl: AccessControl)
         clock: EvakaClock
     ): List<ChildBasicInfo> {
         val personId = user.id
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.READ_CHILDREN,
-            personId
-        )
-        return db.connect { dbc -> dbc.read { it.getIncomeStatementChildrenByGuardian(personId) } }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Citizen.Person.READ_CHILDREN,
+                        personId
+                    )
+                    it.getIncomeStatementChildrenByGuardian(personId)
+                }
+            }
             .also {
                 Audit.CitizenChildrenRead.log(targetId = personId, args = mapOf("count" to it.size))
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeAlterationController.kt
@@ -45,9 +45,15 @@ class FeeAlterationController(
         clock: EvakaClock,
         @RequestParam personId: PersonId
     ): List<FeeAlterationWithPermittedActions> {
-        accessControl.requirePermissionFor(user, clock, Action.Child.READ_FEE_ALTERATIONS, personId)
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Child.READ_FEE_ALTERATIONS,
+                        personId
+                    )
                     val feeAlterations = tx.getFeeAlterationsForPerson(personId)
                     val permittedActions =
                         accessControl.getPermittedActions<FeeAlterationId, Action.FeeAlteration>(
@@ -81,15 +87,16 @@ class FeeAlterationController(
         clock: EvakaClock,
         @RequestBody feeAlteration: FeeAlteration
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Child.CREATE_FEE_ALTERATION,
-            feeAlteration.personId
-        )
         val id = FeeAlterationId(UUID.randomUUID())
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Child.CREATE_FEE_ALTERATION,
+                    feeAlteration.personId
+                )
                 tx.upsertFeeAlteration(
                     clock,
                     feeAlteration.copy(id = id, updatedBy = user.evakaUserId)
@@ -117,14 +124,15 @@ class FeeAlterationController(
         @PathVariable feeAlterationId: FeeAlterationId,
         @RequestBody feeAlteration: FeeAlteration
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.FeeAlteration.UPDATE,
-            feeAlterationId
-        )
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.FeeAlteration.UPDATE,
+                    feeAlterationId
+                )
                 val existing = tx.getFeeAlteration(feeAlterationId)
                 tx.upsertFeeAlteration(
                     clock,
@@ -162,14 +170,15 @@ class FeeAlterationController(
         clock: EvakaClock,
         @PathVariable feeAlterationId: FeeAlterationId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.FeeAlteration.DELETE,
-            feeAlterationId
-        )
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.FeeAlteration.DELETE,
+                    feeAlterationId
+                )
                 val existing = tx.getFeeAlteration(feeAlterationId)
                 tx.deleteFeeAlteration(feeAlterationId)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceCorrectionsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceCorrectionsController.kt
@@ -40,14 +40,15 @@ class InvoiceCorrectionsController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable personId: PersonId
     ): List<InvoiceCorrectionWithPermittedActions> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Person.READ_INVOICE_CORRECTIONS,
-            personId
-        )
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Person.READ_INVOICE_CORRECTIONS,
+                        personId
+                    )
                     val invoiceCorrections =
                         tx.createQuery(
                                 """
@@ -106,15 +107,16 @@ WHERE c.head_of_family_id = :personId AND NOT applied_completely
         clock: EvakaClock,
         @RequestBody body: NewInvoiceCorrection
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Person.CREATE_INVOICE_CORRECTION,
-            body.headOfFamilyId
-        )
         val invoiceCorrectionId =
             db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Person.CREATE_INVOICE_CORRECTION,
+                        body.headOfFamilyId
+                    )
                     tx.createUpdate(
                             """
 INSERT INTO invoice_correction (head_of_family_id, child_id, unit_id, product, period, amount, unit_price, description, note)
@@ -141,9 +143,15 @@ RETURNING id
         clock: EvakaClock,
         @PathVariable id: InvoiceCorrectionId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.InvoiceCorrection.DELETE, id)
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.InvoiceCorrection.DELETE,
+                    id
+                )
                 try {
                     tx.createUpdate(
                             """
@@ -180,9 +188,15 @@ DELETE FROM invoice_correction WHERE id = :id RETURNING id
         @PathVariable id: InvoiceCorrectionId,
         @RequestBody body: NoteUpdateBody
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.InvoiceCorrection.UPDATE_NOTE, id)
         db.connect { dbc ->
             dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.InvoiceCorrection.UPDATE_NOTE,
+                    id
+                )
                 tx.createUpdate("UPDATE invoice_correction SET note = :note WHERE id = :id")
                     .bind("id", id)
                     .bind("note", body.note)

--- a/service/src/main/kotlin/fi/espoo/evaka/note/NotesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/NotesController.kt
@@ -36,10 +36,9 @@ class NotesController(private val ac: AccessControl) {
         clock: EvakaClock,
         @PathVariable groupId: GroupId
     ): NotesByGroupResponse {
-        ac.requirePermissionFor(user, clock, Action.Group.READ_NOTES, groupId)
-
         return db.connect { dbc ->
                 dbc.read {
+                    ac.requirePermissionFor(it, user, clock, Action.Group.READ_NOTES, groupId)
                     NotesByGroupResponse(
                         childDailyNotes = it.getChildDailyNotesInGroup(groupId, clock.today()),
                         childStickyNotes = it.getChildStickyNotesForGroup(groupId, clock.today()),

--- a/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/note/child/daily/ChildDailyNoteController.kt
@@ -34,10 +34,19 @@ class ChildDailyNoteController(private val ac: AccessControl) {
         @PathVariable childId: ChildId,
         @RequestBody body: ChildDailyNoteBody
     ): ChildDailyNoteId {
-        ac.requirePermissionFor(user, clock, Action.Child.CREATE_DAILY_NOTE, childId)
-
         try {
-            return db.connect { dbc -> dbc.transaction { it.createChildDailyNote(childId, body) } }
+            return db.connect { dbc ->
+                    dbc.transaction {
+                        ac.requirePermissionFor(
+                            it,
+                            user,
+                            clock,
+                            Action.Child.CREATE_DAILY_NOTE,
+                            childId
+                        )
+                        it.createChildDailyNote(childId, body)
+                    }
+                }
                 .also { noteId ->
                     Audit.ChildDailyNoteCreate.log(targetId = childId, objectId = noteId)
                 }
@@ -57,10 +66,11 @@ class ChildDailyNoteController(private val ac: AccessControl) {
         @PathVariable noteId: ChildDailyNoteId,
         @RequestBody body: ChildDailyNoteBody
     ): ChildDailyNote {
-        ac.requirePermissionFor(user, clock, Action.ChildDailyNote.UPDATE, noteId)
-
         return db.connect { dbc ->
-                dbc.transaction { it.updateChildDailyNote(clock, noteId, body) }
+                dbc.transaction {
+                    ac.requirePermissionFor(it, user, clock, Action.ChildDailyNote.UPDATE, noteId)
+                    it.updateChildDailyNote(clock, noteId, body)
+                }
             }
             .also { Audit.ChildDailyNoteUpdate.log(targetId = noteId) }
     }
@@ -72,9 +82,12 @@ class ChildDailyNoteController(private val ac: AccessControl) {
         clock: EvakaClock,
         @PathVariable noteId: ChildDailyNoteId
     ) {
-        ac.requirePermissionFor(user, clock, Action.ChildDailyNote.DELETE, noteId)
-
-        db.connect { dbc -> dbc.transaction { it.deleteChildDailyNote(noteId) } }
+        db.connect { dbc ->
+            dbc.transaction {
+                ac.requirePermissionFor(it, user, clock, Action.ChildDailyNote.DELETE, noteId)
+                it.deleteChildDailyNote(noteId)
+            }
+        }
         Audit.ChildDailyNoteDelete.log(targetId = noteId)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
@@ -47,11 +47,16 @@ class OccupancyController(
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
         @RequestParam type: OccupancyType
     ): OccupancyResponse {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_OCCUPANCIES, unitId)
-
         val occupancies =
             db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Unit.READ_OCCUPANCIES,
+                        unitId
+                    )
                     it.calculateOccupancyPeriods(
                         clock.today(),
                         unitId,
@@ -84,9 +89,6 @@ class OccupancyController(
         preschoolDaycareFrom: LocalDate?,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) preschoolDaycareTo: LocalDate?
     ): OccupancyResponseSpeculated {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_OCCUPANCIES, unitId)
-        accessControl.requirePermissionFor(user, clock, Action.Application.READ, applicationId)
-
         val period = FiniteDateRange(from, to)
         val preschoolDaycarePeriod =
             if (preschoolDaycareFrom != null && preschoolDaycareTo != null) {
@@ -97,6 +99,21 @@ class OccupancyController(
 
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Unit.READ_OCCUPANCIES,
+                        unitId
+                    )
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Application.READ,
+                        applicationId
+                    )
+
                     val unit = tx.getDaycare(unitId) ?: throw NotFound("Unit $unitId not found")
                     val application =
                         tx.fetchApplicationDetails(applicationId)
@@ -156,11 +173,16 @@ class OccupancyController(
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
         @RequestParam type: OccupancyType
     ): List<OccupancyResponseGroupLevel> {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_OCCUPANCIES, unitId)
-
         val occupancies =
             db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Unit.READ_OCCUPANCIES,
+                        unitId
+                    )
                     it.calculateOccupancyPeriodsGroupLevel(
                         clock.today(),
                         unitId,

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/MobileDevicesController.kt
@@ -32,8 +32,18 @@ class MobileDevicesController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @RequestParam unitId: DaycareId
     ): List<MobileDevice> {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_MOBILE_DEVICES, unitId)
-        return db.connect { dbc -> dbc.read { it.listSharedDevices(unitId) } }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Unit.READ_MOBILE_DEVICES,
+                        unitId
+                    )
+                    it.listSharedDevices(unitId)
+                }
+            }
             .also {
                 Audit.MobileDevicesList.log(targetId = unitId, args = mapOf("count" to it.size))
             }
@@ -45,8 +55,17 @@ class MobileDevicesController(private val accessControl: AccessControl) {
         user: AuthenticatedUser.Employee,
         clock: EvakaClock
     ): List<MobileDevice> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_PERSONAL_MOBILE_DEVICES)
-        return db.connect { dbc -> dbc.read { it.listPersonalDevices(user.id) } }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_PERSONAL_MOBILE_DEVICES
+                    )
+                    it.listPersonalDevices(user.id)
+                }
+            }
             .also {
                 Audit.MobileDevicesList.log(targetId = user.id, args = mapOf("count" to it.size))
             }
@@ -73,8 +92,18 @@ class MobileDevicesController(private val accessControl: AccessControl) {
         @PathVariable id: MobileDeviceId,
         @RequestBody body: RenameRequest
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.MobileDevice.UPDATE_NAME, id)
-        db.connect { dbc -> dbc.transaction { it.renameDevice(id, body.name) } }
+        db.connect { dbc ->
+            dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.MobileDevice.UPDATE_NAME,
+                    id
+                )
+                it.renameDevice(id, body.name)
+            }
+        }
         Audit.MobileDevicesRename.log(targetId = id)
     }
 
@@ -85,8 +114,12 @@ class MobileDevicesController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable id: MobileDeviceId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.MobileDevice.DELETE, id)
-        db.connect { dbc -> dbc.transaction { it.deleteDevice(id) } }
+        db.connect { dbc ->
+            dbc.transaction {
+                accessControl.requirePermissionFor(it, user, clock, Action.MobileDevice.DELETE, id)
+                it.deleteDevice(id)
+            }
+        }
         Audit.MobileDevicesDelete.log(targetId = id)
     }
 
@@ -97,25 +130,32 @@ class MobileDevicesController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @RequestBody params: PinLoginRequest
     ): PinLoginResponse =
-        when (accessControl.verifyPinCode(params.employeeId, params.pin, clock)) {
-            AccessControl.PinError.PIN_LOCKED -> PinLoginResponse(PinLoginStatus.PIN_LOCKED)
-            AccessControl.PinError.WRONG_PIN -> PinLoginResponse(PinLoginStatus.WRONG_PIN)
-            null ->
-                db.connect { dbc ->
-                    dbc.transaction { tx ->
-                        val employee = tx.getEmployeeUser(params.employeeId)
-                        employee?.let {
-                            PinLoginResponse(
-                                PinLoginStatus.SUCCESS,
-                                Employee(it.preferredFirstName ?: it.firstName, it.lastName)
-                            )
+        db.connect { dbc ->
+                dbc.transaction { tx ->
+                    when (accessControl.verifyPinCode(tx, params.employeeId, params.pin, clock)) {
+                        AccessControl.PinError.PIN_LOCKED ->
+                            PinLoginResponse(PinLoginStatus.PIN_LOCKED)
+                        AccessControl.PinError.WRONG_PIN ->
+                            PinLoginResponse(PinLoginStatus.WRONG_PIN)
+                        null -> {
+                            val employee = tx.getEmployeeUser(params.employeeId)
+                            employee?.let {
+                                PinLoginResponse(
+                                    PinLoginStatus.SUCCESS,
+                                    Employee(it.preferredFirstName ?: it.firstName, it.lastName)
+                                )
+                            }
+                                ?: PinLoginResponse(PinLoginStatus.WRONG_PIN)
                         }
-                            ?: PinLoginResponse(PinLoginStatus.WRONG_PIN)
                     }
                 }
-        }.also {
-            Audit.PinLogin.log(targetId = params.employeeId, args = mapOf("status" to it.status))
-        }
+            }
+            .also {
+                Audit.PinLogin.log(
+                    targetId = params.employeeId,
+                    args = mapOf("status" to it.status)
+                )
+            }
 }
 
 data class PinLoginRequest(val pin: String, val employeeId: EmployeeId)

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentControllerCitizen.kt
@@ -32,14 +32,15 @@ class PedagogicalDocumentControllerCitizen(private val accessControl: AccessCont
         clock: EvakaClock,
         @PathVariable childId: ChildId
     ): List<PedagogicalDocumentCitizen> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Child.READ_PEDAGOGICAL_DOCUMENTS,
-            childId
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Citizen.Child.READ_PEDAGOGICAL_DOCUMENTS,
+                        childId
+                    )
                     val documents =
                         it.getChildPedagogicalDocuments(childId, user.id).filter { pd ->
                             pd.description.isNotEmpty() || pd.attachments.isNotEmpty()
@@ -69,14 +70,17 @@ class PedagogicalDocumentControllerCitizen(private val accessControl: AccessCont
         clock: EvakaClock,
         @PathVariable documentId: PedagogicalDocumentId
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.PedagogicalDocument.READ,
-            documentId
-        )
         db.connect { dbc ->
-            dbc.transaction { it.markDocumentReadByGuardian(clock, documentId, user.id) }
+            dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Citizen.PedagogicalDocument.READ,
+                    documentId
+                )
+                it.markDocumentReadByGuardian(clock, documentId, user.id)
+            }
         }
         Audit.PedagogicalDocumentUpdate.log(targetId = documentId)
     }
@@ -87,14 +91,17 @@ class PedagogicalDocumentControllerCitizen(private val accessControl: AccessCont
         user: AuthenticatedUser.Citizen,
         clock: EvakaClock
     ): Map<ChildId, Int> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.READ_PEDAGOGICAL_DOCUMENT_UNREAD_COUNTS,
-            user.id
-        )
         return db.connect { dbc ->
-                dbc.transaction { it.countUnreadDocumentsByUser(clock.today(), user.id) }
+                dbc.transaction {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Citizen.Person.READ_PEDAGOGICAL_DOCUMENT_UNREAD_COUNTS,
+                        user.id
+                    )
+                    it.countUnreadDocumentsByUser(clock.today(), user.id)
+                }
             }
             .also { Audit.PedagogicalDocumentCountUnread.log(user.id) }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/CitizenUserController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/CitizenUserController.kt
@@ -36,12 +36,6 @@ class CitizenUserController(
         clock: EvakaClock,
         @PathVariable(value = "personId") personId: PersonId
     ): UserDetailsResponse {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.READ_VTJ_DETAILS,
-            personId
-        )
         val notFound = { throw NotFound("Person not found") }
         if (user.id != personId) {
             notFound()
@@ -49,6 +43,13 @@ class CitizenUserController(
 
         return db.connect { dbc ->
                 dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Citizen.Person.READ_VTJ_DETAILS,
+                        personId
+                    )
                     val person = tx.getPersonById(personId) ?: notFound()
                     val userDetails =
                         CitizenUserDetails.from(

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
@@ -44,12 +44,24 @@ class FamilyController(
         clock: EvakaClock,
         @PathVariable(value = "id") id: PersonId
     ): FamilyOverview {
-        accessControl.requirePermissionFor(user, clock, Action.Person.READ_FAMILY_OVERVIEW, id)
-        val includeIncome =
-            accessControl.hasPermissionFor(user, clock, Action.Person.READ_INCOME, id)
-
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Person.READ_FAMILY_OVERVIEW,
+                        id
+                    )
+                    val includeIncome =
+                        accessControl.hasPermissionFor(
+                            it,
+                            user,
+                            clock,
+                            Action.Person.READ_INCOME,
+                            id
+                        )
+
                     val overview = familyOverviewService.getFamilyByAdult(it, clock, id)
                     if (includeIncome) {
                         overview
@@ -73,8 +85,18 @@ class FamilyController(
         clock: EvakaClock,
         @RequestParam(value = "childId", required = true) childId: ChildId
     ): List<FamilyContact> {
-        accessControl.requirePermissionFor(user, clock, Action.Child.READ_FAMILY_CONTACTS, childId)
-        return db.connect { dbc -> dbc.read { it.fetchFamilyContacts(clock, childId) } }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Child.READ_FAMILY_CONTACTS,
+                        childId
+                    )
+                    it.fetchFamilyContacts(clock, childId)
+                }
+            }
             .also {
                 Audit.FamilyContactsRead.log(targetId = childId, args = mapOf("count" to it.size))
             }
@@ -87,14 +109,15 @@ class FamilyController(
         clock: EvakaClock,
         @RequestBody body: FamilyContactUpdate
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Child.UPDATE_FAMILY_CONTACT_DETAILS,
-            body.childId
-        )
         db.connect { dbc ->
             dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Child.UPDATE_FAMILY_CONTACT_DETAILS,
+                    body.childId
+                )
                 if (
                     !it.isFamilyContactForChild(clock.today(), body.childId, body.contactPersonId)
                 ) {
@@ -121,14 +144,15 @@ class FamilyController(
         clock: EvakaClock,
         @RequestBody body: FamilyContactPriorityUpdate
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Child.UPDATE_FAMILY_CONTACT_PRIORITY,
-            body.childId
-        )
         db.connect { dbc ->
             dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Child.UPDATE_FAMILY_CONTACT_PRIORITY,
+                    body.childId
+                )
                 if (
                     !it.isFamilyContactForChild(clock.today(), body.childId, body.contactPersonId)
                 ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FosterParentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FosterParentController.kt
@@ -38,14 +38,18 @@ class FosterParentController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable parentId: PersonId
     ): List<FosterParentRelationship> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Person.READ_FOSTER_CHILDREN,
-            parentId
-        )
-
-        return db.connect { dbc -> dbc.read { tx -> tx.getFosterChildren(parentId) } }
+        return db.connect { dbc ->
+                dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Person.READ_FOSTER_CHILDREN,
+                        parentId
+                    )
+                    tx.getFosterChildren(parentId)
+                }
+            }
             .also { Audit.FosterParentReadChildren.log(targetId = parentId) }
     }
 
@@ -56,9 +60,18 @@ class FosterParentController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable childId: PersonId
     ): List<FosterParentRelationship> {
-        accessControl.requirePermissionFor(user, clock, Action.Person.READ_FOSTER_PARENTS, childId)
-
-        return db.connect { dbc -> dbc.read { tx -> tx.getFosterParents(childId) } }
+        return db.connect { dbc ->
+                dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Person.READ_FOSTER_PARENTS,
+                        childId
+                    )
+                    tx.getFosterParents(childId)
+                }
+            }
             .also { Audit.FosterParentReadParents.log(targetId = childId) }
     }
 
@@ -69,14 +82,18 @@ class FosterParentController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @RequestBody body: CreateFosterParentRelationshipBody
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Person.CREATE_FOSTER_PARENT_RELATIONSHIP,
-            body.parentId
-        )
-
-        db.connect { dbc -> dbc.transaction { tx -> tx.createFosterParentRelationship(body) } }
+        db.connect { dbc ->
+                dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Person.CREATE_FOSTER_PARENT_RELATIONSHIP,
+                        body.parentId
+                    )
+                    tx.createFosterParentRelationship(body)
+                }
+            }
             .also { id ->
                 Audit.FosterParentCreateRelationship.log(
                     targetId = body.parentId,
@@ -94,10 +111,17 @@ class FosterParentController(private val accessControl: AccessControl) {
         @PathVariable id: FosterParentId,
         @RequestBody validDuring: DateRange
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.FosterParent.UPDATE, id)
-
         db.connect { dbc ->
-                dbc.transaction { tx -> tx.updateFosterParentRelationshipValidity(id, validDuring) }
+                dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.FosterParent.UPDATE,
+                        id
+                    )
+                    tx.updateFosterParentRelationshipValidity(id, validDuring)
+                }
             }
             .also {
                 Audit.FosterParentUpdateRelationship.log(
@@ -114,9 +138,18 @@ class FosterParentController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @PathVariable id: FosterParentId
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.FosterParent.DELETE, id)
-
-        db.connect { dbc -> dbc.transaction { tx -> tx.deleteFosterParentRelationship(id) } }
+        db.connect { dbc ->
+                dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.FosterParent.DELETE,
+                        id
+                    )
+                    tx.deleteFosterParentRelationship(id)
+                }
+            }
             .also { Audit.FosterParentDeleteRelationship.log(targetId = id) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
@@ -29,15 +29,16 @@ class PersonalDataControllerCitizen(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @RequestBody body: PersonalDataUpdate
     ) {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Citizen.Person.UPDATE_PERSONAL_DATA,
-            user.id
-        )
-
         db.connect { dbc ->
             dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Citizen.Person.UPDATE_PERSONAL_DATA,
+                    user.id
+                )
+
                 val person = it.getPersonById(user.id) ?: error("User not found")
 
                 val validationErrors =

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ApplicationsReport.kt
@@ -34,11 +34,16 @@ class ApplicationsReportController(
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): List<ApplicationsReportRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_APPLICATIONS_REPORT)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
 
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_APPLICATIONS_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getApplicationsRows(from, to, acl.getAuthorizedUnits(user))
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedDecisionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedDecisionsReport.kt
@@ -49,13 +49,17 @@ class AssistanceNeedDecisionsReport(private val accessControl: AccessControl) {
         user: AuthenticatedUser,
         clock: EvakaClock
     ): Int {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.READ_ASSISTANCE_NEED_DECISIONS_REPORT
-        )
-
-        return db.connect { dbc -> dbc.read { it.getDecisionMakerUnreadCount(user.evakaUserId) } }
+        return db.connect { dbc ->
+                dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_ASSISTANCE_NEED_DECISIONS_REPORT
+                    )
+                    it.getDecisionMakerUnreadCount(user.evakaUserId)
+                }
+            }
             .also { Audit.AssistanceNeedDecisionsReportUnreadCount.log() }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReportController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReportController.kt
@@ -39,13 +39,14 @@ class AssistanceNeedsAndActionsReportController(
         clock: EvakaClock,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): AssistanceNeedsAndActionsReport {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.READ_ASSISTANCE_NEEDS_AND_ACTIONS_REPORT
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_ASSISTANCE_NEEDS_AND_ACTIONS_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     AssistanceNeedsAndActionsReport(
                         bases = it.getAssistanceBasisOptions(),

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
@@ -38,14 +38,15 @@ class AttendanceReservationReportController(private val accessControl: AccessCon
         user: AuthenticatedUser,
         clock: EvakaClock
     ): List<AttendanceReservationReportRow> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.READ_ATTENDANCE_RESERVATION_REPORT,
-            unitId
-        )
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Unit.READ_ATTENDANCE_RESERVATION_REPORT,
+                        unitId
+                    )
                     tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     tx.getAttendanceReservationReport(
                         start,
@@ -79,14 +80,15 @@ class AttendanceReservationReportController(private val accessControl: AccessCon
         clock: EvakaClock,
         user: AuthenticatedUser
     ): List<AttendanceReservationReportByChildRow> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.READ_ATTENDANCE_RESERVATION_REPORT,
-            unitId
-        )
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Unit.READ_ATTENDANCE_RESERVATION_REPORT,
+                        unitId
+                    )
                     tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     tx.getAttendanceReservationReportByChild(
                         start,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildAgeLanguageReport.kt
@@ -32,13 +32,14 @@ class ChildAgeLanguageReportController(
         clock: EvakaClock,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): List<ChildAgeLanguageReportRow> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.READ_CHILD_AGE_AND_LANGUAGE_REPORT
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_CHILD_AGE_AND_LANGUAGE_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getChildAgeLanguageRows(date, acl.getAuthorizedUnits(user))
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ChildrenInDifferentAddressReport.kt
@@ -29,13 +29,14 @@ class ChildrenInDifferentAddressReportController(
         user: AuthenticatedUser,
         clock: EvakaClock
     ): List<ChildrenInDifferentAddressReportRow> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.READ_CHILD_IN_DIFFERENT_ADDRESS_REPORT
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_CHILD_IN_DIFFERENT_ADDRESS_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getChildrenInDifferentAddressRows(acl.getAuthorizedUnits(user), clock)
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DecisionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DecisionsReport.kt
@@ -30,11 +30,16 @@ class DecisionsReportController(private val accessControl: AccessControl) {
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): List<DecisionsReportRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_DECISIONS_REPORT)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
 
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_DECISIONS_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getDecisionsRows(FiniteDateRange(from, to))
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
@@ -25,9 +25,14 @@ class DuplicatePeopleReportController(private val accessControl: AccessControl) 
         user: AuthenticatedUser,
         clock: EvakaClock
     ): List<DuplicatePeopleReportRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_DUPLICATE_PEOPLE_REPORT)
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_DUPLICATE_PEOPLE_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getDuplicatePeople()
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
@@ -26,12 +26,17 @@ class EndedPlacementsReportController(private val accessControl: AccessControl) 
         @RequestParam year: Int,
         @RequestParam month: Int
     ): List<EndedPlacementsReportRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_ENDED_PLACEMENTS_REPORT)
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_ENDED_PLACEMENTS_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getEndedPlacementsRows(from, to)
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyConflictReport.kt
@@ -28,9 +28,14 @@ class FamilyConflictReportController(
         user: AuthenticatedUser,
         clock: EvakaClock
     ): List<FamilyConflictReportRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_FAMILY_CONFLICT_REPORT)
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_FAMILY_CONFLICT_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getFamilyConflicts(acl.getAuthorizedUnits(user))
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FamilyContactReport.kt
@@ -29,14 +29,15 @@ class FamilyContactReportController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @RequestParam unitId: DaycareId
     ): List<FamilyContactReportRow> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.READ_FAMILY_CONTACT_REPORT,
-            unitId
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Unit.READ_FAMILY_CONTACT_REPORT,
+                        unitId
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getFamilyContacts(clock.today(), unitId)
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
@@ -37,9 +37,14 @@ class InvoiceReportController(private val accessControl: AccessControl) {
         clock: EvakaClock,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): InvoiceReport {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_INVOICE_REPORT)
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_INVOICE_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getInvoiceReportWithRows(getMonthPeriod(date))
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
@@ -33,13 +33,14 @@ class MissingHeadOfFamilyReportController(
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?
     ): List<MissingHeadOfFamilyReportRow> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.READ_MISSING_HEAD_OF_FAMILY_REPORT
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_MISSING_HEAD_OF_FAMILY_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getMissingHeadOfFamilyRows(from, to, acl.getAuthorizedUnits(user))
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingServiceNeedReport.kt
@@ -34,15 +34,16 @@ class MissingServiceNeedReportController(
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?
     ): List<MissingServiceNeedReportRow> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.READ_MISSING_SERVICE_NEED_REPORT
-        )
         if (to != null && to.isBefore(from)) throw BadRequest("Invalid time range")
 
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_MISSING_SERVICE_NEED_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getMissingServiceNeedRows(from, to, acl.getAuthorizedUnits(user))
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/OccupancyReport.kt
@@ -45,12 +45,17 @@ class OccupancyReportController(
         @RequestParam year: Int,
         @RequestParam month: Int
     ): List<OccupancyUnitReportResultRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_OCCUPANCY_REPORT)
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Global.READ_OCCUPANCY_REPORT
+                    )
                     tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     tx.calculateUnitOccupancyReport(
                         clock.today(),
@@ -90,12 +95,17 @@ class OccupancyReportController(
         @RequestParam year: Int,
         @RequestParam month: Int
     ): List<OccupancyGroupReportResultRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_OCCUPANCY_REPORT)
         val from = LocalDate.of(year, month, 1)
         val to = from.plusMonths(1).minusDays(1)
 
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Global.READ_OCCUPANCY_REPORT
+                    )
                     tx.calculateGroupOccupancyReport(
                         clock.today(),
                         careAreaId,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PartnersInDifferentAddressReport.kt
@@ -28,13 +28,14 @@ class PartnersInDifferentAddressReportController(
         user: AuthenticatedUser,
         clock: EvakaClock
     ): List<PartnersInDifferentAddressReportRow> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.READ_PARTNERS_IN_DIFFERENT_ADDRESS_REPORT
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_PARTNERS_IN_DIFFERENT_ADDRESS_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getPartnersInDifferentAddressRows(acl.getAuthorizedUnits(user), clock)
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
@@ -33,13 +33,14 @@ class PlacementSketchingReportController(private val accessControl: AccessContro
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         earliestPreferredStartDate: LocalDate?
     ): List<PlacementSketchingReportRow> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.READ_PLACEMENT_SKETCHING_REPORT
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_PLACEMENT_SKETCHING_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getPlacementSketchingReportRows(
                         placementStartDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PresenceReport.kt
@@ -30,13 +30,18 @@ class PresenceReportController(private val accessControl: AccessControl) {
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): List<PresenceReportRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_PRESENCE_REPORT)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
         if (to.isAfter(from.plusDays(MAX_NUMBER_OF_DAYS.toLong())))
             throw BadRequest("Period is too long. Use maximum of $MAX_NUMBER_OF_DAYS days")
 
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_PRESENCE_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getPresenceRows(from, to)
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -34,12 +34,17 @@ class RawReportController(private val accessControl: AccessControl) {
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ): List<RawReportRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_RAW_REPORT)
         if (to.isBefore(from)) throw BadRequest("Inverted time range")
         if (to.isAfter(from.plusDays(7))) throw BadRequest("Time range too long")
 
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_RAW_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getRawRows(from, to)
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceNeedReport.kt
@@ -31,9 +31,14 @@ class ServiceNeedReport(
         clock: EvakaClock,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
     ): List<ServiceNeedReportRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_SERVICE_NEED_REPORT)
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_SERVICE_NEED_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getServiceNeedRows(date, acl.getAuthorizedUnits(user))
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -46,11 +46,18 @@ class ServiceVoucherValueReportController(
         @RequestParam month: Int,
         @RequestParam(required = false) areaId: AreaId?
     ): ServiceVoucherReport {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_SERVICE_VOUCHER_REPORT)
         val authorization = acl.getAuthorizedUnits(user, setOf(UserRole.UNIT_SUPERVISOR))
 
         return db.connect { dbc ->
-            dbc.read { tx -> getServiceVoucherReport(tx, year, month, areaId, authorization.ids) }
+            dbc.read { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Global.READ_SERVICE_VOUCHER_REPORT
+                )
+                getServiceVoucherReport(tx, year, month, areaId, authorization.ids)
+            }
         }
     }
 
@@ -69,15 +76,16 @@ class ServiceVoucherValueReportController(
         @RequestParam year: Int,
         @RequestParam month: Int
     ): ServiceVoucherUnitReport {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Unit.READ_SERVICE_VOUCHER_VALUES_REPORT,
-            unitId
-        )
-
         return db.connect { dbc ->
             dbc.read { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Unit.READ_SERVICE_VOUCHER_VALUES_REPORT,
+                    unitId
+                )
+
                 val snapshotTime = tx.getSnapshotDate(year, month)
                 val rows =
                     if (snapshotTime != null) {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/SextetReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/SextetReport.kt
@@ -27,10 +27,15 @@ class SextetReportController(private val accessControl: AccessControl) {
         @RequestParam year: Int,
         @RequestParam placementType: PlacementType
     ): List<SextetReportRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_SEXTET_REPORT)
-
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_SEXTET_REPORT
+                    )
+
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.sextetReport(
                         LocalDate.of(year, 1, 1),

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
@@ -28,13 +28,14 @@ class StartingPlacementsReportController(private val accessControl: AccessContro
         @RequestParam("year") year: Int,
         @RequestParam("month") month: Int
     ): List<StartingPlacementsRow> {
-        accessControl.requirePermissionFor(
-            user,
-            clock,
-            Action.Global.READ_STARTING_PLACEMENTS_REPORT
-        )
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_STARTING_PLACEMENTS_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getStartingPlacementsRows(year, month)
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
@@ -24,9 +24,14 @@ class VardaErrorReport(private val accessControl: AccessControl) {
         user: AuthenticatedUser,
         clock: EvakaClock
     ): List<VardaErrorReportRow> {
-        accessControl.requirePermissionFor(user, clock, Action.Global.READ_VARDA_REPORT)
         return db.connect { dbc ->
                 dbc.read {
+                    accessControl.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Global.READ_VARDA_REPORT
+                    )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
                     it.getVardaErrors()
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/patu/PatuReportingController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/patu/PatuReportingController.kt
@@ -39,10 +39,10 @@ class PatuReportingController(
         @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate
     ) {
-        accessControl.requirePermissionFor(user, clock, Action.Global.SEND_PATU_REPORT)
+        val range = DateRange(from, to)
         db.connect { dbc ->
             dbc.transaction { tx ->
-                val range = DateRange(from, to)
+                accessControl.requirePermissionFor(tx, user, clock, Action.Global.SEND_PATU_REPORT)
                 logger.info("Scheduling patu report $range")
                 asyncJobRunner.plan(
                     tx,

--- a/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInfoController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sensitive/ChildSensitiveInfoController.kt
@@ -26,10 +26,16 @@ class ChildSensitiveInfoController(private val ac: AccessControl) {
         clock: EvakaClock,
         @PathVariable childId: ChildId
     ): ChildSensitiveInformation {
-        ac.requirePermissionFor(user, clock, Action.Child.READ_SENSITIVE_INFO, childId)
-
         return db.connect { dbc ->
                 dbc.read {
+                    ac.requirePermissionFor(
+                        it,
+                        user,
+                        clock,
+                        Action.Child.READ_SENSITIVE_INFO,
+                        childId
+                    )
+
                     it.getChildSensitiveInfo(clock, childId) ?: throw NotFound("Child not found")
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/SecurityConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/SecurityConfig.kt
@@ -16,6 +16,6 @@ class SecurityConfig {
     @Bean fun accessControlList(jdbi: Jdbi): AccessControlList = AccessControlList(jdbi)
 
     @Bean
-    fun accessControl(actionRuleMapping: ActionRuleMapping, jdbi: Jdbi): AccessControl =
-        AccessControl(actionRuleMapping, jdbi)
+    fun accessControl(actionRuleMapping: ActionRuleMapping): AccessControl =
+        AccessControl(actionRuleMapping)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -259,10 +259,7 @@ class DevApi(
     }
 
     @DeleteMapping("/daycare/{daycareId}/cost-center")
-    fun deleteDaycareCostCenter(
-        db: Database,
-        @PathVariable daycareId: DaycareId
-    ) {
+    fun deleteDaycareCostCenter(db: Database, @PathVariable daycareId: DaycareId) {
         db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.createUpdate("UPDATE daycare SET cost_center = NULL WHERE id = :daycareId")

--- a/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/units/UnitsView.kt
@@ -74,11 +74,16 @@ class UnitsView(private val accessControl: AccessControl, private val acl: Acces
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         to: LocalDate
     ): UnitDataResponse {
-        accessControl.requirePermissionFor(user, clock, Action.Unit.READ_BASIC, unitId)
-
         val period = FiniteDateRange(from, to)
         return db.connect { dbc ->
                 dbc.read { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Unit.READ_BASIC,
+                        unitId
+                    )
                     val groups = tx.getDaycareGroups(unitId, from, to)
                     val placements =
                         tx.getDetailedDaycarePlacements(unitId, null, from, to).toList()
@@ -86,6 +91,7 @@ class UnitsView(private val accessControl: AccessControl, private val acl: Acces
                     val missingGroupPlacements =
                         if (
                             accessControl.hasPermissionFor(
+                                tx,
                                 user,
                                 clock,
                                 Action.Unit.READ_MISSING_GROUP_PLACEMENTS,
@@ -99,6 +105,7 @@ class UnitsView(private val accessControl: AccessControl, private val acl: Acces
                     val recentlyTerminatedPlacements =
                         if (
                             accessControl.hasPermissionFor(
+                                tx,
                                 user,
                                 clock,
                                 Action.Unit.READ_TERMINATED_PLACEMENTS,
@@ -145,6 +152,7 @@ class UnitsView(private val accessControl: AccessControl, private val acl: Acces
                     val capacities =
                         if (
                             accessControl.hasPermissionFor(
+                                tx,
                                 user,
                                 clock,
                                 Action.Unit.READ_CHILD_CAPACITY_FACTORS,
@@ -184,6 +192,7 @@ class UnitsView(private val accessControl: AccessControl, private val acl: Acces
 
                     if (
                         accessControl.hasPermissionFor(
+                            tx,
                             user,
                             clock,
                             Action.Unit.READ_DETAILED,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- Remove AccessControl functions without a tx parameter. These functions provide no real advantage, because we always have at least a connection or even a transaction at every use site. Previously we often consumed two connections from the db pool and did separate transactions in AccessControl and the "main" flow
- Move all use sites inside a transaction