### PR TITLE
Fix reservation modal default start date

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -117,7 +117,7 @@ const CalendarPage = React.memo(function CalendarPage() {
     [activeFixedPeriodQuestionnaire]
   )
 
-  const firstReservableDate: LocalDate = useMemo(() => {
+  const firstReservableDate = useMemo(() => {
     if (data.isSuccess) {
       const earliestReservableDate = getEarliestReservableDate(
         data.value.children,
@@ -126,12 +126,11 @@ const CalendarPage = React.memo(function CalendarPage() {
       // First reservable day that has no reservations
       const firstReservableEmptyDate = data.value.dailyData.find(
         (day) =>
-          day.date.isEqualOrAfter(earliestReservableDate) &&
-          day.children.length == 0
+          earliestReservableDate?.isBefore(day.date) && day.children.length == 0
       )
       return firstReservableEmptyDate
         ? firstReservableEmptyDate.date
-        : earliestReservableDate
+        : earliestReservableDate ?? null
     } else {
       return LocalDate.todayInSystemTz()
     }

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -56,7 +56,7 @@ interface Props {
   onReload: () => void
   availableChildren: ReservationChild[]
   reservableDays: Record<string, FiniteDateRange[]>
-  initialStart: LocalDate
+  initialStart: LocalDate | null
   initialEnd: LocalDate | null
   existingReservations: DailyReservationData[]
 }

--- a/frontend/src/citizen-frontend/calendar/utils.ts
+++ b/frontend/src/citizen-frontend/calendar/utils.ts
@@ -11,15 +11,14 @@ export const getEarliestReservableDate = (
   reservableDays: Record<string, FiniteDateRange[]>
 ) => {
   const earliestReservableDateByChild = childInfo.map((c) =>
-    reservableDays[c.id].reduce(
-      (acc, cur) => (cur.start.isBefore(acc) ? cur.start : acc),
-      LocalDate.todayInSystemTz()
+    reservableDays[c.id].reduce<LocalDate | undefined>(
+      (acc, cur) => (!acc || cur.start.isBefore(acc) ? cur.start : acc),
+      undefined
     )
   )
-  const earliestReservableDate = earliestReservableDateByChild.reduce(
-    (acc, cur) => (cur.isBefore(acc) ? cur : acc),
-    LocalDate.todayInSystemTz()
-  )
+  const earliestReservableDate = earliestReservableDateByChild.reduce<
+    LocalDate | undefined
+  >((acc, cur) => (!acc || cur?.isBefore(acc) ? cur : acc), undefined)
   return earliestReservableDate
 }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Fix the `getEarliestReservableDate` function that would always return `LocalDate.todayInSystemTz()` as reservable days are always in the future.

