### PR TITLE
Fix finance decision search query filters

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionSearchTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionSearchTest.kt
@@ -216,13 +216,16 @@ class FeeDecisionSearchTest : PureJdbiTest(resetDbBeforeEach = true) {
 
     @Test
     fun `starting children filter search`() {
+        val now = MockEvakaClock(HelsinkiDateTime.of(LocalDateTime.of(2022, 1, 1, 12, 0)))
+
         db.transaction { tx ->
             tx.upsertFeeDecisions(
                 listOf(
                     decisionFixture(
                         headOfFamily = testAdult_3.id,
                         children =
-                            listOf(childFixture(testChild_3, testDaycare.id, serviceNeed = null))
+                            listOf(childFixture(testChild_3, testDaycare.id, serviceNeed = null)),
+                        period = DateRange(now.today(), now.today())
                     )
                 )
             )
@@ -246,8 +249,8 @@ class FeeDecisionSearchTest : PureJdbiTest(resetDbBeforeEach = true) {
                 DevPlacement(
                     childId = testChild_3.id,
                     unitId = testDaycare.id,
-                    startDate = LocalDate.now(),
-                    endDate = LocalDate.now()
+                    startDate = now.today(),
+                    endDate = now.today()
                 )
             )
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueriesTest.kt
@@ -42,6 +42,7 @@ import fi.espoo.evaka.testChild_5
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.toValueDecisionServiceNeed
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -985,13 +986,15 @@ internal class VoucherValueDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach 
 
     @Test
     fun `search with NO_STARTING_CHILDREN`() {
+        val now = MockEvakaClock(HelsinkiDateTime.of(LocalDateTime.of(2022, 1, 1, 12, 0)))
+
         db.transaction { tx ->
             tx.upsertValueDecisions(
                 listOf(
                     createVoucherValueDecisionFixture(
                         status = VoucherValueDecisionStatus.DRAFT,
-                        validFrom = LocalDate.now(),
-                        validTo = LocalDate.now(),
+                        validFrom = now.today(),
+                        validTo = now.today(),
                         headOfFamilyId = testAdult_1.id,
                         childId = testChild_1.id,
                         dateOfBirth = testChild_1.dateOfBirth,
@@ -1006,9 +1009,7 @@ internal class VoucherValueDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach 
                 1,
                 tx.searchValueDecisions(
                         evakaClock =
-                            MockEvakaClock(
-                                HelsinkiDateTime.of(LocalDate.now(), LocalTime.of(15, 6))
-                            ),
+                            MockEvakaClock(HelsinkiDateTime.of(now.today(), LocalTime.of(15, 6))),
                         postOffice = "ESPOO",
                         page = 0,
                         pageSize = 100,
@@ -1032,8 +1033,8 @@ internal class VoucherValueDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach 
                 DevPlacement(
                     childId = testChild_1.id,
                     unitId = testDaycare.id,
-                    startDate = LocalDate.now(),
-                    endDate = LocalDate.now()
+                    startDate = now.today(),
+                    endDate = now.today()
                 )
             )
 
@@ -1041,9 +1042,7 @@ internal class VoucherValueDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach 
                 0,
                 tx.searchValueDecisions(
                         evakaClock =
-                            MockEvakaClock(
-                                HelsinkiDateTime.of(LocalDate.now(), LocalTime.of(15, 6))
-                            ),
+                            MockEvakaClock(HelsinkiDateTime.of(now.today(), LocalTime.of(15, 6))),
                         postOffice = "ESPOO",
                         page = 0,
                         pageSize = 100,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueriesTest.kt
@@ -18,6 +18,8 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPlacement
+import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -31,6 +33,7 @@ import fi.espoo.evaka.testAdult_4
 import fi.espoo.evaka.testAdult_5
 import fi.espoo.evaka.testAdult_6
 import fi.espoo.evaka.testAdult_7
+import fi.espoo.evaka.testArea
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
 import fi.espoo.evaka.testChild_3
@@ -41,6 +44,7 @@ import fi.espoo.evaka.toValueDecisionServiceNeed
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
+import kotlin.test.assertEquals
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.BeforeEach
@@ -977,5 +981,87 @@ internal class VoucherValueDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach 
                 Tuple(testAdult_1.lastName, testAdult_1.firstName, testChild_1.dateOfBirth),
                 Tuple(testAdult_1.lastName, testAdult_1.firstName, testChild_2.dateOfBirth)
             )
+    }
+
+    @Test
+    fun `search with NO_STARTING_CHILDREN`() {
+        db.transaction { tx ->
+            tx.upsertValueDecisions(
+                listOf(
+                    createVoucherValueDecisionFixture(
+                        status = VoucherValueDecisionStatus.DRAFT,
+                        validFrom = LocalDate.now(),
+                        validTo = LocalDate.now(),
+                        headOfFamilyId = testAdult_1.id,
+                        childId = testChild_1.id,
+                        dateOfBirth = testChild_1.dateOfBirth,
+                        unitId = testDaycare.id,
+                        placementType = PlacementType.DAYCARE,
+                        serviceNeed = snDefaultDaycare.toValueDecisionServiceNeed()
+                    )
+                )
+            )
+
+            assertEquals(
+                1,
+                tx.searchValueDecisions(
+                        evakaClock =
+                            MockEvakaClock(
+                                HelsinkiDateTime.of(LocalDate.now(), LocalTime.of(15, 6))
+                            ),
+                        postOffice = "ESPOO",
+                        page = 0,
+                        pageSize = 100,
+                        sortBy = VoucherValueDecisionSortParam.HEAD_OF_FAMILY,
+                        sortDirection = SortDirection.ASC,
+                        status = VoucherValueDecisionStatus.DRAFT,
+                        areas = listOf(testArea.shortName),
+                        unit = null,
+                        startDate = null,
+                        endDate = null,
+                        financeDecisionHandlerId = null,
+                        difference = emptySet(),
+                        distinctiveParams =
+                            listOf(VoucherValueDecisionDistinctiveParams.NO_STARTING_PLACEMENTS)
+                    )
+                    .data
+                    .size
+            )
+
+            tx.insertTestPlacement(
+                DevPlacement(
+                    childId = testChild_1.id,
+                    unitId = testDaycare.id,
+                    startDate = LocalDate.now(),
+                    endDate = LocalDate.now()
+                )
+            )
+
+            assertEquals(
+                0,
+                tx.searchValueDecisions(
+                        evakaClock =
+                            MockEvakaClock(
+                                HelsinkiDateTime.of(LocalDate.now(), LocalTime.of(15, 6))
+                            ),
+                        postOffice = "ESPOO",
+                        page = 0,
+                        pageSize = 100,
+                        sortBy = VoucherValueDecisionSortParam.HEAD_OF_FAMILY,
+                        sortDirection = SortDirection.ASC,
+                        status = VoucherValueDecisionStatus.DRAFT,
+                        areas = emptyList(),
+                        unit = null,
+                        startDate = null,
+                        endDate = null,
+                        financeDecisionHandlerId = null,
+                        difference = emptySet(),
+                        distinctiveParams =
+                            listOf(VoucherValueDecisionDistinctiveParams.NO_STARTING_PLACEMENTS)
+                    )
+                    .data
+                    .size
+            )
+        }
     }
 }


### PR DESCRIPTION
#### Summary
- If both area filter and starting child filter was on, the generated SQL was invalid
- Add unit tests for both fee decision search and voucher value decision search

