### PR TITLE
EVAKA-4667 employee unread messages icons

### DIFF
--- a/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
+++ b/frontend/src/employee-frontend/components/messages/GroupMessageAccountList.tsx
@@ -75,10 +75,17 @@ export default function GroupMessageAccountList({
   const { unreadCountsByAccount } = useContext(MessageContext)
   const startCollapsed = (acc: AuthorizedMessageAccount, i: number) =>
     i > 0 &&
-    ((unreadCountsByAccount.isSuccess &&
-      !unreadCountsByAccount.value.find((a) => a.accountId === acc.account.id)
-        ?.unreadCount) ||
-      !unreadCountsByAccount.isSuccess)
+    unreadCountsByAccount
+      .map((counts) => {
+        const accountUnreadCounts = counts.find(
+          (a) => a.accountId === acc.account.id
+        )
+        return accountUnreadCounts
+          ? accountUnreadCounts.unreadCount +
+              accountUnreadCounts.unreadCopyCount
+          : 0
+      })
+      .getOrElse(0) === 0
 
   return (
     <CollapsibleMessageBoxesContainer>

--- a/frontend/src/employee-frontend/components/messages/MessageBox.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageBox.tsx
@@ -6,6 +6,7 @@ import React, { useContext } from 'react'
 import styled from 'styled-components'
 
 import { MessageAccount } from 'lib-common/generated/api-types/messaging'
+import RoundIcon from 'lib-components/atoms/RoundIcon'
 import { fontWeights } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
@@ -20,13 +21,6 @@ export const MessageBoxRow = styled.div<{ active: boolean }>`
   padding: 12px ${defaultMargins.m};
   font-weight: ${(p) => (p.active ? fontWeights.semibold : 'unset')};
   background-color: ${(p) => (p.active ? colors.main.m4 : 'unset')};
-`
-
-const UnreadCount = styled.span`
-  color: ${colors.main.m2};
-  font-size: 14px;
-  font-weight: ${fontWeights.semibold};
-  padding-left: ${defaultMargins.xxs};
 `
 
 interface MessageBoxProps {
@@ -70,7 +64,17 @@ export default function MessageBox({
       data-qa={`message-box-row-${view}`}
     >
       {i18n.messages.messageBoxes.names[view]}{' '}
-      {unreadCount > 0 && <UnreadCount>{unreadCount}</UnreadCount>}
+      {unreadCount > 0 && (
+        <RoundIconWithMargin
+          content={String(unreadCount)}
+          color={colors.status.warning}
+          size="s"
+        />
+      )}
     </MessageBoxRow>
   )
 }
+
+const RoundIconWithMargin = styled(RoundIcon)`
+  margin-left: ${defaultMargins.xs};
+`


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Update employee unread messages count visual:

old
<img width="181" alt="Screenshot 2022-10-26 at 16 27 18" src="https://user-images.githubusercontent.com/4426547/198038300-f65be7ec-38ba-468b-a99a-8788fababc83.png">

new
<img width="180" alt="Screenshot 2022-10-26 at 16 27 07" src="https://user-images.githubusercontent.com/4426547/198038326-a9104133-d594-46dc-a11b-d3685e6e1eb9.png">

Also fix group account message boxes not being expanded by default if they have any unread messages.

