### PR TITLE
EVAKA add messaging role to user management ui

### DIFF
--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -688,6 +688,8 @@ function RedirectToMainPage() {
     return <Navigate replace to="/units" />
   } else if (hasRole(roles, 'DIRECTOR') || hasRole(roles, 'REPORT_VIEWER')) {
     return <Navigate replace to="/reports" />
+  } else if (hasRole(roles, 'MESSAGING')) {
+    return <Navigate replace to="/messages" />
   } else if (roles.length === 0) {
     return <Navigate replace to="/welcome" />
   } else {

--- a/frontend/src/lib-common/api-types/employee-auth.ts
+++ b/frontend/src/lib-common/api-types/employee-auth.ts
@@ -24,7 +24,8 @@ export const globalRoles = [
   'SERVICE_WORKER',
   'FINANCE_ADMIN',
   'REPORT_VIEWER',
-  'DIRECTOR'
+  'DIRECTOR',
+  'MESSAGING'
 ] as const
 
 export type GlobalRole = typeof globalRoles[number]

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -3689,6 +3689,7 @@ export const fi = {
     adRoles: {
       ADMIN: 'Pääkäyttäjä',
       DIRECTOR: 'Hallinto',
+      MESSAGING: 'Viestintä',
       REPORT_VIEWER: 'Raportointi',
       FINANCE_ADMIN: 'Talous',
       SERVICE_WORKER: 'Palveluohjaus',

--- a/service/src/main/resources/dev-data/employees.sql
+++ b/service/src/main/resources/dev-data/employees.sql
@@ -7,7 +7,8 @@ INSERT INTO employee (id, first_name, last_name, email, external_id, roles) VALU
     ('00000000-0000-0000-0001-000000000000', 'Paula', 'Palveluohjaaja', 'paula.palveluohjaaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0001-000000000000', '{SERVICE_WORKER}'::user_role[]),
     ('00000000-0000-0000-0002-000000000000', 'Lasse', 'Laskuttaja', 'lasse.laskuttaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0002-000000000000', '{FINANCE_ADMIN}'::user_role[]),
     ('00000000-0000-0000-0003-000000000000', 'Hemmo', 'Hallinto', 'hemmo.hallinto@espoo.fi', 'espoo-ad:00000000-0000-0000-0003-000000000000', '{DIRECTOR}'::user_role[]),
-    ('00000000-0000-0000-0007-000000000000', 'Raisa', 'Raportoija', 'raisa.raportoija@espoo.fi', 'espoo-ad:00000000-0000-0000-0007-000000000000', '{REPORT_VIEWER}'::user_role[]);
+    ('00000000-0000-0000-0007-000000000000', 'Raisa', 'Raportoija', 'raisa.raportoija@espoo.fi', 'espoo-ad:00000000-0000-0000-0007-000000000000', '{REPORT_VIEWER}'::user_role[]),
+    ('00000000-0000-0000-0008-000000000000', 'Viena', 'Viestittäjä', 'viena.viestittaja@espoo.fi', 'espoo-ad:00000000-0000-0000-0008-000000000000', '{MESSAGING}'::user_role[]);
 INSERT INTO employee (id, first_name, last_name, email, external_id) VALUES
     ('00000000-0000-0000-0004-000000000000', 'Essi', 'Esimies', 'essi.esimies@espoo.fi', 'espoo-ad:00000000-0000-0000-0004-000000000000'),
     ('00000000-0000-0000-0004-000000000001', 'Eemeli', 'Esimies', 'eemeli.esimies@espoo.fi', 'espoo-ad:00000000-0000-0000-0004-000000000001'),


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
- Add MESSAGING role to employee management roles
- Add a messaging user to dev env test users
- Direct user with MESSAGING role to messages page by default

