### PR TITLE
Fix fee decision children being added to sent decisions

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -287,7 +287,7 @@ class FeeDecisionController(
                     Action.Person.GENERATE_RETROACTIVE_FEE_DECISIONS,
                     id
                 )
-                generator.createRetroactiveFeeDecisions(it, id, body.from)
+                generator.createRetroactiveFeeDecisions(it, clock, id, body.from)
             }
         }
         Audit.FeeDecisionHeadOfFamilyCreateRetroactive.log(targetId = id)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGenerator.kt
@@ -178,7 +178,8 @@ internal fun Database.Transaction.handleFeeDecisionChanges(
     val updatedDecisions =
         updateExistingDecisions(from, newDrafts, existingDrafts, combinedActiveDecisions)
     deleteFeeDecisions(existingDrafts.map { it.id })
-    upsertFeeDecisions(updatedDecisions.updatedDrafts + updatedDecisions.updatedActiveDecisions)
+    updateFeeDecisionStatusAndDates(updatedDecisions.updatedActiveDecisions)
+    upsertFeeDecisions(updatedDecisions.updatedDrafts)
 }
 
 private fun generateFeeDecisions(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGenerator.kt
@@ -137,7 +137,8 @@ internal fun Database.Transaction.handleValueDecisionChanges(
     val existingDrafts =
         findValueDecisionsForChild(child.id, null, listOf(VoucherValueDecisionStatus.DRAFT))
 
-    val updatedDecisions = updateExistingDecisions(from, newDrafts, existingDrafts, activeDecisions)
+    val updatedDecisions =
+        updateExistingDecisions(clock.now(), from, newDrafts, existingDrafts, activeDecisions)
     deleteValueDecisions(existingDrafts.map { it.id })
     upsertValueDecisions(updatedDecisions.updatedDrafts)
     updateVoucherValueDecisionEndDates(updatedDecisions.updatedActiveDecisions, clock.now())

--- a/service/src/main/resources/db/migration/V286__fee_decision_child_unique_constraint.sql
+++ b/service/src/main/resources/db/migration/V286__fee_decision_child_unique_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE fee_decision_child ADD CONSTRAINT unique_child_decision_pair UNIQUE (fee_decision_id, child_id);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -282,3 +282,4 @@ V282__municipal_message_account.sql
 V283__add_messaging_user_role.sql
 V284__update_employee_role_check.sql
 V285__message_thread_folder.sql
+V286__fee_decision_child_unique_constraint.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Add a database constraint that makes sure a child is included only once on a fee decision. Fix a bug that caused children being duplicated on sent fee decisions. Make sure that automatic fee decision validity updates work for a family's both parents if their decisions used to be split into two in the past.
