### PR TITLE
Fix finance decision generation start date when partners are updated

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PartnershipService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PartnershipService.kt
@@ -39,18 +39,13 @@ class PartnershipService {
         partnershipId: PartnershipId,
         startDate: LocalDate,
         endDate: LocalDate?
-    ): Partnership {
-        val partnership =
-            tx.getPartnership(partnershipId)
-                ?: throw NotFound("No partnership found with id $partnershipId")
+    ) {
         try {
             val success = tx.updatePartnershipDuration(partnershipId, startDate, endDate)
             if (!success) throw NotFound("No partnership found with id $partnershipId")
         } catch (e: Exception) {
             throw mapPSQLException(e)
         }
-
-        return partnership.copy(startDate = startDate, endDate = endDate)
     }
 
     fun retryPartnership(tx: Database.Transaction, partnershipId: PartnershipId): Partnership? {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Previously decisions would be generated starting from the new start date only which meant that if the start date was moved into the future draft finance decisions would not have updated family compositions for the period between the old and the new start dates.

