### PR TITLE
External staff attendance editing

### DIFF
--- a/frontend/src/employee-frontend/api/staff-attendance.ts
+++ b/frontend/src/employee-frontend/api/staff-attendance.ts
@@ -7,13 +7,13 @@ import FiniteDateRange from 'lib-common/finite-date-range'
 import {
   EmployeeAttendance,
   ExternalAttendance,
-  SingleDayStaffAttendanceUpsert,
   StaffAttendanceResponse,
-  UpsertStaffAndExternalAttendanceRequest
+  UpsertStaffAndExternalAttendanceRequest,
+  StaffAttendanceBody,
+  ExternalAttendanceBody
 } from 'lib-common/generated/api-types/attendance'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { JsonOf } from 'lib-common/json'
-import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
 import { client } from './client'
@@ -76,17 +76,20 @@ export function postStaffAndExternalAttendances(
     .catch((e) => Failure.fromError(e))
 }
 
-export function postSingleDayStaffAttendances(
-  unitId: UUID,
-  employeeId: UUID,
-  date: LocalDate,
-  body: SingleDayStaffAttendanceUpsert[]
+export function upsertStaffAttendances(
+  body: StaffAttendanceBody
 ): Promise<Result<void>> {
   return client
-    .post(
-      `/staff-attendances/realtime/${unitId}/${employeeId}/${date.formatIso()}`,
-      body
-    )
+    .post(`/staff-attendances/realtime/upsert`, body)
+    .then(() => Success.of())
+    .catch((e) => Failure.fromError(e))
+}
+
+export function upsertExternalAttendances(
+  body: ExternalAttendanceBody
+): Promise<Result<void>> {
+  return client
+    .post(`/staff-attendances/realtime/upsert-external`, body)
     .then(() => Success.of())
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -48,8 +48,8 @@ import { faCircleEllipsis } from 'lib-icons'
 import { useTranslation } from '../../../state/i18n'
 import { formatName } from '../../../utils'
 
-import { AddPersonModal } from './StaffAttendanceAddPersonModal'
 import StaffAttendanceDetailsModal from './StaffAttendanceDetailsModal'
+import StaffAttendanceExternalPersonModal from './StaffAttendanceExternalPersonModal'
 import {
   AttendanceTableHeader,
   DayTd,
@@ -86,9 +86,10 @@ export default React.memo(function StaffAttendanceTable({
   }>()
   const closeDetailsModal = useCallback(() => setDetailsModal(undefined), [])
 
-  const [showAddPersonModal, setShowAddPersonModal] = useState<boolean>(false)
+  const [showExternalPersonModal, setShowExternalPersonModal] =
+    useState<boolean>(false)
   const toggleAddPersonModal = useCallback(
-    () => setShowAddPersonModal((prev) => !prev),
+    () => setShowExternalPersonModal((prev) => !prev),
     []
   )
 
@@ -356,8 +357,8 @@ export default React.memo(function StaffAttendanceTable({
           }
         />
       )}
-      {showAddPersonModal && (
-        <AddPersonModal
+      {showExternalPersonModal && (
+        <StaffAttendanceExternalPersonModal
           onClose={toggleAddPersonModal}
           onSave={async () => {
             await reloadStaffAttendances()

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/attendanceEditState.spec.ts
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/attendanceEditState.spec.ts
@@ -21,8 +21,7 @@ describe('validateEditState', () => {
           type: 'PRESENT',
           groupId: 'group1',
           arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
-          departed: null,
-          occupancyCoefficient: 1
+          departed: null
         }
       ],
       today,
@@ -45,14 +44,14 @@ describe('validateEditState', () => {
     )
     expect(body).toEqual([
       {
-        attendanceId: 'id1',
+        id: 'id1',
         type: 'PRESENT',
         groupId: 'group1',
         arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
         departed: HelsinkiDateTime.fromLocal(today, LocalTime.of(7, 0))
       },
       {
-        attendanceId: null,
+        id: null,
         type: 'PRESENT',
         groupId: 'group1',
         arrived: HelsinkiDateTime.fromLocal(today, LocalTime.of(8, 0)),
@@ -81,14 +80,14 @@ describe('validateEditState', () => {
     ])
     expect(body).toEqual([
       {
-        attendanceId: null,
+        id: null,
         type: 'PRESENT',
         groupId: 'group1',
         arrived: HelsinkiDateTime.fromLocal(today, LocalTime.of(12, 0)),
         departed: HelsinkiDateTime.fromLocal(today, LocalTime.of(16, 0))
       },
       {
-        attendanceId: null,
+        id: null,
         type: 'PRESENT',
         groupId: 'group1',
         arrived: HelsinkiDateTime.fromLocal(today, LocalTime.of(16, 0)),
@@ -120,8 +119,7 @@ describe('validateEditState', () => {
           type: 'PRESENT',
           groupId: 'group1',
           arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
-          departed: null,
-          occupancyCoefficient: 1
+          departed: null
         }
       ],
       today,
@@ -137,7 +135,7 @@ describe('validateEditState', () => {
     )
     expect(body).toEqual([
       {
-        attendanceId: 'id1',
+        id: 'id1',
         groupId: 'group1',
         arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
         departed: null,
@@ -189,8 +187,7 @@ describe('validateEditState', () => {
           type: 'PRESENT',
           groupId: 'group1',
           arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
-          departed: null,
-          occupancyCoefficient: 1
+          departed: null
         }
       ],
       today,

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -170,7 +170,6 @@ export interface EmployeeAttendance {
   employeeId: UUID
   firstName: string
   groups: UUID[]
-  hasFutureAttendances: boolean
   lastName: string
   plannedAttendances: PlannedStaffAttendance[]
 }
@@ -182,7 +181,6 @@ export interface ExternalAttendance {
   arrived: HelsinkiDateTime
   departed: HelsinkiDateTime | null
   groupId: UUID
-  hasFutureAttendances: boolean
   id: UUID
   name: string
   occupancyCoefficient: number
@@ -212,7 +210,6 @@ export interface ExternalStaffDepartureRequest {
 export interface ExternalStaffMember {
   arrived: HelsinkiDateTime
   groupId: UUID
-  hasFutureAttendances: boolean
   id: UUID
   name: string
 }

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -188,6 +188,27 @@ export interface ExternalAttendance {
 }
 
 /**
+* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.ExternalAttendanceBody
+*/
+export interface ExternalAttendanceBody {
+  date: LocalDate
+  entries: ExternalAttendanceUpsert[]
+  name: string
+  unitId: UUID
+}
+
+/**
+* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.ExternalAttendanceUpsert
+*/
+export interface ExternalAttendanceUpsert {
+  arrived: HelsinkiDateTime
+  departed: HelsinkiDateTime | null
+  groupId: UUID
+  id: UUID | null
+  type: StaffAttendanceType
+}
+
+/**
 * Generated from fi.espoo.evaka.attendance.MobileRealtimeStaffAttendanceController.ExternalStaffArrivalRequest
 */
 export interface ExternalStaffArrivalRequest {
@@ -249,17 +270,6 @@ export interface PlannedStaffAttendance {
 }
 
 /**
-* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.SingleDayStaffAttendanceUpsert
-*/
-export interface SingleDayStaffAttendanceUpsert {
-  arrived: HelsinkiDateTime
-  attendanceId: UUID | null
-  departed: HelsinkiDateTime | null
-  groupId: UUID
-  type: StaffAttendanceType
-}
-
-/**
 * Generated from fi.espoo.evaka.attendance.Staff
 */
 export interface Staff {
@@ -283,6 +293,16 @@ export interface StaffArrivalRequest {
 }
 
 /**
+* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.StaffAttendanceBody
+*/
+export interface StaffAttendanceBody {
+  date: LocalDate
+  employeeId: UUID
+  entries: StaffAttendanceUpsert[]
+  unitId: UUID
+}
+
+/**
 * Generated from fi.espoo.evaka.attendance.StaffAttendanceResponse
 */
 export interface StaffAttendanceResponse {
@@ -302,6 +322,17 @@ export const staffAttendanceTypes = [
 ] as const
 
 export type StaffAttendanceType = typeof staffAttendanceTypes[number]
+
+/**
+* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.StaffAttendanceUpsert
+*/
+export interface StaffAttendanceUpsert {
+  arrived: HelsinkiDateTime
+  departed: HelsinkiDateTime | null
+  groupId: UUID
+  id: UUID | null
+  type: StaffAttendanceType
+}
 
 /**
 * Generated from fi.espoo.evaka.attendance.MobileRealtimeStaffAttendanceController.StaffDepartureRequest

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -323,6 +323,7 @@ enum class Audit(
     StaffAttendanceUpdate,
     StaffAttendanceDelete,
     StaffAttendanceExternalDelete,
+    StaffAttendanceExternalUpdate,
     StaffOccupancyCoefficientRead,
     StaffOccupancyCoefficientUpsert,
     StartingPlacementsReportRead,

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -93,7 +93,6 @@ class RealtimeStaffAttendanceController(private val accessControl: AccessControl
                                             att.type
                                         )
                                     },
-                                hasFutureAttendances = data[0].hasFutureAttendances,
                                 plannedAttendances = plannedAttendances[employeeId] ?: emptyList()
                             )
                         }
@@ -109,7 +108,6 @@ class RealtimeStaffAttendanceController(private val accessControl: AccessControl
                                     currentOccupancyCoefficient = emp.currentOccupancyCoefficient
                                             ?: BigDecimal.ZERO,
                                     listOf(),
-                                    hasFutureAttendances = emp.hasFutureAttendances,
                                     plannedAttendances = plannedAttendances[emp.id] ?: emptyList()
                                 )
                             }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendance.kt
@@ -46,7 +46,6 @@ data class ExternalStaffMember(
     val name: String,
     val groupId: GroupId,
     val arrived: HelsinkiDateTime,
-    val hasFutureAttendances: Boolean
 )
 
 data class StaffMember(
@@ -93,7 +92,6 @@ data class ExternalAttendance(
     val arrived: HelsinkiDateTime,
     val departed: HelsinkiDateTime?,
     val occupancyCoefficient: BigDecimal,
-    val hasFutureAttendances: Boolean
 ) {
     val type = StaffAttendanceType.PRESENT
 }
@@ -114,7 +112,6 @@ data class EmployeeAttendance(
     val lastName: String,
     val currentOccupancyCoefficient: BigDecimal,
     val attendances: List<Attendance>,
-    val hasFutureAttendances: Boolean,
     val plannedAttendances: List<PlannedStaffAttendance>
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
@@ -537,18 +537,34 @@ FROM staff_attendance_realtime WHERE employee_id = :employeeId AND departed IS N
         .findOne()
         .orElseGet { null }
 
-fun Database.Transaction.deleteStaffAttendanceWithoutIds(
+fun Database.Transaction.deleteStaffAttendancesInRangeExcept(
     employeeId: EmployeeId,
     timeRange: HelsinkiDateTimeRange,
-    attendanceIds: List<StaffAttendanceId>
+    exceptIds: List<StaffAttendanceId>
 ) =
     createUpdate(
             """
 DELETE FROM staff_attendance_realtime
-WHERE employee_id = :employeeId AND tstzrange(arrived, departed) && :timeRange AND NOT id = ANY(:attendanceIds)
+WHERE employee_id = :employeeId AND tstzrange(arrived, departed) && :timeRange AND NOT id = ANY(:exceptIds)
 """
         )
         .bind("employeeId", employeeId)
         .bind("timeRange", timeRange)
-        .bind("attendanceIds", attendanceIds)
+        .bind("exceptIds", exceptIds)
+        .execute()
+
+fun Database.Transaction.deleteExternalAttendancesInRangeExcept(
+    name: String,
+    timeRange: HelsinkiDateTimeRange,
+    exceptIds: List<StaffAttendanceExternalId>
+) =
+    createUpdate(
+            """
+DELETE FROM staff_attendance_external
+WHERE name = :name AND tstzrange(arrived, departed) && :timeRange AND NOT id = ANY(:exceptIds)
+"""
+        )
+        .bind("name", name)
+        .bind("timeRange", timeRange)
+        .bind("exceptIds", exceptIds)
         .execute()


### PR DESCRIPTION
#### Summary

A previous PR accidentally removed the possibility to edit attendance data of externals. This PR brings it to the same modal that's used for staff.

All tests are missing ~and the frontend has rough edges still~ (fixed), but these will be fixed in the next PR because we need this to unblock production deployments.