### PR TITLE
Use `describe.each()` instead of manual looping

### DIFF
--- a/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
@@ -123,14 +123,15 @@ const defaultMessage = {
 
 describe('Sending and receiving messages', () => {
   const initConfigurations = [
-    { init: initCitizenPage, name: 'direct login' },
-    { init: initCitizenPageWeak, name: 'weak login' }
+    ['direct login', initCitizenPage] as const,
+    ['weak login', initCitizenPageWeak] as const
   ]
 
-  for (const configuration of initConfigurations) {
-    describe(`Interactions with ${configuration.name}`, () => {
+  describe.each(initConfigurations)(
+    `Interactions with $%s`,
+    (_name, initCitizen) => {
       beforeEach(async () => {
-        await Promise.all([initStaffPage(), configuration.init()])
+        await Promise.all([initStaffPage(), initCitizen()])
       })
 
       const sendMessageAsStaff = async () => {
@@ -173,8 +174,8 @@ describe('Sending and receiving messages', () => {
         await messagesPage.deleteFirstThread()
         await waitUntilEqual(() => messagesPage.getReceivedMessageCount(), 0)
       })
-    })
-  }
+    }
+  )
 })
 
 describe('Staff copies', () => {

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -120,14 +120,15 @@ const defaultMessage = {
 
 describe('Sending and receiving messages', () => {
   const initConfigurations = [
-    { init: initCitizenPage, name: 'direct login' },
-    { init: initCitizenPageWeak, name: 'weak login' }
+    ['direct login', initCitizenPage] as const,
+    ['weak login', initCitizenPageWeak] as const
   ]
 
-  for (const configuration of initConfigurations) {
-    describe(`Interactions with ${configuration.name}`, () => {
+  describe.each(initConfigurations)(
+    'Interactions with %s',
+    (_name, initCitizen) => {
       beforeEach(async () => {
-        await Promise.all([initSupervisorPage(), configuration.init()])
+        await Promise.all([initSupervisorPage(), initCitizen()])
       })
 
       test('Unit supervisor sends message and citizen replies', async () => {
@@ -451,35 +452,35 @@ describe('Sending and receiving messages', () => {
           await citizenMessagesPage.assertInboxIsEmpty()
         })
       })
+    }
+  )
+
+  describe('Drafts', () => {
+    beforeEach(async () => {
+      await initSupervisorPage()
+    })
+    test('A draft is saved correctly', async () => {
+      await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
+      const messagesPage = new MessagesPage(unitSupervisorPage)
+      await messagesPage.draftNewMessage(defaultTitle, defaultContent)
+      await messagesPage.closeMessageEditor()
+      await messagesPage.assertDraftContent(defaultTitle, defaultContent)
     })
 
-    describe('Drafts', () => {
-      beforeEach(async () => {
-        await initSupervisorPage()
-      })
-      test('A draft is saved correctly', async () => {
-        await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
-        const messagesPage = new MessagesPage(unitSupervisorPage)
-        await messagesPage.draftNewMessage(defaultTitle, defaultContent)
-        await messagesPage.closeMessageEditor()
-        await messagesPage.assertDraftContent(defaultTitle, defaultContent)
-      })
-
-      test('A draft is not saved when a message is sent', async () => {
-        await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
-        const messagesPage = new MessagesPage(unitSupervisorPage)
-        await messagesPage.draftNewMessage(defaultTitle, defaultContent)
-        await messagesPage.sendEditedMessage()
-        await messagesPage.assertNoDrafts()
-      })
-
-      test("A draft is not saved when it's discarded", async () => {
-        await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
-        const messagesPage = new MessagesPage(unitSupervisorPage)
-        await messagesPage.draftNewMessage(defaultTitle, defaultContent)
-        await messagesPage.discardMessage()
-        await messagesPage.assertNoDrafts()
-      })
+    test('A draft is not saved when a message is sent', async () => {
+      await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
+      const messagesPage = new MessagesPage(unitSupervisorPage)
+      await messagesPage.draftNewMessage(defaultTitle, defaultContent)
+      await messagesPage.sendEditedMessage()
+      await messagesPage.assertNoDrafts()
     })
-  }
+
+    test("A draft is not saved when it's discarded", async () => {
+      await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
+      const messagesPage = new MessagesPage(unitSupervisorPage)
+      await messagesPage.draftNewMessage(defaultTitle, defaultContent)
+      await messagesPage.discardMessage()
+      await messagesPage.assertNoDrafts()
+    })
+  })
 })


### PR DESCRIPTION
#### Summary

This way, IntelliJ IDEA detects the test cases correctly and they can be run from the IDE.