### PR TITLE
[EVAKA-4422] E-mail notifications about missing reservations

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -74,7 +74,6 @@ interface ChildWithReservations {
   absence: AbsenceType | undefined
   reservations: TimeRange[]
   attendances: OpenTimeRange[]
-  dayOff: boolean
   reservationEditable: boolean
   markedByEmployee: boolean
 }
@@ -102,15 +101,13 @@ function getChildrenWithReservations(
       const reservationEditable =
         !markedByEmployee &&
         (!dailyData.isHoliday || child.inShiftCareUnit) &&
-        child.maxOperationalDays.includes(date.getIsoDayOfWeek()) &&
-        !childReservations?.dayOff
+        child.maxOperationalDays.includes(date.getIsoDayOfWeek())
 
       return {
         child,
         absence: childReservations?.absence ?? undefined,
         reservations: childReservations?.reservations ?? [],
         attendances: childReservations?.attendances ?? [],
-        dayOff: childReservations?.dayOff ?? false,
         reservationEditable,
         markedByEmployee
       }
@@ -237,7 +234,6 @@ export default React.memo(function DayView({
                         absence,
                         reservations,
                         attendances,
-                        dayOff,
                         reservationEditable,
                         markedByEmployee
                       } = childWithReservation
@@ -352,8 +348,6 @@ export default React.memo(function DayView({
                                         absence={absence}
                                         markedByEmployee={markedByEmployee}
                                       />
-                                    ) : reservations.length === 0 && dayOff ? (
-                                      <DayOff />
                                     ) : (
                                       <Reservations
                                         reservations={reservations}
@@ -820,36 +814,6 @@ const Absence = React.memo(function Absence({
             onClick={onClick}
             aria-label={i18n.common.openExpandingInfo}
             open={open}
-          />
-        </FixedSpaceColumn>
-      </FixedSpaceRow>
-      {open && (
-        <Colspan2>
-          <ExpandingInfoBox
-            width="auto"
-            info={i18n.calendar.contactStaffToEditAbsence}
-            close={onClick}
-            closeLabel={i18n.common.close}
-          />
-        </Colspan2>
-      )}
-    </>
-  )
-})
-
-const DayOff = React.memo(function DayOff() {
-  const i18n = useTranslation()
-  const [open, setOpen] = useState(false)
-  const onClick = useCallback(() => setOpen((prev) => !prev), [])
-
-  return (
-    <>
-      <FixedSpaceRow data-qa="day-off">
-        <FixedSpaceColumn>{i18n.calendar.dayOff}</FixedSpaceColumn>
-        <FixedSpaceColumn>
-          <InfoButton
-            onClick={onClick}
-            aria-label={i18n.common.openExpandingInfo}
           />
         </FixedSpaceColumn>
       </FixedSpaceRow>

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -28,7 +28,6 @@ import RoundChildImages, { ChildImageData } from './RoundChildImages'
 type DailyChildGroupElementType =
   | 'attendance'
   | 'reservation'
-  | 'day-off'
   | 'absent'
   | 'missing-reservation'
   | 'absent-free'
@@ -96,8 +95,6 @@ export const Reservations = React.memo(function Reservations({
                 ? i18n.calendar.absent
                 : group.type === 'absent-free'
                 ? i18n.calendar.absentFree
-                : group.type === 'day-off'
-                ? i18n.calendar.dayOff
                 : group.text}
             </GroupedElementText>
           </FixedSpaceRow>
@@ -181,13 +178,6 @@ const groupChildren = (
               text: child.reservations
                 .map(({ startTime, endTime }) => `${startTime}–${endTime}`)
                 .join(', ')
-            }
-          }
-
-          if (child.dayOff) {
-            return {
-              childId: child.childId,
-              type: 'day-off'
             }
           }
 

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/DailyRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/DailyRepetitionTimeInputGrid.tsx
@@ -68,16 +68,6 @@ export default React.memo(function DailyRepetitionTimeInputGrid({
     }`}</Label>
   )
 
-  if (formData.dailyTimes === 'day-off') {
-    return (
-      <>
-        <div>{label}</div>
-        <div>{i18n.calendar.reservationModal.dayOff}</div>
-        <div />
-      </>
-    )
-  }
-
   return (
     <TimeInputs
       label={label}

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/IrregularRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/IrregularRepetitionTimeInputGrid.tsx
@@ -16,7 +16,6 @@ import TimeInputs from './TimeInputs'
 import {
   allChildrenAreAbsent,
   allChildrenAreAbsentMarkedByEmployee,
-  allChildrenHaveDayOff,
   bindUnboundedTimeRanges,
   emptyTimeRange,
   getCommonTimeRanges,
@@ -48,14 +47,7 @@ export default React.memo(function IrregularRepetitionTimeInputGrid({
         [...selectedRange.dates()].map<
           [
             string,
-            (
-              | TimeRanges
-              | 'absent'
-              | 'day-off'
-              | 'not-editable'
-              | 'holiday'
-              | undefined
-            )
+            TimeRanges | 'absent' | 'not-editable' | 'holiday' | undefined
           ]
         >((rangeDate) => {
           const existingTimes = reservations.find(({ date }) =>
@@ -68,12 +60,6 @@ export default React.memo(function IrregularRepetitionTimeInputGrid({
 
           if (existingTimes.isHoliday) {
             return [rangeDate.formatIso(), 'holiday']
-          }
-
-          if (
-            allChildrenHaveDayOff([existingTimes], formData.selectedChildren)
-          ) {
-            return [rangeDate.formatIso(), 'day-off']
           }
 
           if (

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -29,21 +29,9 @@ interface BaseTimeInputProps {
 }
 
 interface TimeInputWithAbsencesProps extends BaseTimeInputProps {
-  times:
-    | TimeRanges
-    | 'absent'
-    | 'day-off'
-    | 'not-editable'
-    | 'holiday'
-    | undefined
+  times: TimeRanges | 'absent' | 'not-editable' | 'holiday' | undefined
   updateTimes: (
-    v:
-      | TimeRanges
-      | 'absent'
-      | 'day-off'
-      | 'not-editable'
-      | 'holiday'
-      | undefined
+    v: TimeRanges | 'absent' | 'not-editable' | 'holiday' | undefined
   ) => void
   showAbsences: true
 }
@@ -127,18 +115,6 @@ export default React.memo(function TimeInputs(props: TimeInputProps) {
           </FixedSpaceRow>
         )}
       </>
-    )
-  }
-
-  if (props.times === 'day-off') {
-    return (
-      <FixedSpaceRow fullWidth>
-        <LeftCell>{props.label}</LeftCell>
-        <MiddleCell textOnly>
-          {i18n.calendar.reservationModal.dayOff}
-        </MiddleCell>
-        <RightCell />
-      </FixedSpaceRow>
     )
   }
 

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/WeeklyRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/WeeklyRepetitionTimeInputGrid.tsx
@@ -15,7 +15,6 @@ import TimeInputs from './TimeInputs'
 import {
   allChildrenAreAbsent,
   allChildrenAreAbsentMarkedByEmployee,
-  allChildrenHaveDayOff,
   bindUnboundedTimeRanges,
   emptyTimeRange,
   getCommonTimeRanges,
@@ -59,15 +58,6 @@ export default React.memo(function WeeklyRepetitionTimeInputGrid({
           const relevantReservations = reservations.filter(({ date }) =>
             dayOfWeekDays.some((d) => d.isEqual(date))
           )
-
-          if (
-            allChildrenHaveDayOff(
-              relevantReservations,
-              formData.selectedChildren
-            )
-          ) {
-            return 'day-off'
-          }
 
           if (
             allChildrenAreAbsentMarkedByEmployee(

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/utils.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/utils.ts
@@ -54,18 +54,6 @@ export const allChildrenAreAbsentMarkedByEmployee = (
     )
   )
 
-export const allChildrenHaveDayOff = (
-  dayData: DailyReservationData[],
-  childIds: string[]
-) =>
-  dayData.every((reservations) =>
-    childIds.every((childId) =>
-      reservations.children.some(
-        (child) => child.childId === childId && !!child.dayOff
-      )
-    )
-  )
-
 export const bindUnboundedTimeRanges = (ranges: TimeRange[]): TimeRanges => {
   if (ranges.length === 1) {
     return ranges as [TimeRange]

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -26,7 +26,6 @@ export interface ChildDailyData {
   absence: AbsenceType | null
   attendances: OpenTimeRange[]
   childId: UUID
-  dayOff: boolean
   markedByEmployee: boolean
   reservations: TimeRange[]
 }

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -100,6 +100,7 @@ export type ScheduledJob =
   | 'VardaReset'
   | 'InactivePeopleCleanup'
   | 'InactiveEmployeesRoleReset'
+  | 'SendMissingReservationReminders'
 
 /**
 * Generated from fi.espoo.evaka.shared.domain.Translatable

--- a/frontend/src/lib-common/reservations.ts
+++ b/frontend/src/lib-common/reservations.ts
@@ -19,13 +19,11 @@ export interface ReservationFormData {
   startDate: LocalDate | null
   endDate: LocalDate | null
   repetition: Repetition
-  dailyTimes: TimeRanges | 'day-off'
-  weeklyTimes: Array<
-    TimeRanges | 'absent' | 'day-off' | 'not-editable' | undefined
-  >
+  dailyTimes: TimeRanges
+  weeklyTimes: Array<TimeRanges | 'absent' | 'not-editable' | undefined>
   irregularTimes: Record<
     string,
-    TimeRanges | 'absent' | 'day-off' | 'not-editable' | 'holiday' | undefined
+    TimeRanges | 'absent' | 'not-editable' | 'holiday' | undefined
   >
 }
 
@@ -94,18 +92,14 @@ export function validateForm(
   }
 
   if (formData.repetition === 'DAILY') {
-    errors['dailyTimes'] =
-      formData.dailyTimes === 'day-off'
-        ? undefined
-        : formData.dailyTimes.map((timeRange) => validateTimeRange(timeRange))
+    errors['dailyTimes'] = formData.dailyTimes.map((timeRange) =>
+      validateTimeRange(timeRange)
+    )
   }
 
   if (formData.repetition === 'WEEKLY') {
     errors['weeklyTimes'] = formData.weeklyTimes.map((times) =>
-      times &&
-      times !== 'absent' &&
-      times !== 'day-off' &&
-      times !== 'not-editable'
+      times && times !== 'absent' && times !== 'not-editable'
         ? times.map((timeRange) => validateTimeRange(timeRange))
         : undefined
     )
@@ -117,7 +111,6 @@ export function validateForm(
         date,
         times &&
         times !== 'absent' &&
-        times !== 'day-off' &&
         times !== 'not-editable' &&
         times !== 'holiday'
           ? times.map((timeRange) => validateTimeRange(timeRange))
@@ -181,20 +174,9 @@ export function validateForm(
 }
 
 function filterReservations(
-  times:
-    | TimeRanges
-    | 'absent'
-    | 'day-off'
-    | 'not-editable'
-    | 'holiday'
-    | undefined
+  times: TimeRanges | 'absent' | 'not-editable' | 'holiday' | undefined
 ) {
-  if (
-    times === 'absent' ||
-    times === 'day-off' ||
-    times === 'not-editable' ||
-    times === 'holiday'
-  ) {
+  if (times === 'absent' || times === 'not-editable' || times === 'holiday') {
     return null
   }
 

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/en.tsx
@@ -254,7 +254,6 @@ const en: Translations = {
     holiday: 'Holiday',
     absent: 'Absent',
     absentFree: 'Free absence',
-    dayOff: 'Day off',
     absences: {
       SICKLEAVE: 'Absence due to illness'
     },
@@ -295,7 +294,6 @@ const en: Translations = {
       start: 'Start',
       end: 'End',
       absent: 'Absent',
-      dayOff: 'Day off',
       saveErrors: {
         failure: 'Could not save',
         NON_RESERVABLE_DAYS: 'Some of the selected days cannot be reserved'

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/fi.tsx
@@ -251,7 +251,6 @@ export default {
     holiday: 'Pyhäpäivä',
     absent: 'Poissa',
     absentFree: 'Maksuton poissaolo',
-    dayOff: 'Vapaapäivä',
     absences: {
       SICKLEAVE: 'Sairauspoissaolo'
     },
@@ -292,7 +291,6 @@ export default {
       start: 'Alkaa',
       end: 'Päättyy',
       absent: 'Poissa',
-      dayOff: 'Vapaapäivä',
       saveErrors: {
         failure: 'Tallennus epäonnistui',
         NON_RESERVABLE_DAYS: 'Joitain valittuja päiviä ei voida varata'

--- a/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen/assets/i18n/sv.tsx
@@ -252,7 +252,6 @@ const sv: Translations = {
     holiday: 'Helgdag',
     absent: 'Frånvarande',
     absentFree: 'Gratis frånvaro',
-    dayOff: 'Ledighet',
     absences: {
       SICKLEAVE: 'Sjukfrånvaro'
     },
@@ -292,7 +291,6 @@ const sv: Translations = {
       start: 'Börjar',
       end: 'Slutar',
       absent: 'Frånvarande',
-      dayOff: 'Ledighet',
       saveErrors: {
         failure: 'Kunde inte spara',
         NON_RESERVABLE_DAYS: 'Alla valda dagar kan inte reserveras.'

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -116,7 +116,7 @@ class MessageNotificationEmailServiceIntegrationTest :
 
         assertEquals(testAddresses.toSet(), MockEmailClient.emails.map { it.toAddress }.toSet())
         assertEquals(
-            "Uusi viesti eVakassa / Nytt meddelande i eVaka / New message in eVaka [null]",
+            "Uusi viesti eVakassa / Nytt meddelande i eVaka / New message in eVaka",
             getEmailFor(testPersonFi).subject
         )
         assertEquals(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationServiceIntegrationTest.kt
@@ -125,7 +125,7 @@ class PedagogicalDocumentNotificationServiceIntegrationTest :
 
         assertEquals(testAddresses.toSet(), MockEmailClient.emails.map { it.toAddress }.toSet())
         assertEquals(
-            "Uusi pedagoginen dokumentti eVakassa / Nytt pedagogiskt dokument i eVaka / New pedagogical document in eVaka [null]",
+            "Uusi pedagoginen dokumentti eVakassa / Nytt pedagogiskt dokument i eVaka / New pedagogical document in eVaka",
             getEmailFor(testGuardianFi).subject
         )
         assertEquals(
@@ -211,7 +211,7 @@ class PedagogicalDocumentNotificationServiceIntegrationTest :
 
         assertEquals(testAddresses.toSet(), MockEmailClient.emails.map { it.toAddress }.toSet())
         assertEquals(
-            "Uusi pedagoginen dokumentti eVakassa / Nytt pedagogiskt dokument i eVaka / New pedagogical document in eVaka [null]",
+            "Uusi pedagoginen dokumentti eVakassa / Nytt pedagogiskt dokument i eVaka / New pedagogical document in eVaka",
             getEmailFor(testGuardianFi).subject
         )
         assertEquals(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/MissingReservationsRemindersTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/MissingReservationsRemindersTest.kt
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.reservations
+
+import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.daycare.service.AbsenceCategory
+import fi.espoo.evaka.emailclient.MockEmailClient
+import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevChild
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevGuardian
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPlacement
+import fi.espoo.evaka.shared.dev.DevReservation
+import fi.espoo.evaka.shared.dev.insertTestAbsence
+import fi.espoo.evaka.shared.dev.insertTestCareArea
+import fi.espoo.evaka.shared.dev.insertTestChild
+import fi.espoo.evaka.shared.dev.insertTestDaycare
+import fi.espoo.evaka.shared.dev.insertTestGuardian
+import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.dev.insertTestReservation
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.shared.job.ScheduledJobs
+import fi.espoo.evaka.shared.security.PilotFeature
+import fi.espoo.evaka.shared.security.upsertCitizenUser
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class MissingReservationsRemindersTest : FullApplicationTest(resetDbBeforeEach = true) {
+    @Autowired private lateinit var scheduledJobs: ScheduledJobs
+    @Autowired private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
+
+    private val guardianEmail = "guardian@example.com"
+    private val operationDays: Set<Int> = setOf(1, 2, 3, 4, 5)
+    private lateinit var guardian: PersonId
+    private lateinit var child: ChildId
+
+    private val checkedRange =
+        FiniteDateRange(LocalDate.of(2022, 10, 31), LocalDate.of(2022, 11, 6))
+    private val clock =
+        MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2022, 10, 23), LocalTime.of(21, 0)))
+
+    init {
+        assertEquals(DayOfWeek.SUNDAY, clock.today().dayOfWeek)
+        assertEquals(DayOfWeek.MONDAY, checkedRange.start.dayOfWeek)
+        assertEquals(DayOfWeek.SUNDAY, checkedRange.end.dayOfWeek)
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        MockEmailClient.emails.clear()
+        db.transaction { tx ->
+            guardian = tx.insertTestPerson(DevPerson(email = guardianEmail))
+            tx.upsertCitizenUser(guardian)
+            val areaId = tx.insertTestCareArea(DevCareArea())
+            val daycareId =
+                tx.insertTestDaycare(
+                    DevDaycare(
+                        areaId = areaId,
+                        operationDays = operationDays,
+                        enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS)
+                    )
+                )
+            child = tx.insertTestPerson(DevPerson()).also { tx.insertTestChild(DevChild(it)) }
+            tx.insertTestGuardian(DevGuardian(guardianId = guardian, childId = child))
+            tx.insertTestPlacement(
+                DevPlacement(
+                    childId = child,
+                    unitId = daycareId,
+                    startDate = checkedRange.start,
+                    endDate = checkedRange.end
+                )
+            )
+        }
+    }
+    @Test
+    fun `reminder is sent when a placement exists but there are no reservations`() {
+        assertEquals(listOf(guardianEmail), getReminderRecipients())
+    }
+
+    @Test
+    fun `reminder is sent when only some days in range have reservations`() {
+        db.transaction { it.createReservation(checkedRange.start) }
+        assertEquals(listOf(guardianEmail), getReminderRecipients())
+    }
+
+    @Test
+    fun `reminder is not sent when all days have reservations`() {
+        db.transaction { tx -> checkedRange.dates().forEach { tx.createReservation(it) } }
+        assertEquals(emptyList(), getReminderRecipients())
+    }
+
+    @Test
+    fun `reminder is not sent when there are absences`() {
+        db.transaction { tx ->
+            checkedRange.dates().forEach {
+                tx.insertTestAbsence(
+                    childId = child,
+                    date = it,
+                    category = AbsenceCategory.NONBILLABLE
+                )
+            }
+        }
+        assertEquals(emptyList(), getReminderRecipients())
+    }
+
+    @Test
+    fun `reminder is not sent when reservations are missing only from non-operational days`() {
+        db.transaction { tx -> checkedRange.dates().take(5).forEach { tx.createReservation(it) } }
+        assertEquals(emptyList(), getReminderRecipients())
+    }
+
+    private fun Database.Transaction.createReservation(date: LocalDate) =
+        insertTestReservation(
+            DevReservation(
+                childId = child,
+                date = date,
+                startTime = LocalTime.of(8, 0),
+                endTime = LocalTime.of(16, 0),
+                createdBy = AuthenticatedUser.SystemInternalUser.evakaUserId
+            )
+        )
+    private fun getReminderRecipients(): List<String> {
+        scheduledJobs.sendMissingReservationReminders(db, clock)
+        asyncJobRunner.runPendingJobsSync(clock)
+        return MockEmailClient.emails.map { it.toAddress }
+    }
+}

--- a/service/src/integrationTest/resources/application-integration-test.yaml
+++ b/service/src/integrationTest/resources/application-integration-test.yaml
@@ -14,6 +14,10 @@ evaka:
   clock:
     mock: true
   email:
+    sender_address: no-reply.evaka@espoo.fi
+    sender_name:
+      fi: Espoon Varhaiskasvatus
+      sv: Esbo småbarnspedagogik
     application_received:
       sender_address:
         fi: testemail_fi@test.com

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka
 
+import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.shared.job.JobSchedule
 import fi.espoo.evaka.shared.job.ScheduledJob
 import fi.espoo.evaka.shared.job.ScheduledJobSettings
@@ -166,6 +167,17 @@ data class EmailEnv(
     val applicationReceivedSenderNameFi: String,
     val applicationReceivedSenderNameSv: String
 ) {
+    fun sender(language: Language): String =
+        when (language) {
+            Language.sv -> "$senderNameSv <$senderAddress>"
+            else -> "$senderNameFi <$senderAddress>"
+        }
+    fun applicationReceivedSender(language: Language): String =
+        when (language) {
+            Language.sv -> "$applicationReceivedSenderNameSv <$applicationReceivedSenderAddressSv>"
+            else -> "$applicationReceivedSenderNameFi <$applicationReceivedSenderAddressFi>"
+        }
+
     companion object {
         private fun getLegacyPostfix(): String? =
             when (val volttiEnv = System.getenv("VOLTTI_ENV")) {

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -160,12 +160,20 @@ data class EmailEnv(
     val senderAddress: String,
     val senderNameFi: String,
     val senderNameSv: String,
+    val subjectPostfix: String?,
     val applicationReceivedSenderAddressFi: String,
     val applicationReceivedSenderAddressSv: String,
     val applicationReceivedSenderNameFi: String,
     val applicationReceivedSenderNameSv: String
 ) {
     companion object {
+        private fun getLegacyPostfix(): String? =
+            when (val volttiEnv = System.getenv("VOLTTI_ENV")) {
+                "prod",
+                null -> null
+                else -> volttiEnv
+            }
+
         fun fromEnvironment(env: Environment) =
             EmailEnv(
                 enabled = env.lookup("evaka.email.enabled", "application.email.enabled") ?: false,
@@ -184,6 +192,7 @@ data class EmailEnv(
                     env.lookup("evaka.email.sender_name.fi", "fi.espoo.evaka.email.sender_name.fi"),
                 senderNameSv =
                     env.lookup("evaka.email.sender_name.sv", "fi.espoo.evaka.email.sender_name.sv"),
+                subjectPostfix = env.lookup("evaka.email.subject_postfix") ?: getLegacyPostfix(),
                 applicationReceivedSenderAddressFi =
                     env.lookup(
                         "evaka.email.application_received.sender_address.fi",

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailService.kt
@@ -18,14 +18,8 @@ private val logger = KotlinLogging.logger {}
 class ApplicationReceivedEmailService(
     private val emailClient: IEmailClient,
     private val emailMessageProvider: IEmailMessageProvider,
-    env: EmailEnv
+    private val emailEnv: EmailEnv
 ) {
-
-    private val senderAddressFi = env.applicationReceivedSenderAddressFi
-    private val senderNameFi = env.applicationReceivedSenderNameFi
-    private val senderAddressSv = env.applicationReceivedSenderAddressSv
-    private val senderNameSv = env.applicationReceivedSenderNameSv
-
     fun sendApplicationEmail(
         personId: PersonId,
         toAddress: String,
@@ -33,11 +27,7 @@ class ApplicationReceivedEmailService(
         type: ApplicationType,
         sentWithinPreschoolApplicationPeriod: Boolean? = null
     ) {
-        val fromAddress =
-            when (language) {
-                Language.sv -> "$senderNameSv <$senderAddressSv>"
-                else -> "$senderNameFi <$senderAddressFi>"
-            }
+        val fromAddress = emailEnv.applicationReceivedSender(language)
 
         val subject =
             when (type) {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -26,21 +26,11 @@ class PendingDecisionEmailService(
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val emailClient: IEmailClient,
     private val emailMessageProvider: IEmailMessageProvider,
-    env: EmailEnv
+    private val emailEnv: EmailEnv
 ) {
     init {
         asyncJobRunner.registerHandler(::doSendPendingDecisionsEmail)
     }
-
-    val senderAddress: String = env.senderAddress
-    val senderNameFi: String = env.senderNameFi
-    val senderNameSv: String = env.senderNameSv
-
-    fun getFromAddress(language: Language) =
-        when (language) {
-            Language.sv -> "$senderNameSv <$senderAddress>"
-            else -> "$senderNameFi <$senderAddress>"
-        }
 
     fun doSendPendingDecisionsEmail(
         db: Database.Connection,
@@ -140,7 +130,7 @@ GROUP BY application.guardian_id
             emailClient.sendEmail(
                 "${pendingDecision.guardianId} - ${pendingDecision.decisionIds.joinToString("-")}",
                 pendingDecision.email,
-                getFromAddress(lang),
+                emailEnv.sender(lang),
                 emailMessageProvider.getPendingDecisionEmailSubject(),
                 emailMessageProvider.getPendingDecisionEmailHtml(),
                 emailMessageProvider.getPendingDecisionEmailText()

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/domain/Language.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/domain/Language.kt
@@ -8,5 +8,15 @@ package fi.espoo.evaka.daycare.domain
 enum class Language {
     fi,
     sv,
-    en
+    en;
+
+    companion object {
+        fun tryValueOf(value: String): Language? =
+            when (value) {
+                "fi" -> fi
+                "sv" -> sv
+                "en" -> en
+                else -> null
+            }
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailClient.kt
@@ -18,8 +18,11 @@ import software.amazon.awssdk.services.ses.model.SendEmailRequest
 
 private val logger = KotlinLogging.logger {}
 
-class EmailClient(private val client: SesClient, private val whitelist: List<Regex>?) :
-    IEmailClient {
+class EmailClient(
+    private val client: SesClient,
+    private val whitelist: List<Regex>?,
+    private val subjectPostfix: String?
+) : IEmailClient {
     private val charset = "UTF-8"
 
     override fun sendEmail(
@@ -55,7 +58,18 @@ class EmailClient(private val client: SesClient, private val whitelist: List<Reg
                                         )
                                         .build()
                                 )
-                                .subject(Content.builder().charset(charset).data(subject).build())
+                                .subject(
+                                    Content.builder()
+                                        .charset(charset)
+                                        .data(
+                                            when (subjectPostfix) {
+                                                null,
+                                                "" -> subject
+                                                else -> "$subject [$subjectPostfix]"
+                                            }
+                                        )
+                                        .build()
+                                )
                                 .build()
                         )
                         .source(fromAddress)

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailConfig.kt
@@ -14,7 +14,12 @@ class EmailConfig {
     @Bean
     fun emailClient(client: SesClient, env: EmailEnv): IEmailClient =
         when (env.enabled) {
-            true -> EmailClient(client = client, whitelist = env.whitelist)
+            true ->
+                EmailClient(
+                    client = client,
+                    whitelist = env.whitelist,
+                    subjectPostfix = env.subjectPostfix
+                )
             false -> MockEmailClient()
         }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -4,8 +4,13 @@
 
 package fi.espoo.evaka.emailclient
 
+import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.shared.AssistanceNeedDecisionId
 import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
 
 class EvakaEmailMessageProvider : IEmailMessageProvider {
 
@@ -585,4 +590,40 @@ class EvakaEmailMessageProvider : IEmailMessageProvider {
         The decision can be viewed on eVaka at https://www.espoonvarhaiskasvatus.fi/.
     """
             .trimIndent()
+
+    override fun missingReservationsNotification(
+        language: Language,
+        checkedRange: FiniteDateRange
+    ): EmailContent {
+        val start =
+            checkedRange.start.format(
+                DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(Locale("fi", "FI"))
+            )
+        return EmailContent(
+            subject =
+                "Läsnäolovarauksia puuttuu / Det finns några närvarobokningar som saknas / There are missing attendance reservations",
+            text =
+                """
+Läsnäolovarauksia puuttuu seuraavalta viikolta: $start. Käythän merkitsemässä ne mahdollisimman pian.
+
+-----
+
+Det finns några närvarobokningar som saknas för följande vecka: $start. Vänligen markera dem så snart som möjligt.
+
+----
+
+There are missing attendance reservations for the following week: $start. Please mark them as soon as possible.
+                """
+                    .trimIndent(),
+            html =
+                """
+<p>Läsnäolovarauksia puuttuu seuraavalta viikolta: $start. Käythän merkitsemässä ne mahdollisimman pian.</p>
+<hr>
+<p>Det finns några närvarobokningar som saknas för följande vecka: $start. Vänligen markera dem så snart som möjligt.</p>
+<hr>
+<p>There are missing attendance reservations for the following week: $start. Please mark them as soon as possible.</p>
+            """
+                    .trimIndent()
+        )
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
@@ -4,8 +4,16 @@
 
 package fi.espoo.evaka.emailclient
 
+import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.shared.AssistanceNeedDecisionId
 import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+
+data class EmailContent(
+    val subject: String,
+    val text: String,
+    @org.intellij.lang.annotations.Language("html") val html: String
+)
 
 interface IEmailMessageProvider {
 
@@ -49,4 +57,9 @@ interface IEmailMessageProvider {
 
     fun getDecisionEmailHtml(childId: ChildId, decisionId: AssistanceNeedDecisionId): String
     fun getDecisionEmailText(childId: ChildId, decisionId: AssistanceNeedDecisionId): String
+
+    fun missingReservationsNotification(
+        language: Language,
+        checkedRange: FiniteDateRange
+    ): EmailContent
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
@@ -16,41 +16,37 @@ interface IEmailMessageProvider {
     val subjectForDecisionEmail: String
 
     fun getPendingDecisionEmailSubject(): String {
-        return subjectForPendingDecisionEmail + getMessagePostfix()
+        return subjectForPendingDecisionEmail
     }
 
     fun getPendingDecisionEmailHtml(): String
     fun getPendingDecisionEmailText(): String
 
     fun getClubApplicationReceivedEmailSubject(): String {
-        return subjectForClubApplicationReceivedEmail + getMessagePostfix()
+        return subjectForClubApplicationReceivedEmail
     }
 
     fun getClubApplicationReceivedEmailHtml(): String
     fun getClubApplicationReceivedEmailText(): String
 
     fun getDaycareApplicationReceivedEmailSubject(): String {
-        return subjectForDaycareApplicationReceivedEmail + getMessagePostfix()
+        return subjectForDaycareApplicationReceivedEmail
     }
 
     fun getDaycareApplicationReceivedEmailHtml(): String
     fun getDaycareApplicationReceivedEmailText(): String
 
     fun getPreschoolApplicationReceivedEmailSubject(): String {
-        return subjectForPreschoolApplicationReceivedEmail + getMessagePostfix()
+        return subjectForPreschoolApplicationReceivedEmail
     }
 
     fun getPreschoolApplicationReceivedEmailHtml(withinApplicationPeriod: Boolean): String
     fun getPreschoolApplicationReceivedEmailText(withinApplicationPeriod: Boolean): String
 
     fun getDecisionEmailSubject(): String {
-        return subjectForDecisionEmail + getMessagePostfix()
+        return subjectForDecisionEmail
     }
 
     fun getDecisionEmailHtml(childId: ChildId, decisionId: AssistanceNeedDecisionId): String
     fun getDecisionEmailText(childId: ChildId, decisionId: AssistanceNeedDecisionId): String
-
-    private fun getMessagePostfix(): String {
-        return if (System.getenv("VOLTTI_ENV") == "staging") " [staging]" else ""
-    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailService.kt
@@ -23,7 +23,7 @@ class MessageNotificationEmailService(
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val emailClient: IEmailClient,
     env: EvakaEnv,
-    emailEnv: EmailEnv
+    private val emailEnv: EmailEnv
 ) {
     init {
         asyncJobRunner.registerHandler(::sendMessageNotification)
@@ -31,15 +31,6 @@ class MessageNotificationEmailService(
 
     val baseUrl: String = env.frontendBaseUrlFi
     val baseUrlSv: String = env.frontendBaseUrlSv
-    val senderAddress: String = emailEnv.senderAddress
-    val senderNameFi: String = emailEnv.senderNameFi
-    val senderNameSv: String = emailEnv.senderNameSv
-
-    fun getFromAddress(language: Language) =
-        when (language) {
-            Language.sv -> "$senderNameSv <$senderAddress>"
-            else -> "$senderNameFi <$senderAddress>"
-        }
 
     fun getMessageNotifications(
         tx: Database.Transaction,
@@ -107,7 +98,7 @@ class MessageNotificationEmailService(
             emailClient.sendEmail(
                 traceId = messageRecipientId.toString(),
                 toAddress = personEmail,
-                fromAddress = getFromAddress(language),
+                fromAddress = emailEnv.sender(language),
                 subject = getSubject(urgent),
                 htmlBody = getHtml(language, threadId, urgent),
                 textBody = getText(language, threadId, urgent)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailService.kt
@@ -117,13 +117,10 @@ class MessageNotificationEmailService(
     }
 
     private fun getSubject(urgent: Boolean): String {
-        val postfix =
-            if (System.getenv("VOLTTI_ENV") == "prod") "" else " [${System.getenv("VOLTTI_ENV")}]"
-
         return if (urgent) {
-            "Uusi kiireellinen viesti eVakassa / Nytt brådskande meddelande i eVaka / New urgent message in eVaka$postfix"
+            "Uusi kiireellinen viesti eVakassa / Nytt brådskande meddelande i eVaka / New urgent message in eVaka"
         } else {
-            "Uusi viesti eVakassa / Nytt meddelande i eVaka / New message in eVaka$postfix"
+            "Uusi viesti eVakassa / Nytt meddelande i eVaka / New message in eVaka"
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationService.kt
@@ -25,7 +25,7 @@ class PedagogicalDocumentNotificationService(
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val emailClient: IEmailClient,
     env: EvakaEnv,
-    emailEnv: EmailEnv
+    private val emailEnv: EmailEnv
 ) {
     init {
         asyncJobRunner.registerHandler(::sendNotification)
@@ -33,15 +33,6 @@ class PedagogicalDocumentNotificationService(
 
     val baseUrl: String = env.frontendBaseUrlFi
     val baseUrlSv: String = env.frontendBaseUrlSv
-    val senderAddress: String = emailEnv.senderAddress
-    val senderNameFi: String = emailEnv.senderNameFi
-    val senderNameSv: String = emailEnv.senderNameSv
-
-    fun getFromAddress(language: Language) =
-        when (language) {
-            Language.sv -> "$senderNameSv <$senderAddress>"
-            else -> "$senderNameFi <$senderAddress>"
-        }
 
     fun getPedagogicalDocumentationNotifications(
         tx: Database.Transaction,
@@ -146,7 +137,7 @@ SELECT EXISTS(
             emailClient.sendEmail(
                 traceId = pedagogicalDocumentId.toString(),
                 toAddress = recipientEmail,
-                fromAddress = getFromAddress(language),
+                fromAddress = emailEnv.sender(language),
                 subject = getSubject(),
                 htmlBody = getHtml(language),
                 textBody = getText(language)

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationService.kt
@@ -156,10 +156,7 @@ SELECT EXISTS(
     }
 
     private fun getSubject(): String {
-        val postfix =
-            if (System.getenv("VOLTTI_ENV") == "prod") "" else " [${System.getenv("VOLTTI_ENV")}]"
-
-        return "Uusi pedagoginen dokumentti eVakassa / Nytt pedagogiskt dokument i eVaka / New pedagogical document in eVaka$postfix"
+        return "Uusi pedagoginen dokumentti eVakassa / Nytt pedagogiskt dokument i eVaka / New pedagogical document in eVaka"
     }
 
     private fun getDocumentsUrl(lang: Language): String {

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingReservationsReminders.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingReservationsReminders.kt
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.reservations
+
+import fi.espoo.evaka.EmailEnv
+import fi.espoo.evaka.daycare.domain.Language
+import fi.espoo.evaka.emailclient.IEmailClient
+import fi.espoo.evaka.emailclient.IEmailMessageProvider
+import fi.espoo.evaka.shared.DatabaseTable
+import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.async.AsyncJobType
+import fi.espoo.evaka.shared.async.removeUnclaimedJobs
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.db.QuerySql
+import fi.espoo.evaka.shared.db.mapColumn
+import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import java.time.DayOfWeek
+import org.springframework.stereotype.Service
+
+@Service
+class MissingReservationsReminders(
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
+    private val emailClient: IEmailClient,
+    private val emailMessageProvider: IEmailMessageProvider,
+    private val emailEnv: EmailEnv
+) {
+    init {
+        asyncJobRunner.registerHandler { db, _, msg: AsyncJob.SendMissingReservationsReminder ->
+            sendReminder(db, msg)
+        }
+    }
+
+    fun scheduleReminders(tx: Database.Transaction, clock: EvakaClock): Int {
+        tx.removeUnclaimedJobs(setOf(AsyncJobType(AsyncJob.SendMissingReservationsReminder::class)))
+
+        val range =
+            clock.today().plusDays(8).with(DayOfWeek.MONDAY).let { start ->
+                FiniteDateRange(start, start.plusDays(7))
+            }
+        val guardians =
+            tx.createQuery<Any> {
+                    sql(
+                        """
+SELECT DISTINCT missing.guardian_id
+FROM (${subquery(missingReservationsQuery(range))}) missing
+JOIN person p ON missing.guardian_id = p.id
+WHERE p.email IS NOT NULL
+    """
+                            .trimIndent()
+                    )
+                }
+                .mapTo<PersonId>()
+                .toList()
+
+        asyncJobRunner.plan(
+            tx,
+            payloads = guardians.map { AsyncJob.SendMissingReservationsReminder(it, range) },
+            runAt = clock.now()
+        )
+        return guardians.size
+    }
+
+    fun sendReminder(db: Database.Connection, msg: AsyncJob.SendMissingReservationsReminder) {
+        val (recipient, language) =
+            db.read { tx ->
+                tx.createQuery<DatabaseTable> {
+                        sql(
+                            """
+SELECT email, language
+FROM (${subquery(missingReservationsQuery(msg.range))}) missing
+JOIN person p ON missing.guardian_id = p.id
+WHERE missing.guardian_id = ${bind(msg.guardian)}
+AND email IS NOT NULL
+        """
+                                .trimIndent()
+                        )
+                    }
+                    .map { row ->
+                        Pair(
+                            row.mapColumn<String>("email"),
+                            row.mapColumn<String?>("language")
+                                ?.lowercase()
+                                ?.let(Language::tryValueOf)
+                                ?: Language.fi
+                        )
+                    }
+                    .firstOrNull()
+            }
+                ?: return
+        val email = emailMessageProvider.missingReservationsNotification(language, msg.range)
+        emailClient.sendEmail(
+            traceId = msg.guardian.toString(),
+            toAddress = recipient,
+            fromAddress = emailEnv.sender(language),
+            subject = email.subject,
+            htmlBody = email.html,
+            textBody = email.text,
+        )
+    }
+}
+
+private fun missingReservationsQuery(range: FiniteDateRange) =
+    QuerySql.of<PersonId> {
+        sql(
+            """
+SELECT guardian_id
+FROM (
+    SELECT p.child_id, t::date AS date
+    FROM generate_series(${bind(range.start)}, ${bind(range.end)}, '1 day') t
+    JOIN placement p ON daterange(p.start_date, p.end_date, '[]') @> t::date
+    JOIN daycare d ON p.unit_id = d.id
+    LEFT JOIN holiday h ON t::date = h.date AND NOT d.operation_days @> ARRAY[1, 2, 3, 4, 5, 6, 7]
+    WHERE date_part('isodow', t::date) = ANY(d.operation_days)
+    AND h.date IS NULL
+    AND 'RESERVATIONS' = ANY(d.enabled_pilot_features)
+    AND NOT EXISTS (
+        SELECT 1
+        FROM attendance_reservation ar
+        WHERE ar.child_id = p.child_id AND ar.date = t::date
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM child_attendance a
+        WHERE a.child_id = p.child_id AND a.date = t::date
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM absence a
+        WHERE a.child_id = p.child_id AND a.date = t::date
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM daily_service_time dst
+        WHERE dst.child_id = p.child_id AND dst.validity_period @> t::date AND dst.type = 'IRREGULAR'
+        AND (
+            CASE date_part('isodow', t::date)
+                WHEN 1 THEN monday_times IS NULL
+                WHEN 2 THEN tuesday_times IS NULL
+                WHEN 3 THEN wednesday_times IS NULL
+                WHEN 4 THEN thursday_times IS NULL
+                WHEN 5 THEN friday_times IS NULL
+                WHEN 6 THEN saturday_times IS NULL
+                WHEN 7 THEN sunday_times IS NULL
+            END
+        )
+    )
+) missing
+JOIN LATERAL (
+    SELECT guardian_id
+    FROM guardian
+    WHERE missing.child_id = guardian.child_id
+    
+    UNION ALL
+    
+    SELECT parent_id AS guardian_id
+    FROM foster_parent
+    WHERE missing.child_id = foster_parent.child_id AND valid_during @> missing.date
+) guardian ON TRUE
+    """
+                .trimIndent()
+        )
+    }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingReservationsReminders.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingReservationsReminders.kt
@@ -133,22 +133,6 @@ FROM (
         FROM absence a
         WHERE a.child_id = p.child_id AND a.date = t::date
     )
-    AND NOT EXISTS (
-        SELECT 1
-        FROM daily_service_time dst
-        WHERE dst.child_id = p.child_id AND dst.validity_period @> t::date AND dst.type = 'IRREGULAR'
-        AND (
-            CASE date_part('isodow', t::date)
-                WHEN 1 THEN monday_times IS NULL
-                WHEN 2 THEN tuesday_times IS NULL
-                WHEN 3 THEN wednesday_times IS NULL
-                WHEN 4 THEN thursday_times IS NULL
-                WHEN 5 THEN friday_times IS NULL
-                WHEN 6 THEN saturday_times IS NULL
-                WHEN 7 THEN sunday_times IS NULL
-            END
-        )
-    )
 ) missing
 JOIN LATERAL (
     SELECT guardian_id

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservableDays.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservableDays.kt
@@ -11,10 +11,10 @@ import java.time.LocalDate
 
 private fun getNextMonday(now: LocalDate): LocalDate = now.plusDays(7 - now.dayOfWeek.value + 1L)
 
-private fun getNextReservableMonday(
+fun getNextReservableMonday(
     now: HelsinkiDateTime,
     thresholdHours: Long,
-    nextMonday: LocalDate
+    nextMonday: LocalDate = getNextMonday(now.toLocalDate())
 ): LocalDate =
     if (nextMonday.isAfter(now.plusHours(thresholdHours).toLocalDate())) {
         nextMonday

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -25,6 +25,7 @@ import fi.espoo.evaka.shared.VasuDocumentId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.job.ScheduledJob
 import fi.espoo.evaka.varda.VardaChildCalculatedServiceNeedChanges
@@ -220,6 +221,11 @@ sealed interface AsyncJob : AsyncJobPayload {
     }
 
     data class UpdateIrregularAbsences(val childId: ChildId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class SendMissingReservationsReminder(val guardian: PersonId, val range: FiniteDateRange) :
+        AsyncJob {
         override val user: AuthenticatedUser? = null
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -1424,3 +1424,13 @@ VALUES (:id, :childId, :type, :validityPeriod, :regularTimes, :mondayTimes, :tue
         )
         .bindKotlin(dailyServiceTimes)
         .execute()
+
+fun Database.Transaction.insertTestGuardian(guardian: DevGuardian) =
+    createUpdate(
+            """
+INSERT INTO guardian (guardian_id, child_id) VALUES (:guardianId, :childId) ON CONFLICT (guardian_id, child_id) DO NOTHING
+"""
+                .trimIndent()
+        )
+        .bindKotlin(guardian)
+        .execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -621,23 +621,10 @@ RETURNING id
             }
         }
 
-    data class DevGuardian(val guardianId: PersonId, val childId: ChildId)
-
     @PostMapping("/guardian")
     fun insertGuardians(db: Database, @RequestBody guardians: List<DevGuardian>) {
         db.connect { dbc ->
-            dbc.transaction {
-                guardians.forEach { guardian ->
-                    it.createUpdate(
-                            """
-INSERT INTO guardian (guardian_id, child_id) VALUES (:guardianId, :childId) ON CONFLICT (guardian_id, child_id) DO NOTHING
-                        """
-                                .trimIndent()
-                        )
-                        .bindKotlin(guardian)
-                        .execute()
-                }
-            }
+            dbc.transaction { tx -> guardians.forEach { tx.insertTestGuardian(it) } }
         }
     }
 
@@ -1929,3 +1916,5 @@ data class DevAbsenceBody(
     val absenceCategory: AbsenceCategory,
     val modifiedBy: PersonId
 )
+
+data class DevGuardian(val guardianId: PersonId, val childId: ChildId)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -107,6 +107,11 @@ data class ScheduledJobSettings(
                         enabled = true,
                         schedule = JobSchedule.daily(LocalTime.of(3, 15))
                     )
+                ScheduledJob.SendMissingReservationReminders ->
+                    ScheduledJobSettings(
+                        enabled = false,
+                        schedule = JobSchedule.cron("0 0 18 * * 0") // Sunday 18:00
+                    )
             }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuNotificationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuNotificationService.kt
@@ -115,9 +115,7 @@ WHERE
     }
 
     private fun getSubject(): String {
-        val postfix =
-            if (System.getenv("VOLTTI_ENV") == "prod") "" else " [${System.getenv("VOLTTI_ENV")}]"
-        return "Uusi dokumentti eVakassa / Nytt dokument i eVaka / New document in eVaka$postfix"
+        return "Uusi dokumentti eVakassa / Nytt dokument i eVaka / New document in eVaka"
     }
 
     private fun getDocumentsUrl(childId: ChildId, lang: Language): String {

--- a/service/src/main/resources/application-espoo_evaka.yaml
+++ b/service/src/main/resources/application-espoo_evaka.yaml
@@ -3,6 +3,18 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 ---
 evaka:
+  email:
+    sender_address: "no-reply.evaka@espoo.fi"
+    sender_name:
+      fi: "Espoon Varhaiskasvatus"
+      sv: "Esbo småbarnspedagogik"
+    application_received:
+      sender_address:
+        fi: "vaka.palveluohjaus@espoo.fi"
+        sv: "dagis@esbo.fi"
+      sender_name:
+        fi: "Varhaiskasvatuksen palveluohjaus"
+        sv: "Barninvalskoordinatorer / Esbo stad"
   oph:
     municipality_code: "049"
     organizer_oid: "1.2.246.562.10.90008375488"

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -5,11 +5,6 @@
 evaka:
   database:
     maximum_pool_size: 20
-  email:
-    sender_address: "no-reply.evaka@espoo.fi"
-    sender_name:
-      fi: "Espoon Varhaiskasvatus"
-      sv: "Esbo småbarnspedagogik"
   fee_decision:
     min_date: "2020-03-01"
   five_years_old_daycare:


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Send e-mail notifications to guardians/foster parents of children that don't yet have attendance reservations.

Requirements for a notification to be sent:

- guardian/foster parent must have an e-mail address
- placement unit (*actual placement*, not backup care) must have the RESERVATIONS feature flag

Possible reasons why a certain date would *not* trigger a notification:

- it's a holiday
- it's not an operational day in actual placement unit
- there's already an attendance reservation / absence / actual child attendance information
- ~there's irregular daily service times info for the child that has no times for the week day~