### PR TITLE
Fix the looks of the applications list table

### DIFF
--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -88,8 +88,70 @@ const PaginationWrapper = styled.div<PaginationWrapperProps>`
 `
 
 const StatusColorTd = styled(Td)<{ color: string }>`
-  border-left-color: ${(p) => p.color};
-  border-left-width: 7px;
+  border-left: solid 7px ${(p) => p.color};
+`
+
+const SortableThWithBorder = styled(SortableTh)`
+  border-left: solid 7px white;
+`
+
+const ApplicationsTableContainer = styled.div`
+  table {
+    width: auto;
+  }
+
+  @media screen and (min-width: 1024px) {
+    table {
+      max-width: 960px;
+    }
+
+    th,
+    td {
+      padding: ${defaultMargins.s} ${defaultMargins.xs};
+    }
+    th:last-of-type,
+    td:last-of-type {
+      padding: ${defaultMargins.s};
+    }
+  }
+  @media screen and (max-width: 1215px) {
+    table {
+      max-width: 1152px;
+    }
+
+    th,
+    td {
+      padding: ${defaultMargins.s} ${defaultMargins.xs};
+    }
+    th:last-of-type,
+    td:last-of-type {
+      padding: ${defaultMargins.s};
+    }
+  }
+  @media screen and (max-width: 1407px) {
+    table {
+      max-width: 1344px;
+    }
+  }
+  @media screen and (min-width: 1216px) {
+    table {
+      max-width: 1152px;
+    }
+
+    th,
+    td {
+      padding: ${defaultMargins.s} ${defaultMargins.xs};
+    }
+    th:last-of-type,
+    td:last-of-type {
+      padding: ${defaultMargins.s};
+    }
+  }
+  @media screen and (min-width: 1408px) {
+    table {
+      max-width: 1344px;
+    }
+  }
 `
 
 interface Props {
@@ -458,54 +520,38 @@ const ApplicationsList = React.memo(function Applications({
         </PaginationWrapper>
       </TitleRowContainer>
 
-      <div>
+      <ApplicationsTableContainer>
         <Table data-qa="table-of-applications">
-          <Thead>
+          <Thead sticky="90px">
             <Tr>
-              <SortableTh
-                sticky
-                top="106px"
+              <SortableThWithBorder
                 sorted={isSorted('APPLICATION_TYPE')}
                 onClick={toggleSort('APPLICATION_TYPE')}
               >
                 {i18n.applications.list.type}
-              </SortableTh>
-              <Th sticky top="106px">
-                {i18n.applications.list.subtype}
-              </Th>
+              </SortableThWithBorder>
+              <Th>{i18n.applications.list.subtype}</Th>
               <SortableTh
-                sticky
-                top="106px"
                 sorted={isSorted('CHILD_NAME')}
                 onClick={toggleSort('CHILD_NAME')}
               >
                 {i18n.applications.list.name}
               </SortableTh>
               <SortableTh
-                sticky
-                top="106px"
                 sorted={isSorted('DUE_DATE')}
                 onClick={toggleSort('DUE_DATE')}
               >
                 {i18n.applications.list.dueDate}
               </SortableTh>
               <SortableTh
-                sticky
-                top="106px"
                 sorted={isSorted('START_DATE')}
                 onClick={toggleSort('START_DATE')}
               >
                 {i18n.applications.list.startDate}
               </SortableTh>
-              <Th sticky top="106px">
-                {i18n.applications.list.basis}
-              </Th>
-              <Th sticky top="106px">
-                {i18n.applications.list.unit}
-              </Th>
+              <Th>{i18n.applications.list.basis}</Th>
+              <Th>{i18n.applications.list.unit}</Th>
               <SortableTh
-                sticky
-                top="106px"
                 sorted={isSorted('STATUS')}
                 onClick={toggleSort('STATUS')}
               >
@@ -532,7 +578,7 @@ const ApplicationsList = React.memo(function Applications({
           <Tbody>{rows}</Tbody>
         </Table>
         <ActionBar reloadApplications={reloadApplications} fullWidth />
-      </div>
+      </ApplicationsTableContainer>
 
       {!!editedNote && (
         <AsyncFormModal

--- a/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/espoo/employee/assets/i18n/fi.tsx
@@ -265,7 +265,7 @@ export const fi = {
       resultCount: 'Hakutuloksia',
       noResults: 'Ei hakutuloksia',
       type: 'Hakutyyppi',
-      subtype: 'Osa/Koko',
+      subtype: 'Osa / Koko',
       areaPlaceholder: 'Valitse alue',
       transferFilter: {
         title: 'Siirtohakemukset',


### PR DESCRIPTION
- Avoid overflowing the content area on the right side by removing a bit of padding and making the table scale with the window.
- Make the table header sticky, instead of each column header separately to avoid content flashing behind the header

Before:
![before](https://user-images.githubusercontent.com/417206/201327076-5a88674f-cc65-4c8f-a257-b30604e4ab37.gif)

After:
![after](https://user-images.githubusercontent.com/417206/201327166-c242f912-6e03-40ce-853a-af09f1056687.gif)

