### PR TITLE
Evaka 4598 staff attendance fixes

### DIFF
--- a/frontend/src/e2e-test/pages/mobile/staff-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/staff-page.ts
@@ -124,7 +124,9 @@ export class StaffAttendancePage {
   #staffDeparturePage = {
     departureTime: new TextInput(this.page.findByDataQa('set-time')),
     markDepartedBtn: this.page.findByDataQa('mark-departed-btn'),
-    timeInputWarningText: this.page.findByDataQa('set-time-info')
+    timeInputWarningText: this.page.findByDataQa('set-time-info'),
+    departureTypeCheckbox: (type: StaffAttendanceType) =>
+      new Checkbox(this.page.findByDataQa(`attendance-type-${type}`))
   }
 
   #anyMemberPage = {
@@ -318,5 +320,15 @@ export class StaffAttendancePage {
 
   async selectGroup(groupId: string) {
     await this.#staffArrivalPage.groupSelect.selectOption(groupId)
+  }
+
+  async assertDepartureTypeVisible(
+    type: StaffAttendanceType,
+    visible: boolean
+  ) {
+    await waitUntilEqual(
+      () => this.#staffDeparturePage.departureTypeCheckbox(type).visible,
+      visible
+    )
   }
 }

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -208,6 +208,7 @@ describe('Realtime staff attendances', () => {
         .with({
           employeeId: groupStaff.id,
           groupId,
+          type: 'OVERTIME',
           arrived: mockedToday.toHelsinkiDateTime(LocalTime.of(7, 3)),
           departed: null
         })

--- a/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts
@@ -331,6 +331,18 @@ describe('Realtime staff attendance page', () => {
     // Departure is possible when the plan ends
     await staffAttendancePage.setDepartureTime('16:00')
     await staffAttendancePage.assertMarkDepartedButtonEnabled(true)
+    await staffAttendancePage.assertDepartureTypeVisible(
+      'JUSTIFIED_CHANGE',
+      false
+    )
+
+    // More than 5 min from the plan -> ask for reason
+    await staffAttendancePage.setDepartureTime('15:54')
+    await staffAttendancePage.assertMarkDepartedButtonEnabled(true)
+    await staffAttendancePage.assertDepartureTypeVisible(
+      'JUSTIFIED_CHANGE',
+      true
+    )
   })
 
   test('Staff departs in the middle of the planned day', async () => {

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -673,13 +673,18 @@ function getAttendancesForGroupAndDate(
           a.departed.toLocalDate()
         ).includes(date))
   )
-  const matchingAttendances = attendancesForDate.filter(
+
+  const presentAttendances = attendancesForDate.filter(
     ({ groupId, type }) =>
-      groupFilter([groupId]) && (type === undefined || type === 'PRESENT')
+      groupFilter([groupId]) &&
+      (type === undefined ||
+        type === 'PRESENT' ||
+        type === 'JUSTIFIED_CHANGE' ||
+        type === 'OVERTIME')
   )
   return {
-    matchingAttendances,
-    hasHiddenAttendances: matchingAttendances.length < attendancesForDate.length
+    matchingAttendances: presentAttendances,
+    hasHiddenAttendances: presentAttendances.length < attendancesForDate.length
   }
 }
 

--- a/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkDepartedPage.tsx
+++ b/frontend/src/employee-mobile-frontend/components/staff-attendance/StaffMarkDepartedPage.tsx
@@ -82,7 +82,7 @@ export default React.memo(function StaffMarkDepartedPage() {
   const [attendanceType, setAttendanceType] = useState<StaffAttendanceType>()
 
   const isValidTimeString = (time: string) =>
-    LocalTime.parse(time, 'HH:mm') ? true : false
+    LocalTime.tryParse(time, 'HH:mm') ? true : false
 
   const staffInfo = useMemo(
     () =>

--- a/frontend/src/employee-mobile-frontend/utils/staffAttendances.ts
+++ b/frontend/src/employee-mobile-frontend/utils/staffAttendances.ts
@@ -68,9 +68,9 @@ export function getAttendanceDepartureDifferenceReasons(
   departure: HelsinkiDateTime
 ): StaffAttendanceType[] {
   const departedBeforeMinThreshold = departure.isBefore(
-    plannedEnd.subMinutes(15)
+    plannedEnd.subMinutes(5)
   )
-  const depratedAfterMaxThreshold = departure.isAfter(plannedEnd.addMinutes(15))
+  const depratedAfterMaxThreshold = departure.isAfter(plannedEnd.addMinutes(5))
 
   if (departedBeforeMinThreshold) {
     return ['OTHER_WORK', 'TRAINING', 'JUSTIFIED_CHANGE']


### PR DESCRIPTION
#### Summary
- Use correct time parse function
- Use 5min tolerance instead of 15 on departure
- Show all present -type attendances on desktop unit group calendar + test

