### PR TITLE
Snakeyaml CVE suppression

### DIFF
--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
         api("org.thymeleaf:thymeleaf:3.0.15.RELEASE")
         api("org.xhtmlrenderer:flying-saucer-core:${Version.flyingSaucer}")
         api("org.xhtmlrenderer:flying-saucer-pdf-openpdf:${Version.flyingSaucer}")
-        api("org.yaml:snakeyaml:1.31")
+        api("org.yaml:snakeyaml:1.33")
         api("redis.clients:jedis:4.2.3")
     }
 

--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -35,6 +35,12 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     </suppress>
     <suppress>
         <notes><![CDATA[
+        Those using Snakeyaml to parse untrusted YAML files may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by stack overflow. This effect may support a denial of service attack. No fix released yet as of 2022-11-14. We don't parse YAML files from untrusted sources.
+        ]]></notes>
+        <cve>CVE-2022-41854</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
         Only applies to configuration we don't use
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>

--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -35,18 +35,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     </suppress>
     <suppress>
         <notes><![CDATA[
-        Users can cause snakeyaml to crash by submitting a malicious input. No fix released yet as of 2022-09-07. We don't parse YAML files from untrusted sources.
-        ]]></notes>
-        <cve>CVE-2022-38752</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        Using snakeYAML to parse untrusted YAML files may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by stackoverflow. No fix released yet as of 2022-09-07. We don't parse YAML files from untrusted sources.
-        ]]></notes>
-        <cve>CVE-2022-38751</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
         Only applies to configuration we don't use
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
- Upgrade snakeyaml to 1.33
- Add a suppression for snakeyaml CVE-2022-41854, which does not concern us as we do not parse untrusted YAML files
