### PR TITLE
Update default permissions for assistance need decisions report

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -591,14 +591,14 @@ sealed interface Action {
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
                 .inPlacementUnitOfChildOfAssistanceNeedDecision()
         ),
-        READ_IN_REPORT(IsEmployee.andIsDecisionMakerForAssistanceNeedDecision()),
         SEND(
             HasGlobalRole(SERVICE_WORKER),
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
                 .inPlacementUnitOfChildOfAssistanceNeedDecision()
         ),
-        DECIDE(HasGlobalRole(DIRECTOR).andIsDecisionMakerForAssistanceNeedDecision()),
-        MARK_AS_OPENED(HasGlobalRole(DIRECTOR).andIsDecisionMakerForAssistanceNeedDecision()),
+        READ_IN_REPORT(IsEmployee.andIsDecisionMakerForAssistanceNeedDecision()),
+        DECIDE(IsEmployee.andIsDecisionMakerForAssistanceNeedDecision()),
+        MARK_AS_OPENED(IsEmployee.andIsDecisionMakerForAssistanceNeedDecision()),
         UPDATE_DECISION_MAKER(HasGlobalRole(DIRECTOR).andAssistanceNeedDecisionHasBeenSent());
 
         override fun toString(): String = "${javaClass.name}.$name"


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Decision makers already had the permission to read the report but not to perform any actual actions on it -> remove the need for DIRECTOR role for other actions too