### PR TITLE
Use a cache key in access control query caching

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
@@ -421,7 +421,7 @@ open class SqlBuilder {
  * `Tag` can be used to assign some type to a query for documentation purpose and to prevent mixing
  * different types of queries.
  */
-class QuerySql<@Suppress("unused") in Tag>(
+data class QuerySql<@Suppress("unused") in Tag>(
     val sql: QuerySqlString,
     val bindings: List<ValueBinding<out Any?>>
 ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/ActionRule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/ActionRule.kt
@@ -96,10 +96,16 @@ object DatabaseActionRule {
         val query: Query<T, P>
 
         interface Query<T, P> {
+            /**
+             * Return some value that is used to decide whether two queries are considered
+             * identical.
+             *
+             * If the cache keys of two queries of the same type (= same class) are equal, we can
+             * skip execution of one if we already have cached results from the other one
+             */
+            fun cacheKey(user: AuthenticatedUser, now: HelsinkiDateTime): Any
             fun executeWithTargets(ctx: QueryContext, targets: Set<T>): Map<T, Deferred<P>>
             fun queryWithParams(ctx: QueryContext, params: P): QuerySql<T>?
-            override fun hashCode(): Int
-            override fun equals(other: Any?): Boolean
         }
         data class Simple<T, P : Params>(override val params: P, override val query: Query<T, P>) :
             Scoped<T, P>
@@ -108,9 +114,15 @@ object DatabaseActionRule {
     data class Unscoped<P : Any>(val params: P, val query: Query<P>) :
         ScopedActionRule<Any>, UnscopedActionRule {
         interface Query<P> {
+            /**
+             * Return some value that is used to decide whether two queries are considered
+             * identical.
+             *
+             * If the cache keys of two queries of the same type (= same class) are equal, we can
+             * skip execution of one if we already have cached results from the other one
+             */
+            fun cacheKey(user: AuthenticatedUser, now: HelsinkiDateTime): Any
             fun execute(ctx: QueryContext): Deferred<P>?
-            override fun hashCode(): Int
-            override fun equals(other: Any?): Boolean
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasGlobalRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasGlobalRole.kt
@@ -43,6 +43,11 @@ data class HasGlobalRole(val oneOf: EnumSet<UserRole>) :
         DatabaseActionRule.Scoped.Simple(this, Query(filter))
     data class Query<T : Id<*>>(private val filter: Filter<T>) :
         DatabaseActionRule.Scoped.Query<T, HasGlobalRole> {
+        override fun cacheKey(user: AuthenticatedUser, now: HelsinkiDateTime): Any =
+            when (user) {
+                is AuthenticatedUser.Employee -> QuerySql.of { filter(user, now) }
+                else -> Pair(user, now)
+            }
         override fun executeWithTargets(
             ctx: DatabaseActionRule.QueryContext,
             targets: Set<T>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsMobile.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsMobile.kt
@@ -43,6 +43,11 @@ data class IsMobile(val requirePinLogin: Boolean) : DatabaseActionRule.Params {
         DatabaseActionRule.Scoped.Simple(this, Query(filter))
     private data class Query<T : Id<*>>(private val filter: FilterByMobile<T>) :
         DatabaseActionRule.Scoped.Query<T, IsMobile> {
+        override fun cacheKey(user: AuthenticatedUser, now: HelsinkiDateTime): Any =
+            when (user) {
+                is AuthenticatedUser.MobileDevice -> QuerySql.of { filter(user, now) }
+                else -> Pair(user, now)
+            }
         override fun executeWithTargets(
             ctx: DatabaseActionRule.QueryContext,
             targets: Set<T>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

equals/hashCode on the query itself was fine in many cases, but doesn't work well when the query itself is parameterized. Now that queries are defined using functions that *return QuerySql* instead of actually executing a query, we can use the returned QuerySql object as the cache key. This conveniently captures all information about the query, including its parameters, so caching works even for parameterized queries.

The only downside is slightly lower performance, because we need to create a QuerySql twice (one for the cache check, one for the query execution). This can be improved later by changing the Query abstraction slightly if necessary.