### PR TITLE
Fix special education teacher daycare group messages

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -1143,12 +1143,11 @@ sealed interface Action {
     ) : ScopedAction<MessageAccountId> {
         ACCESS(
             IsEmployee.hasPersonalMessageAccount(),
-            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER).hasDaycareMessageAccount(),
+            HasUnitRole(UNIT_SUPERVISOR).hasDaycareMessageAccount(),
             IsEmployee.hasDaycareGroupMessageAccount(),
             IsEmployee.hasMunicipalMessageAccount(),
             IsMobile(requirePinLogin = true).hasPersonalMessageAccount(),
-            IsMobile(requirePinLogin = true)
-                .hasDaycareMessageAccount(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER),
+            IsMobile(requirePinLogin = true).hasDaycareMessageAccount(UNIT_SUPERVISOR),
             IsMobile(requirePinLogin = true).hasDaycareGroupMessageAccount(),
             IsCitizen(allowWeakLogin = true).hasMessageAccount()
         );


### PR DESCRIPTION
#### Summary

Special education teacher should see groups only from group_acl.

This default should work for Espoo, Tampere & Oulu so no overrides needed anymore.