### PR TITLE
Fix using the `DatePicker` calendar dialog with mouse on Safari

### DIFF
--- a/frontend/src/citizen-frontend/utils.ts
+++ b/frontend/src/citizen-frontend/utils.ts
@@ -1,8 +1,0 @@
-// SPDX-FileCopyrightText: 2017-2022 City of Espoo
-//
-// SPDX-License-Identifier: LGPL-2.1-or-later
-
-import { scrollElementToPos } from 'lib-common/utils/scrolling'
-
-export const scrollMainToPos = (opts: ScrollToOptions) =>
-  scrollElementToPos(document.getElementById('main'), opts)

--- a/frontend/src/lib-components/atoms/Main.tsx
+++ b/frontend/src/lib-components/atoms/Main.tsx
@@ -14,9 +14,5 @@ export default React.memo(function Loader({
 }: {
   children: React.ReactNode
 }) {
-  return (
-    <MainContainer tabIndex={-1} id="main">
-      {children}
-    </MainContainer>
-  )
+  return <MainContainer id="main">{children}</MainContainer>
 })


### PR DESCRIPTION
#### Summary

Remove `tabindex="-1"` from `<main>`. This has the effect that `<main>` won't receive focus events, and thus fixes the premature closing of the <DatePicker> calendar dialog on Safari.

Removen `tabindex` from `<main>` shouldn't break anything, as `tabindex="-1"` means that the element can be focused programmatically or by clicking, but not by keyboard. I don't see why this would be required. See the [MDN article on `tabindex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex).

Also remove some dead code.