### PR TITLE
Remove permissions to a child via an active application

### DIFF
--- a/service/src/main/resources/db/migration/R__acl_views.sql
+++ b/service/src/main/resources/db/migration/R__acl_views.sql
@@ -73,7 +73,7 @@ TABLE (
     SELECT a.child_id, pp.unit_id AS daycare_id, FALSE AS is_backup_care
     FROM placement_plan pp
     JOIN application a ON pp.application_id = a.id
-    WHERE a.status = ANY ('{SENT,WAITING_PLACEMENT,WAITING_CONFIRMATION,WAITING_DECISION,WAITING_MAILING,WAITING_UNIT_CONFIRMATION, ACTIVE}'::application_status_type[])
+    WHERE a.status = ANY ('{SENT,WAITING_PLACEMENT,WAITING_CONFIRMATION,WAITING_DECISION,WAITING_MAILING,WAITING_UNIT_CONFIRMATION}'::application_status_type[])
 
     UNION ALL
 

--- a/service/src/main/resources/db/migration/R__acl_views.sql
+++ b/service/src/main/resources/db/migration/R__acl_views.sql
@@ -66,7 +66,7 @@ TABLE (
 ) AS $$
     SELECT pl.child_id, pl.unit_id AS daycare_id, FALSE AS is_backup_care
     FROM placement pl
-    WHERE pl.end_date > today - interval '1 month'
+    WHERE today < pl.end_date + interval '1 month'
 
     UNION ALL
 
@@ -79,7 +79,7 @@ TABLE (
 
     SELECT child_id, bc.unit_id AS daycare_id, TRUE AS is_backup_care
     FROM backup_care bc
-    WHERE bc.end_date > today - INTERVAL '1 month'
+    WHERE today < bc.end_date + INTERVAL '1 month'
 $$ LANGUAGE SQL STABLE;
 
 CREATE FUNCTION employee_child_daycare_acl(today date) RETURNS


### PR DESCRIPTION
#### Summary

The `ACTIVE` status means that the application has been accepted. In this state, employees shouldn't get permission through the application anymore, because the placement gives it the the correct employees.

The PR also refactors the date comparisons to be in a more natural order, at least to my brain 🧠 