### PR TITLE
Evaka fix varda use child deleteall

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaResetService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaResetService.kt
@@ -191,42 +191,8 @@ fun deleteChildDataFromVardaAndDbByVardaId(
     vardaClient: VardaClient,
     vardaChildId: Long
 ) {
-    val decisionIds = vardaClient.getDecisionsByChild(vardaChildId)
-    logger.info(
-        "VardaUpdate: found ${decisionIds.size} decisions to be deleted for child $vardaChildId"
-    )
-
-    val placementIds = decisionIds.flatMap { vardaClient.getPlacementsByDecision(it) }
-    logger.info(
-        "VardaUpdate: found ${placementIds.size} placements to be deleted for child $vardaChildId"
-    )
-
-    val feeIds = vardaClient.getFeeDataByChild(vardaChildId)
-    logger.info("VardaUpdate: found ${feeIds.size} fee data to be deleted for child $vardaChildId")
-
-    feeIds.forEachIndexed { index, feeId ->
-        logger.info(
-            "VardaUpdate: deleting fee data $feeId for child $vardaChildId (${index + 1} / ${feeIds.size})"
-        )
-        vardaClient.deleteFeeData(feeId)
-    }
-
-    placementIds.forEachIndexed { index, placementId ->
-        logger.info(
-            "VardaUpdate: deleting placement $placementId for child $vardaChildId (${index + 1} / ${placementIds.size})"
-        )
-        vardaClient.deletePlacement(placementId)
-    }
-
-    decisionIds.forEachIndexed { index, decisionId ->
-        logger.info(
-            "VardaUpdate: deleting decision $decisionId for child $vardaChildId (${index + 1} / ${decisionIds.size})"
-        )
-        vardaClient.deleteDecision(decisionId)
-    }
-
-    logger.info("VardaUpdate: deleting child $vardaChildId")
-    vardaClient.deleteChild(vardaChildId)
+    logger.info("VardaUpdate: deleting all child data from varda (child id: $vardaChildId)")
+    vardaClient.deleteChildAllData(vardaChildId)
     db.transaction { it.deleteVardaOrganizerChildByVardaChildId(vardaChildId) }
 
     logger.info("VardaUpdate: deleting from varda_service_need for child $vardaChildId")

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
@@ -363,6 +363,25 @@ class VardaClient(
         }
     }
 
+    fun deleteChildAllData(vardaChildId: Long): Boolean {
+        logger.info("VardaUpdate: client deleting all child data (id: $vardaChildId)")
+
+        val (request, _, result) =
+                fuel.delete("${getChildUrl(vardaChildId)}/delete-all").authenticatedResponseStringWithRetries()
+
+        return when (result) {
+            is Result.Success -> {
+                logger.info("VardaUpdate: client successfully deleted all child data (id: $vardaChildId)")
+                true
+            }
+            is Result.Failure -> {
+                vardaError(request, result.error) { err ->
+                    "VardaUpdate: client failed to delete all child data $vardaChildId: $err"
+                }
+            }
+        }
+    }
+
     fun createUnit(unit: VardaUnitRequest): VardaUnitResponse {
         logger.info("VardaUpdate: client sending new unit ${unit.nimi}")
         val (request, _, result) =

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/VardaClient.kt
@@ -367,11 +367,15 @@ class VardaClient(
         logger.info("VardaUpdate: client deleting all child data (id: $vardaChildId)")
 
         val (request, _, result) =
-                fuel.delete("${getChildUrl(vardaChildId)}/delete-all").authenticatedResponseStringWithRetries()
+            fuel
+                .delete("${getChildUrl(vardaChildId)}/delete-all")
+                .authenticatedResponseStringWithRetries()
 
         return when (result) {
             is Result.Success -> {
-                logger.info("VardaUpdate: client successfully deleted all child data (id: $vardaChildId)")
+                logger.info(
+                    "VardaUpdate: client successfully deleted all child data (id: $vardaChildId)"
+                )
                 true
             }
             is Result.Failure -> {


### PR DESCRIPTION
#### Summary
- Use new endpoint /v1/lapset/{id}/delete-all to delete all child data (https://virkailija.opintopolku.fi/varda/julkinen/swagger)
