### PR TITLE
Fix formatCents leaving out minus sign with values less than euro

### DIFF
--- a/frontend/src/lib-common/money.spec.ts
+++ b/frontend/src/lib-common/money.spec.ts
@@ -34,6 +34,14 @@ describe('utils/money', () => {
       expect(formatCents(undefined)).toBe(undefined)
     })
 
+    it('-1', () => {
+      expect(formatCents(-1)).toBe('-0,01')
+    })
+
+    it('-10', () => {
+      expect(formatCents(-10)).toBe('-0,10')
+    })
+
     it('-10050', () => {
       expect(formatCents(-10050)).toBe('-100,50')
     })
@@ -70,6 +78,14 @@ describe('utils/money', () => {
 
     it('1,001', () => {
       expect(isValidCents('1,001')).toBe(false)
+    })
+
+    it('-0,01', () => {
+      expect(isValidCents('-0,01')).toBe(true)
+    })
+
+    it('-0,10', () => {
+      expect(isValidCents('-0,10')).toBe(true)
     })
 
     it('-1,01', () => {
@@ -112,6 +128,14 @@ describe('utils/money', () => {
 
     it('1,001', () => {
       expect(parseCents('1,001')).toBe(undefined)
+    })
+
+    it('-0,01', () => {
+      expect(parseCents('-0,01')).toBe(-1)
+    })
+
+    it('-0,10', () => {
+      expect(parseCents('-0,10')).toBe(-10)
     })
 
     it('-1,01', () => {

--- a/frontend/src/lib-common/money.ts
+++ b/frontend/src/lib-common/money.ts
@@ -15,13 +15,14 @@ export function formatCents(
     return undefined
   }
 
-  const euros = amount >= 0 ? Math.floor(amount / 100) : Math.ceil(amount / 100)
+  const euros = Math.floor(Math.abs(amount) / 100)
   const cents = Math.abs(amount % 100)
+  const sign = amount < 0 ? '-' : ''
 
   if (cents !== 0 || fixedCents) {
-    return `${euros},${cents.toString().padStart(2, '0')}`
+    return `${sign}${euros},${cents.toString().padStart(2, '0')}`
   } else {
-    return euros.toString()
+    return `${sign}${euros}`
   }
 }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Values were being parsed and stored correctly, only the formatting was off.

