### PR TITLE
EVAKA do not send email notifications for undone messages

### DIFF
--- a/evaka-bom/build.gradle.kts
+++ b/evaka-bom/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
         api("org.mockito:mockito-core:${Version.mockito}")
         api("org.mockito:mockito-junit-jupiter:${Version.mockito}")
         api("org.mockito.kotlin:mockito-kotlin:4.0.0")
-        api("org.postgresql:postgresql:42.5.0")
+        api("org.postgresql:postgresql:42.5.1")
         api("org.skyscreamer:jsonassert:1.5.1")
         api("org.thymeleaf.extras:thymeleaf-extras-java8time:3.0.4.RELEASE")
         api("org.thymeleaf:thymeleaf:3.0.15.RELEASE")

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -245,7 +245,7 @@ fun Database.Transaction.upsertReceiverThreadParticipants(
         prepareBatch(
             """
         INSERT INTO message_thread_participant as tp (thread_id, participant_id, last_message_timestamp, last_received_timestamp)
-        VALUES (:threadId, :accountId, :now, :now)
+        SELECT id, :accountId, :now, :now FROM message_thread WHERE id = :threadId
         ON CONFLICT (thread_id, participant_id) DO UPDATE SET last_message_timestamp = :now, last_received_timestamp = :now
     """
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -1262,3 +1262,20 @@ WHERE thread_id = :threadId AND participant_id = :senderId
         .bind("senderId", senderId)
         .execute()
 }
+
+fun Database.Read.messageForRecipientExists(
+    messageId: MessageId,
+    recipientId: MessageAccountId
+): Boolean {
+    return createQuery<Boolean> {
+            sql(
+                """
+SELECT EXISTS (
+    SELECT * FROM message_recipients WHERE message_id = ${bind(messageId)} AND recipient_id = ${bind(recipientId)}
+)
+"""
+            )
+        }
+        .mapTo<Boolean>()
+        .first()
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
@@ -72,7 +72,11 @@ class MessageService(
                     municipalAccountName = municipalAccountName
                 )
             tx.insertRecipients(recipientIds, messageId)
-            notificationEmailService.scheduleSendingMessageNotifications(tx, messageId)
+            notificationEmailService.scheduleSendingMessageNotifications(
+                tx,
+                messageId,
+                now.plusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS + 5)
+            )
         }
 
         if (staffCopyRecipients.isNotEmpty()) {
@@ -142,7 +146,11 @@ class MessageService(
                         municipalAccountName = municipalAccountName
                     )
                 tx.insertRecipients(recipientAccountIds, messageId)
-                notificationEmailService.scheduleSendingMessageNotifications(tx, messageId)
+                notificationEmailService.scheduleSendingMessageNotifications(
+                    tx,
+                    messageId,
+                    now.plusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS + 5)
+                )
                 tx.getSentMessage(senderAccount, messageId)
             }
         return ThreadReply(threadId, message)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.MessageAccountId
+import fi.espoo.evaka.shared.MessageId
 import fi.espoo.evaka.shared.MessageRecipientId
 import fi.espoo.evaka.shared.MessageThreadId
 import fi.espoo.evaka.shared.PairingId
@@ -98,9 +99,11 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
-    // threadId is nullable for backwards compatibility
+    // threadId, messageId and recipientId are nullable for backwards compatibility
     data class SendMessageNotificationEmail(
         val threadId: MessageThreadId?,
+        val messageId: MessageId?,
+        val recipientId: MessageAccountId?,
         val messageRecipientId: MessageRecipientId,
         val personEmail: String,
         val language: Language,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
- Update thread participants only if thread still exists
- Send message email notification after undo period and only if the message still exists

