### PR TITLE
Calculate application due date only if not already set

### DIFF
--- a/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { OtherGuardianAgreementStatus } from 'lib-common/generated/api-types/application'
+import LocalDate from 'lib-common/local-date'
 
 import { waitUntilEqual, waitUntilFalse } from '../../../utils'
 import {
@@ -70,6 +71,12 @@ export default class ApplicationEditView {
       return
     }
     await this.#urgentCheckbox.click()
+  }
+
+  async setDueDate(date: LocalDate) {
+    await new DatePickerDeprecated(this.page.findByDataQa('due-date')).fill(
+      date.format()
+    )
   }
 
   async uploadUrgentAttachment(filePath: string) {

--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { DecisionType } from 'lib-common/generated/api-types/decision'
+import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
 import config from '../../../config'
@@ -151,6 +152,13 @@ export default class ApplicationReadView {
 
   async assertApplicantIsDead() {
     await this.page.find('[data-qa="applicant-dead"]').waitUntilVisible()
+  }
+
+  async assertDueDate(dueDate: LocalDate) {
+    await waitUntilEqual(
+      () => this.page.findByDataQa('application-due-date').textContent,
+      dueDate.format()
+    )
   }
 
   async startEditing(): Promise<ApplicationEditView> {

--- a/frontend/src/e2e-test/specs/5_employee/paper-application.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/paper-application.spec.ts
@@ -142,4 +142,22 @@ describe('Employee - paper application', () => {
     const applicationViewPage = await applicationEditPage.saveApplication()
     await applicationViewPage.waitUntilLoaded()
   })
+
+  test('Paper application due date is saved on submit', async () => {
+    const applicationEditPage = await createApplicationModal.submit()
+    await applicationEditPage.fillStartDate(
+      LocalDate.todayInSystemTz().format()
+    )
+    await applicationEditPage.fillTimes()
+    await applicationEditPage.pickUnit(fixtures.daycareFixture.name)
+    await applicationEditPage.fillApplicantPhoneAndEmail(
+      '123456',
+      'email@evaka.test'
+    )
+    const dueDate = LocalDate.todayInSystemTz().addDays(7)
+    await applicationEditPage.setDueDate(dueDate)
+    const applicationViewPage = await applicationEditPage.saveApplication()
+    await applicationViewPage.waitUntilLoaded()
+    await applicationViewPage.assertDueDate(dueDate)
+  })
 })

--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -1145,6 +1145,7 @@ export default React.memo(function ApplicationEditView({
           <DatePickerDeprecated
             date={application.dueDate || undefined}
             onChange={(value) => setApplication(set('dueDate', value))}
+            data-qa="due-date"
           />
         }
       />

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -243,13 +243,14 @@ class ApplicationStateService(
 
         val sentDate = application.sentDate ?: currentDate
         val dueDate =
-            calculateDueDate(
-                application.type,
-                sentDate,
-                application.form.preferences.urgent,
-                applicationFlags.isTransferApplication,
-                application.attachments
-            )
+            application.dueDate
+                ?: calculateDueDate(
+                    application.type,
+                    sentDate,
+                    application.form.preferences.urgent,
+                    applicationFlags.isTransferApplication,
+                    application.attachments
+                )
         tx.updateApplicationDates(application.id, sentDate, dueDate)
 
         tx.getPersonById(application.guardianId)?.let {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Previously the due date set at paper application creation would always get overwritten when the application is saved (or technically "sent").

