### PR TITLE
Make sure to only suggest actually reservable days

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -40,7 +40,6 @@ import NonReservableDaysWarningModal from './NonReservableDaysWarningModal'
 import ReservationModal from './ReservationModal'
 import { getCalendarEvents, getReservations } from './api'
 import FixedPeriodSelectionModal from './holiday-modal/FixedPeriodSelectionModal'
-import { getEarliestReservableDate } from './utils'
 
 async function getReservationsDefaultRange(): Promise<
   Result<ReservationsResponse>
@@ -121,19 +120,17 @@ const CalendarPage = React.memo(function CalendarPage() {
 
   const firstReservableDate = useMemo(() => {
     if (data.isSuccess) {
-      const earliestReservableDate = getEarliestReservableDate(
-        data.value.children,
+      const allReservableDateRanges = Object.keys(
         data.value.reservableDays
-      )
+      ).flatMap((childId) => data.value.reservableDays[childId])
+
       // First reservable day that has no reservations
       const firstReservableEmptyDate = data.value.dailyData.find(
         (day) =>
-          earliestReservableDate?.isEqualOrBefore(day.date) &&
+          allReservableDateRanges.find((range) => range.includes(day.date)) &&
           day.children.length == 0
       )
-      return firstReservableEmptyDate
-        ? firstReservableEmptyDate.date
-        : earliestReservableDate ?? null
+      return firstReservableEmptyDate?.date ?? null
     } else {
       return LocalDate.todayInSystemTz()
     }


### PR DESCRIPTION
#### Summary
The suggested first reservable date in the reservation modal suggested the first day of a holiday period in the following case:
- A holiday period is defined to start at a date later than today
- The deadline for reservations during the holiday period was earlier than today
- A reservation has been made for the kids, starting today and ending at a date after the end of the holiday period

---> The reservation modal suggested the first date of the holiday as the next reservable date.

This is now fixed by checking that the suggestion is an actual reservable day, which holidays are not.
