### PR TITLE
Allow failing on future Flyway migrations

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -104,6 +104,7 @@ data class DatabaseEnv(
     val password: Sensitive<String>,
     val flywayUsername: String,
     val flywayPassword: Sensitive<String>,
+    val flywayIgnoreFutureMigrations: Boolean,
     val leakDetectionThreshold: Long,
     val defaultStatementTimeout: Duration,
     val maximumPoolSize: Int,
@@ -119,6 +120,8 @@ data class DatabaseEnv(
                 flywayUsername = env.lookup("evaka.database.flyway.username", "flyway.username"),
                 flywayPassword =
                     Sensitive(env.lookup("evaka.database.flyway.password", "flyway.password")),
+                flywayIgnoreFutureMigrations =
+                    env.lookup("evaka.database.flyway.ignore-future-migrations") ?: true,
                 leakDetectionThreshold =
                     env.lookup(
                         "evaka.database.leak_detection_threshold",

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
@@ -36,6 +36,13 @@ class DatabaseConfig {
                     .getPlugin(PostgreSQLConfigurationExtension::class.java)
                     .isTransactionalLock = false
             }
+            .ignoreMigrationPatterns(
+                if (env.flywayIgnoreFutureMigrations) {
+                    "*:future"
+                } else {
+                    ""
+                }
+            )
             .dataSource(env.url, env.flywayUsername, env.flywayPassword.value)
             .placeholders(
                 mapOf("application_user" to env.username, "migration_user" to env.flywayUsername)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

By default, future migrations (= in flyway_schema table but not in code) are ignored. This makes it possible to attempt a rollback to a different version even if the old version doesn't have all the migrations.

If we configure future migrations to not be ignored, this makes it possible to detect when data and code are out of sync, which is useful in some special scenarios.