### PR TITLE
Make sure people do not see other people's children in their messages

### DIFF
--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -41,6 +41,12 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     </suppress>
     <suppress>
         <notes><![CDATA[
+        SnakeYaml's Constructor() class does not restrict types which can be instantiated during deserialization. Deserializing yaml content provided by an attacker can lead to remote code execution. No fix released yet as of 2022-12-02. We don't parse YAML files from untrusted sources.
+        ]]></notes>
+        <cve>CVE-2022-1471</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
         Only applies to configuration we don't use
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -313,7 +313,7 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                     allAccounts.map { it.name },
                     "Espoo"
                 )
-            tx.insertRecipients(allAccounts.map { it.id }.toSet(), messageId)
+            tx.insertRecipients(listOf(messageId to allAccounts.map { it.id }.toSet()))
         }
 
         assertEquals(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -442,7 +442,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         recipientNames = tx.getAccountNames(setOf(employee1Account)),
                         municipalAccountName = "Espoo"
                     )
-                tx.insertRecipients(setOf(employee1Account), messageId)
+                tx.insertRecipients(listOf(messageId to setOf(employee1Account)))
                 tx.getThreadByMessageId(messageId)
             }
         assertEquals(
@@ -889,8 +889,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                     recipientNames = tx.getAccountNames(recipientAccounts.toSet()),
                     municipalAccountName = "Espoo"
                 )
-            tx.insertRecipients(recipientAccounts.toSet(), messageId)
-            tx.upsertSenderThreadParticipants(threadId, sender, now)
+            tx.insertRecipients(listOf(messageId to recipientAccounts.toSet()))
+            tx.upsertSenderThreadParticipants(sender, listOf(threadId), now)
             tx.upsertReceiverThreadParticipants(threadId, recipientAccounts.toSet(), now)
             threadId
         }
@@ -917,8 +917,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                     recipientNames = listOf(),
                     municipalAccountName = "Espoo"
                 )
-            it.insertRecipients(recipientAccountIds = recipients, messageId = messageId)
-            it.upsertSenderThreadParticipants(threadId, sender, now)
+            it.insertRecipients(listOf(messageId to recipients))
+            it.upsertSenderThreadParticipants(sender, listOf(threadId), now)
             it.upsertReceiverThreadParticipants(threadId, recipients, now)
         }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
@@ -229,7 +229,7 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
                     listOf("recipient name"),
                     "Espoo"
                 )
-            tx.insertRecipients(setOf(personAccount), messageId)
+            tx.insertRecipients(listOf(messageId to setOf(personAccount)))
         }
 
         assertCleanedUpPeople(testDate, setOf(testAdult_1.id))
@@ -259,7 +259,7 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
                     listOf("employee name"),
                     "Espoo"
                 )
-            tx.insertRecipients(setOf(employeeAccount), messageId)
+            tx.insertRecipients(listOf(messageId to setOf(employeeAccount)))
         }
 
         assertCleanedUpPeople(testDate, setOf())

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -42,6 +42,7 @@ import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.security.upsertCitizenUser
+import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1
 import java.time.LocalDate
@@ -257,10 +258,9 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                 type = MessageType.MESSAGE,
                 urgent = false,
                 sender = senderDuplicateAccount,
-                recipientGroups = setOf(setOf(receiverAccount)),
+                messageRecipients = listOf(receiverAccount to testChild_1.id),
                 recipientNames = listOf(),
                 staffCopyRecipients = setOf(),
-                accountIdsToChildIds = mapOf(),
                 municipalAccountName = "Espoo"
             )
         }
@@ -305,10 +305,9 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                 type = MessageType.MESSAGE,
                 urgent = false,
                 sender = senderAccount,
-                recipientGroups = setOf(setOf(receiverDuplicateAccount)),
+                messageRecipients = listOf(receiverDuplicateAccount to testChild_1.id),
                 recipientNames = listOf(),
                 staffCopyRecipients = setOf(),
-                accountIdsToChildIds = mapOf(),
                 municipalAccountName = "Espoo"
             )
             val threadId = tx.getThreads(now, senderAccount, 1, 1, "Espoo").data.first().id
@@ -375,10 +374,9 @@ class MergeServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                 type = MessageType.MESSAGE,
                 urgent = false,
                 sender = senderAccount,
-                recipientGroups = setOf(setOf(receiverDuplicateAccount)),
+                messageRecipients = listOf(receiverDuplicateAccount to testChild_1.id),
                 recipientNames = listOf(),
                 staffCopyRecipients = setOf(),
-                accountIdsToChildIds = mapOf(),
                 municipalAccountName = "Espoo"
             )
             val threadId = tx.getThreads(now, senderAccount, 1, 1, "Espoo").data.first().id

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -295,14 +295,12 @@ class MessageController(
                         )
                     }
 
-                    val messageAccountIdsToChildIds =
+                    val messageRecipients =
                         tx.getMessageAccountsForRecipients(
                             accountId,
                             body.recipients,
                             clock.today()
                         )
-                    val messageRecipients = messageAccountIdsToChildIds.keys
-
                     if (messageRecipients.isEmpty()) return@transaction null
 
                     val staffCopyRecipients =
@@ -327,8 +325,6 @@ class MessageController(
                             setOf()
                         }
 
-                    val groupedRecipients =
-                        tx.groupRecipientAccountsByGuardianship(messageRecipients)
                     val messageContentId =
                         messageService.createMessageThreadsForRecipientGroups(
                             tx,
@@ -339,10 +335,9 @@ class MessageController(
                             type = body.type,
                             urgent = body.urgent,
                             recipientNames = body.recipientNames,
-                            recipientGroups = groupedRecipients,
+                            messageRecipients = messageRecipients,
                             attachmentIds = body.attachmentIds,
                             staffCopyRecipients = staffCopyRecipients,
-                            accountIdsToChildIds = messageAccountIdsToChildIds,
                             municipalAccountName = featureConfig.municipalMessageAccountName
                         )
                     if (body.draftId != null)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -194,11 +194,10 @@ class MessageControllerCitizen(
                                 urgent = false,
                                 isCopy = false
                             )
-                        tx.upsertSenderThreadParticipants(threadId, senderId, now)
+                        tx.upsertSenderThreadParticipants(senderId, listOf(threadId), now)
                         asyncJobRunner.scheduleThreadRecipientsUpdate(
                             tx,
-                            threadId,
-                            recipientIds,
+                            listOf(threadId to recipientIds),
                             now
                         )
                         val messageId =
@@ -210,8 +209,8 @@ class MessageControllerCitizen(
                                 recipientNames = body.recipients.map { it.name },
                                 municipalAccountName = featureConfig.municipalMessageAccountName
                             )
-                        tx.insertMessageThreadChildren(body.children, threadId)
-                        tx.insertRecipients(recipientIds, messageId)
+                        tx.insertMessageThreadChildren(listOf(body.children to threadId))
+                        tx.insertRecipients(listOf(messageId to recipientIds))
                         threadId
                     }
                 } else {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
Previously an ex-pair that both were recipients of a message and had new families would get copies of their ex-partner's messages. The problem was basically non existant before municipal messaging.

Now bulletins are not grouped by family as they cannot be replied to so grouping has no benefits. This is to prevent multiple copies of bulletins in cases where all the adults in a family do not have the right to see all of their children's messages.

