### PR TITLE
Use 14-alpine3.16 as db base image

### DIFF
--- a/compose/db-integration-test/Dockerfile
+++ b/compose/db-integration-test/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-FROM postgres:14-alpine
+FROM postgres:14-alpine3.16
 
 ENV POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres
 COPY postgresql.conf /var/lib/postgresql/

--- a/compose/db/Dockerfile
+++ b/compose/db/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 ARG BASE_IMAGE=library/postgres
-ARG BASE_IMAGE_VERSION=14-alpine
+ARG BASE_IMAGE_VERSION=14-alpine3.16
 
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} AS ext_builder


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
The pgextwlist psql extension does not work with 14-alpine3.17

