### PR TITLE
[EVAKA-4604] Allow citizen to choose secondary recipients when sending a new message

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -111,6 +111,8 @@ export default React.memo(function MessageEditor({
 
   const showSecondaryRecipientSelection = validAccounts.secondary.length > 0
 
+  const required = (text: string) => `${text}*`
+
   return (
     <ModalAccessibilityWrapper>
       <FocusLock>
@@ -137,7 +139,7 @@ export default React.memo(function MessageEditor({
             {childIds && childIds.length > 1 && (
               <>
                 <label>
-                  <Bold>{i18n.messages.messageEditor.children}</Bold>
+                  <Bold>{required(i18n.messages.messageEditor.children)}</Bold>
                   {renderResult(children, (children) => (
                     <FixedSpaceFlexWrap horizontalSpacing="xs">
                       {children
@@ -179,7 +181,7 @@ export default React.memo(function MessageEditor({
             )}
 
             <label>
-              <Bold>{i18n.messages.messageEditor.recipients}</Bold>
+              <Bold>{required(i18n.messages.messageEditor.recipients)}</Bold>
               <Gap size="xs" />
               <MultiSelect
                 placeholder={i18n.messages.messageEditor.search}
@@ -241,7 +243,7 @@ export default React.memo(function MessageEditor({
             <Gap size="s" />
 
             <label>
-              <Bold>{i18n.messages.messageEditor.subject}</Bold>
+              <Bold>{required(i18n.messages.messageEditor.subject)}</Bold>
               <InputField
                 value={message.title ?? ''}
                 onChange={(updated) =>
@@ -254,7 +256,7 @@ export default React.memo(function MessageEditor({
             <Gap size="s" />
 
             <label>
-              <Bold>{i18n.messages.messageEditor.message}</Bold>
+              <Bold>{required(i18n.messages.messageEditor.message)}</Bold>
               <Gap size="s" />
               <StyledTextArea
                 value={message.content}

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -95,11 +95,13 @@ export default React.memo(function MessageEditor({
   const { children } = useContext(ChildrenContext)
 
   const validAccounts = useMemo(() => {
-    const validIds = message.children.flatMap(
-      (childId) => receiverOptions.childrenToMessageAccounts[childId] ?? []
-    )
     const accounts = receiverOptions.messageAccounts.filter((account) =>
-      validIds.includes(account.id)
+      message.children.every(
+        (childId) =>
+          receiverOptions.childrenToMessageAccounts[childId]?.includes(
+            account.id
+          ) ?? false
+      )
     )
     return partitionByType(accounts)
   }, [message.children, receiverOptions])

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -2,13 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState
-} from 'react'
+import partition from 'lodash/partition'
+import React, { useCallback, useContext, useMemo, useState } from 'react'
 import FocusLock from 'react-focus-lock'
 import styled from 'styled-components'
 
@@ -17,7 +12,8 @@ import { ChildrenContext } from 'citizen-frontend/children/state'
 import { Result } from 'lib-common/api'
 import {
   CitizenMessageBody,
-  GetReceiversResponse
+  GetReceiversResponse,
+  MessageAccount
 } from 'lib-common/generated/api-types/messaging'
 import { formatPreferredName } from 'lib-common/names'
 import { SelectionChip } from 'lib-components/atoms/Chip'
@@ -28,6 +24,7 @@ import InputField from 'lib-components/atoms/form/InputField'
 import MultiSelect from 'lib-components/atoms/form/MultiSelect'
 import { desktopMin } from 'lib-components/breakpoints'
 import { FixedSpaceFlexWrap } from 'lib-components/layout/flex-helpers'
+import { ToggleableRecipient } from 'lib-components/molecules/ToggleableRecipient'
 import { Bold, P } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
@@ -44,8 +41,17 @@ const emptyMessage: CitizenMessageBody = {
   children: []
 }
 
+const isPrimaryRecipient = ({ type }: MessageAccount) => type !== 'CITIZEN'
+
+const partitionByType = (
+  accounts: MessageAccount[]
+): { primary: MessageAccount[]; secondary: MessageAccount[] } => {
+  const [primary, secondary] = partition(accounts, isPrimaryRecipient)
+  return { primary, secondary }
+}
+
 const areRequiredFieldsFilledForMessage = (msg: CitizenMessageBody): boolean =>
-  !!(msg.recipients.length && msg.content && msg.title)
+  !!(msg.recipients.some(isPrimaryRecipient) && msg.content && msg.title)
 
 interface Props {
   receiverOptions: GetReceiversResponse
@@ -67,7 +73,19 @@ export default React.memo(function MessageEditor({
   const i18n = useTranslation()
   const user = useUser()
 
-  const [message, setMessage] = useState<CitizenMessageBody>(emptyMessage)
+  const childIds = useMemo(
+    () => Object.keys(receiverOptions.childrenToMessageAccounts),
+    [receiverOptions]
+  )
+
+  const [message, setMessage] = useState<CitizenMessageBody>(
+    childIds.length === 1
+      ? {
+          ...emptyMessage,
+          children: [childIds[0]]
+        }
+      : emptyMessage
+  )
 
   const title = message.title || i18n.messages.messageEditor.newMessage
 
@@ -76,31 +94,22 @@ export default React.memo(function MessageEditor({
 
   const { children } = useContext(ChildrenContext)
 
-  const childIds = useMemo(
-    () => Object.keys(receiverOptions.childrenToMessageAccounts),
-    [receiverOptions]
-  )
-
   const validAccounts = useMemo(() => {
     const validIds = message.children.flatMap(
       (childId) => receiverOptions.childrenToMessageAccounts[childId] ?? []
     )
-    return receiverOptions.messageAccounts.filter((account) =>
+    const accounts = receiverOptions.messageAccounts.filter((account) =>
       validIds.includes(account.id)
     )
+    return partitionByType(accounts)
   }, [message.children, receiverOptions])
 
-  useEffect(
-    function autoselectOnlyChild() {
-      if (childIds && childIds.length === 1) {
-        setMessage((message) => ({
-          ...message,
-          children: [childIds[0]]
-        }))
-      }
-    },
-    [childIds]
+  const recipients = useMemo(
+    () => partitionByType(message.recipients),
+    [message.recipients]
   )
+
+  const showSecondaryRecipientSelection = validAccounts.secondary.length > 0
 
   return (
     <ModalAccessibilityWrapper>
@@ -144,20 +153,19 @@ export default React.memo(function MessageEditor({
                                 : message.children.filter(
                                     (id) => id !== child.id
                                   )
-
+                              const recipients = message.recipients.filter(
+                                (account) =>
+                                  children.every(
+                                    (childId) =>
+                                      receiverOptions.childrenToMessageAccounts[
+                                        childId
+                                      ]?.includes(account.id) ?? false
+                                  )
+                              )
                               setMessage((message) => ({
                                 ...message,
                                 children,
-                                recipients: message.recipients.filter(
-                                  (account) =>
-                                    children.every((childId) =>
-                                      (
-                                        receiverOptions
-                                          .childrenToMessageAccounts[childId] ??
-                                        []
-                                      ).includes(account.id)
-                                    )
-                                )
+                                recipients
                               }))
                             }}
                             data-qa={`child-${child.id}`}
@@ -175,12 +183,12 @@ export default React.memo(function MessageEditor({
               <Gap size="xs" />
               <MultiSelect
                 placeholder={i18n.messages.messageEditor.search}
-                value={message.recipients}
-                options={validAccounts}
-                onChange={(change) =>
+                value={recipients.primary}
+                options={validAccounts.primary}
+                onChange={(primary) =>
                   setMessage((message) => ({
                     ...message,
-                    recipients: change
+                    recipients: [...primary, ...recipients.secondary]
                   }))
                 }
                 noOptionsMessage={i18n.messages.messageEditor.noResults}
@@ -191,7 +199,47 @@ export default React.memo(function MessageEditor({
               />
             </label>
 
+            {showSecondaryRecipientSelection && (
+              <>
+                <Gap size="xs" />
+                <div>
+                  <label>
+                    <Bold>
+                      {i18n.messages.messageEditor.secondaryRecipients}
+                    </Bold>
+                  </label>
+                  <Gap size="xs" horizontal={true} />
+                  <SecondaryRecipients>
+                    {validAccounts.secondary.map((recipient) => (
+                      <ToggleableRecipient
+                        key={recipient.id}
+                        id={recipient.id}
+                        data-qa="secondary-recipient"
+                        toggleable={true}
+                        selected={recipients.secondary.some(
+                          (acc) => acc.id === recipient.id
+                        )}
+                        name={recipient.name}
+                        onToggleRecipient={(_, selected) =>
+                          setMessage((message) => ({
+                            ...message,
+                            recipients: selected
+                              ? [...message.recipients, recipient]
+                              : message.recipients.filter(
+                                  (acc) => acc.id !== recipient.id
+                                )
+                          }))
+                        }
+                        labelAdd={i18n.common.add}
+                      />
+                    ))}
+                  </SecondaryRecipients>
+                </div>
+              </>
+            )}
+
             <Gap size="s" />
+
             <label>
               <Bold>{i18n.messages.messageEditor.subject}</Bold>
               <InputField
@@ -315,5 +363,10 @@ const BottomRow = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
+  align-items: center;
+`
+
+const SecondaryRecipients = styled.span`
+  display: inline-flex;
   align-items: center;
 `

--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -138,11 +138,23 @@ export default class CitizenMessagesPage {
     }
   }
 
-  async sendNewMessage(title: string, content: string, recipients: string[]) {
+  async sendNewMessage(
+    title: string,
+    content: string,
+    childIds: string[],
+    recipients: string[]
+  ) {
     await this.clickNewMessage()
-    await this.typeMessage(title, content)
+    if (childIds.length > 0) {
+      await this.selectMessageChildren(childIds)
+    }
     await this.selectNewMessageRecipients(recipients)
+    await this.typeMessage(title, content)
     await this.clickSendMessage()
     await waitUntilTrue(() => this.getThreadCount().then((count) => count > 0))
+  }
+
+  secondaryRecipient(name: string) {
+    return this.page.find(`[data-qa="secondary-recipient"]`, { hasText: name })
   }
 }

--- a/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
@@ -357,8 +357,9 @@ async function citizenSendsMessageToGroup() {
   const citizenMessagesPage = new CitizenMessagesPage(citizenPage)
   const title = 'Otsikko'
   const content = 'Testiviestin sisältö'
+  const childIds = [child.id]
   const receivers = [daycareGroup.data.name + ' (Henkilökunta)']
-  await citizenMessagesPage.sendNewMessage(title, content, receivers)
+  await citizenMessagesPage.sendNewMessage(title, content, childIds, receivers)
 }
 
 async function citizenSendsMessageToGroup2() {
@@ -366,8 +367,9 @@ async function citizenSendsMessageToGroup2() {
   const citizenMessagesPage = new CitizenMessagesPage(citizenPage)
   const title = 'Hei ryhmä 2'
   const content = 'Testiviestin sisältö'
+  const childIds = [child2.id]
   const receivers = [daycareGroup2.data.name + ' (Henkilökunta)']
-  await citizenMessagesPage.sendNewMessage(title, content, receivers)
+  await citizenMessagesPage.sendNewMessage(title, content, childIds, receivers)
 }
 
 async function userSeesNewMessagesIndicator() {

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -257,6 +257,7 @@ describe('Sending and receiving messages', () => {
         await citizenMessagesPage.sendNewMessage(
           'Test message',
           'Test message content',
+          [],
           ['Varayksikön ryhmä (Henkilökunta)']
         )
       })
@@ -366,6 +367,7 @@ describe('Sending and receiving messages', () => {
         await citizenMessagesPage.sendNewMessage(
           defaultTitle,
           defaultContent,
+          [],
           receivers
         )
 
@@ -386,6 +388,7 @@ describe('Sending and receiving messages', () => {
         await citizenMessagesPage.sendNewMessage(
           defaultTitle,
           defaultContent,
+          [],
           receivers
         )
 
@@ -451,6 +454,40 @@ describe('Sending and receiving messages', () => {
         )
       })
 
+      test('The guardian can select another guardian as an recipient', async () => {
+        const otherGuardian = fixtures.enduserChildJariOtherGuardianFixture
+        await insertGuardianFixtures([
+          {
+            childId,
+            guardianId: otherGuardian.id
+          }
+        ])
+
+        const recipients = ['Esimies Essi']
+        await openCitizen(mockedDateAt10)
+        await citizenPage.goto(config.enduserMessagesUrl)
+        const citizenMessagesPage = new CitizenMessagesPage(citizenPage)
+        await citizenMessagesPage.clickNewMessage()
+        await citizenMessagesPage.selectNewMessageRecipients(recipients)
+        await citizenMessagesPage
+          .secondaryRecipient(
+            `${otherGuardian.lastName} ${otherGuardian.firstName}`
+          )
+          .click()
+        await citizenMessagesPage.typeMessage(defaultTitle, defaultContent)
+        await citizenMessagesPage.clickSendMessage()
+
+        await openSupervisorPage(mockedDateAt11)
+        await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
+        const messagesPage = new MessagesPage(unitSupervisorPage)
+        await messagesPage.openInbox(0)
+        await waitUntilEqual(() => messagesPage.getReceivedMessageCount(), 1)
+        await messagesPage.assertReceivedMessageParticipantsContains(
+          0,
+          `${otherGuardian.lastName} ${otherGuardian.firstName}`
+        )
+      })
+
       test('Citizen sends message to the unit supervisor and the group', async () => {
         const receivers = ['Esimies Essi', 'Kosmiset vakiot (Henkilökunta)']
         await openCitizen(mockedDateAt10)
@@ -459,6 +496,7 @@ describe('Sending and receiving messages', () => {
         await citizenMessagesPage.sendNewMessage(
           defaultTitle,
           defaultContent,
+          [],
           receivers
         )
 

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -429,7 +429,6 @@ describe('Sending and receiving messages', () => {
         await citizenPage.goto(config.enduserMessagesUrl)
         const citizenMessagesPage = new CitizenMessagesPage(citizenPage)
         await citizenMessagesPage.clickNewMessage()
-        await citizenMessagesPage.selectNewMessageRecipients(recipients)
         await citizenMessagesPage.assertChildrenSelectable([
           fixtures.enduserChildFixtureJari.id,
           enduserChildFixtureKaarina.id
@@ -437,6 +436,7 @@ describe('Sending and receiving messages', () => {
         await citizenMessagesPage.selectMessageChildren([
           enduserChildFixtureKaarina.id
         ])
+        await citizenMessagesPage.selectNewMessageRecipients(recipients)
         await citizenMessagesPage.typeMessage(defaultTitle, defaultContent)
         await citizenMessagesPage.clickSendMessage()
 

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -63,8 +63,8 @@ export interface EditRecipientRequest {
 * Generated from fi.espoo.evaka.messaging.MessageControllerCitizen.GetReceiversResponse
 */
 export interface GetReceiversResponse {
+  childrenToMessageAccounts: Record<string, UUID[]>
   messageAccounts: MessageAccount[]
-  messageAccountsToChildren: Record<string, UUID[]>
 }
 
 /**

--- a/frontend/src/lib-components/molecules/MessageReplyEditor.tsx
+++ b/frontend/src/lib-components/molecules/MessageReplyEditor.tsx
@@ -2,20 +2,21 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React from 'react'
 import styled from 'styled-components'
 
 import { Result } from 'lib-common/api'
 import { UUID } from 'lib-common/types'
-import { faTimes, faTrash } from 'lib-icons'
+import { faTrash } from 'lib-icons'
 
 import Button from '../atoms/buttons/Button'
 import InlineButton from '../atoms/buttons/InlineButton'
 import TextArea from '../atoms/form/TextArea'
 import ButtonContainer from '../layout/ButtonContainer'
-import { fontWeights, Label } from '../typography'
+import { Label } from '../typography'
 import { defaultMargins } from '../white-space'
+
+import { ToggleableRecipient } from './ToggleableRecipient'
 
 const MultiRowTextArea = styled(TextArea)`
   height: unset;
@@ -32,66 +33,11 @@ const EditorRow = styled.div`
   }
 `
 
-const Recipient = styled.button<{ selected: boolean; toggleable: boolean }>`
-  cursor: ${(p) => (p.toggleable ? 'pointer' : 'default')};;
-  padding: 0 ${(p) => (p.selected ? '12px' : defaultMargins.xs)};
-  background-color: ${(p) =>
-    p.selected ? p.theme.colors.grayscale.g15 : 'unset'};
-  border-radius: 1000px;
-  border-width: 0;
-  font-weight: ${fontWeights.semibold};
-  color: ${(p) => (p.selected ? 'unset' : p.theme.colors.main.m2)};
-
-  & > :last-child {
-    margin-left: ${defaultMargins.xs};
-  }
-
-  :not(:last-child) {
-    margin-right: ${defaultMargins.xs};
-`
-
 export interface SelectableAccount {
   id: UUID
   name: string
   selected: boolean
   toggleable: boolean
-}
-
-interface ToggleableRecipientProps extends SelectableAccount {
-  onToggleRecipient: (id: UUID, selected: boolean) => void
-  labelAdd: string
-}
-
-function ToggleableRecipient({
-  id,
-  labelAdd,
-  name,
-  onToggleRecipient,
-  selected,
-  toggleable
-}: ToggleableRecipientProps) {
-  const onClick = toggleable
-    ? () => onToggleRecipient(id, !selected)
-    : undefined
-
-  return (
-    <Recipient
-      onClick={onClick}
-      selected={selected}
-      toggleable={toggleable}
-      aria-disabled={!toggleable}
-      disabled={!toggleable}
-    >
-      {selected ? (
-        <>
-          {name}
-          {toggleable && <FontAwesomeIcon icon={faTimes} />}
-        </>
-      ) : (
-        `+ ${labelAdd} ${name}`
-      )}
-    </Recipient>
-  )
 }
 
 interface Labels {

--- a/frontend/src/lib-components/molecules/ToggleableRecipient.tsx
+++ b/frontend/src/lib-components/molecules/ToggleableRecipient.tsx
@@ -1,0 +1,77 @@
+{
+  /*
+SPDX-FileCopyrightText: 2017-2022 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+*/
+}
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTimes } from 'Icons'
+import React from 'react'
+import styled from 'styled-components'
+
+import { UUID } from 'lib-common/types'
+
+import { fontWeights } from '../typography'
+import { defaultMargins } from '../white-space'
+
+import { SelectableAccount } from './MessageReplyEditor'
+
+interface ToggleableRecipientProps extends SelectableAccount {
+  'data-qa'?: string
+  onToggleRecipient: (id: UUID, selected: boolean) => void
+  labelAdd: string
+}
+
+const Recipient = styled.button<{ selected: boolean; toggleable: boolean }>`
+  cursor: ${(p) => (p.toggleable ? 'pointer' : 'default')};;
+  padding: 0 ${(p) => (p.selected ? '12px' : defaultMargins.xs)};
+  background-color: ${(p) =>
+    p.selected ? p.theme.colors.grayscale.g15 : 'unset'};
+  border-radius: 1000px;
+  border-width: 0;
+  font-weight: ${fontWeights.semibold};
+  color: ${(p) => (p.selected ? 'unset' : p.theme.colors.main.m2)};
+
+  & > :last-child {
+    margin-left: ${defaultMargins.xs};
+  }
+
+  :not(:last-child) {
+    margin-right: ${defaultMargins.xs};
+`
+
+export function ToggleableRecipient({
+  'data-qa': dataQa,
+  id,
+  labelAdd,
+  name,
+  onToggleRecipient,
+  selected,
+  toggleable
+}: ToggleableRecipientProps) {
+  const onClick = toggleable
+    ? () => onToggleRecipient(id, !selected)
+    : undefined
+
+  return (
+    <Recipient
+      onClick={onClick}
+      selected={selected}
+      toggleable={toggleable}
+      aria-disabled={!toggleable}
+      disabled={!toggleable}
+      data-qa={dataQa}
+    >
+      {selected ? (
+        <>
+          {name}
+          {toggleable && <FontAwesomeIcon icon={faTimes} />}
+        </>
+      ) : (
+        `+ ${labelAdd} ${name}`
+      )}
+    </Recipient>
+  )
+}

--- a/frontend/src/lib-components/molecules/ToggleableRecipient.tsx
+++ b/frontend/src/lib-components/molecules/ToggleableRecipient.tsx
@@ -1,10 +1,6 @@
-{
-  /*
-SPDX-FileCopyrightText: 2017-2022 City of Espoo
-
-SPDX-License-Identifier: LGPL-2.1-or-later
-*/
-}
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTimes } from 'Icons'
@@ -60,7 +56,6 @@ export function ToggleableRecipient({
       onClick={onClick}
       selected={selected}
       toggleable={toggleable}
-      aria-disabled={!toggleable}
       disabled={!toggleable}
       data-qa={dataQa}
     >

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -371,6 +371,7 @@ const en: Translations = {
     messageEditor: {
       newMessage: 'New message',
       recipients: 'Recipients',
+      secondaryRecipients: 'Other recipients',
       children: 'The message is regarding',
       subject: 'Subject',
       message: 'Message',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -368,6 +368,7 @@ export default {
     messageEditor: {
       newMessage: 'Uusi viesti',
       recipients: 'Vastaanottajat',
+      secondaryRecipients: 'Muut vastaanottajat',
       children: 'Viesti koskee',
       subject: 'Otsikko',
       message: 'Viesti',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -368,6 +368,7 @@ const sv: Translations = {
     messageEditor: {
       newMessage: 'Nytt Meddelande',
       recipients: 'Mottagare',
+      secondaryRecipients: 'Andra mottagare',
       children: 'Meddelandet angår',
       subject: 'Ämne',
       message: 'Meddelande',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -562,7 +562,10 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 .first { it != group1Account && it != group2Account }
 
         // when we get the receivers for the citizen person1
-        val receivers = db.read { it.getCitizenReceivers(LocalDate.now(), person1Account).keys }
+        val receivers =
+            db.read {
+                it.getCitizenReceivers(LocalDate.now(), person1Account).values.flatten().toSet()
+            }
 
         assertEquals(
             setOf(
@@ -644,7 +647,10 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         val person1Account = db.read { it.getCitizenMessageAccount(person1Id) }
         // when we get the receivers for the citizen person1
-        val receivers = db.read { it.getCitizenReceivers(LocalDate.now(), person1Account).keys }
+        val receivers =
+            db.read {
+                it.getCitizenReceivers(LocalDate.now(), person1Account).values.flatten().toSet()
+            }
 
         // the result is empty
         assertEquals(setOf(), receivers.map { it.id }.toSet())

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -184,7 +184,7 @@ class MessageControllerCitizen(
                         .mapValues { entry -> entry.value.map { it.id }.toSet() }
                 val allReceiversValid =
                     body.recipients.all { recipient ->
-                        body.children.any { child ->
+                        body.children.all { child ->
                             validReceivers[child]?.contains(recipient.id) ?: false
                         }
                     }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -681,7 +681,7 @@ WHERE m.id = :messageId AND m.sender_id = :senderId
 fun Database.Read.getCitizenReceivers(
     today: LocalDate,
     accountId: MessageAccountId
-): Map<MessageAccount, List<ChildId>> {
+): Map<ChildId, List<MessageAccount>> {
     data class MessageAccountWithChildId(
         val id: MessageAccountId,
         val name: String,
@@ -771,7 +771,7 @@ ORDER BY type, name  -- groups first
         .bind("accountId", accountId)
         .bind("today", today)
         .mapTo<MessageAccountWithChildId>()
-        .groupBy({ MessageAccount(it.id, it.name, it.type) }, { it.childId })
+        .groupBy({ it.childId }, { MessageAccount(it.id, it.name, it.type) })
 }
 
 fun Database.Read.getMessagesSentByAccount(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- change the UI so that children are selected first and then receivers
- when selecting multiple children, only receivers that are related to *all selected children* are valid
- allow citizen to choose secondary recipients: if the citizen is a guardian, this means other guardians, and if the citizen is a foster parent, this means other foster parents. A foster parent can never select a guardian, and vice versa.