### PR TITLE
Add tracing to access control operations

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -28,6 +28,7 @@ import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.shared.security.actionrule.DefaultActionRuleMapping
+import io.opentracing.noop.NoopTracerFactory
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
@@ -42,7 +43,8 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
     private val supervisorId = EmployeeId(UUID.randomUUID())
     private val employee1Id = EmployeeId(UUID.randomUUID())
     private val employee2Id = EmployeeId(UUID.randomUUID())
-    private val accessControl = AccessControl(DefaultActionRuleMapping())
+    private val accessControl =
+        AccessControl(DefaultActionRuleMapping(), NoopTracerFactory.create())
     private lateinit var clock: EvakaClock
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -45,6 +45,7 @@ import fi.espoo.evaka.shared.security.actionrule.DefaultActionRuleMapping
 import fi.espoo.evaka.testArea
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
+import io.opentracing.noop.NoopTracerFactory
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
@@ -62,7 +63,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
     private val person2Id = PersonId(UUID.randomUUID())
     private val employee1Id = EmployeeId(UUID.randomUUID())
     private val employee2Id = EmployeeId(UUID.randomUUID())
-    private val accessControl = AccessControl(DefaultActionRuleMapping())
+    private val accessControl =
+        AccessControl(DefaultActionRuleMapping(), NoopTracerFactory.create())
     private lateinit var clock: EvakaClock
     private val sendTime = HelsinkiDateTime.of(LocalDate.of(2022, 5, 14), LocalTime.of(12, 11))
     private val readTime = sendTime.plusSeconds(30)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/AclIntegrationTest.kt
@@ -43,6 +43,7 @@ import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import fi.espoo.evaka.shared.security.actionrule.DefaultActionRuleMapping
+import io.opentracing.noop.NoopTracerFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
@@ -118,7 +119,7 @@ class AclIntegrationTest : PureJdbiTest(resetDbBeforeEach = false) {
             mobileId = it.insertTestMobileDevice(DevMobileDevice(unitId = daycareId))
         }
         acl = AccessControlList(jdbi)
-        accessControl = AccessControl(DefaultActionRuleMapping())
+        accessControl = AccessControl(DefaultActionRuleMapping(), NoopTracerFactory.create())
     }
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/AccessControlTest.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.security.actionrule.ActionRuleMapping
 import fi.espoo.evaka.shared.security.actionrule.ScopedActionRule
 import fi.espoo.evaka.shared.security.actionrule.UnscopedActionRule
+import io.opentracing.noop.NoopTracerFactory
 import org.junit.jupiter.api.BeforeEach
 
 abstract class AccessControlTest : PureJdbiTest(resetDbBeforeEach = true) {
@@ -28,7 +29,7 @@ abstract class AccessControlTest : PureJdbiTest(resetDbBeforeEach = true) {
     @BeforeEach
     fun prepareRules() {
         rules = TestActionRuleMapping()
-        accessControl = AccessControl(rules)
+        accessControl = AccessControl(rules, NoopTracerFactory.create())
     }
 
     class TestActionRuleMapping : ActionRuleMapping {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/JwtToAuthenticatedUser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/JwtToAuthenticatedUser.kt
@@ -30,7 +30,7 @@ class JwtToAuthenticatedUser(private val tracer: Tracer) : HttpFilter() {
 
         if (user != null) {
             request.setAuthenticatedUser(user)
-            tracer.activeSpan()?.setTag(Tracing.enduserIdHash, user.rawIdHash.toString())
+            tracer.activeSpan()?.setTag(Tracing.enduserIdHash, user.rawIdHash)
             MdcKey.USER_ID.set(user.rawId().toString())
             MdcKey.USER_ID_HASH.set(user.rawIdHash.toString())
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/SecurityConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/SecurityConfig.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.shared.config
 import fi.espoo.evaka.shared.auth.AccessControlList
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.actionrule.ActionRuleMapping
+import io.opentracing.Tracer
 import org.jdbi.v3.core.Jdbi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -16,6 +17,6 @@ class SecurityConfig {
     @Bean fun accessControlList(jdbi: Jdbi): AccessControlList = AccessControlList(jdbi)
 
     @Bean
-    fun accessControl(actionRuleMapping: ActionRuleMapping): AccessControl =
-        AccessControl(actionRuleMapping)
+    fun accessControl(actionRuleMapping: ActionRuleMapping, tracer: Tracer): AccessControl =
+        AccessControl(actionRuleMapping, tracer)
 }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- access control operations start a new span in Datadog traces. This makes it easier to understand the total duration of the whole access control operation, including all database queries *and* normal CPU work
