### PR TITLE
Placement count report csv decimal separator fix

### DIFF
--- a/frontend/src/employee-frontend/components/reports/PlacementCount.tsx
+++ b/frontend/src/employee-frontend/components/reports/PlacementCount.tsx
@@ -158,9 +158,8 @@ export default React.memo(function PlacementCount() {
         ...areaResult.daycareResults.map((daycareResult) => {
           return {
             ...daycareResult,
-            calculatedPlacements: daycareResult.calculatedPlacements
-              .toString()
-              .replace('.', ','),
+            calculatedPlacements:
+              daycareResult.calculatedPlacements.toLocaleString('fi-FI'),
             areaName: areaResult.areaName
           }
         }),
@@ -170,9 +169,8 @@ export default React.memo(function PlacementCount() {
           placementCount: areaResult.placementCount,
           placementCountUnder3v: areaResult.placementCountUnder3v,
           placementCount3vAndOver: areaResult.placementCount3vAndOver,
-          calculatedPlacements: areaResult.calculatedPlacements
-            .toString()
-            .replace('.', ',')
+          calculatedPlacements:
+            areaResult.calculatedPlacements.toLocaleString('fi-FI')
         }
       ]
     })
@@ -186,9 +184,8 @@ export default React.memo(function PlacementCount() {
             placementCount: filteredTotals.placementCount,
             placementCountUnder3v: filteredTotals.placementCountUnder3v,
             placementCount3vAndOver: filteredTotals.placementCount3vAndOver,
-            calculatedPlacements: filteredTotals.calculatedPlacements
-              .toString()
-              .replace('.', ',')
+            calculatedPlacements:
+              filteredTotals.calculatedPlacements.toLocaleString('fi-FI')
           }
         ]
       : []

--- a/frontend/src/employee-frontend/components/reports/PlacementCount.tsx
+++ b/frontend/src/employee-frontend/components/reports/PlacementCount.tsx
@@ -76,7 +76,7 @@ interface CsvReportRow {
   placementCountUnder3v: number
   placementCount3vAndOver: number
   placementCount: number
-  calculatedPlacements: number
+  calculatedPlacements: string
 }
 
 export default React.memo(function PlacementCount() {
@@ -158,6 +158,9 @@ export default React.memo(function PlacementCount() {
         ...areaResult.daycareResults.map((daycareResult) => {
           return {
             ...daycareResult,
+            calculatedPlacements: daycareResult.calculatedPlacements
+              .toString()
+              .replace('.', ','),
             areaName: areaResult.areaName
           }
         }),
@@ -168,6 +171,8 @@ export default React.memo(function PlacementCount() {
           placementCountUnder3v: areaResult.placementCountUnder3v,
           placementCount3vAndOver: areaResult.placementCount3vAndOver,
           calculatedPlacements: areaResult.calculatedPlacements
+            .toString()
+            .replace('.', ',')
         }
       ]
     })
@@ -182,6 +187,8 @@ export default React.memo(function PlacementCount() {
             placementCountUnder3v: filteredTotals.placementCountUnder3v,
             placementCount3vAndOver: filteredTotals.placementCount3vAndOver,
             calculatedPlacements: filteredTotals.calculatedPlacements
+              .toString()
+              .replace('.', ',')
           }
         ]
       : []


### PR DESCRIPTION
Replace decimal separator `.` to `,` in calculated CSV report values to enable easier Excel processing for FI users.