### PR TITLE
Suppress CVE-2022-41915 due to fix being misidentified as vulnerable

### DIFF
--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -65,4 +65,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         <packageUrl regex="true">^(?!pkg:maven/commons-net/commons-net).*$</packageUrl>
         <cpe>cpe:/a:apache:commons_net</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Fixed version in use, but misidentified as vulnerable
+        ]]></notes>
+        <cve>CVE-2022-41915</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

