### PR TITLE
Don't call logout when req.user is undefined

### DIFF
--- a/apigw/src/shared/routes/auth/saml/index.ts
+++ b/apigw/src/shared/routes/auth/saml/index.ts
@@ -150,7 +150,8 @@ function createLogoutHandler({
     )
     try {
       const redirectUrl = await fromCallback<string | null>((cb) =>
-        strategy.logout(req as RequestWithUser, cb)
+        // passport-saml logout requires req.user to be present, despite what the typings claim
+        req.user ? strategy.logout(req as RequestWithUser, cb) : cb(null, null)
       )
       logDebug('Logging user out from passport.', req)
       await logoutExpress(req, res, sessionType)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

passport-saml typings claim req.user can be optional, but this is not true in practice