### PR TITLE
Add E2E assertion helpers

### DIFF
--- a/frontend/src/e2e-test/pages/admin/application-details-page.ts
+++ b/frontend/src/e2e-test/pages/admin/application-details-page.ts
@@ -56,8 +56,7 @@ export default class ApplicationDetailsPage {
   async assertNote(index: number, note: string) {
     await waitUntilEqual(
       () =>
-        this.#notes.nth(index).findByDataQa('application-note-content')
-          .textContent,
+        this.#notes.nth(index).findByDataQa('application-note-content').text,
       note
     )
   }

--- a/frontend/src/e2e-test/pages/admin/application-details-page.ts
+++ b/frontend/src/e2e-test/pages/admin/application-details-page.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual } from '../../utils'
 import { Page, TextInput } from '../../utils/page'
 
 export default class ApplicationDetailsPage {
@@ -54,11 +53,10 @@ export default class ApplicationDetailsPage {
   }
 
   async assertNote(index: number, note: string) {
-    await waitUntilEqual(
-      () =>
-        this.#notes.nth(index).findByDataQa('application-note-content').text,
-      note
-    )
+    await this.#notes
+      .nth(index)
+      .findByDataQa('application-note-content')
+      .assertTextEquals(note)
   }
 
   async assertNoNote(index: number) {

--- a/frontend/src/e2e-test/pages/admin/application-workbench-page.ts
+++ b/frontend/src/e2e-test/pages/admin/application-workbench-page.ts
@@ -171,8 +171,7 @@ export class ApplicationWorkbenchPage {
     matchingText: string
   ) {
     await this.#applicationPlacementProposalStatusIndicator.hover()
-    const tooltip = await this.#applicationPlacementProposalStatusTooltip
-      .innerText
+    const tooltip = await this.#applicationPlacementProposalStatusTooltip.text
     const match = tooltip.match(matchingText)
     return match ? match.length > 0 : false
   }
@@ -185,16 +184,13 @@ export class ApplicationWorkbenchPage {
 
   async assertAgreementStatusNotAgreed() {
     await waitUntilTrue(async () =>
-      (await this.#agreementStatus.innerText).includes('Ei ole sovittu yhdessä')
+      (await this.#agreementStatus.text).includes('Ei ole sovittu yhdessä')
     )
   }
 
   async assertContactDetails(expectedTel: string, expectedEmail: string) {
-    await waitUntilEqual(() => this.#otherGuardianTel.innerText, expectedTel)
-    await waitUntilEqual(
-      () => this.#otherGuardianEmail.innerText,
-      expectedEmail
-    )
+    await waitUntilEqual(() => this.#otherGuardianTel.text, expectedTel)
+    await waitUntilEqual(() => this.#otherGuardianEmail.text, expectedEmail)
   }
 
   async assertDecisionGuardians(
@@ -202,12 +198,12 @@ export class ApplicationWorkbenchPage {
     expectedOtherGuardian?: string
   ) {
     await waitUntilEqual(
-      () => this.page.findByDataQa('guardian-name').innerText,
+      () => this.page.findByDataQa('guardian-name').text,
       expectedGuardian
     )
     if (expectedOtherGuardian !== undefined) {
       await waitUntilEqual(
-        () => this.page.findByDataQa('other-guardian-name').innerText,
+        () => this.page.findByDataQa('other-guardian-name').text,
         expectedOtherGuardian
       )
     }

--- a/frontend/src/e2e-test/pages/admin/application-workbench-page.ts
+++ b/frontend/src/e2e-test/pages/admin/application-workbench-page.ts
@@ -4,7 +4,7 @@
 
 import { ApplicationStatus } from 'lib-common/generated/api-types/application'
 
-import { waitUntilEqual, waitUntilTrue } from '../../utils'
+import { waitUntilTrue } from '../../utils'
 import { Checkbox, Page } from '../../utils/page'
 import ApplicationListView from '../employee/applications/application-list-view'
 import { PlacementDraftPage } from '../employee/placement-draft-page'
@@ -189,23 +189,21 @@ export class ApplicationWorkbenchPage {
   }
 
   async assertContactDetails(expectedTel: string, expectedEmail: string) {
-    await waitUntilEqual(() => this.#otherGuardianTel.text, expectedTel)
-    await waitUntilEqual(() => this.#otherGuardianEmail.text, expectedEmail)
+    await this.#otherGuardianTel.assertTextEquals(expectedTel)
+    await this.#otherGuardianEmail.assertTextEquals(expectedEmail)
   }
 
   async assertDecisionGuardians(
     expectedGuardian: string,
     expectedOtherGuardian?: string
   ) {
-    await waitUntilEqual(
-      () => this.page.findByDataQa('guardian-name').text,
-      expectedGuardian
-    )
+    await this.page
+      .findByDataQa('guardian-name')
+      .assertTextEquals(expectedGuardian)
     if (expectedOtherGuardian !== undefined) {
-      await waitUntilEqual(
-        () => this.page.findByDataQa('other-guardian-name').text,
-        expectedOtherGuardian
-      )
+      await this.page
+        .findByDataQa('other-guardian-name')
+        .assertTextEquals(expectedOtherGuardian)
     }
   }
 }

--- a/frontend/src/e2e-test/pages/admin/application-workbench-page.ts
+++ b/frontend/src/e2e-test/pages/admin/application-workbench-page.ts
@@ -183,8 +183,8 @@ export class ApplicationWorkbenchPage {
   }
 
   async assertAgreementStatusNotAgreed() {
-    await waitUntilTrue(async () =>
-      (await this.#agreementStatus.text).includes('Ei ole sovittu yhdessä')
+    await this.#agreementStatus.assertText((text) =>
+      text.includes('Ei ole sovittu yhdessä')
     )
   }
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -5,9 +5,9 @@
 import { ApplicationFormData } from 'lib-common/api-types/application/ApplicationFormData'
 import { JsonOf } from 'lib-common/json'
 
-import { waitUntilEqual, waitUntilDefined, waitUntilTrue } from '../../utils'
+import { waitUntilDefined, waitUntilEqual } from '../../utils'
 import { FormInput, Section, sections } from '../../utils/application-forms'
-import { Page, Checkbox, Radio, TextInput, FileInput } from '../../utils/page'
+import { Checkbox, FileInput, Page, Radio, TextInput } from '../../utils/page'
 
 export default class CitizenApplicationsPage {
   constructor(private readonly page: Page) {}
@@ -100,10 +100,8 @@ export default class CitizenApplicationsPage {
     await this.#applicationPreferredStartDate(id).assertTextEquals(
       preferredStartDate
     )
-    await waitUntilTrue(async () =>
-      (await this.#applicationStatus(id).innerText)
-        .toLowerCase()
-        .includes(status.toLowerCase())
+    await this.#applicationStatus(id).assertText((text) =>
+      text.toLowerCase().includes(status.toLowerCase())
     )
   }
 
@@ -340,13 +338,9 @@ class CitizenApplicationEditor {
   }
 
   async assertAttachmentUploaded(attachmentFileName: string) {
-    await waitUntilTrue(async () =>
-      (
-        await this.page.find(
-          '[data-qa="uploaded-files"] [data-qa="file-download-button"]'
-        ).text
-      ).includes(attachmentFileName)
-    )
+    await this.page
+      .find('[data-qa="uploaded-files"] [data-qa="file-download-button"]')
+      .assertText((text) => text.includes(attachmentFileName))
   }
 
   async assertUrgencyFileDownload() {

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -55,7 +55,7 @@ export default class CitizenApplicationsPage {
         : type === 'CLUB'
         ? 'Kerhohakemus'
         : ''
-    await waitUntilEqual(() => this.#applicationTitle.text, title)
+    await this.#applicationTitle.assertTextEquals(title)
 
     return new CitizenApplicationEditor(this.page)
   }
@@ -85,7 +85,7 @@ export default class CitizenApplicationsPage {
   }
 
   async assertChildIsShown(childId: string, childName: string) {
-    await waitUntilEqual(() => this.#childTitle(childId).text, childName)
+    await this.#childTitle(childId).assertTextEquals(childName)
   }
 
   async assertApplicationIsListed(
@@ -95,14 +95,13 @@ export default class CitizenApplicationsPage {
     preferredStartDate: string,
     status: string
   ) {
-    await waitUntilEqual(() => this.#applicationType(id).text, title)
-    await waitUntilEqual(() => this.#applicationUnit(id).text, unitName)
-    await waitUntilEqual(
-      () => this.#applicationPreferredStartDate(id).text,
+    await this.#applicationType(id).assertTextEquals(title)
+    await this.#applicationUnit(id).assertTextEquals(unitName)
+    await this.#applicationPreferredStartDate(id).assertTextEquals(
       preferredStartDate
     )
     await waitUntilTrue(async () =>
-      (await this.#applicationStatus(id).text)
+      (await this.#applicationStatus(id).innerText)
         .toLowerCase()
         .includes(status.toLowerCase())
     )
@@ -305,10 +304,9 @@ class CitizenApplicationEditor {
 
   async assertChildAddress(fullAddress: string) {
     await this.openSection('contactInfo')
-    await waitUntilEqual(
-      () => this.page.find('[data-qa="child-street-address"]').text,
-      fullAddress
-    )
+    await this.page
+      .find('[data-qa="child-street-address"]')
+      .assertTextEquals(fullAddress)
   }
 
   async setPreferredStartDate(formattedDate: string) {
@@ -328,7 +326,7 @@ class CitizenApplicationEditor {
       await this.#preferredStartDateInfo.waitUntilHidden()
       return
     }
-    await waitUntilEqual(() => this.#preferredStartDateInfo.text, infoText)
+    await this.#preferredStartDateInfo.assertTextEquals(infoText)
   }
 
   async markApplicationUrgentAndAddAttachment(attachmentFilePath: string) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -55,7 +55,7 @@ export default class CitizenApplicationsPage {
         : type === 'CLUB'
         ? 'Kerhohakemus'
         : ''
-    await waitUntilEqual(() => this.#applicationTitle.innerText, title)
+    await waitUntilEqual(() => this.#applicationTitle.text, title)
 
     return new CitizenApplicationEditor(this.page)
   }
@@ -85,7 +85,7 @@ export default class CitizenApplicationsPage {
   }
 
   async assertChildIsShown(childId: string, childName: string) {
-    await waitUntilEqual(() => this.#childTitle(childId).innerText, childName)
+    await waitUntilEqual(() => this.#childTitle(childId).text, childName)
   }
 
   async assertApplicationIsListed(
@@ -95,14 +95,14 @@ export default class CitizenApplicationsPage {
     preferredStartDate: string,
     status: string
   ) {
-    await waitUntilEqual(() => this.#applicationType(id).innerText, title)
-    await waitUntilEqual(() => this.#applicationUnit(id).innerText, unitName)
+    await waitUntilEqual(() => this.#applicationType(id).text, title)
+    await waitUntilEqual(() => this.#applicationUnit(id).text, unitName)
     await waitUntilEqual(
-      () => this.#applicationPreferredStartDate(id).innerText,
+      () => this.#applicationPreferredStartDate(id).text,
       preferredStartDate
     )
     await waitUntilTrue(async () =>
-      (await this.#applicationStatus(id).innerText)
+      (await this.#applicationStatus(id).text)
         .toLowerCase()
         .includes(status.toLowerCase())
     )
@@ -306,7 +306,7 @@ class CitizenApplicationEditor {
   async assertChildAddress(fullAddress: string) {
     await this.openSection('contactInfo')
     await waitUntilEqual(
-      () => this.page.find('[data-qa="child-street-address"]').innerText,
+      () => this.page.find('[data-qa="child-street-address"]').text,
       fullAddress
     )
   }
@@ -328,7 +328,7 @@ class CitizenApplicationEditor {
       await this.#preferredStartDateInfo.waitUntilHidden()
       return
     }
-    await waitUntilEqual(() => this.#preferredStartDateInfo.innerText, infoText)
+    await waitUntilEqual(() => this.#preferredStartDateInfo.text, infoText)
   }
 
   async markApplicationUrgentAndAddAttachment(attachmentFilePath: string) {
@@ -346,7 +346,7 @@ class CitizenApplicationEditor {
       (
         await this.page.find(
           '[data-qa="uploaded-files"] [data-qa="file-download-button"]'
-        ).innerText
+        ).text
       ).includes(attachmentFileName)
     )
   }

--- a/frontend/src/e2e-test/pages/citizen/citizen-assistance-need-decision.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-assistance-need-decision.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 
 export default class AssistanceNeedDecisionPage {
@@ -22,7 +21,7 @@ export default class AssistanceNeedDecisionPage {
       .waitUntilVisible()
   readonly structuralMotivationDescription = this.page.findByDataQa(
     'structural-motivation-description'
-  ).text
+  )
   readonly careMotivation = this.getLabelledValue('care-motivation')
   readonly assertServiceOption = (opt: string) =>
     this.page
@@ -30,13 +29,9 @@ export default class AssistanceNeedDecisionPage {
       .findByDataQa(`list-option-${opt}`)
       .waitUntilVisible()
   readonly guardiansHeardOn = this.getLabelledValue('guardians-heard-at')
-  readonly heardGuardian = (id: string) =>
-    this.page
-      .findByDataQa('guardians-heard-section')
-      .findByDataQa(`guardian-${id}`).text
   readonly otherRepresentativeDetails = this.page.findByDataQa(
     'other-representative-details'
-  ).text
+  )
   readonly viewOfGuardians = this.getLabelledValue('view-of-the-guardians')
   readonly futureLevelOfAssistance = this.getLabelledValue(
     'future-level-of-assistance'
@@ -48,13 +43,4 @@ export default class AssistanceNeedDecisionPage {
   )
   readonly preparedBy1 = this.getLabelledValue('prepared-by-1')
   readonly decisionMaker = this.getLabelledValue('decision-maker')
-
-  readonly sendDecisionButton = this.page.findByDataQa('send-decision')
-  get decisionSentAt() {
-    return this.page.findByDataQa('decision-sent-at')
-  }
-
-  async assertPageTitle(title: string): Promise<void> {
-    await waitUntilEqual(() => this.page.findByDataQa('page-title').text, title)
-  }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-assistance-need-decision.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-assistance-need-decision.ts
@@ -9,7 +9,7 @@ export default class AssistanceNeedDecisionPage {
   constructor(private readonly page: Page) {}
 
   private getLabelledValue(label: string) {
-    return this.page.findByDataQa(`labelled-value-${label}`).innerText
+    return this.page.findByDataQa(`labelled-value-${label}`).text
   }
 
   readonly pedagogicalMotivation = this.getLabelledValue(
@@ -22,7 +22,7 @@ export default class AssistanceNeedDecisionPage {
       .waitUntilVisible()
   readonly structuralMotivationDescription = this.page.findByDataQa(
     'structural-motivation-description'
-  ).innerText
+  ).text
   readonly careMotivation = this.getLabelledValue('care-motivation')
   readonly assertServiceOption = (opt: string) =>
     this.page
@@ -33,10 +33,10 @@ export default class AssistanceNeedDecisionPage {
   readonly heardGuardian = (id: string) =>
     this.page
       .findByDataQa('guardians-heard-section')
-      .findByDataQa(`guardian-${id}`).innerText
+      .findByDataQa(`guardian-${id}`).text
   readonly otherRepresentativeDetails = this.page.findByDataQa(
     'other-representative-details'
-  ).innerText
+  ).text
   readonly viewOfGuardians = this.getLabelledValue('view-of-the-guardians')
   readonly futureLevelOfAssistance = this.getLabelledValue(
     'future-level-of-assistance'
@@ -55,9 +55,6 @@ export default class AssistanceNeedDecisionPage {
   }
 
   async assertPageTitle(title: string): Promise<void> {
-    await waitUntilEqual(
-      () => this.page.findByDataQa('page-title').innerText,
-      title
-    )
+    await waitUntilEqual(() => this.page.findByDataQa('page-title').text, title)
   }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -60,10 +60,9 @@ export default class CitizenCalendarPage {
   }
 
   async assertEventCount(date: LocalDate, count: number) {
-    await waitUntilEqual(
-      () => this.#dayCell(date).findByDataQa('event-count').text,
-      count.toString()
-    )
+    await this.#dayCell(date)
+      .findByDataQa('event-count')
+      .assertTextEquals(count.toString())
   }
 
   async openReservationsModal() {
@@ -133,16 +132,17 @@ export default class CitizenCalendarPage {
           .find(`[data-qa="child-image"][data-qa-child-id="${childId}"]`)
           .waitUntilVisible()
       }
-      await waitUntilEqual(
-        () => row.findByDataQa('reservation-text').text,
-        'absence' in reservation
-          ? 'Poissa'
-          : 'freeAbsence' in reservation
-          ? 'Maksuton poissaolo'
-          : 'missing' in reservation
-          ? 'Ilmoitus puuttuu'
-          : `${reservation.startTime}–${reservation.endTime}`
-      )
+      await row
+        .findByDataQa('reservation-text')
+        .assertTextEquals(
+          'absence' in reservation
+            ? 'Poissa'
+            : 'freeAbsence' in reservation
+            ? 'Maksuton poissaolo'
+            : 'missing' in reservation
+            ? 'Ilmoitus puuttuu'
+            : `${reservation.startTime}–${reservation.endTime}`
+        )
     }
   }
 
@@ -363,17 +363,15 @@ class DayView extends Element {
   }
 
   async assertReservations(childId: UUID, value: string) {
-    await waitUntilEqual(
-      () => this.#childSection(childId).findByDataQa('reservations').text,
-      value
-    )
+    await this.#childSection(childId)
+      .findByDataQa('reservations')
+      .assertTextEquals(value)
   }
 
   async assertAbsence(childId: UUID, value: string) {
-    await waitUntilEqual(
-      () => this.#childSection(childId).findByDataQa('absence').text,
-      value
-    )
+    await this.#childSection(childId)
+      .findByDataQa('absence')
+      .assertTextEquals(value)
   }
 
   async assertNoActivePlacementsMsgVisible() {
@@ -400,11 +398,8 @@ class DayView extends Element {
     { title, description }: { title: string; description: string }
   ) {
     const event = this.#childSection(childId).findByDataQa(`event-${eventId}`)
-    await waitUntilEqual(() => event.findByDataQa('event-title').text, title)
-    await waitUntilEqual(
-      () => event.findByDataQa('event-description').text,
-      description
-    )
+    await event.findByDataQa('event-title').assertTextEquals(title)
+    await event.findByDataQa('event-description').assertTextEquals(description)
   }
 }
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -157,13 +157,9 @@ export default class CitizenCalendarPage {
   }
 
   async assertHolidayCtaNotVisible(): Promise<void> {
-    await waitUntilEqual(
-      () =>
-        this.page
-          .find('[data-holiday-period-cta-status]')
-          .getAttribute('data-holiday-period-cta-status'),
-      'success'
-    )
+    await this.page
+      .find('[data-holiday-period-cta-status]')
+      .assertAttributeEquals('data-holiday-period-cta-status', 'success')
     await this.#ctas.assertCount(0)
   }
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -61,7 +61,7 @@ export default class CitizenCalendarPage {
 
   async assertEventCount(date: LocalDate, count: number) {
     await waitUntilEqual(
-      () => this.#dayCell(date).findByDataQa('event-count').innerText,
+      () => this.#dayCell(date).findByDataQa('event-count').text,
       count.toString()
     )
   }
@@ -134,7 +134,7 @@ export default class CitizenCalendarPage {
           .waitUntilVisible()
       }
       await waitUntilEqual(
-        () => row.findByDataQa('reservation-text').innerText,
+        () => row.findByDataQa('reservation-text').text,
         'absence' in reservation
           ? 'Poissa'
           : 'freeAbsence' in reservation
@@ -149,7 +149,7 @@ export default class CitizenCalendarPage {
   #ctas = this.page.findAllByDataQa('holiday-period-cta')
 
   async getHolidayCtaContent(): Promise<string> {
-    return this.#ctas.nth(0).innerText
+    return this.#ctas.nth(0).text
   }
 
   async clickHolidayCta(): Promise<void> {
@@ -172,7 +172,7 @@ export default class CitizenCalendarPage {
   )
 
   async getDailyServiceTimeNotificationContent(nth: number): Promise<string> {
-    return this.#dailyServiceTimeNotifications.nth(nth).innerText
+    return this.#dailyServiceTimeNotifications.nth(nth).text
   }
 
   #dailyServiceTimeNotificationModal = this.page.findByDataQa(
@@ -180,8 +180,7 @@ export default class CitizenCalendarPage {
   )
 
   async getDailyServiceTimeNotificationModalContent(): Promise<string> {
-    return this.#dailyServiceTimeNotificationModal.findByDataQa('text')
-      .innerText
+    return this.#dailyServiceTimeNotificationModal.findByDataQa('text').text
   }
 
   async assertChildCountOnDay(date: LocalDate, expectedCount: number) {
@@ -365,15 +364,14 @@ class DayView extends Element {
 
   async assertReservations(childId: UUID, value: string) {
     await waitUntilEqual(
-      () =>
-        this.#childSection(childId).findByDataQa('reservations').textContent,
+      () => this.#childSection(childId).findByDataQa('reservations').text,
       value
     )
   }
 
   async assertAbsence(childId: UUID, value: string) {
     await waitUntilEqual(
-      () => this.#childSection(childId).findByDataQa('absence').textContent,
+      () => this.#childSection(childId).findByDataQa('absence').text,
       value
     )
   }
@@ -402,12 +400,9 @@ class DayView extends Element {
     { title, description }: { title: string; description: string }
   ) {
     const event = this.#childSection(childId).findByDataQa(`event-${eventId}`)
+    await waitUntilEqual(() => event.findByDataQa('event-title').text, title)
     await waitUntilEqual(
-      () => event.findByDataQa('event-title').innerText,
-      title
-    )
-    await waitUntilEqual(
-      () => event.findByDataQa('event-description').innerText,
+      () => event.findByDataQa('event-description').text,
       description
     )
   }

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -299,8 +299,8 @@ class AbsencesModal {
   #childCheckbox = (childId: string) =>
     new Checkbox(this.page.find(`[data-qa="child-${childId}"]`))
 
-  #startDateInput = new TextInput(this.page.find('[data-qa="start-date"]'))
-  #endDateInput = new TextInput(this.page.find('[data-qa="end-date"]'))
+  startDateInput = new TextInput(this.page.find('[data-qa="start-date"]'))
+  endDateInput = new TextInput(this.page.find('[data-qa="end-date"]'))
   #absenceChip = (type: string) =>
     new Checkbox(this.page.find(`[data-qa="absence-${type}"]`))
   #modalSendButton = this.page.find('[data-qa="modal-okBtn"]')
@@ -313,9 +313,9 @@ class AbsencesModal {
   ) {
     await this.deselectChildren(3)
     await this.#childCheckbox(child.id).click()
-    await this.#startDateInput.fill(dateRange.start.format())
-    await this.#endDateInput.fill(dateRange.end.format())
-    await this.#endDateInput.press('Enter')
+    await this.startDateInput.fill(dateRange.start.format())
+    await this.endDateInput.fill(dateRange.end.format())
+    await this.endDateInput.press('Enter')
     await this.#absenceChip(absenceType).click()
 
     await this.#modalSendButton.click()
@@ -329,14 +329,6 @@ class AbsencesModal {
         .nth(i)
         .click()
     }
-  }
-
-  async assertStartDate(text: string) {
-    await waitUntilEqual(() => this.#startDateInput.inputValue, text)
-  }
-
-  async assertEndDate(text: string) {
-    await waitUntilEqual(() => this.#endDateInput.inputValue, text)
   }
 }
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
@@ -16,7 +16,7 @@ export class CitizenChildIncomeStatementViewPage {
   }
 
   async assertOtherInfo(expected: string) {
-    await waitUntilEqual(() => this.otherInfo.innerText, expected)
+    await waitUntilEqual(() => this.otherInfo.text, expected)
   }
 
   async assertAttachmentExists(name: string) {
@@ -90,9 +90,7 @@ export class CitizenChildIncomeStatementListPage {
 
   async assertChildName(expectedName: string) {
     await waitUntilEqual(
-      () =>
-        this.childIncomeStatementList.find('[data-qa="child-name"]')
-          .textContent,
+      () => this.childIncomeStatementList.find('[data-qa="child-name"]').text,
       expectedName
     )
   }

--- a/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
@@ -16,7 +16,7 @@ export class CitizenChildIncomeStatementViewPage {
   }
 
   async assertOtherInfo(expected: string) {
-    await waitUntilEqual(() => this.otherInfo.text, expected)
+    await this.otherInfo.assertTextEquals(expected)
   }
 
   async assertAttachmentExists(name: string) {
@@ -89,10 +89,9 @@ export class CitizenChildIncomeStatementListPage {
   }
 
   async assertChildName(expectedName: string) {
-    await waitUntilEqual(
-      () => this.childIncomeStatementList.find('[data-qa="child-name"]').text,
-      expectedName
-    )
+    await this.childIncomeStatementList
+      .find('[data-qa="child-name"]')
+      .assertTextEquals(expectedName)
   }
 
   async assertIncomeStatementMissingWarningIsShown() {

--- a/frontend/src/e2e-test/pages/citizen/citizen-children.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-children.ts
@@ -97,7 +97,7 @@ export class CitizenChildPage {
       () =>
         this.page
           .findByDataQa('collapsible-consents')
-          .findByDataQa('count-indicator').innerText,
+          .findByDataQa('count-indicator').text,
       count.toString()
     )
   }
@@ -116,11 +116,11 @@ export class CitizenChildPage {
     expectedPublishedAt: string
   ) {
     await waitUntilEqual(
-      () => this.#vasuRowStateChip(vasuId).textContent,
+      () => this.#vasuRowStateChip(vasuId).text,
       expectedStatus
     )
     await waitUntilEqual(
-      () => this.#vasuRowPublishedAt(vasuId).textContent,
+      () => this.#vasuRowPublishedAt(vasuId).text,
       expectedPublishedAt
     )
   }

--- a/frontend/src/e2e-test/pages/citizen/citizen-children.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-children.ts
@@ -9,6 +9,7 @@ import { AsyncButton, Page, Radio, TextInput } from '../../utils/page'
 
 export class CitizenChildPage {
   constructor(private readonly page: Page) {}
+
   #placements = this.page.findAllByDataQa('placement')
   #terminatedPlacements = this.page.findAllByDataQa('terminated-placement')
 
@@ -93,13 +94,10 @@ export class CitizenChildPage {
   }
 
   async assertUnconsentedCount(count: number) {
-    await waitUntilEqual(
-      () =>
-        this.page
-          .findByDataQa('collapsible-consents')
-          .findByDataQa('count-indicator').text,
-      count.toString()
-    )
+    await this.page
+      .findByDataQa('collapsible-consents')
+      .findByDataQa('count-indicator')
+      .assertTextEquals(count.toString())
   }
 
   readonly #vasuRowStateChip = (vasuId: string) =>
@@ -115,14 +113,8 @@ export class CitizenChildPage {
     expectedStatus: string,
     expectedPublishedAt: string
   ) {
-    await waitUntilEqual(
-      () => this.#vasuRowStateChip(vasuId).text,
-      expectedStatus
-    )
-    await waitUntilEqual(
-      () => this.#vasuRowPublishedAt(vasuId).text,
-      expectedPublishedAt
-    )
+    await this.#vasuRowStateChip(vasuId).assertTextEquals(expectedStatus)
+    await this.#vasuRowPublishedAt(vasuId).assertTextEquals(expectedPublishedAt)
   }
 
   async openVasu(vasuId: string) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
@@ -27,14 +27,12 @@ export default class CitizenDecisionsPage {
     const decision = this.page
       .findByDataQa(`child-decisions-${childId}`)
       .findByDataQa(`application-decision-${decisionId}`)
-    await waitUntilEqual(
-      () => decision.findByDataQa('title-decision-type').text,
-      expectedTitle
-    )
-    await waitUntilEqual(
-      () => decision.findByDataQa('decision-sent-date').text,
-      expectedSentDate
-    )
+    await decision
+      .findByDataQa('title-decision-type')
+      .assertTextEquals(expectedTitle)
+    await decision
+      .findByDataQa('decision-sent-date')
+      .assertTextEquals(expectedSentDate)
     await waitUntilEqual(
       async () =>
         (await decision.findByDataQa('decision-status').text).toLowerCase(),
@@ -83,26 +81,21 @@ export default class CitizenDecisionsPage {
     const decision = this.page
       .findByDataQa(`child-decisions-${childId}`)
       .findByDataQa(`assistance-decision-${decisionId}`)
-    await waitUntilEqual(
-      () => decision.findByDataQa('assistance-level').text,
-      contents.assistanceLevel
-    )
-    await waitUntilEqual(
-      () => decision.findByDataQa('selected-unit').text,
-      contents.selectedUnit
-    )
-    await waitUntilEqual(
-      () => decision.findByDataQa('validity-period').text,
-      contents.validityPeriod
-    )
-    await waitUntilEqual(
-      () => decision.findByDataQa('decision-made').text,
-      contents.decisionMade
-    )
-    await waitUntilEqual(
-      () => decision.findByDataQa('decision-status').text,
-      contents.status
-    )
+    await decision
+      .findByDataQa('assistance-level')
+      .assertTextEquals(contents.assistanceLevel)
+    await decision
+      .findByDataQa('selected-unit')
+      .assertTextEquals(contents.selectedUnit)
+    await decision
+      .findByDataQa('validity-period')
+      .assertTextEquals(contents.validityPeriod)
+    await decision
+      .findByDataQa('decision-made')
+      .assertTextEquals(contents.decisionMade)
+    await decision
+      .findByDataQa('decision-status')
+      .assertTextEquals(contents.status)
   }
 
   async assertUnreadAssistanceNeedDecisions(childId: string, count: number) {
@@ -142,7 +135,7 @@ class CitizenDecisionResponsePage {
     this.#decisionBlock(decisionId).find('[data-qa="decision-status"]')
 
   async assertPageTitle() {
-    await waitUntilEqual(() => this.#title.text, 'Päätökset')
+    await this.#title.assertTextEquals('Päätökset')
   }
 
   async assertUnresolvedDecisionsCount(count: number) {
@@ -162,14 +155,8 @@ class CitizenDecisionResponsePage {
     decisionUnitText: string,
     decisionStatusText: string
   ) {
-    await waitUntilEqual(
-      () => this.#decisionTitle(decisionId).text,
-      decisionTypeText
-    )
-    await waitUntilEqual(
-      () => this.#decisionUnit(decisionId).text,
-      decisionUnitText
-    )
+    await this.#decisionTitle(decisionId).assertTextEquals(decisionTypeText)
+    await this.#decisionUnit(decisionId).assertTextEquals(decisionUnitText)
     await this.assertDecisionStatus(decisionId, decisionStatusText)
   }
 
@@ -205,14 +192,10 @@ async function assertUnresolvedDecisionsCount(page: Page, count: number) {
   }
 
   if (count === 1) {
-    return await waitUntilEqual(
-      () => element.text,
-      '1 päätös odottaa vahvistustasi'
-    )
+    return await element.assertTextEquals('1 päätös odottaa vahvistustasi')
   }
 
-  return await waitUntilEqual(
-    () => element.text,
+  return await element.assertTextEquals(
     `${count} päätöstä odottaa vahvistustasi`
   )
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
@@ -28,18 +28,16 @@ export default class CitizenDecisionsPage {
       .findByDataQa(`child-decisions-${childId}`)
       .findByDataQa(`application-decision-${decisionId}`)
     await waitUntilEqual(
-      () => decision.findByDataQa('title-decision-type').innerText,
+      () => decision.findByDataQa('title-decision-type').text,
       expectedTitle
     )
     await waitUntilEqual(
-      () => decision.findByDataQa('decision-sent-date').innerText,
+      () => decision.findByDataQa('decision-sent-date').text,
       expectedSentDate
     )
     await waitUntilEqual(
       async () =>
-        (
-          await decision.findByDataQa('decision-status').innerText
-        ).toLowerCase(),
+        (await decision.findByDataQa('decision-status').text).toLowerCase(),
       expectedStatus.toLowerCase()
     )
   }
@@ -86,23 +84,23 @@ export default class CitizenDecisionsPage {
       .findByDataQa(`child-decisions-${childId}`)
       .findByDataQa(`assistance-decision-${decisionId}`)
     await waitUntilEqual(
-      () => decision.findByDataQa('assistance-level').textContent,
+      () => decision.findByDataQa('assistance-level').text,
       contents.assistanceLevel
     )
     await waitUntilEqual(
-      () => decision.findByDataQa('selected-unit').textContent,
+      () => decision.findByDataQa('selected-unit').text,
       contents.selectedUnit
     )
     await waitUntilEqual(
-      () => decision.findByDataQa('validity-period').textContent,
+      () => decision.findByDataQa('validity-period').text,
       contents.validityPeriod
     )
     await waitUntilEqual(
-      () => decision.findByDataQa('decision-made').textContent,
+      () => decision.findByDataQa('decision-made').text,
       contents.decisionMade
     )
     await waitUntilEqual(
-      () => decision.findByDataQa('decision-status').textContent,
+      () => decision.findByDataQa('decision-status').text,
       contents.status
     )
   }
@@ -144,7 +142,7 @@ class CitizenDecisionResponsePage {
     this.#decisionBlock(decisionId).find('[data-qa="decision-status"]')
 
   async assertPageTitle() {
-    await waitUntilEqual(() => this.#title.innerText, 'Päätökset')
+    await waitUntilEqual(() => this.#title.text, 'Päätökset')
   }
 
   async assertUnresolvedDecisionsCount(count: number) {
@@ -165,11 +163,11 @@ class CitizenDecisionResponsePage {
     decisionStatusText: string
   ) {
     await waitUntilEqual(
-      () => this.#decisionTitle(decisionId).innerText,
+      () => this.#decisionTitle(decisionId).text,
       decisionTypeText
     )
     await waitUntilEqual(
-      () => this.#decisionUnit(decisionId).innerText,
+      () => this.#decisionUnit(decisionId).text,
       decisionUnitText
     )
     await this.assertDecisionStatus(decisionId, decisionStatusText)
@@ -177,8 +175,7 @@ class CitizenDecisionResponsePage {
 
   async assertDecisionStatus(decisionId: string, statusText: string) {
     await waitUntilEqual(
-      async () =>
-        (await this.#decisionStatus(decisionId).innerText).toLowerCase(),
+      async () => (await this.#decisionStatus(decisionId).text).toLowerCase(),
       statusText.toLowerCase()
     )
   }
@@ -209,13 +206,13 @@ async function assertUnresolvedDecisionsCount(page: Page, count: number) {
 
   if (count === 1) {
     return await waitUntilEqual(
-      () => element.innerText,
+      () => element.text,
       '1 päätös odottaa vahvistustasi'
     )
   }
 
   return await waitUntilEqual(
-    () => element.innerText,
+    () => element.text,
     `${count} päätöstä odottaa vahvistustasi`
   )
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
@@ -143,8 +143,8 @@ class CitizenDecisionResponsePage {
   }
 
   async assertDecisionCannotBeAccepted(decisionId: string) {
-    await waitUntilEqual(
-      () => this.#submitResponseButton(decisionId).getAttribute('disabled'),
+    await this.#submitResponseButton(decisionId).assertAttributeEquals(
+      'disabled',
       ''
     )
   }

--- a/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
@@ -33,11 +33,9 @@ export default class CitizenDecisionsPage {
     await decision
       .findByDataQa('decision-sent-date')
       .assertTextEquals(expectedSentDate)
-    await waitUntilEqual(
-      async () =>
-        (await decision.findByDataQa('decision-status').text).toLowerCase(),
-      expectedStatus.toLowerCase()
-    )
+    await decision
+      .findByDataQa('decision-status')
+      .assertText((text) => text.toLowerCase() === expectedStatus.toLowerCase())
   }
 
   async navigateToDecisionResponse(applicationId: string) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-header.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-header.ts
@@ -128,7 +128,7 @@ export default class CitizenHeader {
     await this.#childrenNav.waitUntilVisible()
     expectedCount != 0
       ? await waitUntilEqual(
-          () => this.#unreadChildrenCount.textContent,
+          () => this.#unreadChildrenCount.text,
           expectedCount.toString()
         )
       : await waitUntilFalse(() => this.#unreadChildrenCount.visible)
@@ -143,7 +143,7 @@ export default class CitizenHeader {
       )
       expectedCount != 0
         ? await waitUntilEqual(
-            () => notification.textContent,
+            () => notification.text,
             expectedCount.toString()
           )
         : await notification.waitUntilHidden()

--- a/frontend/src/e2e-test/pages/citizen/citizen-header.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-header.ts
@@ -4,7 +4,7 @@
 
 import { Lang } from 'lib-customizations/citizen'
 
-import { waitUntilEqual, waitUntilFalse } from '../../utils'
+import { waitUntilFalse } from '../../utils'
 import { Page } from '../../utils/page'
 
 export default class CitizenHeader {
@@ -141,9 +141,8 @@ export default class CitizenHeader {
         `children-menu-${childId}-notification-count`
       )
       expectedCount != 0
-        ? await waitUntilEqual(
-            () => notification.text,
-            expectedCount.toString()
+        ? await notification.assertText(
+            (text) => text === expectedCount.toString()
           )
         : await notification.waitUntilHidden()
       await this.#toggleChildrenMenu()

--- a/frontend/src/e2e-test/pages/citizen/citizen-header.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-header.ts
@@ -127,8 +127,7 @@ export default class CitizenHeader {
   async assertUnreadChildrenCount(expectedCount: number) {
     await this.#childrenNav.waitUntilVisible()
     expectedCount != 0
-      ? await waitUntilEqual(
-          () => this.#unreadChildrenCount.text,
+      ? await this.#unreadChildrenCount.assertTextEquals(
           expectedCount.toString()
         )
       : await waitUntilFalse(() => this.#unreadChildrenCount.visible)

--- a/frontend/src/e2e-test/pages/citizen/citizen-map.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-map.ts
@@ -118,7 +118,7 @@ class UnitDetailsPanel extends Element {
   readonly backButton = this.find('[data-qa="map-unit-details-back"]')
 
   get name(): Promise<string | null> {
-    return this.find('[data-qa="map-unit-details-name"]').textContent
+    return this.find('[data-qa="map-unit-details-name"]').text
   }
 }
 
@@ -127,11 +127,11 @@ class MapPopup extends Element {
   readonly #noApplying = this.find('[data-qa="map-popup-no-applying"]')
 
   get name(): Promise<string | null> {
-    return this.#name.textContent
+    return this.#name.text
   }
 
   get noApplying(): Promise<string | null> {
-    return this.#noApplying.textContent
+    return this.#noApplying.text
   }
 }
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual, waitUntilTrue } from '../../utils'
+import { waitUntilTrue } from '../../utils'
 import { Page, TextInput } from '../../utils/page'
 
 export default class CitizenMessagesPage {
@@ -42,8 +42,8 @@ export default class CitizenMessagesPage {
     urgent?: boolean
   }) {
     await this.#threadListItem.click()
-    await waitUntilEqual(() => this.#threadTitle.text, message.title)
-    await waitUntilEqual(() => this.#threadContent.elem().text, message.content)
+    await this.#threadTitle.assertTextEquals(message.title)
+    await this.#threadContent.only().assertTextEquals(message.content)
     if (message.urgent ?? false) {
       await this.#threadUrgent.waitUntilVisible()
     } else {
@@ -81,7 +81,7 @@ export default class CitizenMessagesPage {
   }
 
   async assertReplyContentIsEmpty() {
-    return waitUntilEqual(() => this.#messageReplyContent.text, '')
+    return this.#messageReplyContent.assertTextEquals('')
   }
 
   async replyToFirstThread(content: string) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -42,11 +42,8 @@ export default class CitizenMessagesPage {
     urgent?: boolean
   }) {
     await this.#threadListItem.click()
-    await waitUntilEqual(() => this.#threadTitle.innerText, message.title)
-    await waitUntilEqual(
-      () => this.#threadContent.elem().innerText,
-      message.content
-    )
+    await waitUntilEqual(() => this.#threadTitle.text, message.title)
+    await waitUntilEqual(() => this.#threadContent.elem().text, message.content)
     if (message.urgent ?? false) {
       await this.#threadUrgent.waitUntilVisible()
     } else {
@@ -84,7 +81,7 @@ export default class CitizenMessagesPage {
   }
 
   async assertReplyContentIsEmpty() {
-    return waitUntilEqual(() => this.#messageReplyContent.textContent, '')
+    return waitUntilEqual(() => this.#messageReplyContent.text, '')
   }
 
   async replyToFirstThread(content: string) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-pedagogical-documents.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-pedagogical-documents.ts
@@ -22,11 +22,8 @@ export default class CitizenPedagogicalDocumentsPage {
     expectedDate: string,
     expectedDescription: string
   ) {
-    await waitUntilEqual(() => this.#date(id).innerText, expectedDate)
-    await waitUntilEqual(
-      () => this.#description(id).innerText,
-      expectedDescription
-    )
+    await waitUntilEqual(() => this.#date(id).text, expectedDate)
+    await waitUntilEqual(() => this.#description(id).text, expectedDescription)
   }
 
   async downloadAttachment(id: string) {
@@ -42,6 +39,6 @@ export default class CitizenPedagogicalDocumentsPage {
   }
 
   async assertChildNameIs(id: string, expectedName: string) {
-    await waitUntilEqual(() => this.#childName(id).innerText, expectedName)
+    await waitUntilEqual(() => this.#childName(id).text, expectedName)
   }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-pedagogical-documents.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-pedagogical-documents.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 
 export default class CitizenPedagogicalDocumentsPage {
@@ -22,8 +21,8 @@ export default class CitizenPedagogicalDocumentsPage {
     expectedDate: string,
     expectedDescription: string
   ) {
-    await waitUntilEqual(() => this.#date(id).text, expectedDate)
-    await waitUntilEqual(() => this.#description(id).text, expectedDescription)
+    await this.#date(id).assertTextEquals(expectedDate)
+    await this.#description(id).assertTextEquals(expectedDescription)
   }
 
   async downloadAttachment(id: string) {
@@ -39,6 +38,6 @@ export default class CitizenPedagogicalDocumentsPage {
   }
 
   async assertChildNameIs(id: string, expectedName: string) {
-    await waitUntilEqual(() => this.#childName(id).text, expectedName)
+    await this.#childName(id).assertTextEquals(expectedName)
   }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
@@ -22,7 +22,7 @@ export default class CitizenPersonalDetails {
   async checkMissingEmailWarningIsShown() {
     await waitUntilTrue(() => this.#missingEmailOrPhoneBox.visible)
     await waitUntilTrue(async () =>
-      ((await this.#missingEmailOrPhoneBox.textContent) ?? '').includes(
+      ((await this.#missingEmailOrPhoneBox.text) ?? '').includes(
         'Sähköpostiosoitteesi puuttuu'
       )
     )
@@ -31,7 +31,7 @@ export default class CitizenPersonalDetails {
   async checkMissingPhoneWarningIsShown() {
     await waitUntilTrue(() => this.#missingEmailOrPhoneBox.visible)
     await waitUntilTrue(async () =>
-      ((await this.#missingEmailOrPhoneBox.textContent) ?? '').includes(
+      ((await this.#missingEmailOrPhoneBox.text) ?? '').includes(
         'Puhelinnumerosi puuttuu'
       )
     )
@@ -81,17 +81,14 @@ export default class CitizenPersonalDetails {
     backupPhone: string
     email: string | null
   }) {
+    await waitUntilEqual(() => this.#preferredName.text, data.preferredName)
     await waitUntilEqual(
-      () => this.#preferredName.textContent,
-      data.preferredName
-    )
-    await waitUntilEqual(
-      () => this.#phone.textContent,
+      () => this.#phone.text,
       data.phone === null ? 'Puhelinnumerosi puuttuu' : data.phone
     )
-    await waitUntilEqual(() => this.#backupPhone.textContent, data.backupPhone)
+    await waitUntilEqual(() => this.#backupPhone.text, data.backupPhone)
     await waitUntilEqual(
-      () => this.#email.textContent,
+      () => this.#email.text,
       data.email === null ? 'Sähköpostiosoite puuttuu' : data.email
     )
   }

--- a/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
@@ -20,11 +20,9 @@ export default class CitizenPersonalDetails {
   #save = this.page.find('[data-qa="save"]')
 
   async checkMissingEmailWarningIsShown() {
-    await waitUntilTrue(() => this.#missingEmailOrPhoneBox.visible)
-    await waitUntilTrue(async () =>
-      ((await this.#missingEmailOrPhoneBox.text) ?? '').includes(
-        'Sähköpostiosoitteesi puuttuu'
-      )
+    await this.#missingEmailOrPhoneBox.waitUntilVisible()
+    await this.#missingEmailOrPhoneBox.assertText((text) =>
+      text.includes('Sähköpostiosoitteesi puuttuu')
     )
   }
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual, waitUntilFalse, waitUntilTrue } from '../../utils'
-import { Page, Checkbox, Select, TextInput } from '../../utils/page'
+import { waitUntilFalse, waitUntilTrue } from '../../utils'
+import { Checkbox, Page, Select, TextInput } from '../../utils/page'
 
 export default class CitizenPersonalDetails {
   constructor(private readonly page: Page) {}
@@ -81,14 +81,12 @@ export default class CitizenPersonalDetails {
     backupPhone: string
     email: string | null
   }) {
-    await waitUntilEqual(() => this.#preferredName.text, data.preferredName)
-    await waitUntilEqual(
-      () => this.#phone.text,
+    await this.#preferredName.assertTextEquals(data.preferredName)
+    await this.#phone.assertTextEquals(
       data.phone === null ? 'Puhelinnumerosi puuttuu' : data.phone
     )
-    await waitUntilEqual(() => this.#backupPhone.text, data.backupPhone)
-    await waitUntilEqual(
-      () => this.#email.text,
+    await this.#backupPhone.assertTextEquals(data.backupPhone)
+    await this.#email.assertTextEquals(
       data.email === null ? 'Sähköpostiosoite puuttuu' : data.email
     )
   }

--- a/frontend/src/e2e-test/pages/employee/IncomeStatementPage.ts
+++ b/frontend/src/e2e-test/pages/employee/IncomeStatementPage.ts
@@ -22,10 +22,7 @@ export class IncomeStatementPage {
     expectedOtherInfo: string,
     expectedAttachmentsCount: number
   ) {
-    await waitUntilEqual(
-      () => this.#childOtherInfo.textContent,
-      expectedOtherInfo
-    )
+    await waitUntilEqual(() => this.#childOtherInfo.text, expectedOtherInfo)
     expectedAttachmentsCount > 0
       ? await this.#attachments.assertCount(expectedAttachmentsCount)
       : await this.#noAttachments.waitUntilVisible()

--- a/frontend/src/e2e-test/pages/employee/applications.ts
+++ b/frontend/src/e2e-test/pages/employee/applications.ts
@@ -44,6 +44,6 @@ export class ApplicationRow extends Element {
   }
 
   async assertStatus(expectedStatus: string) {
-    await waitUntilEqual(() => this.#status.innerText, expectedStatus)
+    await waitUntilEqual(() => this.#status.text, expectedStatus)
   }
 }

--- a/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
@@ -90,7 +90,7 @@ export default class ApplicationEditView {
       () =>
         this.#urgentAttachmentFileUpload.find(
           '[data-qa="file-download-button"]'
-        ).innerText,
+        ).text,
       fileName
     )
   }
@@ -129,7 +129,7 @@ export default class ApplicationEditView {
       () =>
         this.#shiftCareAttachmentFileUpload.find(
           '[data-qa="file-download-button"]'
-        ).innerText,
+        ).text,
       fileName
     )
   }

--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -50,7 +50,7 @@ export default class ApplicationReadView {
   }
 
   async assertPageTitle(expectedTitle: string) {
-    await waitUntilEqual(() => this.#title.innerText, expectedTitle)
+    await waitUntilEqual(() => this.#title.text, expectedTitle)
   }
 
   async assertOtherVtjGuardian(
@@ -58,9 +58,9 @@ export default class ApplicationReadView {
     expectedPhone: string,
     expectedEmail: string
   ) {
-    await waitUntilEqual(() => this.#vtjGuardianName.innerText, expectedName)
-    await waitUntilEqual(() => this.#vtjGuardianPhone.innerText, expectedPhone)
-    await waitUntilEqual(() => this.#vtjGuardianEmail.innerText, expectedEmail)
+    await waitUntilEqual(() => this.#vtjGuardianName.text, expectedName)
+    await waitUntilEqual(() => this.#vtjGuardianPhone.text, expectedPhone)
+    await waitUntilEqual(() => this.#vtjGuardianEmail.text, expectedEmail)
   }
 
   async assertOtherVtjGuardianMissing() {
@@ -72,13 +72,10 @@ export default class ApplicationReadView {
     expectedEmail: string
   ) {
     await waitUntilEqual(
-      () => this.#givenOtherGuardianPhone.innerText,
+      () => this.#givenOtherGuardianPhone.text,
       expectedPhone
     )
-    await waitUntilEqual(
-      () => this.#giveOtherGuardianEmail.innerText,
-      expectedEmail
-    )
+    await waitUntilEqual(() => this.#giveOtherGuardianEmail.text, expectedEmail)
   }
 
   async setDecisionStartDate(type: DecisionType, startDate: string) {
@@ -126,7 +123,7 @@ export default class ApplicationReadView {
     await text.waitUntilVisible()
 
     await waitUntilTrue(async () =>
-      ((await text.textContent) ?? '').startsWith(
+      ((await text.text) ?? '').startsWith(
         byPaper ? 'Toimitettu paperisena' : 'Toimitettu sähköisesti'
       )
     )
@@ -156,7 +153,7 @@ export default class ApplicationReadView {
 
   async assertDueDate(dueDate: LocalDate) {
     await waitUntilEqual(
-      () => this.page.findByDataQa('application-due-date').textContent,
+      () => this.page.findByDataQa('application-due-date').text,
       dueDate.format()
     )
   }

--- a/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-edit-page.ts
+++ b/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-edit-page.ts
@@ -25,14 +25,14 @@ export default class AssistanceNeedDecisionEditPage {
 
   async assertDecisionStatus(status: string) {
     await waitUntilEqual(
-      () => this.page.findByDataQa('decision-status').innerText,
+      () => this.page.findByDataQa('decision-status').text,
       status
     )
   }
 
   async assertDecisionNumber(decisionNumber: number | null) {
     await waitUntilEqual(
-      () => this.page.findByDataQa('decision-number').innerText,
+      () => this.page.findByDataQa('decision-number').text,
       `${decisionNumber ?? 'null'}`
     )
   }
@@ -62,10 +62,7 @@ export default class AssistanceNeedDecisionEditPage {
   }
 
   async assertPageTitle(title: string): Promise<void> {
-    await waitUntilEqual(
-      () => this.page.findByDataQa('page-title').innerText,
-      title
-    )
+    await waitUntilEqual(() => this.page.findByDataQa('page-title').text, title)
   }
 
   async selectUnit(unit: string): Promise<void> {

--- a/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-preview-page.ts
+++ b/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-preview-page.ts
@@ -9,7 +9,7 @@ export default class AssistanceNeedDecisionPreviewPage {
   constructor(private readonly page: Page) {}
 
   private getLabelledValue(label: string) {
-    return this.page.findByDataQa(`labelled-value-${label}`).innerText
+    return this.page.findByDataQa(`labelled-value-${label}`).text
   }
 
   get pedagogicalMotivation() {
@@ -22,7 +22,7 @@ export default class AssistanceNeedDecisionPreviewPage {
       .waitUntilVisible()
   }
   get structuralMotivationDescription() {
-    return this.page.findByDataQa('structural-motivation-description').innerText
+    return this.page.findByDataQa('structural-motivation-description').text
   }
   get careMotivation() {
     return this.getLabelledValue('care-motivation')
@@ -39,10 +39,10 @@ export default class AssistanceNeedDecisionPreviewPage {
   async heardGuardian(id: string) {
     return this.page
       .findByDataQa('guardians-heard-section')
-      .findByDataQa(`guardian-${id}`).innerText
+      .findByDataQa(`guardian-${id}`).text
   }
   get otherRepresentativeDetails() {
-    return this.page.findByDataQa('other-representative-details').innerText
+    return this.page.findByDataQa('other-representative-details').text
   }
   get viewOfGuardians() {
     return this.getLabelledValue('view-of-the-guardians')
@@ -72,9 +72,6 @@ export default class AssistanceNeedDecisionPreviewPage {
   }
 
   async assertPageTitle(title: string): Promise<void> {
-    await waitUntilEqual(
-      () => this.page.findByDataQa('page-title').innerText,
-      title
-    )
+    await waitUntilEqual(() => this.page.findByDataQa('page-title').text, title)
   }
 }

--- a/frontend/src/e2e-test/pages/employee/child-information.ts
+++ b/frontend/src/e2e-test/pages/employee/child-information.ts
@@ -63,7 +63,7 @@ export default class ChildInformationPage {
   }
 
   async assertOphPersonOid(expected: string) {
-    await waitUntilEqual(() => this.#ophPersonOidInput.innerText, expected)
+    await waitUntilEqual(() => this.#ophPersonOidInput.text, expected)
   }
 
   async setOphPersonOid(text: string) {
@@ -119,7 +119,7 @@ export class AdditionalInformationSection extends Section {
   #confirmBtn = this.find('[data-qa="confirm-edited-child-button"]')
 
   async assertMedication(text: string) {
-    await waitUntilEqual(() => this.#medication.textContent, text)
+    await waitUntilEqual(() => this.#medication.text, text)
   }
 
   async fillMedication(text: string) {
@@ -184,7 +184,7 @@ export class DailyServiceTimeSection extends Section {
     const row = this.findAllByDataQa('daily-service-times-row').nth(nth)
 
     await waitUntilEqual(
-      () => row.findByDataQa('daily-service-times-row-title').innerText,
+      () => row.findByDataQa('daily-service-times-row-title').text,
       title
     )
     await waitUntilEqual(
@@ -206,7 +206,7 @@ export class DailyServiceTimeSection extends Section {
       }) + [data-qa="daily-service-times-row-collapsible"]`
     )
 
-    await waitUntilEqual(() => collapsible.innerText, text)
+    await waitUntilEqual(() => collapsible.text, text)
   }
 
   async editTableRow(nth: number) {
@@ -332,15 +332,15 @@ export class PedagogicalDocumentsSection extends Section {
   }
 
   get startDate(): Promise<string> {
-    return this.#startDate.innerText
+    return this.#startDate.text
   }
 
   get document(): Promise<string> {
-    return this.#document.innerText
+    return this.#document.text
   }
 
   get description(): Promise<string> {
-    return this.#description.innerText
+    return this.#description.text
   }
 
   async setDescription(text: string) {
@@ -436,7 +436,7 @@ export class BackupCaresSection extends Section {
   }
 
   async assertError(expectedError: string) {
-    await waitUntilEqual(() => this.#error.innerText, expectedError)
+    await waitUntilEqual(() => this.#error.text, expectedError)
   }
 
   async getBackupCares(): Promise<Array<{ unit: string; period: string }>> {
@@ -512,7 +512,7 @@ export class FamilyContactsSection extends Section {
 
     if (data.email) {
       await waitUntilEqual(
-        () => row.findByDataQa('family-contact-email').textContent,
+        () => row.findByDataQa('family-contact-email').text,
         data.email
       )
     } else {
@@ -520,7 +520,7 @@ export class FamilyContactsSection extends Section {
     }
     if (data.phone) {
       await waitUntilEqual(
-        () => row.findByDataQa('family-contact-phone').textContent,
+        () => row.findByDataQa('family-contact-phone').text,
         data.phone
       )
     } else {
@@ -528,7 +528,7 @@ export class FamilyContactsSection extends Section {
     }
     if (data.backupPhone) {
       await waitUntilEqual(
-        () => row.findByDataQa('family-contact-backup-phone').textContent,
+        () => row.findByDataQa('family-contact-backup-phone').text,
         `${data.backupPhone} (Varanro)`
       )
     } else {
@@ -571,12 +571,9 @@ export class GuardiansSection extends Section {
     end: LocalDate | null
   ) {
     const row = this.findByDataQa(`foster-parent-row-${parentId}`)
+    await waitUntilEqual(() => row.findByDataQa('start').text, start.format())
     await waitUntilEqual(
-      () => row.findByDataQa('start').textContent,
-      start.format()
-    )
-    await waitUntilEqual(
-      () => row.findByDataQa('end').textContent,
+      () => row.findByDataQa('end').text,
       end?.format() ?? ''
     )
   }
@@ -616,8 +613,7 @@ export class GuardiansSection extends Section {
   async assertGuardianStatusAllowed(id: UUID) {
     await this.waitUntilNotLoading()
     await waitUntilEqual(
-      () =>
-        this.guardianRow(id).findByDataQa('evaka-rights-status').textContent,
+      () => this.guardianRow(id).findByDataQa('evaka-rights-status').text,
       'Sallittu'
     )
   }
@@ -625,8 +621,7 @@ export class GuardiansSection extends Section {
   async assertGuardianStatusDenied(id: UUID) {
     await this.waitUntilNotLoading()
     await waitUntilEqual(
-      () =>
-        this.guardianRow(id).findByDataQa('evaka-rights-status').textContent,
+      () => this.guardianRow(id).findByDataQa('evaka-rights-status').text,
       'Kielletty'
     )
   }
@@ -664,7 +659,7 @@ export class PlacementsSection extends Section {
 
   async assertNthServiceNeedName(index: number, optionName: string) {
     await waitUntilEqual(
-      () => this.#serviceNeedRowOptionName(index).textContent,
+      () => this.#serviceNeedRowOptionName(index).text,
       optionName
     )
   }
@@ -757,7 +752,7 @@ export class AssistanceNeedSection extends Section {
 
   async assertAssistanceNeedMultiplier(expected: string, nth = 0) {
     await waitUntilEqual(
-      () => this.#assistanceNeedMultiplier.nth(nth).innerText,
+      () => this.#assistanceNeedMultiplier.nth(nth).text,
       expected
     )
   }
@@ -779,14 +774,14 @@ export class AssistanceNeedSection extends Section {
       .nth(nth)
 
     return {
-      date: await row.findByDataQa('assistance-need-decision-date').innerText,
+      date: await row.findByDataQa('assistance-need-decision-date').text,
       unitName: await row.findByDataQa('assistance-need-decision-unit-name')
-        .innerText,
+        .text,
       sentDate: await row.findByDataQa('assistance-need-decision-sent-date')
-        .innerText,
+        .text,
       decisionMadeDate: await row.findByDataQa(
         'assistance-need-decision-made-date'
-      ).innerText,
+      ).text,
       status: await row
         .findByDataQa('decision-status')
         .getAttribute('data-qa-status'),
@@ -812,10 +807,10 @@ export class AssistanceNeedSection extends Section {
     return {
       coefficient: await row.findByDataQa(
         'assistance-need-voucher-coefficient-coefficient'
-      ).innerText,
+      ).text,
       validityPeriod: await row.findByDataQa(
         'assistance-need-voucher-coefficient-validity-period'
-      ).innerText,
+      ).text,
       status: await row
         .findByDataQa('assistance-need-voucher-coefficient-status')
         .getAttribute('data-qa-status'),

--- a/frontend/src/e2e-test/pages/employee/finance-basics.ts
+++ b/frontend/src/e2e-test/pages/employee/finance-basics.ts
@@ -35,9 +35,9 @@ export default class FinanceBasicsPage {
             key: keyof FeeThresholds,
             expected: string
           ) => {
-            return expect(
-              await element.find(`[data-qa="${key}"]`).innerText
-            ).toBe(expected)
+            return expect(await element.find(`[data-qa="${key}"]`).text).toBe(
+              expected
+            )
           }
 
           const formatEuros = (cents: number) => `${formatCents(cents)} €`

--- a/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
@@ -119,12 +119,12 @@ export class FeeDecisionDetailsPage {
   #childIncome = this.page.findAll('[data-qa="child-income"]')
 
   async assertPartnerName(expectedName: string) {
-    await waitUntilEqual(() => this.#partnerName.innerText, expectedName)
+    await waitUntilEqual(() => this.#partnerName.text, expectedName)
   }
 
   async assertChildIncome(nth: number, expectedTotalText: string) {
     await waitUntilTrue(async () =>
-      (await this.#childIncome.nth(nth).innerText).includes(expectedTotalText)
+      (await this.#childIncome.nth(nth).text).includes(expectedTotalText)
     )
   }
 
@@ -226,7 +226,7 @@ export class ValueDecisionDetailsPage {
   }
 
   async assertPartnerName(expectedName: string) {
-    await waitUntilEqual(() => this.#partnerName.innerText, expectedName)
+    await waitUntilEqual(() => this.#partnerName.text, expectedName)
   }
 
   async assertPartnerNameNotShown() {
@@ -236,7 +236,7 @@ export class ValueDecisionDetailsPage {
 
   async assertChildIncome(nth: number, expectedTotalText: string) {
     await waitUntilTrue(async () =>
-      (await this.#childIncome.nth(nth).innerText).includes(expectedTotalText)
+      (await this.#childIncome.nth(nth).text).includes(expectedTotalText)
     )
   }
 }
@@ -333,10 +333,7 @@ export class InvoicesPage {
 
   async assertInvoiceHeadOfFamily(fullName: string) {
     await this.#invoiceDetailsPage.waitUntilVisible()
-    await waitUntilEqual(
-      () => this.#invoiceDetailsHeadOfFamily.innerText,
-      fullName
-    )
+    await waitUntilEqual(() => this.#invoiceDetailsHeadOfFamily.text, fullName)
   }
 
   async navigateBackToInvoices() {
@@ -378,7 +375,7 @@ export class InvoicesPage {
 
   async assertInvoiceTotal(total: number) {
     await waitUntilEqual(
-      () => this.#invoiceInList.find('[data-qa="invoice-total"]').innerText,
+      () => this.#invoiceInList.find('[data-qa="invoice-total"]').text,
       this.formatFinnishDecimal(total)
     )
   }
@@ -438,14 +435,14 @@ export class IncomeStatementsPage {
     expecteTypeText: string
   ) {
     await waitUntilEqual(
-      () => this.#incomeStatementRows.nth(nth).find('a').textContent,
+      () => this.#incomeStatementRows.nth(nth).find('a').text,
       expectedName
     )
     await waitUntilEqual(
       () =>
         this.#incomeStatementRows
           .nth(nth)
-          .find('[data-qa="income-statement-type"]').textContent,
+          .find('[data-qa="income-statement-type"]').text,
       expecteTypeText
     )
   }

--- a/frontend/src/e2e-test/pages/employee/guardian-information.ts
+++ b/frontend/src/e2e-test/pages/employee/guardian-information.ts
@@ -52,14 +52,14 @@ export default class GuardianInformationPage {
       case true:
         await this.#restrictedDetailsEnabledLabel.waitUntilVisible()
         await waitUntilEqual(
-          () => this.#personStreetAddress.innerText,
+          () => this.#personStreetAddress.text,
           'Osoite ei ole saatavilla turvakiellon vuoksi'
         )
         break
       default:
         await this.#restrictedDetailsEnabledLabel.waitUntilHidden()
         await waitUntilNotEqual(
-          () => this.#personStreetAddress.innerText,
+          () => this.#personStreetAddress.text,
           'Osoite ei ole saatavilla turvakiellon vuoksi'
         )
     }
@@ -118,14 +118,14 @@ class FamilyOverviewSection extends Section {
 
     if (age !== undefined) {
       const personAge = person.find('[data-qa="person-age"]')
-      await waitUntilEqual(() => personAge.textContent, age.toString())
+      await waitUntilEqual(() => personAge.text, age.toString())
     }
 
     if (incomeCents !== undefined) {
       const personIncome = person.find('[data-qa="person-income-total"]')
       const expectedIncome = formatCents(incomeCents)
       await waitUntilEqual(
-        async () => ((await personIncome.textContent) ?? '').split(' ')[0],
+        async () => ((await personIncome.text) ?? '').split(' ')[0],
         expectedIncome
       )
     }
@@ -177,7 +177,7 @@ class ChildrenSection extends Section {
 
   async verifyChildAge(age: number) {
     const childAge = this.#childrenTableRow.nth(0).find('[data-qa="child-age"]')
-    await waitUntilEqual(() => childAge.textContent, age.toString())
+    await waitUntilEqual(() => childAge.text, age.toString())
   }
 }
 
@@ -251,12 +251,9 @@ class FosterChildrenSection extends Section {
     end: LocalDate | null
   ) {
     const row = this.findByDataQa(`foster-child-row-${childId}`)
+    await waitUntilEqual(() => row.findByDataQa('start').text, start.format())
     await waitUntilEqual(
-      () => row.findByDataQa('start').textContent,
-      start.format()
-    )
-    await waitUntilEqual(
-      () => row.findByDataQa('end').textContent,
+      () => row.findByDataQa('end').text,
       end?.format() ?? ''
     )
   }
@@ -314,7 +311,7 @@ export class IncomeSection extends Section {
 
   async assertIncomeStatementChildName(nth: number, childName: string) {
     await waitUntilEqual(
-      () => this.#childIncomeStatementsTitles.nth(nth).textContent,
+      () => this.#childIncomeStatementsTitles.nth(nth).text,
       childName
     )
   }
@@ -335,7 +332,7 @@ export class IncomeSection extends Section {
   }
 
   async getIncomeStatementInnerText(nth = 0) {
-    return this.#incomeStatementRows.nth(nth).innerText
+    return this.#incomeStatementRows.nth(nth).text
   }
 
   // Incomes
@@ -425,13 +422,13 @@ export class IncomeSection extends Section {
   #incomeSum = this.page.find('[data-qa="income-sum-income"]')
 
   async getIncomeSum() {
-    return await this.#incomeSum.textContent
+    return await this.#incomeSum.text
   }
 
   #expensesSum = this.page.find('[data-qa="income-sum-expenses"]')
 
   async getExpensesSum() {
-    return await this.#expensesSum.textContent
+    return await this.#expensesSum.text
   }
 
   #editIncomeItemButton = this.page.find('[data-qa="edit-income-item"]')
@@ -487,12 +484,12 @@ class FeeDecisionsSection extends Section {
   ) {
     const decision = this.#feeDecisionTableRows.nth(n)
     await waitUntilTrue(async () =>
-      ((await decision.textContent) ?? '').includes(
+      ((await decision.text) ?? '').includes(
         `Maksupäätös ${startDate} - ${endDate}`
       )
     )
     await waitUntilTrue(async () =>
-      ((await decision.textContent) ?? '').includes(status)
+      ((await decision.text) ?? '').includes(status)
     )
   }
 
@@ -512,7 +509,7 @@ class FeeDecisionsSection extends Section {
 
   async checkFeeDecisionSentAt(nth: number, expectedSentAt: LocalDate) {
     await waitUntilEqual(
-      () => this.#feeDecisionSentAt.nth(nth).innerText,
+      () => this.#feeDecisionSentAt.nth(nth).text,
       expectedSentAt.format('dd.MM.yyyy')
     )
   }
@@ -536,7 +533,7 @@ class VoucherValueDecisionsSection extends Section {
     expectedSentAt: LocalDate
   ) {
     await waitUntilEqual(
-      () => this.#voucherValueDecisionSentAt.nth(nth).innerText,
+      () => this.#voucherValueDecisionSentAt.nth(nth).text,
       expectedSentAt.format('dd.MM.yyyy')
     )
   }

--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -68,7 +68,7 @@ export default class MessagesPage {
         this.page
           .findAllByDataQa('sent-message-row')
           .nth(nth)
-          .findByDataQa('participants').textContent,
+          .findByDataQa('participants').text,
       participants
     )
   }
@@ -103,7 +103,7 @@ export default class MessagesPage {
   }
 
   async assertReplyContentIsEmpty() {
-    return waitUntilEqual(() => this.#messageReplyContent.textContent, '')
+    return waitUntilEqual(() => this.#messageReplyContent.text, '')
   }
 
   async sendNewMessage(message: {
@@ -201,20 +201,18 @@ export default class MessagesPage {
 
   async assertMessageContent(index: number, content: string) {
     await this.#receivedMessage.click()
-    await waitUntilEqual(() => this.#messageContent(index).innerText, content)
+    await waitUntilEqual(() => this.#messageContent(index).text, content)
   }
 
   async assertDraftContent(title: string, content: string) {
     await this.#draftMessagesBoxRow.click()
     await waitUntilEqual(
-      () =>
-        this.#draftMessage.find('[data-qa="thread-list-item-title"]').innerText,
+      () => this.#draftMessage.find('[data-qa="thread-list-item-title"]').text,
       title
     )
     await waitUntilEqual(
       () =>
-        this.#draftMessage.find('[data-qa="thread-list-item-content"]')
-          .innerText,
+        this.#draftMessage.find('[data-qa="thread-list-item-content"]').text,
       content
     )
   }
@@ -227,11 +225,11 @@ export default class MessagesPage {
   async assertCopyContent(title: string, content: string) {
     await this.#messageCopiesInbox.click()
     await waitUntilEqual(
-      () => this.page.findByDataQa('thread-list-item-title').innerText,
+      () => this.page.findByDataQa('thread-list-item-title').text,
       title
     )
     await waitUntilEqual(
-      () => this.page.findByDataQa('thread-list-item-content').innerText,
+      () => this.page.findByDataQa('thread-list-item-content').text,
       content
     )
   }

--- a/frontend/src/e2e-test/pages/employee/mobile/pairing-flow.ts
+++ b/frontend/src/e2e-test/pages/employee/mobile/pairing-flow.ts
@@ -36,7 +36,7 @@ export class PairingFlow {
 
   async getResponseKey() {
     await this.#responseKey.waitUntilVisible()
-    return this.#responseKey.innerText
+    return this.#responseKey.text
   }
 
   isPairingWizardFinished() {

--- a/frontend/src/e2e-test/pages/employee/person-search.ts
+++ b/frontend/src/e2e-test/pages/employee/person-search.ts
@@ -86,19 +86,19 @@ export default class PersonSearchPage {
     ssn?: string
   }) {
     await waitUntilEqual(
-      () => this.#personData.firstName.innerText,
+      () => this.#personData.firstName.text,
       personData.firstName
     )
     await waitUntilEqual(
-      () => this.#personData.lastName.innerText,
+      () => this.#personData.lastName.text,
       personData.lastName
     )
     await waitUntilEqual(
-      () => this.#personData.dateOfBirth.innerText,
+      () => this.#personData.dateOfBirth.text,
       personData.dateOfBirth.format()
     )
     await waitUntilEqual(
-      () => this.#personData.address.innerText,
+      () => this.#personData.address.text,
       `${personData.streetAddress}, ${personData.postalCode} ${personData.postOffice}`
     )
     if (personData.ssn === undefined) {
@@ -106,11 +106,11 @@ export default class PersonSearchPage {
         .findByDataQa('add-ssn-button')
         .waitUntilVisible()
       await waitUntilEqual(
-        () => this.#personData.ssn.findByDataQa('add-ssn-button').innerText,
+        () => this.#personData.ssn.findByDataQa('add-ssn-button').text,
         'Aseta hetu'
       )
     } else {
-      await waitUntilEqual(() => this.#personData.ssn.innerText, personData.ssn)
+      await waitUntilEqual(() => this.#personData.ssn.text, personData.ssn)
     }
   }
 

--- a/frontend/src/e2e-test/pages/employee/placement-draft-page.ts
+++ b/frontend/src/e2e-test/pages/employee/placement-draft-page.ts
@@ -44,19 +44,19 @@ export class PlacementDraftPage {
       '[data-qa="speculated-occupancies"]'
     )
     await waitUntilEqual(
-      () => current.find('[data-qa="3months"]').innerText,
+      () => current.find('[data-qa="3months"]').text,
       occupancies.max3Months
     )
     await waitUntilEqual(
-      () => current.find('[data-qa="6months"]').innerText,
+      () => current.find('[data-qa="6months"]').text,
       occupancies.max6Months
     )
     await waitUntilEqual(
-      () => speculated.find('[data-qa="3months"]').innerText,
+      () => speculated.find('[data-qa="3months"]').text,
       occupancies.max3MonthsSpeculated
     )
     await waitUntilEqual(
-      () => speculated.find('[data-qa="6months"]').innerText,
+      () => speculated.find('[data-qa="6months"]').text,
       occupancies.max6MonthsSpeculated
     )
   }

--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -106,17 +106,17 @@ export class PlacementSketchingReport {
     await element.waitUntilVisible()
 
     await waitUntilEqual(
-      () => element.find('[data-qa="requested-unit"]').innerText,
+      () => element.find('[data-qa="requested-unit"]').text,
       requestedUnitName
     )
     if (currentUnitName) {
       await waitUntilEqual(
-        () => element.find('[data-qa="current-unit"]').innerText,
+        () => element.find('[data-qa="current-unit"]').text,
         currentUnitName
       )
     }
     await waitUntilEqual(
-      () => element.find('[data-qa="child-name"]').innerText,
+      () => element.find('[data-qa="child-name"]').text,
       childName
     )
   }
@@ -157,10 +157,10 @@ export class VoucherServiceProvidersReport {
   ) {
     const row = this.page.find(`[data-qa="${unitId}"]`)
     await row.waitUntilVisible()
-    expect(await row.find(`[data-qa="child-count"]`).innerText).toStrictEqual(
+    expect(await row.find(`[data-qa="child-count"]`).text).toStrictEqual(
       expectedChildCount
     )
-    expect(await row.find(`[data-qa="child-sum"]`).innerText).toStrictEqual(
+    expect(await row.find(`[data-qa="child-sum"]`).text).toStrictEqual(
       expectedMonthlySum
     )
   }
@@ -194,22 +194,19 @@ export class ServiceVoucherUnitReport {
     expectedRealizedAmount: number
   ) {
     await waitUntilEqual(
-      () => this.page.findAllByDataQa('child-name').nth(nth).textContent,
+      () => this.page.findAllByDataQa('child-name').nth(nth).text,
       expectedName
     )
     await waitUntilEqual(
-      () =>
-        this.page.findAllByDataQa('voucher-value').nth(nth).textContentAsFloat,
+      () => this.page.findAllByDataQa('voucher-value').nth(nth).textAsFloat,
       expectedVoucherValue
     )
     await waitUntilEqual(
-      () => this.page.findAllByDataQa('co-payment').nth(nth).textContentAsFloat,
+      () => this.page.findAllByDataQa('co-payment').nth(nth).textAsFloat,
       expectedCoPayment
     )
     await waitUntilEqual(
-      () =>
-        this.page.findAllByDataQa('realized-amount').nth(nth)
-          .textContentAsFloat,
+      () => this.page.findAllByDataQa('realized-amount').nth(nth).textAsFloat,
       expectedRealizedAmount
     )
   }
@@ -226,7 +223,7 @@ export class VardaErrorsReport {
 
   async assertErrorsContains(childId: string, expected: string) {
     await waitUntilTrue(async () =>
-      ((await this.#errors(childId).textContent) || '').includes(expected)
+      ((await this.#errors(childId).text) || '').includes(expected)
     )
   }
 
@@ -249,11 +246,11 @@ export class AssistanceNeedDecisionsReport {
       .nth(nth)
 
     return {
-      sentForDecision: await row.findByDataQa('sent-for-decision').innerText,
-      childName: await row.findByDataQa('child-name').innerText,
-      careAreaName: await row.findByDataQa('care-area-name').innerText,
-      unitName: await row.findByDataQa('unit-name').innerText,
-      decisionMade: await row.findByDataQa('decision-made').innerText,
+      sentForDecision: await row.findByDataQa('sent-for-decision').text,
+      childName: await row.findByDataQa('child-name').text,
+      careAreaName: await row.findByDataQa('care-area-name').text,
+      unitName: await row.findByDataQa('unit-name').text,
+      decisionMade: await row.findByDataQa('decision-made').text,
       status: await row
         .findByDataQa('decision-chip')
         .getAttribute('data-qa-status'),
@@ -269,7 +266,7 @@ export class AssistanceNeedDecisionsReportDecision {
   constructor(private page: Page) {}
 
   decisionMaker = () =>
-    this.page.findByDataQa('labelled-value-decision-maker').innerText
+    this.page.findByDataQa('labelled-value-decision-maker').text
   decisionStatus = () =>
     this.page.findByDataQa('decision-status').getAttribute('data-qa-status')
   readonly returnForEditBtn = this.page.findByDataQa('return-for-edit')

--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -227,7 +227,7 @@ export class UnitStaffAttendancesTable extends Element {
   }
 
   personCountSum(nth: number) {
-    return this.findAllByDataQa('person-count-sum').nth(nth).innerText
+    return this.findAllByDataQa('person-count-sum').nth(nth).text
   }
 
   #attendanceCell = (date: LocalDate, row: number) =>
@@ -251,7 +251,7 @@ export class UnitStaffAttendancesTable extends Element {
 
     if (name !== undefined) {
       await waitUntilEqual(
-        () => row.findByDataQa('staff-attendance-name').innerText,
+        () => row.findByDataQa('staff-attendance-name').text,
         name
       )
     }
@@ -265,14 +265,14 @@ export class UnitStaffAttendancesTable extends Element {
           () =>
             plannedAttendanceDay
               .findAllByDataQa('planned-attendance-start')
-              .nth(i).innerText,
+              .nth(i).text,
           arrival
         )
         await waitUntilEqual(
           () =>
             plannedAttendanceDay
               .findAllByDataQa('planned-attendance-end')
-              .nth(i).innerText,
+              .nth(i).text,
           departure
         )
       }
@@ -281,12 +281,11 @@ export class UnitStaffAttendancesTable extends Element {
       const attendanceDay = row.findAllByDataQa('attendance-day').nth(nth)
       for (const [i, [arrival, departure]] of attendances.entries()) {
         await waitUntilEqual(
-          () => attendanceDay.findAllByDataQa('arrival-time').nth(i).innerText,
+          () => attendanceDay.findAllByDataQa('arrival-time').nth(i).text,
           arrival
         )
         await waitUntilEqual(
-          () =>
-            attendanceDay.findAllByDataQa('departure-time').nth(i).innerText,
+          () => attendanceDay.findAllByDataQa('departure-time').nth(i).text,
           departure
         )
       }
@@ -336,16 +335,16 @@ export class UnitChildReservationsTable extends Element {
   getReservation(date: LocalDate, row: number): Promise<[string, string]> {
     const cell = this.#reservationCell(date, row)
     return Promise.all([
-      cell.findByDataQa('reservation-start').innerText,
-      cell.findByDataQa('reservation-end').innerText
+      cell.findByDataQa('reservation-start').text,
+      cell.findByDataQa('reservation-end').text
     ])
   }
 
   getAttendance(date: LocalDate, row: number): Promise<[string, string]> {
     const cell = this.#attendanceCell(date, row)
     return Promise.all([
-      cell.findByDataQa('attendance-start').innerText,
-      cell.findByDataQa('attendance-end').innerText
+      cell.findByDataQa('attendance-start').text,
+      cell.findByDataQa('attendance-end').text
     ])
   }
 
@@ -469,25 +468,13 @@ export class UnitOccupanciesSection extends Element {
   }
 
   async assertConfirmed(minimum: string, maximum: string) {
-    await waitUntilEqual(
-      () => this.#elem('minimum', 'confirmed').innerText,
-      minimum
-    )
-    await waitUntilEqual(
-      () => this.#elem('maximum', 'confirmed').innerText,
-      maximum
-    )
+    await waitUntilEqual(() => this.#elem('minimum', 'confirmed').text, minimum)
+    await waitUntilEqual(() => this.#elem('maximum', 'confirmed').text, maximum)
   }
 
   async assertPlanned(minimum: string, maximum: string) {
-    await waitUntilEqual(
-      () => this.#elem('minimum', 'planned').innerText,
-      minimum
-    )
-    await waitUntilEqual(
-      () => this.#elem('maximum', 'planned').innerText,
-      maximum
-    )
+    await waitUntilEqual(() => this.#elem('minimum', 'planned').text, minimum)
+    await waitUntilEqual(() => this.#elem('maximum', 'planned').text, maximum)
   }
 }
 
@@ -538,24 +525,23 @@ export class StaffAttendanceDetailsModal extends Element {
 
   async summary() {
     return {
-      plan: await this.findByDataQa('staff-attendance-summary-plan').innerText,
+      plan: await this.findByDataQa('staff-attendance-summary-plan').text,
       realized: await this.findByDataQa('staff-attendance-summary-realized')
-        .innerText,
-      hours: await this.findByDataQa('staff-attendance-summary-hours').innerText
+        .text,
+      hours: await this.findByDataQa('staff-attendance-summary-hours').text
     }
   }
 
   gapWarning(index: number) {
-    return this.findByDataQa(`attendance-gap-warning-${index}`).innerText
+    return this.findByDataQa(`attendance-gap-warning-${index}`).text
   }
 
   arrivalTimeInfo(index: number) {
-    return this.findAllByDataQa('arrival-time-input-info').nth(index).innerText
+    return this.findAllByDataQa('arrival-time-input-info').nth(index).text
   }
 
   departureTimeInfo(index: number) {
-    return this.findAllByDataQa('departure-time-input-info').nth(index)
-      .innerText
+    return this.findAllByDataQa('departure-time-input-info').nth(index).text
   }
 
   async assertDepartureTimeInfoHidden(index: number) {

--- a/frontend/src/e2e-test/pages/employee/units/unit-diary-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-diary-page.ts
@@ -36,7 +36,7 @@ export class UnitDiaryPage {
   #addAbsencesButton = this.page.find('[data-qa="add-absences-button"]')
 
   async assertUnitName(expectedName: string) {
-    await waitUntilEqual(() => this.#unitName.innerText, expectedName)
+    await waitUntilEqual(() => this.#unitName.text, expectedName)
   }
 
   async assertSelectedGroup(groupId: UUID) {
@@ -129,9 +129,7 @@ export class AbsenceCell extends Element {
 
   async hoverAndGetTooltip(): Promise<string> {
     await this.cell.hover()
-    return (
-      (await this.cell.findByDataQa('absence-cell-tooltip').textContent) || ''
-    )
+    return (await this.cell.findByDataQa('absence-cell-tooltip').text) || ''
   }
 }
 

--- a/frontend/src/e2e-test/pages/employee/units/unit-diary-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-diary-page.ts
@@ -99,7 +99,7 @@ export class UnitDiaryPage {
 
   async assertStaffAttendance(n: number, staffCount: number) {
     const input = new TextInput(this.#staffAttendanceCells.nth(n).find('input'))
-    await waitUntilEqual(() => input.inputValue, staffCount.toString())
+    await input.assertValueEquals(staffCount.toString())
   }
 }
 

--- a/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
@@ -54,9 +54,7 @@ export class UnitGroupsPage {
 
   async assertChildCapacityFactor(childId: string, factor: string) {
     await waitUntilEqual(
-      () =>
-        this.page.find(`[data-qa="child-capacity-factor-${childId}"]`)
-          .innerText,
+      () => this.page.find(`[data-qa="child-capacity-factor-${childId}"]`).text,
       factor
     )
   }
@@ -171,23 +169,20 @@ export class MissingPlacementRow extends Element {
     groupMissingDuration?: string
   }) {
     if (fields.childName !== undefined) {
-      await waitUntilEqual(() => this.#childName.innerText, fields.childName)
+      await waitUntilEqual(() => this.#childName.text, fields.childName)
     }
     if (fields.dateOfBirth !== undefined) {
-      await waitUntilEqual(
-        () => this.#dateOfBirth.innerText,
-        fields.dateOfBirth
-      )
+      await waitUntilEqual(() => this.#dateOfBirth.text, fields.dateOfBirth)
     }
     if (fields.placementDuration !== undefined) {
       await waitUntilEqual(
-        () => this.#placementDuration.innerText,
+        () => this.#placementDuration.text,
         fields.placementDuration
       )
     }
     if (fields.groupMissingDuration !== undefined) {
       await waitUntilEqual(
-        () => this.#groupMissingDuration.innerText,
+        () => this.#groupMissingDuration.text,
         fields.groupMissingDuration
       )
     }
@@ -223,18 +218,15 @@ export class GroupCollapsible extends Element {
   #noChildren = this.find('[data-qa="no-children-placeholder"]')
 
   async assertGroupName(expectedName: string) {
-    await waitUntilEqual(() => this.#groupName.innerText, expectedName)
+    await waitUntilEqual(() => this.#groupName.text, expectedName)
   }
 
   async assertGroupStartDate(expectedStartDate: string) {
-    await waitUntilEqual(
-      () => this.#groupStartDate.innerText,
-      expectedStartDate
-    )
+    await waitUntilEqual(() => this.#groupStartDate.text, expectedStartDate)
   }
 
   async assertGroupEndDate(expectedEndDate: string) {
-    await waitUntilEqual(() => this.#groupEndDate.innerText, expectedEndDate)
+    await waitUntilEqual(() => this.#groupEndDate.text, expectedEndDate)
   }
 
   childRow(childId: string) {
@@ -313,11 +305,11 @@ export class GroupCollapsibleChildRow extends Element {
     placementDuration?: string
   }) {
     if (fields.childName !== undefined) {
-      await waitUntilEqual(() => this.#childName.innerText, fields.childName)
+      await waitUntilEqual(() => this.#childName.text, fields.childName)
     }
     if (fields.placementDuration !== undefined) {
       await waitUntilEqual(
-        () => this.#placementDuration.innerText,
+        () => this.#placementDuration.text,
         fields.placementDuration
       )
     }
@@ -333,7 +325,7 @@ export class GroupCollapsibleChildRow extends Element {
   async assertDailyNoteContainsText(expectedText: string) {
     await this.#dailyNoteIcon.hover()
     await waitUntilTrue(async () =>
-      ((await this.#dailyNoteTooltip.textContent) ?? '').includes(expectedText)
+      ((await this.#dailyNoteTooltip.text) ?? '').includes(expectedText)
     )
   }
 
@@ -402,7 +394,7 @@ export class ChildDailyNoteModal extends Modal {
   #groupNoteInput = this.find('[data-qa="sticky-note"]')
 
   async assertGroupNote(expectedText: string) {
-    await waitUntilEqual(() => this.#groupNote.textContent, expectedText)
+    await waitUntilEqual(() => this.#groupNote.text, expectedText)
   }
 
   async assertNoGroupNote() {

--- a/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
@@ -342,51 +342,20 @@ export class GroupCollapsibleChildRow extends Element {
 }
 
 export class ChildDailyNoteModal extends Modal {
-  #noteInput = new TextInput(this.find('[data-qa="note-input"]'))
-  #sleepingHoursInput = new TextInput(
+  noteInput = new TextInput(this.find('[data-qa="note-input"]'))
+  sleepingHoursInput = new TextInput(
     this.find('[data-qa="sleeping-hours-input"]')
   )
-  #sleepingMinutesInput = new TextInput(
+  sleepingMinutesInput = new TextInput(
     this.find('[data-qa="sleeping-minutes-input"]')
   )
-  #reminderNoteInput = new TextInput(
+  reminderNoteInput = new TextInput(
     this.find('[data-qa="reminder-note-input"]')
   )
-  #submit = this.find('[data-qa="btn-submit"]')
+  submitButton = this.find('[data-qa="btn-submit"]')
 
   async openTab(tab: 'child' | 'sticky' | 'group') {
     await this.find(`[data-qa="tab-${tab}"]`).click()
-  }
-
-  // Child
-  async fillNote(text: string) {
-    await this.#noteInput.fill(text)
-  }
-
-  async assertNote(expectedText: string) {
-    await waitUntilEqual(() => this.#noteInput.inputValue, expectedText)
-  }
-
-  async assertSleepingHours(expectedText: string) {
-    await waitUntilEqual(
-      () => this.#sleepingHoursInput.inputValue,
-      expectedText
-    )
-  }
-
-  async assertSleepingMinutes(expectedText: string) {
-    await waitUntilEqual(
-      () => this.#sleepingMinutesInput.inputValue,
-      expectedText
-    )
-  }
-
-  async assertReminderNote(expectedText: string) {
-    await waitUntilEqual(() => this.#reminderNoteInput.inputValue, expectedText)
-  }
-
-  async submit() {
-    await this.#submit.click()
   }
 
   // Group

--- a/frontend/src/e2e-test/pages/employee/units/unit.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit.ts
@@ -90,11 +90,11 @@ export class UnitInfoPage {
   }
 
   async assertUnitName(expectedName: string) {
-    await waitUntilEqual(() => this.#unitName.innerText, expectedName)
+    await waitUntilEqual(() => this.#unitName.text, expectedName)
   }
 
   async assertVisitingAddress(expectedAddress: string) {
-    await waitUntilEqual(() => this.#visitingAddress.innerText, expectedAddress)
+    await waitUntilEqual(() => this.#visitingAddress.text, expectedAddress)
   }
 
   supervisorAcl = new AclSection(
@@ -137,7 +137,7 @@ export class UnitDetailsPage {
   }
 
   async assertUnitName(expectedName: string) {
-    await waitUntilEqual(() => this.#unitName.innerText, expectedName)
+    await waitUntilEqual(() => this.#unitName.text, expectedName)
   }
 
   readonly #unitManagerName = this.page.find('[data-qa="unit-manager-name"]')
@@ -145,9 +145,9 @@ export class UnitDetailsPage {
   readonly #unitManagerEmail = this.page.find('[data-qa="unit-manager-email"]')
 
   async assertManagerData(name: string, phone: string, email: string) {
-    await waitUntilEqual(() => this.#unitManagerName.innerText, name)
-    await waitUntilEqual(() => this.#unitManagerPhone.innerText, phone)
-    await waitUntilEqual(() => this.#unitManagerEmail.innerText, email)
+    await waitUntilEqual(() => this.#unitManagerName.text, name)
+    await waitUntilEqual(() => this.#unitManagerPhone.text, phone)
+    await waitUntilEqual(() => this.#unitManagerEmail.text, email)
   }
 
   async edit() {
@@ -362,14 +362,8 @@ class AclSection extends Element {
 
   async assertRowFields(fields: { id: UUID; name: string; email: string }) {
     const row = this.#tableRow(fields.id)
-    await waitUntilEqual(
-      () => row.find('[data-qa="name"]').innerText,
-      fields.name
-    )
-    await waitUntilEqual(
-      () => row.find('[data-qa="email"]').innerText,
-      fields.email
-    )
+    await waitUntilEqual(() => row.find('[data-qa="name"]').text, fields.name)
+    await waitUntilEqual(() => row.find('[data-qa="email"]').text, fields.email)
   }
 
   async assertRows(rows: { id: UUID; name: string; email: string }[]) {
@@ -389,14 +383,8 @@ class StaffAclSection extends AclSection {
     groups: string[]
   }) {
     const row = this.#tableRow(fields.id)
-    await waitUntilEqual(
-      () => row.find('[data-qa="name"]').innerText,
-      fields.name
-    )
-    await waitUntilEqual(
-      () => row.find('[data-qa="email"]').innerText,
-      fields.email
-    )
+    await waitUntilEqual(() => row.find('[data-qa="name"]').text, fields.name)
+    await waitUntilEqual(() => row.find('[data-qa="email"]').text, fields.email)
     await waitUntilEqual(
       () => row.find('[data-qa="groups"] > div').findAll('div').allInnerTexts(),
       fields.groups
@@ -424,7 +412,7 @@ class MobileDevicesSection extends Element {
 
   async assertDeviceExists(deviceName: string) {
     await waitUntilEqual(
-      () => this.#rows.find('[data-qa="name"]').innerText,
+      () => this.#rows.find('[data-qa="name"]').text,
       deviceName
     )
   }
@@ -436,8 +424,7 @@ class MobileDevicesSection extends Element {
       this.page.find('[data-qa="mobile-pairing-modal-phase-1"]')
     )
 
-    const challengeKey = await phase1.find('[data-qa="challenge-key"]')
-      .innerText
+    const challengeKey = await phase1.find('[data-qa="challenge-key"]').text
     const { responseKey } = await postPairingChallenge(challengeKey)
     if (!responseKey) {
       throw new Error(
@@ -518,10 +505,7 @@ class WaitingConfirmationSection extends Element {
   )
 
   async assertNotificationCounter(value: number) {
-    await waitUntilEqual(
-      () => this.#notificationCounter.innerText,
-      value.toString()
-    )
+    await waitUntilEqual(() => this.#notificationCounter.text, value.toString())
   }
 
   async assertRowCount(count: number) {

--- a/frontend/src/e2e-test/pages/employee/units/units.ts
+++ b/frontend/src/e2e-test/pages/employee/units/units.ts
@@ -74,11 +74,11 @@ export class UnitRow extends Element {
 
   async assertFields(fields: { name?: string; visitingAddress?: string }) {
     if (fields.name !== undefined) {
-      await waitUntilEqual(() => this.#name.innerText, fields.name)
+      await waitUntilEqual(() => this.#name.text, fields.name)
     }
     if (fields.visitingAddress !== undefined) {
       await waitUntilEqual(
-        () => this.#visitingAddress.innerText,
+        () => this.#visitingAddress.text,
         fields.visitingAddress
       )
     }

--- a/frontend/src/e2e-test/pages/employee/vasu/pageSections.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/pageSections.ts
@@ -11,25 +11,25 @@ class SimpleTextAreaSection extends Element {
 
 export class BasicInfoSection extends SimpleTextAreaSection {
   get childName() {
-    return this.findByDataQa('vasu-basic-info-child-name').innerText
+    return this.findByDataQa('vasu-basic-info-child-name').text
   }
 
   get childDateOfBirth() {
-    return this.findByDataQa('vasu-basic-info-child-dob').innerText
+    return this.findByDataQa('vasu-basic-info-child-dob').text
   }
 
   placement(nth: number) {
-    return this.findAllByDataQa('vasu-basic-info-placement').nth(nth).innerText
+    return this.findAllByDataQa('vasu-basic-info-placement').nth(nth).text
   }
 
   guardian(nth: number) {
-    return this.findAllByDataQa('vasu-basic-info-guardian').nth(nth).innerText
+    return this.findAllByDataQa('vasu-basic-info-guardian').nth(nth).text
   }
 
   additionalContactInfoInput = new TextInput(this.textareas.nth(0))
 
   get additionalContactInfo() {
-    return this.values.nth(0).innerText
+    return this.values.nth(0).text
   }
 }
 
@@ -68,7 +68,7 @@ export class AuthoringSection extends SimpleTextAreaSection {
   ).nth(1)
 
   get primaryValue() {
-    return this.#primaryValue.innerText
+    return this.#primaryValue.text
   }
 
   get otherFieldsCount() {
@@ -76,15 +76,15 @@ export class AuthoringSection extends SimpleTextAreaSection {
   }
 
   get otherValues() {
-    return this.#otherFieldsValues.innerText
+    return this.#otherFieldsValues.text
   }
 
   get childPOV() {
-    return this.values.nth(2).innerText
+    return this.values.nth(2).text
   }
 
   get guardianPOV() {
-    return this.values.nth(3).innerText
+    return this.values.nth(3).text
   }
 }
 
@@ -93,11 +93,11 @@ export class CooperationSection extends SimpleTextAreaSection {
   methodsOfCooperationInput = new TextInput(this.textareas.nth(1))
 
   get collaborators() {
-    return this.values.nth(0).innerText
+    return this.values.nth(0).text
   }
 
   get methodsOfCooperation() {
-    return this.values.nth(1).innerText
+    return this.values.nth(1).text
   }
 }
 
@@ -107,15 +107,15 @@ export class VasuGoalsSection extends SimpleTextAreaSection {
   otherObservationsInput = new TextInput(this.textareas.nth(2))
 
   get goalsRealization() {
-    return this.values.nth(0).innerText
+    return this.values.nth(0).text
   }
 
   get specialNeedsEstimation() {
-    return this.values.nth(1).innerText
+    return this.values.nth(1).text
   }
 
   get otherObservations() {
-    return this.values.nth(2).innerText
+    return this.values.nth(2).text
   }
 }
 
@@ -130,39 +130,39 @@ export class GoalsSection extends SimpleTextAreaSection {
   otherInput = new TextInput(this.textareas.nth(7))
 
   get childsStrengths() {
-    return this.values.nth(0).innerText
+    return this.values.nth(0).text
   }
 
   get languageViews() {
-    return this.values.nth(1).innerText
+    return this.values.nth(1).text
   }
 
   get pedagogicalSupport() {
-    return this.values.nth(2).innerText
+    return this.values.nth(2).text
   }
 
   get structuralSupport() {
-    return this.values.nth(3).innerText
+    return this.values.nth(3).text
   }
 
   get therapeuticSupport() {
-    return this.values.nth(4).innerText
+    return this.values.nth(4).text
   }
 
   get staffGoals() {
-    return this.values.nth(5).innerText
+    return this.values.nth(5).text
   }
 
   get actions() {
-    return this.values.nth(6).innerText
+    return this.values.nth(6).text
   }
 
   get supportLevel() {
-    return this.findByDataQa('value-or-no-record-5.6').innerText
+    return this.findByDataQa('value-or-no-record-5.6').text
   }
 
   get other() {
-    return this.values.nth(7).innerText
+    return this.values.nth(7).text
   }
 
   supportLevelOptions = (key: string) =>
@@ -181,7 +181,7 @@ export class OtherSection extends SimpleTextAreaSection {
   otherInput = new TextInput(this.textareas.nth(0))
 
   get other() {
-    return this.values.nth(0).innerText
+    return this.values.nth(0).text
   }
 }
 
@@ -189,7 +189,7 @@ export class OtherDocsAndPlansSection extends SimpleTextAreaSection {
   otherDocsInput = new TextInput(this.textareas.nth(0))
 
   get otherDocs() {
-    return this.values.nth(0).innerText
+    return this.values.nth(0).text
   }
 }
 
@@ -208,15 +208,15 @@ export class DiscussionSection extends SimpleTextAreaSection {
   collaborationAndOpinionInput = new TextInput(this.textareas.nth(1))
 
   get date() {
-    return this.values.nth(0).innerText
+    return this.values.nth(0).text
   }
 
   get present() {
-    return this.values.nth(1).innerText
+    return this.values.nth(1).text
   }
 
   get collaborationAndOpinion() {
-    return this.values.nth(2).innerText
+    return this.values.nth(2).text
   }
 }
 
@@ -224,6 +224,6 @@ export class EvaluationSection extends SimpleTextAreaSection {
   descriptionInput = new TextInput(this.textareas.nth(0))
 
   get description() {
-    return this.values.nth(0).innerText
+    return this.values.nth(0).text
   }
 }

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu-templates-list.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu-templates-list.ts
@@ -22,9 +22,7 @@ export class VasuTemplatesListPage {
 
   async assertTemplate(nth: number, expectedName: string) {
     await waitUntilEqual(
-      () =>
-        this.templateRows.nth(nth).find('[data-qa="template-name"]')
-          .textContent,
+      () => this.templateRows.nth(nth).find('[data-qa="template-name"]').text,
       expectedName
     )
   }

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
@@ -94,8 +94,7 @@ export class VasuEditPage extends VasuPageCommon {
         new TextInput(question.findByDataQa(`follow-up-${nth}-input`)),
       entryDateInput: (nth: number) =>
         new TextInput(question.findByDataQa(`follow-up-${nth}-date`)),
-      meta: (nth: number) =>
-        question.findByDataQa(`follow-up-${nth}-meta`).innerText
+      meta: (nth: number) => question.findByDataQa(`follow-up-${nth}-meta`).text
     }
   }
 
@@ -187,7 +186,7 @@ export class VasuPage extends VasuPageCommon {
   readonly #templateName = this.page.find('[data-qa="template-name"]')
   readonly #editButton = this.page.find('[data-qa="edit-button"]')
 
-  documentState = () => this.#vasuEventListDocState.innerText
+  documentState = () => this.#vasuEventListDocState.text
 
   // The (first) label for the state chip has no corresponding span, so the index is off by one.
   #valueForLabel = (label: string): Promise<string> =>
@@ -197,7 +196,7 @@ export class VasuPage extends VasuPageCommon {
         labels.reduce(
           async (acc, l, ix) =>
             l === label
-              ? await this.#vasuEventListValues.nth(ix - 1).innerText
+              ? await this.#vasuEventListValues.nth(ix - 1).text
               : acc,
           Promise.resolve('')
         )
@@ -210,7 +209,7 @@ export class VasuPage extends VasuPageCommon {
   closedDate = () => this.#valueForLabel('Päättynyt')
 
   async assertTemplateName(expected: string) {
-    await waitUntilEqual(() => this.#templateName.textContent, expected)
+    await waitUntilEqual(() => this.#templateName.text, expected)
   }
 
   async edit() {
@@ -222,7 +221,7 @@ export class VasuPage extends VasuPageCommon {
       .findAllByDataQa('vasu-followup-question')
       .nth(sectionNth)
       .findAllByDataQa('follow-up-entry')
-      .nth(entryNth).innerText
+      .nth(entryNth).text
   }
 }
 
@@ -237,7 +236,7 @@ export class VasuPreviewPage extends VasuPageCommon {
   readonly #confirmButton = this.page.findByDataQa('confirm-button')
 
   async assertTitleChildName(expectedName: string) {
-    await waitUntilEqual(() => this.#titleChildName.textContent, expectedName)
+    await waitUntilEqual(() => this.#titleChildName.text, expectedName)
   }
 
   async assertGivePermissionToShareSectionIsVisible() {
@@ -260,7 +259,7 @@ export class VasuPreviewPage extends VasuPageCommon {
   ) {
     await waitUntilTrue(async () =>
       (
-        await this.#multiselectAnswer(questionNumber).innerText
+        await this.#multiselectAnswer(questionNumber).text
       ).includes(expectedText)
     )
   }

--- a/frontend/src/e2e-test/pages/mobile/child-attendance-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/child-attendance-page.ts
@@ -78,7 +78,7 @@ export default class ChildAttendancePage {
   }
 
   async assertChildStatusLabelIsShown(expectedText: string) {
-    await waitUntilEqual(() => this.#childStatusLabel.innerText, expectedText)
+    await waitUntilEqual(() => this.#childStatusLabel.text, expectedText)
   }
 
   // time format: "09:46"

--- a/frontend/src/e2e-test/pages/mobile/child-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/child-page.ts
@@ -101,7 +101,7 @@ export default class MobileChildPage {
   }
 
   async assertSensitiveInfoIsShown(name: string) {
-    await waitUntilEqual(() => this.#sensitiveInfo.name.innerText, name)
+    await waitUntilEqual(() => this.#sensitiveInfo.name.text, name)
   }
 
   async assertSensitiveInfo(
@@ -118,33 +118,33 @@ export default class MobileChildPage {
     }>
   ) {
     await waitUntilEqual(
-      () => this.#sensitiveInfo.allergies.innerText,
+      () => this.#sensitiveInfo.allergies.text,
       additionalInfo.allergies
     )
     await waitUntilEqual(
-      () => this.#sensitiveInfo.diet.innerText,
+      () => this.#sensitiveInfo.diet.text,
       additionalInfo.diet
     )
     await waitUntilEqual(
-      () => this.#sensitiveInfo.medication.innerText,
+      () => this.#sensitiveInfo.medication.text,
       additionalInfo.medication
     )
 
     for (let i = 0; i < contacts.length; i++) {
       const contact = contacts[i]
       await waitUntilEqual(
-        () => this.#sensitiveInfo.contactName(i).innerText,
+        () => this.#sensitiveInfo.contactName(i).text,
         `${contact.firstName} ${contact.lastName}`
       )
       if (contact.phone) {
         await waitUntilEqual(
-          () => this.#sensitiveInfo.contactPhone(i).innerText,
+          () => this.#sensitiveInfo.contactPhone(i).text,
           contact.phone
         )
       }
       if (contact.email) {
         await waitUntilEqual(
-          () => this.#sensitiveInfo.contactEmail(i).innerText,
+          () => this.#sensitiveInfo.contactEmail(i).text,
           contact.email
         )
       }
@@ -153,11 +153,11 @@ export default class MobileChildPage {
     for (let i = 0; i < backupPickups.length; i++) {
       const backupPickup = backupPickups[i]
       await waitUntilEqual(
-        () => this.#sensitiveInfo.backupPickupName(i).innerText,
+        () => this.#sensitiveInfo.backupPickupName(i).text,
         backupPickup.name
       )
       await waitUntilEqual(
-        () => this.#sensitiveInfo.backupPickupPhone(i).innerText,
+        () => this.#sensitiveInfo.backupPickupPhone(i).text,
         backupPickup.phone
       )
     }

--- a/frontend/src/e2e-test/pages/mobile/list-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/list-page.ts
@@ -22,7 +22,7 @@ export default class MobileListPage {
 
   async readChildGroupName(childId: UUID) {
     const elem = this.page.find(`[data-qa="child-group-name-${childId}"]`)
-    return elem.innerText
+    return elem.text
   }
 
   async assertChildExists(childId: UUID) {
@@ -56,13 +56,11 @@ export default class MobileListPage {
     const tabToDataQa = (t: string) => `[data-qa="${t}-tab"] [data-qa="count"]`
 
     const counts: Promise<[string, number]>[] = tabs.map((tab) =>
-      this.page
-        .find(tabToDataQa(tab))
-        .innerText.then((val) => [tab, Number(val)])
+      this.page.find(tabToDataQa(tab)).text.then((val) => [tab, Number(val)])
     )
     const total: Promise<[string, number]> = this.page
       .find(`[data-qa="coming-tab"] [data-qa="total"]`)
-      .innerText.then((val) => ['total', Number(val)])
+      .text.then((val) => ['total', Number(val)])
 
     return Object.fromEntries(await Promise.all([...counts, total]))
   }

--- a/frontend/src/e2e-test/pages/mobile/messages.ts
+++ b/frontend/src/e2e-test/pages/mobile/messages.ts
@@ -12,7 +12,7 @@ export default class MobileMessagesPage {
 
   async getThreadTitle(index: number) {
     const titles = this.page.findAll('[data-qa="message-preview-title"]')
-    return titles.nth(index).innerText
+    return titles.nth(index).text
   }
 
   async messagesExist() {

--- a/frontend/src/e2e-test/pages/mobile/mobile-nav.ts
+++ b/frontend/src/e2e-test/pages/mobile/mobile-nav.ts
@@ -21,7 +21,7 @@ export default class MobileNav {
   readonly #staff = this.page.find('[data-qa="bottomnav-staff"]')
 
   get selectedGroupName() {
-    return this.#groupSelectorButton.innerText
+    return this.#groupSelectorButton.text
   }
 
   async selectGroup(id: UUID) {

--- a/frontend/src/e2e-test/pages/mobile/note-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/note-page.ts
@@ -72,7 +72,7 @@ export default class MobileNotePage {
 
   async assertStickyNote(expected: string, nth = 0) {
     await waitUntilEqual(
-      () => this.#stickyNote.note.nth(nth).find('p').textContent,
+      () => this.#stickyNote.note.nth(nth).find('p').text,
       expected
     )
   }
@@ -82,7 +82,7 @@ export default class MobileNotePage {
       this.#stickyNote.note
         .nth(nth)
         .find('[data-qa="sticky-note-expires"]')
-        .textContent.then((t) => !!t?.includes(date.format()))
+        .text.then((t) => !!t?.includes(date.format()))
     )
   }
 

--- a/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
@@ -24,6 +24,6 @@ export default class PinLoginPage {
   }
 
   async assertWrongPinError() {
-    await waitUntilEqual(() => this.#pinInfo.innerText, 'Väärä PIN-koodi')
+    await waitUntilEqual(() => this.#pinInfo.text, 'Väärä PIN-koodi')
   }
 }

--- a/frontend/src/e2e-test/pages/mobile/staff-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/staff-page.ts
@@ -30,11 +30,11 @@ export default class StaffPage {
   }
 
   get staffCount() {
-    return this.#staffCount.find('[data-qa="value"]').innerText
+    return this.#staffCount.find('[data-qa="value"]').text
   }
 
   get staffOtherCount() {
-    return this.#staffOtherCount.find('[data-qa="value"]').innerText
+    return this.#staffOtherCount.find('[data-qa="value"]').text
   }
 
   async incDecButtonsVisible(): Promise<boolean[]> {
@@ -86,11 +86,11 @@ export default class StaffPage {
   }
 
   get updated() {
-    return this.#updated.innerText
+    return this.#updated.text
   }
 
   get occupancy() {
-    return this.#occupancyRealized.innerText
+    return this.#occupancyRealized.text
   }
 }
 
@@ -152,7 +152,7 @@ export class StaffAttendancePage {
 
   async assertShiftTimeTextShown(expectedText: string) {
     await waitUntilEqual(
-      () => this.#staffMemberPage.shiftTimeText.textContent,
+      () => this.#staffMemberPage.shiftTimeText.text,
       expectedText
     )
   }
@@ -185,10 +185,7 @@ export class StaffAttendancePage {
   }
 
   async assertPresentStaffCount(expected: number) {
-    await waitUntilEqual(
-      () => this.#tabs.present.textContent,
-      `Läsnä(${expected})`
-    )
+    await waitUntilEqual(() => this.#tabs.present.text, `LÄSNÄ\n(${expected})`)
   }
 
   async openStaffPage(name: string) {
@@ -196,7 +193,7 @@ export class StaffAttendancePage {
   }
 
   async assertEmployeeStatus(expected: string) {
-    await waitUntilEqual(() => this.#anyMemberPage.status.textContent, expected)
+    await waitUntilEqual(() => this.#anyMemberPage.status.text, expected)
   }
 
   async selectTab(tab: 'present' | 'absent') {
@@ -209,14 +206,14 @@ export class StaffAttendancePage {
 
   async assertEmployeeAttendanceTimes(index: number, expected: string) {
     await waitUntilEqual(
-      () => this.#staffMemberPage.attendanceTimes.nth(index).textContent,
+      () => this.#staffMemberPage.attendanceTimes.nth(index).text,
       expected
     )
   }
 
   async assertExternalStaffArrivalTime(expected: string) {
     await waitUntilEqual(
-      () => this.#externalMemberPage.arrivalTime.textContent,
+      () => this.#externalMemberPage.arrivalTime.text,
       expected
     )
   }
@@ -306,14 +303,14 @@ export class StaffAttendancePage {
 
   async assertArrivalTimeInputInfo(expected: string) {
     await waitUntilEqual(
-      () => this.#staffArrivalPage.timeInputWarningText.textContent,
+      () => this.#staffArrivalPage.timeInputWarningText.text,
       expected
     )
   }
 
   async assertDepartureTimeInputInfo(expected: string) {
     await waitUntilEqual(
-      () => this.#staffDeparturePage.timeInputWarningText.textContent,
+      () => this.#staffDeparturePage.timeInputWarningText.text,
       expected
     )
   }

--- a/frontend/src/e2e-test/pages/mobile/thread-view.ts
+++ b/frontend/src/e2e-test/pages/mobile/thread-view.ts
@@ -24,11 +24,11 @@ export default class ThreadViewPage {
   }
 
   async getMessageContent(index: number): Promise<string> {
-    return this.#singleMessageContents.nth(index).innerText
+    return this.#singleMessageContents.nth(index).text
   }
 
   async getMessageSender(index: number): Promise<string> {
-    return this.#singleMessageSenderName.nth(index).innerText
+    return this.#singleMessageSenderName.nth(index).text
   }
 
   async replyThread(content: string) {

--- a/frontend/src/e2e-test/pages/mobile/top-nav.ts
+++ b/frontend/src/e2e-test/pages/mobile/top-nav.ts
@@ -18,10 +18,10 @@ export default class TopNav {
   }
 
   getUserInitials(): Promise<string> {
-    return this.#userMenu.innerText
+    return this.#userMenu.text
   }
 
   getFullName(): Promise<string> {
-    return this.#userMenu.find('[data-qa="full-name"]').innerText
+    return this.#userMenu.find('[data-qa="full-name"]').text
   }
 }

--- a/frontend/src/e2e-test/pages/mobile/unit-list-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/unit-list-page.ts
@@ -14,9 +14,6 @@ export default class UnitListPage {
     const staffCount = this.page
       .findByDataQa(`unit-${unitId}`)
       .findByDataQa('staff-count')
-    await waitUntilEqual(
-      () => staffCount.textContent,
-      `${present}/${allocated}`
-    )
+    await waitUntilEqual(() => staffCount.text, `${present}/${allocated}`)
   }
 }

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
@@ -242,7 +242,7 @@ describe('Citizen assistance decisions', () => {
       {
         assistanceLevel: 'Tehostettu tuki',
         selectedUnit: fixtures.daycareFixture.name,
-        validityPeriod: '10.02.2022 - ',
+        validityPeriod: '10.02.2022 -',
         decisionMade: '17.01.2021',
         status: 'Hylätty'
       }

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
@@ -363,8 +363,7 @@ describe('Citizen assistance decisions', () => {
     await assistanceNeedDecisionPage.assertStructuralMotivationOption(
       'smallerGroup'
     )
-    await waitUntilEqual(
-      () => assistanceNeedDecisionPage.structuralMotivationDescription,
+    await assistanceNeedDecisionPage.structuralMotivationDescription.assertTextEquals(
       'Structural motivation description text'
     )
     await assistanceNeedDecisionPage.assertServiceOption(
@@ -379,8 +378,7 @@ describe('Citizen assistance decisions', () => {
       () => assistanceNeedDecisionPage.guardiansHeardOn,
       '05.04.2020'
     )
-    await waitUntilEqual(
-      () => assistanceNeedDecisionPage.otherRepresentativeDetails,
+    await assistanceNeedDecisionPage.otherRepresentativeDetails.assertTextEquals(
       'John Doe, 01020304050, via phone'
     )
     await waitUntilEqual(

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
@@ -28,9 +28,9 @@ async function assertIncomeStatementCreated(
   startDate = LocalDate.todayInSystemTz().format()
 ) {
   await waitUntilEqual(async () => await incomeStatementsPage.rows.count(), 1)
-  await waitUntilTrue(async () =>
-    (await incomeStatementsPage.rows.only().text).includes(startDate)
-  )
+  await incomeStatementsPage.rows
+    .only()
+    .assertText((text) => text.includes(startDate))
 }
 
 const assertRequiredAttachment = async (attachment: string, present = true) =>

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
@@ -29,18 +29,18 @@ async function assertIncomeStatementCreated(
 ) {
   await waitUntilEqual(async () => await incomeStatementsPage.rows.count(), 1)
   await waitUntilTrue(async () =>
-    (await incomeStatementsPage.rows.elem().innerText).includes(startDate)
+    (await incomeStatementsPage.rows.only().text).includes(startDate)
   )
 }
 
 const assertRequiredAttachment = async (attachment: string, present = true) =>
   waitUntilTrue(async () =>
     present
-      ? (await incomeStatementsPage.requiredAttachments.innerText).includes(
+      ? (await incomeStatementsPage.requiredAttachments.text).includes(
           attachment
         )
       : !(await incomeStatementsPage.requiredAttachments.visible) ||
-        !(await incomeStatementsPage.requiredAttachments.innerText).includes(
+        !(await incomeStatementsPage.requiredAttachments.text).includes(
           attachment
         )
   )

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -296,8 +296,10 @@ describe.each(e)('Citizen attendance reservations (%s)', (env) => {
     const dayView = await calendarPage.openDayView(reservationDay)
     const absencesModal = await dayView.createAbsence()
 
-    await absencesModal.assertStartDate(reservationDay.format())
-    await absencesModal.assertEndDate(reservationDay.format())
+    await absencesModal.startDateInput.assertValueEquals(
+      reservationDay.format()
+    )
+    await absencesModal.endDateInput.assertValueEquals(reservationDay.format())
   })
 
   test('Children are grouped correctly in calendar', async () => {

--- a/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
@@ -132,13 +132,9 @@ test('Foster parent can create a daycare application and accept a daycare decisi
   const { endedRelationshipPage, endedRelationshipHeader } =
     await openEndedRelationshipPage()
   await endedRelationshipHeader.selectTab('applications')
-  await waitUntilEqual(
-    () =>
-      endedRelationshipPage
-        .findByDataQa('applications-list')
-        .getAttribute('data-isloading'),
-    'false'
-  )
+  await endedRelationshipPage
+    .findByDataQa('applications-list')
+    .assertAttributeEquals('data-isloading', 'false')
   await endedRelationshipPage
     .findByDataQa(`child-${fosterChild.id}`)
     .waitUntilHidden()
@@ -208,13 +204,9 @@ test('Foster parent can create a daycare application and accept a daycare decisi
   const { endedRelationshipPage, endedRelationshipHeader } =
     await openEndedRelationshipPage()
   await endedRelationshipHeader.selectTab('applications')
-  await waitUntilEqual(
-    () =>
-      endedRelationshipPage
-        .findByDataQa('applications-list')
-        .getAttribute('data-isloading'),
-    'false'
-  )
+  await endedRelationshipPage
+    .findByDataQa('applications-list')
+    .assertAttributeEquals('data-isloading', 'false')
   await endedRelationshipPage
     .findByDataQa(`child-${fosterChild.id}`)
     .waitUntilHidden()

--- a/frontend/src/e2e-test/specs/4_finance/finance-basics.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/finance-basics.spec.ts
@@ -90,7 +90,7 @@ describe('Finance basics', () => {
     await financeBasicsPage.feesSection.editor.fillInThresholds(data)
     await financeBasicsPage.feesSection.editor.assertSaveIsDisabled()
     await waitUntilEqual(
-      () => financeBasicsPage.feesSection.editor.maxFeeError(2).innerText,
+      () => financeBasicsPage.feesSection.editor.maxFeeError(2).text,
       'Enimmäismaksu ei täsmää (200 €)'
     )
   })

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
@@ -280,9 +280,9 @@ describe('Assistance Need Decisions - Preview page', () => {
 
   test('Decision can be sent to the decision maker', async () => {
     await assistanceNeedDecisionPreviewPage.sendDecisionButton.click()
-    expect(
-      await assistanceNeedDecisionPreviewPage.decisionSentAt.innerText
-    ).toEqual(LocalDate.todayInSystemTz().format())
+    expect(await assistanceNeedDecisionPreviewPage.decisionSentAt.text).toEqual(
+      LocalDate.todayInSystemTz().format()
+    )
     expect(
       await assistanceNeedDecisionPreviewPage.sendDecisionButton.getAttribute(
         'disabled'

--- a/frontend/src/e2e-test/specs/5_employee/child-information.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information.spec.ts
@@ -451,7 +451,7 @@ describe('Child information - consent', () => {
     await section.evakaProfilePicYes.check()
     await section.save()
     await waitUntilEqual(
-      () => section.evakaProfilePicModifiedBy.innerText,
+      () => section.evakaProfilePicModifiedBy.text,
       `Merkintä: ${mockedDate.format()} ${admin.firstName} ${admin.lastName}`
     )
     await page.reload()
@@ -459,7 +459,7 @@ describe('Child information - consent', () => {
     await section.evakaProfilePicYes.waitUntilChecked(true)
     await section.evakaProfilePicNo.waitUntilChecked(false)
     await waitUntilEqual(
-      () => section.evakaProfilePicModifiedBy.innerText,
+      () => section.evakaProfilePicModifiedBy.text,
       `Merkintä: ${mockedDate.format()} ${admin.firstName} ${admin.lastName}`
     )
   })
@@ -468,7 +468,7 @@ describe('Child information - consent', () => {
     await section.evakaProfilePicNo.check()
     await section.save()
     await waitUntilEqual(
-      () => section.evakaProfilePicModifiedBy.innerText,
+      () => section.evakaProfilePicModifiedBy.text,
       `Merkintä: ${mockedDate.format()} ${admin.firstName} ${admin.lastName}`
     )
     await page.reload()
@@ -476,7 +476,7 @@ describe('Child information - consent', () => {
     await section.evakaProfilePicYes.waitUntilChecked(false)
     await section.evakaProfilePicNo.waitUntilChecked(true)
     await waitUntilEqual(
-      () => section.evakaProfilePicModifiedBy.innerText,
+      () => section.evakaProfilePicModifiedBy.text,
       `Merkintä: ${mockedDate.format()} ${admin.firstName} ${admin.lastName}`
     )
   })
@@ -485,7 +485,7 @@ describe('Child information - consent', () => {
     await section.evakaProfilePicNo.check()
     await section.save()
     await waitUntilEqual(
-      () => section.evakaProfilePicModifiedBy.innerText,
+      () => section.evakaProfilePicModifiedBy.text,
       `Merkintä: ${mockedDate.format()} ${admin.firstName} ${admin.lastName}`
     )
     await section.evakaProfilePicClear.click()

--- a/frontend/src/e2e-test/specs/5_employee/employee-dailynote.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/employee-dailynote.spec.ts
@@ -100,13 +100,15 @@ describe('Mobile employee daily notes', () => {
     await childRow.assertDailyNoteContainsText(daycareDailyNote.note)
 
     const noteModal = await childRow.openDailyNoteModal()
-    await noteModal.assertNote(daycareDailyNote.note)
-    await noteModal.assertSleepingHours(hours)
-    await noteModal.assertSleepingMinutes(minutes)
-    await noteModal.assertReminderNote(daycareDailyNote.reminderNote)
+    await noteModal.noteInput.assertValueEquals(daycareDailyNote.note)
+    await noteModal.sleepingHoursInput.assertValueEquals(hours)
+    await noteModal.sleepingMinutesInput.assertValueEquals(minutes)
+    await noteModal.reminderNoteInput.assertValueEquals(
+      daycareDailyNote.reminderNote
+    )
 
-    await noteModal.fillNote('aardvark')
-    await noteModal.submit()
+    await noteModal.noteInput.fill('aardvark')
+    await noteModal.submitButton.click()
 
     await childRow.assertDailyNoteContainsText('aardvark')
   })

--- a/frontend/src/e2e-test/specs/5_employee/employee-pin.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/employee-pin.spec.ts
@@ -36,7 +36,7 @@ describe('Employees PIN', () => {
   test('shows a warning if PIN is too easy, and warning disappears once PIN is valid', async () => {
     await pinPage.pinInput.fill('1111')
     await waitUntilEqual(
-      () => pinPage.inputInfo.innerText,
+      () => pinPage.inputInfo.text,
       'Liian helppo PIN-koodi tai PIN-koodi sisältää kirjaimia'
     )
 

--- a/frontend/src/e2e-test/specs/5_employee/preferred-first-name.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/preferred-first-name.spec.ts
@@ -51,7 +51,7 @@ describe('Employee preferred first name', () => {
     await employeePreferredFirstNamePage.preferredFirstName('Teppo')
     await employeePreferredFirstNamePage.confirm()
     await waitUntilEqual(
-      () => page.findByDataQa('username').textContent,
+      () => page.findByDataQa('username').text,
       'Teppo Sorsa'
     )
 

--- a/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
@@ -140,7 +140,7 @@ describe('Calendar events', () => {
         calendarPage.calendarEventsSection.getEventOfDay(
           mockedToday.addDays(1),
           0
-        ).innerText,
+        ).text,
       'Testailijat: Test event (G)'
     )
   })
@@ -164,14 +164,11 @@ describe('Calendar events', () => {
     await creationModal.submit()
 
     await waitUntilEqual(
-      () =>
-        calendarPage.calendarEventsSection.getEventOfDay(startDate, 0)
-          .innerText,
+      () => calendarPage.calendarEventsSection.getEventOfDay(startDate, 0).text,
       'Osa ryhmästä: Test event (P)'
     )
     await waitUntilEqual(
-      () =>
-        calendarPage.calendarEventsSection.getEventOfDay(endDate, 0).innerText,
+      () => calendarPage.calendarEventsSection.getEventOfDay(endDate, 0).text,
       'Osa ryhmästä: Test event (P)'
     )
 
@@ -188,14 +185,11 @@ describe('Calendar events', () => {
     await editModal.submit()
 
     await waitUntilEqual(
-      () =>
-        calendarPage.calendarEventsSection.getEventOfDay(startDate, 0)
-          .innerText,
+      () => calendarPage.calendarEventsSection.getEventOfDay(startDate, 0).text,
       'Osa ryhmästä: Edited event title'
     )
     await waitUntilEqual(
-      () =>
-        calendarPage.calendarEventsSection.getEventOfDay(endDate, 0).innerText,
+      () => calendarPage.calendarEventsSection.getEventOfDay(endDate, 0).text,
       'Osa ryhmästä: Edited event title'
     )
 

--- a/frontend/src/e2e-test/specs/5_employee/vasu.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/vasu.spec.ts
@@ -145,7 +145,7 @@ describe('Child Information - Vasu language', () => {
   test('Child placed in a Swedish unit can only use Swedish templates', async () => {
     await section.addNew()
     await waitUntilEqual(
-      () => page.findAllByDataQa('vasu-state-chip').nth(1).textContent,
+      () => page.findAllByDataQa('vasu-state-chip').nth(1).text,
       'Utkast'
     )
   })
@@ -425,11 +425,11 @@ describe('Vasu document page', () => {
       await vasuEditPage.waitUntilSaved()
       const vasuPage = await openDocument()
       await waitUntilEqual(
-        () => vasuPage.infoSharedToSection.recipients.innerText,
+        () => vasuPage.infoSharedToSection.recipients.text,
         'Neuvolaan, Lasten terapiapalveluihin'
       )
       await waitUntilEqual(
-        () => vasuPage.infoSharedToSection.other.innerText,
+        () => vasuPage.infoSharedToSection.other.text,
         'Police'
       )
     })

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -213,7 +213,7 @@ describe('Sending and receiving messages', () => {
 
         await messagesPage.assertMessageIsSentForParticipants(
           0,
-          `${enduserChildFixtureKaarina.lastName} ${enduserChildFixtureKaarina.firstName} `
+          `${enduserChildFixtureKaarina.lastName} ${enduserChildFixtureKaarina.firstName}`
         )
 
         await openCitizen(mockedDateAt11)

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -197,18 +197,13 @@ export class Element {
       .then((value) => (value ? new BoundingBox(value) : null))
   }
 
-  get innerText(): Promise<string> {
+  // Visible text content
+  get text(): Promise<string> {
     return this.locator.innerText()
   }
 
-  get textContent(): Promise<string | null> {
-    return this.locator.textContent()
-  }
-
-  get textContentAsFloat(): Promise<number | null> {
-    return this.locator
-      .textContent()
-      .then((str) => (str ? parseFloat(str) : null))
+  get textAsFloat(): Promise<number | null> {
+    return this.text.then((str) => (str ? parseFloat(str) : null))
   }
 
   get visible(): Promise<boolean> {

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -238,6 +238,13 @@ export class Element {
     return this.locator.getAttribute(name)
   }
 
+  async assertAttributeEquals(
+    name: string,
+    value: string | null
+  ): Promise<void> {
+    await waitUntilEqual(() => this.getAttribute(name), value)
+  }
+
   async hasAttribute(name: string): Promise<boolean> {
     return (await this.getAttribute(name)) !== null
   }

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -274,6 +274,10 @@ export class TextInput extends Element {
   get inputValue(): Promise<string> {
     return this.locator.inputValue()
   }
+
+  async assertValueEquals(expectedValue: string): Promise<void> {
+    await waitUntilEqual(() => this.inputValue, expectedValue)
+  }
 }
 
 export class DatePicker extends Element {

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -206,8 +206,12 @@ export class Element {
     return this.text.then((str) => (str ? parseFloat(str) : null))
   }
 
-  async assertTextEquals(content: string): Promise<void> {
-    await waitUntilEqual(() => this.text, content)
+  async assertText(assertion: (text: string) => boolean): Promise<void> {
+    await waitUntilTrue(async () => assertion(await this.text))
+  }
+
+  async assertTextEquals(expected: string): Promise<void> {
+    await this.assertText((text) => text === expected)
   }
 
   get visible(): Promise<boolean> {

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -126,7 +126,7 @@ export class ElementCollection {
     return this.locator.evaluateAll(fn)
   }
 
-  elem() {
+  only() {
     return new Element(this.locator)
   }
 
@@ -204,6 +204,10 @@ export class Element {
 
   get textAsFloat(): Promise<number | null> {
     return this.text.then((str) => (str ? parseFloat(str) : null))
+  }
+
+  async assertTextEquals(content: string): Promise<void> {
+    await waitUntilEqual(() => this.text, content)
   }
 
   get visible(): Promise<boolean> {


### PR DESCRIPTION
#### Summary

Drop `textContent`, use `innerText` instead. It's counterproductive to have two ways to do almost the same thing, and `innerText` is more useful for E2E purposes, because it returns what the user actually sees.

Add `Element.assertContentEquals`, `Element.assertAttribute` and `TextInput.assertValue` helpers and use them in some places.

Also rename `ElementCollection.elem` to `only`, to better describe what it does: focuses on the only element of a collection.