### PR TITLE
Use E2E helpers more

### DIFF
--- a/frontend/src/e2e-test/pages/employee/IncomeStatementPage.ts
+++ b/frontend/src/e2e-test/pages/employee/IncomeStatementPage.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual } from '../../utils'
-import { Page, Checkbox, TextInput } from '../../utils/page'
+import { Checkbox, Page, TextInput } from '../../utils/page'
 
 export class IncomeStatementPage {
   constructor(private readonly page: Page) {}
@@ -22,7 +21,7 @@ export class IncomeStatementPage {
     expectedOtherInfo: string,
     expectedAttachmentsCount: number
   ) {
-    await waitUntilEqual(() => this.#childOtherInfo.text, expectedOtherInfo)
+    await this.#childOtherInfo.assertTextEquals(expectedOtherInfo)
     expectedAttachmentsCount > 0
       ? await this.#attachments.assertCount(expectedAttachmentsCount)
       : await this.#noAttachments.waitUntilVisible()

--- a/frontend/src/e2e-test/pages/employee/applications.ts
+++ b/frontend/src/e2e-test/pages/employee/applications.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual } from '../../utils'
 import { Element, Page } from '../../utils/page'
 
 import ApplicationReadView from './applications/application-read-view'
@@ -33,7 +32,7 @@ export class ApplicationRow extends Element {
     super(root)
   }
 
-  #status = this.find('[data-qa="application-status"]')
+  status = this.find('[data-qa="application-status"]')
 
   async openApplication() {
     const applicationDetails = new Promise<ApplicationReadView>((res) => {
@@ -41,9 +40,5 @@ export class ApplicationRow extends Element {
     })
     await this.click()
     return applicationDetails
-  }
-
-  async assertStatus(expectedStatus: string) {
-    await waitUntilEqual(() => this.#status.text, expectedStatus)
   }
 }

--- a/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
@@ -5,7 +5,7 @@
 import { OtherGuardianAgreementStatus } from 'lib-common/generated/api-types/application'
 import LocalDate from 'lib-common/local-date'
 
-import { waitUntilEqual, waitUntilFalse } from '../../../utils'
+import { waitUntilFalse } from '../../../utils'
 import {
   Checkbox,
   Combobox,
@@ -86,13 +86,9 @@ export default class ApplicationEditView {
   }
 
   async assertUrgentAttachmentUploaded(fileName: string) {
-    await waitUntilEqual(
-      () =>
-        this.#urgentAttachmentFileUpload.find(
-          '[data-qa="file-download-button"]'
-        ).text,
-      fileName
-    )
+    await this.#urgentAttachmentFileUpload
+      .find('[data-qa="file-download-button"]')
+      .assertTextEquals(fileName)
   }
 
   async assertUrgencyAttachmentReceivedAtVisible(fileName: string) {
@@ -125,13 +121,9 @@ export default class ApplicationEditView {
   }
 
   async assertShiftCareAttachmentUploaded(fileName: string) {
-    await waitUntilEqual(
-      () =>
-        this.#shiftCareAttachmentFileUpload.find(
-          '[data-qa="file-download-button"]'
-        ).text,
-      fileName
-    )
+    await this.#shiftCareAttachmentFileUpload
+      .find('[data-qa="file-download-button"]')
+      .assertTextEquals(fileName)
   }
 
   async assertShiftCareAttachmentsDeleted() {

--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -7,7 +7,7 @@ import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
 import config from '../../../config'
-import { waitUntilEqual, waitUntilTrue } from '../../../utils'
+import { waitUntilTrue } from '../../../utils'
 import { DatePickerDeprecated, Page, Radio } from '../../../utils/page'
 
 import ApplicationEditView from './application-edit-view'
@@ -50,7 +50,7 @@ export default class ApplicationReadView {
   }
 
   async assertPageTitle(expectedTitle: string) {
-    await waitUntilEqual(() => this.#title.text, expectedTitle)
+    await this.#title.assertTextEquals(expectedTitle)
   }
 
   async assertOtherVtjGuardian(
@@ -58,9 +58,9 @@ export default class ApplicationReadView {
     expectedPhone: string,
     expectedEmail: string
   ) {
-    await waitUntilEqual(() => this.#vtjGuardianName.text, expectedName)
-    await waitUntilEqual(() => this.#vtjGuardianPhone.text, expectedPhone)
-    await waitUntilEqual(() => this.#vtjGuardianEmail.text, expectedEmail)
+    await this.#vtjGuardianName.assertTextEquals(expectedName)
+    await this.#vtjGuardianPhone.assertTextEquals(expectedPhone)
+    await this.#vtjGuardianEmail.assertTextEquals(expectedEmail)
   }
 
   async assertOtherVtjGuardianMissing() {
@@ -71,11 +71,8 @@ export default class ApplicationReadView {
     expectedPhone: string,
     expectedEmail: string
   ) {
-    await waitUntilEqual(
-      () => this.#givenOtherGuardianPhone.text,
-      expectedPhone
-    )
-    await waitUntilEqual(() => this.#giveOtherGuardianEmail.text, expectedEmail)
+    await this.#givenOtherGuardianPhone.assertTextEquals(expectedPhone)
+    await this.#giveOtherGuardianEmail.assertTextEquals(expectedEmail)
   }
 
   async setDecisionStartDate(type: DecisionType, startDate: string) {
@@ -152,10 +149,9 @@ export default class ApplicationReadView {
   }
 
   async assertDueDate(dueDate: LocalDate) {
-    await waitUntilEqual(
-      () => this.page.findByDataQa('application-due-date').text,
-      dueDate.format()
-    )
+    await this.page
+      .findByDataQa('application-due-date')
+      .assertTextEquals(dueDate.format())
   }
 
   async startEditing(): Promise<ApplicationEditView> {

--- a/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-edit-page.ts
+++ b/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-edit-page.ts
@@ -24,17 +24,13 @@ export default class AssistanceNeedDecisionEditPage {
   }
 
   async assertDecisionStatus(status: string) {
-    await waitUntilEqual(
-      () => this.page.findByDataQa('decision-status').text,
-      status
-    )
+    await this.page.findByDataQa('decision-status').assertTextEquals(status)
   }
 
   async assertDecisionNumber(decisionNumber: number | null) {
-    await waitUntilEqual(
-      () => this.page.findByDataQa('decision-number').text,
-      `${decisionNumber ?? 'null'}`
-    )
+    await this.page
+      .findByDataQa('decision-number')
+      .assertTextEquals(`${decisionNumber ?? 'null'}`)
   }
 
   async waitUntilSaved(): Promise<void> {
@@ -62,7 +58,7 @@ export default class AssistanceNeedDecisionEditPage {
   }
 
   async assertPageTitle(title: string): Promise<void> {
-    await waitUntilEqual(() => this.page.findByDataQa('page-title').text, title)
+    await this.page.findByDataQa('page-title').assertTextEquals(title)
   }
 
   async selectUnit(unit: string): Promise<void> {

--- a/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-preview-page.ts
+++ b/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-preview-page.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual } from '../../../utils'
 import { Page } from '../../../utils/page'
 
 export default class AssistanceNeedDecisionPreviewPage {
@@ -15,63 +14,78 @@ export default class AssistanceNeedDecisionPreviewPage {
   get pedagogicalMotivation() {
     return this.getLabelledValue('pedagogical-motivation')
   }
+
   async assertStructuralMotivationOption(opt: string) {
     await this.page
       .findByDataQa('structural-motivation-section')
       .findByDataQa(`list-option-${opt}`)
       .waitUntilVisible()
   }
+
   get structuralMotivationDescription() {
     return this.page.findByDataQa('structural-motivation-description').text
   }
+
   get careMotivation() {
     return this.getLabelledValue('care-motivation')
   }
+
   async assertServiceOption(opt: string) {
     await this.page
       .findByDataQa('services-section')
       .findByDataQa(`list-option-${opt}`)
       .waitUntilVisible()
   }
+
   get guardiansHeardOn() {
     return this.getLabelledValue('guardians-heard-at')
   }
+
   async heardGuardian(id: string) {
     return this.page
       .findByDataQa('guardians-heard-section')
       .findByDataQa(`guardian-${id}`).text
   }
+
   get otherRepresentativeDetails() {
     return this.page.findByDataQa('other-representative-details').text
   }
+
   get viewOfGuardians() {
     return this.getLabelledValue('view-of-the-guardians')
   }
+
   get futureLevelOfAssistance() {
     return this.getLabelledValue('future-level-of-assistance')
   }
+
   get startDate() {
     return this.getLabelledValue('start-date')
   }
+
   get selectedUnit() {
     return this.getLabelledValue('selected-unit')
   }
+
   get motivationForDecision() {
     return this.getLabelledValue('motivation-for-decision')
   }
+
   get preparedBy1() {
     return this.getLabelledValue('prepared-by-1')
   }
+
   get decisionMaker() {
     return this.getLabelledValue('decision-maker')
   }
 
   readonly sendDecisionButton = this.page.findByDataQa('send-decision')
+
   get decisionSentAt() {
     return this.page.findByDataQa('decision-sent-at')
   }
 
   async assertPageTitle(title: string): Promise<void> {
-    await waitUntilEqual(() => this.page.findByDataQa('page-title').text, title)
+    await this.page.findByDataQa('page-title').assertTextEquals(title)
   }
 }

--- a/frontend/src/e2e-test/pages/employee/child-information.ts
+++ b/frontend/src/e2e-test/pages/employee/child-information.ts
@@ -63,7 +63,7 @@ export default class ChildInformationPage {
   }
 
   async assertOphPersonOid(expected: string) {
-    await waitUntilEqual(() => this.#ophPersonOidInput.text, expected)
+    await this.#ophPersonOidInput.assertTextEquals(expected)
   }
 
   async setOphPersonOid(text: string) {
@@ -113,26 +113,10 @@ class Section extends Element {
 }
 
 export class AdditionalInformationSection extends Section {
-  #medication = this.find('[data-qa="medication"]')
-  #editBtn = this.find('[data-qa="edit-child-settings-button"]')
-  #medicationInput = new TextInput(this.find('[data-qa="medication-input"]'))
-  #confirmBtn = this.find('[data-qa="confirm-edited-child-button"]')
-
-  async assertMedication(text: string) {
-    await waitUntilEqual(() => this.#medication.text, text)
-  }
-
-  async fillMedication(text: string) {
-    await this.#medicationInput.fill(text)
-  }
-
-  async edit() {
-    await this.#editBtn.click()
-  }
-
-  async save() {
-    await this.#confirmBtn.click()
-  }
+  medication = this.find('[data-qa="medication"]')
+  editBtn = this.find('[data-qa="edit-child-settings-button"]')
+  medicationInput = new TextInput(this.find('[data-qa="medication-input"]'))
+  confirmBtn = this.find('[data-qa="confirm-edited-child-button"]')
 }
 
 class DailyServiceTimeSectionBaseForm extends Section {
@@ -183,14 +167,12 @@ export class DailyServiceTimeSection extends Section {
   async assertTableRow(nth: number, title: string, status: string) {
     const row = this.findAllByDataQa('daily-service-times-row').nth(nth)
 
-    await waitUntilEqual(
-      () => row.findByDataQa('daily-service-times-row-title').text,
-      title
-    )
-    await waitUntilEqual(
-      () => row.findByDataQa('status').getAttribute('data-qa-status'),
-      status
-    )
+    await row
+      .findByDataQa('daily-service-times-row-title')
+      .assertTextEquals(title)
+    await row
+      .findByDataQa('status')
+      .assertAttributeEquals('data-qa-status', status)
   }
 
   async toggleTableRowCollapsible(nth: number) {
@@ -206,7 +188,7 @@ export class DailyServiceTimeSection extends Section {
       }) + [data-qa="daily-service-times-row-collapsible"]`
     )
 
-    await waitUntilEqual(() => collapsible.text, text)
+    await collapsible.assertTextEquals(text)
   }
 
   async editTableRow(nth: number) {
@@ -436,7 +418,7 @@ export class BackupCaresSection extends Section {
   }
 
   async assertError(expectedError: string) {
-    await waitUntilEqual(() => this.#error.text, expectedError)
+    await this.#error.assertTextEquals(expectedError)
   }
 
   async getBackupCares(): Promise<Array<{ unit: string; period: string }>> {
@@ -511,26 +493,23 @@ export class FamilyContactsSection extends Section {
     await row.waitUntilVisible()
 
     if (data.email) {
-      await waitUntilEqual(
-        () => row.findByDataQa('family-contact-email').text,
-        data.email
-      )
+      await row
+        .findByDataQa('family-contact-email')
+        .assertTextEquals(data.email)
     } else {
       await row.findByDataQa('family-contact-email').waitUntilHidden()
     }
     if (data.phone) {
-      await waitUntilEqual(
-        () => row.findByDataQa('family-contact-phone').text,
-        data.phone
-      )
+      await row
+        .findByDataQa('family-contact-phone')
+        .assertTextEquals(data.phone)
     } else {
       await row.findByDataQa('family-contact-phone').waitUntilHidden()
     }
     if (data.backupPhone) {
-      await waitUntilEqual(
-        () => row.findByDataQa('family-contact-backup-phone').text,
-        `${data.backupPhone} (Varanro)`
-      )
+      await row
+        .findByDataQa('family-contact-backup-phone')
+        .assertTextEquals(`${data.backupPhone} (Varanro)`)
     } else {
       await row.findByDataQa('family-contact-backup-phone').waitUntilHidden()
     }
@@ -571,11 +550,8 @@ export class GuardiansSection extends Section {
     end: LocalDate | null
   ) {
     const row = this.findByDataQa(`foster-parent-row-${parentId}`)
-    await waitUntilEqual(() => row.findByDataQa('start').text, start.format())
-    await waitUntilEqual(
-      () => row.findByDataQa('end').text,
-      end?.format() ?? ''
-    )
+    await row.findByDataQa('start').assertTextEquals(start.format())
+    await row.findByDataQa('end').assertTextEquals(end?.format() ?? '')
   }
 
   async removeGuardianEvakaRights(id: UUID) {
@@ -612,18 +588,16 @@ export class GuardiansSection extends Section {
 
   async assertGuardianStatusAllowed(id: UUID) {
     await this.waitUntilNotLoading()
-    await waitUntilEqual(
-      () => this.guardianRow(id).findByDataQa('evaka-rights-status').text,
-      'Sallittu'
-    )
+    await this.guardianRow(id)
+      .findByDataQa('evaka-rights-status')
+      .assertTextEquals('Sallittu')
   }
 
   async assertGuardianStatusDenied(id: UUID) {
     await this.waitUntilNotLoading()
-    await waitUntilEqual(
-      () => this.guardianRow(id).findByDataQa('evaka-rights-status').text,
-      'Kielletty'
-    )
+    await this.guardianRow(id)
+      .findByDataQa('evaka-rights-status')
+      .assertTextEquals('Kielletty')
   }
 }
 
@@ -658,10 +632,7 @@ export class PlacementsSection extends Section {
   }
 
   async assertNthServiceNeedName(index: number, optionName: string) {
-    await waitUntilEqual(
-      () => this.#serviceNeedRowOptionName(index).text,
-      optionName
-    )
+    await this.#serviceNeedRowOptionName(index).assertTextEquals(optionName)
   }
 
   async assertServiceNeedOptions(placementId: string, optionIds: string[]) {
@@ -751,10 +722,7 @@ export class AssistanceNeedSection extends Section {
   }
 
   async assertAssistanceNeedMultiplier(expected: string, nth = 0) {
-    await waitUntilEqual(
-      () => this.#assistanceNeedMultiplier.nth(nth).text,
-      expected
-    )
+    await this.#assistanceNeedMultiplier.nth(nth).assertTextEquals(expected)
   }
 
   async assertAssistanceNeedCount(expectedCount: number) {

--- a/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
@@ -119,7 +119,7 @@ export class FeeDecisionDetailsPage {
   #childIncome = this.page.findAll('[data-qa="child-income"]')
 
   async assertPartnerName(expectedName: string) {
-    await waitUntilEqual(() => this.#partnerName.text, expectedName)
+    await this.#partnerName.assertTextEquals(expectedName)
   }
 
   async assertChildIncome(nth: number, expectedTotalText: string) {
@@ -226,7 +226,7 @@ export class ValueDecisionDetailsPage {
   }
 
   async assertPartnerName(expectedName: string) {
-    await waitUntilEqual(() => this.#partnerName.text, expectedName)
+    await this.#partnerName.assertTextEquals(expectedName)
   }
 
   async assertPartnerNameNotShown() {
@@ -333,7 +333,7 @@ export class InvoicesPage {
 
   async assertInvoiceHeadOfFamily(fullName: string) {
     await this.#invoiceDetailsPage.waitUntilVisible()
-    await waitUntilEqual(() => this.#invoiceDetailsHeadOfFamily.text, fullName)
+    await this.#invoiceDetailsHeadOfFamily.assertTextEquals(fullName)
   }
 
   async navigateBackToInvoices() {
@@ -374,10 +374,9 @@ export class InvoicesPage {
   }
 
   async assertInvoiceTotal(total: number) {
-    await waitUntilEqual(
-      () => this.#invoiceInList.find('[data-qa="invoice-total"]').text,
-      this.formatFinnishDecimal(total)
-    )
+    await this.#invoiceInList
+      .find('[data-qa="invoice-total"]')
+      .assertTextEquals(this.formatFinnishDecimal(total))
   }
 
   async freeTextFilter(text: string) {
@@ -434,17 +433,14 @@ export class IncomeStatementsPage {
     expectedName: string,
     expecteTypeText: string
   ) {
-    await waitUntilEqual(
-      () => this.#incomeStatementRows.nth(nth).find('a').text,
-      expectedName
-    )
-    await waitUntilEqual(
-      () =>
-        this.#incomeStatementRows
-          .nth(nth)
-          .find('[data-qa="income-statement-type"]').text,
-      expecteTypeText
-    )
+    await this.#incomeStatementRows
+      .nth(nth)
+      .find('a')
+      .assertTextEquals(expectedName)
+    await this.#incomeStatementRows
+      .nth(nth)
+      .find('[data-qa="income-statement-type"]')
+      .assertTextEquals(expecteTypeText)
   }
 }
 

--- a/frontend/src/e2e-test/pages/employee/guardian-information.ts
+++ b/frontend/src/e2e-test/pages/employee/guardian-information.ts
@@ -7,7 +7,7 @@ import { formatCents } from 'lib-common/money'
 import { UUID } from 'lib-common/types'
 
 import config from '../../config'
-import { waitUntilEqual, waitUntilNotEqual, waitUntilTrue } from '../../utils'
+import { waitUntilEqual, waitUntilTrue } from '../../utils'
 import {
   Checkbox,
   Combobox,
@@ -51,16 +51,14 @@ export default class GuardianInformationPage {
     switch (enabled) {
       case true:
         await this.#restrictedDetailsEnabledLabel.waitUntilVisible()
-        await waitUntilEqual(
-          () => this.#personStreetAddress.text,
+        await this.#personStreetAddress.assertTextEquals(
           'Osoite ei ole saatavilla turvakiellon vuoksi'
         )
         break
       default:
         await this.#restrictedDetailsEnabledLabel.waitUntilHidden()
-        await waitUntilNotEqual(
-          () => this.#personStreetAddress.text,
-          'Osoite ei ole saatavilla turvakiellon vuoksi'
+        await this.#personStreetAddress.assertText(
+          (text) => text !== 'Osoite ei ole saatavilla turvakiellon vuoksi'
         )
     }
   }
@@ -118,7 +116,7 @@ class FamilyOverviewSection extends Section {
 
     if (age !== undefined) {
       const personAge = person.find('[data-qa="person-age"]')
-      await waitUntilEqual(() => personAge.text, age.toString())
+      await personAge.assertTextEquals(age.toString())
     }
 
     if (incomeCents !== undefined) {
@@ -177,7 +175,7 @@ class ChildrenSection extends Section {
 
   async verifyChildAge(age: number) {
     const childAge = this.#childrenTableRow.nth(0).find('[data-qa="child-age"]')
-    await waitUntilEqual(() => childAge.text, age.toString())
+    await childAge.assertTextEquals(age.toString())
   }
 }
 
@@ -251,11 +249,8 @@ class FosterChildrenSection extends Section {
     end: LocalDate | null
   ) {
     const row = this.findByDataQa(`foster-child-row-${childId}`)
-    await waitUntilEqual(() => row.findByDataQa('start').text, start.format())
-    await waitUntilEqual(
-      () => row.findByDataQa('end').text,
-      end?.format() ?? ''
-    )
+    await row.findByDataQa('start').assertTextEquals(start.format())
+    await row.findByDataQa('end').assertTextEquals(end?.format() ?? '')
   }
 
   async assertRowDoesNotExist(childId: string) {
@@ -310,10 +305,7 @@ export class IncomeSection extends Section {
   )
 
   async assertIncomeStatementChildName(nth: number, childName: string) {
-    await waitUntilEqual(
-      () => this.#childIncomeStatementsTitles.nth(nth).text,
-      childName
-    )
+    await this.#childIncomeStatementsTitles.nth(nth).assertTextEquals(childName)
   }
 
   async assertIncomeStatementRowCount(expected: number) {
@@ -508,10 +500,9 @@ class FeeDecisionsSection extends Section {
   }
 
   async checkFeeDecisionSentAt(nth: number, expectedSentAt: LocalDate) {
-    await waitUntilEqual(
-      () => this.#feeDecisionSentAt.nth(nth).text,
-      expectedSentAt.format('dd.MM.yyyy')
-    )
+    await this.#feeDecisionSentAt
+      .nth(nth)
+      .assertTextEquals(expectedSentAt.format('dd.MM.yyyy'))
   }
 }
 
@@ -532,10 +523,9 @@ class VoucherValueDecisionsSection extends Section {
     nth: number,
     expectedSentAt: LocalDate
   ) {
-    await waitUntilEqual(
-      () => this.#voucherValueDecisionSentAt.nth(nth).text,
-      expectedSentAt.format('dd.MM.yyyy')
-    )
+    await this.#voucherValueDecisionSentAt
+      .nth(nth)
+      .assertTextEquals(expectedSentAt.format('dd.MM.yyyy'))
   }
 
   async checkVoucherValueDecisionCount(expectedCount: number) {

--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -63,14 +63,11 @@ export default class MessagesPage {
 
   async assertMessageIsSentForParticipants(nth: number, participants: string) {
     await this.page.findAll('[data-qa="message-box-row-sent"]').first().click()
-    await waitUntilEqual(
-      () =>
-        this.page
-          .findAllByDataQa('sent-message-row')
-          .nth(nth)
-          .findByDataQa('participants').text,
-      participants
-    )
+    await this.page
+      .findAllByDataQa('sent-message-row')
+      .nth(nth)
+      .findByDataQa('participants')
+      .assertTextEquals(participants)
   }
 
   async assertReceivedMessageParticipantsContains(nth: number, str: string) {
@@ -103,7 +100,7 @@ export default class MessagesPage {
   }
 
   async assertReplyContentIsEmpty() {
-    return waitUntilEqual(() => this.#messageReplyContent.text, '')
+    await this.#messageReplyContent.assertTextEquals('')
   }
 
   async sendNewMessage(message: {
@@ -201,20 +198,17 @@ export default class MessagesPage {
 
   async assertMessageContent(index: number, content: string) {
     await this.#receivedMessage.click()
-    await waitUntilEqual(() => this.#messageContent(index).text, content)
+    await this.#messageContent(index).assertTextEquals(content)
   }
 
   async assertDraftContent(title: string, content: string) {
     await this.#draftMessagesBoxRow.click()
-    await waitUntilEqual(
-      () => this.#draftMessage.find('[data-qa="thread-list-item-title"]').text,
-      title
-    )
-    await waitUntilEqual(
-      () =>
-        this.#draftMessage.find('[data-qa="thread-list-item-content"]').text,
-      content
-    )
+    await this.#draftMessage
+      .find('[data-qa="thread-list-item-title"]')
+      .assertTextEquals(title)
+    await this.#draftMessage
+      .find('[data-qa="thread-list-item-content"]')
+      .assertTextEquals(content)
   }
 
   async assertNoDrafts() {
@@ -224,14 +218,12 @@ export default class MessagesPage {
 
   async assertCopyContent(title: string, content: string) {
     await this.#messageCopiesInbox.click()
-    await waitUntilEqual(
-      () => this.page.findByDataQa('thread-list-item-title').text,
-      title
-    )
-    await waitUntilEqual(
-      () => this.page.findByDataQa('thread-list-item-content').text,
-      content
-    )
+    await this.page
+      .findByDataQa('thread-list-item-title')
+      .assertTextEquals(title)
+    await this.page
+      .findByDataQa('thread-list-item-content')
+      .assertTextEquals(content)
   }
 
   async assertNoCopies() {

--- a/frontend/src/e2e-test/pages/employee/person-search.ts
+++ b/frontend/src/e2e-test/pages/employee/person-search.ts
@@ -4,8 +4,7 @@
 
 import LocalDate from 'lib-common/local-date'
 
-import { waitUntilEqual } from '../../utils'
-import { Page, Checkbox, TextInput } from '../../utils/page'
+import { Checkbox, Page, TextInput } from '../../utils/page'
 
 export default class PersonSearchPage {
   constructor(private readonly page: Page) {}
@@ -85,32 +84,23 @@ export default class PersonSearchPage {
     postOffice: string
     ssn?: string
   }) {
-    await waitUntilEqual(
-      () => this.#personData.firstName.text,
-      personData.firstName
-    )
-    await waitUntilEqual(
-      () => this.#personData.lastName.text,
-      personData.lastName
-    )
-    await waitUntilEqual(
-      () => this.#personData.dateOfBirth.text,
+    await this.#personData.firstName.assertTextEquals(personData.firstName)
+    await this.#personData.lastName.assertTextEquals(personData.lastName)
+    await this.#personData.dateOfBirth.assertTextEquals(
       personData.dateOfBirth.format()
     )
-    await waitUntilEqual(
-      () => this.#personData.address.text,
+    await this.#personData.address.assertTextEquals(
       `${personData.streetAddress}, ${personData.postalCode} ${personData.postOffice}`
     )
     if (personData.ssn === undefined) {
       await this.#personData.ssn
         .findByDataQa('add-ssn-button')
         .waitUntilVisible()
-      await waitUntilEqual(
-        () => this.#personData.ssn.findByDataQa('add-ssn-button').text,
-        'Aseta hetu'
-      )
+      await this.#personData.ssn
+        .findByDataQa('add-ssn-button')
+        .assertTextEquals('Aseta hetu')
     } else {
-      await waitUntilEqual(() => this.#personData.ssn.text, personData.ssn)
+      await this.#personData.ssn.assertTextEquals(personData.ssn)
     }
   }
 

--- a/frontend/src/e2e-test/pages/employee/placement-draft-page.ts
+++ b/frontend/src/e2e-test/pages/employee/placement-draft-page.ts
@@ -4,7 +4,6 @@
 
 import { UUID } from 'lib-common/types'
 
-import { waitUntilEqual } from '../../utils'
 import { Combobox, Page } from '../../utils/page'
 
 export class PlacementDraftPage {
@@ -43,22 +42,18 @@ export class PlacementDraftPage {
     const speculated = this.#unitCard(unitId).find(
       '[data-qa="speculated-occupancies"]'
     )
-    await waitUntilEqual(
-      () => current.find('[data-qa="3months"]').text,
-      occupancies.max3Months
-    )
-    await waitUntilEqual(
-      () => current.find('[data-qa="6months"]').text,
-      occupancies.max6Months
-    )
-    await waitUntilEqual(
-      () => speculated.find('[data-qa="3months"]').text,
-      occupancies.max3MonthsSpeculated
-    )
-    await waitUntilEqual(
-      () => speculated.find('[data-qa="6months"]').text,
-      occupancies.max6MonthsSpeculated
-    )
+    await current
+      .find('[data-qa="3months"]')
+      .assertTextEquals(occupancies.max3Months)
+    await current
+      .find('[data-qa="6months"]')
+      .assertTextEquals(occupancies.max6Months)
+    await speculated
+      .find('[data-qa="3months"]')
+      .assertTextEquals(occupancies.max3MonthsSpeculated)
+    await speculated
+      .find('[data-qa="6months"]')
+      .assertTextEquals(occupancies.max6MonthsSpeculated)
   }
 
   async addOtherUnit(unitName: string) {

--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -193,22 +193,22 @@ export class ServiceVoucherUnitReport {
     expectedCoPayment: number,
     expectedRealizedAmount: number
   ) {
-    await waitUntilEqual(
-      () => this.page.findAllByDataQa('child-name').nth(nth).text,
-      expectedName
-    )
-    await waitUntilEqual(
-      () => this.page.findAllByDataQa('voucher-value').nth(nth).textAsFloat,
-      expectedVoucherValue
-    )
-    await waitUntilEqual(
-      () => this.page.findAllByDataQa('co-payment').nth(nth).textAsFloat,
-      expectedCoPayment
-    )
-    await waitUntilEqual(
-      () => this.page.findAllByDataQa('realized-amount').nth(nth).textAsFloat,
-      expectedRealizedAmount
-    )
+    await this.page
+      .findAllByDataQa('child-name')
+      .nth(nth)
+      .assertTextEquals(expectedName)
+    await this.page
+      .findAllByDataQa('voucher-value')
+      .nth(nth)
+      .assertText((text) => parseFloat(text) === expectedVoucherValue)
+    await this.page
+      .findAllByDataQa('co-payment')
+      .nth(nth)
+      .assertText((text) => parseFloat(text) === expectedCoPayment)
+    await this.page
+      .findAllByDataQa('realized-amount')
+      .nth(nth)
+      .assertText((text) => parseFloat(text) === expectedRealizedAmount)
   }
 }
 

--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -11,6 +11,7 @@ import {
   DatePickerDeprecated,
   Page,
   Select,
+  StaticChip,
   TextInput
 } from '../../utils/page'
 
@@ -105,20 +106,15 @@ export class PlacementSketchingReport {
     const element = this.page.find(`[data-qa="${applicationId}"]`)
     await element.waitUntilVisible()
 
-    await waitUntilEqual(
-      () => element.find('[data-qa="requested-unit"]').text,
-      requestedUnitName
-    )
+    await element
+      .find('[data-qa="requested-unit"]')
+      .assertTextEquals(requestedUnitName)
     if (currentUnitName) {
-      await waitUntilEqual(
-        () => element.find('[data-qa="current-unit"]').text,
-        currentUnitName
-      )
+      await element
+        .find('[data-qa="current-unit"]')
+        .assertTextEquals(currentUnitName)
     }
-    await waitUntilEqual(
-      () => element.find('[data-qa="child-name"]').text,
-      childName
-    )
+    await element.find('[data-qa="child-name"]').assertTextEquals(childName)
   }
 }
 
@@ -180,6 +176,7 @@ export class VoucherServiceProvidersReport {
 
 export class ServiceVoucherUnitReport {
   constructor(private page: Page) {}
+
   #childRows = this.page.findAllByDataQa('child-row')
 
   async assertChildRowCount(expected: number) {
@@ -265,11 +262,10 @@ export class AssistanceNeedDecisionsReport {
 export class AssistanceNeedDecisionsReportDecision {
   constructor(private page: Page) {}
 
-  decisionMaker = () =>
-    this.page.findByDataQa('labelled-value-decision-maker').text
-  decisionStatus = () =>
-    this.page.findByDataQa('decision-status').getAttribute('data-qa-status')
+  decisionMaker = this.page.findByDataQa('labelled-value-decision-maker')
+  decisionStatus = new StaticChip(this.page.findByDataQa('decision-status'))
   readonly returnForEditBtn = this.page.findByDataQa('return-for-edit')
+
   get returnForEditModal() {
     return {
       okBtn: this.page.findByDataQa('modal-okBtn')
@@ -281,6 +277,7 @@ export class AssistanceNeedDecisionsReportDecision {
   readonly modalOkBtn = this.page.findByDataQa('modal-okBtn')
 
   readonly mismatchModalLink = this.page.findByDataQa('mismatch-modal-link')
+
   get mismatchModal() {
     return {
       titleInput: new TextInput(this.page.findByDataQa('title-input')),

--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -250,10 +250,7 @@ export class UnitStaffAttendancesTable extends Element {
     const row = this.findByDataQa(`attendance-row-${rowIx}`)
 
     if (name !== undefined) {
-      await waitUntilEqual(
-        () => row.findByDataQa('staff-attendance-name').text,
-        name
-      )
+      await row.findByDataQa('staff-attendance-name').assertTextEquals(name)
     }
 
     if (plannedAttendances !== undefined) {
@@ -261,33 +258,27 @@ export class UnitStaffAttendancesTable extends Element {
         .findAllByDataQa('planned-attendance-day')
         .nth(nth)
       for (const [i, [arrival, departure]] of plannedAttendances.entries()) {
-        await waitUntilEqual(
-          () =>
-            plannedAttendanceDay
-              .findAllByDataQa('planned-attendance-start')
-              .nth(i).text,
-          arrival
-        )
-        await waitUntilEqual(
-          () =>
-            plannedAttendanceDay
-              .findAllByDataQa('planned-attendance-end')
-              .nth(i).text,
-          departure
-        )
+        await plannedAttendanceDay
+          .findAllByDataQa('planned-attendance-start')
+          .nth(i)
+          .assertTextEquals(arrival)
+        await plannedAttendanceDay
+          .findAllByDataQa('planned-attendance-end')
+          .nth(i)
+          .assertTextEquals(departure)
       }
     }
     if (attendances !== undefined) {
       const attendanceDay = row.findAllByDataQa('attendance-day').nth(nth)
       for (const [i, [arrival, departure]] of attendances.entries()) {
-        await waitUntilEqual(
-          () => attendanceDay.findAllByDataQa('arrival-time').nth(i).text,
-          arrival
-        )
-        await waitUntilEqual(
-          () => attendanceDay.findAllByDataQa('departure-time').nth(i).text,
-          departure
-        )
+        await attendanceDay
+          .findAllByDataQa('arrival-time')
+          .nth(i)
+          .assertTextEquals(arrival)
+        await attendanceDay
+          .findAllByDataQa('departure-time')
+          .nth(i)
+          .assertTextEquals(departure)
       }
     }
   }
@@ -468,13 +459,13 @@ export class UnitOccupanciesSection extends Element {
   }
 
   async assertConfirmed(minimum: string, maximum: string) {
-    await waitUntilEqual(() => this.#elem('minimum', 'confirmed').text, minimum)
-    await waitUntilEqual(() => this.#elem('maximum', 'confirmed').text, maximum)
+    await this.#elem('minimum', 'confirmed').assertTextEquals(minimum)
+    await this.#elem('maximum', 'confirmed').assertTextEquals(maximum)
   }
 
   async assertPlanned(minimum: string, maximum: string) {
-    await waitUntilEqual(() => this.#elem('minimum', 'planned').text, minimum)
-    await waitUntilEqual(() => this.#elem('maximum', 'planned').text, maximum)
+    await this.#elem('minimum', 'planned').assertTextEquals(minimum)
+    await this.#elem('maximum', 'planned').assertTextEquals(maximum)
   }
 }
 

--- a/frontend/src/e2e-test/pages/employee/units/unit-diary-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-diary-page.ts
@@ -36,7 +36,7 @@ export class UnitDiaryPage {
   #addAbsencesButton = this.page.find('[data-qa="add-absences-button"]')
 
   async assertUnitName(expectedName: string) {
-    await waitUntilEqual(() => this.#unitName.text, expectedName)
+    await this.#unitName.assertTextEquals(expectedName)
   }
 
   async assertSelectedGroup(groupId: UUID) {

--- a/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
@@ -53,10 +53,9 @@ export class UnitGroupsPage {
   )
 
   async assertChildCapacityFactor(childId: string, factor: string) {
-    await waitUntilEqual(
-      () => this.page.find(`[data-qa="child-capacity-factor-${childId}"]`).text,
-      factor
-    )
+    await this.page
+      .find(`[data-qa="child-capacity-factor-${childId}"]`)
+      .assertTextEquals(factor)
   }
 
   readonly childCapacityFactorColumnHeading = this.page.find(
@@ -169,20 +168,16 @@ export class MissingPlacementRow extends Element {
     groupMissingDuration?: string
   }) {
     if (fields.childName !== undefined) {
-      await waitUntilEqual(() => this.#childName.text, fields.childName)
+      await this.#childName.assertTextEquals(fields.childName)
     }
     if (fields.dateOfBirth !== undefined) {
-      await waitUntilEqual(() => this.#dateOfBirth.text, fields.dateOfBirth)
+      await this.#dateOfBirth.assertTextEquals(fields.dateOfBirth)
     }
     if (fields.placementDuration !== undefined) {
-      await waitUntilEqual(
-        () => this.#placementDuration.text,
-        fields.placementDuration
-      )
+      await this.#placementDuration.assertTextEquals(fields.placementDuration)
     }
     if (fields.groupMissingDuration !== undefined) {
-      await waitUntilEqual(
-        () => this.#groupMissingDuration.text,
+      await this.#groupMissingDuration.assertTextEquals(
         fields.groupMissingDuration
       )
     }
@@ -218,15 +213,15 @@ export class GroupCollapsible extends Element {
   #noChildren = this.find('[data-qa="no-children-placeholder"]')
 
   async assertGroupName(expectedName: string) {
-    await waitUntilEqual(() => this.#groupName.text, expectedName)
+    await this.#groupName.assertTextEquals(expectedName)
   }
 
   async assertGroupStartDate(expectedStartDate: string) {
-    await waitUntilEqual(() => this.#groupStartDate.text, expectedStartDate)
+    await this.#groupStartDate.assertTextEquals(expectedStartDate)
   }
 
   async assertGroupEndDate(expectedEndDate: string) {
-    await waitUntilEqual(() => this.#groupEndDate.text, expectedEndDate)
+    await this.#groupEndDate.assertTextEquals(expectedEndDate)
   }
 
   childRow(childId: string) {
@@ -305,13 +300,10 @@ export class GroupCollapsibleChildRow extends Element {
     placementDuration?: string
   }) {
     if (fields.childName !== undefined) {
-      await waitUntilEqual(() => this.#childName.text, fields.childName)
+      await this.#childName.assertTextEquals(fields.childName)
     }
     if (fields.placementDuration !== undefined) {
-      await waitUntilEqual(
-        () => this.#placementDuration.text,
-        fields.placementDuration
-      )
+      await this.#placementDuration.assertTextEquals(fields.placementDuration)
     }
   }
 
@@ -363,7 +355,7 @@ export class ChildDailyNoteModal extends Modal {
   #groupNoteInput = this.find('[data-qa="sticky-note"]')
 
   async assertGroupNote(expectedText: string) {
-    await waitUntilEqual(() => this.#groupNote.text, expectedText)
+    await this.#groupNote.assertTextEquals(expectedText)
   }
 
   async assertNoGroupNote() {

--- a/frontend/src/e2e-test/pages/employee/units/unit.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit.ts
@@ -90,11 +90,11 @@ export class UnitInfoPage {
   }
 
   async assertUnitName(expectedName: string) {
-    await waitUntilEqual(() => this.#unitName.text, expectedName)
+    await this.#unitName.assertTextEquals(expectedName)
   }
 
   async assertVisitingAddress(expectedAddress: string) {
-    await waitUntilEqual(() => this.#visitingAddress.text, expectedAddress)
+    await this.#visitingAddress.assertTextEquals(expectedAddress)
   }
 
   supervisorAcl = new AclSection(
@@ -137,7 +137,7 @@ export class UnitDetailsPage {
   }
 
   async assertUnitName(expectedName: string) {
-    await waitUntilEqual(() => this.#unitName.text, expectedName)
+    await this.#unitName.assertTextEquals(expectedName)
   }
 
   readonly #unitManagerName = this.page.find('[data-qa="unit-manager-name"]')
@@ -145,9 +145,9 @@ export class UnitDetailsPage {
   readonly #unitManagerEmail = this.page.find('[data-qa="unit-manager-email"]')
 
   async assertManagerData(name: string, phone: string, email: string) {
-    await waitUntilEqual(() => this.#unitManagerName.text, name)
-    await waitUntilEqual(() => this.#unitManagerPhone.text, phone)
-    await waitUntilEqual(() => this.#unitManagerEmail.text, email)
+    await this.#unitManagerName.assertTextEquals(name)
+    await this.#unitManagerPhone.assertTextEquals(phone)
+    await this.#unitManagerEmail.assertTextEquals(email)
   }
 
   async edit() {
@@ -362,8 +362,8 @@ class AclSection extends Element {
 
   async assertRowFields(fields: { id: UUID; name: string; email: string }) {
     const row = this.#tableRow(fields.id)
-    await waitUntilEqual(() => row.find('[data-qa="name"]').text, fields.name)
-    await waitUntilEqual(() => row.find('[data-qa="email"]').text, fields.email)
+    await row.find('[data-qa="name"]').assertTextEquals(fields.name)
+    await row.find('[data-qa="email"]').assertTextEquals(fields.email)
   }
 
   async assertRows(rows: { id: UUID; name: string; email: string }[]) {
@@ -383,8 +383,8 @@ class StaffAclSection extends AclSection {
     groups: string[]
   }) {
     const row = this.#tableRow(fields.id)
-    await waitUntilEqual(() => row.find('[data-qa="name"]').text, fields.name)
-    await waitUntilEqual(() => row.find('[data-qa="email"]').text, fields.email)
+    await row.find('[data-qa="name"]').assertTextEquals(fields.name)
+    await row.find('[data-qa="email"]').assertTextEquals(fields.email)
     await waitUntilEqual(
       () => row.find('[data-qa="groups"] > div').findAll('div').allInnerTexts(),
       fields.groups
@@ -411,10 +411,7 @@ class MobileDevicesSection extends Element {
   #startPairingButton = this.find('[data-qa="start-mobile-pairing"]')
 
   async assertDeviceExists(deviceName: string) {
-    await waitUntilEqual(
-      () => this.#rows.find('[data-qa="name"]').text,
-      deviceName
-    )
+    await this.#rows.find('[data-qa="name"]').assertTextEquals(deviceName)
   }
 
   async addMobileDevice(deviceName: string) {
@@ -505,7 +502,7 @@ class WaitingConfirmationSection extends Element {
   )
 
   async assertNotificationCounter(value: number) {
-    await waitUntilEqual(() => this.#notificationCounter.text, value.toString())
+    await this.#notificationCounter.assertTextEquals(value.toString())
   }
 
   async assertRowCount(count: number) {

--- a/frontend/src/e2e-test/pages/employee/units/units.ts
+++ b/frontend/src/e2e-test/pages/employee/units/units.ts
@@ -74,13 +74,10 @@ export class UnitRow extends Element {
 
   async assertFields(fields: { name?: string; visitingAddress?: string }) {
     if (fields.name !== undefined) {
-      await waitUntilEqual(() => this.#name.text, fields.name)
+      await this.#name.assertTextEquals(fields.name)
     }
     if (fields.visitingAddress !== undefined) {
-      await waitUntilEqual(
-        () => this.#visitingAddress.text,
-        fields.visitingAddress
-      )
+      await this.#visitingAddress.assertTextEquals(fields.visitingAddress)
     }
   }
 

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu-templates-list.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu-templates-list.ts
@@ -21,9 +21,9 @@ export class VasuTemplatesListPage {
   }
 
   async assertTemplate(nth: number, expectedName: string) {
-    await waitUntilEqual(
-      () => this.templateRows.nth(nth).find('[data-qa="template-name"]').text,
-      expectedName
-    )
+    await this.templateRows
+      .nth(nth)
+      .find('[data-qa="template-name"]')
+      .assertTextEquals(expectedName)
   }
 }

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
@@ -94,7 +94,7 @@ export class VasuEditPage extends VasuPageCommon {
         new TextInput(question.findByDataQa(`follow-up-${nth}-input`)),
       entryDateInput: (nth: number) =>
         new TextInput(question.findByDataQa(`follow-up-${nth}-date`)),
-      meta: (nth: number) => question.findByDataQa(`follow-up-${nth}-meta`).text
+      meta: (nth: number) => question.findByDataQa(`follow-up-${nth}-meta`)
     }
   }
 
@@ -146,7 +146,7 @@ export class VasuEditPage extends VasuPageCommon {
     await waitUntilEqual(() => input.inputValue, comment)
   }
 
-  followupEntryMetadata(nth: number, entryNth: number): Promise<string> {
+  followupEntryMetadata(nth: number, entryNth: number): Element {
     return this.#followup(nth).meta(entryNth)
   }
 
@@ -179,14 +179,12 @@ export class VasuPage extends VasuPageCommon {
   readonly #vasuEventListValues = this.page.findAll(
     '[data-qa="vasu-event-list"] span'
   )
-  readonly #vasuEventListDocState = this.page.find(
+  readonly documentState = this.page.find(
     '[data-qa="vasu-event-list"] [data-qa="vasu-state-chip"]'
   )
 
   readonly #templateName = this.page.find('[data-qa="template-name"]')
   readonly #editButton = this.page.find('[data-qa="edit-button"]')
-
-  documentState = () => this.#vasuEventListDocState.text
 
   // The (first) label for the state chip has no corresponding span, so the index is off by one.
   #valueForLabel = (label: string): Promise<string> =>
@@ -209,7 +207,7 @@ export class VasuPage extends VasuPageCommon {
   closedDate = () => this.#valueForLabel('Päättynyt')
 
   async assertTemplateName(expected: string) {
-    await waitUntilEqual(() => this.#templateName.text, expected)
+    await this.#templateName.assertTextEquals(expected)
   }
 
   async edit() {
@@ -236,7 +234,7 @@ export class VasuPreviewPage extends VasuPageCommon {
   readonly #confirmButton = this.page.findByDataQa('confirm-button')
 
   async assertTitleChildName(expectedName: string) {
-    await waitUntilEqual(() => this.#titleChildName.text, expectedName)
+    await this.#titleChildName.assertTextEquals(expectedName)
   }
 
   async assertGivePermissionToShareSectionIsVisible() {

--- a/frontend/src/e2e-test/pages/mobile/child-attendance-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/child-attendance-page.ts
@@ -78,7 +78,7 @@ export default class ChildAttendancePage {
   }
 
   async assertChildStatusLabelIsShown(expectedText: string) {
-    await waitUntilEqual(() => this.#childStatusLabel.text, expectedText)
+    await this.#childStatusLabel.assertTextEquals(expectedText)
   }
 
   // time format: "09:46"

--- a/frontend/src/e2e-test/pages/mobile/child-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/child-page.ts
@@ -84,6 +84,7 @@ export default class MobileChildPage {
   async returnToPresent() {
     await this.#returnToPresentButton.click()
   }
+
   async goBack() {
     await this.#goBack.click()
   }
@@ -101,7 +102,7 @@ export default class MobileChildPage {
   }
 
   async assertSensitiveInfoIsShown(name: string) {
-    await waitUntilEqual(() => this.#sensitiveInfo.name.text, name)
+    await this.#sensitiveInfo.name.assertTextEquals(name)
   }
 
   async assertSensitiveInfo(
@@ -117,49 +118,41 @@ export default class MobileChildPage {
       phone: string
     }>
   ) {
-    await waitUntilEqual(
-      () => this.#sensitiveInfo.allergies.text,
-      additionalInfo.allergies
+    await this.#sensitiveInfo.allergies.assertTextEquals(
+      additionalInfo.allergies ?? 'should be defined'
     )
-    await waitUntilEqual(
-      () => this.#sensitiveInfo.diet.text,
-      additionalInfo.diet
+    await this.#sensitiveInfo.diet.assertTextEquals(
+      additionalInfo.diet ?? 'should be defined'
     )
-    await waitUntilEqual(
-      () => this.#sensitiveInfo.medication.text,
-      additionalInfo.medication
+    await this.#sensitiveInfo.medication.assertTextEquals(
+      additionalInfo.medication ?? 'should be defined'
     )
 
     for (let i = 0; i < contacts.length; i++) {
       const contact = contacts[i]
-      await waitUntilEqual(
-        () => this.#sensitiveInfo.contactName(i).text,
-        `${contact.firstName} ${contact.lastName}`
-      )
+      await this.#sensitiveInfo
+        .contactName(i)
+        .assertTextEquals(`${contact.firstName} ${contact.lastName}`)
       if (contact.phone) {
-        await waitUntilEqual(
-          () => this.#sensitiveInfo.contactPhone(i).text,
-          contact.phone
-        )
+        await this.#sensitiveInfo
+          .contactPhone(i)
+          .assertTextEquals(contact.phone)
       }
       if (contact.email) {
-        await waitUntilEqual(
-          () => this.#sensitiveInfo.contactEmail(i).text,
-          contact.email
-        )
+        await this.#sensitiveInfo
+          .contactEmail(i)
+          .assertTextEquals(contact.email)
       }
     }
 
     for (let i = 0; i < backupPickups.length; i++) {
       const backupPickup = backupPickups[i]
-      await waitUntilEqual(
-        () => this.#sensitiveInfo.backupPickupName(i).text,
-        backupPickup.name
-      )
-      await waitUntilEqual(
-        () => this.#sensitiveInfo.backupPickupPhone(i).text,
-        backupPickup.phone
-      )
+      await this.#sensitiveInfo
+        .backupPickupName(i)
+        .assertTextEquals(backupPickup.name)
+      await this.#sensitiveInfo
+        .backupPickupPhone(i)
+        .assertTextEquals(backupPickup.phone)
     }
   }
 

--- a/frontend/src/e2e-test/pages/mobile/note-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/note-page.ts
@@ -71,10 +71,7 @@ export default class MobileNotePage {
   }
 
   async assertStickyNote(expected: string, nth = 0) {
-    await waitUntilEqual(
-      () => this.#stickyNote.note.nth(nth).find('p').text,
-      expected
-    )
+    await this.#stickyNote.note.nth(nth).find('p').assertTextEquals(expected)
   }
 
   async assertStickyNoteExpires(date: LocalDate, nth = 0) {

--- a/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilEqual } from '../../utils'
 import { Page, Select, TextInput } from '../../utils/page'
 
 export default class PinLoginPage {
@@ -24,6 +23,6 @@ export default class PinLoginPage {
   }
 
   async assertWrongPinError() {
-    await waitUntilEqual(() => this.#pinInfo.text, 'Väärä PIN-koodi')
+    await this.#pinInfo.assertTextEquals('Väärä PIN-koodi')
   }
 }

--- a/frontend/src/e2e-test/pages/mobile/staff-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/staff-page.ts
@@ -151,10 +151,7 @@ export class StaffAttendancePage {
     this.page.find(`[data-qa="staff-link"]`, { hasText: name })
 
   async assertShiftTimeTextShown(expectedText: string) {
-    await waitUntilEqual(
-      () => this.#staffMemberPage.shiftTimeText.text,
-      expectedText
-    )
+    await this.#staffMemberPage.shiftTimeText.assertTextEquals(expectedText)
   }
 
   async assertAttendanceTimeTextShown(expectedText: string) {
@@ -185,7 +182,7 @@ export class StaffAttendancePage {
   }
 
   async assertPresentStaffCount(expected: number) {
-    await waitUntilEqual(() => this.#tabs.present.text, `LÄSNÄ\n(${expected})`)
+    await this.#tabs.present.assertTextEquals(`LÄSNÄ\n(${expected})`)
   }
 
   async openStaffPage(name: string) {
@@ -193,7 +190,7 @@ export class StaffAttendancePage {
   }
 
   async assertEmployeeStatus(expected: string) {
-    await waitUntilEqual(() => this.#anyMemberPage.status.text, expected)
+    await this.#anyMemberPage.status.assertTextEquals(expected)
   }
 
   async selectTab(tab: 'present' | 'absent') {
@@ -205,17 +202,13 @@ export class StaffAttendancePage {
   }
 
   async assertEmployeeAttendanceTimes(index: number, expected: string) {
-    await waitUntilEqual(
-      () => this.#staffMemberPage.attendanceTimes.nth(index).text,
-      expected
-    )
+    await this.#staffMemberPage.attendanceTimes
+      .nth(index)
+      .assertTextEquals(expected)
   }
 
   async assertExternalStaffArrivalTime(expected: string) {
-    await waitUntilEqual(
-      () => this.#externalMemberPage.arrivalTime.text,
-      expected
-    )
+    await this.#externalMemberPage.arrivalTime.assertTextEquals(expected)
   }
 
   async selectAttendanceType(type: StaffAttendanceType) {
@@ -302,15 +295,11 @@ export class StaffAttendancePage {
   }
 
   async assertArrivalTimeInputInfo(expected: string) {
-    await waitUntilEqual(
-      () => this.#staffArrivalPage.timeInputWarningText.text,
-      expected
-    )
+    await this.#staffArrivalPage.timeInputWarningText.assertTextEquals(expected)
   }
 
   async assertDepartureTimeInputInfo(expected: string) {
-    await waitUntilEqual(
-      () => this.#staffDeparturePage.timeInputWarningText.text,
+    await this.#staffDeparturePage.timeInputWarningText.assertTextEquals(
       expected
     )
   }

--- a/frontend/src/e2e-test/pages/mobile/unit-list-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/unit-list-page.ts
@@ -4,7 +4,6 @@
 
 import { UUID } from 'lib-common/types'
 
-import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 
 export default class UnitListPage {
@@ -14,6 +13,6 @@ export default class UnitListPage {
     const staffCount = this.page
       .findByDataQa(`unit-${unitId}`)
       .findByDataQa('staff-count')
-    await waitUntilEqual(() => staffCount.text, `${present}/${allocated}`)
+    await staffCount.assertTextEquals(`${present}/${allocated}`)
   }
 }

--- a/frontend/src/e2e-test/specs/4_finance/finance-basics.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/finance-basics.spec.ts
@@ -10,7 +10,6 @@ import { insertFeeThresholds, resetDatabase } from '../../dev-api'
 import { Fixture } from '../../dev-api/fixtures'
 import EmployeeNav from '../../pages/employee/employee-nav'
 import FinanceBasicsPage from '../../pages/employee/finance-basics'
-import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
 
@@ -89,10 +88,9 @@ describe('Finance basics', () => {
     await financeBasicsPage.feesSection.createFeeThresholdsButton.click()
     await financeBasicsPage.feesSection.editor.fillInThresholds(data)
     await financeBasicsPage.feesSection.editor.assertSaveIsDisabled()
-    await waitUntilEqual(
-      () => financeBasicsPage.feesSection.editor.maxFeeError(2).text,
-      'Enimmäismaksu ei täsmää (200 €)'
-    )
+    await financeBasicsPage.feesSection.editor
+      .maxFeeError(2)
+      .assertTextEquals('Enimmäismaksu ei täsmää (200 €)')
   })
 
   test('Copying existing fee thresholds', async () => {

--- a/frontend/src/e2e-test/specs/5_employee/applications.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/applications.spec.ts
@@ -58,7 +58,7 @@ describe('Applications', () => {
     await applicationsPage.toggleApplicationStatusFilter('ALL')
     await applicationsPage
       .applicationRow(application.id)
-      .assertStatus('Odottaa postitusta')
+      .status.assertTextEquals('Odottaa postitusta')
   })
 
   test('Application with a dead applicant has an indicator for the date of death', async () => {

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
@@ -280,13 +280,12 @@ describe('Assistance Need Decisions - Preview page', () => {
 
   test('Decision can be sent to the decision maker', async () => {
     await assistanceNeedDecisionPreviewPage.sendDecisionButton.click()
-    expect(await assistanceNeedDecisionPreviewPage.decisionSentAt.text).toEqual(
+    await assistanceNeedDecisionPreviewPage.decisionSentAt.assertTextEquals(
       LocalDate.todayInSystemTz().format()
     )
-    expect(
-      await assistanceNeedDecisionPreviewPage.sendDecisionButton.getAttribute(
-        'disabled'
-      )
-    ).toEqual('')
+    await assistanceNeedDecisionPreviewPage.sendDecisionButton.assertAttributeEquals(
+      'disabled',
+      ''
+    )
   })
 })

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
@@ -25,7 +25,6 @@ import {
   AssistanceNeedDecisionsReport,
   AssistanceNeedDecisionsReportDecision
 } from '../../pages/employee/reports'
-import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
 
@@ -157,8 +156,7 @@ describe('Assistance need decisions report', () => {
     )
 
     const decisionPage = new AssistanceNeedDecisionsReportDecision(page)
-    await waitUntilEqual(
-      decisionPage.decisionMaker,
+    await decisionPage.decisionMaker.assertTextEquals(
       `${decisionMaker.firstName} ${decisionMaker.lastName}, regional director`
     )
 
@@ -184,7 +182,7 @@ describe('Assistance need decisions report', () => {
     await decisionPage.returnForEditBtn.click()
     await decisionPage.returnForEditModal.okBtn.click()
 
-    await waitUntilEqual(decisionPage.decisionStatus, 'NEEDS_WORK')
+    await decisionPage.decisionStatus.assertStatus('NEEDS_WORK')
   })
 
   test('Decision can be rejected', async () => {
@@ -200,7 +198,7 @@ describe('Assistance need decisions report', () => {
     await decisionPage.rejectBtn.click()
     await decisionPage.modalOkBtn.click()
 
-    await waitUntilEqual(decisionPage.decisionStatus, 'REJECTED')
+    await decisionPage.decisionStatus.assertStatus('REJECTED')
   })
 
   test('Decision can be accepted', async () => {
@@ -216,7 +214,7 @@ describe('Assistance need decisions report', () => {
     await decisionPage.approveBtn.click()
     await decisionPage.modalOkBtn.click()
 
-    await waitUntilEqual(decisionPage.decisionStatus, 'ACCEPTED')
+    await decisionPage.decisionStatus.assertStatus('ACCEPTED')
   })
 
   test('Decision-maker can be changed', async () => {
@@ -229,8 +227,7 @@ describe('Assistance need decisions report', () => {
 
     const decisionPage = new AssistanceNeedDecisionsReportDecision(page)
 
-    await waitUntilEqual(
-      decisionPage.decisionMaker,
+    await decisionPage.decisionMaker.assertTextEquals(
       `${decisionMaker.firstName} ${decisionMaker.lastName}, regional director`
     )
 
@@ -240,8 +237,7 @@ describe('Assistance need decisions report', () => {
     await decisionPage.mismatchModal.titleInput.type('director')
     await decisionPage.mismatchModal.okBtn.click()
 
-    await waitUntilEqual(
-      decisionPage.decisionMaker,
+    await decisionPage.decisionMaker.assertTextEquals(
       `${director.firstName} ${director.lastName}, director`
     )
 

--- a/frontend/src/e2e-test/specs/5_employee/child-information.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information.spec.ts
@@ -92,17 +92,17 @@ describe('Child Information - edit additional information', () => {
   test('medication info and be added and removed', async () => {
     const medication = 'Epipen'
 
-    await section.assertMedication('')
+    await section.medication.assertTextEquals('')
 
-    await section.edit()
-    await section.fillMedication(medication)
-    await section.save()
-    await section.assertMedication(medication)
+    await section.editBtn.click()
+    await section.medicationInput.fill(medication)
+    await section.confirmBtn.click()
+    await section.medication.assertTextEquals(medication)
 
-    await section.edit()
-    await section.fillMedication('')
-    await section.save()
-    await section.assertMedication('')
+    await section.editBtn.click()
+    await section.medicationInput.fill('')
+    await section.confirmBtn.click()
+    await section.medication.assertTextEquals('')
   })
 })
 
@@ -450,16 +450,14 @@ describe('Child information - consent', () => {
   test('profile photo consent can be consented to', async () => {
     await section.evakaProfilePicYes.check()
     await section.save()
-    await waitUntilEqual(
-      () => section.evakaProfilePicModifiedBy.text,
+    await section.evakaProfilePicModifiedBy.assertTextEquals(
       `Merkintä: ${mockedDate.format()} ${admin.firstName} ${admin.lastName}`
     )
     await page.reload()
     section = await childInformationPage.openCollapsible('consents')
     await section.evakaProfilePicYes.waitUntilChecked(true)
     await section.evakaProfilePicNo.waitUntilChecked(false)
-    await waitUntilEqual(
-      () => section.evakaProfilePicModifiedBy.text,
+    await section.evakaProfilePicModifiedBy.assertTextEquals(
       `Merkintä: ${mockedDate.format()} ${admin.firstName} ${admin.lastName}`
     )
   })
@@ -467,16 +465,15 @@ describe('Child information - consent', () => {
   test('profile photo consent can be not consented to', async () => {
     await section.evakaProfilePicNo.check()
     await section.save()
-    await waitUntilEqual(
-      () => section.evakaProfilePicModifiedBy.text,
+
+    await section.evakaProfilePicModifiedBy.assertTextEquals(
       `Merkintä: ${mockedDate.format()} ${admin.firstName} ${admin.lastName}`
     )
     await page.reload()
     section = await childInformationPage.openCollapsible('consents')
     await section.evakaProfilePicYes.waitUntilChecked(false)
     await section.evakaProfilePicNo.waitUntilChecked(true)
-    await waitUntilEqual(
-      () => section.evakaProfilePicModifiedBy.text,
+    await section.evakaProfilePicModifiedBy.assertTextEquals(
       `Merkintä: ${mockedDate.format()} ${admin.firstName} ${admin.lastName}`
     )
   })
@@ -484,8 +481,7 @@ describe('Child information - consent', () => {
   test('profile photo consent can be cleared', async () => {
     await section.evakaProfilePicNo.check()
     await section.save()
-    await waitUntilEqual(
-      () => section.evakaProfilePicModifiedBy.text,
+    await section.evakaProfilePicModifiedBy.assertTextEquals(
       `Merkintä: ${mockedDate.format()} ${admin.firstName} ${admin.lastName}`
     )
     await section.evakaProfilePicClear.click()

--- a/frontend/src/e2e-test/specs/5_employee/employee-pin.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/employee-pin.spec.ts
@@ -8,7 +8,6 @@ import { Fixture } from '../../dev-api/fixtures'
 import { EmployeeDetail } from '../../dev-api/types'
 import EmployeeNav from '../../pages/employee/employee-nav'
 import { EmployeePinPage } from '../../pages/employee/employee-pin'
-import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
 
@@ -35,8 +34,7 @@ describe('Employees PIN', () => {
 
   test('shows a warning if PIN is too easy, and warning disappears once PIN is valid', async () => {
     await pinPage.pinInput.fill('1111')
-    await waitUntilEqual(
-      () => pinPage.inputInfo.text,
+    await pinPage.inputInfo.assertTextEquals(
       'Liian helppo PIN-koodi tai PIN-koodi sisältää kirjaimia'
     )
 

--- a/frontend/src/e2e-test/specs/5_employee/preferred-first-name.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/preferred-first-name.spec.ts
@@ -8,7 +8,6 @@ import { Fixture } from '../../dev-api/fixtures'
 import { EmployeeDetail } from '../../dev-api/types'
 import EmployeeNav from '../../pages/employee/employee-nav'
 import { EmployeePreferredFirstNamePage } from '../../pages/employee/employee-preferred-first-name'
-import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
 
@@ -50,10 +49,7 @@ describe('Employee preferred first name', () => {
 
     await employeePreferredFirstNamePage.preferredFirstName('Teppo')
     await employeePreferredFirstNamePage.confirm()
-    await waitUntilEqual(
-      () => page.findByDataQa('username').text,
-      'Teppo Sorsa'
-    )
+    await page.findByDataQa('username').assertTextEquals('Teppo Sorsa')
 
     await employeePreferredFirstNamePage.assertSelectedPreferredFirstName(
       'Teppo'

--- a/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
@@ -135,14 +135,9 @@ describe('Calendar events', () => {
     await creationModal.attendees.close()
     await creationModal.submit()
 
-    await waitUntilEqual(
-      () =>
-        calendarPage.calendarEventsSection.getEventOfDay(
-          mockedToday.addDays(1),
-          0
-        ).text,
-      'Testailijat: Test event (G)'
-    )
+    await calendarPage.calendarEventsSection
+      .getEventOfDay(mockedToday.addDays(1), 0)
+      .assertTextEquals('Testailijat: Test event (G)')
   })
 
   test('Employee can add multi-day event for individual child and edit and delete it', async () => {
@@ -163,14 +158,12 @@ describe('Calendar events', () => {
     await creationModal.attendees.close()
     await creationModal.submit()
 
-    await waitUntilEqual(
-      () => calendarPage.calendarEventsSection.getEventOfDay(startDate, 0).text,
-      'Osa ryhmästä: Test event (P)'
-    )
-    await waitUntilEqual(
-      () => calendarPage.calendarEventsSection.getEventOfDay(endDate, 0).text,
-      'Osa ryhmästä: Test event (P)'
-    )
+    await calendarPage.calendarEventsSection
+      .getEventOfDay(startDate, 0)
+      .assertTextEquals('Osa ryhmästä: Test event (P)')
+    await calendarPage.calendarEventsSection
+      .getEventOfDay(endDate, 0)
+      .assertTextEquals('Osa ryhmästä: Test event (P)')
 
     await calendarPage.calendarEventsSection.getEventOfDay(startDate, 0).click()
 
@@ -184,14 +177,12 @@ describe('Calendar events', () => {
     await editModal.description.fill('Edited event description')
     await editModal.submit()
 
-    await waitUntilEqual(
-      () => calendarPage.calendarEventsSection.getEventOfDay(startDate, 0).text,
-      'Osa ryhmästä: Edited event title'
-    )
-    await waitUntilEqual(
-      () => calendarPage.calendarEventsSection.getEventOfDay(endDate, 0).text,
-      'Osa ryhmästä: Edited event title'
-    )
+    await calendarPage.calendarEventsSection
+      .getEventOfDay(startDate, 0)
+      .assertTextEquals('Osa ryhmästä: Edited event title')
+    await calendarPage.calendarEventsSection
+      .getEventOfDay(endDate, 0)
+      .assertTextEquals('Osa ryhmästä: Edited event title')
 
     await calendarPage.calendarEventsSection.getEventOfDay(startDate, 0).click()
 

--- a/frontend/src/e2e-test/specs/5_employee/vasu.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/vasu.spec.ts
@@ -144,10 +144,10 @@ describe('Child Information - Vasu language', () => {
 
   test('Child placed in a Swedish unit can only use Swedish templates', async () => {
     await section.addNew()
-    await waitUntilEqual(
-      () => page.findAllByDataQa('vasu-state-chip').nth(1).text,
-      'Utkast'
-    )
+    await page
+      .findAllByDataQa('vasu-state-chip')
+      .nth(1)
+      .assertTextEquals('Utkast')
   })
 })
 
@@ -424,14 +424,10 @@ describe('Vasu document page', () => {
 
       await vasuEditPage.waitUntilSaved()
       const vasuPage = await openDocument()
-      await waitUntilEqual(
-        () => vasuPage.infoSharedToSection.recipients.text,
+      await vasuPage.infoSharedToSection.recipients.assertTextEquals(
         'Neuvolaan, Lasten terapiapalveluihin'
       )
-      await waitUntilEqual(
-        () => vasuPage.infoSharedToSection.other.text,
-        'Police'
-      )
+      await vasuPage.infoSharedToSection.other.assertTextEquals('Police')
     })
 
     test('Fill the discussion section', async () => {
@@ -518,14 +514,12 @@ describe('Vasu document page', () => {
         const refreshedVasuEditPage = await editDocument()
 
         const expectedMetadataStr = `${LocalDate.todayInSystemTz().format()} Seppo Sorsa`
-        await waitUntilEqual(
-          () => refreshedVasuEditPage.followupEntryMetadata(0, 0),
-          expectedMetadataStr
-        )
-        await waitUntilEqual(
-          () => refreshedVasuEditPage.followupEntryMetadata(0, 1),
-          expectedMetadataStr
-        )
+        await refreshedVasuEditPage
+          .followupEntryMetadata(0, 0)
+          .assertTextEquals(expectedMetadataStr)
+        await refreshedVasuEditPage
+          .followupEntryMetadata(0, 1)
+          .assertTextEquals(expectedMetadataStr)
 
         await refreshedVasuEditPage.waitUntilSaved()
         const vasuPage = await openDocument()
@@ -556,14 +550,12 @@ describe('Vasu document page', () => {
         const refreshedVasuEditPage = await editDocument()
 
         const expectedMetadataStr = `${LocalDate.todayInSystemTz().format()} Seppo Sorsa, muokattu ${LocalDate.todayInSystemTz().format()} Essi Esimies`
-        await waitUntilEqual(
-          () => refreshedVasuEditPage.followupEntryMetadata(0, 0),
-          expectedMetadataStr
-        )
-        await waitUntilEqual(
-          () => refreshedVasuEditPage.followupEntryMetadata(0, 1),
-          expectedMetadataStr
-        )
+        await refreshedVasuEditPage
+          .followupEntryMetadata(0, 0)
+          .assertTextEquals(expectedMetadataStr)
+        await refreshedVasuEditPage
+          .followupEntryMetadata(0, 1)
+          .assertTextEquals(expectedMetadataStr)
 
         await refreshedVasuEditPage.waitUntilSaved()
         const vasuPage = await openDocument()
@@ -594,7 +586,7 @@ describe('Vasu document page', () => {
       await finalizeDocument()
       vasuPage = await openDocument()
 
-      await waitUntilEqual(() => vasuPage.documentState(), 'Laadittu')
+      await vasuPage.documentState.assertTextEquals('Laadittu')
       await waitUntilEqual(
         () => vasuPage.publishedDate(),
         LocalDate.todayInSystemTz().format()
@@ -633,7 +625,7 @@ describe('Vasu document page', () => {
       vasuPage = await openDocument()
       await vasuPage.assertDocumentVisible()
 
-      await waitUntilEqual(() => vasuPage.documentState(), 'Arvioitu')
+      await vasuPage.documentState.assertTextEquals('Arvioitu')
       await waitUntilEqual(
         () => vasuPage.reviewedDate(),
         LocalDate.todayInSystemTz().format()
@@ -657,7 +649,7 @@ describe('Vasu document page', () => {
       vasuPage = await openDocument()
       await vasuPage.assertDocumentVisible()
 
-      await waitUntilEqual(() => vasuPage.documentState(), 'Päättynyt')
+      await vasuPage.documentState.assertTextEquals('Päättynyt')
       await waitUntilEqual(
         () => vasuPage.closedDate(),
         LocalDate.todayInSystemTz().format()

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -514,3 +514,13 @@ export class TreeDropdown extends Element {
     }
   }
 }
+
+export class StaticChip extends Element {
+  get status(): Promise<string | null> {
+    return this.getAttribute('data-qa-status')
+  }
+
+  async assertStatus(status: string) {
+    await waitUntilEqual(() => this.status, status)
+  }
+}

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -202,10 +202,6 @@ export class Element {
     return this.locator.innerText()
   }
 
-  get textAsFloat(): Promise<number | null> {
-    return this.text.then((str) => (str ? parseFloat(str) : null))
-  }
-
   async assertText(assertion: (text: string) => boolean): Promise<void> {
     await waitUntilTrue(async () => assertion(await this.text))
   }


### PR DESCRIPTION
#### Summary

* Use `Element.assertTextEquals` in all places where it was an easy change.
* Remove `Element.textAsFloat` in favor of `Element.assertText`.
* Add a new element helper for `<StaticChip>`.
