### PR TITLE
HOTFIX: Avoid infinite loop caused by mutation in `useEffect`

### DIFF
--- a/frontend/src/citizen-frontend/children/sections/consents/ChildConsentsSection.tsx
+++ b/frontend/src/citizen-frontend/children/sections/consents/ChildConsentsSection.tsx
@@ -33,7 +33,9 @@ export default React.memo(function ChildConsentsSection({
   const t = useTranslation()
 
   const childConsents = useQueryResult(childConsentsQuery)
-  const insertChildConsents = useMutationResult(insertChildConsentsMutation)
+  const { mutateAsync: insertChildConsents } = useMutationResult(
+    insertChildConsentsMutation
+  )
 
   const [open, setOpen] = useState(false)
 
@@ -93,7 +95,7 @@ export default React.memo(function ChildConsentsSection({
       return Promise.resolve(Failure.of({ message: 'Form not loaded' }))
     }
 
-    return insertChildConsents.mutateAsync({
+    return insertChildConsents({
       childId,
       consents: Object.entries(form)
         .filter(

--- a/frontend/src/citizen-frontend/children/sections/pedagogical-documents/PedagogicalDocumentsSection.tsx
+++ b/frontend/src/citizen-frontend/children/sections/pedagogical-documents/PedagogicalDocumentsSection.tsx
@@ -383,7 +383,7 @@ export default React.memo(function PedagogicalDocumentsSection({
   const pedagogicalDocuments = useQueryResult(
     pedagogicalDocumentsQuery(childId)
   )
-  const markPedagogicalDocumentAsRead = useMutation(
+  const { mutate: markPedagogicalDocumentAsRead } = useMutation(
     markPedagogicalDocumentAsReadMutation
   )
 
@@ -392,7 +392,7 @@ export default React.memo(function PedagogicalDocumentsSection({
   )
 
   const onRead = (doc: PedagogicalDocumentCitizen) => {
-    void markPedagogicalDocumentAsRead.mutate({ childId, documentId: doc.id })
+    markPedagogicalDocumentAsRead({ childId, documentId: doc.id })
   }
 
   const t = useTranslation()

--- a/frontend/src/citizen-frontend/children/sections/vasu-and-leops/vasu/VasuPage.tsx
+++ b/frontend/src/citizen-frontend/children/sections/vasu-and-leops/vasu/VasuPage.tsx
@@ -52,7 +52,7 @@ export default React.memo(function VasuPage() {
   const [givePermissionToShareSelected, setGivePermissionToShareSelected] =
     useState<boolean>(false)
   const vasuDocument = useQueryResult(vasuDocumentQuery(id))
-  const givePermissionToShareVasu = useMutationResult(
+  const { mutateAsync: givePermissionToShareVasu } = useMutationResult(
     givePermissionToShareVasuMutation
   )
 
@@ -157,7 +157,7 @@ export default React.memo(function VasuPage() {
                         primary
                         text={t.common.confirm}
                         disabled={!givePermissionToShareSelected}
-                        onClick={() => givePermissionToShareVasu.mutate(id)}
+                        onClick={() => givePermissionToShareVasu(id)}
                         onSuccess={() => undefined}
                         data-qa="confirm-button"
                       />

--- a/frontend/src/citizen-frontend/decisions/assistance-decision-page/AssistanceDecisionPage.tsx
+++ b/frontend/src/citizen-frontend/decisions/assistance-decision-page/AssistanceDecisionPage.tsx
@@ -32,11 +32,11 @@ export default React.memo(function AssistanceNeedDecisionPage() {
   const assistanceNeedDecision = useQueryResult(assistanceDecisionQuery(id))
   const i18n = useTranslation()
 
-  const markAssistanceNeedDecisionAsRead = useMutationResult(
+  const { mutate: markAssistanceNeedDecisionAsRead } = useMutationResult(
     markAssistanceNeedDecisionAsReadMutation
   )
   useEffect(() => {
-    markAssistanceNeedDecisionAsRead.mutate(id)
+    markAssistanceNeedDecisionAsRead(id)
   }, [id, markAssistanceNeedDecisionAsRead])
 
   return (

--- a/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
+++ b/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponse.tsx
@@ -84,8 +84,12 @@ export default React.memo(function DecisionResponse({
     }
   }
 
-  const acceptDecision = useMutationResult(acceptDecisionMutation)
-  const rejectDecision = useMutationResult(rejectDecisionMutation)
+  const { mutateAsync: acceptDecision } = useMutationResult(
+    acceptDecisionMutation
+  )
+  const { mutateAsync: rejectDecision } = useMutationResult(
+    rejectDecisionMutation
+  )
 
   const handleAcceptDecision = async () => {
     if (requestedStartDate === null) {
@@ -94,7 +98,7 @@ export default React.memo(function DecisionResponse({
       })
     }
     setSubmitting(true)
-    return acceptDecision.mutateAsync({
+    return acceptDecision({
       applicationId,
       decisionId,
       requestedStartDate
@@ -103,7 +107,7 @@ export default React.memo(function DecisionResponse({
 
   const handleRejectDecision = async () => {
     setSubmitting(true)
-    return rejectDecision.mutateAsync({ applicationId, decisionId })
+    return rejectDecision({ applicationId, decisionId })
   }
 
   const onSubmit = async () => {


### PR DESCRIPTION
#### Summary

Extract the mutation function from useMutation/useMutationResult return value instead of passing the return value around as-is.
