### PR TITLE
Move from N async job runners model to 1 runner, N pools

### DIFF
--- a/evaka-base/dd-jmxfetch/conf.yaml
+++ b/evaka-base/dd-jmxfetch/conf.yaml
@@ -131,15 +131,23 @@ instances:
       - include:
           domain: metrics
           type: gauges
-          name: asyncJobWorkersActive.payloadType.AsyncJob
+          name: asyncJobWorkersActive.jobType.AsyncJob.pool.main
           attribute:
             Value:
-              alias: asyncjob.workers.asyncjob
+              alias: asyncjob.workers.main
               metric_type: gauge
       - include:
           domain: metrics
           type: gauges
-          name: asyncJobWorkersActive.payloadType.SuomiFiAsyncJob
+          name: asyncJobWorkersActive.jobType.AsyncJob.pool.email
+          attribute:
+            Value:
+              alias: asyncjob.workers.email
+              metric_type: gauge
+      - include:
+          domain: metrics
+          type: gauges
+          name: asyncJobWorkersActive.jobtype.AsyncJob.pool.suomiFi
           attribute:
             Value:
               alias: asyncjob.workers.suomifi
@@ -147,7 +155,7 @@ instances:
       - include:
           domain: metrics
           type: gauges
-          name: asyncJobWorkersActive.payloadType.UrgentAsyncJob
+          name: asyncJobWorkersActive.jobtype.AsyncJob.pool.urgent
           attribute:
             Value:
               alias: asyncjob.workers.urgent
@@ -155,7 +163,7 @@ instances:
       - include:
           domain: metrics
           type: gauges
-          name: asyncJobWorkersActive.payloadType.VardaAsyncJob
+          name: asyncJobWorkersActive.jobtype.AsyncJob.pool.varda
           attribute:
             Value:
               alias: asyncjob.workers.varda
@@ -163,15 +171,15 @@ instances:
       - include:
           domain: metrics
           type: meters
-          name: asyncJobsExecuted.payloadType.AsyncJob
+          name: asyncJobsExecuted.jobType.AsyncJob.pool.main
           attribute:
             Count:
-              alias: asyncjobs.executed.asyncjob
+              alias: asyncjobs.executed.main
               metric_type: counter
       - include:
           domain: metrics
           type: meters
-          name: asyncJobsExecuted.payloadType.SuomiFiAsyncJob
+          name: asyncJobsExecuted.jobType.AsyncJob.pool.email
           attribute:
             Count:
               alias: asyncjobs.executed.suomifi
@@ -179,7 +187,15 @@ instances:
       - include:
           domain: metrics
           type: meters
-          name: asyncJobsExecuted.payloadType.UrgentAsyncJob
+          name: asyncJobsExecuted.jobType.AsyncJob.pool.suomiFi
+          attribute:
+            Count:
+              alias: asyncjobs.executed.suomifi
+              metric_type: counter
+      - include:
+          domain: metrics
+          type: meters
+          name: asyncJobsExecuted.jobType.AsyncJob.pool.urgent
           attribute:
             Count:
               alias: asyncjobs.executed.urgent
@@ -187,7 +203,7 @@ instances:
       - include:
           domain: metrics
           type: meters
-          name: asyncJobsExecuted.payloadType.VardaAsyncJob
+          name: asyncJobsExecuted.jobType.AsyncJob.pool.varda
           attribute:
             Count:
               alias: asyncjobs.executed.varda
@@ -195,15 +211,23 @@ instances:
       - include:
           domain: metrics
           type: meters
-          name: asyncJobsFailed.payloadType.AsyncJob
+          name: asyncJobsFailed.jobType.AsyncJob.pool.main
           attribute:
             Count:
-              alias: asyncjobs.failed.asyncjob
+              alias: asyncjobs.failed.main
               metric_type: counter
       - include:
           domain: metrics
           type: meters
-          name: asyncJobsFailed.payloadType.SuomiFiAsyncJob
+          name: asyncJobsFailed.jobType.AsyncJob.pool.email
+          attribute:
+            Count:
+              alias: asyncjobs.failed.email
+              metric_type: counter
+      - include:
+          domain: metrics
+          type: meters
+          name: asyncJobsFailed.jobType.AsyncJob.pool.suomiFi
           attribute:
             Count:
               alias: asyncjobs.failed.suomifi
@@ -211,7 +235,7 @@ instances:
       - include:
           domain: metrics
           type: meters
-          name: asyncJobsFailed.payloadType.UrgentAsyncJob
+          name: asyncJobsFailed.jobType.AsyncJob.pool.urgent
           attribute:
             Count:
               alias: asyncjobs.failed.urgent
@@ -219,7 +243,7 @@ instances:
       - include:
           domain: metrics
           type: meters
-          name: asyncJobsFailed.payloadType.VardaAsyncJob
+          name: asyncJobsFailed.jobType.AsyncJob.pool.varda
           attribute:
             Count:
               alias: asyncjobs.failed.varda

--- a/evaka-base/dd-jmxfetch/conf.yaml
+++ b/evaka-base/dd-jmxfetch/conf.yaml
@@ -165,7 +165,7 @@ instances:
           type: meters
           name: asyncJobsExecuted.payloadType.AsyncJob
           attribute:
-            Value:
+            Count:
               alias: asyncjobs.executed.asyncjob
               metric_type: counter
       - include:
@@ -173,7 +173,7 @@ instances:
           type: meters
           name: asyncJobsExecuted.payloadType.SuomiFiAsyncJob
           attribute:
-            Value:
+            Count:
               alias: asyncjobs.executed.suomifi
               metric_type: counter
       - include:
@@ -181,7 +181,7 @@ instances:
           type: meters
           name: asyncJobsExecuted.payloadType.UrgentAsyncJob
           attribute:
-            Value:
+            Count:
               alias: asyncjobs.executed.urgent
               metric_type: counter
       - include:
@@ -189,7 +189,7 @@ instances:
           type: meters
           name: asyncJobsExecuted.payloadType.VardaAsyncJob
           attribute:
-            Value:
+            Count:
               alias: asyncjobs.executed.varda
               metric_type: counter
       - include:
@@ -197,7 +197,7 @@ instances:
           type: meters
           name: asyncJobsFailed.payloadType.AsyncJob
           attribute:
-            Value:
+            Count:
               alias: asyncjobs.failed.asyncjob
               metric_type: counter
       - include:
@@ -205,7 +205,7 @@ instances:
           type: meters
           name: asyncJobsFailed.payloadType.SuomiFiAsyncJob
           attribute:
-            Value:
+            Count:
               alias: asyncjobs.failed.suomifi
               metric_type: counter
       - include:
@@ -213,7 +213,7 @@ instances:
           type: meters
           name: asyncJobsFailed.payloadType.UrgentAsyncJob
           attribute:
-            Value:
+            Count:
               alias: asyncjobs.failed.urgent
               metric_type: counter
       - include:
@@ -221,6 +221,6 @@ instances:
           type: meters
           name: asyncJobsFailed.payloadType.VardaAsyncJob
           attribute:
-            Value:
+            Count:
               alias: asyncjobs.failed.varda
               metric_type: counter

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -37,7 +37,6 @@ import fi.espoo.evaka.shared.PartnershipId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
@@ -93,8 +92,6 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
     @Autowired private lateinit var decisionDraftService: DecisionDraftService
 
     @Autowired private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
-
-    @Autowired private lateinit var sfiAsyncJobRunner: AsyncJobRunner<SuomiFiAsyncJob>
 
     @Autowired lateinit var mapper: JsonMapper
 
@@ -1209,8 +1206,6 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.sendDecisionsWithoutProposal(tx, serviceWorker, clock, applicationId)
         }
         asyncJobRunner.runPendingJobsSync(clock)
-        asyncJobRunner.runPendingJobsSync(clock)
-        sfiAsyncJobRunner.runPendingJobsSync(clock)
 
         // then
         db.read {
@@ -1361,8 +1356,6 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.confirmPlacementProposalChanges(tx, serviceWorker, clock, testDaycare.id)
         }
         asyncJobRunner.runPendingJobsSync(clock)
-        asyncJobRunner.runPendingJobsSync(clock)
-        sfiAsyncJobRunner.runPendingJobsSync(clock)
         db.read { tx ->
             // then
             val application = tx.fetchApplicationDetails(applicationId)!!
@@ -1432,7 +1425,6 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             service.confirmPlacementProposalChanges(tx, serviceWorker, clock, testDaycare.id)
         }
         asyncJobRunner.runPendingJobsSync(clock)
-        sfiAsyncJobRunner.runPendingJobsSync(clock)
         db.read { tx ->
             // then
             val application = tx.fetchApplicationDetails(applicationId)!!

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -28,7 +28,6 @@ import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.dev.DevPerson
@@ -71,7 +70,6 @@ import org.springframework.beans.factory.annotation.Autowired
 class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     @Autowired private lateinit var feeDecisionController: FeeDecisionController
     @Autowired private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
-    @Autowired private lateinit var sfiAsyncJobRunner: AsyncJobRunner<SuomiFiAsyncJob>
 
     private val user =
         AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
@@ -1846,7 +1844,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         assertThrows<Forbidden> { getPdf(decision.id, user) }
 
         // Check that message is still sent via sfi
-        sfiAsyncJobRunner.runPendingJobsSync(MockEvakaClock(HelsinkiDateTime.now()))
+        asyncJobRunner.runPendingJobsSync(MockEvakaClock(HelsinkiDateTime.now()))
         assertEquals(1, MockSfiMessagesClient.getMessages().size)
     }
 
@@ -1874,7 +1872,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
 
         assertThrows<Forbidden> { getPdf(decision.id, user) }
 
-        sfiAsyncJobRunner.runPendingJobsSync(MockEvakaClock(HelsinkiDateTime.now()))
+        asyncJobRunner.runPendingJobsSync(MockEvakaClock(HelsinkiDateTime.now()))
         assertEquals(1, MockSfiMessagesClient.getMessages().size)
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -32,7 +32,6 @@ import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.asUser
@@ -68,8 +67,6 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
     @Autowired lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     @Autowired lateinit var voucherValueDecisionService: VoucherValueDecisionService
-
-    @Autowired private lateinit var sfiAsyncJobRunner: AsyncJobRunner<SuomiFiAsyncJob>
 
     @BeforeEach
     fun beforeEach() {
@@ -430,7 +427,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
         assertEquals(403, getPdfStatus(decisionIds[0], financeWorker))
 
         // Check that message is still sent via sfi
-        sfiAsyncJobRunner.runPendingJobsSync(MockEvakaClock(now))
+        asyncJobRunner.runPendingJobsSync(MockEvakaClock(now))
         assertEquals(1, MockSfiMessagesClient.getMessages().size)
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -19,7 +19,6 @@ import fi.espoo.evaka.shared.MessageThreadId
 import fi.espoo.evaka.shared.Paged
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.UrgentAsyncJob
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
@@ -75,7 +74,6 @@ import org.springframework.mock.web.MockMultipartFile
 class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     @Autowired lateinit var attachmentsController: AttachmentsController
     @Autowired lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
-    @Autowired lateinit var urgentAsyncJobRunner: AsyncJobRunner<UrgentAsyncJob>
 
     private val clock = RealEvakaClock()
 
@@ -801,7 +799,6 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             .response()
             .also { assertEquals(statusCode, it.second.statusCode) }
             .also { asyncJobRunner.runPendingJobsSync(MockEvakaClock(readTime)) }
-            .also { urgentAsyncJobRunner.runPendingJobsSync(MockEvakaClock(readTime)) }
 
     private fun replyAsCitizen(
         user: AuthenticatedUser.Citizen,
@@ -820,7 +817,6 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             .withMockedTime(sendTime)
             .response()
             .also { asyncJobRunner.runPendingJobsSync(MockEvakaClock(readTime)) }
-            .also { urgentAsyncJobRunner.runPendingJobsSync(MockEvakaClock(readTime)) }
 
     private fun replyAsEmployee(
         user: AuthenticatedUser.Employee,
@@ -840,7 +836,6 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             .withMockedTime(sendTime)
             .response()
             .also { asyncJobRunner.runPendingJobsSync(MockEvakaClock(readTime)) }
-            .also { urgentAsyncJobRunner.runPendingJobsSync(MockEvakaClock(readTime)) }
 
     private fun markThreadRead(
         user: AuthenticatedUser,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
@@ -49,7 +49,7 @@ class AsyncJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
         asyncJobRunner =
             AsyncJobRunner(
                 TestJob::class,
-                AsyncJobPoolConfig(backgroundPollingInterval = Duration.ofSeconds(1)),
+                AsyncJobPool.Config(backgroundPollingInterval = Duration.ofSeconds(1)),
                 jdbi,
                 noopTracer
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
@@ -46,7 +46,13 @@ class AsyncJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
 
     @BeforeEach
     fun clean() {
-        asyncJobRunner = AsyncJobRunner(TestJob::class, jdbi, AsyncJobRunnerConfig(), noopTracer)
+        asyncJobRunner =
+            AsyncJobRunner(
+                TestJob::class,
+                AsyncJobPoolConfig(backgroundPollingInterval = Duration.ofSeconds(1)),
+                jdbi,
+                noopTracer
+            )
         asyncJobRunner.registerHandler { _, _, msg: TestJob -> currentCallback.get()(msg) }
     }
 
@@ -106,7 +112,7 @@ class AsyncJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
         val job = TestJob()
         val future = this.setAsyncJobCallback { assertEquals(job, it) }
         db.transaction { asyncJobRunner.plan(it, listOf(job), runAt = HelsinkiDateTime.now()) }
-        asyncJobRunner.start(pollingInterval = Duration.ofSeconds(1))
+        asyncJobRunner.startBackgroundPolling()
         future.get(10, TimeUnit.SECONDS)
     }
 
@@ -114,8 +120,7 @@ class AsyncJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
     fun `AsyncJobRunner wakes up automatically after a transaction plans jobs`() {
         val job = TestJob()
         val future = this.setAsyncJobCallback { assertEquals(job, it) }
-        asyncJobRunner.start(pollingInterval = Duration.ofDays(1))
-        TimeUnit.MILLISECONDS.sleep(100)
+        asyncJobRunner.enableAfterCommitHook()
         db.transaction { asyncJobRunner.plan(it, listOf(job), runAt = HelsinkiDateTime.now()) }
         future.get(10, TimeUnit.SECONDS)
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunnerTest.kt
@@ -52,7 +52,7 @@ class AsyncJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
                 listOf(
                     AsyncJobRunner.Pool(
                         AsyncJobPool.Id(TestJob::class, "default"),
-                        AsyncJobPool.Config(backgroundPollingInterval = Duration.ofSeconds(1)),
+                        AsyncJobPool.Config(),
                         setOf(TestJob::class)
                     )
                 ),
@@ -118,7 +118,7 @@ class AsyncJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
         val job = TestJob()
         val future = this.setAsyncJobCallback { assertEquals(job, it) }
         db.transaction { asyncJobRunner.plan(it, listOf(job), runAt = HelsinkiDateTime.now()) }
-        asyncJobRunner.startBackgroundPolling()
+        asyncJobRunner.startBackgroundPolling(Duration.ofSeconds(1))
         future.get(10, TimeUnit.SECONDS)
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
@@ -6,7 +6,6 @@ package fi.espoo.evaka.shared.job
 
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.shared.async.AsyncJob
-import fi.espoo.evaka.shared.async.AsyncJobPool
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.domain.europeHelsinki
@@ -34,7 +33,7 @@ class ScheduledJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
 
     @BeforeEach
     fun beforeEach() {
-        asyncJobRunner = AsyncJobRunner(AsyncJob::class, AsyncJobPool.Config(), jdbi, noopTracer)
+        asyncJobRunner = AsyncJobRunner(AsyncJob::class, listOf(AsyncJob.main), jdbi, noopTracer)
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
@@ -6,8 +6,8 @@ package fi.espoo.evaka.shared.job
 
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobPoolConfig
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.AsyncJobRunnerConfig
 import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.domain.europeHelsinki
 import java.time.Duration
@@ -34,7 +34,7 @@ class ScheduledJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
 
     @BeforeEach
     fun beforeEach() {
-        asyncJobRunner = AsyncJobRunner(AsyncJob::class, jdbi, AsyncJobRunnerConfig(), noopTracer)
+        asyncJobRunner = AsyncJobRunner(AsyncJob::class, AsyncJobPoolConfig(), jdbi, noopTracer)
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.shared.job
 
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.shared.async.AsyncJob
-import fi.espoo.evaka.shared.async.AsyncJobPoolConfig
+import fi.espoo.evaka.shared.async.AsyncJobPool
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.shared.domain.europeHelsinki
@@ -34,7 +34,7 @@ class ScheduledJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
 
     @BeforeEach
     fun beforeEach() {
-        asyncJobRunner = AsyncJobRunner(AsyncJob::class, AsyncJobPoolConfig(), jdbi, noopTracer)
+        asyncJobRunner = AsyncJobRunner(AsyncJob::class, AsyncJobPool.Config(), jdbi, noopTracer)
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -26,7 +26,6 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
@@ -52,7 +51,6 @@ class DecisionService(
     private val pdfService: PDFService,
     private val messageProvider: IMessageProvider,
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
-    private val sfiAsyncJobRunner: AsyncJobRunner<SuomiFiAsyncJob>,
     env: BucketEnv
 ) {
     private val decisionBucket = env.decisions
@@ -306,11 +304,7 @@ class DecisionService(
                 messageContent = messageProvider.getDecisionContent(lang.messageLang)
             )
 
-        sfiAsyncJobRunner.plan(
-            tx,
-            listOf(SuomiFiAsyncJob.SendMessage(message)),
-            runAt = clock.now()
-        )
+        asyncJobRunner.plan(tx, listOf(AsyncJob.SendMessage(message)), runAt = clock.now())
     }
 
     fun getDecisionPdf(dbc: Database.Connection, decision: Decision): ResponseEntity<Any> {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
@@ -35,8 +35,8 @@ import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.setting.getSettings
 import fi.espoo.evaka.sficlient.SfiMessage
 import fi.espoo.evaka.shared.FeeDecisionId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -57,7 +57,7 @@ class FeeDecisionService(
     private val pdfService: PDFService,
     private val documentClient: DocumentService,
     private val messageProvider: IMessageProvider,
-    private val sfiAsyncJobRunner: AsyncJobRunner<SuomiFiAsyncJob>,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val env: EvakaEnv,
     private val bucketEnv: BucketEnv
 ) {
@@ -259,11 +259,7 @@ class FeeDecisionService(
 
         logger.info("Sending fee decision as suomi.fi message ${message.documentId}")
 
-        sfiAsyncJobRunner.plan(
-            tx,
-            listOf(SuomiFiAsyncJob.SendMessage(message)),
-            runAt = clock.now()
-        )
+        asyncJobRunner.plan(tx, listOf(AsyncJob.SendMessage(message)), runAt = clock.now())
         tx.setFeeDecisionSent(clock, listOf(decision.id))
 
         return true

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
@@ -22,8 +22,8 @@ import fi.espoo.evaka.setting.SettingType
 import fi.espoo.evaka.setting.getSettings
 import fi.espoo.evaka.sficlient.SfiMessage
 import fi.espoo.evaka.shared.VoucherValueDecisionId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
@@ -38,7 +38,7 @@ class VoucherValueDecisionService(
     private val pdfService: PDFService,
     private val documentClient: DocumentService,
     private val messageProvider: IMessageProvider,
-    private val sfiAsyncJobRunner: AsyncJobRunner<SuomiFiAsyncJob>,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     env: BucketEnv
 ) {
     private val bucket = env.voucherValueDecisions
@@ -101,10 +101,10 @@ class VoucherValueDecisionService(
         val documentDisplayName = suomiFiDocumentFileName(lang)
         val messageHeader = messageProvider.getVoucherValueDecisionHeader(lang.messageLang)
         val messageContent = messageProvider.getVoucherValueDecisionContent(lang.messageLang)
-        sfiAsyncJobRunner.plan(
+        asyncJobRunner.plan(
             tx,
             listOf(
-                SuomiFiAsyncJob.SendMessage(
+                AsyncJob.SendMessage(
                     SfiMessage(
                         messageId = decision.id.toString(),
                         documentId = decision.id.toString(),

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -11,8 +11,8 @@ import fi.espoo.evaka.shared.MessageAccountId
 import fi.espoo.evaka.shared.MessageId
 import fi.espoo.evaka.shared.MessageThreadId
 import fi.espoo.evaka.shared.Paged
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.UrgentAsyncJob
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
@@ -36,7 +36,7 @@ data class CitizenMessageBody(
 @RestController
 @RequestMapping("/citizen/messages")
 class MessageControllerCitizen(
-    private val urgentAsyncJobRunner: AsyncJobRunner<UrgentAsyncJob>,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val featureConfig: FeatureConfig,
     private val messageService: MessageService
 ) {
@@ -200,7 +200,7 @@ class MessageControllerCitizen(
                                 isCopy = false
                             )
                         tx.upsertSenderThreadParticipants(senderId, listOf(threadId), now)
-                        urgentAsyncJobRunner.scheduleThreadRecipientsUpdate(
+                        asyncJobRunner.scheduleThreadRecipientsUpdate(
                             tx,
                             listOf(threadId to recipientIds),
                             now

--- a/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiAsyncJobs.kt
@@ -4,17 +4,17 @@
 
 package fi.espoo.evaka.sficlient
 
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
 import org.springframework.stereotype.Service
 
 @Service
 class SfiAsyncJobs(
     private val sfiClient: SfiMessagesClient,
-    asyncJobRunner: AsyncJobRunner<SuomiFiAsyncJob>
+    asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     init {
-        asyncJobRunner.registerHandler { _, _, payload: SuomiFiAsyncJob.SendMessage ->
+        asyncJobRunner.registerHandler { _, _, payload: AsyncJob.SendMessage ->
             sendMessagePDF(payload.message)
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -49,38 +49,6 @@ interface AsyncJobPayload {
     val user: AuthenticatedUser?
 }
 
-sealed interface VardaAsyncJob : AsyncJobPayload {
-    data class UpdateVardaChild(
-        val serviceNeedDiffByChild: VardaChildCalculatedServiceNeedChanges
-    ) : VardaAsyncJob {
-        override val user: AuthenticatedUser? = null
-    }
-
-    data class ResetVardaChild(val childId: ChildId) : VardaAsyncJob {
-        override val user: AuthenticatedUser? = null
-    }
-
-    data class DeleteVardaChild(val vardaChildId: Long) : VardaAsyncJob {
-        override val user: AuthenticatedUser? = null
-    }
-}
-
-sealed interface SuomiFiAsyncJob : AsyncJobPayload {
-    data class SendMessage(val message: SfiMessage) : SuomiFiAsyncJob {
-        override val user: AuthenticatedUser? = null
-    }
-}
-
-sealed interface UrgentAsyncJob : AsyncJobPayload {
-    data class UpdateMessageThreadRecipients(
-        val threadId: MessageThreadId,
-        val recipientIds: Set<MessageAccountId>,
-        val sentAt: HelsinkiDateTime
-    ) : UrgentAsyncJob {
-        override val user: AuthenticatedUser? = null
-    }
-}
-
 sealed interface AsyncJob : AsyncJobPayload {
     data class DvvModificationsRefresh(val ssns: List<String>, val requestingUserId: UUID) :
         AsyncJob {
@@ -241,6 +209,98 @@ sealed interface AsyncJob : AsyncJobPayload {
     data class SendMissingReservationsReminder(val guardian: PersonId, val range: FiniteDateRange) :
         AsyncJob {
         override val user: AuthenticatedUser? = null
+    }
+
+    data class UpdateMessageThreadRecipients(
+        val threadId: MessageThreadId,
+        val recipientIds: Set<MessageAccountId>,
+        val sentAt: HelsinkiDateTime
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class SendMessage(val message: SfiMessage) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class UpdateVardaChild(
+        val serviceNeedDiffByChild: VardaChildCalculatedServiceNeedChanges
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class ResetVardaChild(val childId: ChildId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class DeleteVardaChild(val vardaChildId: Long) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    companion object {
+        val main =
+            AsyncJobRunner.Pool(
+                AsyncJobPool.Id(AsyncJob::class, "main"),
+                AsyncJobPool.Config(concurrency = 4),
+                setOf(
+                    CreateAssistanceNeedDecisionPdf::class,
+                    DvvModificationsRefresh::class,
+                    GarbageCollectPairing::class,
+                    GenerateFinanceDecisions::class,
+                    InitializeFamilyFromApplication::class,
+                    NotifyDecisionCreated::class,
+                    NotifyFeeDecisionApproved::class,
+                    NotifyFeeDecisionPdfGenerated::class,
+                    NotifyFeeThresholdsUpdated::class,
+                    NotifyVoucherValueDecisionApproved::class,
+                    NotifyVoucherValueDecisionPdfGenerated::class,
+                    RunScheduledJob::class,
+                    ScheduleKoskiUploads::class,
+                    SendAssistanceNeedDecisionSfiMessage::class,
+                    SendDecision::class,
+                    SendPatuReport::class,
+                    UpdateFromVtj::class,
+                    UpdateIrregularAbsences::class,
+                    UploadToKoski::class,
+                    VTJRefresh::class,
+                )
+            )
+        val email =
+            AsyncJobRunner.Pool(
+                AsyncJobPool.Id(AsyncJob::class, "email"),
+                AsyncJobPool.Config(concurrency = 4),
+                setOf(
+                    SendApplicationEmail::class,
+                    SendAssistanceNeedDecisionEmail::class,
+                    SendMessageNotificationEmail::class,
+                    SendMissingReservationsReminder::class,
+                    SendPedagogicalDocumentNotificationEmail::class,
+                    SendPendingDecisionEmail::class,
+                    SendVasuNotificationEmail::class,
+                )
+            )
+        val urgent =
+            AsyncJobRunner.Pool(
+                AsyncJobPool.Id(AsyncJob::class, "urgent"),
+                AsyncJobPool.Config(concurrency = 4),
+                setOf(UpdateMessageThreadRecipients::class)
+            )
+        val suomiFi =
+            AsyncJobRunner.Pool(
+                AsyncJobPool.Id(AsyncJob::class, "suomiFi"),
+                AsyncJobPool.Config(concurrency = 1),
+                setOf(SendMessage::class)
+            )
+        val varda =
+            AsyncJobRunner.Pool(
+                AsyncJobPool.Id(AsyncJob::class, "varda"),
+                AsyncJobPool.Config(concurrency = 1),
+                setOf(
+                    UpdateVardaChild::class,
+                    ResetVardaChild::class,
+                    DeleteVardaChild::class,
+                )
+            )
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobPool.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobPool.kt
@@ -31,17 +31,9 @@ import kotlin.concurrent.thread
 import mu.KotlinLogging
 import org.jdbi.v3.core.Jdbi
 
-data class AsyncJobPoolConfig(
-    val concurrency: Int = 1,
-    val backgroundPollingInterval: Duration = Duration.ofMinutes(1),
-    val throttleInterval: Duration? = null
-)
-
-class AsyncJobMetrics(val executedJobs: Counter, val failedJobs: Counter)
-
 class AsyncJobPool<T : AsyncJobPayload>(
     name: String,
-    private val config: AsyncJobPoolConfig,
+    private val config: Config,
     private val jdbi: Jdbi,
     private val tracer: Tracer,
     private val metrics: AtomicReference<AsyncJobMetrics>,
@@ -192,6 +184,12 @@ class AsyncJobPool<T : AsyncJobPayload>(
         }
         executor.shutdownNow()
     }
+
+    data class Config(
+        val concurrency: Int = 1,
+        val backgroundPollingInterval: Duration = Duration.ofMinutes(1),
+        val throttleInterval: Duration? = null
+    )
 
     data class Handler<T : AsyncJobPayload>(
         val handler: (db: Database, clock: EvakaClock, msg: T) -> Unit

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobPool.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobPool.kt
@@ -36,8 +36,8 @@ import mu.KotlinLogging
 import org.jdbi.v3.core.Jdbi
 
 data class AsyncJobPoolConfig(
-    val concurrency: Int,
-    val backgroundPollingInterval: Duration,
+    val concurrency: Int = 1,
+    val backgroundPollingInterval: Duration = Duration.ofMinutes(1),
     val throttleInterval: Duration? = null
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobPool.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobPool.kt
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.async
+
+import fi.espoo.evaka.shared.Tracing
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.domain.RealEvakaClock
+import fi.espoo.evaka.shared.randomTracingId
+import fi.espoo.evaka.shared.withDetachedSpan
+import fi.espoo.evaka.shared.withValue
+import fi.espoo.voltti.logging.MdcKey
+import fi.espoo.voltti.logging.loggers.error
+import fi.espoo.voltti.logging.loggers.info
+import io.micrometer.core.instrument.Counter
+import io.opentracing.Tracer
+import io.opentracing.tag.Tags
+import java.lang.reflect.UndeclaredThrowableException
+import java.time.Duration
+import java.util.Timer
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.FutureTask
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.fixedRateTimer
+import kotlin.concurrent.thread
+import kotlin.concurrent.withLock
+import mu.KotlinLogging
+import org.jdbi.v3.core.Jdbi
+
+data class AsyncJobPoolConfig(
+    val concurrency: Int,
+    val backgroundPollingInterval: Duration,
+    val throttleInterval: Duration? = null
+)
+
+private data class Registration<T : AsyncJobPayload>(
+    val handler: (db: Database, clock: EvakaClock, msg: T) -> Unit
+) {
+    fun run(db: Database, clock: EvakaClock, msg: AsyncJobPayload) =
+        @Suppress("UNCHECKED_CAST") handler(db, clock, msg as T)
+}
+
+class AsyncJobMetrics(val executedJobs: Counter, val failedJobs: Counter)
+
+class AsyncJobPool<T : AsyncJobPayload>(
+    name: String,
+    private val config: AsyncJobPoolConfig,
+    private val jdbi: Jdbi,
+    private val tracer: Tracer,
+    private val metrics: AtomicReference<AsyncJobMetrics>
+) : AutoCloseable {
+    private val fullName: String = "${AsyncJobPool::class.simpleName}.$name"
+    private val logger = KotlinLogging.logger("${AsyncJobPool::class.qualifiedName}.$name")
+
+    private val handlersLock: Lock = ReentrantLock()
+    private val handlers: ConcurrentHashMap<AsyncJobType<out T>, Registration<*>> =
+        ConcurrentHashMap()
+
+    private val backgroundTimer: AtomicReference<Timer> = AtomicReference()
+    private val executor =
+        config.let {
+            val corePoolSize = 1
+            val maximumPoolSize = it.concurrency
+            val keepAliveTime = Pair(1L, TimeUnit.MINUTES)
+            val workQueue = SynchronousQueue<Runnable>()
+            val threadNumber = AtomicInteger(1)
+            val threadFactory = { r: Runnable ->
+                thread(
+                    start = false,
+                    name = "$fullName.worker-${threadNumber.getAndIncrement()}",
+                    priority = Thread.MIN_PRIORITY,
+                    block = r::run
+                )
+            }
+            ThreadPoolExecutor(
+                corePoolSize,
+                maximumPoolSize,
+                keepAliveTime.first,
+                keepAliveTime.second,
+                workQueue,
+                threadFactory,
+                ThreadPoolExecutor.DiscardPolicy()
+            )
+        }
+
+    val activeWorkerCount: Int
+        get() = executor.activeCount
+
+    fun <P : T> registerHandler(
+        jobType: AsyncJobType<out P>,
+        handler: (db: Database, clock: EvakaClock, msg: P) -> Unit
+    ): Unit =
+        handlersLock.withLock {
+            require(!handlers.containsKey(jobType)) {
+                "handler for $jobType has already been registered"
+            }
+            val ambiguousKey = handlers.keys.find { it.name == jobType.name }
+            require(ambiguousKey == null) {
+                "handlers for $jobType and $ambiguousKey have a name conflict"
+            }
+            handlers[jobType] = Registration(handler)
+        }
+
+    fun startBackgroundPolling() {
+        val newTimer =
+            fixedRateTimer(
+                "$fullName.timer",
+                daemon = true,
+                period = config.backgroundPollingInterval.toMillis()
+            ) {
+                executor.execute { runWorker(RealEvakaClock()) }
+            }
+        backgroundTimer.getAndSet(newTimer)?.cancel()
+    }
+
+    fun runPendingJobs(clock: EvakaClock, maxCount: Int) {
+        executor.execute { runWorker(clock, maxCount) }
+    }
+
+    fun runPendingJobsSync(clock: EvakaClock, maxCount: Int): Int {
+        val task = FutureTask { runWorker(clock, maxCount) }
+        while (!executor.queue.offer(task)) {
+            // no available workers
+            if (!executor.prestartCoreThread()) {
+                // worker capacity full
+                TimeUnit.MILLISECONDS.sleep(100)
+            }
+        }
+        return task.get()
+    }
+
+    private fun runWorker(clock: EvakaClock, maxCount: Int = 1_000) =
+        tracer.withDetachedSpan("asyncjob.worker $fullName") {
+            var executed = 0
+            Database(jdbi, tracer).connect { dbc ->
+                var remaining = maxCount
+                do {
+                    val job = dbc.transaction { it.claimJob(clock.now(), handlers.keys) }
+                    if (job != null) {
+                        tracer.withDetachedSpan(
+                            "asyncjob.run ${job.jobType.name}",
+                            Tracing.asyncJobId withValue job.jobId,
+                            Tracing.asyncJobRemainingAttempts withValue job.remainingAttempts,
+                        ) {
+                            runPendingJob(dbc, clock, job)
+                        }
+                        metrics.get()?.executedJobs?.increment()
+                        executed += 1
+                    }
+                    remaining -= 1
+                    config.throttleInterval?.toMillis()?.run { Thread.sleep(this) }
+                } while (job != null && remaining > 0 && !executor.isTerminating)
+            }
+            executed
+        }
+
+    private fun runPendingJob(
+        db: Database.Connection,
+        clock: EvakaClock,
+        job: ClaimedJobRef<out T>
+    ) {
+        val logMeta =
+            mapOf(
+                "jobId" to job.jobId,
+                "jobType" to job.jobType.name,
+                "remainingAttempts" to job.remainingAttempts
+            )
+        try {
+            val traceId = randomTracingId()
+            MdcKey.TRACE_ID.set(traceId)
+            MdcKey.SPAN_ID.set(randomTracingId())
+            tracer.activeSpan()?.setTag(Tracing.evakaTraceId, traceId)
+            logger.info(logMeta) { "Running async job $job" }
+            val completed =
+                db.transaction { tx ->
+                    tx.setLockTimeout(Duration.ofSeconds(5))
+                    val registration =
+                        handlers[job.jobType]
+                            ?: throw IllegalStateException("No handler found for ${job.jobType}")
+                    tx.startJob(job, clock.now())?.let { msg ->
+                        msg.user?.let {
+                            MdcKey.USER_ID.set(it.rawId().toString())
+                            MdcKey.USER_ID_HASH.set(it.rawIdHash.toString())
+                            tracer.activeSpan()?.setTag(Tracing.enduserIdHash, it.rawIdHash)
+                        }
+                        registration.run(Database(jdbi, tracer), clock, msg)
+                        tx.completeJob(job, clock.now())
+                        true
+                    }
+                        ?: false
+                }
+            if (completed) {
+                logger.info(logMeta) { "Completed async job $job" }
+            } else {
+                logger.info(logMeta) { "Skipped async job $job due to contention" }
+            }
+        } catch (e: Throwable) {
+            metrics.get()?.failedJobs?.increment()
+            tracer.activeSpan()?.setTag(Tags.ERROR, true)
+            val exception = (e as? UndeclaredThrowableException)?.cause ?: e
+            logger.error(exception, logMeta) { "Failed to run async job $job" }
+        } finally {
+            MdcKey.USER_ID_HASH.unset()
+            MdcKey.USER_ID.unset()
+            MdcKey.SPAN_ID.unset()
+            MdcKey.TRACE_ID.unset()
+        }
+    }
+
+    override fun close() {
+        backgroundTimer.get()?.cancel()
+
+        executor.shutdown()
+        if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+            logger.error { "Some async jobs did not terminate in time during shutdown" }
+        }
+        executor.shutdownNow()
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobPool.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobPool.kt
@@ -216,7 +216,7 @@ class AsyncJobPool<T : AsyncJobPayload>(
     }
 
     override fun close() {
-        backgroundTimer.get()?.cancel()
+        backgroundTimer.getAndSet(null)?.cancel()
 
         executor.shutdown()
         if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -27,7 +27,7 @@ private val defaultRetryInterval = Duration.ofMinutes(5)
 
 class AsyncJobRunner<T : AsyncJobPayload>(
     private val payloadType: KClass<T>,
-    config: AsyncJobPoolConfig,
+    config: AsyncJobPool.Config,
     jdbi: Jdbi,
     tracer: Tracer
 ) : AutoCloseable {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -4,52 +4,24 @@
 
 package fi.espoo.evaka.shared.async
 
-import fi.espoo.evaka.shared.Tracing
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.RealEvakaClock
-import fi.espoo.evaka.shared.randomTracingId
-import fi.espoo.evaka.shared.withDetachedSpan
-import fi.espoo.evaka.shared.withValue
-import fi.espoo.voltti.logging.MdcKey
-import fi.espoo.voltti.logging.loggers.error
-import fi.espoo.voltti.logging.loggers.info
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.opentracing.Tracer
-import io.opentracing.tag.Tags
-import java.lang.reflect.UndeclaredThrowableException
 import java.time.Duration
 import java.time.Instant
-import java.util.Timer
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.FutureTask
-import java.util.concurrent.SynchronousQueue
-import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.locks.Lock
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.fixedRateTimer
-import kotlin.concurrent.thread
-import kotlin.concurrent.withLock
 import kotlin.reflect.KClass
-import mu.KotlinLogging
 import org.jdbi.v3.core.Jdbi
 
 private const val defaultRetryCount =
     24 * 60 / 5 // 24h when used with default 5 minute retry interval
 private val defaultRetryInterval = Duration.ofMinutes(5)
-
-private data class Registration<T : AsyncJobPayload>(
-    val handler: (db: Database, clock: EvakaClock, msg: T) -> Unit
-) {
-    fun run(db: Database, clock: EvakaClock, msg: AsyncJobPayload) =
-        @Suppress("UNCHECKED_CAST") handler(db, clock, msg as T)
-}
 
 data class AsyncJobRunnerConfig(
     val threadPoolSize: Int = 4,
@@ -58,73 +30,45 @@ data class AsyncJobRunnerConfig(
 
 class AsyncJobRunner<T : AsyncJobPayload>(
     private val payloadType: KClass<T>,
-    private val jdbi: Jdbi,
-    private val config: AsyncJobRunnerConfig,
-    private val tracer: Tracer
+    jdbi: Jdbi,
+    config: AsyncJobRunnerConfig,
+    tracer: Tracer
 ) : AutoCloseable {
     val name = "${AsyncJobRunner::class.simpleName}.${payloadType.simpleName}"
-    private val logger =
-        KotlinLogging.logger("${AsyncJobRunner::class.qualifiedName}.${payloadType.simpleName}")
 
-    private val handlersLock: Lock = ReentrantLock()
-    private val handlers: ConcurrentHashMap<AsyncJobType<out T>, Registration<*>> =
-        ConcurrentHashMap()
+    private val metrics: AtomicReference<AsyncJobMetrics> = AtomicReference()
+    private val pool: AsyncJobPool<T> =
+        AsyncJobPool(
+            name = payloadType.simpleName!!,
+            config =
+                AsyncJobPoolConfig(
+                    concurrency = config.threadPoolSize,
+                    backgroundPollingInterval = Duration.ofMinutes(1),
+                    throttleInterval = config.throttleInterval
+                ),
+            jdbi,
+            tracer,
+            metrics
+        )
 
-    private val periodicTimer: AtomicReference<Timer> = AtomicReference()
-    private val wakeUpHook: () -> Unit = {
-        if (isStarted) {
-            workerExecutor.execute { runWorker(RealEvakaClock()) }
-        }
-    }
-
-    private val workerExecutor =
-        config.let {
-            val corePoolSize = 1
-            val maximumPoolSize = it.threadPoolSize
-            val keepAliveTime = Pair(1L, TimeUnit.MINUTES)
-            val workQueue = SynchronousQueue<Runnable>()
-            val threadNumber = AtomicInteger(1)
-            val threadFactory = { r: Runnable ->
-                thread(
-                    start = false,
-                    name = "$name.worker-${threadNumber.getAndIncrement()}",
-                    priority = Thread.MIN_PRIORITY,
-                    block = r::run
-                )
-            }
-            ThreadPoolExecutor(
-                corePoolSize,
-                maximumPoolSize,
-                keepAliveTime.first,
-                keepAliveTime.second,
-                workQueue,
-                threadFactory,
-                ThreadPoolExecutor.DiscardPolicy()
-            )
-        }
-
-    private val isStarted: Boolean
-        get() = periodicTimer.get() != null
+    private val wakeUpHook: AtomicReference<() -> Unit> = AtomicReference()
 
     private val isBusy: Boolean
-        get() = workerExecutor.activeCount > 0
-
-    private val executedJobs: AtomicReference<Counter> = AtomicReference()
-    private val failedJobs: AtomicReference<Counter> = AtomicReference()
+        get() = pool.activeWorkerCount > 0
 
     fun registerMeters(meterRegistry: MeterRegistry) {
-        Gauge.builder("asyncJobWorkersActive") { workerExecutor.activeCount }
+        Gauge.builder("asyncJobWorkersActive") { pool.activeWorkerCount }
             .tag("payloadType", payloadType.simpleName!!)
             .register(meterRegistry)
-        executedJobs.set(
-            Counter.builder("asyncJobsExecuted")
-                .tag("payloadType", payloadType.simpleName!!)
-                .register(meterRegistry)
-        )
-        failedJobs.set(
-            Counter.builder("asyncJobsFailed")
-                .tag("payloadType", payloadType.simpleName!!)
-                .register(meterRegistry)
+        metrics.set(
+            AsyncJobMetrics(
+                Counter.builder("asyncJobsExecuted")
+                    .tag("payloadType", payloadType.simpleName!!)
+                    .register(meterRegistry),
+                Counter.builder("asyncJobsFailed")
+                    .tag("payloadType", payloadType.simpleName!!)
+                    .register(meterRegistry)
+            )
         )
     }
 
@@ -138,17 +82,7 @@ class AsyncJobRunner<T : AsyncJobPayload>(
     fun <P : T> registerHandler(
         jobType: AsyncJobType<out P>,
         handler: (db: Database, clock: EvakaClock, msg: P) -> Unit
-    ): Unit =
-        handlersLock.withLock {
-            require(!handlers.containsKey(jobType)) {
-                "handler for $jobType has already been registered"
-            }
-            val ambiguousKey = handlers.keys.find { it.name == jobType.name }
-            require(ambiguousKey == null) {
-                "handlers for $jobType and $ambiguousKey have a name conflict"
-            }
-            handlers[jobType] = Registration(handler)
-        }
+    ): Unit = pool.registerHandler(jobType, handler)
 
     fun plan(
         tx: Database.Transaction,
@@ -156,44 +90,31 @@ class AsyncJobRunner<T : AsyncJobPayload>(
         retryCount: Int = defaultRetryCount,
         retryInterval: Duration = defaultRetryInterval,
         runAt: HelsinkiDateTime
-    ) {
-        payloads.forEach { payload ->
-            tx.insertJob(
+    ) =
+        plan(
+            tx,
+            payloads.map { payload ->
                 JobParams(
                     payload = payload,
                     retryCount = retryCount,
                     retryInterval = retryInterval,
                     runAt = runAt
                 )
-            )
-        }
-        tx.afterCommit(wakeUpHook)
-    }
+            }
+        )
 
-    fun plan(tx: Database.Transaction, jobs: List<JobParams<out T>>) {
+    fun plan(tx: Database.Transaction, jobs: Iterable<JobParams<out T>>) {
         jobs.forEach { job -> tx.insertJob(job) }
-        tx.afterCommit(wakeUpHook)
+        wakeUpHook.get()?.let { tx.afterCommit(it) }
     }
 
-    fun start(pollingInterval: Duration) {
-        val newTimer =
-            fixedRateTimer("$name.timer", daemon = true, period = pollingInterval.toMillis()) {
-                workerExecutor.execute { runWorker(RealEvakaClock()) }
-            }
-        periodicTimer.getAndSet(newTimer)?.cancel()
+    fun start() {
+        pool.startBackgroundPolling()
+        wakeUpHook.set { pool.runPendingJobs(RealEvakaClock(), maxCount = 1_000) }
     }
 
-    fun runPendingJobsSync(clock: EvakaClock, maxCount: Int = 1_000): Int {
-        val task = FutureTask { runWorker(clock, maxCount) }
-        while (!workerExecutor.queue.offer(task)) {
-            // no available workers
-            if (!workerExecutor.prestartCoreThread()) {
-                // worker capacity full
-                TimeUnit.MILLISECONDS.sleep(100)
-            }
-        }
-        return task.get()
-    }
+    fun runPendingJobsSync(clock: EvakaClock, maxCount: Int = 1_000): Int =
+        pool.runPendingJobsSync(clock, maxCount)
 
     fun waitUntilNoRunningJobs(timeout: Duration = Duration.ofSeconds(10)) {
         val start = Instant.now()
@@ -204,91 +125,7 @@ class AsyncJobRunner<T : AsyncJobPayload>(
         error { "Timed out while waiting for running jobs to finish" }
     }
 
-    private fun runWorker(clock: EvakaClock, maxCount: Int = 1_000) =
-        tracer.withDetachedSpan("asyncjob.worker $name") {
-            var executed = 0
-            Database(jdbi, tracer).connect { dbc ->
-                var remaining = maxCount
-                do {
-                    val job = dbc.transaction { it.claimJob(clock.now(), handlers.keys) }
-                    if (job != null) {
-                        tracer.withDetachedSpan(
-                            "asyncjob.run ${job.jobType.name}",
-                            Tracing.asyncJobId withValue job.jobId,
-                            Tracing.asyncJobRemainingAttempts withValue job.remainingAttempts,
-                        ) {
-                            runPendingJob(dbc, clock, job)
-                        }
-                        executedJobs.get()?.increment()
-                        executed += 1
-                    }
-                    remaining -= 1
-                    config.throttleInterval?.toMillis()?.run { Thread.sleep(this) }
-                } while (job != null && remaining > 0 && !workerExecutor.isTerminating)
-            }
-            executed
-        }
-
-    private fun runPendingJob(
-        db: Database.Connection,
-        clock: EvakaClock,
-        job: ClaimedJobRef<out T>
-    ) {
-        val logMeta =
-            mapOf(
-                "jobId" to job.jobId,
-                "jobType" to job.jobType.name,
-                "remainingAttempts" to job.remainingAttempts
-            )
-        try {
-            val traceId = randomTracingId()
-            MdcKey.TRACE_ID.set(traceId)
-            MdcKey.SPAN_ID.set(randomTracingId())
-            tracer.activeSpan()?.setTag(Tracing.evakaTraceId, traceId)
-            logger.info(logMeta) { "Running async job $job" }
-            val completed =
-                db.transaction { tx ->
-                    tx.setLockTimeout(Duration.ofSeconds(5))
-                    val registration =
-                        handlers[job.jobType]
-                            ?: throw IllegalStateException("No handler found for ${job.jobType}")
-                    tx.startJob(job, clock.now())?.let { msg ->
-                        msg.user?.let {
-                            MdcKey.USER_ID.set(it.rawId().toString())
-                            MdcKey.USER_ID_HASH.set(it.rawIdHash.toString())
-                            tracer.activeSpan()?.setTag(Tracing.enduserIdHash, it.rawIdHash)
-                        }
-                        registration.run(Database(jdbi, tracer), clock, msg)
-                        tx.completeJob(job, clock.now())
-                        true
-                    }
-                        ?: false
-                }
-            if (completed) {
-                logger.info(logMeta) { "Completed async job $job" }
-            } else {
-                logger.info(logMeta) { "Skipped async job $job due to contention" }
-            }
-        } catch (e: Throwable) {
-            failedJobs.get()?.increment()
-            tracer.activeSpan()?.setTag(Tags.ERROR, true)
-            val exception = (e as? UndeclaredThrowableException)?.cause ?: e
-            logger.error(exception, logMeta) { "Failed to run async job $job" }
-        } finally {
-            MdcKey.USER_ID_HASH.unset()
-            MdcKey.USER_ID.unset()
-            MdcKey.SPAN_ID.unset()
-            MdcKey.TRACE_ID.unset()
-        }
-    }
-
     override fun close() {
-        periodicTimer.get()?.cancel()
-
-        workerExecutor.shutdown()
-        if (!workerExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
-            logger.error { "Some async jobs did not terminate in time during shutdown" }
-        }
-        workerExecutor.shutdownNow()
+        pool.close()
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.shared.config
 
 import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.shared.async.AsyncJob
-import fi.espoo.evaka.shared.async.AsyncJobPoolConfig
+import fi.espoo.evaka.shared.async.AsyncJobPool
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
 import fi.espoo.evaka.shared.async.UrgentAsyncJob
@@ -26,15 +26,15 @@ import org.springframework.core.env.Environment
 class AsyncJobConfig {
     @Bean
     fun asyncJobRunner(jdbi: Jdbi, tracer: Tracer): AsyncJobRunner<AsyncJob> =
-        AsyncJobRunner(AsyncJob::class, AsyncJobPoolConfig(concurrency = 4), jdbi, tracer)
+        AsyncJobRunner(AsyncJob::class, AsyncJobPool.Config(concurrency = 4), jdbi, tracer)
 
     @Bean
     fun urgentAsyncJobRunner(jdbi: Jdbi, tracer: Tracer): AsyncJobRunner<UrgentAsyncJob> =
-        AsyncJobRunner(UrgentAsyncJob::class, AsyncJobPoolConfig(concurrency = 4), jdbi, tracer)
+        AsyncJobRunner(UrgentAsyncJob::class, AsyncJobPool.Config(concurrency = 4), jdbi, tracer)
 
     @Bean
     fun vardaAsyncJobRunner(jdbi: Jdbi, tracer: Tracer): AsyncJobRunner<VardaAsyncJob> =
-        AsyncJobRunner(VardaAsyncJob::class, AsyncJobPoolConfig(concurrency = 1), jdbi, tracer)
+        AsyncJobRunner(VardaAsyncJob::class, AsyncJobPool.Config(concurrency = 1), jdbi, tracer)
 
     @Bean
     fun sfiAsyncJobRunner(
@@ -44,7 +44,7 @@ class AsyncJobConfig {
     ): AsyncJobRunner<SuomiFiAsyncJob> =
         AsyncJobRunner(
             SuomiFiAsyncJob::class,
-            AsyncJobPoolConfig(
+            AsyncJobPool.Config(
                 concurrency = 1,
                 throttleInterval =
                     Duration.ofSeconds(1).takeIf { env.activeProfiles.contains("production") },

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -66,7 +66,7 @@ class AsyncJobConfig {
             } else {
                 asyncJobRunners.forEach {
                     it.registerMeters(meterRegistry)
-                    it.start(pollingInterval = Duration.ofMinutes(1))
+                    it.start()
                     logger.info("Async job runner ${it.name} started")
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -51,7 +51,7 @@ class AsyncJobConfig {
                 asyncJobRunners.forEach {
                     it.registerMeters(meterRegistry)
                     it.enableAfterCommitHooks()
-                    it.startBackgroundPolling()
+                    it.startBackgroundPolling(Duration.ofMinutes(1))
                     logger.info("Async job runner ${it.name} started")
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -130,8 +130,6 @@ import fi.espoo.evaka.shared.VasuDocumentId
 import fi.espoo.evaka.shared.VasuTemplateId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.SuomiFiAsyncJob
-import fi.espoo.evaka.shared.async.VardaAsyncJob
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
@@ -198,8 +196,6 @@ private val logger = KotlinLogging.logger {}
 class DevApi(
     private val personService: PersonService,
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
-    private val vardaAsyncJobRunner: AsyncJobRunner<VardaAsyncJob>,
-    private val suomiFiAsyncJobRunner: AsyncJobRunner<SuomiFiAsyncJob>,
     private val placementPlanService: PlacementPlanService,
     private val applicationStateService: ApplicationStateService,
     private val decisionService: DecisionService,
@@ -211,7 +207,7 @@ class DevApi(
     private val digitransit = MockDigitransit()
 
     private fun runAllAsyncJobs(clock: EvakaClock) {
-        listOf(asyncJobRunner, vardaAsyncJobRunner, suomiFiAsyncJobRunner).forEach {
+        listOf(asyncJobRunner).forEach {
             it.runPendingJobsSync(clock)
             it.waitUntilNoRunningJobs(timeout = Duration.ofSeconds(20))
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUpdateService.kt
@@ -19,8 +19,8 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.async.VardaAsyncJob
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.EvakaClock
@@ -37,7 +37,7 @@ private val logger = KotlinLogging.logger {}
 
 @Service
 class VardaUpdateService(
-    private val asyncJobRunner: AsyncJobRunner<VardaAsyncJob>,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val tokenProvider: VardaTokenProvider,
     private val fuel: FuelManager,
     private val mapper: JsonMapper,
@@ -81,7 +81,7 @@ class VardaUpdateService(
         db.transaction { tx ->
             asyncJobRunner.plan(
                 tx,
-                serviceNeedDiffsByChild.values.map { VardaAsyncJob.UpdateVardaChild(it) },
+                serviceNeedDiffsByChild.values.map { AsyncJob.UpdateVardaChild(it) },
                 runAt = clock.now(),
                 retryCount = 2,
                 retryInterval = Duration.ofMinutes(10)
@@ -92,7 +92,7 @@ class VardaUpdateService(
     fun updateVardaChildByAsyncJob(
         db: Database.Connection,
         clock: EvakaClock,
-        msg: VardaAsyncJob.UpdateVardaChild
+        msg: AsyncJob.UpdateVardaChild
     ) {
         logger.info("VardaUpdate: starting to update child ${msg.serviceNeedDiffByChild.childId}")
         updateVardaChild(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This makes the runner implementation slightly more complicated, but usage is simpler because we no longer need to inject multiple runners in tests or real code, or care about which runner to call specifically. The pool concept also enables some future possibilities (e.g. *global* concurrency limit across all evaka-service instances).
