### PR TITLE
Fix message visibility during undo period

### DIFF
--- a/frontend/src/citizen-frontend/messages/api.ts
+++ b/frontend/src/citizen-frontend/messages/api.ts
@@ -13,8 +13,7 @@ import {
   GetReceiversResponse,
   MessageThread,
   ReplyToMessageBody,
-  ThreadReply,
-  UnreadCountByAccount
+  ThreadReply
 } from 'lib-common/generated/api-types/messaging'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
@@ -71,11 +70,9 @@ export async function markThreadRead(id: string): Promise<Result<void>> {
     .catch((e) => Failure.fromError(e))
 }
 
-export async function getUnreadMessagesCount(): Promise<
-  Result<UnreadCountByAccount[]>
-> {
+export async function getUnreadMessagesCount(): Promise<Result<number>> {
   return client
-    .get<UnreadCountByAccount[]>(`/citizen/messages/unread-count`)
+    .get<number>(`/citizen/messages/unread-count`)
     .then((res) => Success.of(res.data))
     .catch((e) => Failure.fromError(e))
 }

--- a/frontend/src/citizen-frontend/messages/state.tsx
+++ b/frontend/src/citizen-frontend/messages/state.tsx
@@ -14,8 +14,7 @@ import React, {
 import { Loading, Paged, Result } from 'lib-common/api'
 import {
   MessageThread,
-  ThreadReply,
-  UnreadCountByAccount
+  ThreadReply
 } from 'lib-common/generated/api-types/messaging'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { UUID } from 'lib-common/types'
@@ -195,14 +194,11 @@ export const MessageContextProvider = React.memo(
     }, [])
 
     const [unreadMessagesCount, setUnreadMessagesCount] = useState<number>()
-    const setUnreadResult = useCallback(
-      (res: Result<UnreadCountByAccount[]>) => {
-        if (res.isSuccess) {
-          setUnreadMessagesCount(res.value[0]?.unreadCount ?? 0)
-        }
-      },
-      []
-    )
+    const setUnreadResult = useCallback((res: Result<number>) => {
+      if (res.isSuccess) {
+        setUnreadMessagesCount(res.value)
+      }
+    }, [])
     const refreshUnreadMessagesCount = useRestApi(
       getUnreadMessagesCount,
       setUnreadResult

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -306,12 +306,13 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 tx.insertThread(MessageType.MESSAGE, "title", urgent = false, isCopy = false)
             val messageId =
                 tx.insertMessage(
-                    now.minusSeconds(30),
-                    contentId,
-                    threadId,
-                    employeeAccount,
-                    allAccounts.map { it.name },
-                    "Espoo"
+                    now = now.minusSeconds(30),
+                    contentId = contentId,
+                    threadId = threadId,
+                    sender = employeeAccount,
+                    sentAt = now.minusSeconds(30),
+                    recipientNames = allAccounts.map { it.name },
+                    municipalAccountName = "Espoo"
                 )
             tx.insertRecipients(listOf(messageId to allAccounts.map { it.id }.toSet()))
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -55,6 +55,10 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+/*
+ * TODO: These tests should be moved to MessageIntegrationTest because inserting directly to the database doesn't
+ * reflect reality: it's controllers' and MessageService's job but these tests don't invoke them
+ */
 class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
     private val person1 = DevPerson(firstName = "Firstname", lastName = "Person")
     private val person2 = DevPerson(firstName = "Firstname", lastName = "Person Two")
@@ -604,53 +608,6 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `unread messages and marking messages read`() {
-        // given
-        val thread1 =
-            createThread(
-                "Title",
-                "Content",
-                accounts.person1,
-                listOf(accounts.employee1, accounts.person2)
-            )
-
-        // then unread count is zero for sender and one for recipients
-        assertEquals(0, unreadMessagesCount(accounts.person1))
-        assertEquals(1, unreadMessagesCount(accounts.employee1))
-        assertEquals(1, unreadMessagesCount(accounts.person2))
-
-        // when employee reads the message
-        db.transaction { it.markThreadRead(RealEvakaClock(), accounts.employee1.id, thread1) }
-
-        // then the thread does not count towards unread messages
-        assertEquals(0, unreadMessagesCount(accounts.person1))
-        assertEquals(0, unreadMessagesCount(accounts.employee1))
-        assertEquals(1, unreadMessagesCount(accounts.person2))
-
-        // when a new thread is created
-        val thread2 =
-            createThread(
-                "Title",
-                "Content",
-                accounts.employee1,
-                listOf(accounts.person1, accounts.person2)
-            )
-
-        // then unread counts are bumped by one for recipients
-        assertEquals(1, unreadMessagesCount(accounts.person1))
-        assertEquals(0, unreadMessagesCount(accounts.employee1))
-        assertEquals(2, unreadMessagesCount(accounts.person2))
-
-        // when person two reads a thread
-        db.transaction { it.markThreadRead(RealEvakaClock(), accounts.person2.id, thread2) }
-
-        // then unread count goes down by one
-        assertEquals(1, unreadMessagesCount(accounts.person1))
-        assertEquals(0, unreadMessagesCount(accounts.employee1))
-        assertEquals(1, unreadMessagesCount(accounts.person2))
-    }
-
-    @Test
     fun `a thread can be archived`() {
         val content = "Content"
         val title = "Hello"
@@ -726,7 +683,10 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
     }
 
-    // TODO: Remove this function, creating threads should be MessageService's job
+    /*
+     * TODO: Tests in this file should be moved to MessageIntegrationTest because creating a thread like this
+     * doesn't reflect reality
+     */
     private fun createThread(
         title: String,
         content: String,
@@ -754,7 +714,10 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             threadId
         }
 
-    // TODO: Remove this function; replying to a thread should be MessageService's job
+    /*
+     * TODO: Tests in this file should be moved to MessageIntegrationTest because replying to a thread like this
+     * doesn't reflect reality
+     */
     private fun replyToThread(
         threadId: MessageThreadId,
         sender: MessageAccount,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -713,7 +713,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 )
             tx.insertRecipients(listOf(messageId to recipientAccounts.map { it.id }.toSet()))
             tx.upsertSenderThreadParticipants(sender.id, listOf(threadId), now)
-            tx.upsertReceiverThreadParticipants(threadId, recipientIds, now)
+            tx.upsertReceiverThreadParticipants(contentId, now)
             threadId
         }
 
@@ -745,7 +745,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 )
             tx.insertRecipients(listOf(messageId to recipientIds))
             tx.upsertSenderThreadParticipants(sender.id, listOf(threadId), now)
-            tx.upsertReceiverThreadParticipants(threadId, recipientIds, now)
+            tx.upsertReceiverThreadParticipants(contentId, now)
         }
 
     private fun unreadMessagesCount(account: MessageAccount) =

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -347,15 +347,17 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             participants
         )
 
+        val now = HelsinkiDateTime.now()
         val participants2 =
             db.transaction { tx ->
                 val contentId = tx.insertMessageContent("foo", accounts.person2.id)
                 val messageId =
                     tx.insertMessage(
-                        RealEvakaClock().now(),
+                        now = now,
                         contentId = contentId,
                         threadId = threadId,
                         sender = accounts.person2.id,
+                        sentAt = now,
                         recipientNames = tx.getAccountNames(setOf(accounts.employee1.id)),
                         municipalAccountName = "Espoo"
                     )
@@ -701,10 +703,11 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 tx.insertThread(MessageType.MESSAGE, title, urgent = false, isCopy = false)
             val messageId =
                 tx.insertMessage(
-                    now,
+                    now = now,
                     contentId = contentId,
                     threadId = threadId,
                     sender = sender.id,
+                    sentAt = now,
                     recipientNames = tx.getAccountNames(recipientIds),
                     municipalAccountName = "Espoo"
                 )
@@ -735,6 +738,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                     contentId = contentId,
                     threadId = threadId,
                     sender = sender.id,
+                    sentAt = now,
                     repliesToMessageId = repliesToMessageId,
                     recipientNames = listOf(),
                     municipalAccountName = "Espoo"

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
@@ -40,7 +40,7 @@ import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
-import fi.espoo.evaka.shared.domain.RealEvakaClock
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testArea
@@ -258,6 +258,7 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
 
     @Test
     fun `adult with received messages is cleaned up`() {
+        val now = HelsinkiDateTime.now()
         db.transaction { tx ->
             val supervisorId = EmployeeId(UUID.randomUUID())
             tx.insertTestEmployee(
@@ -273,12 +274,13 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
                 tx.insertThread(MessageType.MESSAGE, "title", urgent = false, isCopy = false)
             val messageId =
                 tx.insertMessage(
-                    RealEvakaClock().now(),
-                    contentId,
-                    threadId,
-                    employeeAccount,
-                    listOf("recipient name"),
-                    "Espoo"
+                    now = now,
+                    contentId = contentId,
+                    threadId = threadId,
+                    sender = employeeAccount,
+                    sentAt = now,
+                    recipientNames = listOf("recipient name"),
+                    municipalAccountName = "Espoo"
                 )
             tx.insertRecipients(listOf(messageId to setOf(personAccount)))
         }
@@ -288,6 +290,7 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
 
     @Test
     fun `adult with sent messages is not cleaned up`() {
+        val now = HelsinkiDateTime.now()
         db.transaction { tx ->
             val supervisorId = EmployeeId(UUID.randomUUID())
             tx.insertTestEmployee(
@@ -303,12 +306,13 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
                 tx.insertThread(MessageType.MESSAGE, "title", urgent = false, isCopy = false)
             val messageId =
                 tx.insertMessage(
-                    RealEvakaClock().now(),
-                    contentId,
-                    threadId,
-                    personAccount,
-                    listOf("employee name"),
-                    "Espoo"
+                    now = now,
+                    contentId = contentId,
+                    threadId = threadId,
+                    sender = personAccount,
+                    sentAt = now,
+                    recipientNames = listOf("employee name"),
+                    municipalAccountName = "Espoo"
                 )
             tx.insertRecipients(listOf(messageId to setOf(employeeAccount)))
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -48,19 +48,18 @@ class MessageControllerCitizen(
     }
 
     @GetMapping("/unread-count")
-    fun getUnreadMessages(
-        db: Database,
-        user: AuthenticatedUser.Citizen,
-        clock: EvakaClock
-    ): Set<UnreadCountByAccount> {
+    fun getUnreadMessages(db: Database, user: AuthenticatedUser.Citizen, clock: EvakaClock): Int {
         return db.connect { dbc ->
-                val accountId = dbc.read { it.getCitizenMessageAccount(user.id) }
-                dbc.read { it.getUnreadMessagesCounts(clock.now(), setOf(accountId)) }
+                dbc.read { tx ->
+                    val accountId = tx.getCitizenMessageAccount(user.id)
+                    val counts = tx.getUnreadMessagesCounts(clock.now(), setOf(accountId))
+                    counts.firstOrNull()?.unreadCount ?: 0
+                }
             }
             .also {
                 Audit.MessagingUnreadMessagesRead.log(
                     targetId = user.id,
-                    meta = mapOf("count" to it.size)
+                    meta = mapOf("count" to it)
                 )
             }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -211,12 +211,7 @@ class MessageControllerCitizen(
                             )
                         tx.insertMessageThreadChildren(listOf(body.children to threadId))
                         tx.insertRecipients(listOf(messageId to recipientIds))
-                        asyncJobRunner.scheduleMarkMessagesAsSent(
-                            tx,
-                            listOf(threadId to recipientIds),
-                            setOf(messageId),
-                            now
-                        )
+                        asyncJobRunner.scheduleMarkMessagesAsSent(tx, contentId, now)
                         threadId
                     }
                 } else {

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -199,15 +199,10 @@ class MessageControllerCitizen(
                                 isCopy = false
                             )
                         tx.upsertSenderThreadParticipants(senderId, listOf(threadId), now)
-                        asyncJobRunner.scheduleThreadRecipientsUpdate(
-                            tx,
-                            listOf(threadId to recipientIds),
-                            now
-                        )
                         val recipientNames = tx.getAccountNames(recipientIds)
                         val messageId =
                             tx.insertMessage(
-                                now = clock.now(),
+                                now = now,
                                 contentId = contentId,
                                 threadId = threadId,
                                 sender = senderId,
@@ -216,6 +211,12 @@ class MessageControllerCitizen(
                             )
                         tx.insertMessageThreadChildren(listOf(body.children to threadId))
                         tx.insertRecipients(listOf(messageId to recipientIds))
+                        asyncJobRunner.scheduleMarkMessagesAsSent(
+                            tx,
+                            listOf(threadId to recipientIds),
+                            setOf(messageId),
+                            now
+                        )
                         threadId
                     }
                 } else {

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -50,14 +50,14 @@ fun Database.Read.getUnreadMessagesCounts(
         LEFT JOIN message m ON mr.message_id = m.id
         LEFT JOIN message_thread mt ON m.thread_id = mt.id
         LEFT JOIN message_thread_participant mtp ON m.thread_id = mtp.thread_id AND mtp.participant_id = acc.id
-        WHERE acc.id = ANY(:accountIds) AND (m.id IS NULL OR m.sent_at < :undoThreshold)
+        WHERE acc.id = ANY(:accountIds) AND (m.id IS NULL OR m.sent_at IS NOT NULL)
         GROUP BY acc.id
     """
             .trimIndent()
 
     return this.createQuery(sql)
         .bind("accountIds", accountIds)
-        .bind("undoThreshold", now.minusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS))
+        .bind("now", now)
         .mapTo<UnreadCountByAccount>()
         .toSet()
 }
@@ -79,7 +79,7 @@ fun Database.Read.getUnreadMessagesCountsByDaycare(
         LEFT JOIN message m ON mr.message_id = m.id
         LEFT JOIN message_thread mt ON m.thread_id = mt.id
         JOIN daycare_group dg ON acc.daycare_group_id = dg.id AND dg.daycare_id = :daycareId
-        WHERE acc.active = true AND m.sent_at < :undoThreshold
+        WHERE acc.active = true AND m.sent_at IS NOT NULL
         GROUP BY acc.id, acc.daycare_group_id
     """
             .trimIndent()
@@ -148,19 +148,22 @@ fun Database.Transaction.insertMessage(
     sender: MessageAccountId,
     recipientNames: List<String>,
     municipalAccountName: String,
+    sentAt: HelsinkiDateTime? =
+        null, // Only needed because some tests bypass the message service and controllers
     repliesToMessageId: MessageId? = null
 ): MessageId {
     // language=SQL
     val insertMessageSql =
         """
-        INSERT INTO message (content_id, thread_id, sender_id, sender_name, replies_to, sent_at, recipient_names)
+        INSERT INTO message (created, content_id, thread_id, sender_id, sender_name, replies_to, sent_at, recipient_names)
         SELECT
+            :now,
             :contentId,
             :threadId,
             :senderId,
             CASE WHEN name_view.type = 'MUNICIPAL' THEN :municipalAccountName ELSE name_view.name END,
             :repliesToId,
-            :now,
+            :sentAt,
             :recipientNames
         FROM message_account_view name_view
         WHERE name_view.id = :senderId
@@ -173,6 +176,7 @@ fun Database.Transaction.insertMessage(
         .bind("threadId", threadId)
         .bind("repliesToId", repliesToMessageId)
         .bind("senderId", sender)
+        .bind("sentAt", sentAt)
         .bind("recipientNames", recipientNames)
         .bind("municipalAccountName", municipalAccountName)
         .mapTo<MessageId>()
@@ -274,6 +278,16 @@ fun Database.Transaction.upsertReceiverThreadParticipants(
         .execute()
 }
 
+fun Database.Transaction.markMessagesAsSent(messageIds: Set<MessageId>, sentAt: HelsinkiDateTime) {
+    createUpdate("""
+UPDATE message
+SET sent_at = :sentAt WHERE id = ANY(:messageIds)
+""")
+        .bind("messageIds", messageIds)
+        .bind("sentAt", sentAt)
+        .execute()
+}
+
 fun Database.Transaction.insertThreadsWithMessages(
     count: Int,
     now: HelsinkiDateTime,
@@ -292,14 +306,14 @@ fun Database.Transaction.insertThreadsWithMessages(
 WITH new_thread AS (
     INSERT INTO message_thread (message_type, title, urgent, is_copy) VALUES (:messageType, :title, :urgent, :isCopy) RETURNING id
 )
-INSERT INTO message (content_id, thread_id, sender_id, sender_name, replies_to, sent_at, recipient_names)
+INSERT INTO message (created, content_id, thread_id, sender_id, sender_name, replies_to, recipient_names)
 SELECT
+    :now,
     :contentId,
     new_thread.id,
     :senderId,
     CASE WHEN name_view.type = 'MUNICIPAL' THEN :municipalAccountName ELSE name_view.name END,
     NULL,
-    :now,
     :recipientNames
 FROM message_account_view name_view, new_thread
 WHERE name_view.id = :senderId
@@ -531,14 +545,14 @@ WHERE
         FROM message_recipients mr
         WHERE mr.message_id = m.id AND mr.recipient_id = :accountId
     )) AND
-    (m.sender_id = :accountId OR m.sent_at < :undoThreshold)
+    (m.sender_id = :accountId OR m.sent_at IS NOT NULL)
 ORDER BY m.sent_at
             """
         )
         .bind("accountId", accountId)
         .bind("threadIds", threadIds)
         .bind("municipalAccountName", municipalAccountName)
-        .bind("undoThreshold", now.minusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS))
+        .bind("now", now)
         .mapTo<Message>()
         .groupBy { it.threadId }
 }
@@ -630,7 +644,7 @@ JOIN message_account_view acc ON rec.recipient_id = acc.id
 JOIN message_account sender_acc ON sender_acc.id = m.sender_id
 JOIN message_account recipient_acc ON recipient_acc.id = rec.recipient_id
 JOIN message_thread t ON m.thread_id = t.id
-WHERE rec.recipient_id = :accountId AND t.is_copy AND m.sent_at < :undoThreshold
+WHERE rec.recipient_id = :accountId AND t.is_copy AND m.sent_at IS NOT NULL
 ORDER BY m.sent_at DESC
 LIMIT :pageSize OFFSET :offset
 """
@@ -649,7 +663,7 @@ fun Database.Read.getSentMessage(senderId: MessageAccountId, messageId: MessageI
 SELECT
     m.id,
     m.thread_id,
-    m.sent_at,
+    COALESCE(m.sent_at, m.created) AS sent_at,  -- use the created timestamp until the asyncjob marks the message as sent
     mc.content,
     (
         SELECT jsonb_build_object('id', mav.id, 'name', mav.name, 'type', mav.type)
@@ -809,7 +823,7 @@ fun Database.Read.getMessagesSentByAccount(
 WITH pageable_messages AS (
     SELECT
         m.content_id,
-        m.sent_at,
+        COALESCE(m.sent_at, m.created) AS sent_at,  -- use the created timestamp until the asyncjob marks the message as sent
         m.recipient_names,
         t.title,
         t.message_type,
@@ -818,7 +832,7 @@ WITH pageable_messages AS (
     FROM message m
     JOIN message_thread t ON m.thread_id = t.id
     WHERE sender_id = :accountId
-    GROUP BY content_id, sent_at, recipient_names, title, message_type, urgent
+    GROUP BY m.content_id, m.sent_at, m.created, m.recipient_names, t.title, t.message_type, t.urgent
     ORDER BY sent_at DESC
     LIMIT :pageSize OFFSET :offset
 ),
@@ -1204,7 +1218,7 @@ fun Database.Read.getArchiveFolderId(accountId: MessageAccountId): MessageThread
         .firstOrNull()
 
 data class MessageToUndo(
-    val sentAt: HelsinkiDateTime,
+    val created: HelsinkiDateTime,
     val messageId: MessageId,
     val contentId: MessageContentId,
     val threadId: MessageThreadId,
@@ -1220,7 +1234,7 @@ fun Database.Transaction.undoMessageReply(
     val messageToUndo =
         this.createQuery(
                 """
-SELECT sent_at, id AS message_id, content_id, thread_id, sender_id, FALSE AS only_message_in_thread
+SELECT created, id AS message_id, content_id, thread_id, sender_id, FALSE AS only_message_in_thread
 FROM message WHERE sender_id = :accountId AND id = :messageId
 """
             )
@@ -1230,7 +1244,7 @@ FROM message WHERE sender_id = :accountId AND id = :messageId
             .findOne()
             .orElseThrow { throw BadRequest("No message found with messageId $messageId") }
 
-    if (messageToUndo.sentAt.plusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS).isBefore(now)) {
+    if (messageToUndo.created.plusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS).isBefore(now)) {
         throw BadRequest(
             "Messages older than $MESSAGE_UNDO_WINDOW_IN_SECONDS seconds cannot be undone"
         )
@@ -1248,7 +1262,7 @@ fun Database.Transaction.undoMessageAndAllThreads(
     val messagesToUndo =
         this.createQuery(
                 """
-SELECT m.sent_at, m.id AS message_id, m.content_id, m.thread_id, m.sender_id,
+SELECT m.created, m.id AS message_id, m.content_id, m.thread_id, m.sender_id,
     NOT EXISTS (SELECT 1 FROM message m2 WHERE m.thread_id = m2.thread_id AND m2.content_id != :contentId) AS only_message_in_thread
 FROM message m
 WHERE sender_id = :accountId AND content_id = :contentId
@@ -1264,7 +1278,7 @@ WHERE sender_id = :accountId AND content_id = :contentId
     }
 
     if (
-        messagesToUndo.any { it.sentAt.plusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS).isBefore(now) }
+        messagesToUndo.any { it.created.plusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS).isBefore(now) }
     ) {
         throw BadRequest(
             "Messages older than $MESSAGE_UNDO_WINDOW_IN_SECONDS seconds cannot be undone"

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.MessageAccountId
+import fi.espoo.evaka.shared.MessageContentId
 import fi.espoo.evaka.shared.MessageId
 import fi.espoo.evaka.shared.MessageRecipientId
 import fi.espoo.evaka.shared.MessageThreadId
@@ -219,10 +220,8 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
-    data class MarkMessageAsSent(
-        val threadId: MessageThreadId,
-        val recipientIds: Set<MessageAccountId>,
-        val messageIds: Set<MessageId>,
+    data class MarkMessagesAsSent(
+        val messageContentId: MessageContentId,
         val sentAt: HelsinkiDateTime
     ) : AsyncJob {
         override val user: AuthenticatedUser? = null
@@ -292,7 +291,7 @@ sealed interface AsyncJob : AsyncJobPayload {
             AsyncJobRunner.Pool(
                 AsyncJobPool.Id(AsyncJob::class, "urgent"),
                 AsyncJobPool.Config(concurrency = 4),
-                setOf(UpdateMessageThreadRecipients::class, MarkMessageAsSent::class)
+                setOf(UpdateMessageThreadRecipients::class, MarkMessagesAsSent::class)
             )
         val suomiFi =
             AsyncJobRunner.Pool(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -219,6 +219,15 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class MarkMessageAsSent(
+        val threadId: MessageThreadId,
+        val recipientIds: Set<MessageAccountId>,
+        val messageIds: Set<MessageId>,
+        val sentAt: HelsinkiDateTime
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     data class SendMessage(val message: SfiMessage) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
@@ -283,7 +292,7 @@ sealed interface AsyncJob : AsyncJobPayload {
             AsyncJobRunner.Pool(
                 AsyncJobPool.Id(AsyncJob::class, "urgent"),
                 AsyncJobPool.Config(concurrency = 4),
-                setOf(UpdateMessageThreadRecipients::class)
+                setOf(UpdateMessageThreadRecipients::class, MarkMessageAsSent::class)
             )
         val suomiFi =
             AsyncJobRunner.Pool(

--- a/service/src/main/resources/db/migration/V292__message_sent_nullable.sql
+++ b/service/src/main/resources/db/migration/V292__message_sent_nullable.sql
@@ -1,0 +1,3 @@
+ALTER TABLE message
+    ALTER COLUMN sent_at DROP DEFAULT,
+    ALTER COLUMN sent_at DROP NOT NULL;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -288,3 +288,4 @@ V288__staff_attendance_realtime_optional_group_id.sql
 V289__placement_type_preschool_club.sql
 V290__application_other_guardian_access.sql
 V291__application_other_guardian_cascade.sql
+V292__message_sent_nullable.sql


### PR DESCRIPTION
#### Background

When an employee sends a message, there's a period during which the message sending can be undone. This was implemented by adjusting message state in the db in an async job that was scheduled to run after the undo period expires.

#### The Problem

This PR fixes two problems:
- The citizen saw unread message count bubble as soon as the employee hit the send button even _before the undo time expired_
- If the message was a reply, the citizen saw that the thread contained unread messages, and saw the message by opening the thread after the undo period expired. _The thread moved to the top of the list only after the async job was run._

After this PR, both the unread count bubble and the message (new message or reply) are visible only after the async job has run.

#### Tech

Keep `message`'s `sent_at` timestamp as `NULL` to mark that the message should not be seen by the receiver(s). The `created` timestamp is used instead of the `sent_at` timestamp when the _sender_ is looking at their own sent messages. The async job sets `sent_at` as well as updating the thread timestamps.