### PR TITLE
Avoid double arrival/departure bookings

### DIFF
--- a/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
@@ -58,7 +58,9 @@ export default React.memo(function AttendanceChildPage() {
 
   const { unitInfoResponse } = useContext(UnitContext)
   const child = useChild(useQueryResult(childrenQuery(unitId)), childId)
-  const attendanceStatuses = useQueryResult(attendanceStatusesQuery(unitId))
+  const attendanceStatuses = useQueryResult(attendanceStatusesQuery(unitId), {
+    staleTime: 0
+  })
 
   const [uiMode, setUiMode] = useState<
     | 'default'


### PR DESCRIPTION
#### Summary

Refresh the unit's attendance data each time a child page is opened in employee mobile. This way it should be much more unlikely that two employees mark the same child as arrived or departed.
