### PR TITLE
VP-778: Update Evaka Keycloak to version 20.0.3.

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -38,7 +38,7 @@ COPY ./theme/ /work/
 
 RUN npm run build
 
-FROM quay.io/keycloak/keycloak:20.0.2 AS keycloak
+FROM quay.io/keycloak/keycloak:20.0.3 AS keycloak
 
 USER root
 

--- a/keycloak/evaka-logging/pom.xml
+++ b/keycloak/evaka-logging/pom.xml
@@ -17,7 +17,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <groupId>com.espoo.keycloak</groupId>
     <version>0.7.0</version>
     <properties>
-        <keycloak.version>20.0.2</keycloak.version>
+        <keycloak.version>20.0.3</keycloak.version>
         <jboss.logging.version>3.4.1.Final</jboss.logging.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/keycloak/evaka-review-profile/pom.xml
+++ b/keycloak/evaka-review-profile/pom.xml
@@ -17,7 +17,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <groupId>com.espoo.keycloak</groupId>
     <version>0.7.0</version>
     <properties>
-        <keycloak.version>20.0.2</keycloak.version>
+        <keycloak.version>20.0.3</keycloak.version>
         <jboss.logging.version>3.4.1.Final</jboss.logging.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
#### Summary
- Update Evaka Keycloak to version 20.0.3.

