### PR TITLE
Replace weak custom Profile types with validation code

### DIFF
--- a/apigw/src/enduser/__tests__/csrf.ts
+++ b/apigw/src/enduser/__tests__/csrf.ts
@@ -9,9 +9,14 @@ import { csrfCookieName } from '../../shared/middleware/csrf'
 import { CitizenUser } from '../../shared/service-client'
 import enduserGwApp from '../app'
 import { configFromEnv } from '../../shared/config'
+import { DevCitizen } from '../../shared/dev-api'
 
-const mockUser: CitizenUser = {
-  id: '4f73e4f8-8759-46c6-9b9d-4da860138ce2'
+const mockUser: DevCitizen & CitizenUser = {
+  id: '4f73e4f8-8759-46c6-9b9d-4da860138ce2',
+  firstName: 'dummy',
+  lastName: 'dummy',
+  ssn: '010101-999X',
+  dependantCount: 0
 }
 
 describe('CSRF middleware and cookie handling in enduser-gw', () => {

--- a/apigw/src/shared/__tests__/saml-slo.ts
+++ b/apigw/src/shared/__tests__/saml-slo.ts
@@ -13,13 +13,18 @@ import xmldom from '@xmldom/xmldom'
 import zlib from 'zlib'
 import { configFromEnv } from '../config'
 import { fromCallback } from '../promise-utils'
-import type { CitizenUser } from '../service-client'
 import { sessionCookie } from '../session'
 import { GatewayTester } from '../test/gateway-tester'
 import redisMock from 'redis-mock'
+import { DevCitizen } from '../dev-api'
+import { CitizenUser } from '../service-client'
 
-const mockUser: CitizenUser = {
-  id: '942b9cab-210d-4d49-b4c9-65f26390eed3'
+const mockUser: DevCitizen & CitizenUser = {
+  id: '942b9cab-210d-4d49-b4c9-65f26390eed3',
+  firstName: 'dummy',
+  lastName: 'dummy',
+  ssn: '010101-999X',
+  dependantCount: 0
 }
 
 const SP_CALLBACK_URL =
@@ -285,7 +290,12 @@ function buildLoginResponse(
               <saml:Audience>${SP_ISSUER}</saml:Audience>
           </saml:AudienceRestriction>
       </saml:Conditions>
-     <saml:AuthnStatement
+      <saml:AttributeStatement>
+        <saml:Attribute Name="urn:oid:1.2.246.21">
+          <saml:AttributeValue>010101-999X</saml:AttributeValue>
+        </saml:Attribute>
+      </saml:AttributeStatement>
+      <saml:AuthnStatement
           AuthnInstant="${issueInstant}"
           SessionNotOnOrAfter="${notOnOrAfter}"
           SessionIndex="${sessionIndex}">

--- a/apigw/src/shared/auth/ad-saml.ts
+++ b/apigw/src/shared/auth/ad-saml.ts
@@ -20,8 +20,6 @@ import { Config } from '../config'
 
 const AD_OID_KEY =
   'http://schemas.microsoft.com/identity/claims/objectidentifier'
-const AD_ROLES_KEY =
-  'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'
 const AD_GIVEN_NAME_KEY =
   'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname'
 const AD_FAMILY_NAME_KEY =
@@ -101,7 +99,6 @@ export default function createAdStrategy(
       return verifyProfile(config.externalIdPrefix, {
         nameID: 'dummyid',
         [AD_OID_KEY]: userId,
-        [AD_ROLES_KEY]: [],
         [AD_GIVEN_NAME_KEY]: employee.firstName,
         [AD_FAMILY_NAME_KEY]: employee.lastName,
         [AD_EMAIL_KEY]: employee.email ? employee.email : ''
@@ -126,7 +123,6 @@ export default function createAdStrategy(
       return verifyProfile(config.externalIdPrefix, {
         nameID: 'dummyid',
         [AD_OID_KEY]: userId,
-        [AD_ROLES_KEY]: roles,
         [AD_GIVEN_NAME_KEY]: firstName,
         [AD_FAMILY_NAME_KEY]: lastName,
         [AD_EMAIL_KEY]: email

--- a/apigw/src/shared/auth/ad-saml.ts
+++ b/apigw/src/shared/auth/ad-saml.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import {
+import passportSaml, {
   Profile,
   SamlConfig,
   Strategy as SamlStrategy,
@@ -18,7 +18,7 @@ import { RedisClient } from 'redis'
 import redisCacheProvider from './passport-saml-cache-redis'
 import { Config } from '../config'
 
-const AD_USER_ID_KEY =
+const AD_OID_KEY =
   'http://schemas.microsoft.com/identity/claims/objectidentifier'
 const AD_ROLES_KEY =
   'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'
@@ -31,32 +31,21 @@ const AD_EMAIL_KEY =
 const AD_EMPLOYEE_NUMBER_KEY =
   'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/employeenumber'
 
-interface AdProfile {
-  nameID?: Profile['nameID']
-  nameIDFormat?: Profile['nameIDFormat']
-  nameQualifier?: Profile['nameQualifier']
-  spNameQualifier?: Profile['spNameQualifier']
-  sessionIndex?: Profile['sessionIndex']
-  [AD_USER_ID_KEY]: string
-  [AD_ROLES_KEY]: string | string[]
-  [AD_GIVEN_NAME_KEY]: string
-  [AD_FAMILY_NAME_KEY]: string
-  [AD_EMAIL_KEY]: string
-  [AD_EMPLOYEE_NUMBER_KEY]?: string
-}
-
 async function verifyProfile(
   idPrefix: string,
-  profile: AdProfile
+  profile: passportSaml.Profile
 ): Promise<SamlUser> {
-  const aad = profile[AD_USER_ID_KEY]
+  const asString = (value: unknown) =>
+    value == null ? undefined : String(value)
+
+  const aad = asString(profile[AD_OID_KEY])
   if (!aad) throw Error('No user ID in SAML data')
   const person = await employeeLogin({
     externalId: `${idPrefix}:${aad}`,
-    firstName: profile[AD_GIVEN_NAME_KEY],
-    lastName: profile[AD_FAMILY_NAME_KEY],
-    email: profile[AD_EMAIL_KEY],
-    employeeNumber: profile[AD_EMPLOYEE_NUMBER_KEY]
+    firstName: asString(profile[AD_GIVEN_NAME_KEY]) ?? '',
+    lastName: asString(profile[AD_FAMILY_NAME_KEY]) ?? '',
+    email: asString(profile[AD_EMAIL_KEY]),
+    employeeNumber: asString(profile[AD_EMPLOYEE_NUMBER_KEY])
   })
   return {
     id: person.id,
@@ -111,7 +100,7 @@ export default function createAdStrategy(
       )
       return verifyProfile(config.externalIdPrefix, {
         nameID: 'dummyid',
-        [AD_USER_ID_KEY]: userId,
+        [AD_OID_KEY]: userId,
         [AD_ROLES_KEY]: [],
         [AD_GIVEN_NAME_KEY]: employee.firstName,
         [AD_FAMILY_NAME_KEY]: employee.lastName,
@@ -136,7 +125,7 @@ export default function createAdStrategy(
       })
       return verifyProfile(config.externalIdPrefix, {
         nameID: 'dummyid',
-        [AD_USER_ID_KEY]: userId,
+        [AD_OID_KEY]: userId,
         [AD_ROLES_KEY]: roles,
         [AD_GIVEN_NAME_KEY]: firstName,
         [AD_FAMILY_NAME_KEY]: lastName,
@@ -149,10 +138,13 @@ export default function createAdStrategy(
     return new SamlStrategy(
       samlConfig,
       (profile: Profile | null | undefined, done: VerifiedCallback) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        verifyProfile(config.externalIdPrefix, profile as any as AdProfile)
-          .then((user) => done(null, user))
-          .catch(done)
+        if (!profile) {
+          done(new Error('No SAML profile'))
+        } else {
+          verifyProfile(config.externalIdPrefix, profile)
+            .then((user) => done(null, user))
+            .catch(done)
+        }
       }
     )
   }

--- a/apigw/src/shared/dev-api.ts
+++ b/apigw/src/shared/dev-api.ts
@@ -27,17 +27,17 @@ export async function getEmployeeByExternalId(externalId: string) {
   return data
 }
 
-export async function getCitizenBySsn(ssn: string): Promise<Citizen> {
-  const { data } = await client.get<Citizen>(`/dev-api/citizen/ssn/${ssn}`)
+export async function getCitizenBySsn(ssn: string): Promise<DevCitizen> {
+  const { data } = await client.get<DevCitizen>(`/dev-api/citizen/ssn/${ssn}`)
   return data
 }
 
-export async function getCitizens(): Promise<Citizen[]> {
+export async function getCitizens(): Promise<DevCitizen[]> {
   const { data } = await client.get(`/dev-api/citizen`)
   return data
 }
 
-interface Citizen {
+export interface DevCitizen {
   ssn: string
   firstName: string
   lastName: string

--- a/apigw/src/shared/test/gateway-tester.ts
+++ b/apigw/src/shared/test/gateway-tester.ts
@@ -11,6 +11,7 @@ import { evakaServiceUrl } from '../config'
 import { sessionCookie, SessionType } from '../session'
 import { csrfCookieName } from '../middleware/csrf'
 import { CitizenUser, EmployeeUser } from '../service-client'
+import { DevCitizen } from '../dev-api'
 
 export class GatewayTester {
   public readonly client: AxiosInstance
@@ -82,7 +83,7 @@ export class GatewayTester {
   }
 
   public async login(
-    user: CitizenUser | EmployeeUser,
+    user: (CitizenUser & DevCitizen) | EmployeeUser,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     postData?: any
   ): Promise<void> {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The custom types didn't provide any type safety since we just did a type assertion and assumed the types were correct. Embrace the unknown typing instead, and validate/cast the data.