### PR TITLE
Show a warning when there's no internet connection

### DIFF
--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -27,6 +27,7 @@ export interface Translations {
   notifications: {
     close: string
   }
+  offlineNotification: string
   reloadNotification: {
     title: string
     buttonText: string

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -27,6 +27,7 @@ const components = {
   notifications: {
     close: 'Close'
   },
+  offlineNotification: 'No internet connection',
   reloadNotification: {
     title: 'New version of eVaka is available',
     buttonText: 'Reload page'

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -27,6 +27,7 @@ const components = {
   notifications: {
     close: 'Sulje'
   },
+  offlineNotification: 'Ei verkkoyhteyttä',
   reloadNotification: {
     title: 'Uusi versio eVakasta saatavilla',
     buttonText: 'Lataa sivu uudelleen'

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -27,6 +27,7 @@ const components = {
   notifications: {
     close: 'Stäng'
   },
+  offlineNotification: 'Ingen internetanslutning',
   reloadNotification: {
     title: 'En ny version av eVaka är tillgänglig',
     buttonText: 'Ladda om sidan'


### PR DESCRIPTION
#### Summary

The toast is shown in all the 3 frontends.

In employee mobile it looks like this:

<img width="375" alt="Screenshot 2023-01-16 at 10 05 40" src="https://user-images.githubusercontent.com/70927/212627588-4e36f3aa-d873-4178-95de-4731b48bde68.png">

