### PR TITLE
Allow arrival after a departure

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceControllerIntegrationTest.kt
@@ -820,7 +820,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
         val pinCode = "1212"
         lateinit var employeeId: EmployeeId
         val plannedStart = HelsinkiDateTime.of(today, LocalTime.of(8, 0))
-        val plannedEnd = HelsinkiDateTime.of(today, LocalTime.of(12, 0))
+        val plannedEnd = HelsinkiDateTime.of(today, LocalTime.of(14, 0))
         db.transaction { tx ->
             FixtureBuilder(tx)
                 .addEmployee()
@@ -879,7 +879,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             thirdArrivalTime.toLocalTime(),
             StaffAttendanceType.TRAINING
         )
-        val thirdDepartureTime = plannedEnd.minusMinutes(5)
+        val thirdDepartureTime = thirdArrivalTime.plusMinutes(15)
         markDeparture(
             thirdDepartureTime,
             employeeId,
@@ -888,12 +888,30 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             thirdDepartureTime.toLocalTime(),
             null
         )
+        val fourthArrivalTime = thirdDepartureTime.plusMinutes(30)
+        markArrival(
+            fourthArrivalTime,
+            employeeId,
+            pinCode,
+            groupId,
+            fourthArrivalTime.toLocalTime(),
+            null
+        )
+        val fourthDepartureTime = plannedEnd.minusMinutes(5)
+        markDeparture(
+            fourthDepartureTime,
+            employeeId,
+            pinCode,
+            groupId,
+            fourthDepartureTime.toLocalTime(),
+            null
+        )
         val attendances = fetchRealtimeStaffAttendances(testDaycare.id, mobileUser)
         assertEquals(1, attendances.staff.size)
         attendances.staff.first().let {
             assertEquals(employeeId, it.employeeId)
             assertEquals(null, it.present)
-            assertEquals(5, it.attendances.size)
+            assertEquals(6, it.attendances.size)
             assertEquals(firstArrivalTime, it.attendances[0].arrived)
             assertEquals(firstDepartureTime, it.attendances[0].departed)
             assertEquals(StaffAttendanceType.OVERTIME, it.attendances[0].type)
@@ -909,6 +927,9 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             assertEquals(thirdArrivalTime, it.attendances[4].arrived)
             assertEquals(thirdDepartureTime, it.attendances[4].departed)
             assertEquals(StaffAttendanceType.PRESENT, it.attendances[4].type)
+            assertEquals(fourthArrivalTime, it.attendances[5].arrived)
+            assertEquals(fourthDepartureTime, it.attendances[5].departed)
+            assertEquals(StaffAttendanceType.PRESENT, it.attendances[5].type)
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
@@ -98,7 +98,7 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
                             tx.getPlannedStaffAttendances(body.employeeId, clock.now())
                         val ongoingAttendance = tx.getOngoingAttendance(body.employeeId)
                         val latestDepartureToday =
-                            tx.getLatestDepartureToday(body.employeeId, clock)
+                            tx.getLatestDepartureToday(body.employeeId, clock.now())
                         val attendances =
                             createAttendancesFromArrival(
                                 clock.now(),

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
@@ -97,11 +97,14 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
                         val plannedAttendances =
                             tx.getPlannedStaffAttendances(body.employeeId, clock.now())
                         val ongoingAttendance = tx.getOngoingAttendance(body.employeeId)
+                        val latestDepartureToday =
+                            tx.getLatestDepartureToday(body.employeeId, clock)
                         val attendances =
                             createAttendancesFromArrival(
                                 clock.now(),
                                 plannedAttendances,
                                 ongoingAttendance,
+                                latestDepartureToday,
                                 body
                             )
                         val occupancyCoefficient =
@@ -283,6 +286,7 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
         now: HelsinkiDateTime,
         plans: List<PlannedStaffAttendance>,
         ongoingAttendance: StaffAttendance?,
+        latestDepartureToday: StaffAttendance?,
         arrival: StaffArrivalRequest
     ): List<StaffAttendance> {
         val arrivalTime =
@@ -346,13 +350,15 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
                             "Arrival type ${arrival.type} does not match ongoing attendance type ${ongoingAttendance.type}"
                         )
                     }
-                    listOf(
+                    listOfNotNull(
                         ongoingAttendance?.copy(departed = arrivalTime)
-                            ?: createNewAttendance(
-                                planStart,
-                                arrivalTime,
-                                arrival.type ?: StaffAttendanceType.PRESENT
-                            ),
+                            ?: if (latestDepartureToday != null) null
+                            else
+                                createNewAttendance(
+                                    planStart,
+                                    arrivalTime,
+                                    arrival.type ?: StaffAttendanceType.PRESENT
+                                ),
                         createNewAttendance(arrivalTime, null, StaffAttendanceType.PRESENT)
                     )
                 }

--- a/service/src/main/resources/db/migration/V293__staff_attendance_realtime_index.sql
+++ b/service/src/main/resources/db/migration/V293__staff_attendance_realtime_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx$staff_attendance_realtime_employee_departed ON staff_attendance_realtime (employee_id, departed);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -289,3 +289,4 @@ V289__placement_type_preschool_club.sql
 V290__application_other_guardian_access.sql
 V291__application_other_guardian_cascade.sql
 V292__message_sent_nullable.sql
+V293__staff_attendance_realtime_index.sql


### PR DESCRIPTION
#### Summary
Allow arrival after a non work departure.

Example: If employee departs 1400, allow arriving 1500. This leaves a gap in the attendance data between 14-15 

