### PR TITLE
Hide decisions from blocked guardians

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -1313,7 +1313,14 @@ fun Database.Read.fetchApplicationNotificationCountForCitizen(citizenId: PersonI
         """
         SELECT COUNT(*)
         FROM application_view a
-        WHERE guardianId = :guardianId AND NOT a.hidefromguardian AND a.status = 'WAITING_CONFIRMATION'
+        WHERE guardianId = :guardianId
+        AND NOT a.hidefromguardian
+        AND NOT EXISTS (
+            SELECT 1 FROM guardian_blocklist
+            WHERE child_id = a.childId
+            AND guardian_id = :guardianId
+        )
+        AND a.status = 'WAITING_CONFIRMATION'
         """
             .trimIndent()
 


### PR DESCRIPTION
#### Summary

Before this change, blocked guardians were able to see the decision count in a notification bubble, and the decision data also ended up in the browser in a HTTP response (but was not shown in the UI).