### PR TITLE
EVAKA-4694 service worker messaging: send a message

### DIFF
--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -9,6 +9,7 @@ import { UUID } from 'lib-common/types'
 import config from '../../../config'
 import { waitUntilTrue } from '../../../utils'
 import { DatePickerDeprecated, Page, Radio } from '../../../utils/page'
+import MessagesPage from '../messages/messages-page'
 
 import ApplicationEditView from './application-edit-view'
 
@@ -23,6 +24,7 @@ export default class ApplicationReadView {
   #givenOtherGuardianPhone = this.page.find('[data-qa="second-guardian-phone"]')
   #giveOtherGuardianEmail = this.page.find('[data-qa="second-guardian-email"]')
   #applicationStatus = this.page.find('[data-qa="application-status"]')
+  #sendMessageButton = this.page.findByDataQa('send-message-button')
 
   async waitUntilLoaded() {
     await this.page.find('[data-qa="application-read-view"]').waitUntilVisible()
@@ -157,5 +159,12 @@ export default class ApplicationReadView {
   async startEditing(): Promise<ApplicationEditView> {
     await this.#editButton.click()
     return new ApplicationEditView(this.page)
+  }
+
+  async openMessagesPage(): Promise<MessagesPage> {
+    const popup = await this.page.capturePopup(
+      async () => await this.#sendMessageButton.click()
+    )
+    return new MessagesPage(popup)
   }
 }

--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -124,11 +124,11 @@ export default class MessagesPage {
     if (message.receiver) {
       await this.#receiverSelection.open()
       await this.#receiverSelection.expandAll()
-      await this.#receiverSelection.option(message.receiver).click()
+      await this.#receiverSelection.option(message.receiver).check()
       await this.#receiverSelection.close()
     } else {
       await this.#receiverSelection.open()
-      await this.#receiverSelection.firstOption().click()
+      await this.#receiverSelection.firstOption().check()
       await this.#receiverSelection.close()
     }
     if (message.urgent ?? false) {

--- a/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
+
+import config from '../../config'
+import {
+  insertApplications,
+  resetDatabase,
+  upsertMessageAccounts
+} from '../../dev-api'
+import {
+  AreaAndPersonFixtures,
+  initializeAreaAndPersonData
+} from '../../dev-api/data-init'
+import {
+  Fixture,
+  applicationFixture,
+  applicationFixtureId
+} from '../../dev-api/fixtures'
+import { EmployeeDetail } from '../../dev-api/types'
+import CitizenHeader from '../../pages/citizen/citizen-header'
+import CitizenMessagesPage from '../../pages/citizen/citizen-messages'
+import ApplicationsPage from '../../pages/employee/applications'
+import EmployeeNav from '../../pages/employee/employee-nav'
+import { Page } from '../../utils/page'
+import { employeeLogin, enduserLogin } from '../../utils/user'
+
+let fixtures: AreaAndPersonFixtures
+let citizenPage: Page
+let staffPage: Page
+let serviceWorker: EmployeeDetail
+
+const mockedTime = HelsinkiDateTime.fromLocal(
+  LocalDate.of(2022, 11, 8),
+  LocalTime.of(10, 49, 0)
+)
+
+beforeEach(async () => {
+  await resetDatabase()
+  fixtures = await initializeAreaAndPersonData()
+  serviceWorker = (await Fixture.employeeServiceWorker().save()).data
+  await upsertMessageAccounts()
+})
+
+async function openCitizenPage(mockedTime: HelsinkiDateTime) {
+  citizenPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  await enduserLogin(citizenPage)
+}
+
+async function openStaffPage(mockedTime: HelsinkiDateTime) {
+  staffPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  await employeeLogin(staffPage, serviceWorker)
+  await staffPage.goto(config.employeeUrl)
+}
+
+describe('Service Worker Messaging', () => {
+  describe('Citizen only', () => {
+    it('should NOT show the messaging section for a citizen', async () => {
+      await openCitizenPage(mockedTime)
+      const header = new CitizenHeader(citizenPage)
+      await header.assertNoTab('messages')
+    })
+  })
+
+  describe('Service Worker and citizen', () => {
+    beforeEach(async () => {
+      const applFixture = applicationFixture(
+        fixtures.enduserChildFixtureJari,
+        fixtures.enduserGuardianFixture
+      )
+      await insertApplications([applFixture])
+    })
+
+    it('should be possible for service workers to send messages relating to an application', async () => {
+      await openStaffPage(mockedTime)
+      const applicationsPage = new ApplicationsPage(staffPage)
+      await new EmployeeNav(staffPage).applicationsTab.click()
+      const applReadView = await applicationsPage
+        .applicationRow(applicationFixtureId)
+        .openApplication()
+      const messagesPage = await applReadView.openMessagesPage()
+      const message = {
+        title: 'Message to citizen',
+        content: 'Hello citizen!'
+      }
+      await messagesPage.sendNewMessage({
+        ...message,
+        receiver: fixtures.enduserGuardianFixture.id
+      })
+
+      await openCitizenPage(mockedTime.addHours(1))
+      const header = new CitizenHeader(citizenPage)
+      await header.selectTab('messages')
+      const citizenMessagesPage = new CitizenMessagesPage(citizenPage)
+      await citizenMessagesPage.openFirstThread()
+      await citizenMessagesPage.assertThreadContent(message)
+    })
+  })
+})

--- a/frontend/src/e2e-test/specs/8_access/access.spec.ts
+++ b/frontend/src/e2e-test/specs/8_access/access.spec.ts
@@ -60,7 +60,7 @@ describe('Child information page', () => {
       search: true,
       finance: false,
       reports: true,
-      messages: false
+      messages: true
     })
   })
 

--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -551,6 +551,14 @@ export default function App() {
                     }
                   />
                   <Route
+                    path="/messages/send"
+                    element={
+                      <EmployeeRoute title={i18n.titles.messages}>
+                        <MessagesPage showEditor />
+                      </EmployeeRoute>
+                    }
+                  />
+                  <Route
                     path="/personal-mobile-devices"
                     element={
                       <EmployeeRoute title={i18n.titles.personalMobileDevices}>

--- a/frontend/src/employee-frontend/components/ApplicationPage.tsx
+++ b/frontend/src/employee-frontend/components/ApplicationPage.tsx
@@ -18,10 +18,13 @@ import useNonNullableParams from 'lib-common/useNonNullableParams'
 import { scrollToPos } from 'lib-common/utils/scrolling'
 import { useDebounce } from 'lib-common/utils/useDebounce'
 import { useRestApi } from 'lib-common/utils/useRestApi'
+import AddButton from 'lib-components/atoms/buttons/AddButton'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
+import { Gap } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/employee'
+import { faEnvelope } from 'lib-icons'
 
 import {
   getApplication,
@@ -34,6 +37,7 @@ import ApplicationActionsBar from '../components/application-page/ApplicationAct
 import ApplicationEditView from '../components/application-page/ApplicationEditView'
 import ApplicationNotes from '../components/application-page/ApplicationNotes'
 import ApplicationReadView from '../components/application-page/ApplicationReadView'
+import { getEmployeeUrlPrefix } from '../constants'
 import { Translations, useTranslation } from '../state/i18n'
 import { TitleContext, TitleState } from '../state/title'
 import { ApplicationResponse } from '../types/application'
@@ -45,7 +49,7 @@ const ApplicationArea = styled(ContentArea)`
   width: 77%;
 `
 
-const NotesArea = styled(ContentArea)`
+const SidebarArea = styled(ContentArea)`
   width: 23%;
   padding: 0;
 `
@@ -214,14 +218,31 @@ export default React.memo(function ApplicationPage() {
                 applicationData.permittedActions.has(
                   'READ_SPECIAL_EDUCATION_TEACHER_NOTES'
                 )) && (
-                <NotesArea opaque={false}>
+                <SidebarArea opaque={false}>
                   <ApplicationNotes
                     applicationId={applicationId}
                     allowCreate={applicationData.permittedActions.has(
                       'CREATE_NOTE'
                     )}
                   />
-                </NotesArea>
+                  {featureFlags.experimental?.serviceWorkerMessaging && (
+                    <>
+                      <Gap size="m" />
+                      <AddButton
+                        onClick={() =>
+                          window.open(
+                            `${getEmployeeUrlPrefix()}/employee/messages`,
+                            '_blank'
+                          )
+                        }
+                        text={i18n.application.messaging.sendMessage}
+                        darker
+                        icon={faEnvelope}
+                        data-qa="send-message-button"
+                      />
+                    </>
+                  )}
+                </SidebarArea>
               )}
             </FixedSpaceRow>
           )

--- a/frontend/src/employee-frontend/components/ApplicationPage.tsx
+++ b/frontend/src/employee-frontend/components/ApplicationPage.tsx
@@ -231,7 +231,7 @@ export default React.memo(function ApplicationPage() {
                       <AddButton
                         onClick={() =>
                           window.open(
-                            `${getEmployeeUrlPrefix()}/employee/messages`,
+                            `${getEmployeeUrlPrefix()}/employee/messages/send`,
                             '_blank'
                           )
                         }

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -34,7 +34,8 @@ import {
   GroupMessageAccount,
   isGroupMessageAccount,
   isMunicipalMessageAccount,
-  isPersonalMessageAccount
+  isPersonalMessageAccount,
+  isServiceWorkerMessageAccount
 } from 'lib-components/employee/messages/types'
 import { SelectOption } from 'lib-components/molecules/Select'
 import { faCheck } from 'lib-icons'
@@ -60,7 +61,8 @@ import {
   groupMessageBoxes,
   isValidView,
   municipalMessageBoxes,
-  personalMessageBoxes
+  personalMessageBoxes,
+  serviceWorkerMessageBoxes
 } from './types-view'
 
 const PAGE_SIZE = 20
@@ -73,6 +75,7 @@ export type CancelableMessage = {
 export interface MessagesState {
   accounts: Result<AuthorizedMessageAccount[]>
   municipalAccount: AuthorizedMessageAccount | undefined
+  serviceWorkerAccount: AuthorizedMessageAccount | undefined
   personalAccount: AuthorizedMessageAccount | undefined
   groupAccounts: GroupMessageAccount[]
   unitOptions: SelectOption[]
@@ -108,6 +111,7 @@ export interface MessagesState {
 const defaultState: MessagesState = {
   accounts: Loading.of(),
   municipalAccount: undefined,
+  serviceWorkerAccount: undefined,
   personalAccount: undefined,
   groupAccounts: [],
   unitOptions: [],
@@ -202,6 +206,13 @@ export const MessageContextProvider = React.memo(
       () =>
         accounts
           .map((accounts) => accounts.find(isMunicipalMessageAccount))
+          .getOrElse(undefined),
+      [accounts]
+    )
+    const serviceWorkerAccount = useMemo(
+      () =>
+        accounts
+          .map((accounts) => accounts.find(isServiceWorkerMessageAccount))
           .getOrElse(undefined),
       [accounts]
     )
@@ -604,6 +615,12 @@ export const MessageContextProvider = React.memo(
           account: municipalAccount.account,
           unitId: null
         })
+      } else if (serviceWorkerAccount) {
+        selectAccount({
+          view: serviceWorkerMessageBoxes[0],
+          account: serviceWorkerAccount.account,
+          unitId: null
+        })
       } else if (personalAccount) {
         selectAccount({
           view: personalMessageBoxes[0],
@@ -617,12 +634,19 @@ export const MessageContextProvider = React.memo(
           unitId: groupAccounts[0].daycareGroup.unitId
         })
       }
-    }, [groupAccounts, municipalAccount, personalAccount, selectAccount])
+    }, [
+      groupAccounts,
+      municipalAccount,
+      serviceWorkerAccount,
+      personalAccount,
+      selectAccount
+    ])
 
     const value = useMemo(
       () => ({
         accounts,
         municipalAccount,
+        serviceWorkerAccount,
         personalAccount,
         groupAccounts,
         unitOptions,
@@ -657,6 +681,7 @@ export const MessageContextProvider = React.memo(
       [
         accounts,
         municipalAccount,
+        serviceWorkerAccount,
         personalAccount,
         groupAccounts,
         unitOptions,

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -37,7 +37,11 @@ const PanelContainer = styled.div`
   display: flex;
 `
 
-export default React.memo(function MessagesPage() {
+export default React.memo(function MessagesPage({
+  showEditor: initialShowEditor
+}: {
+  showEditor?: boolean
+}) {
   const {
     accounts,
     selectedDraft,
@@ -55,7 +59,9 @@ export default React.memo(function MessagesPage() {
 
   useEffect(() => refreshMessages(), [refreshMessages])
   const [sending, setSending] = useState(false)
-  const [showEditor, setShowEditor] = useState<boolean>(false)
+  const [showEditor, setShowEditor] = useState<boolean>(
+    initialShowEditor ?? false
+  )
 
   // Select first account if no account is selected. This modifies MessageContextProvider state and so has
   // to be in useEffect. Calling setState() directly in the render function is only allowed if the state

--- a/frontend/src/employee-frontend/components/messages/Sidebar.tsx
+++ b/frontend/src/employee-frontend/components/messages/Sidebar.tsx
@@ -21,7 +21,11 @@ import GroupMessageAccountList from './GroupMessageAccountList'
 import MessageBox from './MessageBox'
 import { MessageContext } from './MessageContext'
 import { getReceivers } from './api'
-import { municipalMessageBoxes, personalMessageBoxes } from './types-view'
+import {
+  municipalMessageBoxes,
+  personalMessageBoxes,
+  serviceWorkerMessageBoxes
+} from './types-view'
 
 const Container = styled.div`
   flex: 0 1 260px;
@@ -83,6 +87,7 @@ function Accounts({ setReceivers }: AccountsProps) {
   const {
     selectedAccount,
     municipalAccount,
+    serviceWorkerAccount,
     personalAccount,
     groupAccounts,
     unitOptions,
@@ -121,9 +126,12 @@ function Accounts({ setReceivers }: AccountsProps) {
 
   return (
     <>
-      {!municipalAccount && !personalAccount && groupAccounts.length === 0 && (
-        <NoAccounts>{i18n.messages.sidePanel.noAccountAccess}</NoAccounts>
-      )}
+      {!municipalAccount &&
+        !serviceWorkerAccount &&
+        !personalAccount &&
+        groupAccounts.length === 0 && (
+          <NoAccounts>{i18n.messages.sidePanel.noAccountAccess}</NoAccounts>
+        )}
 
       {municipalAccount && (
         <AccountSection data-qa="municipal-account">
@@ -135,6 +143,24 @@ function Accounts({ setReceivers }: AccountsProps) {
               key={view}
               view={view}
               account={municipalAccount.account}
+              unitId={null}
+              activeView={selectedAccount}
+              selectAccount={selectAccount}
+            />
+          ))}
+        </AccountSection>
+      )}
+
+      {serviceWorkerAccount && (
+        <AccountSection data-qa="service-worker-account">
+          <AccountHeader>
+            {i18n.messages.sidePanel.serviceWorkerMessages}
+          </AccountHeader>
+          {serviceWorkerMessageBoxes.map((view) => (
+            <MessageBox
+              key={view}
+              view={view}
+              account={serviceWorkerAccount.account}
               unitId={null}
               activeView={selectedAccount}
               selectAccount={selectAccount}

--- a/frontend/src/employee-frontend/components/messages/types-view.ts
+++ b/frontend/src/employee-frontend/components/messages/types-view.ts
@@ -18,6 +18,12 @@ export interface AccountView {
 }
 
 export const municipalMessageBoxes: View[] = ['sent', 'drafts']
+export const serviceWorkerMessageBoxes: View[] = [
+  'received',
+  'sent',
+  'drafts',
+  'archive'
+]
 export const personalMessageBoxes: View[] = [
   'received',
   'sent',

--- a/frontend/src/lib-common/api-types/messaging.ts
+++ b/frontend/src/lib-common/api-types/messaging.ts
@@ -21,6 +21,7 @@ export type MessageReceiver =
   | MessageReceiverUnit
   | MessageReceiverGroup
   | MessageReceiverChild
+  | MessageReceiverCitizen
 
 interface MessageReceiverBase {
   id: UUID
@@ -43,6 +44,7 @@ interface MessageReceiverGroup extends MessageReceiverBase {
 }
 
 type MessageReceiverChild = MessageReceiverBase
+type MessageReceiverCitizen = MessageReceiverBase
 
 export const deserializeMessageAccount = (
   account: JsonOf<MessageAccount>,

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -18,6 +18,7 @@ export type AccountType =
   | 'GROUP'
   | 'CITIZEN'
   | 'MUNICIPAL'
+  | 'SERVICE_WORKER'
 
 /**
 * Generated from fi.espoo.evaka.messaging.AuthorizedMessageAccount

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -158,6 +158,7 @@ export type MessageRecipientType =
   | 'UNIT'
   | 'GROUP'
   | 'CHILD'
+  | 'CITIZEN'
 
 /**
 * Generated from fi.espoo.evaka.messaging.MessageThread

--- a/frontend/src/lib-components/employee/messages/types.ts
+++ b/frontend/src/lib-components/employee/messages/types.ts
@@ -26,6 +26,10 @@ export const isMunicipalMessageAccount = (
   acc: AuthorizedMessageAccount
 ): acc is AuthorizedMessageAccount => acc.account.type === 'MUNICIPAL'
 
+export const isServiceWorkerMessageAccount = (
+  acc: AuthorizedMessageAccount
+): acc is AuthorizedMessageAccount => acc.account.type === 'SERVICE_WORKER'
+
 export interface SaveDraftParams {
   accountId: UUID
   draftId: UUID

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3455,6 +3455,7 @@ export const fi = {
     },
     sidePanel: {
       municipalMessages: 'Kunnan tiedotteet',
+      serviceWorkerMessages: 'Palveluohjauksen viestit',
       ownMessages: 'Omat viestit',
       groupsMessages: 'Ryhmien viestit',
       noAccountAccess:

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -544,6 +544,9 @@ export const fi = {
         save: 'Muistiinpanon tallentaminen epäonnnistui',
         remove: 'Muistiinpanon poistaminen epäonnnistui'
       }
+    },
+    messaging: {
+      sendMessage: 'Lähetä viesti'
     }
   },
   childInformation: {

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -36,7 +36,8 @@ const features: Features = {
       assistanceNeedDecisions: true,
       assistanceNeedDecisionsLanguageSelect: true,
       staffAttendanceTypes: true,
-      fosterParents: true
+      fosterParents: true,
+      serviceWorkerMessaging: true
     }
   },
   staging: {
@@ -61,7 +62,8 @@ const features: Features = {
       assistanceNeedDecisions: true,
       assistanceNeedDecisionsLanguageSelect: true,
       staffAttendanceTypes: true,
-      fosterParents: true
+      fosterParents: true,
+      serviceWorkerMessaging: true
     }
   },
   prod: {
@@ -86,7 +88,8 @@ const features: Features = {
       assistanceNeedDecisions: true,
       assistanceNeedDecisionsLanguageSelect: true,
       staffAttendanceTypes: false,
-      fosterParents: true
+      fosterParents: true,
+      serviceWorkerMessaging: false
     }
   }
 }

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -139,6 +139,7 @@ interface BaseFeatureFlags {
     assistanceNeedDecisionsLanguageSelect?: boolean
     staffAttendanceTypes?: boolean
     fosterParents?: boolean
+    serviceWorkerMessaging?: boolean
   }
 }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/DraftQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/DraftQueriesTest.kt
@@ -24,7 +24,7 @@ class DraftQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             val employeeId =
                 tx.insertTestEmployee(DevEmployee(firstName = "Firstname", lastName = "Employee"))
             tx.createUpdate(
-                    "INSERT INTO message_account (id, employee_id) VALUES (:id, :employeeId)"
+                    "INSERT INTO message_account (id, employee_id, type) VALUES (:id, :employeeId, 'PERSONAL')"
                 )
                 .bind("id", accountId)
                 .bind("employeeId", employeeId)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -147,7 +147,8 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         clock,
                         Action.MessageAccount.ACCESS
                     ),
-                    "Espoo"
+                    "Espoo",
+                    "Espoo palveluohjaus"
                 )
             }
         assertEquals(3, accounts2.size)
@@ -199,7 +200,8 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         clock,
                         Action.MessageAccount.ACCESS
                     ),
-                    "Espoo"
+                    "Espoo",
+                    "Espoo palveluohjaus"
                 )
             }
         assertEquals(1, accounts2.size)
@@ -237,7 +239,8 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         clock,
                         Action.MessageAccount.ACCESS
                     ),
-                    "Espoo"
+                    "Espoo",
+                    "Espoo palveluohjaus"
                 )
             }
         assertEquals(0, accounts2.size)
@@ -312,7 +315,8 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                     sender = employeeAccount,
                     sentAt = now.minusSeconds(30),
                     recipientNames = allAccounts.map { it.name },
-                    municipalAccountName = "Espoo"
+                    municipalAccountName = "Espoo",
+                    serviceWorkerAccountName = "Espoo palveluohjaus"
                 )
             tx.insertRecipients(listOf(messageId to allAccounts.map { it.id }.toSet()))
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -161,9 +161,20 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         // employee is not a recipient in any threads
         assertEquals(
             0,
-            db.read { it.getReceivedThreads(accounts.employee1.id, 10, 1, "Espoo") }.data.size
+            db.read {
+                    it.getReceivedThreads(
+                        accounts.employee1.id,
+                        10,
+                        1,
+                        "Espoo",
+                        "Espoon palveluohjaus"
+                    )
+                }
+                .data
+                .size
         )
-        val personResult = db.read { it.getThreads(accounts.employee1.id, 10, 1, "Espoo") }
+        val personResult =
+            db.read { it.getThreads(accounts.employee1.id, 10, 1, "Espoo", "Espoon palveluohjaus") }
         assertEquals(2, personResult.data.size)
 
         val thread = personResult.data.first()
@@ -174,7 +185,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         db.transaction { it.markThreadRead(RealEvakaClock(), accounts.person1.id, thread1Id) }
 
         // then the message has correct readAt
-        val person1Threads = db.read { it.getThreads(accounts.person1.id, 10, 1, "Espoo") }
+        val person1Threads =
+            db.read { it.getThreads(accounts.person1.id, 10, 1, "Espoo", "Espoon palveluohjaus") }
         assertEquals(2, person1Threads.data.size)
         val readMessages = person1Threads.data.flatMap { it.messages.mapNotNull { m -> m.readAt } }
         assertEquals(1, readMessages.size)
@@ -183,7 +195,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         // then person 2 threads are not affected
         assertEquals(
             0,
-            db.read { it.getThreads(accounts.person2.id, 10, 1, "Espoo") }
+            db.read { it.getThreads(accounts.person2.id, 10, 1, "Espoo", "Espoon palveluohjaus") }
                 .data
                 .flatMap { it.messages.mapNotNull { m -> m.readAt } }
                 .size
@@ -201,13 +213,16 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         // then employee sees the thread
         val employeeResult =
-            db.read { it.getReceivedThreads(accounts.employee1.id, 10, 1, "Espoo") }
+            db.read {
+                it.getReceivedThreads(accounts.employee1.id, 10, 1, "Espoo", "Espoon palveluohjaus")
+            }
         assertEquals(1, employeeResult.data.size)
         assertEquals("Newest thread", employeeResult.data[0].title)
         assertEquals(2, employeeResult.data[0].messages.size)
 
         // person 1 is recipient in both threads
-        val person1Result = db.read { it.getThreads(accounts.person1.id, 10, 1, "Espoo") }
+        val person1Result =
+            db.read { it.getThreads(accounts.person1.id, 10, 1, "Espoo", "Espoon palveluohjaus") }
         assertEquals(2, person1Result.data.size)
 
         val newestThread = person1Result.data[0]
@@ -228,14 +243,17 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertNull(oldestThread.messages.find { it.content == "Just replying here" }?.readAt)
 
         // person 2 is recipient in the oldest thread only
-        val person2Result = db.read { it.getThreads(accounts.person2.id, 10, 1, "Espoo") }
+        val person2Result =
+            db.read { it.getThreads(accounts.person2.id, 10, 1, "Espoo", "Espoon palveluohjaus") }
         assertEquals(1, person2Result.data.size)
         assertEquals(oldestThread.id, person2Result.data[0].id)
         assertEquals(0, person2Result.data.flatMap { it.messages }.mapNotNull { it.readAt }.size)
 
         // employee 2 is participating with himself
         val employee2Result =
-            db.read { it.getReceivedThreads(accounts.employee2.id, 10, 1, "Espoo") }
+            db.read {
+                it.getReceivedThreads(accounts.employee2.id, 10, 1, "Espoo", "Espoon palveluohjaus")
+            }
         assertEquals(1, employee2Result.data.size)
         assertEquals(1, employee2Result.data[0].messages.size)
         assertEquals(accounts.employee2, employee2Result.data[0].messages[0].sender)
@@ -247,7 +265,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         createThread("t1", "c1", accounts.employee1, listOf(accounts.person1))
         createThread("t2", "c2", accounts.employee1, listOf(accounts.person1))
 
-        val messages = db.read { it.getThreads(accounts.person1.id, 10, 1, "Espoo") }
+        val messages =
+            db.read { it.getThreads(accounts.person1.id, 10, 1, "Espoo", "Espoon palveluohjaus") }
         assertEquals(2, messages.total)
         assertEquals(2, messages.data.size)
         assertEquals(setOf("t1", "t2"), messages.data.map { it.title }.toSet())
@@ -255,8 +274,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         val (page1, page2) =
             db.read {
                 listOf(
-                    it.getThreads(accounts.person1.id, 1, 1, "Espoo"),
-                    it.getThreads(accounts.person1.id, 1, 2, "Espoo")
+                    it.getThreads(accounts.person1.id, 1, 1, "Espoo", "Espoon palveluohjaus"),
+                    it.getThreads(accounts.person1.id, 1, 2, "Espoo", "Espoon palveluohjaus")
                 )
             }
         assertEquals(2, page1.total)
@@ -355,7 +374,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         sender = accounts.person2.id,
                         sentAt = now,
                         recipientNames = tx.getAccountNames(setOf(accounts.employee1.id)),
-                        municipalAccountName = "Espoo"
+                        municipalAccountName = "Espoo",
+                        serviceWorkerAccountName = "Espoon palveluohjaus"
                     )
                 tx.insertRecipients(listOf(messageId to setOf(accounts.employee1.id)))
                 tx.getThreadByMessageId(messageId)
@@ -621,7 +641,15 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             1,
             db.read {
                 val archiveFolderId = it.getArchiveFolderId(accounts.person1.id)
-                it.getReceivedThreads(accounts.person1.id, 50, 1, "Espoo", archiveFolderId).total
+                it.getReceivedThreads(
+                        accounts.person1.id,
+                        50,
+                        1,
+                        "Espoo",
+                        "Espoon palveluohjaus",
+                        archiveFolderId
+                    )
+                    .total
             }
         )
     }
@@ -636,7 +664,15 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             1,
             db.read {
                 val archiveFolderId = it.getArchiveFolderId(accounts.person1.id)
-                it.getReceivedThreads(accounts.person1.id, 50, 1, "Espoo", archiveFolderId).total
+                it.getReceivedThreads(
+                        accounts.person1.id,
+                        50,
+                        1,
+                        "Espoo",
+                        "Espoon palveluohjaus",
+                        archiveFolderId
+                    )
+                    .total
             }
         )
 
@@ -644,13 +680,31 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         assertEquals(
             1,
-            db.read { it.getReceivedThreads(accounts.person1.id, 50, 1, "Espoo", null).total }
+            db.read {
+                it.getReceivedThreads(
+                        accounts.person1.id,
+                        50,
+                        1,
+                        "Espoo",
+                        "Espoon palveluohjaus",
+                        null
+                    )
+                    .total
+            }
         )
         assertEquals(
             0,
             db.read {
                 val archiveFolderId = it.getArchiveFolderId(accounts.person1.id)
-                it.getReceivedThreads(accounts.person1.id, 50, 1, "Espoo", archiveFolderId).total
+                it.getReceivedThreads(
+                        accounts.person1.id,
+                        50,
+                        1,
+                        "Espoo",
+                        "Espoon palveluohjaus",
+                        archiveFolderId
+                    )
+                    .total
             }
         )
     }
@@ -679,7 +733,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                     sender = sender.id,
                     sentAt = now,
                     recipientNames = tx.getAccountNames(recipientIds),
-                    municipalAccountName = "Espoo"
+                    municipalAccountName = "Espoo",
+                    serviceWorkerAccountName = "Espoon palveluohjaus"
                 )
             tx.insertRecipients(listOf(messageId to recipientAccounts.map { it.id }.toSet()))
             tx.upsertSenderThreadParticipants(sender.id, listOf(threadId), now)
@@ -711,7 +766,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                     sentAt = now,
                     repliesToMessageId = repliesToMessageId,
                     recipientNames = listOf(),
-                    municipalAccountName = "Espoo"
+                    municipalAccountName = "Espoo",
+                    serviceWorkerAccountName = "Espoon palveluohjaus"
                 )
             tx.insertRecipients(listOf(messageId to recipientIds))
             tx.upsertSenderThreadParticipants(sender.id, listOf(threadId), now)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactivePeopleCleanupIntegrationTest.kt
@@ -280,7 +280,8 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
                     sender = employeeAccount,
                     sentAt = now,
                     recipientNames = listOf("recipient name"),
-                    municipalAccountName = "Espoo"
+                    municipalAccountName = "Espoo",
+                    serviceWorkerAccountName = "Espoon palveluohjaus"
                 )
             tx.insertRecipients(listOf(messageId to setOf(personAccount)))
         }
@@ -312,7 +313,8 @@ class InactivePeopleCleanupIntegrationTest : PureJdbiTest(resetDbBeforeEach = tr
                     sender = personAccount,
                     sentAt = now,
                     recipientNames = listOf("employee name"),
-                    municipalAccountName = "Espoo"
+                    municipalAccountName = "Espoo",
+                    serviceWorkerAccountName = "Espoon palveluohjaus"
                 )
             tx.insertRecipients(listOf(messageId to setOf(employeeAccount)))
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/service/MergeServiceIntegrationTest.kt
@@ -257,7 +257,8 @@ class MergeServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
                 messageRecipients = listOf(receiverAccount to testChild_1.id),
                 recipientNames = listOf(),
                 staffCopyRecipients = setOf(),
-                municipalAccountName = "Espoo"
+                municipalAccountName = "Espoo",
+                serviceWorkerAccountName = "Espoon palveluohjaus"
             )
         }
         assertEquals(listOf(0, 1), sentMessageCounts(senderAccount, senderDuplicateAccount))
@@ -307,7 +308,8 @@ class MergeServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
                 messageRecipients = listOf(receiverDuplicateAccount to testChild_1.id),
                 recipientNames = listOf(),
                 staffCopyRecipients = setOf(),
-                municipalAccountName = "Espoo"
+                municipalAccountName = "Espoo",
+                serviceWorkerAccountName = "Espoon palveluohjaus"
             )
         }
         asyncJobRunner.runPendingJobsSync(MockEvakaClock(now))
@@ -329,13 +331,18 @@ class MergeServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
     }
 
     private fun receivedThreadCounts(accountIds: List<MessageAccountId>): List<Int> =
-        db.read { tx -> accountIds.map { tx.getReceivedThreads(it, 10, 1, "Espoo").total } }
+        db.read { tx ->
+            accountIds.map {
+                tx.getReceivedThreads(it, 10, 1, "Espoo", "Espoon palveluohjaus").total
+            }
+        }
 
     private fun archivedThreadCounts(accountIds: List<MessageAccountId>): List<Int> =
         db.read { tx ->
             accountIds.map {
                 val archiveFolderId = tx.getArchiveFolderId(it)
-                tx.getReceivedThreads(it, 10, 1, "Espoo", archiveFolderId).total
+                tx.getReceivedThreads(it, 10, 1, "Espoo", "Espoon palveluohjaus", archiveFolderId)
+                    .total
             }
         }
 
@@ -370,12 +377,14 @@ class MergeServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
                 messageRecipients = listOf(receiverDuplicateAccount to testChild_1.id),
                 recipientNames = listOf(),
                 staffCopyRecipients = setOf(),
-                municipalAccountName = "Espoo"
+                municipalAccountName = "Espoo",
+                serviceWorkerAccountName = "Espoon palveluohjaus"
             )
         }
         asyncJobRunner.runPendingJobsSync(MockEvakaClock(now))
         db.transaction { tx ->
-            val threadId = tx.getThreads(senderAccount, 1, 1, "Espoo").data.first().id
+            val threadId =
+                tx.getThreads(senderAccount, 1, 1, "Espoo", "Espoon palveluohjaus").data.first().id
             tx.archiveThread(receiverDuplicateAccount, threadId)
         }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -215,5 +215,7 @@ val testFeatureConfig =
         requestedStartUpperLimit = 14,
         partialAbsenceThresholdsEnabled = true,
         postOffice = "ESPOO",
-        municipalMessageAccountName = "Espoon kaupunki - Esbo stad - City of Espoo"
+        municipalMessageAccountName = "Espoon kaupunki - Esbo stad - City of Espoo",
+        serviceWorkerMessageAccountName =
+            "Espoon kaupungin palveluohjaus - Esbo stads serviceledning - City of Espoo service guidance"
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -143,7 +143,9 @@ class EspooConfig {
             requestedStartUpperLimit = 14,
             partialAbsenceThresholdsEnabled = true,
             postOffice = "ESPOO",
-            municipalMessageAccountName = "Espoon kaupunki - Esbo stad - City of Espoo"
+            municipalMessageAccountName = "Espoon kaupunki - Esbo stad - City of Espoo",
+            serviceWorkerMessageAccountName =
+                "Espoon kaupungin palveluohjaus - Esbo stads servicehandledning - City of Espoo service guidance"
         )
 
     @Bean

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
@@ -98,7 +98,8 @@ enum class AccountType {
     PERSONAL,
     GROUP,
     CITIZEN,
-    MUNICIPAL;
+    MUNICIPAL,
+    SERVICE_WORKER;
 
     fun isPrimaryRecipientForCitizenMessage(): Boolean =
         when (this) {
@@ -106,6 +107,7 @@ enum class AccountType {
             GROUP -> true
             CITIZEN -> false
             MUNICIPAL -> false
+            SERVICE_WORKER -> false
         }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.shared.MessageAccountId
 import fi.espoo.evaka.shared.MessageContentId
 import fi.espoo.evaka.shared.MessageId
 import fi.espoo.evaka.shared.MessageThreadId
+import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.jdbi.v3.core.mapper.Nested
 import org.jdbi.v3.core.mapper.PropagateNull
@@ -92,6 +93,9 @@ sealed class MessageReceiver(val type: MessageRecipientType) {
 
     data class Child(override val id: ChildId, override val name: String) :
         MessageReceiver(MessageRecipientType.CHILD)
+
+    data class Citizen(override val id: PersonId, override val name: String) :
+        MessageReceiver(MessageRecipientType.CITIZEN)
 }
 
 enum class AccountType {
@@ -129,7 +133,8 @@ enum class MessageRecipientType {
     AREA,
     UNIT,
     GROUP,
-    CHILD
+    CHILD,
+    CITIZEN
 }
 
 data class MessageRecipient(val type: MessageRecipientType, val id: Id<*>)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageAccountQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageAccountQueries.kt
@@ -85,6 +85,7 @@ AND (
     'MESSAGING' = ANY(dc.enabled_pilot_features)
     OR 'MESSAGING' = ANY(supervisor_dc.enabled_pilot_features)
     OR acc.type = 'MUNICIPAL'
+    OR acc.type = 'SERVICE_WORKER'
 )
 """
     return this.createQuery(sql)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -73,7 +73,8 @@ class MessageController(
                         )
                     it.getAuthorizedMessageAccountsForEmployee(
                         filter,
-                        featureConfig.municipalMessageAccountName
+                        featureConfig.municipalMessageAccountName,
+                        featureConfig.serviceWorkerMessageAccountName
                     )
                 }
             }
@@ -100,7 +101,8 @@ class MessageController(
                             )
                         it.getAuthorizedMessageAccountsForEmployee(
                             filter,
-                            featureConfig.municipalMessageAccountName
+                            featureConfig.municipalMessageAccountName,
+                            featureConfig.serviceWorkerMessageAccountName
                         )
                     } else setOf()
                 }
@@ -125,7 +127,8 @@ class MessageController(
                         accountId,
                         pageSize,
                         page,
-                        featureConfig.municipalMessageAccountName
+                        featureConfig.municipalMessageAccountName,
+                        featureConfig.serviceWorkerMessageAccountName
                     )
                 }
             }
@@ -158,6 +161,7 @@ class MessageController(
                             pageSize,
                             page,
                             featureConfig.municipalMessageAccountName,
+                            featureConfig.serviceWorkerMessageAccountName,
                             archiveFolderId
                         )
                     }
@@ -336,7 +340,8 @@ class MessageController(
                             messageRecipients = messageRecipients,
                             attachmentIds = body.attachmentIds,
                             staffCopyRecipients = staffCopyRecipients,
-                            municipalAccountName = featureConfig.municipalMessageAccountName
+                            municipalAccountName = featureConfig.municipalMessageAccountName,
+                            serviceWorkerAccountName = featureConfig.serviceWorkerMessageAccountName
                         )
                     if (body.draftId != null)
                         tx.deleteDraft(accountId = accountId, draftId = body.draftId)
@@ -431,7 +436,8 @@ class MessageController(
                     senderAccount = accountId,
                     recipientAccountIds = body.recipientAccountIds,
                     content = body.content,
-                    municipalAccountName = featureConfig.municipalMessageAccountName
+                    municipalAccountName = featureConfig.municipalMessageAccountName,
+                    serviceWorkerAccountName = featureConfig.serviceWorkerMessageAccountName
                 )
             }
             .also {

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -106,7 +106,8 @@ class MessageControllerCitizen(
                         accountId,
                         pageSize,
                         page,
-                        featureConfig.municipalMessageAccountName
+                        featureConfig.municipalMessageAccountName,
+                        featureConfig.serviceWorkerMessageAccountName
                     )
                 }
             }
@@ -159,7 +160,8 @@ class MessageControllerCitizen(
                     senderAccount = accountId,
                     recipientAccountIds = body.recipientAccountIds,
                     content = body.content,
-                    municipalAccountName = featureConfig.municipalMessageAccountName
+                    municipalAccountName = featureConfig.municipalMessageAccountName,
+                    serviceWorkerAccountName = featureConfig.serviceWorkerMessageAccountName
                 )
             }
             .also { Audit.MessagingReplyToMessageWrite.log(targetId = messageId) }
@@ -206,7 +208,9 @@ class MessageControllerCitizen(
                                 threadId = threadId,
                                 sender = senderId,
                                 recipientNames = recipientNames,
-                                municipalAccountName = featureConfig.municipalMessageAccountName
+                                municipalAccountName = featureConfig.municipalMessageAccountName,
+                                serviceWorkerAccountName =
+                                    featureConfig.serviceWorkerMessageAccountName
                             )
                         tx.insertMessageThreadChildren(listOf(body.children to threadId))
                         tx.insertRecipients(listOf(messageId to recipientIds))

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
@@ -81,14 +81,14 @@ class MessageService(
         type: MessageType,
         urgent: Boolean,
         sender: MessageAccountId,
-        messageRecipients: List<Pair<MessageAccountId, ChildId>>,
+        messageRecipients: List<Pair<MessageAccountId, ChildId?>>,
         recipientNames: List<String>,
         attachmentIds: Set<AttachmentId> = setOf(),
         staffCopyRecipients: Set<MessageAccountId>,
         municipalAccountName: String,
         serviceWorkerAccountName: String
     ): MessageContentId {
-        val recipientGroups: List<Pair<Set<MessageAccountId>, Set<ChildId>>> =
+        val recipientGroups: List<Pair<Set<MessageAccountId>, Set<ChildId?>>> =
             if (type == MessageType.BULLETIN) {
                 // bulletins cannot be replied to so there is no need to group threads for families
                 messageRecipients
@@ -133,7 +133,7 @@ class MessageService(
         val recipientGroupsWithMessageIds = threadAndMessageIds.zip(recipientGroups)
         tx.insertMessageThreadChildren(
             recipientGroupsWithMessageIds.map { (ids, recipients) ->
-                recipients.second to ids.first
+                recipients.second.filterNotNull().toSet() to ids.first
             }
         )
         tx.upsertSenderThreadParticipants(

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
@@ -85,7 +85,8 @@ class MessageService(
         recipientNames: List<String>,
         attachmentIds: Set<AttachmentId> = setOf(),
         staffCopyRecipients: Set<MessageAccountId>,
-        municipalAccountName: String
+        municipalAccountName: String,
+        serviceWorkerAccountName: String
     ): MessageContentId {
         val recipientGroups: List<Pair<Set<MessageAccountId>, Set<ChildId>>> =
             if (type == MessageType.BULLETIN) {
@@ -126,7 +127,8 @@ class MessageService(
                 contentId,
                 sender,
                 recipientNames,
-                municipalAccountName
+                municipalAccountName,
+                serviceWorkerAccountName
             )
         val recipientGroupsWithMessageIds = threadAndMessageIds.zip(recipientGroups)
         tx.insertMessageThreadChildren(
@@ -165,7 +167,8 @@ class MessageService(
                     contentId,
                     sender,
                     recipientNames,
-                    municipalAccountName
+                    municipalAccountName,
+                    serviceWorkerAccountName
                 )
             val staffRecipientsWithMessageIds = staffThreadAndMessageIds.zip(staffCopyRecipients)
             tx.upsertSenderThreadParticipants(
@@ -193,7 +196,8 @@ class MessageService(
         senderAccount: MessageAccountId,
         recipientAccountIds: Set<MessageAccountId>,
         content: String,
-        municipalAccountName: String
+        municipalAccountName: String,
+        serviceWorkerAccountName: String
     ): ThreadReply {
         val (threadId, type, isCopy, senders, recipients) =
             db.read { it.getThreadByMessageId(replyToMessageId) }
@@ -222,7 +226,8 @@ class MessageService(
                         sender = senderAccount,
                         repliesToMessageId = replyToMessageId,
                         recipientNames = recipientNames,
-                        municipalAccountName = municipalAccountName
+                        municipalAccountName = municipalAccountName,
+                        serviceWorkerAccountName = serviceWorkerAccountName
                     )
                 tx.insertRecipients(listOf(messageId to recipientAccountIds))
                 asyncJobRunner.scheduleMarkMessagesAsSent(tx, contentId, now)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -122,5 +122,8 @@ data class FeatureConfig(
     val postOffice: String,
 
     /** Name of the message sender when sending messages on the municipal message account */
-    val municipalMessageAccountName: String
+    val municipalMessageAccountName: String,
+
+    /** Name of the message sender when sending messages on the service worker message account */
+    val serviceWorkerMessageAccountName: String
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -658,16 +658,19 @@ RETURNING id
         db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.execute(
-                    "INSERT INTO message_account (daycare_group_id) SELECT id FROM daycare_group ON CONFLICT DO NOTHING"
+                    "INSERT INTO message_account (daycare_group_id, type) SELECT id, 'GROUP'::message_account_type as type FROM daycare_group ON CONFLICT DO NOTHING"
                 )
                 tx.execute(
-                    "INSERT INTO message_account (person_id) SELECT id FROM person ON CONFLICT DO NOTHING"
+                    "INSERT INTO message_account (person_id, type) SELECT id, 'CITIZEN'::message_account_type as type FROM person ON CONFLICT DO NOTHING"
                 )
                 tx.execute(
-                    "INSERT INTO message_account (employee_id) SELECT employee_id FROM daycare_acl WHERE role = 'UNIT_SUPERVISOR' ON CONFLICT DO NOTHING"
+                    "INSERT INTO message_account (employee_id, type) SELECT employee_id, 'PERSONAL'::message_account_type as type FROM daycare_acl WHERE role = 'UNIT_SUPERVISOR' ON CONFLICT DO NOTHING"
                 )
                 tx.execute(
-                    "INSERT INTO message_account (daycare_group_id, person_id, employee_id) VALUES (NULL, NULL, NULL) ON CONFLICT DO NOTHING"
+                    "INSERT INTO message_account (daycare_group_id, person_id, employee_id, type) VALUES (NULL, NULL, NULL, 'MUNICIPAL') ON CONFLICT DO NOTHING"
+                )
+                tx.execute(
+                    "INSERT INTO message_account (daycare_group_id, person_id, employee_id, type) VALUES (NULL, NULL, NULL, 'SERVICE_WORKER') ON CONFLICT DO NOTHING"
                 )
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlCitizen.kt
@@ -55,6 +55,13 @@ SELECT EXISTS (
         WHERE child_id = c.child_id
         AND blocked_recipient = c.parent_id
     )
+    UNION 
+    SELECT 1
+    FROM person p 
+    JOIN message_account ma ON p.id = ma.person_id
+    JOIN message_recipients mr ON ma.id = mr.recipient_id
+    JOIN application app ON p.id = app.guardian_id
+    WHERE app.status = 'SENT' AND p.id = :userId AND mr.id IS NOT NULL
 )
 """
         return createQuery(sql)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -86,7 +86,7 @@ sealed interface Action {
         FINANCE_PAGE(HasGlobalRole(ADMIN, FINANCE_ADMIN)),
         HOLIDAY_PERIODS_PAGE(HasGlobalRole(ADMIN)),
         MESSAGES_PAGE(
-            HasGlobalRole(ADMIN, MESSAGING),
+            HasGlobalRole(ADMIN, MESSAGING, SERVICE_WORKER),
             HasUnitRole(
                     STAFF,
                     UNIT_SUPERVISOR,
@@ -1233,6 +1233,7 @@ sealed interface Action {
             HasUnitRole(UNIT_SUPERVISOR).hasDaycareMessageAccount(),
             IsEmployee.hasDaycareGroupMessageAccount(),
             IsEmployee.hasMunicipalMessageAccount(),
+            IsEmployee.hasServiceWorkerMessageAccount(),
             IsMobile(requirePinLogin = true).hasPersonalMessageAccount(),
             IsMobile(requirePinLogin = true).hasDaycareMessageAccount(UNIT_SUPERVISOR),
             IsMobile(requirePinLogin = true).hasDaycareGroupMessageAccount(),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsEmployee.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsEmployee.kt
@@ -223,6 +223,19 @@ WHERE e.id = ${bind(user.id)} AND e.roles && '{ADMIN, MESSAGING}'::user_role[]
             )
         }
 
+    fun hasServiceWorkerMessageAccount() =
+        rule<MessageAccountId> { user, _ ->
+            sql(
+                """
+SELECT acc.id
+FROM employee e
+JOIN message_account acc ON acc.type = 'SERVICE_WORKER'
+WHERE e.id = ${bind(user.id)} AND e.roles && '{SERVICE_WORKER}'::user_role[]
+                """
+                    .trimIndent()
+            )
+        }
+
     fun andIsDecisionMakerForAssistanceNeedDecision() =
         rule<AssistanceNeedDecisionId> { employee, _ ->
             sql(

--- a/service/src/main/resources/db/migration/R__message_account_access_view.sql
+++ b/service/src/main/resources/db/migration/R__message_account_access_view.sql
@@ -27,4 +27,11 @@ CREATE VIEW message_account_access_view(employee_id, account_id) AS (
     FROM employee e
     JOIN message_account acc ON acc.type = 'MUNICIPAL'
     WHERE e.roles && '{ADMIN, MESSAGING}'::user_role[]
+
+    UNION
+
+   SELECT e.id AS employee_id, acc.id AS account_id
+   FROM employee e
+   JOIN message_account acc ON acc.type = 'SERVICE_WORKER'
+   WHERE e.roles && '{SERVICE_WORKER}'::user_role[]
 );

--- a/service/src/main/resources/db/migration/R__message_account_name_view.sql
+++ b/service/src/main/resources/db/migration/R__message_account_name_view.sql
@@ -22,6 +22,7 @@ CREATE VIEW message_account_view(id, type, name) AS (
                 WHERE p.id = acc.person_id
             )
             WHEN 'MUNICIPAL' THEN NULL
+            WHEN 'SERVICE_WORKER' THEN NULL
         END
     FROM message_account acc
 );

--- a/service/src/main/resources/db/migration/V294__add_service_worker_message_account_type.sql
+++ b/service/src/main/resources/db/migration/V294__add_service_worker_message_account_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE message_account_type ADD VALUE 'SERVICE_WORKER';

--- a/service/src/main/resources/db/migration/V295__service_worker_message_account.sql
+++ b/service/src/main/resources/db/migration/V295__service_worker_message_account.sql
@@ -1,0 +1,13 @@
+ALTER TABLE message_account DROP COLUMN type CASCADE;
+ALTER TABLE message_account ADD COLUMN type message_account_type;
+
+CREATE UNIQUE INDEX only_one_service_worker_account ON message_account (type) WHERE type = 'SERVICE_WORKER';
+
+UPDATE message_account SET type = CASE
+    WHEN employee_id IS NOT NULL THEN 'PERSONAL'::message_account_type
+    WHEN daycare_group_id IS NOT NULL THEN 'GROUP'::message_account_type
+    WHEN person_id IS NOT NULL THEN 'CITIZEN'::message_account_type
+    ELSE 'MUNICIPAL'::message_account_type
+END;
+
+INSERT INTO message_account (employee_id, daycare_group_id, person_id, type) VALUES (NULL, NULL, NULL, 'SERVICE_WORKER');

--- a/service/src/main/resources/dev-data/employees.sql
+++ b/service/src/main/resources/dev-data/employees.sql
@@ -28,8 +28,8 @@ INSERT INTO daycare_acl (daycare_id, employee_id, role) VALUES
     ('2dd6e5f6-788e-11e9-bd72-9f1cfe2d8405', '00000000-0000-0000-0005-000000000001', 'STAFF'),
     ('2dd6e5f6-788e-11e9-bd72-9f1cfe2d8405', '00000000-0000-0000-0006-000000000000', 'SPECIAL_EDUCATION_TEACHER');
 
-INSERT INTO message_account (employee_id)
-SELECT id
+INSERT INTO message_account (employee_id, type)
+SELECT id, 'PERSONAL'::message_account_type AS type
 FROM employee e
 WHERE EXISTS(
     SELECT 1

--- a/service/src/main/resources/dev-data/espoo-dev-data.sql
+++ b/service/src/main/resources/dev-data/espoo-dev-data.sql
@@ -30,7 +30,7 @@ INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES
     ('b4bd39f6-5963-11ea-b4da-ebed8135a791', 3, '2020-03-01', NULL),
     ('4539f160-a616-41cb-ac51-6a12ba2c9645', 3, '2020-03-01', NULL);
 
-INSERT INTO message_account (daycare_group_id) SELECT id FROM daycare_group;
+INSERT INTO message_account (daycare_group_id, type) SELECT id, 'GROUP'::message_account_type as type FROM daycare_group;
 
 INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
     ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10),

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -290,3 +290,5 @@ V290__application_other_guardian_access.sql
 V291__application_other_guardian_cascade.sql
 V292__message_sent_nullable.sql
 V293__staff_attendance_realtime_index.sql
+V294__add_service_worker_message_account_type.sql
+V295__service_worker_message_account.sql


### PR DESCRIPTION
#### Summary
This is the first part of the service worker messaging functionality. It implements the following:
- Messaging access for service workers, with a shared message account
- Messaging access for citizens without actively placed children, IF an application is sent AND any message has been received
- Sending messages to citizens with active applications as a service worker