### PR TITLE
Mobile age chip

### DIFF
--- a/frontend/src/employee-mobile-frontend/child-attendance/ChildListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/ChildListItem.tsx
@@ -87,10 +87,10 @@ const NameRow = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
+  word-break: break-word;
 `
 
 const GroupName = styled(InformationText)`
-  white-space: nowrap;
   text-align: right;
 `
 
@@ -158,12 +158,12 @@ export default React.memo(function ChildListItem({
             </GroupName>
           </NameRow>
           <DetailsRow>
-            <div>
+            <LeftDetailsDiv>
               {infoText}
               {child.backup && (
                 <RoundIcon content="V" size="m" color={colors.main.m1} />
               )}
-            </div>
+            </LeftDetailsDiv>
             <FixedSpaceRowWithLeftMargin alignItems="center">
               {child.dailyNote && (
                 <Link
@@ -194,7 +194,7 @@ export default React.memo(function ChildListItem({
               <RoundIcon
                 content={`${childAge}v`}
                 color={childAge < 3 ? colors.accents.a6turquoise : colors.main.m1}
-                size="L"
+                size="m-age"
               />
             </FixedSpaceRowWithLeftMargin>
           </DetailsRow>
@@ -229,3 +229,12 @@ const childReservationInfo = (
     </em>
   )
 }
+
+const LeftDetailsDiv = styled.div`
+  > * {
+    margin-left: ${defaultMargins.xs};
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+`

--- a/frontend/src/employee-mobile-frontend/child-attendance/ChildListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/ChildListItem.tsx
@@ -27,6 +27,7 @@ import { UnitContext } from '../common/unit'
 
 import { ListItem } from './ChildList'
 import { Reservations } from './Reservations'
+import LocalDate from 'lib-common/local-date'
 
 const ChildBox = styled.div`
   align-items: center;
@@ -130,6 +131,8 @@ export default React.memo(function ChildListItem({
     : childReservationInfo(i18n, child)
 
   const maybeGroupName = type && groupId === 'all' ? groupName : undefined
+  const today = LocalDate.todayInSystemTz()
+  const childAge = today.differenceInYears(child.dateOfBirth)
 
   return (
     <ChildBox data-qa={`child-${child.id}`}>
@@ -161,7 +164,7 @@ export default React.memo(function ChildListItem({
                 <RoundIcon content="V" size="m" color={colors.main.m1} />
               )}
             </div>
-            <FixedSpaceRowWithLeftMargin>
+            <FixedSpaceRowWithLeftMargin alignItems="center">
               {child.dailyNote && (
                 <Link
                   to={`/units/${unitId}/groups/${
@@ -188,6 +191,11 @@ export default React.memo(function ChildListItem({
                   />
                 </Link>
               ) : null}
+              <RoundIcon
+                content={`${childAge}v`}
+                color={childAge < 3 ? colors.accents.a6turquoise : colors.main.m1}
+                size="L"
+              />
             </FixedSpaceRowWithLeftMargin>
           </DetailsRow>
         </ChildBoxInfo>

--- a/frontend/src/employee-mobile-frontend/child-attendance/ChildListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/ChildListItem.tsx
@@ -10,6 +10,7 @@ import {
   AttendanceStatus,
   Child
 } from 'lib-common/generated/api-types/attendance'
+import LocalDate from 'lib-common/local-date'
 import { useQuery } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
@@ -27,7 +28,6 @@ import { UnitContext } from '../common/unit'
 
 import { ListItem } from './ChildList'
 import { Reservations } from './Reservations'
-import LocalDate from 'lib-common/local-date'
 
 const ChildBox = styled.div`
   align-items: center;
@@ -193,7 +193,9 @@ export default React.memo(function ChildListItem({
               ) : null}
               <RoundIcon
                 content={`${childAge}v`}
-                color={childAge < 3 ? colors.accents.a6turquoise : colors.main.m1}
+                color={
+                  childAge < 3 ? colors.accents.a6turquoise : colors.main.m1
+                }
                 size="m-age"
               />
             </FixedSpaceRowWithLeftMargin>

--- a/frontend/src/employee-mobile-frontend/child-attendance/ChildListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/ChildListItem.tsx
@@ -191,12 +191,12 @@ export default React.memo(function ChildListItem({
                   />
                 </Link>
               ) : null}
-              <RoundIcon
+              <AgeRoundIcon
                 content={`${childAge}v`}
                 color={
                   childAge < 3 ? colors.accents.a6turquoise : colors.main.m1
                 }
-                size="m-age"
+                size="m"
               />
             </FixedSpaceRowWithLeftMargin>
           </DetailsRow>
@@ -238,5 +238,10 @@ const LeftDetailsDiv = styled.div`
     &:first-child {
       margin-left: 0;
     }
+  }
+`
+const AgeRoundIcon = styled(RoundIcon)`
+  &.m {
+    font-size: 14px;
   }
 `

--- a/frontend/src/employee-mobile-frontend/child-attendance/api.ts
+++ b/frontend/src/employee-mobile-frontend/child-attendance/api.ts
@@ -196,6 +196,7 @@ function deserializeChildren(data: JsonOf<Child[]>): Child[] {
   return data
     .map((child) => ({
       ...child,
+      dateOfBirth: LocalDate.parseIso(child.dateOfBirth),
       dailyNote: child.dailyNote
         ? {
             ...child.dailyNote,

--- a/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
@@ -14,7 +14,7 @@ import useNonNullableParams from 'lib-common/useNonNullableParams'
 import { StaticChip } from 'lib-components/atoms/Chip'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import Button from 'lib-components/atoms/buttons/Button'
-import { FixedSpaceColumn, FixedSpaceRow } from 'lib-components/layout/flex-helpers'
+import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { fontWeights } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -156,16 +156,9 @@ export default React.memo(function AttendanceChildPage() {
                         </IconBox>
 
                         <Gap size="s" />
-                        <FixedSpaceRow spacing="xs" alignItems="center">
-                          <RoundIcon
-                            content={`${childAge}v`}
-                            color={childAge < 3 ? colors.accents.a6turquoise : colors.main.m1}
-                            size="L"
-                          />
                           <CustomTitle data-qa="child-name">
                             {child.firstName} {child.lastName}
                           </CustomTitle>
-                        </FixedSpaceRow>
 
                         {!!child.preferredName && (
                           <CustomTitle data-qa="child-preferred-name">

--- a/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
@@ -351,7 +351,7 @@ const ChildStatus = styled.div`
 `
 
 const RoundImage = styled.img`
-  display: flex;
+  display: block;
   border-radius: 100%;
   width: 128px;
   height: 128px;
@@ -366,7 +366,7 @@ const CustomTitle = styled.h2`
   margin-top: 0;
   color: ${colors.main.m1};
   text-align: center;
-  margin-bottom: 0;
+  margin-bottom: ${defaultMargins.xs};
 `
 
 const GroupName = styled.div`

--- a/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
@@ -14,7 +14,7 @@ import useNonNullableParams from 'lib-common/useNonNullableParams'
 import { StaticChip } from 'lib-components/atoms/Chip'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import Button from 'lib-components/atoms/buttons/Button'
-import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import { FixedSpaceColumn, FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { fontWeights } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -45,6 +45,7 @@ import AttendanceChildAbsent from './child-state-pages/AttendanceChildAbsent'
 import AttendanceChildComing from './child-state-pages/AttendanceChildComing'
 import AttendanceChildDeparted from './child-state-pages/AttendanceChildDeparted'
 import AttendanceChildPresent from './child-state-pages/AttendanceChildPresent'
+import LocalDate from 'lib-common/local-date'
 
 export default React.memo(function AttendanceChildPage() {
   const { i18n } = useTranslation()
@@ -76,6 +77,7 @@ export default React.memo(function AttendanceChildPage() {
   const { mutateAsync: deleteChildImage } = useMutation(
     deleteChildImageMutation
   )
+
 
   const group = useMemo(
     () =>
@@ -123,6 +125,8 @@ export default React.memo(function AttendanceChildPage() {
               attendanceStatuses,
               child.id
             )
+            const today = LocalDate.todayInSystemTz()
+            const childAge = today.differenceInYears(child.dateOfBirth)
             return (
               <>
                 <Shadow>
@@ -142,13 +146,26 @@ export default React.memo(function AttendanceChildPage() {
                               size="XXL"
                             />
                           )}
+                          <IconPlacementBox>
+                            <RoundIconOnTop
+                              content={`${childAge}v`}
+                              color={childAge < 3 ? colors.accents.a6turquoise : colors.main.m1}
+                              size="L"
+                            />
+                          </IconPlacementBox>
                         </IconBox>
 
                         <Gap size="s" />
-
-                        <CustomTitle data-qa="child-name">
-                          {child.firstName} {child.lastName}
-                        </CustomTitle>
+                        <FixedSpaceRow spacing="xs" alignItems="center">
+                          <RoundIcon
+                            content={`${childAge}v`}
+                            color={childAge < 3 ? colors.accents.a6turquoise : colors.main.m1}
+                            size="L"
+                          />
+                          <CustomTitle data-qa="child-name">
+                            {child.firstName} {child.lastName}
+                          </CustomTitle>
+                        </FixedSpaceRow>
 
                         {!!child.preferredName && (
                           <CustomTitle data-qa="child-preferred-name">
@@ -338,7 +355,7 @@ const ChildStatus = styled.div`
 `
 
 const RoundImage = styled.img`
-  display: block;
+  display: flex;
   border-radius: 100%;
   width: 128px;
   height: 128px;
@@ -353,7 +370,7 @@ const CustomTitle = styled.h2`
   margin-top: 0;
   color: ${colors.main.m1};
   text-align: center;
-  margin-bottom: ${defaultMargins.xs};
+  margin-bottom: 0;
 `
 
 const GroupName = styled.div`
@@ -424,4 +441,15 @@ const Shadow = styled.div`
   flex-direction: column;
   justify-content: space-between;
   min-height: calc(100vh - 74px);
+`
+const RoundIconOnTop = styled(RoundIcon)`
+  position: absolute;
+  left: 100px;
+  top: -34px;
+  z-index: 2;
+`
+const IconPlacementBox = styled.div`
+  position: relative;
+  width: 0;
+  height: 0;
 `

--- a/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 
 import { combine } from 'lib-common/api'
 import { AttendanceStatus } from 'lib-common/generated/api-types/attendance'
+import LocalDate from 'lib-common/local-date'
 import { useMutation, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
@@ -45,7 +46,6 @@ import AttendanceChildAbsent from './child-state-pages/AttendanceChildAbsent'
 import AttendanceChildComing from './child-state-pages/AttendanceChildComing'
 import AttendanceChildDeparted from './child-state-pages/AttendanceChildDeparted'
 import AttendanceChildPresent from './child-state-pages/AttendanceChildPresent'
-import LocalDate from 'lib-common/local-date'
 
 export default React.memo(function AttendanceChildPage() {
   const { i18n } = useTranslation()
@@ -77,7 +77,6 @@ export default React.memo(function AttendanceChildPage() {
   const { mutateAsync: deleteChildImage } = useMutation(
     deleteChildImageMutation
   )
-
 
   const group = useMemo(
     () =>
@@ -149,16 +148,20 @@ export default React.memo(function AttendanceChildPage() {
                           <IconPlacementBox>
                             <RoundIconOnTop
                               content={`${childAge}v`}
-                              color={childAge < 3 ? colors.accents.a6turquoise : colors.main.m1}
+                              color={
+                                childAge < 3
+                                  ? colors.accents.a6turquoise
+                                  : colors.main.m1
+                              }
                               size="L"
                             />
                           </IconPlacementBox>
                         </IconBox>
 
                         <Gap size="s" />
-                          <CustomTitle data-qa="child-name">
-                            {child.firstName} {child.lastName}
-                          </CustomTitle>
+                        <CustomTitle data-qa="child-name">
+                          {child.firstName} {child.lastName}
+                        </CustomTitle>
 
                         {!!child.preferredName && (
                           <CustomTitle data-qa="child-preferred-name">

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -102,6 +102,7 @@ export interface Child {
   backup: boolean
   dailyNote: ChildDailyNote | null
   dailyServiceTimes: DailyServiceTimesValue | null
+  dateOfBirth: LocalDate
   firstName: string
   groupId: UUID | null
   id: UUID

--- a/frontend/src/lib-components/atoms/RoundIcon.tsx
+++ b/frontend/src/lib-components/atoms/RoundIcon.tsx
@@ -15,7 +15,7 @@ import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { fontWeights } from '../typography'
 import { BaseProps } from '../utils'
 
-export type IconSize = 'xs' | 's' | 'm' | 'm-age' | 'L' | 'XL' | 'XXL'
+export type IconSize = 'xs' | 's' | 'm' | 'L' | 'XL' | 'XXL'
 
 type IconContainerProps = {
   color: string
@@ -82,11 +82,6 @@ const IconContainer = styled.div<IconContainerProps>`
 
   &.m {
     font-size: 16px;
-    ${diameter(24)}
-  }
-
-  &.m-age {
-    font-size: 14px;
     ${diameter(24)}
   }
 

--- a/frontend/src/lib-components/atoms/RoundIcon.tsx
+++ b/frontend/src/lib-components/atoms/RoundIcon.tsx
@@ -15,7 +15,7 @@ import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { fontWeights } from '../typography'
 import { BaseProps } from '../utils'
 
-export type IconSize = 'xs' | 's' | 'm' | 'L' | 'XL' | 'XXL'
+export type IconSize = 'xs' | 's' | 'm' | 'm-age' | 'L' | 'XL' | 'XXL'
 
 type IconContainerProps = {
   color: string
@@ -82,6 +82,11 @@ const IconContainer = styled.div<IconContainerProps>`
 
   &.m {
     font-size: 16px;
+    ${diameter(24)}
+  }
+
+  &.m-age {
+    font-size: 14px;
     ${diameter(24)}
   }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import java.time.LocalDate
 
 data class ContactInfo(
     val id: String,
@@ -33,6 +34,7 @@ data class Child(
     val firstName: String,
     val lastName: String,
     val preferredName: String?,
+    val dateOfBirth: LocalDate,
     val placementType: PlacementType,
     val groupId: GroupId?,
     val backup: Boolean,

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceController.kt
@@ -97,6 +97,7 @@ class ChildAttendanceController(
                             firstName = child.firstName,
                             lastName = child.lastName,
                             preferredName = child.preferredName,
+                            dateOfBirth = child.dateOfBirth,
                             placementType = child.placementType,
                             groupId = child.groupId,
                             backup = child.backup,


### PR DESCRIPTION
- Adds a medium sized chip to mobile child list item and a large sized one to child detailed page depicting the child's age
- Additional styling changes to enable word break in order to solve pre-existing issues in child list item spacing and responsiveness
- An additional size for the mobile icon to lower font size for 2-digit ages