### PR TITLE
EVAKA-4694 Prefill message and recipient selector

### DIFF
--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -16,7 +16,7 @@ export default class MessagesPage {
   constructor(private readonly page: Page) {}
 
   #newMessageButton = this.page.find('[data-qa="new-message-btn"]')
-  #sendMessageButton = this.page.find('[data-qa="send-message-btn"]')
+  sendMessageButton = this.page.find('[data-qa="send-message-btn"]')
   #closeMessageEditorButton = this.page.find(
     '[data-qa="close-message-editor-btn"]'
   )
@@ -25,8 +25,8 @@ export default class MessagesPage {
   #receiverSelection = new TreeDropdown(
     this.page.find('[data-qa="select-receiver"]')
   )
-  #inputTitle = new TextInput(this.page.find('[data-qa="input-title"]'))
-  #inputContent = new TextInput(this.page.find('[data-qa="input-content"]'))
+  inputTitle = new TextInput(this.page.find('[data-qa="input-title"]'))
+  inputContent = new TextInput(this.page.find('[data-qa="input-content"]'))
   #fileUpload = this.page.find('[data-qa="upload-message-attachment"]')
   #personalAccount = this.page.find('[data-qa="personal-account"]')
   #draftMessagesBoxRow = new TextInput(
@@ -115,8 +115,8 @@ export default class MessagesPage {
 
     await this.#newMessageButton.click()
     await waitUntilTrue(() => this.isEditorVisible())
-    await this.#inputTitle.fill(message.title)
-    await this.#inputContent.fill(message.content)
+    await this.inputTitle.fill(message.title)
+    await this.inputContent.fill(message.content)
 
     if (message.sender) {
       await this.#senderSelection.fillAndSelectFirst(message.sender)
@@ -147,7 +147,7 @@ export default class MessagesPage {
         )
       }
     }
-    await this.#sendMessageButton.click()
+    await this.sendMessageButton.click()
     await waitUntilEqual(() => this.isEditorVisible(), false)
   }
 
@@ -168,8 +168,8 @@ export default class MessagesPage {
   async draftNewMessage(title: string, content: string) {
     await this.#newMessageButton.click()
     await waitUntilEqual(() => this.isEditorVisible(), true)
-    await this.#inputTitle.fill(title)
-    await this.#inputContent.fill(content)
+    await this.inputTitle.fill(title)
+    await this.inputContent.fill(content)
     await this.#receiverSelection.open()
     await this.#receiverSelection.firstOption().click()
     await this.#receiverSelection.close()
@@ -178,7 +178,7 @@ export default class MessagesPage {
   }
 
   async sendEditedMessage() {
-    await this.#sendMessageButton.click()
+    await this.sendMessageButton.click()
     await waitUntilEqual(() => this.isEditorVisible(), false)
   }
 
@@ -236,5 +236,13 @@ export default class MessagesPage {
       .findByDataQa('undo-message-toast')
       .findByDataQa('cancel-message')
       .click()
+  }
+
+  async assertReceiver(receiverName: string) {
+    return waitUntilEqual(() => this.#receiverSelection.text, receiverName)
+  }
+
+  async assertTitle(title: string) {
+    return waitUntilEqual(() => this.inputTitle.inputValue, title)
   }
 }

--- a/frontend/src/employee-frontend/api/person.ts
+++ b/frontend/src/employee-frontend/api/person.ts
@@ -26,7 +26,10 @@ import { deserializePersonJSON, SearchColumn } from '../types/person'
 
 import { client } from './client'
 
-export async function getPerson(id: UUID): Promise<Result<PersonJSON>> {
+export async function getPerson(id: UUID | null): Promise<Result<PersonJSON>> {
+  if (id === null) {
+    return Failure.of({ message: 'No person id given' })
+  }
   return client
     .get<JsonOf<PersonJSON>>(`/person/identity/${id}`)
     .then((res) => res.data)

--- a/frontend/src/employee-frontend/components/ApplicationPage.tsx
+++ b/frontend/src/employee-frontend/components/ApplicationPage.tsx
@@ -60,6 +60,15 @@ const placementTypeFilters: Record<ApplicationType, PlacementType[]> = {
   CLUB: []
 }
 
+const getMessageSubject = (
+  i18n: Translations,
+  applicationData: ApplicationResponse
+) =>
+  i18n.application.messageSubject(
+    applicationData.application.sentDate?.format() ?? '',
+    `${applicationData.application.form.child.person.firstName} ${applicationData.application.form.child.person.lastName}`
+  )
+
 export default React.memo(function ApplicationPage() {
   const { id: applicationId } = useNonNullableParams<{ id: UUID }>()
 
@@ -231,7 +240,12 @@ export default React.memo(function ApplicationPage() {
                       <AddButton
                         onClick={() =>
                           window.open(
-                            `${getEmployeeUrlPrefix()}/employee/messages/send`,
+                            `${getEmployeeUrlPrefix()}/employee/messages/send?recipient=${
+                              applicationData.guardians[0].id
+                            }&title=${getMessageSubject(
+                              i18n,
+                              applicationData
+                            )}`,
                             '_blank'
                           )
                         }

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -106,6 +106,8 @@ export interface MessagesState {
   sentMessagesAsThreads: Result<MessageThread[]>
   messageCopiesAsThreads: Result<MessageThread[]>
   openMessageUndo: (m: CancelableMessage) => void
+  prefilledRecipient: string | null
+  prefilledTitle: string | null
 }
 
 const defaultState: MessagesState = {
@@ -141,7 +143,9 @@ const defaultState: MessagesState = {
   unreadCountsByAccount: Loading.of(),
   sentMessagesAsThreads: Loading.of(),
   messageCopiesAsThreads: Loading.of(),
-  openMessageUndo: () => undefined
+  openMessageUndo: () => undefined,
+  prefilledRecipient: null,
+  prefilledTitle: null
 }
 
 export const MessageContext = createContext<MessagesState>(defaultState)
@@ -172,6 +176,9 @@ export const MessageContextProvider = React.memo(
     const messageBox = searchParams.get('messageBox')
     const unitId = searchParams.get('unitId')
     const threadId = searchParams.get('threadId')
+    const prefilledTitle = searchParams.get('title')
+    const prefilledRecipient = searchParams.get('recipient')
+
     const setParams = useCallback(
       (params: {
         accountId?: string | null
@@ -186,12 +193,16 @@ export const MessageContextProvider = React.memo(
               ? { messageBox: params.messageBox }
               : undefined),
             ...(params.unitId ? { unitId: params.unitId } : undefined),
-            ...(params.threadId ? { threadId: params.threadId } : undefined)
+            ...(params.threadId ? { threadId: params.threadId } : undefined),
+            ...(prefilledTitle ? { title: prefilledTitle } : undefined),
+            ...(prefilledRecipient
+              ? { recipient: prefilledRecipient }
+              : undefined)
           },
           { replace: true }
         )
       },
-      [setSearchParams]
+      [setSearchParams, prefilledTitle, prefilledRecipient]
     )
 
     const [accounts] = useApiState(
@@ -676,7 +687,9 @@ export const MessageContextProvider = React.memo(
         unreadCountsByAccount,
         sentMessagesAsThreads,
         messageCopiesAsThreads,
-        openMessageUndo
+        openMessageUndo,
+        prefilledRecipient,
+        prefilledTitle
       }),
       [
         accounts,
@@ -708,7 +721,9 @@ export const MessageContextProvider = React.memo(
         unreadCountsByAccount,
         sentMessagesAsThreads,
         messageCopiesAsThreads,
-        openMessageUndo
+        openMessageUndo,
+        prefilledRecipient,
+        prefilledTitle
       ]
     )
 

--- a/frontend/src/lib-components/employee/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/employee/messages/MessageEditor.tsx
@@ -71,18 +71,20 @@ const messageToUpdatableDraftWithAccount = (
   }
 }
 
-const emptyMessage: Omit<Message, 'sender'> = {
+const getEmptyMessage = (sender: SelectOption, title: string): Message => ({
+  sender,
+  title,
   content: '',
   urgent: false,
   attachments: [],
-  title: '',
   type: 'MESSAGE' as const
-}
+})
 
 const getInitialMessage = (
   draft: DraftContent | undefined,
-  sender: SelectOption
-): Message => (draft ? { ...draft, sender } : { sender, ...emptyMessage })
+  sender: SelectOption,
+  title: string
+): Message => (draft ? { ...draft, sender } : getEmptyMessage(sender, title))
 
 const areRequiredFieldsFilled = (
   msg: Message,
@@ -148,6 +150,7 @@ interface Props {
     onUploadProgress: (progressEvent: ProgressEvent) => void
   ) => Promise<Result<UUID>>
   sending: boolean
+  defaultTitle?: string
 }
 
 export default React.memo(function MessageEditor({
@@ -165,13 +168,14 @@ export default React.memo(function MessageEditor({
   onSend,
   saveDraftRaw,
   saveMessageAttachment,
-  sending
+  sending,
+  defaultTitle = ''
 }: Props) {
   const [receiverTree, setReceiverTree] = useState<SelectorNode[]>(
     receiversAsSelectorNode(defaultSender.value, availableReceivers)
   )
   const [message, setMessage] = useState<Message>(() =>
-    getInitialMessage(draftContent, defaultSender)
+    getInitialMessage(draftContent, defaultSender, defaultTitle)
   )
   const {
     draftId,

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -340,6 +340,7 @@ export const fi = {
   },
   application: {
     tabTitle: 'Hakemus',
+    messageSubject: (date: string, name: string) => `Hakemus ${date}: ${name}`,
     types: {
       PRESCHOOL: 'Esiopetushakemus',
       DAYCARE: 'Varhaiskasvatushakemus',

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -1091,37 +1091,7 @@ fun Database.Read.getReceiversForNewMessage(
                 MessageReceiversResponse(accountId = accountId, receivers = accountReceivers)
             }
 
-    val serviceWorkerReceivers =
-        createQuery(
-                """
-        WITH accounts AS (
-            SELECT id, type, daycare_group_id, employee_id, person_id FROM message_account
-            WHERE id = ANY(:accountIds) AND type = 'SERVICE_WORKER'::message_account_type
-        )
-        SELECT acc.id AS account_id, p.id as person_id, p.first_name, p.last_name 
-        FROM accounts acc, person p
-        JOIN application app ON p.id = app.guardian_id
-        WHERE app.status = 'SENT'
-        """
-                    .trimIndent()
-            )
-            .bind("accountIds", accountIds)
-            .bind("date", today)
-            .mapTo<ServiceWorkerMessageReceiversResult>()
-            .toList()
-            .groupBy { it.accountId }
-            .map { (accountId, receivers) ->
-                val accountReceivers =
-                    receivers.map { receiver ->
-                        MessageReceiver.Citizen(
-                            id = receiver.personId,
-                            name = formatName(receiver.firstName, receiver.lastName, true)
-                        )
-                    }
-                MessageReceiversResponse(accountId = accountId, receivers = accountReceivers)
-            }
-
-    return municipalReceivers + serviceWorkerReceivers + unitReceivers
+    return municipalReceivers + unitReceivers
 }
 
 private fun getReceiverGroups(


### PR DESCRIPTION
#### Summary
Prefills the recipient and subject line for messages sent by service workers. Also removes some potentially slow queries introduced in the previous PR, as they are now unnecessary.
