### PR TITLE
Changed placement plan draft creation to use correct preferred start date from application

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -89,7 +89,7 @@ class PlacementPlanService(private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
                         PlacementType.PRESCHOOL_DAYCARE,
                         PlacementType.PREPARATORY_DAYCARE ->
                             FiniteDateRange(
-                                startDate,
+                                maxOf(minStartDate, form.preferences.connectedDaycarePreferredStartDate ?: startDate),
                                 LocalDate.of(preschoolTerms.extendedTerm.end.year, 7, 31)
                             )
                         PlacementType.PRESCHOOL_CLUB -> FiniteDateRange(startDate, exactTerm.end)

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -95,7 +95,14 @@ class PlacementPlanService(private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
                                 ),
                                 LocalDate.of(preschoolTerms.extendedTerm.end.year, 7, 31)
                             )
-                        PlacementType.PRESCHOOL_CLUB -> FiniteDateRange(startDate, exactTerm.end)
+                        PlacementType.PRESCHOOL_CLUB ->
+                            FiniteDateRange(
+                                maxOf(
+                                    minStartDate,
+                                    form.preferences.connectedDaycarePreferredStartDate ?: startDate
+                                ),
+                                exactTerm.end
+                            )
                         else -> null
                     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -89,7 +89,10 @@ class PlacementPlanService(private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
                         PlacementType.PRESCHOOL_DAYCARE,
                         PlacementType.PREPARATORY_DAYCARE ->
                             FiniteDateRange(
-                                maxOf(minStartDate, form.preferences.connectedDaycarePreferredStartDate ?: startDate),
+                                maxOf(
+                                    minStartDate,
+                                    form.preferences.connectedDaycarePreferredStartDate ?: startDate
+                                ),
                                 LocalDate.of(preschoolTerms.extendedTerm.end.year, 7, 31)
                             )
                         PlacementType.PRESCHOOL_CLUB -> FiniteDateRange(startDate, exactTerm.end)


### PR DESCRIPTION
- Preschool start date was used for both preschool and preschool connected daycare despite the application form having separate preferred start dates for both
- Earlier functionality relegated to fallback if no preferred start date for connected daycare is found
