### PR TITLE
Fix null external id on first login

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
@@ -78,7 +78,7 @@ fun Database.Transaction.updateExternalIdByEmployeeNumber(
     externalId: ExternalId
 ) =
     createUpdate(
-            "UPDATE employee SET external_id = :externalId WHERE employee_number = :employeeNumber AND external_id != :externalId"
+            "UPDATE employee SET external_id = :externalId WHERE employee_number = :employeeNumber AND (external_id != :externalId OR external_id IS NULL)"
         )
         .bind("employeeNumber", employeeNumber)
         .bind("externalId", externalId)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -230,8 +230,8 @@ fun Database.Transaction.insertTestEmployee(employee: DevEmployee) =
     insertTestDataRow(
             employee,
             """
-INSERT INTO employee (id, preferred_first_name, first_name, last_name, email, external_id, roles, last_login)
-VALUES (:id, :preferredFirstName, :firstName, :lastName, :email, :externalId, :roles::user_role[], :lastLogin)
+INSERT INTO employee (id, preferred_first_name, first_name, last_name, email, external_id, employee_number, roles, last_login)
+VALUES (:id, :preferredFirstName, :firstName, :lastName, :email, :externalId, :employeeNumber, :roles::user_role[], :lastLogin)
 RETURNING id
 """
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1766,6 +1766,7 @@ data class DevEmployee(
     val lastName: String = "Person",
     val email: String? = "test.person@espoo.fi",
     val externalId: ExternalId? = null,
+    val employeeNumber: String? = null,
     val roles: Set<UserRole> = setOf(),
     val lastLogin: HelsinkiDateTime? = HelsinkiDateTime.now()
 )


### PR DESCRIPTION
#### Summary

We are going to create employees with employee numbers from integration, and on first login to eVaka external id should be set correctly.