### PR TITLE
SAML nameIdFormat and userId configurable in AD SAML messages for apigw

### DIFF
--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -9,6 +9,9 @@ export interface Config {
   ad: {
     mock: boolean
     externalIdPrefix: string
+    userIdKey: string
+    nameIdFormat: string
+    decryptAssertions: boolean
     saml: EvakaSamlConfig | undefined
   }
   sfi: {
@@ -121,9 +124,16 @@ export function configFromEnv(): Config {
     ifNodeEnv(['local', 'test'], true) ??
     false
   const adCallbackUrl = process.env.AD_SAML_CALLBACK_URL
+  const defaultUserIdKey =
+    'http://schemas.microsoft.com/identity/claims/objectidentifier'
+  const defaultNameIdFormat =
+    'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
   const ad: Config['ad'] = {
     mock: adMock,
     externalIdPrefix: process.env.AD_SAML_EXTERNAL_ID_PREFIX ?? 'espoo-ad',
+    userIdKey: process.env.AD_USER_ID_KEY ?? defaultUserIdKey,
+    nameIdFormat: process.env.AD_NAME_ID_FORMAT ?? defaultNameIdFormat,
+    decryptAssertions: env('AD_DECRYPT_ASSERTIONS', parseBoolean) ?? false,
     saml:
       adCallbackUrl && !adMock
         ? {


### PR DESCRIPTION
#### Summary
Turku uses ADFS instead of AzureAD. Hardcoded userId (objectidentifier claim) is not available in ADFS. NameIdFormat by default is unspecified in ADFS. Therefor made both configurable through environment variables AD_USER_ID_KEY, AD_NAME_ID_FORMAT.

Turku ADFS encrypts SAML responses. Added environment variable to be able to define passport to decrypt responses, AD_DECRYPT_ASSERTIONS

Old hardcoded values are used as defaults. Should not require any changes from other cities. 
