### PR TITLE
Add placement unit from decision support

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -217,5 +217,6 @@ val testFeatureConfig =
         postOffice = "ESPOO",
         municipalMessageAccountName = "Espoon kaupunki - Esbo stad - City of Espoo",
         serviceWorkerMessageAccountName =
-            "Espoon kaupungin palveluohjaus - Esbo stads serviceledning - City of Espoo service guidance"
+            "Espoon kaupungin palveluohjaus - Esbo stads serviceledning - City of Espoo service guidance",
+        applyPlacementUnitFromDecision = false
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -145,7 +145,8 @@ class EspooConfig {
             postOffice = "ESPOO",
             municipalMessageAccountName = "Espoon kaupunki - Esbo stad - City of Espoo",
             serviceWorkerMessageAccountName =
-                "Espoon kaupungin palveluohjaus - Esbo stads servicehandledning - City of Espoo service guidance"
+                "Espoon kaupungin palveluohjaus - Esbo stads servicehandledning - City of Espoo service guidance",
+            applyPlacementUnitFromDecision = false
         )
 
     @Bean

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -742,7 +742,7 @@ class ApplicationStateService(
             tx,
             clock,
             application,
-            plan.unitId,
+            if (featureConfig.applyPlacementUnitFromDecision) decision.unit.id else plan.unitId,
             plan.type,
             extent
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -125,5 +125,11 @@ data class FeatureConfig(
     val municipalMessageAccountName: String,
 
     /** Name of the message sender when sending messages on the service worker message account */
-    val serviceWorkerMessageAccountName: String
+    val serviceWorkerMessageAccountName: String,
+
+    /**
+     * true = placement unit is resolved from decision when it's accepted, false = placement unit is
+     * resolved from placement plan
+     */
+    val applyPlacementUnitFromDecision: Boolean
 )


### PR DESCRIPTION
#### Summary

Tampere uses sometimes different units for preschool and preschool daycare placements. With this change we can get correct unit to preschool daycare placement after decision is accepted.

This also works for our family daycare placements because we already select correct unit in placement plan, which is then copied to decision.