### PR TITLE
Avoid focus lock manager fight

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,6 @@
     "date-fns": "^2.29.1",
     "date-fns-tz": "^1.3.6",
     "downshift": "^6.1.9",
-    "focus-trap-react": "^9.0.2",
     "history": "^5.3.0",
     "intersection-observer": "^0.12.2",
     "leaflet": "^1.8.0",

--- a/frontend/src/citizen-frontend/children/ResponsiveWholePageCollapsible.tsx
+++ b/frontend/src/citizen-frontend/children/ResponsiveWholePageCollapsible.tsx
@@ -3,15 +3,14 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import classNames from 'classnames'
-import FocusTrap from 'focus-trap-react'
 import React, { useEffect, useState } from 'react'
+import FocusLock from 'react-focus-lock'
 import styled, { useTheme } from 'styled-components'
 
 import { useTranslation } from 'citizen-frontend/localization'
-import { useUniqueId } from 'lib-common/utils/useUniqueId'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
-import { tabletMin } from 'lib-components/breakpoints'
+import { tabletMin, tabletMinPx } from 'lib-components/breakpoints'
 import {
   CollapsibleContentAreaProps,
   ContentArea,
@@ -36,10 +35,6 @@ const BreakingH2 = styled(H2)`
   word-break: break-word;
   hyphens: auto;
 `
-
-const NormalFocus = React.memo(function UntrapFocus({ children }) {
-  return <div>{children}</div>
-})
 
 export default React.memo(function ResponsiveWholePageCollapsible({
   open,
@@ -76,11 +71,7 @@ export default React.memo(function ResponsiveWholePageCollapsible({
     }
   }, [])
 
-  // 600 = tabletMin
-  const MobileFocusTrap = width < 600 ? FocusTrap : NormalFocus
-
   const [isFocusable, setIsFocusable] = useState(true)
-  const mobileHeaderId = useUniqueId('mobile-header')
 
   return (
     <ContentArea {...props} data-status={open ? 'open' : 'closed'}>
@@ -122,12 +113,7 @@ export default React.memo(function ResponsiveWholePageCollapsible({
           </div>
         </FixedSpaceRow>
       </TitleContainer>
-      <MobileFocusTrap
-        active={open}
-        focusTrapOptions={{
-          initialFocus: `#${mobileHeaderId}`
-        }}
-      >
+      <FocusLock disabled={!open || width >= tabletMinPx}>
         <ResponsiveCollapsibleContainer open={open}>
           <MobileOnly>
             <ResponsiveCollapsibleTitle>
@@ -141,7 +127,7 @@ export default React.memo(function ResponsiveWholePageCollapsible({
                 <div
                   tabIndex={isFocusable ? 0 : undefined}
                   onBlur={() => setIsFocusable(false)}
-                  id={mobileHeaderId}
+                  data-autofocus="true"
                 >
                   {title}
                 </div>
@@ -152,7 +138,7 @@ export default React.memo(function ResponsiveWholePageCollapsible({
             {children}
           </CollapsibleContainer>
         </ResponsiveCollapsibleContainer>
-      </MobileFocusTrap>
+      </FocusLock>
     </ContentArea>
   )
 })

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5984,7 +5984,6 @@ __metadata:
     eslint-plugin-react-hooks: ^4.6.0
     express: ^4.18.1
     express-http-proxy: ^1.6.3
-    focus-trap-react: ^9.0.2
     fork-ts-checker-webpack-plugin: ^7.2.13
     history: ^5.3.0
     html-webpack-plugin: ^5.5.0
@@ -6327,29 +6326,6 @@ __metadata:
   dependencies:
     tslib: ^2.0.3
   checksum: f1a62ea7bbdf71fcc7311a49d84e2f0a37f479539007152c887802e44d4910638611421aec915867353c63212c513e5aab4194bb7fe693d1d8dc1c4c7d43366b
-  languageName: node
-  linkType: hard
-
-"focus-trap-react@npm:^9.0.2":
-  version: 9.0.2
-  resolution: "focus-trap-react@npm:9.0.2"
-  dependencies:
-    focus-trap: ^6.9.4
-    tabbable: ^5.3.3
-  peerDependencies:
-    prop-types: ^15.8.1
-    react: ">=16.3.0"
-    react-dom: ">=16.3.0"
-  checksum: 984a7f1ea831a73018d4dc3af3c2e05611935846ca1c9afad2de08286df566000468786c87bd03e023ff5fff1cf36c2094bd2d0c03c6318bfa54ee3004d42c63
-  languageName: node
-  linkType: hard
-
-"focus-trap@npm:^6.9.4":
-  version: 6.9.4
-  resolution: "focus-trap@npm:6.9.4"
-  dependencies:
-    tabbable: ^5.3.3
-  checksum: 0b4cebcc11010bd9397731092bd59a981e838c710c6497374ba70571875a14ab27c0db7d60f36005ec01bdabc3b9cfeda11d30ddf5b8874596dcc95e18913b3b
   languageName: node
   linkType: hard
 
@@ -10916,13 +10892,6 @@ resolve@^2.0.0-next.3:
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
   checksum: 6e8fc7e1486b8b54bea91199d9535bb72f10842e40c79e882fc94fb7b14b89866adf2fd79efa5ebb5b658bc07fb459ccce5ac0e99ef3d72f474e74aaf284029d
-  languageName: node
-  linkType: hard
-
-"tabbable@npm:^5.3.3":
-  version: 5.3.3
-  resolution: "tabbable@npm:5.3.3"
-  checksum: 1aa56e1bb617cc10616c407f4e756f0607f3e2d30f9803664d70b85db037ca27e75918ed1c71443f3dc902e21dc9f991ce4b52d63a538c9b69b3218d3babcd70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Summary

Use just react-focus-lock for focus locking to avoid a fight between the managers when a modal is used when a focus lock is already active.
