### PR TITLE
Show terminated connected daycare correctly in unit groups page

### DIFF
--- a/frontend/src/employee-frontend/components/common/CareTypeLabel.tsx
+++ b/frontend/src/employee-frontend/components/common/CareTypeLabel.tsx
@@ -9,14 +9,26 @@ import { StaticChip } from 'lib-components/atoms/Chip'
 import { careTypeColors } from 'lib-customizations/common'
 
 import { useTranslation } from '../../state/i18n'
-import { CareTypeLabel } from '../../types'
+
+export type CareTypeLabel =
+  | 'club'
+  | 'daycare'
+  | 'daycare5yo'
+  | 'preschool'
+  | 'preparatory'
+  | 'backup-care'
+  | 'temporary'
+  | 'school-shift-care'
+  | 'connected-daycare'
 
 const placementTypeToCareTypeLabel = (
-  type: PlacementType | 'backup-care'
+  type: PlacementType | 'backup-care' | 'connected-daycare'
 ): CareTypeLabel => {
   switch (type) {
     case 'backup-care':
       return 'backup-care'
+    case 'connected-daycare':
+      return 'connected-daycare'
     case 'CLUB':
       return 'club'
     case 'DAYCARE':
@@ -41,7 +53,7 @@ const placementTypeToCareTypeLabel = (
 }
 
 interface Props {
-  type: PlacementType | 'backup-care'
+  type: PlacementType | 'backup-care' | 'connected-daycare'
 }
 
 export function CareTypeChip({ type }: Props) {

--- a/frontend/src/employee-frontend/components/unit/tab-groups/TerminatedPlacements.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/TerminatedPlacements.tsx
@@ -10,14 +10,16 @@ import { TerminatedPlacement } from 'lib-common/generated/api-types/placement'
 import Title from 'lib-components/atoms/Title'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 
-import { Translations, useTranslation } from '../../../state/i18n'
+import { useTranslation } from '../../../state/i18n'
 import { formatName } from '../../../utils'
 import { CareTypeChip } from '../../common/CareTypeLabel'
 
-function renderTerminatedPlacementRow(
-  placement: TerminatedPlacement,
-  i18n: Translations
-) {
+function TerminatedPlacementRow({
+  placement
+}: {
+  placement: TerminatedPlacement
+}) {
+  const { i18n } = useTranslation()
   return (
     <Tr key={`${placement.child.id}`} data-qa="terminated-placement-row">
       <Td data-qa="child-name">
@@ -32,7 +34,13 @@ function renderTerminatedPlacementRow(
       </Td>
       <Td data-qa="child-dob">{placement.child.dateOfBirth.format()}</Td>
       <Td data-qa="placement-type">
-        <CareTypeChip type={placement.type} />
+        <CareTypeChip
+          type={
+            placement.connectedDaycareOnly
+              ? 'connected-daycare'
+              : placement.type
+          }
+        />
       </Td>
       <Td data-qa="termination-requested-date">{`${
         placement.terminationRequestedDate?.format() ?? ''
@@ -75,7 +83,12 @@ export default React.memo(function TerminatedPlacements({
             </Tr>
           </Thead>
           <Tbody>
-            {sortedRows.map((row) => renderTerminatedPlacementRow(row, i18n))}
+            {sortedRows.map((row) => (
+              <TerminatedPlacementRow
+                key={`${row.id}-${row.type}`}
+                placement={row}
+              />
+            ))}
           </Tbody>
         </Table>
       </div>

--- a/frontend/src/employee-frontend/types/index.ts
+++ b/frontend/src/employee-frontend/types/index.ts
@@ -2,16 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-export type CareTypeLabel =
-  | 'club'
-  | 'daycare'
-  | 'daycare5yo'
-  | 'preschool'
-  | 'preparatory'
-  | 'backup-care'
-  | 'temporary'
-  | 'school-shift-care'
-
 export type SearchOrder = 'ASC' | 'DESC'
 
 export type DayOfWeek = 1 | 2 | 3 | 4 | 5 | 6 | 7

--- a/frontend/src/lib-common/generated/api-types/placement.ts
+++ b/frontend/src/lib-common/generated/api-types/placement.ts
@@ -307,6 +307,7 @@ export type TerminatablePlacementType =
 */
 export interface TerminatedPlacement {
   child: ChildBasics
+  connectedDaycareOnly: boolean
   currentDaycareGroupName: string | null
   endDate: LocalDate
   id: UUID

--- a/frontend/src/lib-customizations/common.tsx
+++ b/frontend/src/lib-customizations/common.tsx
@@ -110,6 +110,7 @@ export const applicationBasisColors = {
 
 export const careTypeColors = {
   'backup-care': accents.a5orangeLight,
+  'connected-daycare': status.success,
   club: grayscale.g15,
   daycare: status.success,
   daycare5yo: accents.a1greenDark,

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -84,7 +84,8 @@ export const fi = {
       preparatory: 'Valmistava',
       'backup-care': 'Varasijoitus',
       temporary: 'Tilapäinen',
-      'school-shift-care': 'Koululaisten vuorohoito'
+      'school-shift-care': 'Koululaisten vuorohoito',
+      'connected-daycare': 'Liittyvä'
     },
     providerType: {
       MUNICIPAL: 'Kunnallinen',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/DaycareControllerIntegrationTest.kt
@@ -7,13 +7,20 @@ package fi.espoo.evaka.daycare.controllers
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.daycare.getDaycare
 import fi.espoo.evaka.daycare.getDaycareGroup
+import fi.espoo.evaka.daycare.service.Caretakers
 import fi.espoo.evaka.daycare.service.DaycareGroup
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.messaging.createDaycareGroupMessageAccount
 import fi.espoo.evaka.messaging.insertMessageContent
+import fi.espoo.evaka.placement.ChildBasics
+import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.placement.TerminatedPlacement
+import fi.espoo.evaka.placement.UnitChildrenCapacityFactors
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
@@ -22,16 +29,26 @@ import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insertTestBackupCare
+import fi.espoo.evaka.shared.dev.insertTestCaretakers
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroup
 import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.domain.RealEvakaClock
+import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testChild_1
+import fi.espoo.evaka.testChild_2
+import fi.espoo.evaka.testChild_3
+import fi.espoo.evaka.testChild_4
 import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.user.EvakaUser
+import fi.espoo.evaka.user.EvakaUserType
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -46,8 +63,8 @@ import org.springframework.beans.factory.annotation.Autowired
 class DaycareControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     @Autowired private lateinit var daycareController: DaycareController
 
-    private val childId = testChild_1.id
-    private val daycareId = testDaycare.id
+    private val today = LocalDate.of(2021, 1, 12)
+    private val now = HelsinkiDateTime.of(today, LocalTime.of(12, 0))
     private val supervisorId = EmployeeId(UUID.randomUUID())
     private val supervisor = AuthenticatedUser.Employee(supervisorId, emptySet())
     private val staffId = EmployeeId(UUID.randomUUID())
@@ -62,16 +79,16 @@ class DaycareControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
                 DevEmployee(id = supervisorId, firstName = "Elina", lastName = "Esimies")
             )
             tx.insertTestEmployee(DevEmployee(id = staffId))
-            tx.insertDaycareAclRow(daycareId, supervisorId, UserRole.UNIT_SUPERVISOR)
-            tx.insertDaycareAclRow(daycareId, staffId, UserRole.STAFF)
+            tx.insertDaycareAclRow(testDaycare.id, supervisorId, UserRole.UNIT_SUPERVISOR)
+            tx.insertDaycareAclRow(testDaycare.id, staffId, UserRole.STAFF)
         }
     }
 
     @Test
     fun `get daycare`() {
-        val (daycare, _, _) = getDaycare(daycareId)
+        val (daycare, _, _) = getDaycare(testDaycare.id)
 
-        db.read { assertEquals(it.getDaycare(daycareId), daycare) }
+        db.read { assertEquals(it.getDaycare(testDaycare.id), daycare) }
     }
 
     @Test
@@ -79,9 +96,9 @@ class DaycareControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
         val name = "Ryh mä"
         val startDate = LocalDate.of(2019, 1, 1)
         val caretakers = 42.0
-        val group = createDaycareGroup(daycareId, name, startDate, caretakers)
+        val group = createDaycareGroup(testDaycare.id, name, startDate, caretakers)
 
-        assertEquals(daycareId, group.daycareId)
+        assertEquals(testDaycare.id, group.daycareId)
         assertEquals(name, group.name)
         assertEquals(startDate, group.startDate)
         assertNull(group.endDate)
@@ -93,9 +110,9 @@ class DaycareControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
     @Test
     fun `delete group`() {
-        val group = createDaycareGroup(daycareId, "Test", LocalDate.of(2019, 1, 1), 5.0)
+        val group = createDaycareGroup(testDaycare.id, "Test", LocalDate.of(2019, 1, 1), 5.0)
 
-        deleteDaycareGroup(daycareId, group.id)
+        deleteDaycareGroup(testDaycare.id, group.id)
 
         db.read { assertNull(it.getDaycareGroup(group.id)) }
         assertFalse(groupHasMessageAccount(group.id))
@@ -103,8 +120,8 @@ class DaycareControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
     @Test
     fun `cannot delete a group when it has a placement`() {
-        val group = DevDaycareGroup(daycareId = daycareId)
-        val placement = DevPlacement(unitId = daycareId, childId = childId)
+        val group = DevDaycareGroup(daycareId = testDaycare.id)
+        val placement = DevPlacement(unitId = testDaycare.id, childId = testChild_1.id)
         db.transaction {
             it.insertTestPlacement(placement)
             it.insertTestDaycareGroup(group)
@@ -112,45 +129,280 @@ class DaycareControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             it.insertTestDaycareGroupPlacement(placement.id, group.id)
         }
 
-        assertThrows<Conflict> { deleteDaycareGroup(daycareId, group.id) }
+        assertThrows<Conflict> { deleteDaycareGroup(testDaycare.id, group.id) }
 
         db.read { assertNotNull(it.getDaycareGroup(group.id)) }
     }
 
     @Test
     fun `cannot delete a group when it is a backup care`() {
-        val group = DevDaycareGroup(daycareId = daycareId)
+        val group = DevDaycareGroup(daycareId = testDaycare.id)
         db.transaction {
             it.insertTestDaycareGroup(group)
             it.createDaycareGroupMessageAccount(group.id)
-            it.insertTestPlacement(childId = childId, unitId = daycareId)
+            it.insertTestPlacement(childId = testChild_1.id, unitId = testDaycare.id)
             it.insertTestBackupCare(
                 DevBackupCare(
-                    childId = childId,
-                    unitId = daycareId,
+                    childId = testChild_1.id,
+                    unitId = testDaycare.id,
                     groupId = group.id,
                     period = FiniteDateRange(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 2, 1))
                 )
             )
         }
 
-        assertThrows<Conflict> { deleteDaycareGroup(daycareId, group.id) }
+        assertThrows<Conflict> { deleteDaycareGroup(testDaycare.id, group.id) }
 
         db.read { assertNotNull(it.getDaycareGroup(group.id)) }
     }
 
     @Test
     fun `cannot delete a group when it has messages`() {
-        val group = DevDaycareGroup(daycareId = daycareId)
+        val group = DevDaycareGroup(daycareId = testDaycare.id)
         db.transaction {
             it.insertTestDaycareGroup(group)
             val accountId = it.createDaycareGroupMessageAccount(group.id)
             it.insertMessageContent("Juhannus tulee pian", accountId)
         }
 
-        assertThrows<Conflict> { deleteDaycareGroup(daycareId, group.id) }
+        assertThrows<Conflict> { deleteDaycareGroup(testDaycare.id, group.id) }
 
         db.read { assertNotNull(it.getDaycareGroup(group.id)) }
+    }
+
+    @Test
+    fun `get details of all groups`() {
+        val group1 = DevDaycareGroup(id = GroupId(UUID.randomUUID()), daycareId = testDaycare.id)
+        val group2 = DevDaycareGroup(id = GroupId(UUID.randomUUID()), daycareId = testDaycare.id)
+        val placementId1 = PlacementId(UUID.randomUUID())
+        val placementId2 = PlacementId(UUID.randomUUID())
+        val placementId3 = PlacementId(UUID.randomUUID())
+        db.transaction {
+            it.insertTestDaycareGroup(group1)
+            it.insertTestCaretakers(group1.id, amount = 3.0)
+
+            it.insertTestDaycareGroup(group2)
+            it.insertTestCaretakers(group2.id, amount = 1.0)
+
+            // Missing group
+            it.insertTestPlacement(
+                id = placementId1,
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusYears(1)
+            )
+
+            // Ok
+            it.insertTestPlacement(
+                id = placementId2,
+                childId = testChild_2.id,
+                unitId = testDaycare.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusYears(1)
+            )
+            it.insertTestDaycareGroupPlacement(
+                daycarePlacementId = placementId2,
+                groupId = group1.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusYears(1),
+            )
+
+            // Terminated
+            it.insertTestPlacement(
+                id = placementId3,
+                childId = testChild_3.id,
+                unitId = testDaycare.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusDays(14),
+                terminationRequestedDate = today.minusDays(5),
+                terminatedBy = EvakaUserId(testAdult_1.id.raw)
+            )
+            it.insertTestDaycareGroupPlacement(
+                daycarePlacementId = placementId3,
+                groupId = group1.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusDays(14),
+            )
+        }
+
+        val details = getGroupDetails(testDaycare.id)
+        assertEquals(setOf(group1.id, group2.id), details.groups.map { it.id }.toSet())
+        assertEquals(
+            setOf(placementId1, placementId2, placementId3),
+            details.placements.map { it.id }.toSet()
+        )
+        assertEquals(listOf(placementId1), details.missingGroupPlacements.map { it.placementId })
+        assertEquals(listOf(placementId3), details.recentlyTerminatedPlacements.map { it.id })
+        assertEquals(
+            listOf(
+                    UnitChildrenCapacityFactors(testChild_1.id, 1.0, 1.0),
+                    UnitChildrenCapacityFactors(testChild_2.id, 1.0, 1.0),
+                    UnitChildrenCapacityFactors(testChild_3.id, 1.0, 1.75),
+                )
+                .sortedBy { it.childId },
+            details.unitChildrenCapacityFactors.sortedBy { it.childId }
+        )
+        assertEquals(
+            mapOf(
+                group1.id to Caretakers(3.0, 3.0),
+                group2.id to Caretakers(1.0, 1.0),
+            ),
+            details.caretakers
+        )
+        assertEquals(2, details.groupOccupancies?.confirmed?.size)
+        assertEquals(2, details.groupOccupancies?.realized?.size)
+    }
+
+    @Test
+    fun `group details - terminated placements`() {
+        val group = DevDaycareGroup(id = GroupId(UUID.randomUUID()), daycareId = testDaycare.id)
+        val placementId1 = PlacementId(UUID.randomUUID())
+        val placementId2 = PlacementId(UUID.randomUUID())
+        val placementId3 = PlacementId(UUID.randomUUID())
+        val placementId4 = PlacementId(UUID.randomUUID())
+        val placementId5 = PlacementId(UUID.randomUUID())
+        db.transaction {
+            it.insertTestDaycareGroup(group)
+
+            // Terminated over 2 weeks ago -> not listed
+            it.insertTestPlacement(
+                id = placementId1,
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusDays(7),
+                terminationRequestedDate = today.minusDays(15),
+                terminatedBy = EvakaUserId(testAdult_1.id.raw)
+            )
+
+            // No group
+            it.insertTestPlacement(
+                id = placementId2,
+                childId = testChild_2.id,
+                unitId = testDaycare.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusDays(7),
+                terminationRequestedDate = today.minusDays(14),
+                terminatedBy = EvakaUserId(testAdult_1.id.raw)
+            )
+
+            // Has group
+            it.insertTestPlacement(
+                id = placementId3,
+                childId = testChild_3.id,
+                unitId = testDaycare.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusDays(14),
+                terminationRequestedDate = today.minusDays(5),
+                terminatedBy = EvakaUserId(testAdult_1.id.raw)
+            )
+            it.insertTestDaycareGroupPlacement(
+                daycarePlacementId = placementId3,
+                groupId = group.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusDays(14),
+            )
+
+            // Connected daycare placement is terminated, preschool continues
+            it.insertTestPlacement(
+                id = placementId4,
+                type = PlacementType.PRESCHOOL_DAYCARE,
+                childId = testChild_4.id,
+                unitId = testDaycare.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusDays(15),
+                terminationRequestedDate = today.minusDays(2),
+                terminatedBy = EvakaUserId(testAdult_1.id.raw)
+            )
+            it.insertTestDaycareGroupPlacement(
+                daycarePlacementId = placementId4,
+                groupId = group.id,
+                startDate = today.minusDays(10),
+                endDate = today.plusDays(15),
+            )
+            it.insertTestPlacement(
+                id = placementId5,
+                type = PlacementType.PRESCHOOL,
+                childId = testChild_4.id,
+                unitId = testDaycare.id,
+                startDate = today.plusDays(16),
+                endDate = today.plusYears(1),
+            )
+        }
+
+        val details = getGroupDetails(testDaycare.id)
+        assertEquals(
+            listOf(
+                TerminatedPlacement(
+                    id = placementId2,
+                    endDate = today.plusDays(7),
+                    type = PlacementType.DAYCARE,
+                    terminationRequestedDate = today.minusDays(14),
+                    child =
+                        ChildBasics(
+                            id = testChild_2.id,
+                            socialSecurityNumber = testChild_2.ssn,
+                            firstName = testChild_2.firstName,
+                            lastName = testChild_2.lastName,
+                            dateOfBirth = testChild_2.dateOfBirth
+                        ),
+                    terminatedBy =
+                        EvakaUser(
+                            id = EvakaUserId(testAdult_1.id.raw),
+                            name = "${testAdult_1.lastName} ${testAdult_1.firstName}",
+                            type = EvakaUserType.CITIZEN
+                        ),
+                    currentDaycareGroupName = null,
+                    connectedDaycareOnly = false
+                ),
+                TerminatedPlacement(
+                    id = placementId3,
+                    endDate = today.plusDays(14),
+                    type = PlacementType.DAYCARE,
+                    terminationRequestedDate = today.minusDays(5),
+                    child =
+                        ChildBasics(
+                            id = testChild_3.id,
+                            socialSecurityNumber = testChild_3.ssn,
+                            firstName = testChild_3.firstName,
+                            lastName = testChild_3.lastName,
+                            dateOfBirth = testChild_3.dateOfBirth
+                        ),
+                    terminatedBy =
+                        EvakaUser(
+                            id = EvakaUserId(testAdult_1.id.raw),
+                            name = "${testAdult_1.lastName} ${testAdult_1.firstName}",
+                            type = EvakaUserType.CITIZEN
+                        ),
+                    currentDaycareGroupName = group.name,
+                    connectedDaycareOnly = false
+                ),
+                TerminatedPlacement(
+                    id = placementId4,
+                    endDate = today.plusDays(15),
+                    type = PlacementType.PRESCHOOL_DAYCARE,
+                    terminationRequestedDate = today.minusDays(2),
+                    child =
+                        ChildBasics(
+                            id = testChild_4.id,
+                            socialSecurityNumber = testChild_4.ssn,
+                            firstName = testChild_4.firstName,
+                            lastName = testChild_4.lastName,
+                            dateOfBirth = testChild_4.dateOfBirth
+                        ),
+                    terminatedBy =
+                        EvakaUser(
+                            id = EvakaUserId(testAdult_1.id.raw),
+                            name = "${testAdult_1.lastName} ${testAdult_1.firstName}",
+                            type = EvakaUserType.CITIZEN
+                        ),
+                    currentDaycareGroupName = group.name,
+                    connectedDaycareOnly = true
+                )
+            ),
+            details.recentlyTerminatedPlacements
+        )
     }
 
     private fun getDaycare(daycareId: DaycareId): DaycareController.DaycareResponse {
@@ -182,6 +434,17 @@ class DaycareControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             RealEvakaClock(),
             daycareId,
             groupId
+        )
+    }
+
+    private fun getGroupDetails(daycareId: DaycareId): UnitGroupDetails {
+        return daycareController.getUnitGroupDetails(
+            dbInstance(),
+            supervisor,
+            MockEvakaClock(now),
+            daycareId,
+            from = today,
+            to = today,
         )
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -477,12 +477,14 @@ fun Database.Transaction.insertTestPlacement(
     unitId: DaycareId = DaycareId(UUID.randomUUID()),
     type: PlacementType = PlacementType.DAYCARE,
     startDate: LocalDate = LocalDate.of(2019, 1, 1),
-    endDate: LocalDate = LocalDate.of(2019, 12, 31)
+    endDate: LocalDate = LocalDate.of(2019, 12, 31),
+    terminationRequestedDate: LocalDate? = null,
+    terminatedBy: EvakaUserId? = null
 ): PlacementId {
     createUpdate(
             """
-            INSERT INTO placement (id, child_id, unit_id, type, start_date, end_date)
-            VALUES (:id, :childId, :unitId, :type::placement_type, :startDate, :endDate)
+            INSERT INTO placement (id, child_id, unit_id, type, start_date, end_date, termination_requested_date, terminated_by)
+            VALUES (:id, :childId, :unitId, :type::placement_type, :startDate, :endDate, :terminationRequestedDate, :terminatedBy)
             """
         )
         .bind("id", id)
@@ -491,6 +493,8 @@ fun Database.Transaction.insertTestPlacement(
         .bind("type", type)
         .bind("startDate", startDate)
         .bind("endDate", endDate)
+        .bind("terminationRequestedDate", terminationRequestedDate)
+        .bind("terminatedBy", terminatedBy)
         .execute()
     return id
 }


### PR DESCRIPTION
#### Summary 

Change the placement type chip to "Liittyvä" when only connected daycare is terminated and preschool continues. It was "Esiopetus ja liittyvä varhaiskasvatus" which is obviously wrong in this case. 

<img width="1285" alt="Screenshot 2023-01-31 at 8 45 38" src="https://user-images.githubusercontent.com/70927/215686520-1db0acc1-1316-4bcd-961a-b2765f853054.png">
