### PR TITLE
Fix map view unit list hover highlight

### DIFF
--- a/frontend/src/citizen-frontend/map/UnitListItem.tsx
+++ b/frontend/src/citizen-frontend/map/UnitListItem.tsx
@@ -49,13 +49,13 @@ const Wrapper = styled.button`
   background: none;
   border: none;
   display: block;
-  width: 100%;
+  width: calc(100% + ${dM.L} + ${dM.L});
   text-align: left;
   margin-bottom: ${dM.s};
   cursor: pointer;
 
-  padding: ${dM.xs} ${dM.s} ${dM.xs} ${dM.L};
-  margin: ${dM.xs} -${dM.s} -${dM.xs} -${dM.L};
+  padding: ${dM.xs} ${dM.L};
+  margin: 0 -${dM.L};
 
   &:hover {
     background-color: ${colors.main.m4};
@@ -69,6 +69,7 @@ const Wrapper = styled.button`
     display: block;
     position: absolute;
     margin-top: ${dM.xs};
+    margin-bottom: -${dM.xs};
   }
 
   :first-child {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->
I noticed hovering over a unit in the map view's unit list was a bit off.

Before: 
<img width="407" alt="Screenshot 2023-01-31 at 10 38 45" src="https://user-images.githubusercontent.com/4426547/215710260-77b92db0-c35f-4109-946f-7bbfca470a42.png">

After:
<img width="404" alt="Screenshot 2023-01-31 at 10 39 07" src="https://user-images.githubusercontent.com/4426547/215710293-2aff622e-7803-4d11-8901-c27098f43f40.png">

