### PR TITLE
Fix preschool/preparatory invoice capping with contract surplus days

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -4707,7 +4707,10 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             InvoiceGenerator(
                 DraftInvoiceGenerator(
                     productProvider,
-                    featureConfig.copy(maxContractDaySurplusThreshold = 13),
+                    featureConfig.copy(
+                        maxContractDaySurplusThreshold = 13,
+                        useContractDaysAsDailyFeeDivisor = false
+                    ),
                     DefaultInvoiceGenerationLogic
                 )
             )
@@ -4783,7 +4786,10 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             InvoiceGenerator(
                 DraftInvoiceGenerator(
                     productProvider,
-                    featureConfig.copy(maxContractDaySurplusThreshold = 13),
+                    featureConfig.copy(
+                        maxContractDaySurplusThreshold = 13,
+                        useContractDaysAsDailyFeeDivisor = false
+                    ),
                     DefaultInvoiceGenerationLogic
                 )
             )


### PR DESCRIPTION
#### Summary

Also cap preschool/preparatory max price with `useContractDaysAsDailyFeeDivisor = false`
