### PR TITLE
EVAKA-4694 Disallow sending new messages without actively placed child

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 
 import Footer, { footerHeightDesktop } from 'citizen-frontend/Footer'
 import { UnwrapResult } from 'citizen-frontend/async-rendering'
+import { useUser } from 'citizen-frontend/auth/state'
 import { combine } from 'lib-common/api'
 import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
@@ -73,6 +74,8 @@ export default React.memo(function MessagesPage() {
     [t.messages.staffAnnotation]
   )
 
+  const user = useUser()
+
   useEffect(() => {
     setEditorVisible(searchParams.get('editorVisible') === 'true')
   }, [setEditorVisible, searchParams])
@@ -109,6 +112,9 @@ export default React.memo(function MessagesPage() {
     changeEditorVisibility(false)
   }, [refreshThreads, changeEditorVisibility])
 
+  const canSendNewMessage =
+    !editorVisible && !!user?.accessibleFeatures.composeNewMessage
+
   return (
     <Container>
       <UnwrapResult result={combine(accountId, receivers)}>
@@ -123,7 +129,7 @@ export default React.memo(function MessagesPage() {
                   accountId={id}
                   selectThread={selectThread}
                   setEditorVisible={changeEditorVisibility}
-                  newMessageButtonEnabled={!editorVisible}
+                  newMessageButtonEnabled={canSendNewMessage}
                 />
                 {selectedThread ? (
                   <ThreadView

--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -20,7 +20,7 @@ export default class CitizenMessagesPage {
   #threadUrgent = this.page.findByDataQa('thread-reader').findByDataQa('urgent')
   #openReplyEditorButton = this.page.find(`[data-qa="${this.replyButtonTag}"]`)
   #sendReplyButton = this.page.find('[data-qa="message-send-btn"]')
-  #newMessageButton = this.page.findAllByDataQa('new-message-btn').first()
+  newMessageButton = this.page.findAllByDataQa('new-message-btn').first()
   #sendMessageButton = this.page.find('[data-qa="send-message-btn"]')
   #receiverSelection = this.page.find('[data-qa="select-receiver"]')
   #inputTitle = new TextInput(this.page.find('[data-qa="input-title"]'))
@@ -102,7 +102,7 @@ export default class CitizenMessagesPage {
   }
 
   async clickNewMessage() {
-    await this.#newMessageButton.click()
+    await this.newMessageButton.click()
     await waitUntilTrue(() => this.isEditorVisible())
   }
 

--- a/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
@@ -101,6 +101,24 @@ describe('Service Worker Messaging', () => {
       await citizenMessagesPage.assertThreadContent({ title, content })
     })
 
+    it('should NOT be possible for a citizen without placed children to send new messages', async () => {
+      await openStaffPage(mockedTime)
+      const applicationsPage = new ApplicationsPage(staffPage)
+      await new EmployeeNav(staffPage).applicationsTab.click()
+      const applReadView = await applicationsPage
+        .applicationRow(applicationFixtureId)
+        .openApplication()
+      const messagesPage = await applReadView.openMessagesPage()
+      await messagesPage.inputContent.fill('message')
+      await messagesPage.sendMessageButton.click()
+
+      await openCitizenPage(mockedTime.addHours(1))
+      const header = new CitizenHeader(citizenPage)
+      await header.selectTab('messages')
+      const citizenMessagesPage = new CitizenMessagesPage(citizenPage)
+      await citizenMessagesPage.newMessageButton.assertDisabled(true)
+    })
+
     it('should prefill the receiver and title fields when sending a new message', async () => {
       await openStaffPage(mockedTime)
       const applicationsPage = new ApplicationsPage(staffPage)

--- a/frontend/src/lib-common/api-types/vtjclient.ts
+++ b/frontend/src/lib-common/api-types/vtjclient.ts
@@ -14,6 +14,7 @@ export interface Child {
 export interface CitizenFeatures {
   childDocumentation: boolean
   messages: boolean
+  composeNewMessage: boolean
   reservations: boolean
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/CitizenFeatures.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/CitizenFeatures.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.shared.security
 
 data class CitizenFeatures(
     val messages: Boolean,
+    val composeNewMessage: Boolean,
     val reservations: Boolean,
     val childDocumentation: Boolean
 )


### PR DESCRIPTION
Citizens are no longer able to compose new messages if none of their children are actively placed.