### PR TITLE
Additions to placement sketching report

### DIFF
--- a/frontend/src/employee-frontend/api/reports.ts
+++ b/frontend/src/employee-frontend/api/reports.ts
@@ -471,6 +471,8 @@ export interface VoucherProviderChildrenReportFilters {
 export interface PlacementSketchingReportFilters {
   earliestPreferredStartDate: LocalDate
   placementStartDate: LocalDate
+  earliestApplicationSentDate: LocalDate | null
+  latestApplicationSentDate: LocalDate | null
 }
 
 export async function getPlacementSketchingReport(
@@ -483,7 +485,11 @@ export async function getPlacementSketchingReport(
         params: {
           earliestPreferredStartDate:
             filters.earliestPreferredStartDate.formatIso(),
-          placementStartDate: filters.placementStartDate.formatIso()
+          placementStartDate: filters.placementStartDate.formatIso(),
+          earliestApplicationSentDate:
+            filters.earliestApplicationSentDate?.formatIso(),
+          latestApplicationSentDate:
+            filters.latestApplicationSentDate?.formatIso()
         }
       }
     )
@@ -493,7 +499,10 @@ export async function getPlacementSketchingReport(
           ...row,
           childDob: LocalDate.parseIso(row.childDob),
           preferredStartDate: LocalDate.parseIso(row.preferredStartDate),
-          sentDate: LocalDate.parseIso(row.sentDate)
+          sentDate: LocalDate.parseIso(row.sentDate),
+          childMovingDate: row.childMovingDate
+            ? LocalDate.parseIso(row.childMovingDate)
+            : null
         }))
       )
     )

--- a/frontend/src/employee-frontend/components/reports/PlacementSketching.tsx
+++ b/frontend/src/employee-frontend/components/reports/PlacementSketching.tsx
@@ -17,6 +17,7 @@ import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { DatePickerDeprecated } from 'lib-components/molecules/DatePickerDeprecated'
+import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
 import { faFileAlt } from 'lib-icons'
 
 import {
@@ -26,6 +27,7 @@ import {
 import ReportDownload from '../../components/reports/ReportDownload'
 import { useTranslation } from '../../state/i18n'
 import { distinct } from '../../utils'
+import { FlexRow } from '../common/styled/containers'
 
 import { FilterLabel, FilterRow, RowCountInfo, TableScrollable } from './common'
 
@@ -42,7 +44,7 @@ const Wrapper = styled.div`
 `
 
 export default React.memo(function PlacementSketching() {
-  const { i18n } = useTranslation()
+  const { i18n, lang } = useTranslation()
   const [rows, setRows] = useState<Result<PlacementSketchingReportRow[]>>(
     Loading.of()
   )
@@ -52,7 +54,9 @@ export default React.memo(function PlacementSketching() {
       LocalDate.todayInSystemTz().year,
       8,
       1
-    )
+    ),
+    earliestApplicationSentDate: null,
+    latestApplicationSentDate: null
   })
 
   const [displayFilters, setDisplayFilters] =
@@ -86,6 +90,8 @@ export default React.memo(function PlacementSketching() {
           .join(',')
       : ''
 
+  const currentLocalDate = LocalDate.todayInSystemTz()
+
   const showServiceNeedOption = filteredRows.some(
     (item) => item.serviceNeedOption !== null
   )
@@ -118,6 +124,39 @@ export default React.memo(function PlacementSketching() {
               setFilters({ ...filters, earliestPreferredStartDate })
             }
           />
+        </FilterRow>
+
+        <FilterRow>
+          <FlexRow>
+            <FilterLabel>
+              {i18n.reports.placementSketching.applicationSentDateRange}
+            </FilterLabel>
+            <DatePicker
+              id="earliest-sent-date"
+              date={filters.earliestApplicationSentDate}
+              onChange={(earliestApplicationSentDate) => {
+                setFilters({ ...filters, earliestApplicationSentDate })
+              }}
+              hideErrorsBeforeTouched
+              locale={lang}
+              isInvalidDate={(d) =>
+                d.isAfter(currentLocalDate)
+                  ? i18n.validationErrors.dateTooEarly
+                  : null
+              }
+            />
+            <span>{' - '}</span>
+
+            <DatePicker
+              id="latest-sent-date"
+              date={filters.latestApplicationSentDate}
+              onChange={(latestApplicationSentDate) => {
+                setFilters({ ...filters, latestApplicationSentDate })
+              }}
+              hideErrorsBeforeTouched
+              locale={lang}
+            />
+          </FlexRow>
         </FilterRow>
 
         <FilterRow>
@@ -176,7 +215,8 @@ export default React.memo(function PlacementSketching() {
                 preparatoryEducation: row.preparatoryEducation ? 'k' : 'e',
                 siblingBasis: row.siblingBasis ? 'k' : 'e',
                 connectedDaycare: row.connectedDaycare ? 'k' : 'e',
-                otherPreferredUnits: formatOtherPreferredUnits(row)
+                otherPreferredUnits: formatOtherPreferredUnits(row),
+                hasAdditionalInfo: row.hasAdditionalInfo ? 'k' : 'e'
               }))}
               headers={[
                 {
@@ -238,6 +278,28 @@ export default React.memo(function PlacementSketching() {
                 {
                   label: i18n.reports.placementSketching.otherPreferredUnits,
                   key: 'otherPreferredUnits'
+                },
+                {
+                  label: i18n.reports.placementSketching.additionalInfo,
+                  key: 'hasAdditionalInfo'
+                },
+                {
+                  label: i18n.reports.placementSketching.childMovingDate,
+                  key: 'childMovingDate'
+                },
+                {
+                  label:
+                    i18n.reports.placementSketching.childCorrectedStreetAddress,
+                  key: 'childCorrectedStreetAddress'
+                },
+                {
+                  label:
+                    i18n.reports.placementSketching.childCorrectedPostalCode,
+                  key: 'childCorrectedPostalCode'
+                },
+                {
+                  label: i18n.reports.placementSketching.childCorrectedCity,
+                  key: 'childCorrectedCity'
                 }
               ]}
               filename={`sijoitushahmottelu_${filters.placementStartDate.formatIso()}-${
@@ -269,6 +331,18 @@ export default React.memo(function PlacementSketching() {
                   <Th>{i18n.reports.placementSketching.preferredStartDate}</Th>
                   <Th>{i18n.reports.common.careAreaName}</Th>
                   <Th>{i18n.reports.placementSketching.otherPreferredUnits}</Th>
+                  <Th>{i18n.reports.placementSketching.additionalInfo}</Th>
+                  <Th>{i18n.reports.placementSketching.childMovingDate}</Th>
+                  <Th>
+                    {
+                      i18n.reports.placementSketching
+                        .childCorrectedStreetAddress
+                    }
+                  </Th>
+                  <Th>
+                    {i18n.reports.placementSketching.childCorrectedPostalCode}
+                  </Th>
+                  <Th>{i18n.reports.placementSketching.childCorrectedCity}</Th>
                 </Tr>
               </Thead>
               <Tbody>
@@ -318,6 +392,11 @@ export default React.memo(function PlacementSketching() {
                     <Td data-qa="other-preferred-units">
                       {formatOtherPreferredUnits(row)}
                     </Td>
+                    <Td>{yesNo(row.hasAdditionalInfo)}</Td>
+                    <Td>{row.childMovingDate?.format()}</Td>
+                    <Td>{row.childCorrectedStreetAddress}</Td>
+                    <Td>{row.childCorrectedPostalCode}</Td>
+                    <Td>{row.childCorrectedCity}</Td>
                   </Tr>
                 ))}
               </Tbody>

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -410,10 +410,14 @@ export interface PlacementSketchingReportRow {
   applicationId: UUID
   areaName: string
   assistanceNeeded: boolean | null
+  childCorrectedCity: string
+  childCorrectedPostalCode: string
+  childCorrectedStreetAddress: string
   childDob: LocalDate
   childFirstName: string
   childId: UUID
   childLastName: string
+  childMovingDate: LocalDate | null
   childPostalCode: string | null
   childStreetAddr: string | null
   connectedDaycare: boolean | null
@@ -421,6 +425,7 @@ export interface PlacementSketchingReportRow {
   currentUnitName: string | null
   guardianEmail: string | null
   guardianPhoneNumber: string | null
+  hasAdditionalInfo: boolean
   otherPreferredUnits: string[]
   preferredStartDate: LocalDate
   preparatoryEducation: boolean | null

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3274,7 +3274,13 @@ export const fi = {
       connected: 'Liittyvä',
       preferredStartDate: 'Toivottu aloituspäivä',
       sentDate: 'Lähetyspäivä',
-      otherPreferredUnits: 'Muut hakutoiveet'
+      otherPreferredUnits: 'Muut hakutoiveet',
+      additionalInfo: 'Lisätiedot',
+      childMovingDate: 'Lapsen muuttopäivä',
+      childCorrectedStreetAddress: 'Lapsen uusi katuosoite',
+      childCorrectedPostalCode: 'Lapsen uusi postinumero',
+      childCorrectedCity: 'Lapsen uusi postitoimipaikka',
+      applicationSentDateRange: 'Hakemus lähetetty välillä'
     },
     vardaErrors: {
       title: 'Varda-virheet',


### PR DESCRIPTION
Adds to placement sketching report:
- optional filtering by application sent date (date range)
  - default filters produce same result as before changes
- 5 new columns:
  - does child have additional information (allergy, diet or other) in application (yes/no)
  - child moving date as provided in the application (and child details not restricted)
  - child corrected address details as provided in the application (and child details not restricted)
    - street address
    - postal code
    - city  