### PR TITLE
EVAKA-4694 Show messaging section only once a message is readable

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlCitizen.kt
@@ -62,8 +62,9 @@ SELECT EXISTS (
     FROM person p 
     JOIN message_account ma ON p.id = ma.person_id
     JOIN message_recipients mr ON ma.id = mr.recipient_id
+    JOIN message m ON mr.message_id = m.id
     JOIN application app ON p.id = app.guardian_id
-    WHERE app.status = 'SENT' AND p.id = :userId AND mr.id IS NOT NULL
+    WHERE app.status = 'SENT' AND p.id = :userId AND mr.id IS NOT NULL AND m.sent_at IS NOT NULL
 )
 """
         return createQuery(sql)


### PR DESCRIPTION
The messaging section was opened too early for citizens who received a message relating to an application. It was visible already before the received message was actually readable (before the undo grace period has passed). Now shows the messaging section only after a message actually is readable.
