### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
@@ -38,6 +38,9 @@ export default class ApplicationEditView {
       '[data-qa="datepicker-connected-daycare-preferred-start-date"]'
     )
   )
+  #connectedDaycarePreferredStartDateInputWarning = this.page.find(
+    '[data-qa="input-warning-connected-daycare-preferred-start-date"]'
+  )
   #preferredUnit = new Combobox(this.page.find('[data-qa="preferred-unit"]'))
   #applicantPhone = new TextInput(
     this.page.find('[data-qa="application-person-phone"]')
@@ -71,7 +74,9 @@ export default class ApplicationEditView {
   }
 
   async fillConnectedDaycarePreferredStartDate(date: string) {
+    await this.#connectedDaycarePreferredStartDateInputWarning.waitUntilVisible()
     await this.#connectedDaycarePreferredStartDate.fill(date)
+    await this.#connectedDaycarePreferredStartDateInputWarning.waitUntilHidden()
   }
 
   async selectPreschoolPlacementType(type: PlacementType) {

--- a/frontend/src/e2e-test/pages/mobile/list-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/list-page.ts
@@ -46,11 +46,6 @@ export default class MobileListPage {
       .waitUntilHidden()
   }
 
-  async gotoMessages() {
-    const elem = this.page.find(`[data-qa="bottomnav-messages"]`)
-    return elem.click()
-  }
-
   async getAttendanceCounts() {
     const tabs = ['coming', 'present', 'departed', 'absent']
     const tabToDataQa = (t: string) => `[data-qa="${t}-tab"] [data-qa="count"]`

--- a/frontend/src/e2e-test/pages/mobile/mobile-nav.ts
+++ b/frontend/src/e2e-test/pages/mobile/mobile-nav.ts
@@ -17,8 +17,9 @@ export default class MobileNav {
     return this.page.find(`[data-qa="group--${id}"]`)
   }
 
-  readonly #children = this.page.find('[data-qa="bottomnav-children"]')
-  readonly #staff = this.page.find('[data-qa="bottomnav-staff"]')
+  children = this.page.find('[data-qa="bottomnav-children"]')
+  staff = this.page.find('[data-qa="bottomnav-staff"]')
+  messages = this.page.find('[data-qa="bottomnav-messages"]')
 
   get selectedGroupName() {
     return this.#groupSelectorButton.text
@@ -27,14 +28,5 @@ export default class MobileNav {
   async selectGroup(id: UUID) {
     await this.#groupSelectorButton.click()
     await this.groupWithId(id).click()
-  }
-
-  async openPage(tab: 'children' | 'staff') {
-    switch (tab) {
-      case 'children':
-        return await this.#children.click()
-      case 'staff':
-        return await this.#staff.click()
-    }
   }
 }

--- a/frontend/src/e2e-test/specs/5_employee/feature-flag-preschool-application-service-need-option.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/feature-flag-preschool-application-service-need-option.spec.ts
@@ -40,10 +40,7 @@ beforeEach(async () => {
           serviceNeedOption: true
         }
       }
-    },
-
-    // Avoid elements from hiding behind the floating footer
-    viewport: { width: 1280, height: 1000 }
+    }
   })
   await employeeLogin(page, admin.data)
 

--- a/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
@@ -281,7 +281,7 @@ describe('Child message thread', () => {
 
   test('Message button goes to messages if user has pin session', async () => {
     await employeeLoginsToMessagesPage()
-    await page.goto(config.mobileUrl)
+    await nav.openPage('children')
     await listPage.gotoMessages()
     await messagesPage.messagesContainer.waitUntilVisible()
   })

--- a/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
@@ -274,15 +274,15 @@ describe('Child message thread', () => {
   })
 
   test('Message button goes to unread messages if user has no pin session', async () => {
-    await listPage.gotoMessages()
+    await nav.messages.click()
     await unreadMessageCountsPage.groupLinksExist()
     await unreadMessageCountsPage.pinButtonExists()
   })
 
   test('Message button goes to messages if user has pin session', async () => {
     await employeeLoginsToMessagesPage()
-    await nav.openPage('children')
-    await listPage.gotoMessages()
+    await nav.children.click()
+    await nav.messages.click()
     await messagesPage.messagesContainer.waitUntilVisible()
   })
 
@@ -379,17 +379,17 @@ async function userSeesNewMessagesIndicator() {
 
 async function userSeesNewMessageIndicatorAndClicks() {
   await userSeesNewMessagesIndicator()
-  await listPage.gotoMessages()
+  await nav.messages.click()
 }
 
 async function staffLoginsToMessagesPage() {
-  await listPage.gotoMessages()
+  await nav.messages.click()
   await unreadMessageCountsPage.pinLoginButton.click()
   await pinLoginPage.login(staffName, pin)
 }
 
 async function staff2LoginsToMessagesPage() {
-  await listPage.gotoMessages()
+  await nav.messages.click()
   await unreadMessageCountsPage.pinLoginButton.click()
   await pinLoginPage.login(staff2Name, pin)
 }
@@ -407,11 +407,11 @@ async function employeeNavigatesToMessagesSelectingGroup() {
 }
 
 async function employeeLoginsToMessagesPage() {
-  await listPage.gotoMessages()
+  await nav.messages.click()
   await employeeNavigatesToMessagesSelectingLogin()
 }
 
 async function employeeLoginsToMessagesPageThroughGroup() {
-  await listPage.gotoMessages()
+  await nav.messages.click()
   await employeeNavigatesToMessagesSelectingGroup()
 }

--- a/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts
@@ -88,7 +88,7 @@ const initPages = async (mockedTime: Date) => {
 
   mobileSignupUrl = await pairMobileDevice(daycare2Fixture.id)
   await page.goto(mobileSignupUrl)
-  await nav.openPage('staff')
+  await nav.staff.click()
   staffAttendancePage = new StaffAttendancePage(page)
 }
 

--- a/frontend/src/e2e-test/specs/6_mobile/staff.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/staff.spec.ts
@@ -40,7 +40,7 @@ beforeEach(async () => {
 
   mobileSignupUrl = await pairMobileDevice(fixtures.daycareFixture.id)
   await page.goto(mobileSignupUrl)
-  await nav.openPage('staff')
+  await nav.staff.click()
   staffPage = new StaffPage(page)
 })
 

--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -480,6 +480,7 @@ export default React.memo(function ApplicationEditView({
                                 'form.preferences.connectedDaycarePreferredStartDate'
                               ]
                             }
+                            data-qa="input-warning-connected-daycare-preferred-start-date"
                           />
                         </>
                       ) : null}

--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -247,7 +247,7 @@ export default React.memo(function ApplicationEditView({
       >
         <ListGrid>
           <Label>{i18n.application.serviceNeed.startDate}</Label>
-          <div data-qa="datepicker-start-date">
+          <div>
             <HorizontalContainer>
               <DatePickerDeprecated
                 type="short"

--- a/frontend/src/employee-frontend/components/common/InputWarning.tsx
+++ b/frontend/src/employee-frontend/components/common/InputWarning.tsx
@@ -12,16 +12,17 @@ import { fasExclamationTriangle } from 'lib-icons'
 interface Props {
   text: string
   iconPosition?: 'before' | 'after'
+  'data-qa'?: string
 }
 
-export function InputWarning({ text, iconPosition }: Props) {
+export function InputWarning({ text, iconPosition, 'data-qa': dataQa }: Props) {
   return iconPosition === 'after' ? (
-    <div>
+    <div data-qa={dataQa}>
       <WarningText margin="right">{text}</WarningText>
       <WarningIcon />
     </div>
   ) : (
-    <div>
+    <div data-qa={dataQa}>
       <WarningIcon />
       <WarningText>{text}</WarningText>
     </div>


### PR DESCRIPTION
#### Summary

- Avoid a misclick by wait for a validation error to hide before attempting to click an element under it.
- Avoid `page.goto()` navigation in employee mobile

Also refactor navigation between pages in employee mobile e2e a bit.
