### PR TITLE
EVAKA-4694 Clearly mark application notes created from messages

### DIFF
--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -186,6 +186,14 @@ export default class ApplicationReadView {
       .assertTextEquals(note)
   }
 
+  async assertNoteNotEditable(index: number) {
+    await this.#notes.nth(index).findByDataQa('edit-note').waitUntilHidden()
+  }
+
+  async assertNoteNotDeletable(index: number) {
+    await this.#notes.nth(index).findByDataQa('delete-note').waitUntilHidden()
+  }
+
   async assertNoNotes() {
     await this.#notes.nth(0).waitUntilHidden()
   }

--- a/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
@@ -282,5 +282,21 @@ describe('Service Worker Messaging', () => {
       const messagesPage = await applReadView.openMessagesPage()
       await messagesPage.assertSimpleViewVisible()
     })
+
+    it('should not be possible for service workers to delete or edit notes created from messages', async () => {
+      await openStaffPage(mockedTime)
+      const applicationsPage = new ApplicationsPage(staffPage)
+      await new EmployeeNav(staffPage).applicationsTab.click()
+      const applReadView = await applicationsPage
+        .applicationRow(applicationFixtureId)
+        .openApplication()
+      const messagesPage = await applReadView.openMessagesPage()
+      await messagesPage.inputContent.fill('message content')
+      await messagesPage.sendMessageButton.click()
+
+      await applReadView.reload()
+      await applReadView.assertNoteNotEditable(0)
+      await applReadView.assertNoteNotDeletable(0)
+    })
   })
 })

--- a/frontend/src/employee-frontend/components/application-page/ApplicationNoteBox.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationNoteBox.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useContext, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
@@ -22,7 +23,7 @@ import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { Label, Light } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import { colors } from 'lib-customizations/common'
-import { faPen, faQuestion, faTrash } from 'lib-icons'
+import { faEnvelope, faPen, faQuestion, faTrash } from 'lib-icons'
 
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
@@ -57,6 +58,10 @@ const ButtonsBar = styled.div`
 
 const DetailText = styled(Light)`
   font-size: 12px;
+`
+
+const NoteIcon = styled(FontAwesomeIcon)`
+  margin-right: ${defaultMargins.xxs};
 `
 
 interface ReadProps {
@@ -184,7 +189,14 @@ export default React.memo(function ApplicationNoteBox(props: Props) {
               <Label>{i18n.application.notes.newNote}</Label>
             ) : (
               <>
-                <Label>{props.note.createdByName}</Label>
+                <Label>
+                  <>
+                    {props.note.messageThreadId !== null && (
+                      <NoteIcon icon={faEnvelope} />
+                    )}
+                    {props.note.createdByName}
+                  </>
+                </Label>
                 <span>
                   {i18n.application.notes.created}:{' '}
                   {props.note.created.format()}

--- a/frontend/src/employee-frontend/components/application-page/ApplicationNotes.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationNotes.tsx
@@ -56,12 +56,14 @@ export default React.memo(function ApplicationNotes({
               editable={
                 !creating &&
                 editing === null &&
-                permittedActions.includes('UPDATE')
+                permittedActions.includes('UPDATE') &&
+                note.messageThreadId === null
               }
               deletable={
                 !creating &&
                 editing === null &&
-                permittedActions.includes('DELETE')
+                permittedActions.includes('DELETE') &&
+                note.messageThreadId === null
               }
               onStartEdit={() => setEditing(note.id)}
             />


### PR DESCRIPTION
- adds an icon to the notes created from an application
- removes the delete and edit buttons
