### PR TITLE
EVAKA-4694 Fix bug where you couldn't navigate to message threads

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -671,17 +671,17 @@ export const MessageContextProvider = React.memo(
     )
 
     const selectDefaultAccount = useCallback(() => {
-      if (municipalAccount) {
-        setParams({
-          messageBox: messageBox ?? municipalMessageBoxes[0],
-          accountId: municipalAccount.account.id,
-          unitId: null,
-          threadId: threadId
-        })
-      } else if (serviceWorkerAccount) {
+      if (serviceWorkerAccount) {
         setParams({
           messageBox: messageBox ?? serviceWorkerMessageBoxes[0],
           accountId: serviceWorkerAccount.account.id,
+          unitId: null,
+          threadId: threadId
+        })
+      } else if (municipalAccount) {
+        setParams({
+          messageBox: messageBox ?? municipalMessageBoxes[0],
+          accountId: municipalAccount.account.id,
           unitId: null,
           threadId: threadId
         })


### PR DESCRIPTION
Employees having both the service worker and messaging roles could not navigate from applications to the relevant message threads. This change fixes that issue.
