### PR TITLE
Duplicate people report changes to support intentional duplicates

### DIFF
--- a/frontend/src/employee-frontend/api/reports.ts
+++ b/frontend/src/employee-frontend/api/reports.ts
@@ -345,12 +345,17 @@ export async function getEndedPlacementsReport(
     )
     .catch((e) => Failure.fromError(e))
 }
+export interface DuplicatePeopleFilters {
+  showIntentionalDuplicates: boolean
+}
 
-export async function getDuplicatePeopleReport(): Promise<
-  Result<DuplicatePeopleReportRow[]>
-> {
+export async function getDuplicatePeopleReport(
+  params: DuplicatePeopleFilters
+): Promise<Result<DuplicatePeopleReportRow[]>> {
   return client
-    .get<JsonOf<DuplicatePeopleReportRow[]>>('/reports/duplicate-people')
+    .get<JsonOf<DuplicatePeopleReportRow[]>>('/reports/duplicate-people', {
+      params
+    })
     .then((res) =>
       Success.of(
         res.data.map((row) => ({

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3040,6 +3040,9 @@ export const fi = {
         'message_content.author_id': 'Kirjoitettuja viesti- sisältöjä',
         'message_recipients.recipient_id': 'Saatuja viestejä',
         'message_draft.account_id': 'Viesti- luonnoksia'
+      },
+      filters: {
+        showIntentionalDuplicates: 'Näytä myös tarkoituksellisesti monistetut'
       }
     },
     familyConflicts: {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
@@ -26,7 +26,7 @@ class DuplicatePeopleReportController(private val accessControl: AccessControl) 
         user: AuthenticatedUser,
         clock: EvakaClock,
         @RequestParam("showIntentionalDuplicates", required = false)
-        showIntentionalDuplicates: Boolean = false,
+        showIntentionalDuplicates: Boolean?,
     ): List<DuplicatePeopleReportRow> {
         return db.connect { dbc ->
                 dbc.read {
@@ -37,7 +37,7 @@ class DuplicatePeopleReportController(private val accessControl: AccessControl) 
                         Action.Global.READ_DUPLICATE_PEOPLE_REPORT
                     )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
-                    it.getDuplicatePeople(showIntentionalDuplicates)
+                    it.getDuplicatePeople(showIntentionalDuplicates ?: false)
                 }
             }
             .also { Audit.DuplicatePeopleReportRead.log(meta = mapOf("count" to it.size)) }


### PR DESCRIPTION
Adds a conditional filter for the duplicate people report that can be used to ignore intentionally duplicated persons:
- visibility of filter is conditional on employee side feature flag `duplicatePerson`
  - if feature is not activated, report functions as before and no filters are visible (all persons evaluated for duplicated data)
  - if feature is activated, a filter for showing intentionally duplicated persons is visible and is set to false as default
