### PR TITLE
Show a message when a child is backup placed in the same unit

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
@@ -40,7 +40,7 @@ let unitSupervisor: EmployeeDetail
 
 const mockedToday = LocalDate.of(2023, 2, 15)
 const placementStartDate = mockedToday.subWeeks(4)
-const placementEndDate = mockedToday.addWeeks(4)
+const placementEndDate = mockedToday.addWeeks(8)
 const backupCareStartDate = mockedToday.startOfWeek().addWeeks(2)
 const backupCareEndDate = backupCareStartDate.addDays(8)
 const groupId: UUID = uuidv4()
@@ -130,6 +130,40 @@ describe('Unit group calendar', () => {
     await waitUntilEqual(
       () => childReservations.childRowCount(child1Fixture.id),
       1
+    )
+  })
+
+  test('Child in backup care part of the week is shown', async () => {
+    const groupId3 = uuidv4()
+    const backupCareSameUnitStartDate = backupCareStartDate.addWeeks(2)
+    const backupCareSameUnitEndDate = backupCareSameUnitStartDate.addDays(3)
+    await Fixture.daycareGroup()
+      .with({
+        id: groupId3,
+        daycareId: daycare.id,
+        name: 'Varasijoitusryhmä samassa'
+      })
+      .save()
+    await Fixture.backupCare()
+      .with({
+        id: uuidv4(),
+        childId: child1Fixture.id,
+        unitId: daycare.id,
+        groupId: groupId3,
+        period: {
+          start: backupCareSameUnitStartDate.formatIso(),
+          end: backupCareSameUnitEndDate.formatIso()
+        }
+      })
+      .save()
+
+    const childReservations = (await loadUnitAttendancesSection())
+      .childReservations
+    await calendarPage.selectMode('week')
+    await calendarPage.changeWeekToDate(backupCareSameUnitStartDate)
+    await waitUntilEqual(
+      () => childReservations.childInOtherUnitCount(child1Fixture.id),
+      4
     )
   })
 

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -108,14 +108,18 @@ export default React.memo(function ChildDay({
   if (day.isHoliday && !dailyData.reservation && !dailyData.attendance)
     return null
 
-  if (dailyData.inOtherUnit) {
+  if (dailyData.inOtherUnit || dailyData.isInBackupGroup) {
     return (
       <FixedSpaceRow
         alignItems="center"
         justifyContent="center"
         data-qa="in-other-unit"
       >
-        <Light>{i18n.unit.attendanceReservations.inOtherUnit}</Light>
+        <Light>
+          {dailyData.isInBackupGroup
+            ? i18n.unit.attendanceReservations.inOtherGroup
+            : i18n.unit.attendanceReservations.inOtherUnit}
+        </Light>
       </FixedSpaceRow>
     )
   }

--- a/frontend/src/lib-common/api-types/reservations.ts
+++ b/frontend/src/lib-common/api-types/reservations.ts
@@ -43,6 +43,7 @@ export interface ChildRecordOfDay {
   absence: { type: AbsenceType } | null
   dailyServiceTimes: DailyServiceTimesValue | null
   inOtherUnit: boolean
+  isInBackupGroup: boolean
 }
 
 interface Group {

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2051,7 +2051,8 @@ export const fi = {
       },
       affectsOccupancy: 'Lasketaan käyttöasteeseen',
       doesNotAffectOccupancy: 'Ei lasketa käyttöasteeseen',
-      inOtherUnit: 'Muussa yksikössä'
+      inOtherUnit: 'Muussa yksikössä',
+      inOtherGroup: 'Muussa ryhmässä'
     },
     staffAttendance: {
       startTime: 'tulo',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/AttendanceReservationsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/AttendanceReservationsControllerIntegrationTest.kt
@@ -310,7 +310,8 @@ class AttendanceReservationsControllerIntegrationTest :
                                         ),
                                     absence = null,
                                     dailyServiceTimes = null,
-                                    inOtherUnit = false
+                                    inOtherUnit = false,
+                                    isInBackupGroup = false
                                 ),
                             tue to
                                 UnitAttendanceReservations.ChildRecordOfDay(
@@ -321,7 +322,8 @@ class AttendanceReservationsControllerIntegrationTest :
                                             AbsenceType.OTHER_ABSENCE
                                         ),
                                     dailyServiceTimes = null,
-                                    inOtherUnit = false
+                                    inOtherUnit = false,
+                                    isInBackupGroup = false
                                 ),
                             wed to
                                 UnitAttendanceReservations.ChildRecordOfDay(
@@ -329,7 +331,8 @@ class AttendanceReservationsControllerIntegrationTest :
                                     attendance = null,
                                     absence = null,
                                     dailyServiceTimes = null,
-                                    inOtherUnit = false
+                                    inOtherUnit = false,
+                                    isInBackupGroup = false
                                 )
                         )
                     )
@@ -349,9 +352,23 @@ class AttendanceReservationsControllerIntegrationTest :
                                     attendance = null,
                                     absence = null,
                                     dailyServiceTimes = null,
-                                    inOtherUnit = false
+                                    inOtherUnit = false,
+                                    isInBackupGroup = false
                                 ),
-                            // Backup in group 2 => thu is missing
+                            // Backup in group 2
+                            thu to
+                                UnitAttendanceReservations.ChildRecordOfDay(
+                                    reservation =
+                                        UnitAttendanceReservations.ReservationTimes(
+                                            "09:00",
+                                            "15:00"
+                                        ),
+                                    attendance = null,
+                                    absence = null,
+                                    dailyServiceTimes = null,
+                                    inOtherUnit = false,
+                                    isInBackupGroup = true
+                                ),
                             // Backup in another unit
                             fri to
                                 UnitAttendanceReservations.ChildRecordOfDay(
@@ -359,7 +376,8 @@ class AttendanceReservationsControllerIntegrationTest :
                                     attendance = null,
                                     absence = null,
                                     dailyServiceTimes = null,
-                                    inOtherUnit = true
+                                    inOtherUnit = true,
+                                    isInBackupGroup = false
                                 )
                         )
                     )
@@ -400,7 +418,8 @@ class AttendanceReservationsControllerIntegrationTest :
                                     attendance = null,
                                     absence = null,
                                     dailyServiceTimes = null,
-                                    inOtherUnit = false
+                                    inOtherUnit = false,
+                                    isInBackupGroup = true
                                 )
                         )
                     )
@@ -425,7 +444,8 @@ class AttendanceReservationsControllerIntegrationTest :
                                             monFri.asDateRange(),
                                             TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0))
                                         ),
-                                    inOtherUnit = false
+                                    inOtherUnit = false,
+                                    isInBackupGroup = false
                                 )
                         )
                     )
@@ -549,7 +569,8 @@ class AttendanceReservationsControllerIntegrationTest :
                                             ),
                                         absence = null,
                                         dailyServiceTimes = null,
-                                        inOtherUnit = false
+                                        inOtherUnit = false,
+                                        isInBackupGroup = false
                                     ),
                                 tue to
                                     UnitAttendanceReservations.ChildRecordOfDay(
@@ -565,7 +586,8 @@ class AttendanceReservationsControllerIntegrationTest :
                                             ),
                                         absence = null,
                                         dailyServiceTimes = null,
-                                        inOtherUnit = false
+                                        inOtherUnit = false,
+                                        isInBackupGroup = false
                                     ),
                                 wed to
                                     UnitAttendanceReservations.ChildRecordOfDay(
@@ -577,7 +599,8 @@ class AttendanceReservationsControllerIntegrationTest :
                                         attendance = null,
                                         absence = null,
                                         dailyServiceTimes = null,
-                                        inOtherUnit = false
+                                        inOtherUnit = false,
+                                        isInBackupGroup = false
                                     )
                             ),
 
@@ -598,7 +621,8 @@ class AttendanceReservationsControllerIntegrationTest :
                                             ),
                                         absence = null,
                                         dailyServiceTimes = null,
-                                        inOtherUnit = false
+                                        inOtherUnit = false,
+                                        isInBackupGroup = false
                                     )
                             )
                     )
@@ -622,7 +646,8 @@ class AttendanceReservationsControllerIntegrationTest :
                         attendance = null,
                         absence = null,
                         dailyServiceTimes = null,
-                        inOtherUnit = false
+                        inOtherUnit = false,
+                        isInBackupGroup = false
                     )
             }
             .toMap()


### PR DESCRIPTION
#### Summary
Before this change, whenever a child was backup placed in another group in the same unit as their regular group, the week calendar would show a blank cell on that day. Now we show a message that the child is in another group instead.