### PR TITLE
Use daily service time as default reservation time on report

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
@@ -127,11 +127,14 @@ private fun Database.Read.getAttendanceReservationReport(
         reservation_times AS (
             SELECT 
                 dates.date,
-                child_id,
-                COALESCE(start_time, (daily_service_time_for_date(dates.date, child_id)).start) AS start_time,
-                COALESCE(end_time, (daily_service_time_for_date(dates.date, child_id)).end) AS end_time
+                pl.child_id,
+                COALESCE(start_time, (daily_service_time_for_date(dates.date, pl.child_id)).start) AS start_time,
+                COALESCE(end_time, (daily_service_time_for_date(dates.date, pl.child_id)).end) AS end_time
             FROM dates
-                LEFT JOIN attendance_reservation ar ON ar.date = dates.date
+                CROSS JOIN person p 
+                JOIN placement pl ON pl.child_id = p.id
+                LEFT JOIN attendance_reservation ar ON ar.date = dates.date AND ar.child_id = p.id
+                WHERE pl.unit_id = :unitId
         ),
         reservations AS (
           SELECT

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
@@ -132,7 +132,7 @@ private fun Database.Read.getAttendanceReservationReport(
                 COALESCE(end_time, (daily_service_time_for_date(dates.date, pl.child_id)).end) AS end_time
             FROM dates
                 CROSS JOIN person p 
-                JOIN placement pl ON pl.child_id = p.id
+                JOIN realized_placement_one(dates.date) pl ON pl.child_id = p.id
                 LEFT JOIN attendance_reservation ar ON ar.date = dates.date AND ar.child_id = p.id
                 WHERE pl.unit_id = :unitId
         ),


### PR DESCRIPTION
Use daily service time as default reservation time on attendance reservation report

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

