### PR TITLE
Improve manual duplication report

### DIFF
--- a/frontend/src/employee-frontend/api/reports.ts
+++ b/frontend/src/employee-frontend/api/reports.ts
@@ -21,6 +21,7 @@ import {
   FamilyContactReportRow,
   InvoiceReport,
   ManualDuplicationReportRow,
+  ManualDuplicationReportViewMode,
   MissingHeadOfFamilyReportRow,
   MissingServiceNeedReportRow,
   OccupancyGroupReportResultRow,
@@ -649,17 +650,15 @@ export async function getAssistanceReservationReportByChild(
     .catch((e) => Failure.fromError(e))
 }
 
-export type ManualDuplicationViewOption = 'NONDUPLICATED' | 'DUPLICATED'
-
 export interface ManualDuplicationReportFilters {
-  viewOption: ManualDuplicationViewOption
+  viewMode: ManualDuplicationReportViewMode
 }
 
 export async function getManualDuplicationReport(
   filters: ManualDuplicationReportFilters
 ): Promise<Result<ManualDuplicationReportRow[]>> {
   const params = {
-    toggleDuplicatedCaseVisibility: filters.viewOption === 'DUPLICATED'
+    viewMode: filters.viewMode
   }
   return client
     .get<JsonOf<ManualDuplicationReportRow[]>>('/reports/manual-duplication', {

--- a/frontend/src/employee-frontend/api/reports.ts
+++ b/frontend/src/employee-frontend/api/reports.ts
@@ -649,11 +649,22 @@ export async function getAssistanceReservationReportByChild(
     .catch((e) => Failure.fromError(e))
 }
 
-export async function getManualDuplicationReport(): Promise<
-  Result<ManualDuplicationReportRow[]>
-> {
+export type ManualDuplicationViewOption = 'NONDUPLICATED' | 'DUPLICATED'
+
+export interface ManualDuplicationReportFilters {
+  viewOption: ManualDuplicationViewOption
+}
+
+export async function getManualDuplicationReport(
+  filters: ManualDuplicationReportFilters
+): Promise<Result<ManualDuplicationReportRow[]>> {
+  const params = {
+    toggleDuplicatedCaseVisibility: filters.viewOption === 'DUPLICATED'
+  }
   return client
-    .get<JsonOf<ManualDuplicationReportRow[]>>('/reports/manual-duplication')
+    .get<JsonOf<ManualDuplicationReportRow[]>>('/reports/manual-duplication', {
+      params
+    })
     .then(({ data }) =>
       Success.of(
         data.map((row) => ({

--- a/frontend/src/employee-frontend/components/reports/ManualDuplicationReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/ManualDuplicationReport.tsx
@@ -9,7 +9,10 @@ import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { SortDirection } from 'lib-common/generated/api-types/invoicing'
-import { ManualDuplicationReportRow } from 'lib-common/generated/api-types/reports'
+import {
+  ManualDuplicationReportRow,
+  ManualDuplicationReportViewMode
+} from 'lib-common/generated/api-types/reports'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Title from 'lib-components/atoms/Title'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
@@ -27,8 +30,7 @@ import { Gap } from 'lib-components/white-space'
 
 import {
   getManualDuplicationReport,
-  ManualDuplicationReportFilters,
-  ManualDuplicationViewOption
+  ManualDuplicationReportFilters
 } from '../../api/reports'
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
@@ -46,7 +48,7 @@ export default React.memo(function ManualDuplicationReport() {
   const { i18n } = useTranslation()
 
   const [filters, setFilters] = useState<ManualDuplicationReportFilters>({
-    viewOption: 'NONDUPLICATED'
+    viewMode: 'NONDUPLICATED'
   })
   const [reportResult] = useApiState(
     () => getManualDuplicationReport(filters),
@@ -80,7 +82,7 @@ export default React.memo(function ManualDuplicationReport() {
     [reportResult, sortColumns, sortDirection]
   )
 
-  const viewOptions: ManualDuplicationViewOption[] = [
+  const viewModes: ManualDuplicationReportViewMode[] = [
     'NONDUPLICATED',
     'DUPLICATED'
   ]
@@ -98,11 +100,11 @@ export default React.memo(function ManualDuplicationReport() {
           <Combobox
             fullWidth={true}
             clearable={false}
-            items={viewOptions}
-            selectedItem={filters.viewOption}
+            items={viewModes}
+            selectedItem={filters.viewMode}
             onChange={(selectionValue) => {
               if (selectionValue !== null) {
-                setFilters({ ...filters, viewOption: selectionValue })
+                setFilters({ ...filters, viewMode: selectionValue })
               }
             }}
             getItemLabel={(selectionValue) =>

--- a/frontend/src/employee-frontend/components/reports/ManualDuplicationReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/ManualDuplicationReport.tsx
@@ -13,6 +13,7 @@ import { ManualDuplicationReportRow } from 'lib-common/generated/api-types/repor
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Title from 'lib-components/atoms/Title'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
+import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import {
   Th,
@@ -22,12 +23,17 @@ import {
   Tbody,
   SortableTh
 } from 'lib-components/layout/Table'
+import { Gap } from 'lib-components/white-space'
 
-import { getManualDuplicationReport } from '../../api/reports'
+import {
+  getManualDuplicationReport,
+  ManualDuplicationReportFilters,
+  ManualDuplicationViewOption
+} from '../../api/reports'
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
 
-import { TableScrollable } from './common'
+import { FilterLabel, FilterRow, TableScrollable } from './common'
 
 type ReportColumnKey = keyof ManualDuplicationReportRow
 
@@ -39,7 +45,13 @@ const WrappableTd = styled(Td)`
 export default React.memo(function ManualDuplicationReport() {
   const { i18n } = useTranslation()
 
-  const [reportResult] = useApiState(getManualDuplicationReport, [])
+  const [filters, setFilters] = useState<ManualDuplicationReportFilters>({
+    viewOption: 'NONDUPLICATED'
+  })
+  const [reportResult] = useApiState(
+    () => getManualDuplicationReport(filters),
+    [filters]
+  )
 
   const [sortColumns, setSortColumns] = useState<ReportColumnKey[]>([
     'connectedDaycareName',
@@ -68,11 +80,39 @@ export default React.memo(function ManualDuplicationReport() {
     [reportResult, sortColumns, sortDirection]
   )
 
+  const viewOptions: ManualDuplicationViewOption[] = [
+    'NONDUPLICATED',
+    'DUPLICATED'
+  ]
+
   return (
     <Container>
       <ReturnButton label={i18n.common.goBack} />
       <ContentArea opaque>
         <Title size={1}>{i18n.reports.manualDuplication.title}</Title>
+
+        <FilterRow>
+          <FilterLabel>
+            {i18n.reports.manualDuplication.filters.viewOption.label}
+          </FilterLabel>
+          <Combobox
+            fullWidth={true}
+            clearable={false}
+            items={viewOptions}
+            selectedItem={filters.viewOption}
+            onChange={(selectionValue) => {
+              if (selectionValue !== null) {
+                setFilters({ ...filters, viewOption: selectionValue })
+              }
+            }}
+            getItemLabel={(selectionValue) =>
+              i18n.reports.manualDuplication.filters.viewOption.items[
+                selectionValue
+              ]
+            }
+          />
+        </FilterRow>
+        <Gap />
         {renderResult(sortedReportResult, (reportRows) => (
           <TableScrollable>
             <Thead>

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -301,6 +301,13 @@ export interface ManualDuplicationReportRow {
 }
 
 /**
+* Generated from fi.espoo.evaka.reports.ManualDuplicationReportViewMode
+*/
+export type ManualDuplicationReportViewMode =
+  | 'DUPLICATED'
+  | 'NONDUPLICATED'
+
+/**
 * Generated from fi.espoo.evaka.reports.MissingHeadOfFamilyReportRow
 */
 export interface MissingHeadOfFamilyReportRow {

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3237,7 +3237,16 @@ export const fi = {
       connectedSno: 'Täydentävän palveluntarve',
       connectedDuration: 'Täydentävän kesto',
       preschoolDaycare: 'Esiopetuksen yksikkö',
-      preschooldDuration: 'Esiopetuksen kesto'
+      preschooldDuration: 'Esiopetuksen kesto',
+      filters: {
+        viewOption: {
+          label: 'Valitse näkymä:',
+          items: {
+            DUPLICATED: 'Näytä vain jo monistetut tapaukset',
+            NONDUPLICATED: 'Näytä vain käsittelemättömät tapaukset'
+          }
+        }
+      }
     },
     placementCount: {
       title: 'Sijoitusten määrä',


### PR DESCRIPTION
Adds a new filter to the manual duplication report for selecting one of two view modes:
- show only cases where the person has already been duplicated
- show only cases without a duplicated person
