### PR TITLE
Fix nullability in query

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -313,8 +313,8 @@ RETURNING id
 
 fun Database.Read.getMessageAuthor(content: MessageContentId): MessageAccountId? =
     createQuery<Any> { sql("SELECT author_id FROM message_content WHERE id = ${bind(content)}") }
-        .mapTo<MessageAccountId?>()
-        .one()
+        .mapTo<MessageAccountId>()
+        .singleOrNull()
 
 fun Database.Transaction.insertThreadsWithMessages(
     count: Int,


### PR DESCRIPTION


#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

mapTo nullable + one() expects *one row* where the value is nullable.
mapTo non-nullable + singleOrNull() expects 0-1 rows where the value is not nullable.

The actual SQL query here uses the latter semantics