### PR TITLE
Use correct query to delete unclaimed async jobs

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -13,6 +13,8 @@ import fi.espoo.evaka.shared.DecisionId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.async.AsyncJobType
+import fi.espoo.evaka.shared.async.removeUnclaimedJobs
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
 import java.time.Duration
@@ -46,10 +48,9 @@ class PendingDecisionEmailService(
     fun scheduleSendPendingDecisionsEmails(db: Database.Connection, clock: EvakaClock): Int {
         val jobCount =
             db.transaction { tx ->
-                tx.createUpdate(
-                        "DELETE FROM async_job WHERE type = 'SEND_PENDING_DECISION_EMAIL' AND claimed_by IS NULL"
-                    )
-                    .execute()
+                tx.removeUnclaimedJobs(
+                    setOf(AsyncJobType(AsyncJob.SendPendingDecisionEmail::class))
+                )
 
                 val pendingGuardianDecisions =
                     tx.createQuery(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The old queries didn't use an index (because we have no index on claimed_by = NULL) and had to search *all* async jobs. The correct way is to use the removeUnclaimedJobs query, which also has a "completed_at IS NULL" condition that can use a suitable index.

One of the queries also removed completed jobs, which is unnecessary since we have a separate cleanup mechanism that handles this.