### PR TITLE
Use Temurin Java 17 Ubuntu 22.04 base image

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-FROM openjdk:17-slim-buster as base
+FROM eclipse-temurin:17-jammy as base
 
 LABEL maintainer="https://github.com/espoon-voltti/evaka"
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Old evaka-srv image: 362.93 MB
New evaka-srv image: 374.66 MB