### PR TITLE
Child application summaries for unit supervisor

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -326,7 +326,14 @@ class ApplicationControllerV2(
                         Action.Child.READ_APPLICATION,
                         childId
                     )
-                    it.fetchApplicationSummariesForChild(childId)
+                    val filter =
+                        accessControl.requireAuthorizationFilter(
+                            it,
+                            user,
+                            clock,
+                            Action.Application.READ
+                        )
+                    it.fetchApplicationSummariesForChild(childId, filter)
                 }
             }
             .also { Audit.ApplicationRead.log(targetId = childId) }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.security.actionrule
 
+import fi.espoo.evaka.application.ApplicationType
 import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AssistanceActionId
@@ -202,7 +203,7 @@ WHERE employee_id = ${bind(ctx.user.id)}
             }
         )
 
-    fun inPlacementPlanUnitOfApplication() =
+    fun inPlacementPlanUnitOfApplication(onlyAllowDeletedForTypes: Set<ApplicationType>? = null) =
         rule<ApplicationId> { user, _ ->
             sql(
                 """
@@ -212,6 +213,7 @@ JOIN placement_plan pp ON pp.application_id = av.id
 JOIN daycare_acl acl ON acl.daycare_id = pp.unit_id
 JOIN daycare ON acl.daycare_id = daycare.id
 WHERE employee_id = ${bind(user.id)} AND av.status = ANY ('{WAITING_CONFIRMATION,WAITING_MAILING,WAITING_UNIT_CONFIRMATION,ACTIVE}'::application_status_type[])
+${if (onlyAllowDeletedForTypes != null) "AND (av.type = ANY(${bind(onlyAllowDeletedForTypes)}) OR NOT pp.deleted)" else ""}
             """
                     .trimIndent()
             )


### PR DESCRIPTION
#### Summary

Currently after citizen accepts (or rejects) decision, application disappears from unit supervisor UI. In Tampere unit supervisor should still see preschool application, even after the decision has been made. With this change and following override we are able to get correct list for unit supervisors at child page:

```
Action.Application.READ -> {
    @Suppress("UNCHECKED_CAST")
    sequenceOf(
        HasUnitRole(UserRole.UNIT_SUPERVISOR).inPlacementPlanUnitOfApplication(onlyAllowDeletedForTypes = setOf(ApplicationType.PRESCHOOL)) as ScopedActionRule<in T>
    )
}

Action.Child.READ_APPLICATION -> {
    @Suppress("UNCHECKED_CAST")
    action.defaultRules.asSequence() + sequenceOf(
        HasUnitRole(UserRole.UNIT_SUPERVISOR).inPlacementUnitOfChild() as ScopedActionRule<in T>
    )
}
```

