### PR TITLE
Outdated income statement notification email

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotificationsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotificationsIntegrationTest.kt
@@ -129,6 +129,22 @@ class OutdatedIncomeNotificationsIntegrationTest : FullApplicationTest(resetDbBe
     }
 
     @Test
+    fun `if expiration date is in the past no notification is sent`() {
+        db.transaction {
+            it.insertTestIncome(
+                DevIncome(
+                    personId = guardianId,
+                    updatedBy = employeeEvakaUserId,
+                    validFrom = clock.today().minusMonths(1),
+                    validTo = clock.today().minusDays(1)
+                )
+            )
+        }
+
+        assertEquals(0, getEmails().size)
+    }
+
+    @Test
     fun `expiring income is not notified if there is a new income statement`() {
         val incomeExpirationDate = clock.today().plusDays(13)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotificationsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotificationsIntegrationTest.kt
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.invoicing.service
+
+import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.emailclient.MockEmail
+import fi.espoo.evaka.emailclient.MockEmailClient
+import fi.espoo.evaka.incomestatement.IncomeStatementType
+import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.EvakaUserId
+import fi.espoo.evaka.shared.IncomeStatementId
+import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevChild
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.DevGuardian
+import fi.espoo.evaka.shared.dev.DevIncome
+import fi.espoo.evaka.shared.dev.DevIncomeStatement
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPlacement
+import fi.espoo.evaka.shared.dev.insertIncomeStatement
+import fi.espoo.evaka.shared.dev.insertTestCareArea
+import fi.espoo.evaka.shared.dev.insertTestChild
+import fi.espoo.evaka.shared.dev.insertTestDaycare
+import fi.espoo.evaka.shared.dev.insertTestEmployee
+import fi.espoo.evaka.shared.dev.insertTestGuardian
+import fi.espoo.evaka.shared.dev.insertTestIncome
+import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.shared.job.ScheduledJobs
+import fi.espoo.evaka.shared.security.upsertCitizenUser
+import fi.espoo.evaka.shared.security.upsertEmployeeUser
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class OutdatedIncomeNotificationsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
+    @Autowired private lateinit var scheduledJobs: ScheduledJobs
+    @Autowired private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
+
+    private val clock =
+        MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2022, 10, 23), LocalTime.of(21, 0)))
+
+    private val guardianEmail = "guardian@example.com"
+    private lateinit var guardianId: PersonId
+    private lateinit var childId: ChildId
+    private lateinit var employeeId: EmployeeId
+    private lateinit var employeeEvakaUserId: EvakaUserId
+
+    @BeforeEach
+    fun beforeEach() {
+        db.transaction { tx ->
+            guardianId = tx.insertTestPerson(DevPerson(email = guardianEmail))
+            tx.upsertCitizenUser(guardianId)
+            val areaId = tx.insertTestCareArea(DevCareArea())
+            val daycareId = tx.insertTestDaycare(DevDaycare(areaId = areaId))
+            childId = tx.insertTestPerson(DevPerson()).also { tx.insertTestChild(DevChild(it)) }
+            tx.insertTestGuardian(DevGuardian(guardianId = guardianId, childId = childId))
+            tx.insertTestPlacement(
+                DevPlacement(
+                    childId = childId,
+                    unitId = daycareId,
+                    startDate = clock.today().minusMonths(2),
+                    endDate = clock.today().plusMonths(2)
+                )
+            )
+            employeeId = tx.insertTestEmployee(DevEmployee(roles = setOf(UserRole.SERVICE_WORKER)))
+            tx.upsertEmployeeUser(employeeId)
+            employeeEvakaUserId = EvakaUserId(employeeId.raw)
+        }
+    }
+
+    @Test
+    fun `only last income is considered when finding outdated incomes`() {
+        db.transaction {
+            // This income is expiring, but not notified because there is another income starting
+            // afterwards
+            it.insertTestIncome(
+                DevIncome(
+                    personId = guardianId,
+                    updatedBy = employeeEvakaUserId,
+                    validFrom = clock.today().minusMonths(1),
+                    validTo = clock.today()
+                )
+            )
+
+            it.insertTestIncome(
+                DevIncome(
+                    personId = guardianId,
+                    updatedBy = employeeEvakaUserId,
+                    validFrom = clock.today().plusDays(1),
+                    validTo = clock.today().plusMonths(6)
+                )
+            )
+        }
+
+        assertEquals(0, getEmails().size)
+    }
+
+    @Test
+    fun `expiring income is notified 2 weeks beforehand`() {
+        db.transaction {
+            it.insertTestIncome(
+                DevIncome(
+                    personId = guardianId,
+                    updatedBy = employeeEvakaUserId,
+                    validFrom = clock.today().minusMonths(1),
+                    validTo = clock.today().plusDays(13)
+                )
+            )
+        }
+
+        assertEquals(1, getEmails().size)
+        assertEquals(1, getIncomeNotifications(guardianId).size)
+    }
+
+    @Test
+    fun `expiring income is not notified if there is a new income statement`() {
+        val incomeExpirationDate = clock.today().plusDays(13)
+
+        db.transaction {
+            it.insertTestIncome(
+                DevIncome(
+                    personId = guardianId,
+                    updatedBy = employeeEvakaUserId,
+                    validFrom = incomeExpirationDate.minusMonths(1),
+                    validTo = incomeExpirationDate
+                )
+            )
+
+            it.insertIncomeStatement(
+                DevIncomeStatement(
+                    id = IncomeStatementId(UUID.randomUUID()),
+                    personId = guardianId,
+                    startDate = incomeExpirationDate.plusDays(1),
+                    type = IncomeStatementType.INCOME,
+                    grossEstimatedMonthlyIncome = 42
+                )
+            )
+        }
+
+        assertEquals(0, getEmails().size)
+    }
+
+    @Test
+    fun `If there is no placement no notification is sent`() {
+        db.transaction {
+            it.insertTestIncome(
+                DevIncome(
+                    personId = guardianId,
+                    updatedBy = employeeEvakaUserId,
+                    validFrom = clock.today().minusMonths(1),
+                    validTo = clock.today().plusDays(13)
+                )
+            )
+
+            it.createUpdate("DELETE FROM placement WHERE child_id = :personId")
+                .bind("personId", childId)
+                .execute()
+        }
+
+        assertEquals(0, getEmails().size)
+    }
+
+    @Test
+    fun `if first notification was already sent and it is not yet time for the second notification a new first notification is not sent`() {
+        db.transaction {
+            it.insertTestIncome(
+                DevIncome(
+                    personId = guardianId,
+                    updatedBy = employeeEvakaUserId,
+                    validFrom = clock.today().minusMonths(1),
+                    validTo = clock.today().plusDays(13)
+                )
+            )
+        }
+
+        val mails = getEmails()
+        assertEquals(1, mails.size)
+        assertTrue(
+            mails
+                .get(0)
+                .textBody
+                .contains(
+                    "Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain"
+                )
+        )
+
+        assertEquals(0, getEmails().size)
+    }
+
+    @Test
+    fun `second notification is only sent after first notification`() {
+        db.transaction {
+            it.insertTestIncome(
+                DevIncome(
+                    personId = guardianId,
+                    updatedBy = employeeEvakaUserId,
+                    validFrom = clock.today().minusMonths(1),
+                    validTo = clock.today().plusDays(6)
+                )
+            )
+        }
+
+        val mails = getEmails()
+        assertEquals(1, mails.size)
+        assertTrue(
+            mails
+                .get(0)
+                .textBody
+                .contains(
+                    "Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain"
+                )
+        )
+
+        val secondMails = getEmails()
+        assertEquals(1, secondMails.size)
+        assertTrue(
+            secondMails.get(0).textBody.contains("Ette ole vielä toimittaneet uusia tulotietoja")
+        )
+    }
+
+    @Test
+    fun `Final notification is sent after income expires`() {
+        db.transaction {
+            it.insertTestIncome(
+                DevIncome(
+                    personId = guardianId,
+                    updatedBy = employeeEvakaUserId,
+                    validFrom = clock.today().minusMonths(1),
+                    validTo = clock.today()
+                )
+            )
+
+            it.createIncomeNotification(
+                receiverId = guardianId,
+                IncomeNotificationType.INITIAL_EMAIL
+            )
+            it.createIncomeNotification(
+                receiverId = guardianId,
+                IncomeNotificationType.REMINDER_EMAIL
+            )
+        }
+
+        val mails = getEmails()
+        assertEquals(1, mails.size)
+        assertTrue(
+            mails
+                .get(0)
+                .textBody
+                .contains("Seuraava asiakasmaksunne määräytyy korkeimman maksuluokan mukaan")
+        )
+
+        assertEquals(0, getEmails().size)
+    }
+
+    private fun getEmails(): List<MockEmail> {
+        scheduledJobs.sendOutdatedIncomeNotifications(db, clock)
+        asyncJobRunner.runPendingJobsSync(clock)
+        val emails = MockEmailClient.emails
+        MockEmailClient.clear()
+        return emails
+    }
+
+    private fun getIncomeNotifications(receiverId: PersonId): List<IncomeNotification> =
+        db.read { it.getIncomeNotifications(receiverId) }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -813,9 +813,9 @@ There are missing attendance reservations for the week starting $start. Please m
                 
                 Inkomstuppgifterna som ligger till grund för klientavgiften för småbarnspedagogik eller servicesedelns egenandel granskas årligen.
                 
-                Vi ber att du skickar en inkomstutredning via eVaka inom 14 dagar från den här anmälan.I eVaka kan du också ge ditt samtycke till den högsta avgiften eller till användning av inkomstregistret.
+                Vi ber att du skickar en inkomstutredning via eVaka inom 14 dagar från den här anmälan. I eVaka kan du också ge ditt samtycke till den högsta avgiften eller till användning av inkomstregistret.
                 
-                Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grundval av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.
+                Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grund av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.
                 
                 Du kan vid behov också skicka inkomstutredningen per post till adressen Esbo stad/sektorn för fostran och lärande, ekonomienheten/klientavgifter för småbarnspedagogik PB 30 02070 Esbo stad
                 
@@ -866,9 +866,9 @@ There are missing attendance reservations for the week starting $start. Please m
                                 
                 <p>Inkomstuppgifterna som ligger till grund för klientavgiften för småbarnspedagogik eller servicesedelns egenandel granskas årligen.</p>
                                 
-                <p>Vi ber att du skickar en inkomstutredning via eVaka inom 14 dagar från den här anmälan.I eVaka kan du också ge ditt samtycke till den högsta avgiften eller till användning av inkomstregistret.</p>
+                <p>Vi ber att du skickar en inkomstutredning via eVaka inom 14 dagar från den här anmälan. I eVaka kan du också ge ditt samtycke till den högsta avgiften eller till användning av inkomstregistret.</p>
                                 
-                <p>Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grundval av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.</p>
+                <p>Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grund av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.</p>
                                 
                 <p>Du kan vid behov också skicka inkomstutredningen per post till adressen Esbo stad/sektorn för fostran och lärande, ekonomienheten/klientavgifter för småbarnspedagogik PB 30 02070 Esbo stad</p>
                                 
@@ -929,7 +929,7 @@ There are missing attendance reservations for the week starting $start. Please m
                 
                 Vi ber att du skickar en inkomstutredning via eVaka inom sju dagar från denna anmälan. I eVaka kan du också ge ditt samtycke till den högsta avgiften eller till användning av inkomstregistret.
                 
-                Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grundval av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.
+                Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grund av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.
                 
                 Du kan vid behov också skicka inkomstutredningen per post till adressen: Esbo stad/sektorn för fostran och lärande, ekonomienheten/klientavgifter för småbarnspedagogik PB 30 02070 Esbo stad
                 
@@ -980,7 +980,7 @@ There are missing attendance reservations for the week starting $start. Please m
                                 
                 <p>Vi ber att du skickar en inkomstutredning via eVaka inom sju dagar från denna anmälan. I eVaka kan du också ge ditt samtycke till den högsta avgiften eller till användning av inkomstregistret.</p>
                                 
-                <p>Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grundval av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.</p>
+                <p>Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grund av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.</p>
                                 
                 <p>Du kan vid behov också skicka inkomstutredningen per post till adressen: Esbo stad/sektorn för fostran och lärande, ekonomienheten/klientavgifter för småbarnspedagogik PB 30 02070 Esbo stad</p>
                                 

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.emailclient
 
 import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.daycare.domain.Language
+import fi.espoo.evaka.invoicing.service.IncomeNotificationType
 import fi.espoo.evaka.messaging.MessageThreadStub
 import fi.espoo.evaka.messaging.MessageType
 import fi.espoo.evaka.shared.ChildId
@@ -763,6 +764,191 @@ There are missing attendance reservations for the week starting $start. Please m
                 <hr>
                 
                 <p>Du har fått ett nytt pedagogiskt dokument i eVaka. Läs dokumentet här: <a href="$documentsUrl">$documentsUrl</a></p>
+                <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>          
+                
+                <hr>
+                
+                <p>You have received a new eVaka pedagogical document. Read the document here: <a href="$documentsUrl">$documentsUrl</a></p>
+                <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>       
+        """
+                    .trimIndent()
+        )
+    }
+
+    override fun outdatedIncomeNotification(
+        notificationType: IncomeNotificationType,
+        language: Language
+    ): EmailContent {
+        return when (notificationType) {
+            IncomeNotificationType.INITIAL_EMAIL -> outdatedIncomeNotificationInitial(language)
+            IncomeNotificationType.REMINDER_EMAIL -> outdatedIncomeNotificationReminder(language)
+            IncomeNotificationType.EXPIRED_EMAIL -> outdatedIncomeNotificationExpired(language)
+        }
+    }
+
+    fun outdatedIncomeNotificationInitial(language: Language): EmailContent {
+        val documentsUrl = "${baseUrl(language)}/income"
+        return EmailContent(
+            subject = "Tulotietojen tarkastus- kehotus",
+            text =
+                """
+                Hyvä asiakkaamme
+                
+                Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain.
+                
+                Pyydämme toimittamaan tuloselvityksen eVakassa 14 päivän kuluessa tästä ilmoituksesta.
+                
+                eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.
+                
+                Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan.
+                
+                Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.
+                
+                Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen 
+                
+                Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut 
+                PL 30 02070 Espoon kaupunki    
+                    
+                Tulotiedot: $documentsUrl
+                
+                Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.
+                
+                -----
+                
+                Detta besked skickas automatiskt av eVaka. Svara inte på detta besked. 
+                
+                -----
+
+                This is an automatic message from the eVaka system. Do not reply to this message.  
+        """
+                    .trimIndent(),
+            html =
+                """
+                <p>Hyvä asiakkaamme</p>
+                <p>Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain.</p>
+                <p>Pyydämme toimittamaan tuloselvityksen eVakassa 14 päivän kuluessa tästä ilmoituksesta.</p>
+                <p>eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.</p>
+                <p>Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan.</p>
+                <p>Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.</p>
+                <p>Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen</p>
+                <p>Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut 
+                PL 30 02070 Espoon kaupunki</p>
+                
+                <p>Tulotiedot: <a href="$documentsUrl">$documentsUrl</a></p>
+                <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
+            
+                <hr>
+                
+                <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>          
+                
+                <hr>
+                
+                <p>You have received a new eVaka pedagogical document. Read the document here: <a href="$documentsUrl">$documentsUrl</a></p>
+                <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>       
+        """
+                    .trimIndent()
+        )
+    }
+
+    fun outdatedIncomeNotificationReminder(language: Language): EmailContent {
+        val documentsUrl = "${baseUrl(language)}/income"
+        return EmailContent(
+            subject = "Tulotietojen tarkastus- kehotus",
+            text =
+                """
+                Hyvä asiakkaamme
+                
+                Ette ole vielä toimittaneet uusia tulotietoja.
+                
+                Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain.
+                
+                Pyydämme toimittamaan tuloselvityksen eVakassa 7 päivän kuluessa tästä ilmoituksesta.
+                
+                eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.
+                
+                Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan.
+                
+                Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.
+                
+                Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen
+                
+                Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut 
+                PL 30 02070 Espoon kaupunki    
+                    
+                Tulotiedot: $documentsUrl
+                
+                Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.
+                
+                -----
+                
+                Detta besked skickas automatiskt av eVaka. Svara inte på detta besked. 
+                
+                -----
+
+                This is an automatic message from the eVaka system. Do not reply to this message.  
+        """
+                    .trimIndent(),
+            html =
+                """
+                <p>Hyvä asiakkaamme</p>
+                <p>Ette ole vielä toimittaneet uusia tulotietoja.</p>
+                <p>Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain.</p>
+                <p>Pyydämme toimittamaan tuloselvityksen eVakassa 7 päivän kuluessa tästä ilmoituksesta.</p>
+                <p>eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.</p>
+                <p>Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan.</p>
+                <p>Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.</p>
+                <p>Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen</p>
+                <p>Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut 
+                PL 30 02070 Espoon kaupunki</p>
+                
+                <p>Tulotiedot: <a href="$documentsUrl">$documentsUrl</a></p>
+                <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
+            
+                <hr>
+                
+                <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>          
+                
+                <hr>
+                
+                <p>You have received a new eVaka pedagogical document. Read the document here: <a href="$documentsUrl">$documentsUrl</a></p>
+                <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>       
+        """
+                    .trimIndent()
+        )
+    }
+
+    fun outdatedIncomeNotificationExpired(language: Language): EmailContent {
+        val documentsUrl = "${baseUrl(language)}/income"
+        return EmailContent(
+            subject = "Tulotietojen tarkastus- kehotus",
+            text =
+                """
+                Hyvä asiakkaamme
+                
+                Seuraava asiakasmaksunne määräytyy korkeimman maksuluokan mukaan, sillä ette ole toimittaneet uusia tulotietoja määräaikaan mennessä.
+                
+                Lisätietoja saatte tarvittaessa: vaka.maksut@espoo.fi.
+                
+                Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.
+                
+                -----
+                
+                Detta besked skickas automatiskt av eVaka. Svara inte på detta besked. 
+                
+                -----
+
+                This is an automatic message from the eVaka system. Do not reply to this message.  
+        """
+                    .trimIndent(),
+            html =
+                """
+                <p>Hyvä asiakkaamme</p>
+                <p>Seuraava asiakasmaksunne määräytyy korkeimman maksuluokan mukaan, sillä ette ole toimittaneet uusia tulotietoja määräaikaan mennessä.</p>
+                <p>Lisätietoja saatte tarvittaessa: vaka.maksut@espoo.fi</p>
+                <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
+            
+                <hr>
+                
                 <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>          
                 
                 <hr>

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -782,32 +782,26 @@ There are missing attendance reservations for the week starting $start. Please m
         return when (notificationType) {
             IncomeNotificationType.INITIAL_EMAIL -> outdatedIncomeNotificationInitial(language)
             IncomeNotificationType.REMINDER_EMAIL -> outdatedIncomeNotificationReminder(language)
-            IncomeNotificationType.EXPIRED_EMAIL -> outdatedIncomeNotificationExpired(language)
+            IncomeNotificationType.EXPIRED_EMAIL -> outdatedIncomeNotificationExpired()
         }
     }
 
     fun outdatedIncomeNotificationInitial(language: Language): EmailContent {
         val documentsUrl = "${baseUrl(language)}/income"
         return EmailContent(
-            subject = "Tulotietojen tarkastus- kehotus",
+            subject =
+                "Tulotietojen tarkastus- kehotus / Uppmaning att göra en inkomstutredning / Request to review income information",
             text =
                 """
                 Hyvä asiakkaamme
                 
                 Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain.
+               
+                Pyydämme toimittamaan tuloselvityksen eVakassa 14 päivän kuluessa tästä ilmoituksesta.eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.
                 
-                Pyydämme toimittamaan tuloselvityksen eVakassa 14 päivän kuluessa tästä ilmoituksesta.
+                Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan. Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.
                 
-                eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.
-                
-                Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan.
-                
-                Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.
-                
-                Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen 
-                
-                Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut 
-                PL 30 02070 Espoon kaupunki    
+                Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut PL 30 02070 Espoon kaupunki    
                     
                 Tulotiedot: $documentsUrl
                 
@@ -815,9 +809,37 @@ There are missing attendance reservations for the week starting $start. Please m
                 
                 -----
                 
+                Bästa klient
+                
+                Inkomstuppgifterna som ligger till grund för klientavgiften för småbarnspedagogik eller servicesedelns egenandel granskas årligen.
+                
+                Vi ber att du skickar en inkomstutredning via eVaka inom 14 dagar från den här anmälan.I eVaka kan du också ge ditt samtycke till den högsta avgiften eller till användning av inkomstregistret.
+                
+                Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grundval av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.
+                
+                Du kan vid behov också skicka inkomstutredningen per post till adressen Esbo stad/sektorn för fostran och lärande, ekonomienheten/klientavgifter för småbarnspedagogik PB 30 02070 Esbo stad
+                
+                Mer information: vaka.maksut@espoo.fi
+                
+                Inkomstuppgifterna: $documentsUrl
+                
                 Detta besked skickas automatiskt av eVaka. Svara inte på detta besked. 
                 
                 -----
+
+                Dear client
+                
+                The income information used for determining the early childhood education fee or the out-of-pocket cost of a service voucher is reviewed every year.
+                
+                We ask you to submit your income statement through eVaka within 14 days of this notification. Through eVaka, you can also give your consent to the highest fee or the use of the Incomes Register.
+                
+                If you do not provide your latest income information, your client fee will be determined based on the highest fee category. We will not retroactively reimburse you for fees charged in a situation where you have not provided your income information.
+                
+                If necessary, you can also send your income information by post to the following address: City of Espoo / Growth and Learning Sector, Financial Management / Early childhood education client fees, P.O. Box 30, 02070 City of Espoo.
+                
+                Inquiries: vaka.maksut@espoo.fi
+
+                Income information: $documentsUrl    
 
                 This is an automatic message from the eVaka system. Do not reply to this message.  
         """
@@ -825,25 +847,53 @@ There are missing attendance reservations for the week starting $start. Please m
             html =
                 """
                 <p>Hyvä asiakkaamme</p>
+                
                 <p>Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain.</p>
-                <p>Pyydämme toimittamaan tuloselvityksen eVakassa 14 päivän kuluessa tästä ilmoituksesta.</p>
-                <p>eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.</p>
-                <p>Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan.</p>
-                <p>Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.</p>
-                <p>Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen</p>
-                <p>Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut 
-                PL 30 02070 Espoon kaupunki</p>
+                
+                <p>Pyydämme toimittamaan tuloselvityksen eVakassa 14 päivän kuluessa tästä ilmoituksesta. eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön. </p>
+                
+                <p>Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan. Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.</p>
+                
+                <p>Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut PL 30 02070 Espoon kaupunki</p>
                 
                 <p>Tulotiedot: <a href="$documentsUrl">$documentsUrl</a></p>
+                
                 <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
             
                 <hr>
                 
+                <p>Bästa klient</p>
+                                
+                <p>Inkomstuppgifterna som ligger till grund för klientavgiften för småbarnspedagogik eller servicesedelns egenandel granskas årligen.</p>
+                                
+                <p>Vi ber att du skickar en inkomstutredning via eVaka inom 14 dagar från den här anmälan.I eVaka kan du också ge ditt samtycke till den högsta avgiften eller till användning av inkomstregistret.</p>
+                                
+                <p>Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grundval av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.</p>
+                                
+                <p>Du kan vid behov också skicka inkomstutredningen per post till adressen Esbo stad/sektorn för fostran och lärande, ekonomienheten/klientavgifter för småbarnspedagogik PB 30 02070 Esbo stad</p>
+                                
+                <p>Mer information: vaka.maksut@espoo.fi</p>
+                                
+                <p>Inkomstuppgifterna: <a href="$documentsUrl">$documentsUrl</a></p>
+                                                
                 <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>          
                 
                 <hr>
                 
-                <p>You have received a new eVaka pedagogical document. Read the document here: <a href="$documentsUrl">$documentsUrl</a></p>
+                <p>Dear client</p>
+                
+                <p>The income information used for determining the early childhood education fee or the out-of-pocket cost of a service voucher is reviewed every year.</p>
+                
+                <p>We ask you to submit your income statement through eVaka within 14 days of this notification. Through eVaka, you can also give your consent to the highest fee or the use of the Incomes Register.</p>
+                
+                <p>If you do not provide your latest income information, your client fee will be determined based on the highest fee category. We will not retroactively reimburse you for fees charged in a situation where you have not provided your income information.</p>
+                
+                <p>If necessary, you can also send your income information by post to the following address: City of Espoo / Growth and Learning Sector, Financial Management / Early childhood education client fees, P.O. Box 30, 02070 City of Espoo.</p>
+                
+                <p>Inquiries: vaka.maksut@espoo.fi</p>
+                
+                <p>Income information: <a href="$documentsUrl">$documentsUrl</a></p>
+
                 <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>       
         """
                     .trimIndent()
@@ -853,27 +903,19 @@ There are missing attendance reservations for the week starting $start. Please m
     fun outdatedIncomeNotificationReminder(language: Language): EmailContent {
         val documentsUrl = "${baseUrl(language)}/income"
         return EmailContent(
-            subject = "Tulotietojen tarkastus- kehotus",
+            subject =
+                "Tulotietojen tarkastus- kehotus / Uppmaning att göra en inkomstutredning / Request to review income information",
             text =
                 """
                 Hyvä asiakkaamme
                 
-                Ette ole vielä toimittaneet uusia tulotietoja.
+                Ette ole vielä toimittaneet uusia tulotietoja. Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain.
                 
-                Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain.
+                Pyydämme toimittamaan tuloselvityksen eVakassa 7 päivän kuluessa tästä ilmoituksesta. eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.
                 
-                Pyydämme toimittamaan tuloselvityksen eVakassa 7 päivän kuluessa tästä ilmoituksesta.
+                Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan. Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.
                 
-                eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.
-                
-                Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan.
-                
-                Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.
-                
-                Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen
-                
-                Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut 
-                PL 30 02070 Espoon kaupunki    
+                Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut PL 30 02070 Espoon kaupunki    
                     
                 Tulotiedot: $documentsUrl
                 
@@ -881,46 +923,99 @@ There are missing attendance reservations for the week starting $start. Please m
                 
                 -----
                 
+                Bästa klient
+                
+                Du har ännu inte lämnat in en ny inkomstutredning. Inkomstuppgifterna som ligger till grund för klientavgiften för småbarnspedagogik eller servicesedelns egenandel granskas årligen.
+                
+                Vi ber att du skickar en inkomstutredning via eVaka inom sju dagar från denna anmälan. I eVaka kan du också ge ditt samtycke till den högsta avgiften eller till användning av inkomstregistret.
+                
+                Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grundval av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.
+                
+                Du kan vid behov också skicka inkomstutredningen per post till adressen: Esbo stad/sektorn för fostran och lärande, ekonomienheten/klientavgifter för småbarnspedagogik PB 30 02070 Esbo stad
+                
+                Mer information: vaka.maksut@espoo.fi
+                
+                Inkomstuppgifterna: $documentsUrl
+                
                 Detta besked skickas automatiskt av eVaka. Svara inte på detta besked. 
                 
                 -----
 
+                Dear client
+                
+                You have not yet submitted your latest income information. The income information used for determining the early childhood education fee or the out-of-pocket cost of a service voucher is reviewed every year.
+                
+                We ask you to submit your income statement through eVaka within 7 days of this notification. Through eVaka, you can also give your consent to the highest fee or the use of the Incomes Register.
+                
+                If you do not provide your latest income information, your client fee will be determined based on the highest fee category. We will not retroactively reimburse you for fees charged in a situation where you have not provided your income information. 
+                
+                If necessary, you can also send your income information by post to the following address: City of Espoo / Growth and Learning Sector, Financial Management / Early childhood education client fees, P.O. Box 30, 02070 City of Espoo
+                
+                Income information: $documentsUrl
+                
                 This is an automatic message from the eVaka system. Do not reply to this message.  
         """
                     .trimIndent(),
             html =
                 """
                 <p>Hyvä asiakkaamme</p>
-                <p>Ette ole vielä toimittaneet uusia tulotietoja.</p>
-                <p>Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain.</p>
-                <p>Pyydämme toimittamaan tuloselvityksen eVakassa 7 päivän kuluessa tästä ilmoituksesta.</p>
-                <p>eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.</p>
-                <p>Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan.</p>
-                <p>Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.</p>
-                <p>Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen</p>
-                <p>Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut 
-                PL 30 02070 Espoon kaupunki</p>
+                
+                <p>Ette ole vielä toimittaneet uusia tulotietoja. Varhaiskasvatuksen asiakasmaksun tai palvelusetelin omavastuuosuuden perusteena olevat tulotiedot tarkistetaan vuosittain.</p>
+                
+                <p>Pyydämme toimittamaan tuloselvityksen eVakassa 7 päivän kuluessa tästä ilmoituksesta. eVakassa voitte myös antaa suostumuksen korkeimpaan maksuluokkaan tai tulorekisterin käyttöön.</p>
+                
+                <p>Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan. Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.</p>
+                
+                <p>Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut PL 30 02070 Espoon kaupunki</p>
                 
                 <p>Tulotiedot: <a href="$documentsUrl">$documentsUrl</a></p>
+                
                 <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
             
                 <hr>
                 
-                <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>          
-                
+                <p>Bästa klient</p>
+                                
+                <p>Du har ännu inte lämnat in en ny inkomstutredning. Inkomstuppgifterna som ligger till grund för klientavgiften för småbarnspedagogik eller servicesedelns egenandel granskas årligen.</p>
+                                
+                <p>Vi ber att du skickar en inkomstutredning via eVaka inom sju dagar från denna anmälan. I eVaka kan du också ge ditt samtycke till den högsta avgiften eller till användning av inkomstregistret.</p>
+                                
+                <p>Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grundval av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.</p>
+                                
+                <p>Du kan vid behov också skicka inkomstutredningen per post till adressen: Esbo stad/sektorn för fostran och lärande, ekonomienheten/klientavgifter för småbarnspedagogik PB 30 02070 Esbo stad</p>
+                                
+                <p>Mer information: vaka.maksut@espoo.fi</p>
+                                
+                <p>Inkomstuppgifterna: <a href="$documentsUrl">$documentsUrl</a></p>
+                                
+                <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>
+                                
                 <hr>
                 
-                <p>You have received a new eVaka pedagogical document. Read the document here: <a href="$documentsUrl">$documentsUrl</a></p>
+                <p>Dear client</p>
+                                
+                <p>You have not yet submitted your latest income information. The income information used for determining the early childhood education fee or the out-of-pocket cost of a service voucher is reviewed every year.</p>
+                
+                <p>We ask you to submit your income statement through eVaka within 7 days of this notification. Through eVaka, you can also give your consent to the highest fee or the use of the Incomes Register.</p>
+                
+                <p>If you do not provide your latest income information, your client fee will be determined based on the highest fee category. We will not retroactively reimburse you for fees charged in a situation where you have not provided your income information.</p> 
+                
+                <p>If necessary, you can also send your income information by post to the following address: City of Espoo / Growth and Learning Sector, Financial Management / Early childhood education client fees, P.O. Box 30, 02070 City of Espoo</p>
+                               
+                <p>Inquiries: vaka.maksut@espoo.fi</p>
+                                
+                <p>Income information: <a href="$documentsUrl">$documentsUrl</a></p>
+                                                
                 <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>       
         """
                     .trimIndent()
         )
     }
 
-    fun outdatedIncomeNotificationExpired(language: Language): EmailContent {
-        val documentsUrl = "${baseUrl(language)}/income"
+    fun outdatedIncomeNotificationExpired(): EmailContent {
         return EmailContent(
-            subject = "Tulotietojen tarkastus- kehotus",
+            subject =
+                "Tulotietojen tarkastus- kehotus / Uppmaning att göra en inkomstutredning / Request to review income information",
             text =
                 """
                 Hyvä asiakkaamme
@@ -933,9 +1028,21 @@ There are missing attendance reservations for the week starting $start. Please m
                 
                 -----
                 
+                Bästä klient
+                
+                Din följande klientavgift bestäms enligt den högsta avgiften, eftersom du inte har lämnat in en inkomstutredning inom utsatt tid.
+                
+                Mer information: vaka.maksut@espoo.fi
+                
                 Detta besked skickas automatiskt av eVaka. Svara inte på detta besked. 
                 
                 -----
+                
+                Dear client
+                
+                Your next client fee will be determined based on the highest fee category as you did not provide your latest income information by the deadline.
+                
+                Inquiries: vaka.maksut@espoo.fi
 
                 This is an automatic message from the eVaka system. Do not reply to this message.  
         """
@@ -943,19 +1050,33 @@ There are missing attendance reservations for the week starting $start. Please m
             html =
                 """
                 <p>Hyvä asiakkaamme</p>
+                
                 <p>Seuraava asiakasmaksunne määräytyy korkeimman maksuluokan mukaan, sillä ette ole toimittaneet uusia tulotietoja määräaikaan mennessä.</p>
+                
                 <p>Lisätietoja saatte tarvittaessa: vaka.maksut@espoo.fi</p>
+                
                 <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
             
                 <hr>
                 
-                <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>          
+                <p>Bästä klient</p>
+                
+                <p>Din följande klientavgift bestäms enligt den högsta avgiften, eftersom du inte har lämnat in en inkomstutredning inom utsatt tid.</p>
+                
+                <p>Mer information: vaka.maksut@espoo.fi</p>
+                
+                <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>  
                 
                 <hr>
                 
-                <p>You have received a new eVaka pedagogical document. Read the document here: <a href="$documentsUrl">$documentsUrl</a></p>
-                <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>       
-        """
+                <p>Dear client</p>
+                
+                <p>Your next client fee will be determined based on the highest fee category as you did not provide your latest income information by the deadline.</p>
+                
+                <p>Inquiries: vaka.maksut@espoo.fi</p>
+
+                <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>
+               """
                     .trimIndent()
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.emailclient
 
 import fi.espoo.evaka.daycare.domain.Language
+import fi.espoo.evaka.invoicing.service.IncomeNotificationType
 import fi.espoo.evaka.messaging.MessageThreadStub
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -37,4 +38,9 @@ interface IEmailMessageProvider {
     fun vasuNotification(language: Language, childId: ChildId): EmailContent
 
     fun pedagogicalDocumentNotification(language: Language): EmailContent
+
+    fun outdatedIncomeNotification(
+        notificationType: IncomeNotificationType,
+        language: Language
+    ): EmailContent
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
@@ -20,7 +20,10 @@ import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.EvakaClock
 import java.time.LocalDate
+import mu.KotlinLogging
 import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
 
 @Service
 class OutdatedIncomeNotifications(
@@ -94,6 +97,10 @@ class OutdatedIncomeNotifications(
             runAt = clock.now()
         )
 
+        logger.info(
+            "OutdatedIncomeNotification scheduled notification emails: ${guardiansForInitialNotification.size } initial, ${guardiansForReminderNotification.size} reminders and ${guardiansForExpirationNotification.size} expired"
+        )
+
         return guardiansForInitialNotification.size +
             guardiansForReminderNotification.size +
             guardiansForExpirationNotification.size
@@ -124,6 +131,8 @@ AND email IS NOT NULL
                     .firstOrNull()
             }
                 ?: return
+
+        logger.info("OutdatedIncomeNotifications: sending ${msg.type} email to ${msg.guardianId}")
         emailClient
             .sendEmail(
                 traceId = msg.guardianId.toString(),

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.invoicing.service
+
+import fi.espoo.evaka.EmailEnv
+import fi.espoo.evaka.daycare.domain.Language
+import fi.espoo.evaka.emailclient.IEmailClient
+import fi.espoo.evaka.emailclient.IEmailMessageProvider
+import fi.espoo.evaka.shared.DatabaseTable
+import fi.espoo.evaka.shared.FeatureConfig
+import fi.espoo.evaka.shared.IncomeNotificationId
+import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.async.AsyncJobType
+import fi.espoo.evaka.shared.async.removeUnclaimedJobs
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.db.mapColumn
+import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import org.springframework.stereotype.Service
+
+@Service
+class OutdatedIncomeNotifications(
+    private val featureConfig: FeatureConfig,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
+    private val emailClient: IEmailClient,
+    private val emailMessageProvider: IEmailMessageProvider,
+    private val emailEnv: EmailEnv
+) {
+    init {
+        asyncJobRunner.registerHandler { db, _, msg: AsyncJob.SendOutdatedIncomeNotificationEmail ->
+            sendEmail(db, msg)
+        }
+    }
+
+    fun scheduleReminders(tx: Database.Transaction, clock: EvakaClock): Int {
+        tx.removeUnclaimedJobs(
+            setOf(AsyncJobType(AsyncJob.SendOutdatedIncomeNotificationEmail::class))
+        )
+
+        val guardiansForInitialNotification =
+            tx.guardiansWithOutdatedIncomeWithoutSentNotification(
+                DateRange(clock.today(), clock.today().plusDays(13)),
+                IncomeNotificationType.INITIAL_EMAIL,
+                clock.now()
+            )
+
+        val guardiansForReminderNotification =
+            tx.guardiansWithOutdatedIncomeWithoutSentNotification(
+                    DateRange(clock.today(), clock.today().plusDays(6)),
+                    IncomeNotificationType.REMINDER_EMAIL,
+                    clock.now()
+                )
+                .filter { !guardiansForInitialNotification.contains(it) }
+
+        val guardiansForExpirationNotification =
+            tx.guardiansWithOutdatedIncomeWithoutSentNotification(
+                    DateRange(clock.today(), clock.today()),
+                    IncomeNotificationType.EXPIRED_EMAIL,
+                    clock.now()
+                )
+                .filter { !guardiansForInitialNotification.contains(it) }
+                .filter { !guardiansForReminderNotification.contains(it) }
+
+        asyncJobRunner.plan(
+            tx,
+            payloads =
+                guardiansForInitialNotification
+                    .map {
+                        AsyncJob.SendOutdatedIncomeNotificationEmail(
+                            it,
+                            IncomeNotificationType.INITIAL_EMAIL
+                        )
+                    }
+                    .plus(
+                        guardiansForReminderNotification.map {
+                            AsyncJob.SendOutdatedIncomeNotificationEmail(
+                                it,
+                                IncomeNotificationType.REMINDER_EMAIL
+                            )
+                        }
+                    )
+                    .plus(
+                        guardiansForExpirationNotification.map {
+                            AsyncJob.SendOutdatedIncomeNotificationEmail(
+                                it,
+                                IncomeNotificationType.EXPIRED_EMAIL
+                            )
+                        }
+                    ),
+            runAt = clock.now()
+        )
+
+        return guardiansForInitialNotification.size +
+            guardiansForReminderNotification.size +
+            guardiansForExpirationNotification.size
+    }
+
+    fun sendEmail(db: Database.Connection, msg: AsyncJob.SendOutdatedIncomeNotificationEmail) {
+        val (recipient, language) =
+            db.read { tx ->
+                tx.createQuery<DatabaseTable> {
+                        sql(
+                            """
+SELECT email, language
+FROM person p
+WHERE p.id = ${bind(msg.guardianId)}
+AND email IS NOT NULL
+        """
+                                .trimIndent()
+                        )
+                    }
+                    .map { row ->
+                        Pair(
+                            row.mapColumn<String>("email"),
+                            row.mapColumn<String?>("language")
+                                ?.lowercase()
+                                ?.let(Language::tryValueOf)
+                                ?: Language.fi
+                        )
+                    }
+                    .firstOrNull()
+            }
+                ?: return
+        emailClient
+            .sendEmail(
+                traceId = msg.guardianId.toString(),
+                toAddress = recipient,
+                fromAddress = emailEnv.sender(language),
+                content = emailMessageProvider.outdatedIncomeNotification(msg.type, language)
+            )
+            .also { db.transaction { it.createIncomeNotification(msg.guardianId, msg.type) } }
+    }
+}
+
+enum class IncomeNotificationType {
+    INITIAL_EMAIL,
+    REMINDER_EMAIL,
+    EXPIRED_EMAIL
+}
+
+// TODO: max_fee_accepted mutta on valid_to asetettu?
+// TODO: jos uusi tuloselvitys, ei muistuteta tuloista
+fun Database.Read.guardiansWithOutdatedIncomeWithoutSentNotification(
+    checkForExpirationRange: DateRange,
+    notificationType: IncomeNotificationType,
+    now: HelsinkiDateTime
+): List<PersonId> {
+    return createQuery(
+            """
+WITH latest_income AS (
+    SELECT DISTINCT ON (person_id)
+    person_id, valid_to
+    FROM income i 
+    ORDER BY person_id, valid_to DESC
+)
+SELECT g.guardian_id
+FROM placement pl 
+LEFT JOIN guardian g ON g.child_id = pl.child_id
+LEFT JOIN latest_income i ON i.person_id = g.guardian_id
+WHERE daterange(pl.start_date, pl.end_date, '[]') @> i.valid_to
+AND pl.type != 'CLUB'::placement_type   
+AND :checkForExpirationRange @> i.valid_to
+AND NOT EXISTS (
+    SELECT 1 FROM income_notification 
+    WHERE receiver_id = g.guardian_id AND notification_type = :notificationType AND created > :now - INTERVAL '1 month' )
+AND NOT EXISTS (
+    SELECT 1 FROM income_statement
+    WHERE person_id = g.guardian_id AND :checkForExpirationRange << daterange(income_statement.start_date, income_statement.end_date)
+)    
+    """
+                .trimIndent()
+        )
+        .bind("checkForExpirationRange", checkForExpirationRange)
+        .bind("notificationType", notificationType)
+        .bind("now", now)
+        .mapTo<PersonId>()
+        .list()
+}
+
+data class IncomeNotification(
+    val receiverId: PersonId,
+    val notificationType: IncomeNotificationType
+)
+
+fun Database.Transaction.createIncomeNotification(
+    receiverId: PersonId,
+    notificationType: IncomeNotificationType
+): IncomeNotificationId {
+    return createUpdate(
+            """
+        INSERT INTO income_notification(receiver_id, notification_type)
+        VALUES (:receiverId, :notificationType)
+        RETURNING id
+    """
+                .trimIndent()
+        )
+        .bind("receiverId", receiverId)
+        .bind("notificationType", notificationType)
+        .executeAndReturnGeneratedKeys()
+        .mapTo<IncomeNotificationId>()
+        .one()
+}
+
+fun Database.Read.getIncomeNotifications(receiverId: PersonId): List<IncomeNotification> =
+    createQuery(
+            """SELECT receiver_id, notification_type FROM income_notification WHERE receiver_id = :receiverId"""
+        )
+        .bind("receiverId", receiverId)
+        .mapTo<IncomeNotification>()
+        .list()

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
@@ -37,7 +37,7 @@ class OutdatedIncomeNotifications(
         }
     }
 
-    fun scheduleReminders(tx: Database.Transaction, clock: EvakaClock): Int {
+    fun scheduleNotifications(tx: Database.Transaction, clock: EvakaClock): Int {
         tx.removeUnclaimedJobs(
             setOf(AsyncJobType(AsyncJob.SendOutdatedIncomeNotificationEmail::class))
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -51,6 +51,7 @@ sealed interface DatabaseTable {
     sealed class HolidayPeriod : DatabaseTable
     sealed class HolidayQuestionnaire : DatabaseTable
     sealed class Income : DatabaseTable
+    sealed class IncomeNotification : DatabaseTable
     sealed class IncomeStatement : DatabaseTable
     sealed class Invoice : DatabaseTable
     sealed class InvoiceCorrection : DatabaseTable
@@ -166,6 +167,8 @@ typealias HolidayPeriodId = Id<DatabaseTable.HolidayPeriod>
 typealias HolidayQuestionnaireId = Id<DatabaseTable.HolidayQuestionnaire>
 
 typealias IncomeId = Id<DatabaseTable.Income>
+
+typealias IncomeNotificationId = Id<DatabaseTable.IncomeNotification>
 
 typealias IncomeStatementId = Id<DatabaseTable.IncomeStatement>
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import fi.espoo.evaka.application.ApplicationType
 import fi.espoo.evaka.daycare.domain.Language
+import fi.espoo.evaka.invoicing.service.IncomeNotificationType
 import fi.espoo.evaka.koski.KoskiSearchParams
 import fi.espoo.evaka.koski.KoskiStudyRightKey
 import fi.espoo.evaka.sficlient.SfiMessage
@@ -240,6 +241,13 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class SendOutdatedIncomeNotificationEmail(
+        val guardianId: PersonId,
+        val type: IncomeNotificationType
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     companion object {
         val main =
             AsyncJobRunner.Pool(
@@ -276,6 +284,7 @@ sealed interface AsyncJob : AsyncJobPayload {
                     SendAssistanceNeedDecisionEmail::class,
                     SendMessageNotificationEmail::class,
                     SendMissingReservationsReminder::class,
+                    SendOutdatedIncomeNotificationEmail::class,
                     SendPedagogicalDocumentNotificationEmail::class,
                     SendPendingDecisionEmail::class,
                     SendVasuNotificationEmail::class,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -112,6 +112,11 @@ data class ScheduledJobSettings(
                         enabled = false,
                         schedule = JobSchedule.cron("0 0 18 * * 0") // Sunday 18:00
                     )
+                ScheduledJob.SendOutdatedIncomeNotifications ->
+                    ScheduledJobSettings(
+                        enabled = false,
+                        schedule = JobSchedule.daily(LocalTime.of(6, 45))
+                    )
                 ScheduledJob.SendPatuReport ->
                     ScheduledJobSettings(
                         enabled = false,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -50,6 +50,8 @@ enum class ScheduledJob(val fn: (ScheduledJobs, Database.Connection, EvakaClock)
     InactivePeopleCleanup(ScheduledJobs::inactivePeopleCleanup),
     InactiveEmployeesRoleReset(ScheduledJobs::inactiveEmployeesRoleReset),
     SendMissingReservationReminders(ScheduledJobs::sendMissingReservationReminders),
+    SendOutdatedIncomeNotifications(ScheduledJobs::sendOutdatedIncomeNotifications)
+    SendMissingReservationReminders(ScheduledJobs::sendMissingReservationReminders),
     SendPatuReport(ScheduledJobs::sendPatuReport)
 }
 
@@ -200,7 +202,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
 
     fun sendOutdatedIncomeNotifications(db: Database.Connection, clock: EvakaClock) {
         db.transaction { tx ->
-            val count = outdatedIncomeNotifications.scheduleReminders(tx, clock)
+            val count = outdatedIncomeNotifications.scheduleNotifications(tx, clock)
             logger.info("Scheduled $count notifications about outdated income")
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -50,8 +50,7 @@ enum class ScheduledJob(val fn: (ScheduledJobs, Database.Connection, EvakaClock)
     InactivePeopleCleanup(ScheduledJobs::inactivePeopleCleanup),
     InactiveEmployeesRoleReset(ScheduledJobs::inactiveEmployeesRoleReset),
     SendMissingReservationReminders(ScheduledJobs::sendMissingReservationReminders),
-    SendOutdatedIncomeNotifications(ScheduledJobs::sendOutdatedIncomeNotifications)
-    SendMissingReservationReminders(ScheduledJobs::sendMissingReservationReminders),
+    SendOutdatedIncomeNotifications(ScheduledJobs::sendOutdatedIncomeNotifications),
     SendPatuReport(ScheduledJobs::sendPatuReport)
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.application.removeOldDrafts
 import fi.espoo.evaka.attachment.AttachmentsController
 import fi.espoo.evaka.attendance.addMissingStaffAttendanceDepartures
 import fi.espoo.evaka.dvv.DvvModificationsBatchRefreshService
+import fi.espoo.evaka.invoicing.service.OutdatedIncomeNotifications
 import fi.espoo.evaka.koski.KoskiSearchParams
 import fi.espoo.evaka.koski.KoskiUpdateService
 import fi.espoo.evaka.note.child.daily.deleteExpiredNotes
@@ -63,6 +64,7 @@ class ScheduledJobs(
     private val pendingDecisionEmailService: PendingDecisionEmailService,
     private val koskiUpdateService: KoskiUpdateService,
     private val missingReservationsReminders: MissingReservationsReminders,
+    private val outdatedIncomeNotifications: OutdatedIncomeNotifications,
     private val patuReportingService: PatuReportingService?,
     asyncJobRunner: AsyncJobRunner<AsyncJob>,
     tracer: Tracer
@@ -193,6 +195,13 @@ WHERE id IN (SELECT id FROM attendances_to_end)
         db.transaction { tx ->
             val count = missingReservationsReminders.scheduleReminders(tx, clock)
             logger.info("Scheduled $count reminders about missing reservations")
+        }
+    }
+
+    fun sendOutdatedIncomeNotifications(db: Database.Connection, clock: EvakaClock) {
+        db.transaction { tx ->
+            val count = outdatedIncomeNotifications.scheduleReminders(tx, clock)
+            logger.info("Scheduled $count notifications about outdated income")
         }
     }
 

--- a/service/src/main/resources/db/migration/V311__income_notification.sql
+++ b/service/src/main/resources/db/migration/V311__income_notification.sql
@@ -9,4 +9,5 @@ CREATE TABLE income_notification
     notification_type       income_notification_type NOT NULL
 );
 
+CREATE INDEX idx$income_notification_receiver_id ON income_notification (receiver_id);
 CREATE TRIGGER set_timestamp BEFORE UPDATE ON income_notification FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();

--- a/service/src/main/resources/db/migration/V311__income_notification.sql
+++ b/service/src/main/resources/db/migration/V311__income_notification.sql
@@ -1,0 +1,12 @@
+CREATE TYPE income_notification_type AS ENUM ('INITIAL_EMAIL', 'REMINDER_EMAIL', 'EXPIRED_EMAIL');
+
+CREATE TABLE income_notification
+(
+    id                      uuid PRIMARY KEY         NOT NULL DEFAULT ext.uuid_generate_v1mc(),
+    created                 timestamp with time zone NOT NULL DEFAULT now(),
+    updated                 timestamp with time zone NOT NULL DEFAULT now(),
+    receiver_id             uuid                     NOT NULL,
+    notification_type       income_notification_type NOT NULL
+);
+
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON income_notification FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated();

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -307,3 +307,4 @@ V307__add_missing_updated_triggers.sql
 V308__remove_old_tables.sql
 V309__language_at_home.sql
 V310__koski_input_data_version.sql
+V311__income_notification.sql


### PR DESCRIPTION
#### Summary
- Send a 2 week and a 1 week warning about income about to expire, and 0 day notification that income has expired
- Income is outdated if the end date is within 2 weeks of today AND today there is a placed child for the income person and the placement is invoiced and there is no invoice statement newer than 1 month and same kind income notification has not been sent during past month

