### PR TITLE
Move Digitransit API calls to server and add API key

### DIFF
--- a/apigw/src/enduser/app.ts
+++ b/apigw/src/enduser/app.ts
@@ -25,6 +25,7 @@ import session, {
 } from '../shared/session'
 import publicRoutes from './publicRoutes'
 import routes from './routes'
+import mapRoutes from './mapRoutes'
 import authStatus from './routes/auth-status'
 import { cacheControl } from '../shared/middleware/cache-control'
 import { RedisClient } from 'redis'
@@ -69,6 +70,7 @@ export default function enduserGwApp(config: Config, redisClient: RedisClient) {
     const router = Router()
 
     router.use(publicRoutes)
+    router.use(mapRoutes)
     const suomifiSamlConfig = createSuomiFiSamlConfig(config.sfi, redisClient)
     router.use(
       createSamlRouter(config, {

--- a/apigw/src/enduser/mapRoutes.ts
+++ b/apigw/src/enduser/mapRoutes.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Router } from 'express'
+import {
+  digitransitApiEnabled,
+  digitransitApiKey,
+  digitransitApiUrl
+} from '../shared/config'
+import expressHttpProxy from 'express-http-proxy'
+import { createProxy } from '../shared/proxy-utils'
+
+const router = Router()
+
+function createDigitransitProxy(path: string) {
+  return expressHttpProxy(digitransitApiUrl, {
+    proxyReqPathResolver: () => path,
+    proxyReqOptDecorator: (proxyReqOpts) => {
+      proxyReqOpts.headers = {
+        ...proxyReqOpts.headers,
+        ...(digitransitApiKey
+          ? { 'digitransit-subscription-key': digitransitApiKey }
+          : {})
+      }
+      return proxyReqOpts
+    }
+  })
+}
+
+router.get(
+  '/map-api/autocomplete',
+  digitransitApiEnabled
+    ? createDigitransitProxy('/geocoding/v1/autocomplete')
+    : createProxy({ path: '/dev-api/digitransit/autocomplete' })
+)
+
+router.post(
+  '/map-api/query',
+  digitransitApiEnabled
+    ? createDigitransitProxy('/routing/v1/routers/finland/index/graphql')
+    : createProxy({ path: '/dev-api/digitransit/query' })
+)
+
+export default router

--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -336,3 +336,9 @@ export const titaniaConfig = titaniaUsername
       password: required(process.env.EVAKA_TITANIA_PASSWORD)
     }
   : undefined
+
+export const digitransitApiEnabled = ifNodeEnv(['local', 'test'], false) ?? true
+export const digitransitApiUrl =
+  ifNodeEnv(['local', 'test'], 'https://dev-api.digitransit.fi') ??
+  'https://api.digitransit.fi'
+export const digitransitApiKey = process.env.DIGITRANSIT_API_KEY

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1016,6 +1016,28 @@ RETURNING id
     fun putDigitransitAutocomplete(@RequestBody mockResponse: MockDigitransit.Autocomplete) =
         digitransit.setAutocomplete(mockResponse)
 
+    @PostMapping("/digitransit/query")
+    fun postDigitransitQuery(@RequestBody body: String): String {
+        return if (body.matches(Regex("^\\{\\s*plan\\("))) {
+            "7"
+        } else {
+            val rex = Regex("(id.*):\\s*plan\\(")
+            val contents =
+                rex.findAll(body)
+                    .mapIndexed { ix, match ->
+                        """
+                        "${match.groupValues[1]}": {
+                            "itineraries": [{
+                                "legs":[{"distance": $ix}]
+                            }]
+                        }
+                    """
+                    }
+                    .joinToString(",")
+            "{ \"data\": { $contents } }"
+        }
+    }
+
     @PostMapping("/family-contact")
     fun createFamilyContact(db: Database, @RequestBody contacts: List<DevFamilyContact>) {
         db.connect { dbc ->


### PR DESCRIPTION
- Move Digitransit API calls to apigw
- Use API key from the environment (Added to infra in https://github.com/espoon-voltti/evaka-infra/pull/657)
- Refactor to call mocked digitransit API (in dev-api) when run locally or in e2e tests
