### PR TITLE
Add sorting the application list by unit name

### DIFF
--- a/frontend/src/employee-frontend/api/applications.ts
+++ b/frontend/src/employee-frontend/api/applications.ts
@@ -15,7 +15,8 @@ import FiniteDateRange from 'lib-common/finite-date-range'
 import {
   ApplicationNoteResponse,
   ApplicationSummary,
-  ApplicationType
+  ApplicationType,
+  ApplicationSortColumn
 } from 'lib-common/generated/api-types/application'
 import { ClubTerm, PreschoolTerm } from 'lib-common/generated/api-types/daycare'
 import { CreatePersonBody } from 'lib-common/generated/api-types/pis'
@@ -31,8 +32,7 @@ import { UUID } from 'lib-common/types'
 import { SearchOrder } from '../types'
 import {
   ApplicationResponse,
-  ApplicationSearchParams,
-  SortByApplications
+  ApplicationSearchParams
 } from '../types/application'
 import { DaycarePlacementPlan, PlacementDraft } from '../types/placementdraft'
 
@@ -88,7 +88,7 @@ export const deserializeApplicationSummary = (
 export async function getApplications(
   page: number,
   pageSize: number,
-  sortBy: SortByApplications,
+  sortBy: ApplicationSortColumn,
   sortDir: SearchOrder,
   params: ApplicationSearchParams
 ): Promise<Result<Paged<ApplicationSummary>>> {

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -550,7 +550,12 @@ const ApplicationsList = React.memo(function Applications({
                 {i18n.applications.list.startDate}
               </SortableTh>
               <Th>{i18n.applications.list.basis}</Th>
-              <Th>{i18n.applications.list.unit}</Th>
+              <SortableTh
+                sorted={isSorted('UNIT_NAME')}
+                onClick={toggleSort('UNIT_NAME')}
+              >
+                {i18n.applications.list.unit}
+              </SortableTh>
               <SortableTh
                 sorted={isSorted('STATUS')}
                 onClick={toggleSort('STATUS')}

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -8,7 +8,10 @@ import styled from 'styled-components'
 
 import { Paged } from 'lib-common/api'
 import { formatDate } from 'lib-common/date'
-import { ApplicationSummary } from 'lib-common/generated/api-types/application'
+import {
+  ApplicationSortColumn,
+  ApplicationSummary
+} from 'lib-common/generated/api-types/application'
 import { UUID } from 'lib-common/types'
 import Pagination from 'lib-components/Pagination'
 import PlacementCircle from 'lib-components/atoms/PlacementCircle'
@@ -52,7 +55,6 @@ import { ApplicationUIContext } from '../../state/application-ui'
 import { useTranslation } from '../../state/i18n'
 import { UserContext } from '../../state/user'
 import { SearchOrder } from '../../types'
-import { SortByApplications } from '../../types/application'
 import { formatName } from '../../utils'
 import { isPartDayPlacement } from '../../utils/placements'
 import { hasRole, RequireRole } from '../../utils/roles'
@@ -158,8 +160,8 @@ interface Props {
   applicationsResult: Paged<ApplicationSummary>
   currentPage: number
   setPage: (page: number) => void
-  sortBy: SortByApplications
-  setSortBy: (v: SortByApplications) => void
+  sortBy: ApplicationSortColumn
+  setSortBy: (v: ApplicationSortColumn) => void
   sortDirection: SearchOrder
   setSortDirection: (v: SearchOrder) => void
   reloadApplications: () => void
@@ -194,10 +196,10 @@ const ApplicationsList = React.memo(function Applications({
   const [editedNote, setEditedNote] = useState<UUID | null>(null)
   const [editedNoteText, setEditedNoteText] = useState<string>('')
 
-  const isSorted = (column: SortByApplications) =>
+  const isSorted = (column: ApplicationSortColumn) =>
     sortBy === column ? sortDirection : undefined
 
-  const toggleSort = (column: SortByApplications) => () => {
+  const toggleSort = (column: ApplicationSortColumn) => () => {
     if (sortBy === column) {
       setSortDirection(sortDirection === 'ASC' ? 'DESC' : 'ASC')
     } else {

--- a/frontend/src/employee-frontend/components/applications/ApplicationsPage.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsPage.tsx
@@ -6,7 +6,10 @@ import React, { useCallback, useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { Paged, Result } from 'lib-common/api'
-import { ApplicationSummary } from 'lib-common/generated/api-types/application'
+import {
+  ApplicationSortColumn,
+  ApplicationSummary
+} from 'lib-common/generated/api-types/application'
 import { useRestApi } from 'lib-common/utils/useRestApi'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
@@ -19,10 +22,7 @@ import ApplicationsList from '../../components/applications/ApplicationsList'
 import { ApplicationUIContext } from '../../state/application-ui'
 import { useTranslation } from '../../state/i18n'
 import { SearchOrder } from '../../types'
-import {
-  ApplicationSearchParams,
-  SortByApplications
-} from '../../types/application'
+import { ApplicationSearchParams } from '../../types/application'
 
 import ApplicationFilters from './ApplicationsFilters'
 
@@ -35,7 +35,8 @@ const pageSize = 50
 export default React.memo(function ApplicationsPage() {
   const { i18n } = useTranslation()
   const [page, setPage] = useState(1)
-  const [sortBy, setSortBy] = useState<SortByApplications>('APPLICATION_TYPE')
+  const [sortBy, setSortBy] =
+    useState<ApplicationSortColumn>('APPLICATION_TYPE')
   const [sortDirection, setSortDirection] = useState<SearchOrder>('ASC')
 
   const {

--- a/frontend/src/employee-frontend/types/application.ts
+++ b/frontend/src/employee-frontend/types/application.ts
@@ -20,14 +20,6 @@ export interface ApplicationResponse {
   permittedActions: Set<Action.Application>
 }
 
-export type SortByApplications =
-  | 'APPLICATION_TYPE'
-  | 'CHILD_NAME'
-  | 'DUE_DATE'
-  | 'START_DATE'
-  | 'STATUS'
-  | 'UNIT_NAME'
-
 export interface ApplicationSearchParams {
   area?: string
   units?: string

--- a/frontend/src/employee-frontend/types/application.ts
+++ b/frontend/src/employee-frontend/types/application.ts
@@ -26,6 +26,7 @@ export type SortByApplications =
   | 'DUE_DATE'
   | 'START_DATE'
   | 'STATUS'
+  | 'UNIT_NAME'
 
 export interface ApplicationSearchParams {
   area?: string

--- a/frontend/src/lib-common/generated/api-types/application.ts
+++ b/frontend/src/lib-common/generated/api-types/application.ts
@@ -175,6 +175,7 @@ export type ApplicationSortColumn =
   | 'DUE_DATE'
   | 'START_DATE'
   | 'STATUS'
+  | 'UNIT_NAME'
 
 /**
 * Generated from fi.espoo.evaka.application.ApplicationSortDirection

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -48,7 +48,8 @@ enum class ApplicationSortColumn {
     CHILD_NAME,
     DUE_DATE,
     START_DATE,
-    STATUS
+    STATUS,
+    UNIT_NAME
 }
 
 enum class ApplicationBasis {
@@ -469,6 +470,8 @@ fun Database.Read.fetchApplicationSummaries(
                 "$sql ORDER BY preferredStartDate $sortDir, last_name, first_name"
             ApplicationSortColumn.STATUS ->
                 "$sql ORDER BY application_status $sortDir, last_name, first_name"
+            ApplicationSortColumn.UNIT_NAME ->
+                "$sql ORDER BY d.name $sortDir, last_name, first_name"
         }.exhaust()
 
     val paginatedSql = "$orderedSql LIMIT $pageSize OFFSET ${(page - 1) * pageSize}"


### PR DESCRIPTION
Unit name sorting of paged application queries whether the unit name is from the top unit preference or the placement plan.
