### PR TITLE
Fix staff attendance upkeep when arrival is plan departure

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
@@ -465,7 +465,7 @@ WITH missing_planned_departures AS (
     FROM staff_attendance_realtime realtime
           JOIN staff_attendance_plan plan ON realtime.employee_id = plan.employee_id
                 AND realtime.departed IS NULL
-                AND realtime.arrived BETWEEN plan.start_time AND plan.end_time
+                AND tstzrange(plan.start_time, plan.end_time, '[)') @> realtime.arrived
                 AND plan.end_time < :now
 )
 UPDATE staff_attendance_realtime realtime


### PR DESCRIPTION
#### Summary

If plan is 08:00 - 15:39 and arrival is 15:39 upkeep job tries to put departure to 15:39 which gives us error `staff_attendance_start_before_end`. This fixes it so departure will be then 20:00.