### PR TITLE
Use the unit language when generating voucher value decision pdfs

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
@@ -153,7 +153,9 @@ class VoucherValueDecisionService(
         decision: VoucherValueDecisionDetailed,
         settings: Map<SettingType, String>
     ): ByteArray {
-        val lang = if (decision.headOfFamily.language == "sv") DocumentLang.SV else DocumentLang.FI
+        val lang =
+            if (decision.placement.unit.language == "sv") DocumentLang.SV else DocumentLang.FI
+
         return pdfGenerator.generateVoucherValueDecisionPdf(
             VoucherValueDecisionPdfData(decision, settings, lang)
         )


### PR DESCRIPTION
Now uses unit language instead of head of family language.