### PR TITLE
Allow employee to edit language at home info

### DIFF
--- a/frontend/src/e2e-test/pages/employee/child-information.ts
+++ b/frontend/src/e2e-test/pages/employee/child-information.ts
@@ -33,18 +33,6 @@ export default class ChildInformationPage {
     this.page.find('[data-qa="person-oph-person-oid"]')
   )
 
-  readonly languageAtHome = this.page.findByDataQa('person-language-at-home')
-  readonly languageAtHomeCombobox = new Combobox(
-    this.page.findByDataQa('input-language-at-home')
-  )
-
-  readonly languageAtHomeDetails = this.page.findByDataQa(
-    'person-language-at-home-details'
-  )
-  readonly languageAtHomeDetailsInput = new TextInput(
-    this.page.findByDataQa('input-language-at-home-details')
-  )
-
   readonly #editButton = this.page.find(
     '[data-qa="edit-person-settings-button"]'
   )
@@ -129,6 +117,18 @@ export class AdditionalInformationSection extends Section {
   editBtn = this.find('[data-qa="edit-child-settings-button"]')
   medicationInput = new TextInput(this.find('[data-qa="medication-input"]'))
   confirmBtn = this.find('[data-qa="confirm-edited-child-button"]')
+
+  readonly languageAtHome = this.page.findByDataQa('person-language-at-home')
+  readonly languageAtHomeCombobox = new Combobox(
+    this.page.findByDataQa('input-language-at-home')
+  )
+
+  readonly languageAtHomeDetails = this.page.findByDataQa(
+    'person-language-at-home-details'
+  )
+  readonly languageAtHomeDetailsInput = new TextInput(
+    this.page.findByDataQa('input-language-at-home-details')
+  )
 }
 
 class DailyServiceTimeSectionBaseForm extends Section {

--- a/frontend/src/e2e-test/specs/5_employee/child-information.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information.spec.ts
@@ -81,28 +81,6 @@ describe('Child Information - edit child information', () => {
     await childInformationPage.setOphPersonOid('1.2.3')
     await childInformationPage.assertOphPersonOid('1.2.3')
   })
-  test('Language at home can be edited', async () => {
-    const language = 'kreikka'
-    const languageSearchText = 'kre'
-    const languageId = 'ell'
-    const details = 'Puhuu modernia kreikkaa, ei antiikin'
-
-    await page.goto(
-      config.employeeUrl + '/child-information/' + enduserNonSsnChildFixture.id
-    )
-    await childInformationPage.waitUntilLoaded()
-    await childInformationPage.languageAtHome.assertTextEquals('')
-    await childInformationPage.languageAtHomeDetails.assertTextEquals('')
-    await childInformationPage.clickEdit()
-    await childInformationPage.languageAtHomeCombobox.fillAndSelectItem(
-      languageSearchText,
-      `language-${languageId}`
-    )
-    await childInformationPage.languageAtHomeDetailsInput.fill(details)
-    await childInformationPage.confirmButton.click()
-    await childInformationPage.languageAtHome.assertTextEquals(language)
-    await childInformationPage.languageAtHomeDetails.assertTextEquals(details)
-  })
 })
 
 describe('Child Information - edit additional information', () => {
@@ -125,6 +103,28 @@ describe('Child Information - edit additional information', () => {
     await section.medicationInput.fill('')
     await section.confirmBtn.click()
     await section.medication.assertTextEquals('')
+  })
+  test('Language at home can be edited', async () => {
+    const language = 'kreikka'
+    const languageSearchText = 'kre'
+    const languageId = 'ell'
+    const details = 'Puhuu modernia kreikkaa, ei antiikin'
+
+    await page.goto(
+      config.employeeUrl + '/child-information/' + enduserNonSsnChildFixture.id
+    )
+    await childInformationPage.waitUntilLoaded()
+    await section.languageAtHome.assertTextEquals('')
+    await section.languageAtHomeDetails.assertTextEquals('')
+    await section.editBtn.click()
+    await section.languageAtHomeCombobox.fillAndSelectItem(
+      languageSearchText,
+      `language-${languageId}`
+    )
+    await section.languageAtHomeDetailsInput.fill(details)
+    await section.confirmBtn.click()
+    await section.languageAtHome.assertTextEquals(language)
+    await section.languageAtHomeDetails.assertTextEquals(details)
   })
 })
 

--- a/frontend/src/employee-frontend/components/person-shared/PersonDetails.tsx
+++ b/frontend/src/employee-frontend/components/person-shared/PersonDetails.tsx
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import sortBy from 'lodash/sortBy'
 import React, {
   useCallback,
   useContext,
@@ -17,15 +16,13 @@ import { Loading, Result, Success } from 'lib-common/api'
 import { UpdateStateFn } from 'lib-common/form-state'
 import { Action } from 'lib-common/generated/action'
 import { PersonJSON } from 'lib-common/generated/api-types/pis'
-import { IsoLanguage, isoLanguages } from 'lib-common/generated/language'
+import { isoLanguages } from 'lib-common/generated/language'
 import LocalDate from 'lib-common/local-date'
 import Button from 'lib-components/atoms/buttons/Button'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
-import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import InputField from 'lib-components/atoms/form/InputField'
 import Radio from 'lib-components/atoms/form/Radio'
-import TextArea from 'lib-components/atoms/form/TextArea'
 import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
 import {
   FixedSpaceColumn,
@@ -87,8 +84,6 @@ interface Form {
   invoicingPostOffice: string
   forceManualFeeDecisions: boolean
   ophPersonOid: string
-  languageAtHome: string
-  languageAtHomeDetails: string
 }
 
 const RightAlignedRow = styled.div`
@@ -100,14 +95,6 @@ const RightAlignedRow = styled.div`
 const ButtonSpacer = styled.div`
   margin-right: 25px;
 `
-
-const filterLanguages = (
-  input: string,
-  items: IsoLanguage[]
-): IsoLanguage[] => {
-  const filter = input.toLowerCase()
-  return items.filter((item) => item.nameFi.includes(filter))
-}
 
 export default React.memo(function PersonDetails({
   person,
@@ -134,9 +121,7 @@ export default React.memo(function PersonDetails({
     invoicingPostalCode: '',
     invoicingPostOffice: '',
     forceManualFeeDecisions: false,
-    ophPersonOid: '',
-    languageAtHome: '',
-    languageAtHomeDetails: ''
+    ophPersonOid: ''
   })
   const [ssnDisableRequest, setSsnDisableRequest] = useState<Result<void>>(
     Success.of()
@@ -184,9 +169,7 @@ export default React.memo(function PersonDetails({
         invoicingPostalCode: person.invoicingPostalCode ?? '',
         invoicingPostOffice: person.invoicingPostOffice ?? '',
         forceManualFeeDecisions: person.forceManualFeeDecisions ?? false,
-        ophPersonOid: person.ophPersonOid ?? '',
-        languageAtHome: person.languageAtHome,
-        languageAtHomeDetails: person.languageAtHomeDetails
+        ophPersonOid: person.ophPersonOid ?? ''
       })
     }
   }, [person, editing])
@@ -246,18 +229,6 @@ export default React.memo(function PersonDetails({
         : null
       )?.nameFi ?? person.language,
     [person.language]
-  )
-
-  const languageAtHome = useMemo(
-    () =>
-      (person.languageAtHome ? isoLanguages[person.languageAtHome] : null) ??
-      null,
-    [person.languageAtHome]
-  )
-
-  const languages = useMemo(
-    () => sortBy(Object.values(isoLanguages), ({ nameFi }) => nameFi),
-    []
   )
 
   return (
@@ -503,53 +474,6 @@ export default React.memo(function PersonDetails({
                 }
               ]
             : []),
-          {
-            label: i18n.childInformation.personDetails.languageAtHome,
-            value: editing ? (
-              <>
-                <Combobox
-                  data-qa="input-language-at-home"
-                  items={languages}
-                  getItemDataQa={(item) => `language-${item.id}`}
-                  selectedItem={
-                    (form.languageAtHome
-                      ? isoLanguages[form.languageAtHome]
-                      : null) ?? null
-                  }
-                  onChange={(item) =>
-                    updateForm({ languageAtHome: item?.id ?? '' })
-                  }
-                  filterItems={filterLanguages}
-                  getItemLabel={(item) => item?.nameFi}
-                  placeholder={
-                    i18n.childInformation.personDetails.placeholder
-                      .languageAtHome
-                  }
-                  clearable={true}
-                />
-                <TextArea
-                  data-qa="input-language-at-home-details"
-                  value={form.languageAtHomeDetails}
-                  placeholder={
-                    i18n.childInformation.personDetails.placeholder
-                      .languageAtHomeDetails
-                  }
-                  onChange={(languageAtHomeDetails) =>
-                    updateForm({ languageAtHomeDetails })
-                  }
-                />
-              </>
-            ) : (
-              <>
-                <div data-qa="person-language-at-home">
-                  {languageAtHome?.nameFi ?? ''}
-                </div>
-                <div data-qa="person-language-at-home-details">
-                  {person.languageAtHomeDetails}
-                </div>
-              </>
-            )
-          },
           ...(!isChild && permittedActions.has('READ_INVOICE_ADDRESS')
             ? [
                 {

--- a/frontend/src/lib-common/generated/api-types/daycare.ts
+++ b/frontend/src/lib-common/generated/api-types/daycare.ts
@@ -118,6 +118,8 @@ export interface AdditionalInformation {
   additionalInfo: string
   allergies: string
   diet: string
+  languageAtHome: string
+  languageAtHomeDetails: string
   medication: string
   preferredName: string
 }

--- a/frontend/src/lib-common/generated/api-types/pis.ts
+++ b/frontend/src/lib-common/generated/api-types/pis.ts
@@ -385,8 +385,6 @@ export interface PersonJSON {
   invoicingPostalCode: string
   invoicingStreetAddress: string
   language: string | null
-  languageAtHome: string
-  languageAtHomeDetails: string
   lastName: string
   ophPersonOid: string | null
   phone: string
@@ -413,8 +411,6 @@ export interface PersonPatch {
   invoicingPostOffice: string | null
   invoicingPostalCode: string | null
   invoicingStreetAddress: string | null
-  languageAtHome: string | null
-  languageAtHomeDetails: string | null
   lastName: string | null
   ophPersonOid: string | null
   phone: string | null

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pdfgen/PdfGeneratorTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pdfgen/PdfGeneratorTest.kt
@@ -98,9 +98,7 @@ private val child =
         "Kuusikallionrinne 26 A 4",
         "02270",
         "Espoo",
-        "",
-        languageAtHome = "",
-        languageAtHomeDetails = "",
+        ""
     )
 private val guardian =
     PersonDTO(
@@ -119,9 +117,7 @@ private val guardian =
         "Kuusikallionrinne 26 A 4",
         "02270",
         "Espoo",
-        "",
-        languageAtHome = "",
-        languageAtHomeDetails = "",
+        ""
     )
 private val manager =
     DaycareManager("Pirkko Päiväkodinjohtaja", "pirkko.paivakodinjohtaja@example.com", "0401231234")

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/PersonIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/PersonIntegrationTest.kt
@@ -44,9 +44,7 @@ class PersonIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                         streetAddress = "",
                         postalCode = "",
                         postOffice = "",
-                        residenceCode = "",
-                        languageAtHome = "",
-                        languageAtHomeDetails = "",
+                        residenceCode = ""
                     )
                 )
             }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PersonQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/dao/PersonQueriesIntegrationTest.kt
@@ -323,9 +323,7 @@ class PersonQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             postOffice = "Jokula",
             residenceCode = "",
             restrictedDetailsEnabled = true,
-            restrictedDetailsEndDate = LocalDate.now().plusYears(1),
-            languageAtHome = "",
-            languageAtHomeDetails = "",
+            restrictedDetailsEndDate = LocalDate.now().plusYears(1)
         )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/ChildQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/ChildQueries.kt
@@ -19,7 +19,7 @@ fun Database.Read.getChild(id: ChildId): Child? {
 fun Database.Transaction.createChild(child: Child): Child {
     // language=SQL
     val sql =
-        "INSERT INTO child (id, allergies, diet, additionalinfo, medication) VALUES (:id, :allergies, :diet, :additionalInfo, :medication) RETURNING *"
+        "INSERT INTO child (id, allergies, diet, additionalinfo, medication, language_at_home, language_at_home_details) VALUES (:id, :allergies, :diet, :additionalInfo, :medication, :languageAtHome, :languageAtHomeDetails) RETURNING *"
 
     return createQuery(sql)
         .bind("id", child.id)
@@ -27,6 +27,8 @@ fun Database.Transaction.createChild(child: Child): Child {
         .bind("diet", child.additionalInformation.diet)
         .bind("additionalInfo", child.additionalInformation.additionalInfo)
         .bind("medication", child.additionalInformation.medication)
+        .bind("languageAtHome", child.additionalInformation.languageAtHome)
+        .bind("languageAtHomeDetails", child.additionalInformation.languageAtHomeDetails)
         .mapTo<Child>()
         .first()
 }
@@ -50,7 +52,7 @@ fun Database.Transaction.upsertChild(child: Child) {
 fun Database.Transaction.updateChild(child: Child) {
     // language=SQL
     val sql =
-        "UPDATE child SET allergies = :allergies, diet = :diet, additionalinfo = :additionalInfo, medication = :medication WHERE id = :id"
+        "UPDATE child SET allergies = :allergies, diet = :diet, additionalinfo = :additionalInfo, medication = :medication, language_at_home = :languageAtHome, language_at_home_details = :languageAtHomeDetails WHERE id = :id"
 
     createUpdate(sql)
         .bind("id", child.id)
@@ -58,5 +60,7 @@ fun Database.Transaction.updateChild(child: Child) {
         .bind("diet", child.additionalInformation.diet)
         .bind("additionalInfo", child.additionalInformation.additionalInfo)
         .bind("medication", child.additionalInformation.medication)
+        .bind("languageAtHome", child.additionalInformation.languageAtHome)
+        .bind("languageAtHomeDetails", child.additionalInformation.languageAtHomeDetails)
         .execute()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/ChildController.kt
@@ -138,7 +138,9 @@ fun Database.Read.getAdditionalInformation(childId: ChildId): AdditionalInformat
             diet = child.additionalInformation.diet,
             additionalInfo = child.additionalInformation.additionalInfo,
             preferredName = child.additionalInformation.preferredName,
-            medication = child.additionalInformation.medication
+            medication = child.additionalInformation.medication,
+            languageAtHome = child.additionalInformation.languageAtHome,
+            languageAtHomeDetails = child.additionalInformation.languageAtHomeDetails
         )
     } else {
         AdditionalInformation()
@@ -165,5 +167,7 @@ data class AdditionalInformation(
     val diet: String = "",
     val additionalInfo: String = "",
     val preferredName: String = "",
-    val medication: String = ""
+    val medication: String = "",
+    val languageAtHome: String = "",
+    val languageAtHomeDetails: String = ""
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonQueries.kt
@@ -50,9 +50,7 @@ val personDTOColumns =
         "invoicing_post_office",
         "force_manual_fee_decisions",
         "oph_person_oid",
-        "updated_from_vtj",
-        "language_at_home",
-        "language_at_home_details"
+        "updated_from_vtj"
     )
 val commaSeparatedPersonDTOColumns = personDTOColumns.joinToString()
 
@@ -398,9 +396,7 @@ fun Database.Transaction.updatePersonNonVtjDetails(id: PersonId, patch: PersonPa
             invoicing_postal_code = coalesce(:invoicingPostalCode, invoicing_postal_code),
             invoicing_post_office = coalesce(:invoicingPostOffice, invoicing_post_office),
             force_manual_fee_decisions = coalesce(:forceManualFeeDecisions, force_manual_fee_decisions),
-            oph_person_oid = coalesce(:ophPersonOid, oph_person_oid),
-            language_at_home = coalesce(:languageAtHome, language_at_home),
-            language_at_home_details = coalesce(:languageAtHomeDetails, language_at_home_details)
+            oph_person_oid = coalesce(:ophPersonOid, oph_person_oid)
         WHERE id = :id
         RETURNING id
         """
@@ -428,9 +424,7 @@ fun Database.Transaction.updateNonSsnPersonDetails(id: PersonId, patch: PersonPa
             invoicing_postal_code = coalesce(:invoicingPostalCode, invoicing_postal_code),
             invoicing_post_office = coalesce(:invoicingPostOffice, invoicing_post_office),
             force_manual_fee_decisions = coalesce(:forceManualFeeDecisions, force_manual_fee_decisions),
-            oph_person_oid = coalesce(:ophPersonOid, oph_person_oid),
-            language_at_home = coalesce(:languageAtHome, language_at_home),
-            language_at_home_details = coalesce(:languageAtHomeDetails, language_at_home_details)
+            oph_person_oid = coalesce(:ophPersonOid, oph_person_oid)
         WHERE id = :id AND social_security_number IS NULL
         RETURNING id
         """
@@ -479,9 +473,7 @@ private val toPersonDTO: (RowView) -> PersonDTO = { row ->
         invoicingPostalCode = row.mapColumn("invoicing_postal_code"),
         invoicingPostOffice = row.mapColumn("invoicing_post_office"),
         forceManualFeeDecisions = row.mapColumn("force_manual_fee_decisions"),
-        ophPersonOid = row.mapColumn("oph_person_oid"),
-        languageAtHome = row.mapColumn("language_at_home"),
-        languageAtHomeDetails = row.mapColumn("language_at_home_details"),
+        ophPersonOid = row.mapColumn("oph_person_oid")
     )
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
@@ -284,9 +284,7 @@ class PersonService(private val personDetailsService: IPersonDetailsService) {
             postOffice = person.city,
             residenceCode = person.residenceCode,
             restrictedDetailsEnabled = person.restrictedDetailsEnabled,
-            restrictedDetailsEndDate = person.restrictedDetailsEndDate,
-            languageAtHome = "",
-            languageAtHomeDetails = "",
+            restrictedDetailsEndDate = person.restrictedDetailsEndDate
         )
 
     private fun toPersonWithChildrenDTO(
@@ -398,8 +396,6 @@ data class PersonDTO(
     val invoicingPostOffice: String = "",
     val forceManualFeeDecisions: Boolean = false,
     val ophPersonOid: String? = "",
-    val languageAtHome: String = "",
-    val languageAtHomeDetails: String = "",
 ) {
     fun toVtjPersonDTO() =
         VtjPersonDTO(
@@ -496,8 +492,6 @@ data class PersonJSON(
     val forceManualFeeDecisions: Boolean = false,
     val ophPersonOid: String? = "",
     val updatedFromVtj: HelsinkiDateTime? = null,
-    val languageAtHome: String = "",
-    val languageAtHomeDetails: String = "",
 ) {
     companion object {
         fun from(p: PersonDTO): PersonJSON =
@@ -524,9 +518,7 @@ data class PersonJSON(
                 invoicingPostOffice = p.invoicingPostOffice,
                 forceManualFeeDecisions = p.forceManualFeeDecisions,
                 ophPersonOid = p.ophPersonOid,
-                updatedFromVtj = p.updatedFromVtj,
-                languageAtHome = p.languageAtHome,
-                languageAtHomeDetails = p.languageAtHomeDetails,
+                updatedFromVtj = p.updatedFromVtj
             )
     }
 }
@@ -546,9 +538,7 @@ data class PersonPatch(
     val invoicingPostalCode: String? = null,
     val invoicingPostOffice: String? = null,
     val forceManualFeeDecisions: Boolean? = null,
-    val ophPersonOid: String? = null,
-    val languageAtHome: String? = null,
-    val languageAtHomeDetails: String? = null,
+    val ophPersonOid: String? = null
 )
 
 data class PersonWithChildrenDTO(
@@ -592,9 +582,7 @@ data class PersonWithChildrenDTO(
             language = nativeLanguage?.code,
             email = email,
             phone = phone,
-            backupPhone = backupPhone,
-            languageAtHome = "",
-            languageAtHomeDetails = "",
+            backupPhone = backupPhone
         )
 }
 
@@ -700,9 +688,7 @@ private fun newPersonFromVtjData(inputPerson: VtjPersonDTO): PersonDTO =
         dateOfDeath = inputPerson.dateOfDeath,
         email = null,
         phone = "",
-        backupPhone = "",
-        languageAtHome = "",
-        languageAtHomeDetails = "",
+        backupPhone = ""
     )
 
 private fun getPersonWithUpdatedProperties(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -451,10 +451,10 @@ fun Database.Transaction.insertTestChild(child: DevChild) =
     insertTestDataRow(
         child,
         """
-INSERT INTO child (id, allergies, diet, medication, additionalinfo)
-VALUES (:id, :allergies, :diet, :medication, :additionalInfo)
+INSERT INTO child (id, allergies, diet, medication, additionalinfo, language_at_home, language_at_home_details)
+VALUES (:id, :allergies, :diet, :medication, :additionalInfo, :languageAtHome, :languageAtHomeDetails)
 ON CONFLICT(id) DO UPDATE
-SET id = :id, allergies = :allergies, diet = :diet, medication = :medication, additionalInfo = :additionalInfo
+SET id = :id, allergies = :allergies, diet = :diet, medication = :medication, additionalInfo = :additionalInfo, language_at_home = :languageAtHome, language_at_home_details = :languageAtHomeDetails
 RETURNING id
     """
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1607,7 +1607,9 @@ data class DevChild(
     val allergies: String = "",
     val diet: String = "",
     val medication: String = "",
-    val additionalInfo: String = ""
+    val additionalInfo: String = "",
+    val languageAtHome: String = "",
+    val languageAtHomeDetails: String = ""
 )
 
 data class DevDaycare(
@@ -1773,8 +1775,6 @@ data class DevPerson(
     val guardians: List<DevPerson> = emptyList(),
     val updatedFromVtj: HelsinkiDateTime? = null,
     val ophPersonOid: String = "",
-    val languageAtHome: String = "",
-    val languageAtHomeDetails: String = "",
     val duplicateOf: PersonId? = null
 ) {
     fun toPersonDTO() =
@@ -1802,9 +1802,7 @@ data class DevPerson(
             invoicingStreetAddress = this.invoicingStreetAddress,
             invoicingPostalCode = this.invoicingPostalCode,
             invoicingPostOffice = this.invoicingPostOffice,
-            ophPersonOid = this.ophPersonOid,
-            languageAtHome = this.languageAtHome,
-            languageAtHomeDetails = this.languageAtHomeDetails,
+            ophPersonOid = this.ophPersonOid
         )
 }
 

--- a/service/src/main/resources/db/migration/V316__move_language_at_home.sql
+++ b/service/src/main/resources/db/migration/V316__move_language_at_home.sql
@@ -1,0 +1,9 @@
+ALTER TABLE child
+    ADD COLUMN language_at_home text NOT NULL DEFAULT '',
+    ADD COLUMN language_at_home_details text NOT NULL DEFAULT '';
+
+UPDATE child SET (language_at_home, language_at_home_details) = (SELECT language_at_home, language_at_home_details FROM person WHERE child.id = person.id);
+
+ALTER TABLE person
+    DROP COLUMN language_at_home,
+    DROP COLUMN language_at_home_details;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -312,3 +312,4 @@ V312__mobile_device_push_subscription.sql
 V313__message_push_notifications.sql
 V314__attendance_reservation_index.sql
 V315__drop_push_sent_at.sql
+V316__move_language_at_home.sql

--- a/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/VtjClientServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/VtjClientServiceTest.kt
@@ -316,8 +316,6 @@ class VtjClientServiceTest {
             residenceCode = "",
             restrictedDetailsEnabled = false,
             restrictedDetailsEndDate = null,
-            languageAtHome = "",
-            languageAtHomeDetails = "",
         )
 
     private fun createPersonResponse(forSsn: String? = DEFAULT_PERSON_SSN) =

--- a/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/persondetails/VTJPersonDetailsServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/vtjclient/service/persondetails/VTJPersonDetailsServiceTest.kt
@@ -145,9 +145,7 @@ class VTJPersonDetailsServiceTest {
             streetAddress = "",
             postalCode = "",
             postOffice = "",
-            residenceCode = "",
-            languageAtHome = "",
-            languageAtHomeDetails = "",
+            residenceCode = ""
         )
 
     private val validPerson =


### PR DESCRIPTION
- Move the `language_at_home` and  `language_at_home_details` columns from the `person` table to the `child` table
- API changed to reflect the above
- Move the language at home fields to the additional details section in the UI
