### PR TITLE
Fix staff realtime attendance group handling

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -341,6 +341,12 @@ describe('Realtime staff attendances', () => {
       await modal.setDepartureTime(0, '12:00')
       await modal.addNewAttendance()
       await modal.setType(1, 'TRAINING')
+
+      // Bug check: reset group if type does not require one
+      await modal.setType(1, 'PRESENT')
+      await modal.setGroup(1, groupId)
+      await modal.setType(1, 'TRAINING')
+
       await modal.setArrivalTime(1, '12:00')
       await modal.setDepartureTime(1, '13:00')
       await modal.addNewAttendance()

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
@@ -424,7 +424,7 @@ function StaffAttendanceDetailsModal<
                         arrived,
                         departed,
                         type: value,
-                        groupId
+                        groupId: presentInGroup(value) ? groupId : null
                       })
                     }
                     getItemLabel={(item) =>

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
@@ -587,7 +587,7 @@ fun Database.Transaction.deleteStaffAttendancesInRangeExcept(
             """
 DELETE FROM staff_attendance_realtime
 WHERE
-    group_id = ANY (SELECT id FROM daycare_group WHERE daycare_id = :unitId) AND
+    (group_id IS NULL OR group_id = ANY (SELECT id FROM daycare_group WHERE daycare_id = :unitId)) AND
     employee_id = :employeeId AND
     tstzrange(arrived, departed) && :timeRange AND
     NOT id = ANY(:exceptIds)


### PR DESCRIPTION
#### Summary
-If user selects from staff attendance day modal an attendance type which requires selecting a group, and then switches to another that does not require a group, the group id must be removed
-Allow deleting an attendance without a group id

