### PR TITLE
Another fix for service-worker.js, broken by Sentry in master

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -207,7 +207,8 @@ function baseConfig({ isDevelopment }, { name, publicPath, entry }) {
           vendor: {
             test: /[\\/]node_modules[\\/]/,
             name: 'vendor',
-            chunks: 'all'
+            // See above
+            chunks: (chunk) => chunk.name !== 'service-worker'
           }
         }
       }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The previous fix wasn't enough, but it worked as long as Sentry plugin wasn't used (= locally, pull requests). For some reason, the Sentry plugin injects some code when enabled, which broke things in our master build.