### PR TITLE
EVAKA-4785 Show which guardian has approved vasu/leops

### DIFF
--- a/frontend/src/employee-frontend/components/vasu/sections/VasuEvents.tsx
+++ b/frontend/src/employee-frontend/components/vasu/sections/VasuEvents.tsx
@@ -14,6 +14,8 @@ import { Dimmed, H2, Label } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import { VasuTranslations } from 'lib-customizations/employee'
 
+import { useTranslation } from '../../../state/i18n'
+import { formatPersonName } from '../../../utils'
 import { VasuStateChip } from '../../common/VasuStateChip'
 import { isDateQuestion } from '../vasu-content'
 import { getLastPublished } from '../vasu-events'
@@ -55,17 +57,18 @@ function EventRow({
 interface Props {
   document: Pick<
     VasuDocument,
-    'documentState' | 'events' | 'modifiedAt' | 'type'
+    'documentState' | 'events' | 'modifiedAt' | 'type' | 'basics'
   >
   content: VasuDocument['content']
   translations: VasuTranslations
 }
 
 export function VasuEvents({
-  document: { documentState, events, modifiedAt, type },
+  document: { documentState, events, modifiedAt, type, basics },
   content,
   translations
 }: Props) {
+  const { i18n } = useTranslation()
   const lastPublished = getLastPublished(events)
 
   const trackedDates: [string, LocalDate][] = useMemo(
@@ -109,6 +112,22 @@ export function VasuEvents({
             translations={translations}
           />
         ))}
+        {basics.guardians.find(
+          ({ hasGivenPermissionToShare }) => hasGivenPermissionToShare
+        ) === undefined ? null : (
+          <>
+            <Label>{translations.guardianPermissionGiven}</Label>
+            <span>
+              {basics.guardians
+                .map((guardian) =>
+                  guardian.hasGivenPermissionToShare
+                    ? formatPersonName(guardian, i18n, true)
+                    : undefined
+                )
+                .join(', ')}
+            </span>
+          </>
+        )}
       </ListGrid>
       {events.length > 0 && (
         <>

--- a/frontend/src/lib-customizations/defaults/employee/i18n/vasu/fi.ts
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/vasu/fi.ts
@@ -47,5 +47,6 @@ export const fi = {
     CLOSED: 'Päättynyt'
   },
   lastModified: 'Viimeisin muokkauspäivämäärä',
-  lastPublished: 'Viimeksi julkaistu huoltajalle'
+  lastPublished: 'Viimeksi julkaistu huoltajalle',
+  guardianPermissionGiven: 'Tiedonsaajatahot hyväksynyt'
 }

--- a/frontend/src/lib-customizations/defaults/employee/i18n/vasu/sv.ts
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/vasu/sv.ts
@@ -51,5 +51,6 @@ export const sv: typeof fi = {
     CLOSED: 'Avslutad'
   },
   lastModified: 'Senaste redigeringsdatum',
-  lastPublished: 'Senaste publicering för vårdnadshavare'
+  lastPublished: 'Senaste publicering för vårdnadshavare',
+  guardianPermissionGiven: 'Informationsdelning godkänd av'
 }


### PR DESCRIPTION
If one or more of the guardians have given permission to share the vasu / leops as stated in the document, their names are shown in the events section.

Nothing is shown before at least one guardian has given permission.