### PR TITLE
Add Dari language to ISO languages list

### DIFF
--- a/frontend/src/lib-common/generated/language.ts
+++ b/frontend/src/lib-common/generated/language.ts
@@ -138,6 +138,7 @@ const isoLanguages: { [id: string]: IsoLanguage } = {
   pli: { id: "pli", alpha2: "pi", nameFi: "paali" },
   pol: { id: "pol", alpha2: "pl", nameFi: "puola" },
   por: { id: "por", alpha2: "pt", nameFi: "portugali" },
+  prs: { id: "prs", alpha2: "", nameFi: "dari" },
   pus: { id: "pus", alpha2: "ps", nameFi: "paštu" },
   que: { id: "que", alpha2: "qu", nameFi: "ketšua" },
   roh: { id: "roh", alpha2: "rm", nameFi: "retoromaani" },

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Languages.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Languages.kt
@@ -153,6 +153,7 @@ val ISO_LANGUAGES_SUBSET =
         IsoLanguage("pli", "pli", "pli", "pi", "paali"),
         IsoLanguage("pol", "pol", "pol", "pl", "puola"),
         IsoLanguage("por", "por", "por", "pt", "portugali"),
+        IsoLanguage("prs", "", "", "", "dari"),
         IsoLanguage("pus", "pus", "pus", "ps", "paštu"),
         IsoLanguage("que", "que", "que", "qu", "ketšua"),
         IsoLanguage("roh", "roh", "roh", "rm", "retoromaani"),


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Not present in ISO 639-1 / 639-2, but it's included in ISO 639-3.