### PR TITLE
Hide duplicated children from applications block (citizen frontend)

### DIFF
--- a/frontend/src/citizen-frontend/applications/Applications.tsx
+++ b/frontend/src/citizen-frontend/applications/Applications.tsx
@@ -50,12 +50,13 @@ export default React.memo(function Applications() {
       {renderResult(guardianApplications, (guardianApplications) => (
         <>
           {sortBy(guardianApplications, (a) => a.childName).map(
-            (childApplications) => (
-              <Fragment key={childApplications.childId}>
-                <ChildApplicationsBlock data={childApplications} />
-                <Gap size="s" />
-              </Fragment>
-            )
+            (childApplications) =>
+              childApplications.duplicateOf === null && (
+                <Fragment key={childApplications.childId}>
+                  <ChildApplicationsBlock data={childApplications} />
+                  <Gap size="s" />
+                </Fragment>
+              )
           )}
         </>
       ))}

--- a/frontend/src/citizen-frontend/applications/ChildApplicationsBlock.tsx
+++ b/frontend/src/citizen-frontend/applications/ChildApplicationsBlock.tsx
@@ -86,13 +86,7 @@ const ChildHeading = styled(H2)`
 `
 
 export default React.memo(function ChildApplicationsBlock({
-  data: {
-    childId,
-    childName,
-    applicationSummaries,
-    permittedActions,
-    duplicateOf
-  }
+  data: { childId, childName, applicationSummaries, permittedActions }
 }: ChildApplicationsBlockProps) {
   const navigate = useNavigate()
   const t = useTranslation()
@@ -174,13 +168,11 @@ export default React.memo(function ChildApplicationsBlock({
         <ChildHeading data-qa={`title-applications-child-name-${childId}`}>
           {childName}
         </ChildHeading>
-        {duplicateOf === null && (
-          <AddButton
-            text={t.applicationsList.newApplicationLink}
-            onClick={() => navigate(`/applications/new/${childId}`)}
-            data-qa={`new-application-${childId}`}
-          />
-        )}
+        <AddButton
+          text={t.applicationsList.newApplicationLink}
+          onClick={() => navigate(`/applications/new/${childId}`)}
+          data-qa={`new-application-${childId}`}
+        />
       </TitleContainer>
 
       {applicationSummaries.length > 0 &&


### PR DESCRIPTION
Moves the `AddButton` hiding logic for duplicated children up a level to prevent the creation of the entire child fragment for the same page. 
