### PR TITLE
Unify and improve Jackson mapper configuration

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/FullApplicationTest.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.github.kittinunf.fuel.core.FileDataPart
 import com.github.kittinunf.fuel.core.FuelManager
@@ -15,7 +16,7 @@ import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.asUser
 import fi.espoo.evaka.shared.config.SharedIntegrationTestConfig
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import fi.espoo.evaka.shared.config.getTestDataSource
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
@@ -43,7 +44,10 @@ import org.springframework.core.env.Environment
 abstract class FullApplicationTest(private val resetDbBeforeEach: Boolean) {
     @LocalServerPort protected var httpPort: Int = 0
 
-    protected val jsonMapper: JsonMapper = defaultJsonMapper()
+    protected val jsonMapper: JsonMapper =
+        defaultJsonMapperBuilder()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build()
 
     private lateinit var jdbi: Jdbi
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueriesTest.kt
@@ -20,7 +20,7 @@ import fi.espoo.evaka.invoicing.domain.IncomeEffect
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.FeeDecisionId
 import fi.espoo.evaka.shared.PersonId
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.domain.DateRange
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class FeeDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
-    val jsonMapper = defaultJsonMapper()
+    val jsonMapper = defaultJsonMapperBuilder().build()
 
     private val testPeriod = DateRange(LocalDate.of(2019, 5, 1), LocalDate.of(2019, 5, 31))
     private val testPeriod2 = DateRange(LocalDate.of(2019, 5, 15), LocalDate.of(2019, 5, 31))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueriesTest.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.invoicing.domain.IncomeValue
 import fi.espoo.evaka.invoicing.service.EspooIncomeTypesProvider
 import fi.espoo.evaka.shared.IncomeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.RealEvakaClock
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class IncomeQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
-    private val mapper = defaultJsonMapper()
+    private val mapper = defaultJsonMapperBuilder().build()
     private val incomeTypesProvider = EspooIncomeTypesProvider()
 
     @BeforeEach

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
@@ -18,7 +18,7 @@ import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.InvoiceCorrectionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import fi.espoo.evaka.shared.config.testFeatureConfig
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
@@ -44,7 +44,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
     private val generator: InvoiceGenerator = InvoiceGenerator(draftInvoiceGenerator)
     private val invoiceService =
         InvoiceService(
-            InvoiceIntegrationClient.MockClient(defaultJsonMapper()),
+            InvoiceIntegrationClient.MockClient(defaultJsonMapperBuilder().build()),
             TestInvoiceProductProvider(),
             featureConfig
         )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/MockKoskiServer.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/MockKoskiServer.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.koski
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.google.common.collect.Multimaps
 import com.google.common.collect.SetMultimap
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import io.javalin.Javalin
 import io.javalin.apibuilder.ApiBuilder.post
 import io.javalin.apibuilder.ApiBuilder.put
@@ -181,7 +181,7 @@ class MockKoskiServer(private val jsonMapper: JsonMapper, port: Int) : AutoClose
     companion object {
         const val UNIT_OID_THAT_TRIGGERS_400 = "SIMULATE_BAD_REQUEST"
         fun start(): MockKoskiServer {
-            return MockKoskiServer(defaultJsonMapper(), port = 0)
+            return MockKoskiServer(defaultJsonMapperBuilder().build(), port = 0)
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -13,7 +13,6 @@ import fi.espoo.evaka.application.ApplicationPreschoolTypeToggle.PRESCHOOL_DAYCA
 import fi.espoo.evaka.application.ApplicationPreschoolTypeToggle.PRESCHOOL_ONLY
 import fi.espoo.evaka.application.persistence.club.ClubFormV0
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
-import fi.espoo.evaka.application.persistence.jsonMapper
 import fi.espoo.evaka.application.utils.exhaust
 import fi.espoo.evaka.placement.PlacementPlanConfirmationStatus
 import fi.espoo.evaka.placement.PlacementType
@@ -39,7 +38,6 @@ import java.time.LocalDate
 import java.util.UUID
 import mu.KotlinLogging
 import org.jdbi.v3.core.result.RowView
-import org.postgresql.util.PGobject
 
 private val logger = KotlinLogging.logger {}
 
@@ -984,16 +982,7 @@ VALUES (:applicationId, :document, (SELECT coalesce(max(revision) + 1, 1) FROM o
         """
             .trimIndent()
 
-    createUpdate(sql)
-        .bind("applicationId", id)
-        .bind(
-            "document",
-            PGobject().apply {
-                type = "jsonb"
-                value = jsonMapper().writeValueAsString(transformedForm)
-            }
-        )
-        .execute()
+    createUpdate(sql).bind("applicationId", id).bindJson("document", transformedForm).execute()
 }
 
 fun Database.Transaction.setCheckedByAdminToDefault(id: ApplicationId, form: ApplicationForm) {

--- a/service/src/main/kotlin/fi/espoo/evaka/application/persistence/DatabaseForm.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/persistence/DatabaseForm.kt
@@ -4,10 +4,6 @@
 
 package fi.espoo.evaka.application.persistence
 
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.databind.json.JsonMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import fi.espoo.evaka.application.ApplicationType
 import java.time.LocalDate
 
@@ -24,9 +20,3 @@ sealed class DatabaseForm {
     abstract fun hideGuardianAddress(): DatabaseForm
     abstract fun hideChildAddress(): DatabaseForm
 }
-
-fun jsonMapper(): JsonMapper =
-    jacksonMapperBuilder()
-        .addModule(JavaTimeModule())
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-        .build()

--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiClient.kt
@@ -5,12 +5,7 @@
 package fi.espoo.evaka.koski
 
 import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.Headers
@@ -23,6 +18,7 @@ import fi.espoo.evaka.OphEnv
 import fi.espoo.evaka.shared.KoskiStudyRightId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.voltti.logging.loggers.error
 import java.time.LocalDate
@@ -40,10 +36,8 @@ class KoskiClient(
     // global defaults change.
     // This is important, because our payload diffing mechanism relies on the serialization format
     private val jsonMapper =
-        jacksonMapperBuilder()
-            .addModules(JavaTimeModule(), Jdk8Module(), ParameterNamesModule())
+        defaultJsonMapperBuilder()
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             .build()
 
     init {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobQueries.kt
@@ -28,11 +28,7 @@ RETURNING id
         .bind("retryCount", jobParams.retryCount)
         .bind("retryInterval", jobParams.retryInterval)
         .bind("runAt", jobParams.runAt)
-        .bindByType(
-            "payload",
-            jobParams.payload,
-            QualifiedType.of(jobParams.payload.javaClass).with(Json::class.java)
-        )
+        .bindJson("payload", jobParams.payload)
         .executeAndReturnGeneratedKeys()
         .mapTo<UUID>()
         .one()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/JacksonConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/JacksonConfig.kt
@@ -10,26 +10,51 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-fun defaultJsonMapper(): JsonMapper =
-    jacksonMapperBuilder()
-        .addModules(JavaTimeModule(), Jdk8Module(), ParameterNamesModule())
-        .disable(
-            MapperFeature.DEFAULT_VIEW_INCLUSION
-        ) // Disabled by default in Spring Boot autoconfig
-        .disable(
-            DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
-        ) // Disabled by default in Spring Boot autoconfig
+fun defaultJsonMapperBuilder(): JsonMapper.Builder =
+    JsonMapper.builder()
+        .addModules(
+            KotlinModule.Builder()
+                // Without this, Kotlin singletons are not actually singletons when deserialized.
+                // For example, a sealed class `sealed class Foo` where one variant is `object
+                // OneVariant: Foo()`
+                .enable(KotlinFeature.SingletonSupport)
+                .build(),
+            JavaTimeModule(),
+            Jdk8Module(),
+            ParameterNamesModule(),
+        )
+        // We never want to serialize timestamps as numbers but use ISO formats instead.
+        // Our custom types (e.g. HelsinkiDateTime) already have custom serializers that handle
+        // this, but it's still a good idea to ensure global defaults are sane.
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+@Deprecated(
+    "use defaultJsonMapperBuilder instead, and configure features based on actual requirements",
+    replaceWith = ReplaceWith("defaultJsonMapperBuilder()")
+)
+fun defaultJsonMapper(): JsonMapper =
+    defaultJsonMapperBuilder()
+        .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
         .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
         .build()
 
 @Configuration
 class JacksonConfig {
     // This replaces default JsonMapper provided by Spring Boot autoconfiguration
-    @Bean fun jsonMapper() = defaultJsonMapper()
+    @Bean
+    fun jsonMapper(): JsonMapper =
+        defaultJsonMapperBuilder()
+            // Disabled by default in Spring Boot autoconfig
+            .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+            // Disabled by default in Spring Boot autoconfig
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+            .build()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Db.kt
@@ -4,12 +4,8 @@
 
 package fi.espoo.evaka.shared.db
 
-import com.fasterxml.jackson.databind.json.JsonMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import fi.espoo.evaka.shared.Id
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.lang.reflect.Type
 import java.time.LocalDate
@@ -70,12 +66,7 @@ private inline fun <reified T> Jdbi.register(
 }
 
 fun configureJdbi(jdbi: Jdbi): Jdbi {
-    val jsonMapper =
-        JsonMapper()
-            .registerModule(JavaTimeModule())
-            .registerModule(Jdk8Module())
-            .registerModule(ParameterNamesModule())
-            .registerModule(KotlinModule.Builder().build())
+    val jsonMapper = defaultJsonMapperBuilder().build()
     jdbi
         .installPlugin(KotlinPlugin())
         .installPlugin(PostgresPlugin())

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.application.ApplicationType
 import fi.espoo.evaka.application.getApplicationType
 import fi.espoo.evaka.application.persistence.club.ClubFormV0
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
-import fi.espoo.evaka.application.persistence.jsonMapper
 import fi.espoo.evaka.assistanceaction.insertAssistanceActionOptionRefs
 import fi.espoo.evaka.assistanceneed.insertAssistanceBasisOptionRefs
 import fi.espoo.evaka.attendance.StaffAttendanceType
@@ -79,7 +78,6 @@ import java.util.UUID
 import mu.KotlinLogging
 import org.intellij.lang.annotations.Language
 import org.jdbi.v3.json.Json
-import org.postgresql.util.PGobject
 import org.springframework.core.io.ClassPathResource
 
 private val logger = KotlinLogging.logger {}
@@ -400,13 +398,7 @@ VALUES (:applicationId, :revision, :document, TRUE)
         )
         .bind("applicationId", applicationId)
         .bind("revision", revision)
-        .bind(
-            "document",
-            PGobject().apply {
-                type = "jsonb"
-                value = jsonMapper().writeValueAsString(document)
-            }
-        )
+        .bindJson("document", document)
         .execute()
 }
 
@@ -437,13 +429,7 @@ VALUES (:applicationId, :revision, :document, TRUE)
         )
         .bind("applicationId", applicationId)
         .bind("revision", revision)
-        .bind(
-            "document",
-            PGobject().apply {
-                type = "jsonb"
-                value = jsonMapper().writeValueAsString(document)
-            }
-        )
+        .bindJson("document", document)
         .execute()
 }
 
@@ -1161,7 +1147,7 @@ WHERE application_id = :applicationId AND revision < :revision
         .bind("created", applicationForm.createdDate)
         .bind("revision", applicationForm.revision)
         .bind("updated", applicationForm.updated)
-        .bind("document", jsonMapper().writeValueAsString(applicationForm.document))
+        .bindJson("document", applicationForm.document)
         .execute()
 
     return id

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/service/persondetails/MockPersonDetailsService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/service/persondetails/MockPersonDetailsService.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.vtjclient.service.persondetails
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import fi.espoo.evaka.vtjclient.dto.VtjPerson
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
@@ -47,7 +47,7 @@ class MockPersonDetailsService : IPersonDetailsService {
                 ClassPathResource("mock-vtj-data.json").inputStream.use {
                     it.bufferedReader().readText()
                 }
-            return defaultJsonMapper().readValue(content)
+            return defaultJsonMapperBuilder().build().readValue(content)
         }
 
         fun upsertPerson(person: VtjPerson) {

--- a/service/src/main/kotlin/fi/espoo/evaka/webpush/WebPush.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/webpush/WebPush.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.FuelManager
 import fi.espoo.evaka.WebPushEnv
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.voltti.logging.loggers.error
 import java.lang.RuntimeException
@@ -101,7 +101,7 @@ data class WebPushRequestHeaders(
 class WebPush(env: WebPushEnv) {
     private val fuel = FuelManager()
     private val secureRandom = SecureRandom()
-    private val jsonMapper = defaultJsonMapper()
+    private val jsonMapper = defaultJsonMapperBuilder().build()
     private val vapidKeyPair: WebPushKeyPair =
         WebPushKeyPair.fromPrivateKey(WebPushCrypto.decodePrivateKey(env.vapidPrivateKey.value))
     val applicationServerKey: String

--- a/service/src/test/kotlin/fi/espoo/evaka/identity/ExternalIdTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/identity/ExternalIdTest.kt
@@ -5,12 +5,12 @@
 package fi.espoo.evaka.identity
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 
 class ExternalIdTest {
-    private val jsonMapper = defaultJsonMapper()
+    private val jsonMapper = defaultJsonMapperBuilder().build()
 
     @Test
     fun `external ids can serialized to and from json`() {

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTimeTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTimeTest.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.shared.domain
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class HelsinkiDateTimeTest {
-    private val jsonMapper = defaultJsonMapper()
+    private val jsonMapper = defaultJsonMapperBuilder().build()
     private val summerValue =
         HelsinkiDateTime.from(
             ZonedDateTime.of(LocalDate.of(2021, 4, 14), LocalTime.of(16, 2), europeHelsinki)

--- a/service/src/test/kotlin/fi/espoo/evaka/varda/VardaUnitModelTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/varda/VardaUnitModelTest.kt
@@ -4,12 +4,12 @@
 
 package fi.espoo.evaka.varda
 
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 
 class VardaUnitModelTest {
-    private val mapper = defaultJsonMapper()
+    private val mapper = defaultJsonMapperBuilder().build()
 
     @Test
     fun `data output is in correct form`() {

--- a/service/src/test/kotlin/fi/espoo/evaka/varda/integration/VardaClientTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/varda/integration/VardaClientTest.kt
@@ -11,7 +11,7 @@ import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.requests.DefaultBody
 import fi.espoo.evaka.Sensitive
 import fi.espoo.evaka.VardaEnv
-import fi.espoo.evaka.shared.config.defaultJsonMapper
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import java.io.ByteArrayInputStream
 import java.net.URL
 import kotlin.test.assertTrue
@@ -32,7 +32,7 @@ class MockVardaTokenProvider : VardaTokenProvider {
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class VardaClientTest {
-    private val jsonMapper: JsonMapper = defaultJsonMapper()
+    private val jsonMapper: JsonMapper = defaultJsonMapperBuilder().build()
     private lateinit var mockTokenProvider: VardaTokenProvider
 
     @BeforeAll


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- expose a builder instead of the mapper. This lets different parts of the application configure *extra features* as needed, while still having good defaults
- enable Kotlin singleton support. For some reason this is disabled by default, and all singleton deserializations have been broken for a while
- deprecate defaultJsonMapper(). We no longer use it, but let's keep the deprecation for a while to avoid breaking other builds
- use JDBI Json support instead of instantiating a custom mapper in queries