### PR TITLE
Fix flaky E2E test

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -424,12 +424,12 @@ describe('Realtime staff attendances', () => {
     })
     test('Departure time is required when editing days that are not today', async () => {
       await prepareTest({
-        arrived: mockedToday.toHelsinkiDateTime(LocalTime.of(7, 0))
+        arrived: mockedToday.subDays(2).toHelsinkiDateTime(LocalTime.of(7, 0))
       })
 
       const modal = await staffAttendances.openDetails(
         1,
-        mockedToday.addDays(1)
+        mockedToday.subDays(1)
       )
       await modal.setArrivalTime(0, '08:00')
       await waitUntilEqual(() => modal.departureTimeInfo(0), 'Pakollinen tieto')


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The test no longer made any sense, because editing future attendances is not allowed. However, for some reason the test *worked* randomly