### PR TITLE
Fix attachment size limit for citizens

### DIFF
--- a/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -305,6 +305,11 @@ server {
     include     proxy_params;
     proxy_pass  $enduserUrl;
 
+    location /api/application/citizen/attachments {
+      client_max_body_size 100m;
+      proxy_pass  $enduserUrl;
+    }
+
     location /api/application/attachments {
       client_max_body_size 100m;
       proxy_pass  $enduserUrl;


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

A previous fix tried to increase the limit in api gateway, where it had no effect because it only limited the *parsed request body* size, but parsing was disabled for multipart requests.

The actual current limit comes from nginx and its default (1 MB), which was used because the limit was only increased in the config for `/attachments` and not `/citizen/attachments`.

The true final limit is still 10 MB which evaka-service applies to all requests. These limits should probably be harmonized a bit more...