### PR TITLE
Hide the original child of a duplication case from Koski integration

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -446,6 +446,34 @@ val testChildWithNamelessGuardian =
         restrictedDetailsEnabled = false
     )
 
+val testChildDuplicated =
+    DevPerson(
+        id = ChildId(UUID.randomUUID()),
+        dateOfBirth = LocalDate.of(2018, 12, 31),
+        ssn = "311218A999X",
+        firstName = "Monika",
+        lastName = "Monistettu",
+        streetAddress = "Testikatu 1",
+        postalCode = "00340",
+        postOffice = "Espoo",
+        restrictedDetailsEnabled = false
+    )
+
+val testChildDuplicateOf =
+    DevPerson(
+        id = ChildId(UUID.randomUUID()),
+        dateOfBirth = LocalDate.of(2018, 12, 31),
+        ssn = null,
+        ophPersonOid = "1.2.246.562.10.735773577357",
+        firstName = "Monika",
+        lastName = "Monistettu",
+        streetAddress = "Testikatu 1",
+        postalCode = "00340",
+        postOffice = "Espoo",
+        restrictedDetailsEnabled = false,
+        duplicateOf = testChildDuplicated.id
+    )
+
 val allWorkers = setOf(testDecisionMaker_1, testDecisionMaker_2, testDecisionMaker_3)
 val allAdults =
     setOf(testAdult_1, testAdult_2, testAdult_3, testAdult_4, testAdult_5, testAdult_6, testAdult_7)
@@ -459,7 +487,9 @@ val allChildren =
         testChild_6,
         testChild_7,
         testChild_8,
-        testChildWithNamelessGuardian
+        testChildWithNamelessGuardian,
+        testChildDuplicated,
+        testChildDuplicateOf
     )
 val allDaycares = setOf(testDaycare, testDaycare2)
 
@@ -544,7 +574,9 @@ fun Database.Transaction.insertGeneralTestFixtures() {
                 lastName = it.lastName,
                 streetAddress = it.streetAddress,
                 postalCode = it.postalCode,
-                postOffice = it.postOffice
+                postOffice = it.postOffice,
+                duplicateOf = it.duplicateOf,
+                ophPersonOid = it.ophPersonOid
             )
         )
         insertTestChild(DevChild(id = it.id))

--- a/service/src/main/resources/db/migration/R__koski_views.sql
+++ b/service/src/main/resources/db/migration/R__koski_views.sql
@@ -32,8 +32,7 @@ TABLE (
         AND placement.type IN ('PRESCHOOL', 'PRESCHOOL_DAYCARE', 'PRESCHOOL_CLUB', 'PREPARATORY', 'PREPARATORY_DAYCARE')
         WINDOW child AS (PARTITION BY child_id)
     ) p
-    JOIN person pr ON p.child_id = pr.id
-    WHERE NOT EXISTS (SELECT FROM person duplicate WHERE duplicate.duplicate_of = pr.id)
+    WHERE NOT EXISTS (SELECT FROM person duplicate WHERE duplicate.duplicate_of = p.child_id)
     GROUP BY child_id, unit_id, type
 $$ LANGUAGE SQL STABLE;
 

--- a/service/src/main/resources/db/migration/R__koski_views.sql
+++ b/service/src/main/resources/db/migration/R__koski_views.sql
@@ -32,6 +32,8 @@ TABLE (
         AND placement.type IN ('PRESCHOOL', 'PRESCHOOL_DAYCARE', 'PRESCHOOL_CLUB', 'PREPARATORY', 'PREPARATORY_DAYCARE')
         WINDOW child AS (PARTITION BY child_id)
     ) p
+    JOIN person pr ON p.child_id = pr.id
+    WHERE NOT EXISTS (SELECT FROM person duplicate WHERE duplicate.duplicate_of = pr.id)
     GROUP BY child_id, unit_id, type
 $$ LANGUAGE SQL STABLE;
 


### PR DESCRIPTION
- filter to remove persons that have at least one duplicate from Koski study right selection
- integration test to check that a study right is sent for the duplicate but not the original