### PR TITLE
Make citizen calendar more accurate

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarEventCount.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarEventCount.tsx
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import styled from 'styled-components'
+
+import { fontWeights } from 'lib-components/typography'
+
+export const CalendarEventCountContainer = styled.div`
+  position: relative;
+  font-size: 20px;
+  height: fit-content;
+`
+export const CalendarEventCount = styled.div`
+  padding: 2px;
+  height: 20px;
+  min-width: 20px;
+  background-color: ${(p) => p.theme.colors.status.warning};
+  color: ${(p) => p.theme.colors.grayscale.g0};
+  font-weight: ${fontWeights.bold};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 100%;
+  left: 100%;
+  transform: translate(-60%, -60%);
+  font-size: 14px;
+  border-radius: 9999px;
+`

--- a/frontend/src/citizen-frontend/calendar/api.ts
+++ b/frontend/src/citizen-frontend/calendar/api.ts
@@ -18,9 +18,8 @@ import {
 } from 'lib-common/generated/api-types/holidayperiod'
 import {
   AbsenceRequest,
-  DailyReservationData,
   DailyReservationRequest,
-  ReservationChild,
+  ReservationResponseDay,
   ReservationsResponse
 } from 'lib-common/generated/api-types/reservations'
 import { JsonOf } from 'lib-common/json'
@@ -41,11 +40,11 @@ export async function getReservations(
     })
     .then((res) => ({
       ...res.data,
-      dailyData: res.data.dailyData.map(
-        (data): DailyReservationData => ({
-          ...data,
-          date: LocalDate.parseIso(data.date),
-          children: data.children.map((child) => ({
+      days: res.data.days.map(
+        (day): ReservationResponseDay => ({
+          ...day,
+          date: LocalDate.parseIso(day.date),
+          children: day.children.map((child) => ({
             ...child,
             attendances: child.attendances.map((r) => ({
               startTime: LocalTime.parseIso(r.startTime),
@@ -55,18 +54,7 @@ export async function getReservations(
           }))
         })
       ),
-      children: res.data.children.map(
-        (child): ReservationChild => ({
-          ...child,
-          placements: child.placements.map((r) => FiniteDateRange.parseJson(r))
-        })
-      ),
-      reservableDays: Object.entries(res.data.reservableDays).reduce<
-        Record<string, FiniteDateRange[]>
-      >((acc, [childId, ranges]) => {
-        acc[childId] = ranges.map((r) => FiniteDateRange.parseJson(r))
-        return acc
-      }, {})
+      reservableRange: FiniteDateRange.parseJson(res.data.reservableRange)
     }))
 }
 

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/DailyRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/DailyRepetitionTimeInputGrid.tsx
@@ -14,14 +14,14 @@ import { dailyTimes } from './form'
 
 export interface DailyRepetitionTimeInputGridProps {
   bind: BoundForm<typeof dailyTimes>
-  childrenInShiftCare: boolean
+  anyChildInShiftCare: boolean
   showAllErrors: boolean
 }
 
 export default React.memo(function DailyRepetitionTimeInputGrid({
   bind,
   showAllErrors,
-  childrenInShiftCare
+  anyChildInShiftCare
 }: DailyRepetitionTimeInputGridProps) {
   const i18n = useTranslation()
 
@@ -42,7 +42,7 @@ export default React.memo(function DailyRepetitionTimeInputGrid({
           bind={form}
           label={label}
           showAllErrors={showAllErrors}
-          allowExtraTimeRange={childrenInShiftCare}
+          allowExtraTimeRange={anyChildInShiftCare}
           dataQaPrefix="daily"
           onFocus={(ev) => {
             scrollIntoViewSoftKeyboard(ev.target)

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/IrregularRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/IrregularRepetitionTimeInputGrid.tsx
@@ -16,14 +16,14 @@ import { irregularDay, irregularTimes } from './form'
 
 export interface IrregularRepetitionTimeInputGridProps {
   bind: BoundForm<typeof irregularTimes>
-  childrenInShiftCare: boolean
+  anyChildInShiftCare: boolean
   showAllErrors: boolean
 }
 
 export default React.memo(function IrregularRepetitionTimeInputGrid({
   bind,
   showAllErrors,
-  childrenInShiftCare
+  anyChildInShiftCare
 }: IrregularRepetitionTimeInputGridProps) {
   const irregularDays = useFormElems(bind)
   return (
@@ -36,7 +36,7 @@ export default React.memo(function IrregularRepetitionTimeInputGrid({
             bind={irregularDay}
             index={index}
             showAllErrors={showAllErrors}
-            childrenInShiftCare={childrenInShiftCare}
+            anyChildInShiftCare={anyChildInShiftCare}
           />
         )
       })}
@@ -48,12 +48,12 @@ const IrregularDay = React.memo(function IrregularDay({
   bind,
   index,
   showAllErrors,
-  childrenInShiftCare
+  anyChildInShiftCare
 }: {
   bind: BoundForm<typeof irregularDay>
   index: number
   showAllErrors: boolean
-  childrenInShiftCare: boolean
+  anyChildInShiftCare: boolean
 }) {
   const i18n = useTranslation()
   const [lang] = useLang()
@@ -73,7 +73,7 @@ const IrregularDay = React.memo(function IrregularDay({
         bind={day}
         label={<Label>{date.format('EEEEEE d.M.', lang)}</Label>}
         showAllErrors={showAllErrors}
-        allowExtraTimeRange={childrenInShiftCare}
+        allowExtraTimeRange={anyChildInShiftCare}
         dataQaPrefix={`irregular-${date.formatIso()}`}
         onFocus={(ev) => {
           scrollIntoViewSoftKeyboard(ev.target)

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/RepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/RepetitionTimeInputGrid.tsx
@@ -14,7 +14,7 @@ import { timesUnion } from './form'
 
 export interface RepetitionTimeInputGridProps {
   bind: BoundForm<typeof timesUnion>
-  childrenInShiftCare: boolean
+  anyChildInShiftCare: boolean
   showAllErrors: boolean
 }
 

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/WeeklyRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/WeeklyRepetitionTimeInputGrid.tsx
@@ -14,14 +14,14 @@ import { weeklyTimes } from './form'
 
 export interface WeeklyRepetitionTimeInputGridProps {
   bind: BoundForm<typeof weeklyTimes>
-  childrenInShiftCare: boolean
+  anyChildInShiftCare: boolean
   showAllErrors: boolean
 }
 
 export default React.memo(function WeeklyRepetitionTimeInputGrid({
   bind,
   showAllErrors,
-  childrenInShiftCare
+  anyChildInShiftCare
 }: WeeklyRepetitionTimeInputGridProps) {
   const i18n = useTranslation()
   const weekDays = useFormElems(bind)
@@ -35,7 +35,7 @@ export default React.memo(function WeeklyRepetitionTimeInputGrid({
             <LabelLike>{i18n.common.datetime.weekdaysShort[index]}</LabelLike>
           }
           showAllErrors={showAllErrors}
-          allowExtraTimeRange={childrenInShiftCare}
+          allowExtraTimeRange={anyChildInShiftCare}
           dataQaPrefix={`weekly-${index}`}
           onFocus={(ev) => {
             scrollIntoViewSoftKeyboard(ev.target)

--- a/frontend/src/citizen-frontend/calendar/utils.ts
+++ b/frontend/src/citizen-frontend/calendar/utils.ts
@@ -3,52 +3,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Result } from 'lib-common/api'
-import FiniteDateRange from 'lib-common/finite-date-range'
 import { ActiveQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
-import { ReservationChild } from 'lib-common/generated/api-types/reservations'
-import LocalDate from 'lib-common/local-date'
 
 import { User } from '../auth/state'
-
-export const getEarliestReservableDate = (
-  childInfo: ReservationChild[],
-  reservableDays: Record<string, FiniteDateRange[]>
-) => {
-  const earliestReservableDateByChild = childInfo.map((c) =>
-    reservableDays[c.id].reduce<LocalDate | undefined>(
-      (acc, cur) => (!acc || cur.start.isBefore(acc) ? cur.start : acc),
-      undefined
-    )
-  )
-  return earliestReservableDateByChild.reduce<LocalDate | undefined>(
-    (acc, cur) => (!acc || cur?.isBefore(acc) ? cur : acc),
-    undefined
-  )
-}
-
-export const getLatestReservableDate = (
-  childInfo: ReservationChild[],
-  reservableDays: Record<string, FiniteDateRange[]>
-) => {
-  const earliestReservableDateByChild = childInfo.map((c) =>
-    reservableDays[c.id].reduce(
-      (acc, cur) => (cur.end.isAfter(acc) ? cur.end : acc),
-      LocalDate.todayInSystemTz()
-    )
-  )
-  return earliestReservableDateByChild.reduce(
-    (acc, cur) => (cur.isAfter(acc) ? cur : acc),
-    LocalDate.todayInSystemTz()
-  )
-}
-
-export const isDayReservableForSomeone = (
-  date: LocalDate,
-  reservableDays: Record<string, FiniteDateRange[]>
-) =>
-  Object.entries(reservableDays).some(([_childId, ranges]) =>
-    ranges.some((r) => r.includes(date))
-  )
 
 export type QuestionnaireAvailability = boolean | 'with-strong-auth'
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -252,7 +252,14 @@ describe.each(e)('Citizen attendance reservations (%s)', (env) => {
       'SICKLEAVE'
     )
 
-    await calendarPage.assertReservations(firstReservationDay, [reservation])
+    await calendarPage.assertReservations(firstReservationDay, [
+      {
+        startTime: '08:00',
+        endTime: '16:00',
+        childIds: [children[1].id, children[2].id]
+      },
+      { absence: true, childIds: [children[0].id] }
+    ])
   })
 
   test('Citizen creates a repeating reservation and then overwrites it', async () => {
@@ -362,8 +369,8 @@ describe.each(e)('Citizen attendance reservations (%s)', (env) => {
     )
 
     await calendarPage.assertReservations(firstReservationDay, [
-      reservation1,
-      reservation2
+      reservation2,
+      reservation1
     ])
   })
 

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -13,32 +13,20 @@ import { PlacementType } from './placement'
 import { UUID } from '../../types'
 
 /**
+* Generated from fi.espoo.evaka.reservations.AbsenceInfo
+*/
+export interface AbsenceInfo {
+  markedByEmployee: boolean
+  type: AbsenceType
+}
+
+/**
 * Generated from fi.espoo.evaka.reservations.AbsenceRequest
 */
 export interface AbsenceRequest {
   absenceType: AbsenceType
   childIds: UUID[]
   dateRange: FiniteDateRange
-}
-
-/**
-* Generated from fi.espoo.evaka.reservations.ChildDailyData
-*/
-export interface ChildDailyData {
-  absence: AbsenceType | null
-  attendances: OpenTimeRange[]
-  childId: UUID
-  markedByEmployee: boolean
-  reservations: Reservation[]
-}
-
-/**
-* Generated from fi.espoo.evaka.reservations.DailyReservationData
-*/
-export interface DailyReservationData {
-  children: ChildDailyData[]
-  date: LocalDate
-  isHoliday: boolean
 }
 
 export namespace DailyReservationRequest {
@@ -116,15 +104,32 @@ export type Reservation = Reservation.NoTimes | Reservation.Times
 export interface ReservationChild {
   duplicateOf: UUID | null
   firstName: string
-  hasContractDays: boolean
   id: UUID
   imageId: UUID | null
-  inShiftCareUnit: boolean
   lastName: string
-  maxOperationalDays: number[]
-  placements: FiniteDateRange[]
   preferredName: string
   upcomingPlacementType: PlacementType | null
+}
+
+/**
+* Generated from fi.espoo.evaka.reservations.ReservationResponseDay
+*/
+export interface ReservationResponseDay {
+  children: ReservationResponseDayChild[]
+  date: LocalDate
+  holiday: boolean
+}
+
+/**
+* Generated from fi.espoo.evaka.reservations.ReservationResponseDayChild
+*/
+export interface ReservationResponseDayChild {
+  absence: AbsenceInfo | null
+  attendances: OpenTimeRange[]
+  childId: UUID
+  contractDays: boolean
+  reservations: Reservation[]
+  shiftCare: boolean
 }
 
 /**
@@ -132,7 +137,7 @@ export interface ReservationChild {
 */
 export interface ReservationsResponse {
   children: ReservationChild[]
-  dailyData: DailyReservationData[]
+  days: ReservationResponseDay[]
   includesWeekends: boolean
-  reservableDays: Record<string, FiniteDateRange[]>
+  reservableRange: FiniteDateRange
 }

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -385,10 +385,10 @@ const en: Translations = {
       title: 'All changes could not be saved',
       text: (
         <>
-          The registration period for some of the days you selected has already
-          closed. Changes for these times could not be saved. Check the
-          attendances you have marked and notify the staff of missing changes
-          using the <Link to="/messages">messages function</Link>.
+          The range you selected contained days for which you could not make all
+          the reservations you wanted. Check the reservations you have marked
+          and notify the staff of missing changes using the{' '}
+          <Link to="/messages">messages function</Link>.
         </>
       ),
       ok: 'OK'

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -382,10 +382,9 @@ export default {
       title: 'Kaikkia muutoksia ei voitu tallentaa',
       text: (
         <>
-          Valitsemallesi ajanjaksolle sisältyi päiviä, joiden ilmoittautumisaika
-          on jo mennyt kiinni. Muutoksia näille päiville ei voitu tallentaa.
-          Muutoksia näille ajoille ei voitu tallentaa. Tarkista merkitsemäsi
-          läsnäolot ja ilmoita puuttuvat muutokset henkilökunnalle{' '}
+          Valitsemasi aikaväli sisälsi päiviä, joille ei voinut tehdä kaikkia
+          haluamiasi varauksia. Tarkista merkitsemäsi varaukset ja ilmoita
+          puuttuvat muutokset henkilökunnalle{' '}
           <Link to="/messages">viestitoiminnolla</Link>.
         </>
       ),

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -382,9 +382,9 @@ const sv: Translations = {
       title: 'Alla ändringar kunde inte sparas',
       text: (
         <>
-          Registreringsperioden för några av de dagar du valt har redan stängts.
-          Ändringar för dessa tider kunde inte sparas. Kontrollera närvaron du
-          har markerat och meddela personalen om saknade ändringar med hjälp av{' '}
+          Den valda perioden innehöll dagar där det inte var möjligt att göra
+          alla önskade reservationer. Kontrollera de reservationer du har
+          markerat och meddela personalen om saknade ändringar med hjälp av{' '}
           <Link to="/messages">meddelandefunktionen</Link>.
         </>
       ),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
@@ -85,7 +85,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then 2 reservations are added
         val reservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, queryRange, false) }
+            db.read { it.getReservationsCitizen(monday, testAdult_1.id, queryRange) }
                 .flatMap {
                     it.children.mapNotNull { child ->
                         child.reservations.takeIf { it.isNotEmpty() }
@@ -130,7 +130,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then only 1 reservation is added
         val reservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, queryRange, false) }
+            db.read {
+                    it.getReservationsCitizen(
+                        monday,
+                        testAdult_1.id,
+                        queryRange,
+                    )
+                }
                 .mapNotNull { dailyData ->
                     dailyData.date.takeIf {
                         dailyData.children.any { it.reservations.isNotEmpty() }
@@ -176,7 +182,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then no reservation are added
         val reservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, queryRange, false) }
+            db.read {
+                    it.getReservationsCitizen(
+                        monday,
+                        testAdult_1.id,
+                        queryRange,
+                    )
+                }
                 .mapNotNull { dailyData ->
                     dailyData.date.takeIf {
                         dailyData.children.any { it.reservations.isNotEmpty() }
@@ -221,7 +233,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then only 1 reservation is added
         val reservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, queryRange, false) }
+            db.read {
+                    it.getReservationsCitizen(
+                        monday,
+                        testAdult_1.id,
+                        queryRange,
+                    )
+                }
                 .mapNotNull { dailyData ->
                     dailyData.date.takeIf {
                         dailyData.children.any { it.reservations.isNotEmpty() }
@@ -268,7 +286,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then only 1 reservation is added
         val reservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, queryRange, false) }
+            db.read {
+                    it.getReservationsCitizen(
+                        monday,
+                        testAdult_1.id,
+                        queryRange,
+                    )
+                }
                 .mapNotNull { dailyData ->
                     dailyData.date.takeIf {
                         dailyData.children.any { it.reservations.isNotEmpty() }
@@ -321,7 +345,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then 1 reservation is added
         val reservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, queryRange, false) }
+            db.read {
+                    it.getReservationsCitizen(
+                        monday,
+                        testAdult_1.id,
+                        queryRange,
+                    )
+                }
                 .mapNotNull { dailyData ->
                     dailyData.date.takeIf {
                         dailyData.children.any { it.reservations.isNotEmpty() }
@@ -388,7 +418,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then no reservations exist
         val reservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, queryRange, false) }
+            db.read {
+                    it.getReservationsCitizen(
+                        monday,
+                        testAdult_1.id,
+                        queryRange,
+                    )
+                }
                 .flatMap { dailyData -> dailyData.children.flatMap { it.reservations } }
         assertEquals(listOf(), reservations)
 
@@ -462,7 +498,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then 1 reservation is added
         val reservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, queryRange, false) }
+            db.read {
+                    it.getReservationsCitizen(
+                        monday,
+                        testAdult_1.id,
+                        queryRange,
+                    )
+                }
                 .mapNotNull { dailyData ->
                     dailyData.date.takeIf {
                         dailyData.children.any { it.reservations.isNotEmpty() }
@@ -529,7 +571,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then 1 reservation is changed
         val reservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, queryRange, false) }
+            db.read {
+                    it.getReservationsCitizen(
+                        monday,
+                        testAdult_1.id,
+                        queryRange,
+                    )
+                }
                 .flatMap { dailyData ->
                     dailyData.children.map { child -> dailyData.date to child.reservations }
                 }
@@ -579,7 +627,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then
         val dailyReservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, holidayPeriod, false) }
+            db.read {
+                    it.getReservationsCitizen(
+                        monday,
+                        testAdult_1.id,
+                        holidayPeriod,
+                    )
+                }
                 .flatMap { dailyData ->
                     dailyData.children.map { child -> dailyData.date to child.reservations }
                 }
@@ -692,7 +746,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then
         val reservationData =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, holidayPeriod, false) }
+            db.read {
+                it.getReservationsCitizen(
+                    monday,
+                    testAdult_1.id,
+                    holidayPeriod,
+                )
+            }
         val allReservations =
             reservationData.flatMap { dailyData ->
                 dailyData.children.flatMap { child -> child.reservations }
@@ -753,7 +813,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then
         val reservationData =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, holidayPeriod, false) }
+            db.read {
+                it.getReservationsCitizen(
+                    monday,
+                    testAdult_1.id,
+                    holidayPeriod,
+                )
+            }
         val allReservations =
             reservationData.flatMap { dailyData ->
                 dailyData.children.map { child -> dailyData.date to child.reservations }
@@ -818,7 +884,13 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
 
         // then
         val allReservations =
-            db.read { it.getReservationsCitizen(monday, testAdult_1.id, holidayPeriod, false) }
+            db.read {
+                    it.getReservationsCitizen(
+                        monday,
+                        testAdult_1.id,
+                        holidayPeriod,
+                    )
+                }
                 .flatMap { dailyData ->
                     dailyData.children.map { child -> dailyData.date to child.reservations }
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -5,17 +5,22 @@
 package fi.espoo.evaka.reservations
 
 import fi.espoo.evaka.daycare.service.AbsenceType
+import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.AbsenceId
 import fi.espoo.evaka.shared.AttendanceReservationId
 import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.ChildImageId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.HolidayQuestionnaireId
+import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.LocalDate
 import java.time.LocalTime
+import org.jdbi.v3.json.Json
 
 data class AbsenceInsert(
     val childId: ChildId,
@@ -196,4 +201,206 @@ fun Database.Read.getChildAttendanceReservationStartDatesByRange(
         .bind("childId", childId)
         .mapTo<LocalDate>()
         .list()
+}
+
+data class DailyReservationData(val date: LocalDate, @Json val children: List<ChildDailyData>)
+
+@Json
+data class ChildDailyData(
+    val childId: ChildId,
+    val markedByEmployee: Boolean,
+    val absence: AbsenceType?,
+    val reservations: List<Reservation>,
+    val attendances: List<OpenTimeRange>
+)
+
+fun Database.Read.getReservationsCitizen(
+    today: LocalDate,
+    userId: PersonId,
+    range: FiniteDateRange,
+): List<DailyReservationData> {
+    if (range.durationInDays() > 450) throw BadRequest("Range too long")
+
+    return createQuery(
+            """
+WITH children AS (
+    SELECT child_id FROM guardian WHERE guardian_id = :userId
+    UNION
+    SELECT child_id FROM foster_parent WHERE parent_id = :userId AND valid_during @> :today
+)
+SELECT
+    t::date AS date,
+    coalesce(
+        jsonb_agg(
+            jsonb_build_object(
+                'childId', c.child_id,
+                'markedByEmployee', a.modified_by_type <> 'CITIZEN',
+                'absence', a.absence_type,
+                'reservations', coalesce(ar.reservations, '[]'),
+                'attendances', coalesce(ca.attendances, '[]')
+            )
+        ) FILTER (
+            WHERE (a.absence_type IS NOT NULL OR ar.reservations IS NOT NULL OR ca.attendances IS NOT NULL)
+              AND EXISTS(
+                SELECT 1 FROM placement p
+                JOIN daycare d ON p.unit_id = d.id AND 'RESERVATIONS' = ANY(d.enabled_pilot_features)
+                WHERE c.child_id = p.child_id AND p.start_date <= t::date AND p.end_date >= t::date
+              )
+        ),
+        '[]'
+    ) AS children
+FROM generate_series(:start, :end, '1 day') t, children c
+LEFT JOIN LATERAL (
+    SELECT
+        jsonb_agg(
+            CASE WHEN ar.start_time IS NULL OR ar.end_time IS NULL THEN
+                jsonb_build_object('type', 'NO_TIMES')
+            ELSE
+                jsonb_build_object('type', 'TIMES', 'startTime', ar.start_time, 'endTime', ar.end_time)
+            END
+            ORDER BY ar.start_time
+        ) AS reservations
+    FROM attendance_reservation ar WHERE ar.child_id = c.child_id AND ar.date = t::date
+) ar ON true
+LEFT JOIN LATERAL (
+    SELECT
+        jsonb_agg(
+            jsonb_build_object(
+                'startTime', to_char(ca.start_time, 'HH24:MI'),
+                'endTime', to_char(ca.end_time, 'HH24:MI')
+            ) ORDER BY ca.start_time ASC
+        ) AS attendances
+    FROM child_attendance ca WHERE ca.child_id = c.child_id AND ca.date = t::date
+) ca ON true
+LEFT JOIN LATERAL (
+    SELECT a.absence_type, eu.type AS modified_by_type
+    FROM absence a JOIN evaka_user eu ON eu.id = a.modified_by
+    WHERE a.child_id = c.child_id AND a.date = t::date
+    LIMIT 1
+) a ON true
+GROUP BY date
+        """
+                .trimIndent()
+        )
+        .bind("today", today)
+        .bind("userId", userId)
+        .bind("start", range.start)
+        .bind("end", range.end)
+        .mapTo<DailyReservationData>()
+        .toList()
+}
+
+data class ReservationChild(
+    val id: ChildId,
+    val firstName: String,
+    val lastName: String,
+    val preferredName: String,
+    val duplicateOf: PersonId?,
+    val imageId: ChildImageId?,
+    val upcomingPlacementType: PlacementType?,
+)
+
+fun Database.Read.getReservationChildren(
+    childIds: Set<ChildId>,
+    today: LocalDate
+): List<ReservationChild> {
+    return createQuery(
+            """
+SELECT
+    p.id,
+    p.first_name,
+    p.last_name,
+    p.preferred_name,
+    p.duplicate_of,
+    ci.id AS image_id,
+    (
+        SELECT type FROM placement
+        WHERE child_id = p.id AND :today <= end_date
+        ORDER BY start_date
+        LIMIT 1
+    ) AS upcoming_placement_type
+FROM person p
+LEFT JOIN child_images ci ON ci.child_id = p.id
+WHERE p.id = ANY (:childIds)
+ORDER BY p.date_of_birth, p.duplicate_of
+        """
+        )
+        .bind("childIds", childIds)
+        .bind("today", today)
+        .mapTo<ReservationChild>()
+        .list()
+}
+
+data class ReservationPlacement(
+    val isBackup: Boolean,
+    val childId: ChildId,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val operationDays: Set<Int>,
+    val hasContractDays: Boolean
+)
+
+data class ReservationPlacements(
+    val backupPlacements: List<ReservationPlacement>,
+    val regularPlacements: List<ReservationPlacement>
+)
+
+fun Database.Read.getReservationPlacements(
+    guardianId: PersonId,
+    today: LocalDate,
+    range: FiniteDateRange
+): Map<ChildId, ReservationPlacements> {
+    return createQuery(
+            """
+WITH children AS (
+    SELECT child_id FROM guardian WHERE guardian_id = :guardianId
+    UNION
+    SELECT child_id FROM foster_parent WHERE parent_id = :guardianId AND valid_during @> :today
+)
+SELECT
+    FALSE AS is_backup,
+    pl.child_id,
+    pl.start_date,
+    pl.end_date,
+    u.operation_days,
+    coalesce(sno.contract_days_per_month, sno_default.contract_days_per_month) IS NOT NULL AS has_contract_days
+FROM placement pl
+JOIN daycare u ON pl.unit_id = u.id
+LEFT JOIN service_need sn ON sn.placement_id = pl.id AND daterange(sn.start_date, sn.end_date, '[]') && :range
+LEFT JOIN service_need_option sno ON sno.id = sn.option_id
+LEFT JOIN service_need_option sno_default ON sno_default.valid_placement_type = pl.type AND sno_default.default_option
+WHERE
+    pl.child_id = ANY (SELECT child_id FROM children) AND
+    daterange(pl.start_date, pl.end_date, '[]') && :range AND
+    'RESERVATIONS' = ANY(u.enabled_pilot_features)
+
+UNION ALL
+
+SELECT
+    TRUE AS is_backup,
+    bc.child_id,
+    bc.start_date,
+    bc.end_date,
+    u.operation_days,
+    FALSE AS has_contract_days
+FROM backup_care bc
+JOIN daycare u ON bc.unit_id = u.id
+WHERE
+    bc.child_id = ANY (SELECT child_id FROM children) AND
+    daterange(bc.start_date, bc.end_date, '[]') && :range AND
+    'RESERVATIONS' = ANY(u.enabled_pilot_features)
+"""
+        )
+        .bind("guardianId", guardianId)
+        .bind("today", today)
+        .bind("range", range)
+        .mapTo<ReservationPlacement>()
+        .groupBy { it.childId }
+        .mapValues { (_, placements) ->
+            val (backupPlacements, regularPlacements) = placements.partition { it.isBackup }
+            ReservationPlacements(
+                backupPlacements = backupPlacements,
+                regularPlacements = regularPlacements
+            )
+        }
 }


### PR DESCRIPTION
#### Summary

Show children in the calendar only on the days they actually are eligible for daycare.

Rules for eligibility:
- Placement exists
- Operation day in the placement's unit
- Not a holiday (unless placed to a 24/7 unit)

The image below shows an example (only Thu-Sun). 

Placements:
- **K**: normal unit
- **P**: week 1: 24/7 unit, week 2: no placement, week 3: normal unit

Calendar:
- Week 1: Holiday on 1.6. => **K** is no eligible, weekend => **K** is not eligible
- Week 2: **P** has no placement => not eligible
- Week 3: **P** is in a normal unit => not eligible in the weekend

<img width="623" alt="Screenshot 2023-04-18 at 13 25 09" src="https://user-images.githubusercontent.com/70927/232749408-a336097b-09b6-41ba-976b-52afa0f3adcf.png">
