### PR TITLE
Removes deleting staff occupancy coefficient information with daycare ACL removal

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/DaycareAclAdditionModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/DaycareAclAdditionModal.tsx
@@ -66,7 +66,7 @@ export default React.memo(function DaycareAclAdditionModal({
   const [formData, setFormData] = useState<DaycareAclAdditionFormState>({
     selectedEmployee: null,
     selectedGroups: null,
-    hasStaffOccupancyEffect: null
+    hasStaffOccupancyEffect: permittedActions.has('UPSERT_STAFF_OCCUPANCY_COEFFICIENTS') ? false : null
   })
 
   const submit = useCallback(async () => {

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/DaycareAclAdditionModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/DaycareAclAdditionModal.tsx
@@ -66,7 +66,11 @@ export default React.memo(function DaycareAclAdditionModal({
   const [formData, setFormData] = useState<DaycareAclAdditionFormState>({
     selectedEmployee: null,
     selectedGroups: null,
-    hasStaffOccupancyEffect: permittedActions.has('UPSERT_STAFF_OCCUPANCY_COEFFICIENTS') ? false : null
+    hasStaffOccupancyEffect: permittedActions.has(
+      'UPSERT_STAFF_OCCUPANCY_COEFFICIENTS'
+    )
+      ? false
+      : null
   })
 
   const submit = useCallback(async () => {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -195,7 +195,7 @@ class UnitAclControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
         val coefficientsAfterDelete = getDaycareOccupancyCoefficients(testDaycare.id)
 
-        assertEquals(null, coefficientsAfterDelete[employee.id])
+        assertEquals(BigDecimal("7.00"), coefficientsAfterDelete[employee.id])
 
         assertTrue(getAclRows().isEmpty())
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficientQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficientQueries.kt
@@ -80,15 +80,3 @@ RETURNING id
         .executeAndReturnGeneratedKeys()
         .mapTo<StaffOccupancyCoefficientId>()
         .single()
-
-fun Database.Transaction.deleteOccupancyCoefficient(unitId: DaycareId, employeeId: EmployeeId) =
-    createUpdate(
-            """
-DELETE FROM staff_occupancy_coefficient
-WHERE daycare_id = :unitId AND employee_id = :employeeId
-        """
-                .trimIndent()
-        )
-        .bind("unitId", unitId)
-        .bind("employeeId", employeeId)
-        .execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/UnitAcl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/UnitAcl.kt
@@ -4,7 +4,6 @@
 
 package fi.espoo.evaka.daycare
 
-import fi.espoo.evaka.attendance.deleteOccupancyCoefficient
 import fi.espoo.evaka.messaging.deactivateEmployeeMessageAccount
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
@@ -22,7 +21,6 @@ fun removeDaycareAclForRole(
 ) {
     tx.clearDaycareGroupAcl(daycareId, employeeId)
     tx.deleteDaycareAclRow(daycareId, employeeId, role)
-    tx.deleteOccupancyCoefficient(daycareId, employeeId)
     deactivatePersonalMessageAccountIfNeeded(tx, employeeId)
 }
 


### PR DESCRIPTION
Bug fix for reported staff occupancy coefficient issue:
- staff occupancy coefficients are no longer removed with corresponding daycare access
- matching change to fix UI state management logic after removal of delete
- test expectation changes