### PR TITLE
Allow SEOs and unit supervisors to see assistance need decisions

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
@@ -13,10 +13,13 @@ import {
 } from '../../dev-api'
 import { initializeAreaAndPersonData } from '../../dev-api/data-init'
 import {
+  careArea2Fixture,
   careAreaFixture,
   createDaycarePlacementFixture,
+  daycare2Fixture,
   daycareFixture,
   daycareGroupFixture,
+  enduserChildFixtureJari,
   familyWithTwoGuardians,
   Fixture,
   uuidv4
@@ -347,5 +350,73 @@ describe('Assistance need decisions report', () => {
     )
 
     await decisionPage.approveBtn.assertDisabled(false)
+  })
+
+  test('Special education teacher on child s unit can open the decision', async () => {
+    const decisionId = uuidv4()
+    await Fixture.assistanceNeedDecision()
+      .with({
+        id: decisionId,
+        childId,
+        decisionMaker: {
+          employeeId: decisionMaker.id,
+          title: 'regional director'
+        },
+        sentForDecision: LocalDate.of(2021, 1, 6),
+        selectedUnit: { id: unitId }
+      })
+      .save()
+
+    const anotherChildId = enduserChildFixtureJari.id
+    const careArea = await Fixture.careArea().with(careArea2Fixture).save()
+    const anotherDaycare = await Fixture.daycare()
+      .with(daycare2Fixture)
+      .careArea(careArea)
+      .save()
+
+    const daycarePlacementFixture2 = createDaycarePlacementFixture(
+      uuidv4(),
+      anotherChildId,
+      anotherDaycare.data.id
+    )
+
+    await insertDaycarePlacementFixtures([daycarePlacementFixture2])
+
+    await Fixture.assistanceNeedDecision()
+      .with({
+        id: uuidv4(),
+        childId: anotherChildId,
+        decisionMaker: {
+          employeeId: decisionMaker.id,
+          title: 'regional director'
+        },
+        sentForDecision: LocalDate.of(2021, 1, 6),
+        selectedUnit: { id: anotherDaycare.data.id }
+      })
+      .save()
+
+    const seo = (await Fixture.employeeSpecialEducationTeacher(unitId).save())
+      .data
+
+    await employeeLogin(page, seo)
+    await page.goto(`${config.employeeUrl}/reports/assistance-need-decisions`)
+
+    const assistanceNeedDecisionsPage = new AssistanceNeedDecisionsReport(page)
+
+    await waitUntilEqual(() => assistanceNeedDecisionsPage.rows.count(), 1)
+    await waitUntilEqual(() => assistanceNeedDecisionsPage.row(0), {
+      ...baseReportRow,
+      sentForDecision: '06.01.2021',
+      isUnopened: false
+    })
+
+    await page.goto(
+      `${config.employeeUrl}/reports/assistance-need-decisions/${decisionId}`
+    )
+
+    const decisionPage = new AssistanceNeedDecisionsReportDecision(page)
+    await decisionPage.decisionMaker.assertTextEquals(
+      `${decisionMaker.firstName} ${decisionMaker.lastName}, regional director`
+    )
   })
 })

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
@@ -395,10 +395,10 @@ describe('Assistance need decisions report', () => {
       })
       .save()
 
-    const seo = (await Fixture.employeeSpecialEducationTeacher(unitId).save())
+    const VEO = (await Fixture.employeeSpecialEducationTeacher(unitId).save())
       .data
 
-    await employeeLogin(page, seo)
+    await employeeLogin(page, VEO)
     await page.goto(`${config.employeeUrl}/reports/assistance-need-decisions`)
 
     const assistanceNeedDecisionsPage = new AssistanceNeedDecisionsReport(page)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -593,12 +593,11 @@ sealed interface Action {
                 .inPlacementUnitOfChildOfAssistanceNeedDecision()
         ),
         REVERT_TO_UNSENT(HasGlobalRole(ADMIN)),
-        @Suppress("UNCHECKED_CAST")
         READ_IN_REPORT(
             HasGlobalRole(ADMIN),
             IsEmployee.andIsDecisionMakerForAssistanceNeedDecision(),
-            HasUnitRole(UNIT_SUPERVISOR).inUnit() as ScopedActionRule<in AssistanceNeedDecisionId>,
-            HasUnitRole(SPECIAL_EDUCATION_TEACHER).inPlacementUnitOfChildOfAssistanceNeedDecision() as ScopedActionRule<in AssistanceNeedDecisionId>
+            HasUnitRole(UNIT_SUPERVISOR).inSelectedUnitOfAssistanceNeedDecision(),
+            HasUnitRole(SPECIAL_EDUCATION_TEACHER).inPlacementUnitOfChildOfAssistanceNeedDecision()
         ),
         DECIDE(IsEmployee.andIsDecisionMakerForAssistanceNeedDecision()),
         MARK_AS_OPENED(IsEmployee.andIsDecisionMakerForAssistanceNeedDecision()),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -593,9 +593,12 @@ sealed interface Action {
                 .inPlacementUnitOfChildOfAssistanceNeedDecision()
         ),
         REVERT_TO_UNSENT(HasGlobalRole(ADMIN)),
+        @Suppress("UNCHECKED_CAST")
         READ_IN_REPORT(
             HasGlobalRole(ADMIN),
-            IsEmployee.andIsDecisionMakerForAssistanceNeedDecision()
+            IsEmployee.andIsDecisionMakerForAssistanceNeedDecision(),
+            HasUnitRole(UNIT_SUPERVISOR).inUnit() as ScopedActionRule<in AssistanceNeedDecisionId>,
+            HasUnitRole(SPECIAL_EDUCATION_TEACHER).inPlacementUnitOfChildOfAssistanceNeedDecision() as ScopedActionRule<in AssistanceNeedDecisionId>
         ),
         DECIDE(IsEmployee.andIsDecisionMakerForAssistanceNeedDecision()),
         MARK_AS_OPENED(IsEmployee.andIsDecisionMakerForAssistanceNeedDecision()),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
@@ -261,6 +261,20 @@ WHERE employee_id = ${bind(user.id)}
             )
         }
 
+    fun inSelectedUnitOfAssistanceNeedDecision() =
+        rule<AssistanceNeedDecisionId> { user, now ->
+            sql(
+                """
+SELECT ad.id, role, enabled_pilot_features AS unit_features, provider_type AS unit_provider_type
+FROM assistance_need_decision ad
+JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
+JOIN daycare ON acl.daycare_id =  ad.selected_unit
+WHERE employee_id = ${bind(user.id)}
+            """
+                    .trimIndent()
+            )
+        }
+
     // For Tampere
     fun andIsDecisionMakerForAssistanceNeedDecision() =
         rule<AssistanceNeedDecisionId> { user, now ->


### PR DESCRIPTION
#### Summary
Allow VEOs to see assistance need decisions of children they have access to
Allow unit supervisors to see assistance need decisions with selected unit as a unit they work in now

