### PR TITLE
Don't allow reservations on closed holiday period's empty days

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
@@ -701,7 +701,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
     }
 
     @Test
-    fun `citizen cannot override absences in closed holiday periods`() {
+    fun `citizen cannot override days with absences or without reservations in closed holiday periods`() {
         val holidayPeriodStart = monday.plusMonths(1)
         val holidayPeriodEnd = holidayPeriodStart.plusWeeks(1).minusDays(1)
         val holidayPeriod = FiniteDateRange(holidayPeriodStart, holidayPeriodEnd)
@@ -738,6 +738,11 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     DailyReservationRequest.Reservations(
                         childId = testChild_1.id,
                         date = holidayPeriodStart,
+                        Reservation.Times(startTime, endTime),
+                    ),
+                    DailyReservationRequest.Reservations(
+                        childId = testChild_1.id,
+                        date = holidayPeriodStart.plusDays(1),
                         Reservation.Times(startTime, endTime),
                     )
                 )


### PR DESCRIPTION
#### Summary

If a day on a closed holiday period doesn't already have a reservation, the citizen is not allowed to add one. Overriding existing absences was already impossible.

UI changes that show this to the users coming later.