### PR TITLE
Invalidate application form on draft save

### DIFF
--- a/frontend/src/citizen-frontend/applications/queries.ts
+++ b/frontend/src/citizen-frontend/applications/queries.ts
@@ -133,7 +133,10 @@ export const updateApplicationMutation = mutation({
 })
 
 export const saveApplicationDraftMutation = mutation({
-  api: saveApplicationDraft
+  api: saveApplicationDraft,
+  invalidateQueryKeys: ({ applicationId }) => [
+    applicationQuery(applicationId).queryKey
+  ]
 })
 
 export const removeUnprocessableApplicationMutation = mutation({

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -160,6 +160,12 @@ class CitizenApplicationEditor {
     '[data-qa="preferredStartDate-input-info"]'
   )
 
+  saveAsDraftButton = this.page.findByDataQa('save-as-draft-btn')
+  modalOkBtn = this.page.findByDataQa('modal-okBtn')
+  guardianPhoneInput = new TextInput(
+    this.page.findByDataQa('guardianPhone-input')
+  )
+
   async waitUntilLoaded() {
     await this.page
       .find('[data-qa="applications-list"][data-isloading="false"]')

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -246,4 +246,25 @@ describe('Citizen daycare applications', () => {
     await applicationReadView.unitPreferenceSection.waitUntilVisible()
     await applicationReadView.contactInfoSection.waitUntilHidden()
   })
+
+  test('Application can be saved as draft', async () => {
+    await header.selectTab('applications')
+    const editorPage = await applicationsPage.createApplication(
+      fixtures.enduserChildFixtureJari.id,
+      'DAYCARE'
+    )
+    const applicationId = editorPage.getNewApplicationId()
+    await editorPage.fillData({
+      ...minimalDaycareForm().form,
+      contactInfo: {
+        guardianPhone: '040123456789',
+        noGuardianEmail: true,
+        otherGuardianAgreementStatus: 'AGREED'
+      }
+    })
+    await editorPage.saveAsDraftButton.click()
+    await editorPage.modalOkBtn.click()
+    await applicationsPage.editApplication(applicationId)
+    await editorPage.guardianPhoneInput.assertValueEquals('040123456789')
+  })
 })


### PR DESCRIPTION
#### Summary
-Invalidate form on draft save to force update on reopening the application

