### PR TITLE
Fix finance decision generation for families with multisegment partnerships

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -220,7 +220,9 @@ private fun Database.Read.findFamiliesByHeadOfFamily(
     val partners =
         getPartnersForPerson(headOfFamilyId, includeConflicts = false, period = dateRange)
     val fridgePartnerParentships =
-        partners.distinctBy { it.person.id }.flatMap { getParentships(it.person.id, null, false, dateRange) }
+        partners
+            .distinctBy { it.person.id }
+            .flatMap { getParentships(it.person.id, null, false, dateRange) }
 
     return generateFamilyCompositions(
         from,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -220,7 +220,7 @@ private fun Database.Read.findFamiliesByHeadOfFamily(
     val partners =
         getPartnersForPerson(headOfFamilyId, includeConflicts = false, period = dateRange)
     val fridgePartnerParentships =
-        partners.flatMap { getParentships(it.person.id, null, false, dateRange) }
+        partners.distinctBy { it.person.id }.flatMap { getParentships(it.person.id, null, false, dateRange) }
 
     return generateFamilyCompositions(
         from,


### PR DESCRIPTION
When a family had partnerships that consisted of multiple segments in the fridge_partner table, the partner's children would be included multiple times in the family composition causing the finance decision generation to eventually fail. This would be case for example for parents that separated but later moved back together. Fix this to include each partner's children only once

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

