### PR TITLE
Income notification changes

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotificationsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotificationsIntegrationTest.kt
@@ -456,8 +456,8 @@ class OutdatedIncomeNotificationsIntegrationTest : FullApplicationTest(resetDbBe
         val incomes = db.read { it.getIncomesForPerson(mapper, incomeTypesProvider, guardianId) }
         assertEquals(2, incomes.size)
         assertEquals(IncomeEffect.INCOMPLETE, incomes[0].effect)
-        val firstOfNextMonth = clock.today().plusDays(1).plusMonths(1).withDayOfMonth(1)
-        assertEquals(firstOfNextMonth, incomes[0].validFrom)
+        val firstDayAfterExpiration = clock.today().plusDays(1)
+        assertEquals(firstDayAfterExpiration, incomes[0].validFrom)
 
         val feeFecisions = db.read { it.findFeeDecisionsForHeadOfFamily(guardianId, null, null) }
         assertEquals(1, feeFecisions.size)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeControllerCitizen.kt
@@ -8,8 +8,8 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.invoicing.service.expiringIncomes
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import java.time.LocalDate
@@ -37,7 +37,7 @@ class IncomeControllerCitizen(private val accessControl: AccessControl) {
                     )
                     it.expiringIncomes(
                             clock.today(),
-                            DateRange(clock.today(), clock.today().plusWeeks(4)),
+                            FiniteDateRange(clock.today(), clock.today().plusWeeks(4)),
                             null,
                             user.id
                         )

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
@@ -72,8 +72,9 @@ SELECT person_id AS guardian_id, valid_to AS expiration_date
 FROM expiring_income_with_billable_placement_day_after_expiration expiring_income 
 WHERE NOT EXISTS (
     SELECT 1 FROM income_statement
-    WHERE person_id = expiring_income.person_id AND created > :today - INTERVAL '1 month'
+    WHERE person_id = expiring_income.person_id
         AND (end_date IS NULL OR UPPER(:checkForExpirationRange) <= end_date)
+        AND handler_id IS NULL
 ) 
 ${if (checkForExistingRecentIncomeNotificationType != null) " AND NOT EXISTS ($existingRecentIncomeNotificationQuery)" else ""}                
 ${if (guardianId != null) " AND person_id = :guardianId" else ""}

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.invoicing.service
 import fi.espoo.evaka.shared.IncomeNotificationId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.utils.applyIf
 import java.time.LocalDate
@@ -39,10 +39,11 @@ data class GuardianIncomeExpirationDate(val guardianId: PersonId, val expiration
 
 fun Database.Read.expiringIncomes(
     today: LocalDate,
-    checkForExpirationRange: DateRange,
+    checkForExpirationRange: FiniteDateRange,
     checkForExistingRecentIncomeNotificationType: IncomeNotificationType? = null,
     guardianId: PersonId? = null
 ): List<GuardianIncomeExpirationDate> {
+
     val existingRecentIncomeNotificationQuery =
         """
     SELECT 1 FROM income_notification 
@@ -61,7 +62,7 @@ WITH latest_income AS (
 ), expiring_income_with_billable_placement_day_after_expiration AS (
     SELECT DISTINCT i.person_id, i.valid_to
     FROM placement pl
-    JOIN service_need sn ON pl.id = sn.placement_id AND daterange(sn.start_date, sn.end_date, '[]') @> upper(:checkForExpirationRange)
+    JOIN service_need sn ON pl.id = sn.placement_id AND daterange(sn.start_date, sn.end_date, '[]') @> :dayAfterExpiration
     JOIN service_need_option sno ON sn.option_id = sno.id AND sno.fee_coefficient > 0
     JOIN guardian g ON g.child_id = pl.child_id
     JOIN latest_income i ON i.person_id = g.guardian_id
@@ -73,7 +74,7 @@ FROM expiring_income_with_billable_placement_day_after_expiration expiring_incom
 WHERE NOT EXISTS (
     SELECT 1 FROM income_statement
     WHERE person_id = expiring_income.person_id
-        AND (end_date IS NULL OR UPPER(:checkForExpirationRange) <= end_date)
+        AND (end_date IS NULL OR :dayAfterExpiration <= end_date)
         AND handler_id IS NULL
 ) 
 ${if (checkForExistingRecentIncomeNotificationType != null) " AND NOT EXISTS ($existingRecentIncomeNotificationQuery)" else ""}                
@@ -81,7 +82,8 @@ ${if (guardianId != null) " AND person_id = :guardianId" else ""}
     """
                 .trimIndent()
         )
-        .bind("checkForExpirationRange", checkForExpirationRange)
+        .bind("checkForExpirationRange", checkForExpirationRange.asDateRange())
+        .bind("dayAfterExpiration", checkForExpirationRange.end.plusDays(1))
         .bind("notificationType", checkForExistingRecentIncomeNotificationType)
         .bind("today", today)
         .applyIf(checkForExistingRecentIncomeNotificationType != null) {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
@@ -43,7 +43,6 @@ fun Database.Read.expiringIncomes(
     checkForExistingRecentIncomeNotificationType: IncomeNotificationType? = null,
     guardianId: PersonId? = null
 ): List<GuardianIncomeExpirationDate> {
-
     val existingRecentIncomeNotificationQuery =
         """
     SELECT 1 FROM income_notification 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
@@ -22,6 +22,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapColumn
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
@@ -48,7 +49,7 @@ class OutdatedIncomeNotifications(
         val guardiansForInitialNotification =
             tx.expiringIncomes(
                     clock.now().toLocalDate(),
-                    DateRange(clock.today(), clock.today().plusWeeks(4)),
+                    FiniteDateRange(clock.today(), clock.today().plusWeeks(4)),
                     IncomeNotificationType.INITIAL_EMAIL
                 )
                 .map { it.guardianId }
@@ -56,7 +57,7 @@ class OutdatedIncomeNotifications(
         val guardiansForReminderNotification =
             tx.expiringIncomes(
                     clock.now().toLocalDate(),
-                    DateRange(clock.today(), clock.today().plusWeeks(2)),
+                    FiniteDateRange(clock.today(), clock.today().plusWeeks(2)),
                     IncomeNotificationType.REMINDER_EMAIL
                 )
                 .filter { !guardiansForInitialNotification.contains(it.guardianId) }
@@ -65,7 +66,7 @@ class OutdatedIncomeNotifications(
         val guardiansForExpirationNotification =
             tx.expiringIncomes(
                     clock.now().toLocalDate(),
-                    DateRange(clock.today(), clock.today()),
+                    FiniteDateRange(clock.today(), clock.today()),
                     IncomeNotificationType.EXPIRED_EMAIL
                 )
                 .filter { !guardiansForInitialNotification.contains(it.guardianId) }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -580,14 +580,15 @@ data class DevIncomeStatement(
     val personId: PersonId,
     val startDate: LocalDate,
     val type: IncomeStatementType,
-    val grossEstimatedMonthlyIncome: Int
+    val grossEstimatedMonthlyIncome: Int,
+    val handlerId: EmployeeId? = null
 )
 
 fun Database.Transaction.insertIncomeStatement(incomeStatement: DevIncomeStatement) =
     createUpdate(
             """
-INSERT INTO income_statement (id, person_id, start_date, type, gross_estimated_monthly_income)
-VALUES (:id, :personId, :startDate, :type, :grossEstimatedMonthlyIncome)
+INSERT INTO income_statement (id, person_id, start_date, type, gross_estimated_monthly_income, handler_id)
+VALUES (:id, :personId, :startDate, :type, :grossEstimatedMonthlyIncome, :handlerId)
     """
                 .trimIndent()
         )


### PR DESCRIPTION
- Do not send income notification if there is unhandled income statement
- Create unknown income starting the day after expiration (not the start of the next month)