### PR TITLE
Fix time validation

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/attendanceEditState.spec.ts
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/attendanceEditState.spec.ts
@@ -209,14 +209,14 @@ describe('validateEditState', () => {
         id: null,
         type: 'PRESENT',
         groupId: 'group1',
-        arrived: '7:00',
+        arrived: '07:00',
         departed: ''
       },
       {
         id: null,
         type: 'PRESENT',
         groupId: 'group2',
-        arrived: '8:00',
+        arrived: '08:00',
         departed: ''
       }
     ])
@@ -256,7 +256,7 @@ describe('validateEditState', () => {
         id: 'id1',
         type: 'PRESENT',
         groupId: 'group1',
-        arrived: '8:00',
+        arrived: '08:00',
         departed: '07:00'
       },
       {
@@ -308,14 +308,14 @@ describe('validateEditState', () => {
         id: 'id1',
         type: 'PRESENT',
         groupId: null,
-        arrived: '8:00',
-        departed: '9:00'
+        arrived: '08:00',
+        departed: '09:00'
       },
       {
         id: 'id2',
         type: 'OVERTIME',
         groupId: null,
-        arrived: '9:00',
+        arrived: '09:00',
         departed: '10:00'
       },
       {

--- a/frontend/src/employee-mobile-frontend/staff-attendance/StaffMarkArrivedPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/StaffMarkArrivedPage.tsx
@@ -102,8 +102,10 @@ export default React.memo(function StaffMarkArrivedPage() {
     [groupId, staffMember, unitInfoResponse]
   )
 
-  const isValidTimeString = (time: string) =>
-    LocalTime.tryParse(time) ? true : false
+  const isValidTimeString = useMemo(
+    () => (LocalTime.tryParseWithPattern(time, 'HH:mm') ? true : false),
+    [time]
+  )
 
   useEffect(() => {
     if (
@@ -133,17 +135,17 @@ export default React.memo(function StaffMarkArrivedPage() {
   const selectedTimeDiffFromPlannedStartOfDayMinutes = useMemo(
     () =>
       firstPlannedStartOfTheDay &&
-      isValidTimeString(time) &&
+      isValidTimeString &&
       differenceInMinutes(
         HelsinkiDateTime.now().withTime(LocalTime.parse(time)).toSystemTzDate(),
         firstPlannedStartOfTheDay.toSystemTzDate()
       ),
-    [firstPlannedStartOfTheDay, time]
+    [firstPlannedStartOfTheDay, time, isValidTimeString]
   )
 
   const selectedTimeIsWithin30MinsFromNow = useMemo(() => {
     return (
-      isValidTimeString(time) &&
+      isValidTimeString &&
       Math.abs(
         differenceInMinutes(
           HelsinkiDateTime.now()
@@ -153,7 +155,7 @@ export default React.memo(function StaffMarkArrivedPage() {
         )
       ) <= 30
     )
-  }, [time, now])
+  }, [time, now, isValidTimeString])
 
   const hasPlan = useMemo(
     () => firstPlannedStartOfTheDay != null,
@@ -176,7 +178,7 @@ export default React.memo(function StaffMarkArrivedPage() {
     () =>
       staffMember
         .map((staff) => {
-          const parsedTime = LocalTime.tryParse(time)
+          const parsedTime = LocalTime.tryParseWithPattern(time, 'HH:mm')
           if (!parsedTime || !staff?.spanningPlan) return []
           const arrived = HelsinkiDateTime.fromLocal(
             LocalDate.todayInHelsinkiTz(),
@@ -264,7 +266,7 @@ export default React.memo(function StaffMarkArrivedPage() {
             const confirmDisabled =
               pinLocked ||
               !pinSet ||
-              !isValidTimeString(time) ||
+              !isValidTimeString ||
               pinCode.join('').trim().length < 4 ||
               !selectedTimeIsWithin30MinsFromNow ||
               !attendanceGroup ||

--- a/frontend/src/lib-common/local-time.spec.ts
+++ b/frontend/src/lib-common/local-time.spec.ts
@@ -31,8 +31,9 @@ describe('LocalTime', () => {
     expect(LocalTime.parse('1:2', 'HH:mm').isEqual(expected)).toBeTruthy()
   })
   it('fails to parse invalid HH:mm input', () => {
-    expect(LocalTime.tryParse('01:62', 'HH:mm')).toBeUndefined()
-    expect(LocalTime.tryParse('01:00:999', 'HH:mm')).toBeUndefined()
+    expect(LocalTime.tryParse('01:62')).toBeUndefined()
+    expect(LocalTime.tryParse('01:00:999')).toBeUndefined()
+    expect(LocalTime.tryParse('9:15')).toBeUndefined()
   })
   it('has property getters for each part of the time', () => {
     const parts = [1, 2, 3, 123456789] as const

--- a/frontend/src/lib-common/local-time.ts
+++ b/frontend/src/lib-common/local-time.ts
@@ -5,6 +5,7 @@
 import { format, parse } from 'date-fns'
 import isInteger from 'lodash/isInteger'
 
+import { isValidTime } from './date'
 import HelsinkiDateTime from './helsinki-date-time'
 import { Ordered } from './ordered'
 import { isAutomatedTest, mockNow } from './utils/helpers'
@@ -124,7 +125,16 @@ export default class LocalTime implements Ordered<LocalTime> {
     throw new RangeError(`Invalid time ${text}`)
   }
 
-  static tryParse(text: string, pattern = 'HH:mm'): LocalTime | undefined {
+  static tryParse(textHHmm: string): LocalTime | undefined {
+    return isValidTime(textHHmm)
+      ? this.tryParseWithPattern(textHHmm, 'HH:mm')
+      : undefined
+  }
+
+  static tryParseWithPattern(
+    text: string,
+    pattern = 'HH:mm'
+  ): LocalTime | undefined {
     const timestamp = parse(text, pattern, new Date(1970, 0, 1))
     return LocalTime.tryCreate(
       timestamp.getHours(),
@@ -134,7 +144,7 @@ export default class LocalTime implements Ordered<LocalTime> {
     )
   }
   static parse(text: string, pattern = 'HH:mm'): LocalTime {
-    const result = LocalTime.tryParse(text, pattern)
+    const result = LocalTime.tryParseWithPattern(text, pattern)
     if (!result) {
       throw new RangeError(`Invalid time ${text}`)
     }


### PR DESCRIPTION
#### Summary
Validate arrival time on frontend. Previously it was possible to send invalid time strings like 9:00 (should have been 09:00)

