### PR TITLE
Support non-required reservations in calendar day modal

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -95,7 +95,7 @@ const CalendarPage = React.memo(function CalendarPage() {
     [holidayPeriods]
   )
 
-  const upcomingHolidayPeriods = useMemo(() => {
+  const holidayPeriodInfo = useMemo(() => {
     const today = mockToday() ?? LocalDate.todayInSystemTz()
     return holidayPeriods.map((periods) =>
       periods
@@ -136,8 +136,8 @@ const CalendarPage = React.memo(function CalendarPage() {
       <DailyServiceTimeNotifications />
 
       {renderResult(
-        combine(data, events, upcomingHolidayPeriods),
-        ([response, events, upcomingHolidayPeriods]) => (
+        combine(data, events, holidayPeriodInfo),
+        ([response, events, holidayPeriodInfo]) => (
           <div data-qa="calendar-page" data-isloading={isLoading(data)}>
             <CalendarNotifications calendarDays={response.days} />
             <MobileAndTablet>
@@ -183,6 +183,7 @@ const CalendarPage = React.memo(function CalendarPage() {
                 onClose={closeModal}
                 openAbsenceModal={openAbsenceModal}
                 events={events}
+                holidayPeriods={holidayPeriodInfo}
               />
             )}
             {modalState?.type === 'pickAction' && (
@@ -202,7 +203,7 @@ const CalendarPage = React.memo(function CalendarPage() {
                   modalState.initialRange?.start ?? firstReservableDate
                 }
                 initialEnd={modalState.initialRange?.end ?? null}
-                upcomingHolidayPeriods={upcomingHolidayPeriods}
+                holidayPeriods={holidayPeriodInfo}
               />
             )}
             {modalState?.type === 'absences' && (

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -180,7 +180,7 @@ const CalendarPage = React.memo(function CalendarPage() {
                 date={modalState.date}
                 reservationsResponse={response}
                 selectDate={openDayModal}
-                close={closeModal}
+                onClose={closeModal}
                 openAbsenceModal={openAbsenceModal}
                 events={events}
               />

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -60,7 +60,7 @@ interface Props {
   reservationsResponse: ReservationsResponse
   initialStart: LocalDate | null
   initialEnd: LocalDate | null
-  upcomingHolidayPeriods: HolidayPeriodInfo[]
+  holidayPeriods: HolidayPeriodInfo[]
 }
 
 export default React.memo(function ReservationModal({
@@ -69,7 +69,7 @@ export default React.memo(function ReservationModal({
   reservationsResponse,
   initialStart,
   initialEnd,
-  upcomingHolidayPeriods
+  holidayPeriods
 }: Props) {
   const i18n = useTranslation()
   const [lang] = useLang()
@@ -81,8 +81,8 @@ export default React.memo(function ReservationModal({
   } = reservationsResponse
 
   const dayProperties = useMemo(
-    () => new DayProperties(calendarDays, upcomingHolidayPeriods),
-    [calendarDays, upcomingHolidayPeriods]
+    () => new DayProperties(calendarDays, holidayPeriods),
+    [calendarDays, holidayPeriods]
   )
   const form = useForm(
     reservationForm,
@@ -238,9 +238,7 @@ export default React.memo(function ReservationModal({
 
                 <H2>{i18n.calendar.reservationModal.dateRange}</H2>
 
-                <HolidayPeriodInfoBox
-                  upcomingHolidayPeriods={upcomingHolidayPeriods}
-                />
+                <HolidayPeriodInfoBox upcomingHolidayPeriods={holidayPeriods} />
 
                 <Label>{i18n.calendar.reservationModal.selectRecurrence}</Label>
                 <Gap size="xxs" />

--- a/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
+++ b/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
@@ -2,15 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import classNames from 'classnames'
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import { BoundFormShape, useFormField } from 'lib-common/form/hooks'
 import { Form } from 'lib-common/form/types'
-import UnderRowStatusIcon from 'lib-components/atoms/StatusIcon'
-import { InputFieldUnderRow } from 'lib-components/atoms/form/InputField'
+import UnderRowStatusIcon, { InfoStatus } from 'lib-components/atoms/StatusIcon'
 import { TimeInputF } from 'lib-components/atoms/form/TimeInput'
+import { defaultMargins } from 'lib-components/white-space'
 
 import { useTranslation } from '../localization'
 
@@ -42,7 +41,7 @@ export default React.memo(function TimeRangeInputF({
   const inputInfo = bind.inputInfo()
 
   return (
-    <>
+    <div>
       <TimeRangeWrapper>
         <TimeInputF
           bind={startTime}
@@ -63,14 +62,14 @@ export default React.memo(function TimeRangeInputF({
         />
       </TimeRangeWrapper>
       {inputInfo !== undefined && (!hideErrorsBeforeTouched || bothTouched) ? (
-        <InputFieldUnderRow className={classNames(inputInfo.status)}>
+        <ErrorRow $status={inputInfo.status}>
           <span data-qa={dataQa ? `${dataQa}-info` : undefined}>
             {inputInfo.text}
           </span>
           <UnderRowStatusIcon status={inputInfo?.status} />
-        </InputFieldUnderRow>
+        </ErrorRow>
       ) : undefined}
-    </>
+    </div>
   )
 })
 
@@ -83,4 +82,17 @@ const TimeRangeWrapper = styled.div`
     justify-content: center;
     padding-top: 8px;
   }
+`
+
+const ErrorRow = styled.div<{ $status: InfoStatus | undefined }>`
+  font-size: 1rem;
+  line-height: 1rem;
+  margin-top: ${defaultMargins.xxs};
+
+  color: ${(p) =>
+    p.$status === 'success'
+      ? p.theme.colors.accents.a1greenDark
+      : p.$status === 'warning'
+      ? p.theme.colors.accents.a2orangeDark
+      : p.theme.colors.grayscale.g70};
 `

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -23,31 +23,9 @@ import {
 } from 'lib-components/layout/flex-helpers'
 import { Light } from 'lib-components/typography'
 
-import { useTranslation } from '../localization'
+import { Translations, useTranslation } from '../localization'
 
 import RoundChildImages, { ChildImageData } from './RoundChildImages'
-
-type DailyChildGroupElementType =
-  | 'attendance'
-  | 'reservation-no-times'
-  | 'reservation'
-  | 'absent'
-  | 'missing-reservation'
-  | 'absent-free'
-  | 'reservation-not-required'
-
-interface DailyChildGroupElement {
-  type: DailyChildGroupElementType
-  text?: string
-  childId: UUID
-}
-
-interface GroupedDailyChildren {
-  type: DailyChildGroupElementType
-  text?: string
-  childIds: UUID[]
-  key: string
-}
 
 export const Reservations = React.memo(function Reservations({
   data,
@@ -90,17 +68,7 @@ export const Reservations = React.memo(function Reservations({
               className={group.type}
               data-qa="reservation-text"
             >
-              {group.type === 'reservation-no-times'
-                ? i18n.calendar.reservationNoTimes
-                : group.type === 'missing-reservation'
-                ? i18n.calendar.missingReservation
-                : group.type === 'absent'
-                ? i18n.calendar.absent
-                : group.type === 'absent-free'
-                ? i18n.calendar.absentFree
-                : group.type === 'reservation-not-required'
-                ? i18n.calendar.reservationNoTimes
-                : group.text}
+              {groupText(group, i18n)}
             </GroupedElementText>
           </FixedSpaceRow>
         ))}
@@ -123,6 +91,27 @@ const GroupedElementText = styled.div`
     color: ${(p) => p.theme.colors.accents.a2orangeDark};
   }
 `
+
+type DailyChildGroupElementType =
+  | 'attendance'
+  | 'reservation'
+  | 'present'
+  | 'absent'
+  | 'missing-reservation'
+  | 'absent-free'
+
+interface DailyChildGroupElement {
+  type: DailyChildGroupElementType
+  text?: string
+  childId: UUID
+}
+
+interface GroupedDailyChildren {
+  type: DailyChildGroupElementType
+  text?: string
+  childIds: UUID[]
+  key: string
+}
 
 const groupChildren = (relevantChildren: ReservationResponseDayChild[]) =>
   Object.entries(
@@ -159,7 +148,7 @@ const groupChildren = (relevantChildren: ReservationResponseDayChild[]) =>
             // In theory, we could have reservations with and without times, but in practice this shouldn't happen
             return {
               childId: child.childId,
-              type: 'reservation-no-times'
+              type: 'present'
             }
           }
 
@@ -178,7 +167,7 @@ const groupChildren = (relevantChildren: ReservationResponseDayChild[]) =>
         if (!child.requiresReservation) {
           return {
             childId: child.childId,
-            type: 'reservation-not-required'
+            type: 'present'
           }
         }
 
@@ -197,3 +186,19 @@ const groupChildren = (relevantChildren: ReservationResponseDayChild[]) =>
       key
     })
   )
+
+function groupText(group: GroupedDailyChildren, i18n: Translations) {
+  switch (group.type) {
+    case 'attendance':
+    case 'reservation':
+      return group.text
+    case 'present':
+      return i18n.calendar.reservationNoTimes
+    case 'absent':
+      return i18n.calendar.absent
+    case 'missing-reservation':
+      return i18n.calendar.missingReservation
+    case 'absent-free':
+      return i18n.calendar.absentFree
+  }
+}

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -18,7 +18,7 @@ import { faPlus, fasUserMinus, faTrash, faUserMinus } from 'lib-icons'
 
 import TimeRangeInput from '../TimeRangeInput'
 
-import { day, emptyTimeRange, noTimes, times } from './form'
+import { day, emptyTimeRange, noTimes, timeRanges, reservation } from './form'
 
 interface DayProps {
   bind: BoundForm<typeof day>
@@ -65,7 +65,7 @@ export const Day = React.memo(function Day({
 })
 
 interface ReservationTimesProps {
-  bind: BoundForm<typeof times>
+  bind: BoundForm<typeof reservation>
   label: React.ReactNode
   showAllErrors: boolean
   allowExtraTimeRange: boolean
@@ -82,35 +82,43 @@ const ReservationTimes = React.memo(function ReservationTimes({
   onFocus
 }: ReservationTimesProps) {
   const i18n = useTranslation()
-  const { set, state } = bind
+  const { set } = bind
 
-  // Empty reservations array => absent
-  return state.length === 0 ? (
-    <FixedSpaceRow fullWidth alignItems="center">
-      {label !== undefined ? <LeftCell>{label}</LeftCell> : null}
-      <MiddleCell>{i18n.calendar.reservationModal.absent}</MiddleCell>
-      <RightCell>
-        <IconButton
-          data-qa={dataQaPrefix ? `${dataQaPrefix}-absent-button` : undefined}
-          icon={fasUserMinus}
-          onClick={() => {
-            set([emptyTimeRange])
-          }}
-          aria-label={i18n.calendar.absentDisable}
+  const { branch, form } = useFormUnion(bind)
+
+  switch (branch) {
+    case 'absent':
+      return (
+        <FixedSpaceRow fullWidth alignItems="center">
+          {label !== undefined ? <LeftCell>{label}</LeftCell> : null}
+          <MiddleCell>{i18n.calendar.reservationModal.absent}</MiddleCell>
+          <RightCell>
+            <IconButton
+              data-qa={
+                dataQaPrefix ? `${dataQaPrefix}-absent-button` : undefined
+              }
+              icon={fasUserMinus}
+              onClick={() => {
+                set({ branch: 'timeRanges', state: [emptyTimeRange] })
+              }}
+              aria-label={i18n.calendar.absentDisable}
+            />
+          </RightCell>
+        </FixedSpaceRow>
+      )
+    case 'timeRanges':
+      return (
+        <TimeRanges
+          bind={form}
+          label={label}
+          showAllErrors={showAllErrors}
+          onAbsent={() => set({ branch: 'absent', state: true })}
+          allowExtraTimeRange={allowExtraTimeRange}
+          dataQaPrefix={dataQaPrefix}
+          onFocus={onFocus}
         />
-      </RightCell>
-    </FixedSpaceRow>
-  ) : (
-    <Times
-      bind={bind}
-      label={label}
-      showAllErrors={showAllErrors}
-      allowAbsence
-      allowExtraTimeRange={allowExtraTimeRange}
-      dataQaPrefix={dataQaPrefix}
-      onFocus={onFocus}
-    />
-  )
+      )
+  }
 })
 
 interface ReadOnlyDayProps {
@@ -180,25 +188,25 @@ const ReadOnlyDay = React.memo(function ReadOnlyDay({
   }
 })
 
-interface TimesProps {
-  bind: BoundForm<typeof times>
+interface TimeRangesProps {
+  bind: BoundForm<typeof timeRanges>
   label: React.ReactNode
   showAllErrors: boolean
-  allowAbsence?: boolean
   allowExtraTimeRange: boolean
   dataQaPrefix?: string
+  onAbsent?: () => void
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
 }
 
-export const Times = React.memo(function Times({
+const TimeRanges = React.memo(function Times({
   bind,
   label,
   showAllErrors,
-  allowAbsence = false,
   allowExtraTimeRange,
   dataQaPrefix,
+  onAbsent,
   onFocus
-}: TimesProps) {
+}: TimeRangesProps) {
   const i18n = useTranslation()
   const firstTimeRange = useFormElem(bind, 0)
   const secondTimeRange = useFormElem(bind, 1)
@@ -221,13 +229,13 @@ export const Times = React.memo(function Times({
         </MiddleCell>
         <RightCell>
           <FixedSpaceRow>
-            {allowAbsence ? (
+            {onAbsent !== undefined ? (
               <IconButton
                 data-qa={
                   dataQaPrefix ? `${dataQaPrefix}-absent-button` : undefined
                 }
                 icon={faUserMinus}
-                onClick={() => bind.set([])}
+                onClick={onAbsent}
                 aria-label={i18n.calendar.absentEnable}
               />
             ) : null}

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -22,7 +22,7 @@ import { day, emptyTimeRange, noTimes, times } from './form'
 
 interface DayProps {
   bind: BoundForm<typeof day>
-  label: React.ReactNode
+  label: React.ReactNode | undefined
   showAllErrors: boolean
   allowExtraTimeRange: boolean
   dataQaPrefix?: string
@@ -87,7 +87,7 @@ const ReservationTimes = React.memo(function ReservationTimes({
   // Empty reservations array => absent
   return state.length === 0 ? (
     <FixedSpaceRow fullWidth alignItems="center">
-      <LeftCell>{label}</LeftCell>
+      {label !== undefined ? <LeftCell>{label}</LeftCell> : null}
       <MiddleCell>{i18n.calendar.reservationModal.absent}</MiddleCell>
       <RightCell>
         <IconButton
@@ -132,7 +132,7 @@ const ReadOnlyDay = React.memo(function ReadOnlyDay({
     case undefined:
       return (
         <FixedSpaceRow fullWidth alignItems="center">
-          <LeftCell>{label}</LeftCell>
+          {label !== undefined ? <LeftCell>{label}</LeftCell> : null}
           <MiddleCell />
           <RightCell />
         </FixedSpaceRow>
@@ -141,7 +141,7 @@ const ReadOnlyDay = React.memo(function ReadOnlyDay({
       return (
         <>
           <FixedSpaceRow fullWidth alignItems="center">
-            <LeftCell>{label}</LeftCell>
+            {label !== undefined ? <LeftCell>{label}</LeftCell> : null}
             <MiddleCell>{i18n.calendar.reservationModal.absent}</MiddleCell>
             <RightCell>
               <InfoButton
@@ -172,7 +172,7 @@ const ReadOnlyDay = React.memo(function ReadOnlyDay({
     case 'holiday':
       return (
         <FixedSpaceRow fullWidth alignItems="center">
-          <LeftCell>{label}</LeftCell>
+          {label !== undefined ? <LeftCell>{label}</LeftCell> : null}
           <MiddleCell>{i18n.calendar.holiday}</MiddleCell>
           <RightCell />
         </FixedSpaceRow>
@@ -210,7 +210,7 @@ export const Times = React.memo(function Times({
   return (
     <>
       <FixedSpaceRow fullWidth alignItems="center">
-        <LeftCell>{label}</LeftCell>
+        {label !== undefined ? <LeftCell>{label}</LeftCell> : null}
         <MiddleCell>
           <TimeRangeInput
             bind={firstTimeRange}
@@ -245,7 +245,7 @@ export const Times = React.memo(function Times({
       </FixedSpaceRow>
       {secondTimeRange !== undefined ? (
         <FixedSpaceRow fullWidth alignItems="center">
-          <LeftCell />
+          {label !== undefined ? <LeftCell /> : null}
           <MiddleCell>
             <TimeRangeInput
               bind={secondTimeRange}
@@ -278,7 +278,7 @@ export const ReservationNoTimes = React.memo(function ReservationNoTimes({
 
   return (
     <FixedSpaceRow fullWidth alignItems="center">
-      <LeftCell>{label}</LeftCell>
+      {label !== undefined ? <LeftCell>{label}</LeftCell> : null}
       <MiddleCell narrow>
         <Radio
           checked={bind.state === 'present'}

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -70,7 +70,10 @@ describe('resetTimes', () => {
           weekDayRange: undefined,
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }
       })
@@ -100,7 +103,10 @@ describe('resetTimes', () => {
           weekDayRange: [2, 2],
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }
       })
@@ -130,7 +136,10 @@ describe('resetTimes', () => {
           weekDayRange: [1, 5],
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }
       })
@@ -159,7 +168,10 @@ describe('resetTimes', () => {
           weekDayRange: [1, 7],
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }
       })
@@ -216,7 +228,10 @@ describe('resetTimes', () => {
           weekDayRange: [1, 5],
           day: {
             branch: 'reservation',
-            state: [{ startTime: '08:00', endTime: '16:00' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '08:00', endTime: '16:00' }]
+            }
           }
         }
       })
@@ -234,7 +249,10 @@ describe('resetTimes', () => {
           weekDayRange: [1, 5],
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }
       })
@@ -384,7 +402,10 @@ describe('resetTimes', () => {
           weekDayRange: [1, 5],
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }
       })
@@ -626,7 +647,10 @@ describe('resetTimes', () => {
             weekDay: 2,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           }
         ]
@@ -657,7 +681,10 @@ describe('resetTimes', () => {
           weekDay,
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }))
       })
@@ -686,7 +713,10 @@ describe('resetTimes', () => {
           weekDay,
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }))
       })
@@ -738,7 +768,7 @@ describe('resetTimes', () => {
           weekDay,
           day: {
             branch: 'reservation',
-            state: [] // empty reservations array means absent
+            state: { branch: 'absent', state: true }
           }
         }))
       })
@@ -757,35 +787,47 @@ describe('resetTimes', () => {
             weekDay: 1,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             weekDay: 2,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             weekDay: 3,
             day: {
               branch: 'reservation',
-              state: [] // this day has an absence for all children
+              state: { branch: 'absent', state: true } // this day has an absence for all children
             }
           },
           {
             weekDay: 4,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             weekDay: 5,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           }
         ]
@@ -857,14 +899,20 @@ describe('resetTimes', () => {
             weekDay: 1,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             weekDay: 2,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
@@ -879,14 +927,20 @@ describe('resetTimes', () => {
             weekDay: 4,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             weekDay: 5,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           }
         ]
@@ -955,35 +1009,50 @@ describe('resetTimes', () => {
             weekDay: 1,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '08:05', endTime: '16:00' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '08:05', endTime: '16:00' }]
+              }
             }
           },
           {
             weekDay: 2,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '08:10', endTime: '16:00' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '08:10', endTime: '16:00' }]
+              }
             }
           },
           {
             weekDay: 3,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '08:15', endTime: '16:00' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '08:15', endTime: '16:00' }]
+              }
             }
           },
           {
             weekDay: 4,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '08:20', endTime: '16:00' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '08:20', endTime: '16:00' }]
+              }
             }
           },
           {
             weekDay: 5,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '08:25', endTime: '16:00' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '08:25', endTime: '16:00' }]
+              }
             }
           }
         ]
@@ -1003,14 +1072,20 @@ describe('resetTimes', () => {
             weekDay: 1,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             weekDay: 2,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
@@ -1018,21 +1093,30 @@ describe('resetTimes', () => {
             day: {
               // This day has a common reservation for all children
               branch: 'reservation',
-              state: [{ startTime: '08:15', endTime: '16:00' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '08:15', endTime: '16:00' }]
+              }
             }
           },
           {
             weekDay: 4,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             weekDay: 5,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           }
         ]
@@ -1175,14 +1259,20 @@ describe('resetTimes', () => {
             weekDay: 2,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             weekDay: 3,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           }
         ]
@@ -1253,7 +1343,10 @@ describe('resetTimes', () => {
           weekDay,
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }))
       })
@@ -1725,7 +1818,13 @@ describe('resetTimes', () => {
         state: selectedRangeWeekDays.map((date) => ({
           date,
           day: date.isEqual(tuesday)
-            ? { branch: 'reservation', state: [{ startTime: '', endTime: '' }] }
+            ? {
+                branch: 'reservation',
+                state: {
+                  branch: 'timeRanges',
+                  state: [{ startTime: '', endTime: '' }]
+                }
+              }
             : { branch: 'readOnly', state: undefined }
         }))
       })
@@ -1753,7 +1852,10 @@ describe('resetTimes', () => {
           date,
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }))
       })
@@ -1781,7 +1883,10 @@ describe('resetTimes', () => {
           date,
           day: {
             branch: 'reservation',
-            state: [{ startTime: '', endTime: '' }]
+            state: {
+              branch: 'timeRanges',
+              state: [{ startTime: '', endTime: '' }]
+            }
           }
         }))
       })
@@ -1984,35 +2089,47 @@ describe('resetTimes', () => {
             date: rangeWeekDays[0],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '08:00', endTime: '16:00' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '08:00', endTime: '16:00' }]
+              }
             }
           },
           {
             date: rangeWeekDays[1],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             date: rangeWeekDays[2],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             date: rangeWeekDays[3],
             day: {
               branch: 'reservation',
-              state: []
+              state: { branch: 'absent', state: true }
             }
           },
           {
             date: rangeWeekDays[4],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
@@ -2023,7 +2140,10 @@ describe('resetTimes', () => {
             date: rangeWeekDays[6],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
@@ -2100,14 +2220,20 @@ describe('resetTimes', () => {
             date: tuesday,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             date: wednesday,
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           }
         ]
@@ -2356,7 +2482,10 @@ describe('resetTimes', () => {
                   date: selectedRangeWeekDays[1],
                   day: {
                     branch: 'reservation',
-                    state: [{ startTime: '08:15', endTime: '13:45' }]
+                    state: {
+                      branch: 'timeRanges',
+                      state: [{ startTime: '08:15', endTime: '13:45' }]
+                    }
                   }
                 }
               ]
@@ -2378,21 +2507,30 @@ describe('resetTimes', () => {
             date: selectedRangeWeekDays[0],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             date: selectedRangeWeekDays[1],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '08:15', endTime: '13:45' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '08:15', endTime: '13:45' }]
+              }
             }
           },
           {
             date: selectedRangeWeekDays[2],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           }
         ]
@@ -2421,7 +2559,10 @@ describe('resetTimes', () => {
                   date: selectedRangeWeekDays[1],
                   day: {
                     branch: 'reservation',
-                    state: [{ startTime: '08:15', endTime: '13:45' }]
+                    state: {
+                      branch: 'timeRanges',
+                      state: [{ startTime: '08:15', endTime: '13:45' }]
+                    }
                   }
                 }
               ]
@@ -2443,21 +2584,30 @@ describe('resetTimes', () => {
             date: selectedRangeWeekDays[0],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             date: selectedRangeWeekDays[1],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           },
           {
             date: selectedRangeWeekDays[2],
             day: {
               branch: 'reservation',
-              state: [{ startTime: '', endTime: '' }]
+              state: {
+                branch: 'timeRanges',
+                state: [{ startTime: '', endTime: '' }]
+              }
             }
           }
         ]

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -107,7 +107,7 @@ export const timesUnion = union({
   irregularTimes
 })
 
-function toDailyReservationRequest(
+export function toDailyReservationRequest(
   childId: UUID,
   date: LocalDate,
   day: DayOutput
@@ -422,7 +422,7 @@ export function resetTimes(
   }
 }
 
-function resetDay(
+export function resetDay(
   isOpenHolidayPeriod: boolean,
   calendarDays: ReservationResponseDay[],
   selectedChildren: UUID[]

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -481,10 +481,10 @@ class DayViewEditor extends Element {
     endTime: string
   ) {
     const child = this.#childSection(childId)
-    await new TextInput(child.findByDataQa('first-reservation-start')).fill(
-      startTime
-    )
-    await new TextInput(child.findByDataQa('first-reservation-end')).fill(
+    await new TextInput(
+      child.findByDataQa('edit-reservation-time-0-start')
+    ).fill(startTime)
+    await new TextInput(child.findByDataQa('edit-reservation-time-0-end')).fill(
       endTime
     )
   }
@@ -545,6 +545,7 @@ class HolidayModal extends Element {
 
 class DayModal {
   constructor(private readonly page: Page) {}
+
   childName = this.page.findAllByDataQa('child-name')
   closeModal = this.page.findByDataQa('day-view-close-button')
 }

--- a/frontend/src/lib-common/form/hooks.ts
+++ b/frontend/src/lib-common/form/hooks.ts
@@ -56,20 +56,27 @@ export function useForm<F extends AnyForm>(
   initialState: () => StateOf<F>,
   errorDict: Record<Exclude<ErrorOf<F>, ObjectFieldError>, string>,
   options: {
-    onUpdate?: (prevState: StateOf<F>, nextState: StateOf<F>, form: F) => StateOf<F>
+    onUpdate?: (
+      prevState: StateOf<F>,
+      nextState: StateOf<F>,
+      form: F
+    ) => StateOf<F>
   } = {}
 ): BoundForm<F> {
   const onUpdateRef = useRef(options.onUpdate)
   onUpdateRef.current = options.onUpdate
 
   const [state, setState] = useState(initialState)
-  const update = useCallback((fn: (prev: StateOf<F>) => StateOf<F>) => {
-    setState((prev) => {
-      const next = fn(prev)
-      const onUpdate = onUpdateRef.current
-      return onUpdate ? onUpdate(prev, next, form) : next
-    })
-  }, [form])
+  const update = useCallback(
+    (fn: (prev: StateOf<F>) => StateOf<F>) => {
+      setState((prev) => {
+        const next = fn(prev)
+        const onUpdate = onUpdateRef.current
+        return onUpdate ? onUpdate(prev, next, form) : next
+      })
+    },
+    [form]
+  )
   const set = useCallback((value: StateOf<F>) => {
     setState(value)
   }, [])
@@ -408,7 +415,6 @@ function validationHelpers<Output, Error, State>(
 }
 
 export interface UseBoolean {
-  value: boolean
   update: (fn: (value: boolean) => boolean) => void
   set: (value: boolean) => void
   toggle: () => void
@@ -418,15 +424,14 @@ export interface UseBoolean {
 
 export function useBoolean(initialState: boolean): [boolean, UseBoolean] {
   const { state, update, set } = useForm(boolean(), () => initialState, {})
+  const toggle = useCallback(() => update((v) => !v), [update])
+  const on = useCallback(() => set(true), [set])
+  const off = useCallback(() => set(false), [set])
   return [
     state,
-    {
-      value: state,
-      update,
-      set,
-      toggle: useCallback(() => update((v) => !v), [update]),
-      on: useCallback(() => set(true), [set]),
-      off: useCallback(() => set(false), [set])
-    }
+    useMemo(
+      () => ({ update, set, toggle, on, off }),
+      [off, on, set, toggle, update]
+    )
   ]
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -305,7 +305,7 @@ LEFT JOIN LATERAL (
 LEFT JOIN LATERAL (
     SELECT
         a.absence_type,
-        (a.absence_type <> 'FREE_ABSENCE' AND eu.type <> 'EMPLOYEE') AS absence_editable
+        (a.absence_type <> 'FREE_ABSENCE' AND eu.type = 'CITIZEN') AS absence_editable
     FROM absence a
     JOIN evaka_user eu ON eu.id = a.modified_by
     WHERE


### PR DESCRIPTION
#### Summary

- Minor fixes to backend logic that computes properties for each calendar day
- Group no-times holiday reservations and reservation not required children in calendar
- Reuse reservation modal's form elements and reset logic in day modal.