### PR TITLE
Drop old view in migration

### DIFF
--- a/service/src/main/resources/db/migration/V322__move_unit_manager.sql
+++ b/service/src/main/resources/db/migration/V322__move_unit_manager.sql
@@ -1,3 +1,5 @@
+DROP VIEW IF EXISTS old_daycare_acl_view;
+
 ALTER TABLE daycare
     ADD COLUMN unit_manager_name text NOT NULL DEFAULT '',
     ADD COLUMN unit_manager_phone text NOT NULL DEFAULT '',


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Repeatable migrations are run *after* the main migrations, so having the DROP VIEW in R__old_daycare_acl_view.sql is not enough