### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,9 +17,6 @@
 !service/certificates/
 !service/dd-jmxfetch/
 
-!service/buildSrc/*.kts
-!service/buildSrc/src
-
 !service/codegen/*.kts
 !service/codegen/src
 
@@ -36,7 +33,7 @@
 !service/sficlient/*.kts
 !service/sficlient/src
 
-!evaka-bom/build.gradle.kts
+!evaka-bom/*.kts
 
 !service-lib/*.kts
 !service-lib/src


### PR DESCRIPTION
#### Summary

See fcd1973:

- file evaka-bom/settings.gradle.kts shouldn't be ignored.
- folder service/buildSrc doesn't exist anymore.