### PR TITLE
Fix flaky integration test

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/EvakaClock.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/EvakaClock.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.shared.domain
 
 import java.time.Clock
+import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -28,8 +29,8 @@ class MockEvakaClock(private var now: HelsinkiDateTime) : EvakaClock {
     override fun today(): LocalDate = now.toLocalDate()
     override fun now(): HelsinkiDateTime = now
 
-    fun tick() {
-        now = now.plusSeconds(1)
+    fun tick(duration: Duration = Duration.ofSeconds(1)) {
+        now += duration
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/HelsinkiDateTime.kt
@@ -18,6 +18,7 @@ import java.time.Month
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoField
+import java.time.temporal.TemporalAmount
 
 val europeHelsinki: ZoneId = ZoneId.of("Europe/Helsinki")
 
@@ -50,6 +51,7 @@ data class HelsinkiDateTime private constructor(private val instant: Instant) :
     fun minusHours(hours: Long): HelsinkiDateTime = update { it.minusHours(hours) }
     fun minusMinutes(minutes: Long): HelsinkiDateTime = update { it.minusMinutes(minutes) }
     fun minusSeconds(seconds: Long): HelsinkiDateTime = update { it.minusSeconds(seconds) }
+    operator fun minus(duration: TemporalAmount): HelsinkiDateTime = update { it + duration }
 
     fun plusYears(years: Long): HelsinkiDateTime = update { it.plusYears(years) }
     fun plusMonths(months: Long): HelsinkiDateTime = update { it.plusMonths(months) }
@@ -58,6 +60,7 @@ data class HelsinkiDateTime private constructor(private val instant: Instant) :
     fun plusHours(hours: Long): HelsinkiDateTime = update { it.plusHours(hours) }
     fun plusMinutes(minutes: Long): HelsinkiDateTime = update { it.plusMinutes(minutes) }
     fun plusSeconds(seconds: Long): HelsinkiDateTime = update { it.plusSeconds(seconds) }
+    operator fun plus(duration: TemporalAmount): HelsinkiDateTime = update { it + duration }
 
     fun isAfter(other: HelsinkiDateTime): Boolean = this.instant.isAfter(other.instant)
     fun isBefore(other: HelsinkiDateTime): Boolean = this.instant.isBefore(other.instant)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

`clock.now().plusSeconds(MessageService.SPREAD_MESSAGE_NOTIFICATION_SECONDS)` is not the correct calculation, because the messages are scheduled up to `SPREAD_MESSAGE_NOTIFICATIONS_SECONDS` starting from the *moment the original job is executed*, which is *not* `clock.now()` since clock.now() is never updated after the start of the test.

Let's try using mutable clock and `tick()` and see if this style is better.