### PR TITLE
Use unit operation times to validate and limit child reservations (citizen frontend)

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -614,10 +614,7 @@ function initialChildFormState(
 ): StateOf<typeof childForm> {
   return {
     childId,
-    day: resetDay(holidayPeriod?.state, [child], [childId], {
-      unitTimeRange: unitTimes[0],
-      hasVariedUnitTimes: false
-    })
+    day: resetDay(holidayPeriod?.state, [child], [childId], unitTimes[0])
   }
 }
 

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -303,7 +303,9 @@ export default React.memo(function ReservationModal({
               <AsyncButton
                 primary
                 text={i18n.common.confirm}
-                disabled={form.state.selectedChildren.length === 0}
+                disabled={
+                  form.state.selectedChildren.length === 0 || !form.isValid()
+                }
                 onClick={() => {
                   if (!form.isValid()) {
                     setShowAllErrors(true)

--- a/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
+++ b/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
@@ -5,21 +5,19 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
+import { localTimeRangeWithUnitTimes } from 'lib-common/form/fields'
 import { BoundFormShape, useFormField } from 'lib-common/form/hooks'
-import { Form } from 'lib-common/form/types'
+import { ShapeOf, StateOf } from 'lib-common/form/types'
 import UnderRowStatusIcon, { InfoStatus } from 'lib-components/atoms/StatusIcon'
-import { TimeInputF } from 'lib-components/atoms/form/TimeInput'
+import { TimeInputFWithUnitTimes } from 'lib-components/atoms/form/TimeInput'
 import { defaultMargins } from 'lib-components/white-space'
 
 import { useTranslation } from '../localization'
 
 export interface Props {
   bind: BoundFormShape<
-    { startTime: string; endTime: string },
-    {
-      startTime: Form<unknown, string, string, unknown>
-      endTime: Form<unknown, string, string, unknown>
-    }
+    StateOf<typeof localTimeRangeWithUnitTimes>,
+    ShapeOf<typeof localTimeRangeWithUnitTimes>
   >
   hideErrorsBeforeTouched?: boolean
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
@@ -43,7 +41,7 @@ export default React.memo(function TimeRangeInputF({
   return (
     <div>
       <TimeRangeWrapper>
-        <TimeInputF
+        <TimeInputFWithUnitTimes
           bind={startTime}
           placeholder={i18n.calendar.reservationModal.start}
           hideErrorsBeforeTouched={hideErrorsBeforeTouched}
@@ -52,7 +50,7 @@ export default React.memo(function TimeRangeInputF({
           data-qa={dataQa ? `${dataQa}-start` : undefined}
         />
         <span>–</span>
-        <TimeInputF
+        <TimeInputFWithUnitTimes
           bind={endTime}
           placeholder={i18n.calendar.reservationModal.end}
           hideErrorsBeforeTouched={hideErrorsBeforeTouched}

--- a/frontend/src/citizen-frontend/calendar/api.ts
+++ b/frontend/src/citizen-frontend/calendar/api.ts
@@ -46,6 +46,12 @@ export async function getReservations(
           date: LocalDate.parseIso(day.date),
           children: day.children.map((child) => ({
             ...child,
+            unitOperationTime: child.unitOperationTime
+              ? {
+                  start: LocalTime.parseIso(child.unitOperationTime.start),
+                  end: LocalTime.parseIso(child.unitOperationTime.end)
+                }
+              : null,
             attendances: child.attendances.map((r) => ({
               startTime: LocalTime.parseIso(r.startTime),
               endTime: r.endTime ? LocalTime.parseIso(r.endTime) : null

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -279,9 +279,7 @@ const TimeRanges = React.memo(function Times({
                 onClick={() => bind.update((prev) => [prev[0], emptyTimeRange])}
                 aria-label={i18n.common.add}
               />
-            ) : (
-              <div />
-            )}
+            ) : null}
           </FixedSpaceRow>
         </RightCell>
       </FixedSpaceRow>

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -12,7 +12,7 @@ import {
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
-import { DayProperties, resetTimes } from './form'
+import { DayProperties, UnitTimeInfo, resetTimes } from './form'
 
 const monday = LocalDate.of(2021, 2, 1)
 const tuesday = monday.addDays(1)
@@ -48,8 +48,27 @@ const emptyChild: ReservationResponseDayChild = {
   shiftCare: false,
   absence: null,
   reservations: [],
-  attendances: []
+  attendances: [],
+  unitOperationTime: {
+    start: LocalTime.MIN,
+    end: LocalTime.of(23, 59)
+  }
 }
+
+const buildTimeInputState = (value: string, unitTimeInfo?: UnitTimeInfo) =>
+  unitTimeInfo
+    ? {
+        value,
+        unitStartTime: unitTimeInfo.unitTimeRange?.start ?? null,
+        unitEndTime: unitTimeInfo.unitTimeRange?.end ?? null,
+        hasVariedUnitTimes: unitTimeInfo.hasVariedUnitTimes
+      }
+    : {
+        value,
+        unitStartTime: emptyChild.unitOperationTime?.start ?? null,
+        unitEndTime: emptyChild.unitOperationTime?.end ?? null,
+        hasVariedUnitTimes: false
+      }
 
 describe('resetTimes', () => {
   describe('DAILY', () => {
@@ -102,7 +121,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '', endTime: '' }]
+              state: [
+                {
+                  startTime: buildTimeInputState(''),
+                  endTime: buildTimeInputState('')
+                }
+              ]
             }
           }
         }
@@ -135,7 +159,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '', endTime: '' }]
+              state: [
+                {
+                  startTime: buildTimeInputState(''),
+                  endTime: buildTimeInputState('')
+                }
+              ]
             }
           }
         }
@@ -167,7 +196,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '', endTime: '' }]
+              state: [
+                {
+                  startTime: buildTimeInputState(''),
+                  endTime: buildTimeInputState('')
+                }
+              ]
             }
           }
         }
@@ -227,7 +261,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '08:00', endTime: '16:00' }]
+              state: [
+                {
+                  startTime: buildTimeInputState('08:00'),
+                  endTime: buildTimeInputState('16:00')
+                }
+              ]
             }
           }
         }
@@ -248,7 +287,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '', endTime: '' }]
+              state: [
+                {
+                  startTime: buildTimeInputState(''),
+                  endTime: buildTimeInputState('')
+                }
+              ]
             }
           }
         }
@@ -401,7 +445,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '', endTime: '' }]
+              state: [
+                {
+                  startTime: buildTimeInputState(''),
+                  endTime: buildTimeInputState('')
+                }
+              ]
             }
           }
         }
@@ -646,7 +695,18 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState('', {
+                      hasVariedUnitTimes: false,
+                      unitTimeRange: null
+                    }),
+                    endTime: buildTimeInputState('', {
+                      hasVariedUnitTimes: false,
+                      unitTimeRange: null
+                    })
+                  }
+                ]
               }
             }
           }
@@ -680,7 +740,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '', endTime: '' }]
+              state: [
+                {
+                  startTime: buildTimeInputState(''),
+                  endTime: buildTimeInputState('')
+                }
+              ]
             }
           }
         }))
@@ -712,7 +777,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '', endTime: '' }]
+              state: [
+                {
+                  startTime: buildTimeInputState(''),
+                  endTime: buildTimeInputState('')
+                }
+              ]
             }
           }
         }))
@@ -786,7 +856,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -796,7 +871,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -813,7 +893,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -823,7 +908,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           }
@@ -898,7 +988,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -908,7 +1003,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -926,7 +1026,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -936,7 +1041,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           }
@@ -1008,7 +1118,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '08:05', endTime: '16:00' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState('08:05'),
+                    endTime: buildTimeInputState('16:00')
+                  }
+                ]
               }
             }
           },
@@ -1018,7 +1133,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '08:10', endTime: '16:00' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState('08:10'),
+                    endTime: buildTimeInputState('16:00')
+                  }
+                ]
               }
             }
           },
@@ -1028,7 +1148,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '08:15', endTime: '16:00' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState('08:15'),
+                    endTime: buildTimeInputState('16:00')
+                  }
+                ]
               }
             }
           },
@@ -1038,7 +1163,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '08:20', endTime: '16:00' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState('08:20'),
+                    endTime: buildTimeInputState('16:00')
+                  }
+                ]
               }
             }
           },
@@ -1048,7 +1178,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '08:25', endTime: '16:00' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState('08:25'),
+                    endTime: buildTimeInputState('16:00')
+                  }
+                ]
               }
             }
           }
@@ -1071,7 +1206,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -1081,7 +1221,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -1092,7 +1237,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '08:15', endTime: '16:00' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState('08:15'),
+                    endTime: buildTimeInputState('16:00')
+                  }
+                ]
               }
             }
           },
@@ -1102,7 +1252,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -1112,7 +1267,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           }
@@ -1258,7 +1418,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -1268,7 +1433,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           }
@@ -1342,7 +1512,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '', endTime: '' }]
+              state: [
+                {
+                  startTime: buildTimeInputState(''),
+                  endTime: buildTimeInputState('')
+                }
+              ]
             }
           }
         }))
@@ -1819,7 +1994,12 @@ describe('resetTimes', () => {
                 branch: 'reservation',
                 state: {
                   branch: 'timeRanges',
-                  state: [{ startTime: '', endTime: '' }]
+                  state: [
+                    {
+                      startTime: buildTimeInputState(''),
+                      endTime: buildTimeInputState('')
+                    }
+                  ]
                 }
               }
             : { branch: 'readOnly', state: 'noChildren' }
@@ -1851,7 +2031,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '', endTime: '' }]
+              state: [
+                {
+                  startTime: buildTimeInputState(''),
+                  endTime: buildTimeInputState('')
+                }
+              ]
             }
           }
         }))
@@ -1882,7 +2067,12 @@ describe('resetTimes', () => {
             branch: 'reservation',
             state: {
               branch: 'timeRanges',
-              state: [{ startTime: '', endTime: '' }]
+              state: [
+                {
+                  startTime: buildTimeInputState(''),
+                  endTime: buildTimeInputState('')
+                }
+              ]
             }
           }
         }))
@@ -2088,7 +2278,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '08:00', endTime: '16:00' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState('08:00'),
+                    endTime: buildTimeInputState('16:00')
+                  }
+                ]
               }
             }
           },
@@ -2098,7 +2293,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -2108,7 +2308,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -2125,7 +2330,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -2139,7 +2349,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -2219,7 +2434,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -2229,7 +2449,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           }
@@ -2761,7 +2986,12 @@ describe('resetTimes', () => {
                     branch: 'reservation',
                     state: {
                       branch: 'timeRanges',
-                      state: [{ startTime: '08:15', endTime: '13:45' }]
+                      state: [
+                        {
+                          startTime: buildTimeInputState('08:15'),
+                          endTime: buildTimeInputState('13:45')
+                        }
+                      ]
                     }
                   }
                 }
@@ -2786,7 +3016,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -2796,7 +3031,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '08:15', endTime: '13:45' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState('08:15'),
+                    endTime: buildTimeInputState('13:45')
+                  }
+                ]
               }
             }
           },
@@ -2806,7 +3046,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           }
@@ -2838,7 +3083,12 @@ describe('resetTimes', () => {
                     branch: 'reservation',
                     state: {
                       branch: 'timeRanges',
-                      state: [{ startTime: '08:15', endTime: '13:45' }]
+                      state: [
+                        {
+                          startTime: buildTimeInputState('08:15'),
+                          endTime: buildTimeInputState('13:45')
+                        }
+                      ]
                     }
                   }
                 }
@@ -2863,7 +3113,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -2873,7 +3128,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -2883,7 +3143,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           }

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -9,10 +9,11 @@ import {
   ReservationResponseDay,
   ReservationResponseDayChild
 } from 'lib-common/generated/api-types/reservations'
+import { TimeRange } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
-import { DayProperties, UnitTimeInfo, resetTimes } from './form'
+import { DayProperties, resetTimes } from './form'
 
 const monday = LocalDate.of(2021, 2, 1)
 const tuesday = monday.addDays(1)
@@ -55,19 +56,17 @@ const emptyChild: ReservationResponseDayChild = {
   }
 }
 
-const buildTimeInputState = (value: string, unitTimeInfo?: UnitTimeInfo) =>
-  unitTimeInfo
+const buildTimeInputState = (value: string, unitTimeRange?: TimeRange | null) =>
+  unitTimeRange !== undefined
     ? {
         value,
-        unitStartTime: unitTimeInfo.unitTimeRange?.start ?? null,
-        unitEndTime: unitTimeInfo.unitTimeRange?.end ?? null,
-        hasVariedUnitTimes: unitTimeInfo.hasVariedUnitTimes
+        unitStartTime: unitTimeRange?.start ?? null,
+        unitEndTime: unitTimeRange?.end ?? null
       }
     : {
         value,
         unitStartTime: emptyChild.unitOperationTime?.start ?? null,
-        unitEndTime: emptyChild.unitOperationTime?.end ?? null,
-        hasVariedUnitTimes: false
+        unitEndTime: emptyChild.unitOperationTime?.end ?? null
       }
 
 describe('resetTimes', () => {
@@ -697,14 +696,8 @@ describe('resetTimes', () => {
                 branch: 'timeRanges',
                 state: [
                   {
-                    startTime: buildTimeInputState('', {
-                      hasVariedUnitTimes: false,
-                      unitTimeRange: null
-                    }),
-                    endTime: buildTimeInputState('', {
-                      hasVariedUnitTimes: false,
-                      unitTimeRange: null
-                    })
+                    startTime: buildTimeInputState('', null),
+                    endTime: buildTimeInputState('', null)
                   }
                 ]
               }

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -2824,7 +2824,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },
@@ -2841,7 +2846,12 @@ describe('resetTimes', () => {
               branch: 'reservation',
               state: {
                 branch: 'timeRanges',
-                state: [{ startTime: '', endTime: '' }]
+                state: [
+                  {
+                    startTime: buildTimeInputState(''),
+                    endTime: buildTimeInputState('')
+                  }
+                ]
               }
             }
           },

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -56,7 +56,10 @@ const emptyChild: ReservationResponseDayChild = {
   }
 }
 
-const buildTimeInputState = (value: string, unitOperationTimeRange?: TimeRange | null) =>
+const buildTimeInputState = (
+  value: string,
+  unitOperationTimeRange?: TimeRange | null
+) =>
   unitOperationTimeRange !== undefined
     ? {
         value,

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -56,12 +56,12 @@ const emptyChild: ReservationResponseDayChild = {
   }
 }
 
-const buildTimeInputState = (value: string, unitTimeRange?: TimeRange | null) =>
-  unitTimeRange !== undefined
+const buildTimeInputState = (value: string, unitOperationTimeRange?: TimeRange | null) =>
+  unitOperationTimeRange !== undefined
     ? {
         value,
-        unitStartTime: unitTimeRange?.start ?? null,
-        unitEndTime: unitTimeRange?.end ?? null
+        unitStartTime: unitOperationTimeRange?.start ?? null,
+        unitEndTime: unitOperationTimeRange?.end ?? null
       }
     : {
         value,

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -340,7 +340,7 @@ export function resetTimes(
         .map((c) => c.unitOperationTime)
     )
 
-    const unitTimeRange = getMinimalOverlappingRange(unitTimesInRange)
+    const unitOperationTimeRange = getMinimalOverlappingRange(unitTimesInRange)
 
     return {
       branch: 'dailyTimes',
@@ -350,7 +350,7 @@ export function resetTimes(
           holidayPeriodState,
           calendarDaysInRange,
           selectedChildren,
-          unitTimeRange
+          unitOperationTimeRange
         )
       }
     }
@@ -417,7 +417,7 @@ export function resetTimes(
           .filter((c) => selectedChildren.includes(c.childId))
           .map((c) => c.unitOperationTime)
 
-        const unitTimeRange = getMinimalOverlappingRange(dailyUnitTimes)
+        const unitOperationTimeRange = getMinimalOverlappingRange(dailyUnitTimes)
 
         return {
           date: rangeDate,
@@ -425,7 +425,7 @@ export function resetTimes(
             dayProperties.holidayPeriodStateForDate(rangeDate),
             [calendarDay],
             selectedChildren,
-            unitTimeRange
+            unitOperationTimeRange
           )
         }
       }
@@ -443,7 +443,7 @@ export function resetDay(
   holidayPeriodState: 'open' | 'closed' | undefined,
   calendarDays: ReservationResponseDay[],
   selectedChildren: UUID[],
-  unitTimeRange: TimeRange | null
+  unitOperationTimeRange: TimeRange | null
 ): StateOf<typeof day> {
   const reservationNotRequired = reservationNotRequiredForAnyChild(
     calendarDays,
@@ -494,7 +494,7 @@ export function resetDay(
         branch: 'reservation',
         state: {
           branch: 'timeRanges',
-          state: bindUnboundedTimeRanges(commonTimeRanges, unitTimeRange)
+          state: bindUnboundedTimeRanges(commonTimeRanges, unitOperationTimeRange)
         }
       }
     }
@@ -509,7 +509,7 @@ export function resetDay(
 
   return holidayPeriodState === 'open' || reservationNotRequired
     ? { branch: 'reservationNoTimes', state: 'notSet' }
-    : getEmptyDayWithUnitTimes(unitTimeRange)
+    : getEmptyDayWithUnitTimes(unitOperationTimeRange)
 }
 
 const holidayWithNoChildrenInShiftCare = (
@@ -596,11 +596,11 @@ const reservationNotRequiredForAnyChild = (
 
 const bindUnboundedTimeRanges = (
   ranges: TimeRange[],
-  info: TimeRange | null
+  unitOperationTimeRange: TimeRange | null
 ): StateOf<typeof localTimeRangeWithUnitTimes>[] => {
   const formatted = ranges.map(({ start, end }) => ({
-    startTime: createTimeInputState(start.format(), info),
-    endTime: createTimeInputState(end.format(), info)
+    startTime: createTimeInputState(start.format(), unitOperationTimeRange),
+    endTime: createTimeInputState(end.format(), unitOperationTimeRange)
   }))
 
   if (ranges.length === 1 || ranges.length === 2) {
@@ -690,15 +690,15 @@ const getCommonUnitTimeRangesByDayOfWeek = (
 }
 
 const getEmptyDayWithUnitTimes = (
-  unitTimeRange: TimeRange | null
+  unitOperationTimeRange: TimeRange | null
 ): StateOf<typeof day> => ({
   branch: 'reservation',
   state: {
     branch: 'timeRanges',
     state: [
       {
-        startTime: createTimeInputState('', unitTimeRange),
-        endTime: createTimeInputState('', unitTimeRange)
+        startTime: createTimeInputState('', unitOperationTimeRange),
+        endTime: createTimeInputState('', unitOperationTimeRange)
       }
     ]
   }
@@ -706,11 +706,11 @@ const getEmptyDayWithUnitTimes = (
 
 const createTimeInputState = (
   value: string,
-  unitTimeRange: TimeRange | null
+  unitOperationTimeRange: TimeRange | null
 ) => ({
   value,
-  unitStartTime: unitTimeRange?.start ?? null,
-  unitEndTime: unitTimeRange?.end ?? null
+  unitStartTime: unitOperationTimeRange?.start ?? null,
+  unitEndTime: unitOperationTimeRange?.end ?? null
 })
 
 export class DayProperties {

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -417,7 +417,8 @@ export function resetTimes(
           .filter((c) => selectedChildren.includes(c.childId))
           .map((c) => c.unitOperationTime)
 
-        const unitOperationTimeRange = getMinimalOverlappingRange(dailyUnitTimes)
+        const unitOperationTimeRange =
+          getMinimalOverlappingRange(dailyUnitTimes)
 
         return {
           date: rangeDate,
@@ -494,7 +495,10 @@ export function resetDay(
         branch: 'reservation',
         state: {
           branch: 'timeRanges',
-          state: bindUnboundedTimeRanges(commonTimeRanges, unitOperationTimeRange)
+          state: bindUnboundedTimeRanges(
+            commonTimeRanges,
+            unitOperationTimeRange
+          )
         }
       }
     }

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -120,6 +120,11 @@ export const fullDayTimeRange: TimeRange = {
   end: LocalTime.parse('23:59')
 }
 
+export const nonFullDayTimeRange: TimeRange = {
+  start: LocalTime.of(1, 0),
+  end: LocalTime.of(23, 0)
+}
+
 export const careAreaFixture: CareArea = {
   id: '674dfb66-8849-489e-b094-e6a0ebfb3c71',
   name: 'Superkeskus',
@@ -191,7 +196,7 @@ export const daycareFixture: Daycare = {
     fullDayTimeRange,
     fullDayTimeRange,
     fullDayTimeRange,
-    fullDayTimeRange,
+    nonFullDayTimeRange,
     null,
     null
   ],

--- a/frontend/src/lib-common/form/fields.ts
+++ b/frontend/src/lib-common/form/fields.ts
@@ -78,16 +78,13 @@ export const localTimeWithUnitTimes = transformed(
   object({
     value: string(),
     unitStartTime: value<LocalTime | null>(),
-    unitEndTime: value<LocalTime | null>(),
-    hasVariedUnitTimes: boolean()
+    unitEndTime: value<LocalTime | null>()
   }),
   (
     v
   ): ValidationResult<
     LocalTime | undefined,
-    | 'timeFormat'
-    | 'outsideUnitOperationTime'
-    | 'outsideCombinedUnitOperationTime'
+    'timeFormat' | 'outsideUnitOperationTime'
   > => {
     if (v.value === '') return ValidationSuccess.of(undefined)
     const parsed = LocalTime.tryParse(v.value)
@@ -99,9 +96,7 @@ export const localTimeWithUnitTimes = transformed(
       parsed.isBefore(v.unitStartTime) ||
       parsed.isAfter(v.unitEndTime)
     ) {
-      return v.hasVariedUnitTimes
-        ? ValidationError.of('outsideCombinedUnitOperationTime')
-        : ValidationError.of('outsideUnitOperationTime')
+      return ValidationError.of('outsideUnitOperationTime')
     }
     return ValidationSuccess.of(parsed)
   }

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -141,6 +141,7 @@ export interface ReservationResponseDayChild {
   requiresReservation: boolean
   reservations: Reservation[]
   shiftCare: boolean
+  unitOperationTime: TimeRange | null
 }
 
 /**

--- a/frontend/src/lib-components/atoms/form/TimeInput.tsx
+++ b/frontend/src/lib-components/atoms/form/TimeInput.tsx
@@ -5,7 +5,9 @@
 import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
+import { localTimeWithUnitTimes } from 'lib-common/form/fields'
 import { BoundFormState } from 'lib-common/form/hooks'
+import { StateOf } from 'lib-common/form/types'
 import { autocomplete } from 'lib-common/time'
 
 import InputField, { TextInputProps } from './InputField'
@@ -55,6 +57,32 @@ const TimeInput = React.memo(function TimeInput({
   )
 })
 
+const TimeInputWide = React.memo(function TimeInput({
+  value,
+  onChange,
+  onFocus,
+  ...props
+}: TimeInputProps) {
+  const onChangeWithAutocomplete = useCallback(
+    (v: string) => onChange(autocomplete(value, v)),
+    [value, onChange]
+  )
+
+  return (
+    <ScalingInput
+      {...props}
+      value={value}
+      onChange={onChangeWithAutocomplete}
+      type="text"
+      inputMode="numeric"
+      onFocus={(event) => {
+        event.target.select()
+        onFocus?.(event)
+      }}
+    />
+  )
+})
+
 export default TimeInput
 
 const ShorterInput = styled(InputField)`
@@ -63,6 +91,17 @@ const ShorterInput = styled(InputField)`
 
   input {
     font-size: 1em;
+  }
+`
+
+const ScalingInput = styled(InputField)`
+  div.warning {
+    line-height: 1.125rem;
+  }
+
+  input {
+    font-size: 1em;
+    min-width: 80px;
   }
 `
 
@@ -84,3 +123,24 @@ export const TimeInputF = React.memo(function TimeInputF({
     />
   )
 })
+
+export interface TimeInputFWithUnitTimesProps
+  extends Omit<TimeInputProps, 'value' | 'onChange'> {
+  bind: BoundFormState<StateOf<typeof localTimeWithUnitTimes>>
+}
+
+export const TimeInputFWithUnitTimes = React.memo(
+  function TimeInputFWithUnitTimes({
+    bind: { state, set, inputInfo },
+    ...props
+  }: TimeInputFWithUnitTimesProps) {
+    return (
+      <TimeInputWide
+        {...props}
+        value={state.value}
+        onChange={(newValue) => set({ ...state, value: newValue })}
+        info={'info' in props ? props.info : inputInfo()}
+      />
+    )
+  }
+)

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2068,7 +2068,6 @@ const en: Translations = {
     httpUrl: 'Valid url format is https://example.com',
     unselectableDate: 'Invalid date',
     outsideUnitOperationTime: 'Outside opening hours',
-    outsideCombinedUnitOperationTime: 'Outside opening hours',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2067,6 +2067,8 @@ const en: Translations = {
     emailsDoNotMatch: 'The emails do not match',
     httpUrl: 'Valid url format is https://example.com',
     unselectableDate: 'Invalid date',
+    outsideUnitOperationTime: 'Outside opening hours',
+    outsideCombinedUnitOperationTime: 'Outside opening hours',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2146,7 +2146,6 @@ export default {
     httpUrl: 'Anna muodossa https://example.com',
     unselectableDate: 'Päivä ei ole sallittu',
     outsideUnitOperationTime: 'Yksikön aukiolo ylittyy',
-    outsideCombinedUnitOperationTime: 'Yksikön aukiolo ylittyy',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2145,6 +2145,8 @@ export default {
     emailsDoNotMatch: 'Sähköpostiosoitteet eivät täsmää',
     httpUrl: 'Anna muodossa https://example.com',
     unselectableDate: 'Päivä ei ole sallittu',
+    outsideUnitOperationTime: 'Yksikön aukiolo ylittyy',
+    outsideCombinedUnitOperationTime: 'Yksikön aukiolo ylittyy',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2167,7 +2167,6 @@ const sv: Translations = {
     httpUrl: 'Ange i formen https://example.com',
     unselectableDate: 'Ogiltigt datum',
     outsideUnitOperationTime: 'Utanför enhetens öppettid',
-    outsideCombinedUnitOperationTime: 'Utanför enhetens öppettid',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2166,6 +2166,8 @@ const sv: Translations = {
     emailsDoNotMatch: 'E-postadresserna är olika',
     httpUrl: 'Ange i formen https://example.com',
     unselectableDate: 'Ogiltigt datum',
+    outsideUnitOperationTime: 'Utanför enhetens öppettid',
+    outsideCombinedUnitOperationTime: 'Utanför enhetens öppettid',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -169,9 +169,20 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             holiday = false,
                             children =
                                 listOf(
-                                        dayChild(testChild_1.id),
-                                        dayChild(testChild_2.id, contractDays = true),
-                                        dayChild(testChild_3.id, requiresReservation = false)
+                                        dayChild(
+                                            testChild_1.id,
+                                            unitOperationTime = testDaycare.operationTimes[0]
+                                        ),
+                                        dayChild(
+                                            testChild_2.id,
+                                            contractDays = true,
+                                            unitOperationTime = testDaycare.operationTimes[0]
+                                        ),
+                                        dayChild(
+                                            testChild_3.id,
+                                            requiresReservation = false,
+                                            unitOperationTime = testDaycare.operationTimes[0]
+                                        )
                                     )
                                     .sortedBy { it.childId }
                         ),
@@ -180,9 +191,20 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             holiday = false,
                             children =
                                 listOf(
-                                        dayChild(testChild_1.id),
-                                        dayChild(testChild_2.id, contractDays = true),
-                                        dayChild(testChild_3.id, requiresReservation = false)
+                                        dayChild(
+                                            testChild_1.id,
+                                            unitOperationTime = testDaycare.operationTimes[1]
+                                        ),
+                                        dayChild(
+                                            testChild_2.id,
+                                            contractDays = true,
+                                            unitOperationTime = testDaycare.operationTimes[1]
+                                        ),
+                                        dayChild(
+                                            testChild_3.id,
+                                            requiresReservation = false,
+                                            unitOperationTime = testDaycare.operationTimes[1]
+                                        )
                                     )
                                     .sortedBy { it.childId }
                         ),
@@ -273,7 +295,11 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             children =
                                 listOf(
                                     // sunday, only shift care is eligible
-                                    dayChild(testChild_3.id, shiftCare = true),
+                                    dayChild(
+                                        testChild_3.id,
+                                        shiftCare = true,
+                                        unitOperationTime = roundTheClockDaycare.operationTimes[6]
+                                    ),
                                 )
                         ),
                         ReservationResponseDay(
@@ -281,9 +307,21 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             holiday = false,
                             children =
                                 listOf(
-                                        dayChild(testChild_1.id),
-                                        dayChild(testChild_2.id, contractDays = true),
-                                        dayChild(testChild_3.id, shiftCare = true),
+                                        dayChild(
+                                            testChild_1.id,
+                                            unitOperationTime = testDaycare.operationTimes[0]
+                                        ),
+                                        dayChild(
+                                            testChild_2.id,
+                                            contractDays = true,
+                                            unitOperationTime = testDaycare.operationTimes[0]
+                                        ),
+                                        dayChild(
+                                            testChild_3.id,
+                                            shiftCare = true,
+                                            unitOperationTime =
+                                                roundTheClockDaycare.operationTimes[0]
+                                        ),
                                     )
                                     .sortedBy { it.childId }
                         ),
@@ -293,7 +331,11 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             children =
                                 listOf(
                                     // holiday, only shift care is eligible
-                                    dayChild(testChild_3.id, shiftCare = true),
+                                    dayChild(
+                                        testChild_3.id,
+                                        shiftCare = true,
+                                        unitOperationTime = roundTheClockDaycare.operationTimes[1]
+                                    ),
                                 )
                         ),
                         ReservationResponseDay(
@@ -375,9 +417,14 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                                 AbsenceInfo(
                                                     AbsenceType.OTHER_ABSENCE,
                                                     editable = false
-                                                )
+                                                ),
+                                            unitOperationTime = testDaycare.operationTimes[0]
                                         ),
-                                        dayChild(testChild_2.id, contractDays = true),
+                                        dayChild(
+                                            testChild_2.id,
+                                            contractDays = true,
+                                            unitOperationTime = testDaycare.operationTimes[0]
+                                        ),
                                     )
                                     .sortedBy { it.childId }
                         ),
@@ -386,8 +433,15 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             holiday = false,
                             children =
                                 listOf(
-                                        dayChild(testChild_1.id),
-                                        dayChild(testChild_2.id, contractDays = true),
+                                        dayChild(
+                                            testChild_1.id,
+                                            unitOperationTime = testDaycare.operationTimes[1]
+                                        ),
+                                        dayChild(
+                                            testChild_2.id,
+                                            contractDays = true,
+                                            unitOperationTime = testDaycare.operationTimes[0]
+                                        ),
                                     )
                                     .sortedBy { it.childId }
                         ),
@@ -450,12 +504,14 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                 listOf(
                         dayChild(
                             testChild_1.id,
-                            reservations = listOf(Reservation.Times(startTime, endTime))
+                            reservations = listOf(Reservation.Times(startTime, endTime)),
+                            unitOperationTime = testDaycare.operationTimes[0]
                         ),
                         dayChild(
                             testChild_2.id,
                             contractDays = true,
                             reservations = listOf(Reservation.Times(startTime, endTime)),
+                            unitOperationTime = testDaycare.operationTimes[0]
                         )
                     )
                     .sortedBy { it.childId },
@@ -469,12 +525,14 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                 listOf(
                         dayChild(
                             testChild_1.id,
-                            reservations = listOf(Reservation.Times(startTime, endTime))
+                            reservations = listOf(Reservation.Times(startTime, endTime)),
+                            unitOperationTime = testDaycare.operationTimes[1]
                         ),
                         dayChild(
                             testChild_2.id,
                             contractDays = true,
                             reservations = listOf(Reservation.Times(startTime, endTime)),
+                            unitOperationTime = testDaycare.operationTimes[1]
                         )
                     )
                     .sortedBy { it.childId },
@@ -514,9 +572,14 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                 listOf(
                         dayChild(
                             testChild_1.id,
-                            reservations = listOf(Reservation.Times(startTime, endTime))
+                            reservations = listOf(Reservation.Times(startTime, endTime)),
+                            unitOperationTime = testDaycare.operationTimes[0]
                         ),
-                        dayChild(testChild_2.id, contractDays = true)
+                        dayChild(
+                            testChild_2.id,
+                            contractDays = true,
+                            unitOperationTime = testDaycare.operationTimes[0]
+                        )
                     )
                     .sortedBy { it.childId },
                 day.children
@@ -529,9 +592,15 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                 listOf(
                         dayChild(
                             testChild_1.id,
-                            absence = AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true)
+                            absence =
+                                AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
+                            unitOperationTime = testDaycare.operationTimes[1]
                         ),
-                        dayChild(testChild_2.id, contractDays = true)
+                        dayChild(
+                            testChild_2.id,
+                            contractDays = true,
+                            unitOperationTime = testDaycare.operationTimes[1]
+                        )
                     )
                     .sortedBy { it.childId },
                 day.children
@@ -584,12 +653,16 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                 listOf(
                         dayChild(
                             testChild_1.id,
-                            absence = AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true)
+                            absence =
+                                AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
+                            unitOperationTime = testDaycare.operationTimes[0]
                         ),
                         dayChild(
                             testChild_2.id,
                             contractDays = true,
-                            absence = AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true)
+                            absence =
+                                AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
+                            unitOperationTime = testDaycare.operationTimes[0]
                         )
                     )
                     .sortedBy { it.childId },
@@ -603,13 +676,16 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                 listOf(
                         dayChild(
                             testChild_1.id,
-                            absence = AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true)
+                            absence =
+                                AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
+                            unitOperationTime = testDaycare.operationTimes[1]
                         ),
                         dayChild(
                             testChild_2.id,
                             contractDays = true,
                             absence =
                                 AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
+                            unitOperationTime = testDaycare.operationTimes[1]
                         )
                     )
                     .sortedBy { it.childId },
@@ -662,12 +738,13 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(monday, day.date)
             assertEquals(
                 listOf(
-                        dayChild(testChild_1.id),
+                        dayChild(testChild_1.id, unitOperationTime = testDaycare.operationTimes[0]),
                         dayChild(
                             testChild_2.id,
                             contractDays = true,
                             absence =
-                                AbsenceInfo(type = AbsenceType.PLANNED_ABSENCE, editable = false)
+                                AbsenceInfo(type = AbsenceType.PLANNED_ABSENCE, editable = false),
+                            unitOperationTime = testDaycare.operationTimes[0]
                         ),
                     )
                     .sortedBy { it.childId },
@@ -679,11 +756,13 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(tuesday, day.date)
             assertEquals(
                 listOf(
-                        dayChild(testChild_1.id),
+                        dayChild(testChild_1.id, unitOperationTime = testDaycare.operationTimes[1]),
                         dayChild(
                             testChild_2.id,
                             contractDays = true,
-                            absence = AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true)
+                            absence =
+                                AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
+                            unitOperationTime = testDaycare.operationTimes[1]
                         )
                     )
                     .sortedBy { it.childId },
@@ -696,12 +775,13 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
 
     private fun dayChild(
         childId: ChildId,
+        unitOperationTime: TimeRange?,
         requiresReservation: Boolean = true,
         shiftCare: Boolean = false,
         contractDays: Boolean = false,
         absence: AbsenceInfo? = null,
         reservations: List<Reservation> = emptyList(),
-        attendances: List<OpenTimeRange> = emptyList()
+        attendances: List<OpenTimeRange> = emptyList(),
     ) =
         ReservationResponseDayChild(
             childId,
@@ -710,7 +790,8 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             contractDays,
             absence,
             reservations,
-            attendances
+            attendances,
+            unitOperationTime
         )
 
     private fun postReservations(request: List<DailyReservationRequest>) {

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.TimeRange
 import fi.espoo.evaka.shared.domain.getHolidays
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -143,6 +144,8 @@ class ReservationControllerCitizen(
                                                                     ?: listOf(),
                                                             attendances = attendances[key]
                                                                     ?: listOf(),
+                                                            unitOperationTime =
+                                                                placementDay.operationTime
                                                         )
                                                     }
                                             }
@@ -265,7 +268,8 @@ class ReservationControllerCitizen(
 data class PlacementDay(
     val requiresReservation: Boolean,
     val shiftCare: Boolean,
-    val contractDays: Boolean
+    val contractDays: Boolean,
+    val operationTime: TimeRange?
 )
 
 private fun placementDay(
@@ -289,7 +293,8 @@ private fun placementDay(
     return PlacementDay(
             requiresReservation = placement.type.requiresAttendanceReservations(),
             shiftCare = shiftCare,
-            contractDays = contractDays
+            contractDays = contractDays,
+            operationTime = placement.operationTimes[date.dayOfWeek.value - 1]
         )
         .takeIf { shiftCare || isOperationDay && !isHoliday }
 }
@@ -315,6 +320,7 @@ data class ReservationResponseDayChild(
     val absence: AbsenceInfo?,
     val reservations: List<Reservation>,
     val attendances: List<OpenTimeRange>,
+    val unitOperationTime: TimeRange?
 )
 
 data class AbsenceInfo(val type: AbsenceType, val editable: Boolean)

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -376,6 +376,7 @@ data class ReservationPlacement(
     val range: FiniteDateRange,
     val type: PlacementType,
     val operationDays: Set<Int>,
+    val operationTimes: List<TimeRange>
 )
 
 fun Database.Read.getReservationPlacements(
@@ -388,7 +389,8 @@ SELECT
     pl.child_id,
     daterange(pl.start_date, pl.end_date, '[]') * :range AS range,
     pl.type,
-    u.operation_days
+    u.operation_days,
+    u.operation_times
 FROM placement pl
 JOIN daycare u ON pl.unit_id = u.id
 WHERE
@@ -418,7 +420,8 @@ fun Database.Read.getReservationBackupPlacements(
 SELECT
     bc.child_id,
     daterange(bc.start_date, bc.end_date, '[]') * :range AS range,
-    u.operation_days
+    u.operation_days,
+    u.operation_times
 FROM backup_care bc
 JOIN daycare u ON bc.unit_id = u.id
 


### PR DESCRIPTION
Limits allowed citizen reservation inputs by validating them against corresponding combined unit operation hours.

### Backend
- adds unit operation times to child-day response objects (child + day -> placement -> unit)
### UI
- adds combined unit operation times to citizen frontend reservation time validations
  - mass reservation per mode
    - one reservation per date period -> combined validation range over selected children and all days in range
    - one reservation per weekday -> combined validation range over selected children and all days of week in range
    - one reservation per date -> combined validation range over selected children
  - calendar day reservation editing
- modifies time input styling to allow longer validation error messages (citizen frontend only)
  - time inputs scale based on info content
  - input placement scales based on screen width 
- form validation errors now disable save-button visibly, previously only functionally
### Testing
- unit and e2e testing modifications to include modified field shape and state in test fixtures
- e2e tests to cover validation additions