### PR TITLE
Prioritize backup care for daily operation time resolution

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -285,6 +285,8 @@ private fun placementDay(
     val operationDays =
         backupPlacements?.find { it.range.includes(date) }?.operationDays ?: placement.operationDays
 
+    // Backup placements take precedence
+    val operationTime = (backupPlacements?.find { it.range.includes(date) }?.operationTimes ?: placement.operationTimes)[date.dayOfWeek.value - 1]
     val contractDays = contractDayRanges?.includes(date) ?: false
 
     val shiftCare = operationDays == setOf(1, 2, 3, 4, 5, 6, 7)
@@ -294,7 +296,7 @@ private fun placementDay(
             requiresReservation = placement.type.requiresAttendanceReservations(),
             shiftCare = shiftCare,
             contractDays = contractDays,
-            operationTime = placement.operationTimes[date.dayOfWeek.value - 1]
+            operationTime = operationTime
         )
         .takeIf { shiftCare || isOperationDay && !isHoliday }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -281,13 +281,13 @@ private fun placementDay(
 ): PlacementDay? {
     val placement = placements?.find { it.range.includes(date) } ?: return null
 
+    val backupPlacementForDate = backupPlacements?.find { it.range.includes(date) }
     // Backup placements take precedence
-    val operationDays =
-        backupPlacements?.find { it.range.includes(date) }?.operationDays ?: placement.operationDays
+    val operationDays = backupPlacementForDate?.operationDays ?: placement.operationDays
 
     // Backup placements take precedence
     val operationTime =
-        (backupPlacements?.find { it.range.includes(date) }?.operationTimes
+        (backupPlacementForDate?.operationTimes
             ?: placement.operationTimes)[date.dayOfWeek.value - 1]
     val contractDays = contractDayRanges?.includes(date) ?: false
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -286,7 +286,9 @@ private fun placementDay(
         backupPlacements?.find { it.range.includes(date) }?.operationDays ?: placement.operationDays
 
     // Backup placements take precedence
-    val operationTime = (backupPlacements?.find { it.range.includes(date) }?.operationTimes ?: placement.operationTimes)[date.dayOfWeek.value - 1]
+    val operationTime =
+        (backupPlacements?.find { it.range.includes(date) }?.operationTimes
+            ?: placement.operationTimes)[date.dayOfWeek.value - 1]
     val contractDays = contractDayRanges?.includes(date) ?: false
 
     val shiftCare = operationDays == setOf(1, 2, 3, 4, 5, 6, 7)

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -426,6 +426,7 @@ data class ReservationBackupPlacement(
     val childId: ChildId,
     val range: FiniteDateRange,
     val operationDays: Set<Int>,
+    val operationTimes: List<TimeRange>
 )
 
 fun Database.Read.getReservationBackupPlacements(


### PR DESCRIPTION
Fixes issue where regular placement unit times were used to validate citizen reservations even during a backup care period. 
