### PR TITLE
Fix income statement reload spinner issue

### DIFF
--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
@@ -58,7 +58,11 @@ export default React.memo(function IncomeStatementEditor() {
 
   const [state, setState] = useState<Result<EditorState>>(Loading.of())
   const initialEditorState = useInitialEditorState(incomeStatementId)
-  if (state.isLoading && initialEditorState.isSuccess) {
+  if (
+    state.isLoading &&
+    initialEditorState.isSuccess &&
+    !initialEditorState.isReloading
+  ) {
     setState(initialEditorState)
   }
 


### PR DESCRIPTION
#### Summary
If a citizen created an income statement, saved it and reopened it, never-ending spinner was shown

