### PR TITLE
Citizen intermittent shift care

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -172,7 +172,7 @@ const CalendarPage = React.memo(function CalendarPage() {
                   modalState?.type === 'day' ? modalState.date : undefined
                 }
                 selectDate={openDayModal}
-                includeWeekends={response.includesWeekends}
+                includeWeekends={true}
                 dayIsReservable={dayIsReservable}
                 events={events}
               />

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -741,13 +741,19 @@ const Reservations = React.memo(function Reservations({
       {i18n.calendar.reservationNoTimes}
     </ReservationStatus>
   ) : withTimes.length > 0 ? (
-    <span data-qa="reservations">
-      {withTimes
-        .map((reservation) =>
-          formatReservation(shiftCareType, unitTimes, reservation, i18n, ' – ')
-        )
-        .join(', ')}
-    </span>
+    <div data-qa="reservations">
+      {withTimes.map((reservation, i) => (
+        <ReservationRow data-qa={`reservation-output-${i}`} key={`res-${i}`}>
+          {formatReservation(
+            shiftCareType,
+            unitTimes,
+            reservation,
+            i18n,
+            ' – '
+          )}
+        </ReservationRow>
+      ))}
+    </div>
   ) : requiresReservation ? (
     <ReservationStatus data-qa="no-reservations">
       {i18n.calendar.missingReservation}
@@ -863,4 +869,8 @@ const NonGridLabelLike = styled(LabelLike)`
   @media (max-width: ${tabletMin}) {
     margin: ${defaultMargins.xs} 0px ${defaultMargins.xs} 0px;
   }
+`
+const ReservationRow = styled.p`
+  margin-top: 0px;
+  margin-bottom: ${defaultMargins.xs};
 `

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -275,7 +275,6 @@ export default React.memo(function ReservationModal({
                 {selectedRange ? (
                   <RepetitionTimeInputGrid
                     bind={times}
-                    anyChildInShiftCare={dayProperties.anyChildInShiftCare}
                     showAllErrors={showAllErrors}
                   />
                 ) : (

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/DailyRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/DailyRepetitionTimeInputGrid.tsx
@@ -14,14 +14,12 @@ import { dailyTimes } from './form'
 
 export interface DailyRepetitionTimeInputGridProps {
   bind: BoundForm<typeof dailyTimes>
-  anyChildInShiftCare: boolean
   showAllErrors: boolean
 }
 
 export default React.memo(function DailyRepetitionTimeInputGrid({
   bind,
-  showAllErrors,
-  anyChildInShiftCare
+  showAllErrors
 }: DailyRepetitionTimeInputGridProps) {
   const i18n = useTranslation()
 
@@ -43,7 +41,7 @@ export default React.memo(function DailyRepetitionTimeInputGrid({
       bind={day}
       label={label}
       showAllErrors={showAllErrors}
-      allowExtraTimeRange={anyChildInShiftCare}
+      allowExtraTimeRange={true}
       dataQaPrefix="daily"
       onFocus={(ev) => {
         scrollIntoViewSoftKeyboard(ev.target)

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/IrregularRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/IrregularRepetitionTimeInputGrid.tsx
@@ -16,14 +16,12 @@ import { irregularDay, irregularTimes } from './form'
 
 export interface IrregularRepetitionTimeInputGridProps {
   bind: BoundForm<typeof irregularTimes>
-  anyChildInShiftCare: boolean
   showAllErrors: boolean
 }
 
 export default React.memo(function IrregularRepetitionTimeInputGrid({
   bind,
-  showAllErrors,
-  anyChildInShiftCare
+  showAllErrors
 }: IrregularRepetitionTimeInputGridProps) {
   const irregularDays = useFormElems(bind)
   return (
@@ -36,7 +34,6 @@ export default React.memo(function IrregularRepetitionTimeInputGrid({
             bind={irregularDay}
             index={index}
             showAllErrors={showAllErrors}
-            anyChildInShiftCare={anyChildInShiftCare}
           />
         )
       })}
@@ -47,13 +44,11 @@ export default React.memo(function IrregularRepetitionTimeInputGrid({
 const IrregularDay = React.memo(function IrregularDay({
   bind,
   index,
-  showAllErrors,
-  anyChildInShiftCare
+  showAllErrors
 }: {
   bind: BoundForm<typeof irregularDay>
   index: number
   showAllErrors: boolean
-  anyChildInShiftCare: boolean
 }) {
   const i18n = useTranslation()
   const [lang] = useLang()
@@ -73,7 +68,7 @@ const IrregularDay = React.memo(function IrregularDay({
         bind={day}
         label={<Label>{date.format('EEEEEE d.M.', lang)}</Label>}
         showAllErrors={showAllErrors}
-        allowExtraTimeRange={anyChildInShiftCare}
+        allowExtraTimeRange={true}
         dataQaPrefix={`irregular-${date.formatIso()}`}
         onFocus={(ev) => {
           scrollIntoViewSoftKeyboard(ev.target)

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/RepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/RepetitionTimeInputGrid.tsx
@@ -14,7 +14,6 @@ import { timesUnion } from './form'
 
 export interface RepetitionTimeInputGridProps {
   bind: BoundForm<typeof timesUnion>
-  anyChildInShiftCare: boolean
   showAllErrors: boolean
 }
 

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/WeeklyRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/WeeklyRepetitionTimeInputGrid.tsx
@@ -14,14 +14,12 @@ import { weekDay, weeklyTimes } from './form'
 
 export interface WeeklyRepetitionTimeInputGridProps {
   bind: BoundForm<typeof weeklyTimes>
-  anyChildInShiftCare: boolean
   showAllErrors: boolean
 }
 
 export default React.memo(function WeeklyRepetitionTimeInputGrid({
   bind,
-  showAllErrors,
-  anyChildInShiftCare
+  showAllErrors
 }: WeeklyRepetitionTimeInputGridProps) {
   const weekDays = useFormElems(bind)
   return (
@@ -31,7 +29,6 @@ export default React.memo(function WeeklyRepetitionTimeInputGrid({
           key={form.state.weekDay}
           bind={form}
           showAllErrors={showAllErrors}
-          anyChildInShiftCare={anyChildInShiftCare}
         />
       ))}
     </>
@@ -40,12 +37,10 @@ export default React.memo(function WeeklyRepetitionTimeInputGrid({
 
 const WeekDay = React.memo(function WeekDay({
   bind,
-  showAllErrors,
-  anyChildInShiftCare
+  showAllErrors
 }: {
   bind: BoundForm<typeof weekDay>
   showAllErrors: boolean
-  anyChildInShiftCare: boolean
 }) {
   const i18n = useTranslation()
 
@@ -59,7 +54,7 @@ const WeekDay = React.memo(function WeekDay({
         <LabelLike>{i18n.common.datetime.weekdaysShort[weekDay - 1]}</LabelLike>
       }
       showAllErrors={showAllErrors}
-      allowExtraTimeRange={anyChildInShiftCare}
+      allowExtraTimeRange={true}
       dataQaPrefix={`weekly-${weekDay - 1}`}
       onFocus={(ev) => {
         scrollIntoViewSoftKeyboard(ev.target)

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -53,7 +53,8 @@ const emptyChild: ReservationResponseDayChild = {
   unitOperationTime: {
     start: LocalTime.MIN,
     end: LocalTime.of(23, 59)
-  }
+  },
+  shiftCareType: 'NONE'
 }
 
 const buildTimeInputState = (

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -674,7 +674,7 @@ const getMinimalOverlappingRange = (
     }
   })
 
-  return minValue.start && minValue.end
+  return minValue && minValue.start && minValue.end
     ? { start: minValue.start, end: minValue.end }
     : null
 }

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -25,7 +25,8 @@ import { StateOf } from 'lib-common/form/types'
 import {
   DailyReservationRequest,
   ReservationChild,
-  ReservationResponseDay
+  ReservationResponseDay,
+  ReservationResponseDayChild
 } from 'lib-common/generated/api-types/reservations'
 import { TimeRange } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
@@ -33,6 +34,11 @@ import LocalTime from 'lib-common/local-time'
 import { Repetition } from 'lib-common/reservations'
 import { UUID } from 'lib-common/types'
 import { Translations } from 'lib-customizations/citizen'
+
+export const MAX_TIME_RANGE = {
+  start: LocalTime.MIN,
+  end: LocalTime.MAX
+}
 
 interface Dictionary<T> {
   [index: string]: T
@@ -345,7 +351,7 @@ export function resetTimes(
     const unitTimesInRange = calendarDaysInRange.flatMap((d) =>
       d.children
         .filter((c) => selectedChildren.includes(c.childId))
-        .map((c) => c.unitOperationTime)
+        .map(getUnitTimeForDay)
     )
 
     const unitOperationTimeRange = getMinimalOverlappingRange(unitTimesInRange)
@@ -423,7 +429,7 @@ export function resetTimes(
 
         const dailyUnitTimes = calendarDay.children
           .filter((c) => selectedChildren.includes(c.childId))
-          .map((c) => c.unitOperationTime)
+          .map(getUnitTimeForDay)
 
         const unitOperationTimeRange =
           getMinimalOverlappingRange(dailyUnitTimes)
@@ -683,7 +689,7 @@ const getCommonUnitTimeRangesByDayOfWeek = (
     const dayOfWeek = day.date.getIsoDayOfWeek()
     const allChildUnitTimes = day.children
       .filter((c) => selectedChildIds.includes(c.childId))
-      .map((child) => child.unitOperationTime)
+      .map(getUnitTimeForDay)
 
     const dailyTime = weeklyTimes[dayOfWeek]
     const dailyMinimum = getMinimalOverlappingRange(allChildUnitTimes)
@@ -726,9 +732,6 @@ const createTimeInputState = (
 })
 
 export class DayProperties {
-  // Does any child have shift care?
-  readonly anyChildInShiftCare: boolean
-
   private readonly reservableDaysByChild: Record<UUID, Set<string> | undefined>
   private readonly combinedOperationDays: Set<number>
 
@@ -736,7 +739,6 @@ export class DayProperties {
     public readonly calendarDays: ReservationResponseDay[],
     private readonly holidayPeriods: HolidayPeriodInfo[]
   ) {
-    let anyChildInShiftCare = false
     const reservableDaysByChild: Record<UUID, Set<string> | undefined> = {}
     const combinedOperationDays = new Set<number>()
     const holidays = new Set<string>()
@@ -749,8 +751,6 @@ export class DayProperties {
       day.children.forEach((child) => {
         combinedOperationDays.add(dayOfWeek)
 
-        anyChildInShiftCare = anyChildInShiftCare || child.shiftCare
-
         let childReservableDays = reservableDaysByChild[child.childId]
         if (!childReservableDays) {
           childReservableDays = new Set()
@@ -761,7 +761,6 @@ export class DayProperties {
     })
 
     this.calendarDays = calendarDays
-    this.anyChildInShiftCare = anyChildInShiftCare
     this.reservableDaysByChild = reservableDaysByChild
     this.combinedOperationDays = combinedOperationDays
   }
@@ -790,4 +789,12 @@ export class DayProperties {
       holidayPeriod.period.contains(dateRange)
     )?.state
   }
+}
+
+export function getUnitTimeForDay(
+  d: ReservationResponseDayChild
+): TimeRange | null {
+  return d.shiftCareType === 'INTERMITTENT'
+    ? MAX_TIME_RANGE
+    : d.unitOperationTime
 }

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -33,7 +33,7 @@ import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { Repetition } from 'lib-common/reservations'
 import { UUID } from 'lib-common/types'
-import { Translations } from 'lib-customizations/citizen'
+import { Translations, featureFlags } from 'lib-customizations/citizen'
 
 export const MAX_TIME_RANGE = {
   start: LocalTime.MIN,
@@ -794,7 +794,8 @@ export class DayProperties {
 export function getUnitTimeForDay(
   d: ReservationResponseDayChild
 ): TimeRange | null {
-  return d.shiftCareType === 'INTERMITTENT'
+  return featureFlags.experimental?.intermittentShiftCare &&
+    d.shiftCareType === 'INTERMITTENT'
     ? MAX_TIME_RANGE
     : d.unitOperationTime
 }

--- a/frontend/src/citizen-frontend/jest.config.ts
+++ b/frontend/src/citizen-frontend/jest.config.ts
@@ -7,7 +7,13 @@ import type { Config } from '@jest/types'
 const config: Config.InitialOptions = {
   displayName: 'citizen-frontend',
   preset: 'ts-jest',
-  testEnvironment: 'node',
-  testRunner: 'jest-circus/runner'
+  testEnvironment: 'jsdom',
+  testRunner: 'jest-circus/runner',
+  moduleNameMapper: {
+    Icons: '<rootDir>/../lib-icons/free-icons',
+    '\\.css$': '<rootDir>/utils/mocks/styleMock.js',
+    '\\.svg$': '<rootDir>/utils/mocks/fileMock.js',
+    '@evaka/customizations/(.*)': '<rootDir>/../lib-customizations/espoo/$1'
+  }
 }
 export default config

--- a/frontend/src/citizen-frontend/utils/mocks/fileMock.js
+++ b/frontend/src/citizen-frontend/utils/mocks/fileMock.js
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+module.exports = 'filename'

--- a/frontend/src/citizen-frontend/utils/mocks/styleMock.js
+++ b/frontend/src/citizen-frontend/utils/mocks/styleMock.js
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+module.exports = {}

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -12,7 +12,7 @@ import { Checkbox, Element, Page, Select, TextInput } from '../../utils/page'
 export type FormatterReservation = {
   startTime: string
   endTime: string
-  isOverdraft: boolean
+  isOverdraft?: boolean
 }
 export type TwoPartReservation = [FormatterReservation, FormatterReservation]
 
@@ -551,10 +551,19 @@ class DayView extends Element {
       .waitUntilVisible()
   }
 
-  async assertReservations(childId: UUID, value: string) {
-    await this.#childSection(childId)
-      .findByDataQa('reservations')
-      .assertTextEquals(value)
+  async assertReservations(
+    childId: UUID,
+    reservations: FormatterReservation[],
+    formatter: (res: FormatterReservation) => string = (
+      r: FormatterReservation
+    ) => `${r.startTime} – ${r.endTime}`
+  ) {
+    const child = this.#childSection(childId)
+    for (const [i, res] of reservations.entries()) {
+      await child
+        .findByDataQa(`reservation-output-${i}`)
+        .assertTextEquals(formatter(res))
+    }
   }
 
   async assertAbsence(childId: UUID, value: string) {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -254,17 +254,26 @@ describe.each(e)('Citizen attendance reservations (%s)', (env) => {
 
     const dayView = await calendarPage.openDayView(reservationDay)
 
+    const reservation1 = {
+      startTime: '08:00',
+      endTime: '16:00'
+    }
+
     expect(children.length).toEqual(3)
     await dayView.assertNoReservation(children[0].id)
     await dayView.assertNoReservation(children[1].id)
     await dayView.assertNoReservation(children[2].id)
 
     const editor = await dayView.edit()
-    await editor.fillReservationTimes(children[1].id, '08:00', '16:00')
+    await editor.fillReservationTimes(
+      children[1].id,
+      reservation1.startTime,
+      reservation1.endTime
+    )
     await editor.save()
 
     await dayView.assertNoReservation(children[0].id)
-    await dayView.assertReservations(children[1].id, '08:00 – 16:00')
+    await dayView.assertReservations(children[1].id, [reservation1])
     await dayView.assertNoReservation(children[2].id)
   })
 
@@ -745,10 +754,9 @@ describe.each(e)('Citizen calendar shift care reservations', (env) => {
     )
     await editor.save()
 
-    await dayView.assertReservations(
-      fixtures.enduserChildFixtureKaarina.id,
-      `${reservation1.startTime} – ${reservation1.endTime}`
-    )
+    await dayView.assertReservations(fixtures.enduserChildFixtureKaarina.id, [
+      reservation1
+    ])
 
     const editor2 = await dayView.edit()
     await editor2.addSecondReservation(
@@ -758,10 +766,10 @@ describe.each(e)('Citizen calendar shift care reservations', (env) => {
     )
     await editor2.save()
 
-    await dayView.assertReservations(
-      fixtures.enduserChildFixtureKaarina.id,
-      `${reservation1.startTime} – ${reservation1.endTime}, ${reservation2.startTime} – ${reservation2.endTime}`
-    )
+    await dayView.assertReservations(fixtures.enduserChildFixtureKaarina.id, [
+      reservation1,
+      reservation2
+    ])
   })
 
   test(`Citizen creates 2 reservations from reservation modal: ${env}`, async () => {
@@ -797,9 +805,9 @@ describe.each(e)('Citizen calendar shift care reservations', (env) => {
 
     const dayView = await calendarPage.openDayView(reservationDay)
 
-    await dayView.assertReservations(
-      fixtures.enduserChildFixtureKaarina.id,
-      `${reservation1.startTime} – ${reservation1.endTime}, ${reservation2.startTime} – ${reservation2.endTime}`
-    )
+    await dayView.assertReservations(fixtures.enduserChildFixtureKaarina.id, [
+      reservation1,
+      reservation2
+    ])
   })
 })

--- a/frontend/src/e2e-test/specs/0_citizen/feature-flag-citizen-reservations-intermittent-shif-care.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/feature-flag-citizen-reservations-intermittent-shif-care.spec.ts
@@ -13,6 +13,7 @@ import { initializeAreaAndPersonData } from '../../dev-api/data-init'
 import { Fixture, careAreaFixture } from '../../dev-api/fixtures'
 import { PersonDetail } from '../../dev-api/types'
 import CitizenCalendarPage, {
+  FormatterReservation,
   StartAndEndTimeReservation,
   TwoPartReservation
 } from '../../pages/citizen/citizen-calendar'
@@ -212,7 +213,8 @@ describe.each(e)(
 
       await dayView.assertReservations(
         child.id,
-        getTwoPartReservationOutput([reservation1, reservation2], ' – ')
+        [reservation1, reservation2],
+        getFormatterReservationOutput
       )
     })
   }
@@ -326,6 +328,11 @@ const addTestData = async (date: LocalDate) => {
 
 const getReservationOverdraftOutput = (res: StartAndEndTimeReservation) =>
   `${res.startTime}–${res.endTime} Ilta-/vuorohoito`
+
+const getFormatterReservationOutput = (res: FormatterReservation) =>
+  res.isOverdraft
+    ? `${res.startTime} – ${res.endTime} Ilta-/vuorohoito`
+    : `${res.startTime} – ${res.endTime}`
 
 const getTwoPartReservationOutput = (
   reservations: TwoPartReservation,

--- a/frontend/src/e2e-test/specs/0_citizen/feature-flag-citizen-reservations-intermittent-shif-care.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/feature-flag-citizen-reservations-intermittent-shif-care.spec.ts
@@ -1,0 +1,341 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import FiniteDateRange from 'lib-common/finite-date-range'
+import { TimeRange } from 'lib-common/generated/api-types/shared'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
+
+import { resetDatabase } from '../../dev-api'
+import { initializeAreaAndPersonData } from '../../dev-api/data-init'
+import { Fixture, careAreaFixture } from '../../dev-api/fixtures'
+import { PersonDetail } from '../../dev-api/types'
+import CitizenCalendarPage, {
+  StartAndEndTimeReservation,
+  TwoPartReservation
+} from '../../pages/citizen/citizen-calendar'
+import CitizenHeader, { EnvType } from '../../pages/citizen/citizen-header'
+import { Page } from '../../utils/page'
+import { enduserLogin } from '../../utils/user'
+
+const e: EnvType[] = ['desktop', 'mobile']
+const june7th2023 = LocalDate.of(2023, 6, 7)
+
+describe.each(e)(
+  'Citizen reservations with intermittent shift care (%s)',
+  (env) => {
+    beforeEach(resetDatabase)
+
+    test('Citizen creates a repeating reservation outside placement unit times', async () => {
+      const { child, parent } = await addTestData(june7th2023)
+      const calendarPage = await openCalendarPage(
+        june7th2023.toHelsinkiDateTime(LocalTime.of(8, 0)),
+        env,
+        parent
+      )
+
+      const firstReservationDay = june7th2023.addDays(14).addDays(1) //Thursday
+
+      const reservation = {
+        startTime: '08:00',
+        endTime: '22:00',
+        childIds: [child.id]
+      }
+
+      const reservationsModal = await calendarPage.openReservationsModal()
+      await reservationsModal.createRepeatingDailyReservation(
+        new FiniteDateRange(
+          firstReservationDay,
+          firstReservationDay.addDays(6)
+        ),
+        reservation.startTime,
+        reservation.endTime
+      )
+
+      await calendarPage.assertReservations(
+        firstReservationDay,
+        [reservation],
+        getReservationOverdraftOutput
+      )
+    })
+
+    test('Citizen creates a repeating reservation on a bank holiday', async () => {
+      const firstReservationDay = june7th2023.addDays(14).addDays(2) //Friday, holiday
+
+      await Fixture.holiday()
+        .with({ date: firstReservationDay, description: 'Test holiday 1' })
+        .save()
+
+      const { child, parent } = await addTestData(june7th2023)
+      const calendarPage = await openCalendarPage(
+        june7th2023.toHelsinkiDateTime(LocalTime.of(8, 0)),
+        env,
+        parent
+      )
+
+      const reservation = {
+        startTime: '08:00',
+        endTime: '16:00',
+        childIds: [child.id]
+      }
+
+      const reservationsModal = await calendarPage.openReservationsModal()
+      await reservationsModal.createRepeatingDailyReservation(
+        new FiniteDateRange(firstReservationDay, firstReservationDay),
+        reservation.startTime,
+        reservation.endTime
+      )
+
+      await calendarPage.assertReservations(
+        firstReservationDay,
+        [reservation],
+        getReservationOverdraftOutput
+      )
+    })
+
+    test('Citizen creates a repeating reservation for a weekend', async () => {
+      const { child, parent } = await addTestData(june7th2023)
+      const calendarPage = await openCalendarPage(
+        june7th2023.toHelsinkiDateTime(LocalTime.of(8, 0)),
+        env,
+        parent
+      )
+
+      const firstReservationDay = june7th2023.addDays(14).addDays(3) //Sunday, weekend
+
+      const reservation = {
+        startTime: '08:00',
+        endTime: '16:00',
+        childIds: [child.id]
+      }
+
+      const reservationsModal = await calendarPage.openReservationsModal()
+      await reservationsModal.createRepeatingDailyReservation(
+        new FiniteDateRange(firstReservationDay, firstReservationDay),
+        reservation.startTime,
+        reservation.endTime
+      )
+
+      await calendarPage.assertReservations(
+        firstReservationDay,
+        [reservation],
+        getReservationOverdraftOutput
+      )
+    })
+
+    test('Citizen creates a repeating 2-part reservation outside placement unit times', async () => {
+      const { child, parent } = await addTestData(june7th2023)
+      const calendarPage = await openCalendarPage(
+        june7th2023.toHelsinkiDateTime(LocalTime.of(8, 0)),
+        env,
+        parent
+      )
+
+      const firstReservationDay = june7th2023.addDays(14).addDays(1) //Thursday
+
+      const reservation1 = {
+        startTime: '08:00',
+        endTime: '16:00',
+        isOverdraft: false
+      }
+
+      const reservation2 = {
+        startTime: '18:00',
+        endTime: '22:00',
+        isOverdraft: true
+      }
+
+      const reservationsModal = await calendarPage.openReservationsModal()
+
+      await reservationsModal.fillDailyReservationInfo(
+        new FiniteDateRange(firstReservationDay, firstReservationDay),
+        reservation1.startTime,
+        reservation1.endTime,
+        [child.id]
+      )
+
+      await reservationsModal.fillDaily2ndReservationInfo(
+        reservation2.startTime,
+        reservation2.endTime
+      )
+
+      await reservationsModal.save()
+
+      await calendarPage.assertTwoPartReservationFromDayCellGroup(
+        firstReservationDay,
+        [reservation1, reservation2],
+        child.id,
+        getTwoPartReservationOutput
+      )
+    })
+
+    test('Citizen creates a day view 2-part reservation outside placement unit times', async () => {
+      const { child, parent } = await addTestData(june7th2023)
+      const calendarPage = await openCalendarPage(
+        june7th2023.toHelsinkiDateTime(LocalTime.of(8, 0)),
+        env,
+        parent
+      )
+
+      const reservation1 = {
+        startTime: '05:00',
+        endTime: '10:00',
+        isOverdraft: true
+      }
+
+      const reservation2 = {
+        startTime: '10:00',
+        endTime: '16:00',
+        isOverdraft: false
+      }
+
+      const firstReservationDay = june7th2023.addDays(14).addDays(1) //Thursday
+
+      const dayView = await calendarPage.openDayView(firstReservationDay)
+
+      await dayView.assertNoReservation(child.id)
+
+      const editor = await dayView.edit()
+      await editor.fillReservationTimes(
+        child.id,
+        reservation1.startTime,
+        reservation1.endTime
+      )
+      await editor.addSecondReservation(
+        child.id,
+        reservation2.startTime,
+        reservation2.endTime
+      )
+      await editor.save()
+
+      await dayView.assertReservations(
+        child.id,
+        getTwoPartReservationOutput([reservation1, reservation2], ' – ')
+      )
+    })
+  }
+)
+
+async function openCalendarPage(
+  time: HelsinkiDateTime,
+  env: EnvType,
+  endUser?: PersonDetail
+) {
+  const viewport =
+    env === 'mobile'
+      ? { width: 375, height: 812 }
+      : { width: 1920, height: 1080 }
+
+  const page = await Page.open({
+    viewport,
+    screen: viewport,
+    mockedTime: time.toSystemTzDate(),
+    citizenCustomizations: {
+      featureFlags: {
+        experimental: {
+          intermittentShiftCare: true
+        }
+      }
+    }
+  })
+  await enduserLogin(page, endUser?.ssn)
+  const header = new CitizenHeader(page, env)
+  await header.selectTab('calendar')
+  return new CitizenCalendarPage(page, env)
+}
+
+const addTestData = async (date: LocalDate) => {
+  const bulkFixtures = await initializeAreaAndPersonData()
+  const operationTime: TimeRange = {
+    start: LocalTime.of(8, 0),
+    end: LocalTime.of(18, 0)
+  }
+
+  const unit = await Fixture.daycare()
+    .with({
+      name: '10h/5d',
+      areaId: bulkFixtures.careAreaFixture.id,
+      type: ['CENTRE'],
+      providerType: 'MUNICIPAL',
+      operationDays: [1, 2, 3, 4, 5],
+      operationTimes: [
+        operationTime,
+        operationTime,
+        operationTime,
+        operationTime,
+        operationTime,
+        null,
+        null
+      ],
+      roundTheClock: false,
+      enabledPilotFeatures: ['RESERVATIONS']
+    })
+    .save()
+  const group = await Fixture.daycareGroup()
+    .with({ daycareId: unit.data.id })
+    .save()
+
+  const child = bulkFixtures.enduserChildFixtureJari
+  const parent = bulkFixtures.enduserGuardianFixture
+
+  const unitSupervisor = await Fixture.employeeUnitSupervisor(
+    unit.data.id
+  ).save()
+
+  const placement = await Fixture.placement()
+    .with({
+      type: 'DAYCARE',
+      childId: child.id,
+      unitId: unit.data.id,
+      startDate: date,
+      endDate: date.addDays(30)
+    })
+    .save()
+  const serviceNeedOption = await Fixture.serviceNeedOption()
+    .with({ validPlacementType: 'DAYCARE' })
+    .save()
+  await Fixture.serviceNeed()
+    .with({
+      placementId: placement.data.id,
+      startDate: placement.data.startDate,
+      endDate: placement.data.endDate,
+      optionId: serviceNeedOption.data.id,
+      shiftCare: 'INTERMITTENT',
+      confirmedBy: unitSupervisor.data.id,
+      confirmedAt: date
+    })
+    .save()
+  await Fixture.groupPlacement()
+    .with({
+      daycareGroupId: group.data.id,
+      daycarePlacementId: placement.data.id,
+      startDate: placement.data.startDate,
+      endDate: placement.data.endDate
+    })
+    .save()
+
+  return {
+    areaId: careAreaFixture.id,
+    parent,
+    unitId: unit.data.id,
+    child
+  }
+}
+
+const getReservationOverdraftOutput = (res: StartAndEndTimeReservation) =>
+  `${res.startTime}–${res.endTime} Ilta-/vuorohoito`
+
+const getTwoPartReservationOutput = (
+  reservations: TwoPartReservation,
+  separatorString = '–'
+) =>
+  reservations
+    .map(
+      (r) =>
+        `${r.startTime}${separatorString}${r.endTime}${
+          r.isOverdraft ? ' Ilta-/vuorohoito' : ''
+        }`
+    )
+    .join(', ')

--- a/frontend/src/lib-common/form/fields.ts
+++ b/frontend/src/lib-common/form/fields.ts
@@ -91,10 +91,7 @@ export const localTimeWithUnitTimes = transformed(
     if (parsed === undefined) {
       return ValidationError.of('timeFormat')
     } else if (
-      !v.unitStartTime ||
-      !v.unitEndTime ||
-      parsed.isBefore(v.unitStartTime) ||
-      parsed.isAfter(v.unitEndTime)
+      !isValidAgainstUnitTime(parsed, v.unitStartTime, v.unitEndTime)
     ) {
       return ValidationError.of('outsideUnitOperationTime')
     }
@@ -171,3 +168,16 @@ export const localTimeRange = transformed(
 )
 
 const midnight = LocalTime.of(0, 0)
+
+export function isValidAgainstUnitTime(
+  inputTime: LocalTime,
+  unitStartTime: LocalTime | null,
+  unitEndTime: LocalTime | null
+) {
+  return (
+    unitStartTime &&
+    unitEndTime &&
+    !inputTime.isBefore(unitStartTime) &&
+    !inputTime.isAfter(unitEndTime)
+  )
+}

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -10,6 +10,7 @@ import LocalDate from '../../local-date'
 import LocalTime from '../../local-time'
 import { AbsenceType } from './daycare'
 import { PlacementType } from './placement'
+import { ShiftCareType } from './serviceneed'
 import { TimeRange } from './shared'
 import { UUID } from '../../types'
 
@@ -141,6 +142,7 @@ export interface ReservationResponseDayChild {
   requiresReservation: boolean
   reservations: Reservation[]
   shiftCare: boolean
+  shiftCareType: ShiftCareType
   unitOperationTime: TimeRange | null
 }
 
@@ -150,6 +152,5 @@ export interface ReservationResponseDayChild {
 export interface ReservationsResponse {
   children: ReservationChild[]
   days: ReservationResponseDay[]
-  includesWeekends: boolean
   reservableRange: FiniteDateRange
 }

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -305,6 +305,7 @@ const en: Translations = {
     absenceMarkedByEmployee: 'Absence marked by staff',
     contactStaffToEditAbsence:
       'Contact staff if you want to change the absence',
+    intermittentShiftCareNotification: 'Shift care',
     newReservationOrAbsence: 'Attendance / Absence',
     newHoliday: 'Holiday questionnaire',
     newAbsence: 'Register absence',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -302,6 +302,7 @@ export default {
     absenceMarkedByEmployee: 'Henkilökunnan merkitsemä poissaolo',
     contactStaffToEditAbsence:
       'Jos haluat muuttaa poissaoloa, ota yhteyttä henkilökuntaan.',
+    intermittentShiftCareNotification: 'Ilta-/vuorohoito',
     newReservationOrAbsence: 'Läsnäolo / Poissaolo',
     newHoliday: 'Vastaa poissaolokyselyyn',
     newAbsence: 'Ilmoita poissaolo',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -302,6 +302,7 @@ const sv: Translations = {
     },
     absenceMarkedByEmployee: 'Frånvaro markerad av personal',
     contactStaffToEditAbsence: 'Kontakta personalen om du vill ändra frånvaron',
+    intermittentShiftCareNotification: 'Kvälls-/skiftvård',
     newReservationOrAbsence: 'Närvaro / Frånvaro',
     newHoliday: 'Besvara frånvaroenkäten',
     newAbsence: 'Anmäl frånvaro',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -129,7 +129,6 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                         LocalDate.of(2021, 11, 8), // Next week's monday
                         LocalDate.of(2022, 8, 31),
                     ),
-                includesWeekends = false,
                 children =
                     // Sorted by date of birth, oldest child first
                     listOf(
@@ -163,8 +162,12 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                     ),
                 days =
                     listOf(
-                        // sunday is not included because it's not a weekday
-
+                        // sunday without children is included because weekends are always visible
+                        ReservationResponseDay(
+                            date = sunday,
+                            holiday = false,
+                            children = emptyList()
+                        ),
                         ReservationResponseDay(
                             date = monday,
                             holiday = false,
@@ -256,7 +259,6 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                         LocalDate.of(2021, 11, 8), // Next week's monday
                         LocalDate.of(2022, 8, 31),
                     ),
-                includesWeekends = true,
                 children =
                     // Sorted by date of birth, oldest child first
                     listOf(
@@ -382,7 +384,6 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                         LocalDate.of(2021, 11, 8), // Next week's monday
                         LocalDate.of(2022, 8, 31),
                     ),
-                includesWeekends = false,
                 children =
                     // Sorted by date of birth, oldest child first
                     listOf(
@@ -783,11 +784,13 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
         absence: AbsenceInfo? = null,
         reservations: List<Reservation> = emptyList(),
         attendances: List<OpenTimeRange> = emptyList(),
+        shiftCareType: ShiftCareType = ShiftCareType.NONE
     ) =
         ReservationResponseDayChild(
             childId,
             requiresReservation,
             shiftCare,
+            shiftCareType,
             contractDays,
             absence,
             reservations,

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -320,7 +320,7 @@ data class ReservationResponseDay(
 data class ReservationResponseDayChild(
     val childId: ChildId,
     val requiresReservation: Boolean, // Whether reservations are required
-    val shiftCare: Boolean, // Can make more one reservation for this day
+    val shiftCare: Boolean, // Whether child in 7-day-a-week or intermittent shift care
     val shiftCareType: ShiftCareType,
     val contractDays: Boolean,
     val absence: AbsenceInfo?,

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -290,8 +290,8 @@ private fun placementDay(
     val contractDays = contractDayRanges?.includes(date) ?: false
 
     val shiftCareType = serviceNeed?.shiftCareType ?: ShiftCareType.NONE
-    val shiftCare =
-        shiftCareType == ShiftCareType.INTERMITTENT || operationDays == setOf(1, 2, 3, 4, 5, 6, 7)
+    val alwaysOpen = operationDays == setOf(1, 2, 3, 4, 5, 6, 7)
+    val shiftCare = alwaysOpen || shiftCareType == ShiftCareType.INTERMITTENT
 
     val isOperationDay = operationDays.contains(date.dayOfWeek.value)
 
@@ -299,7 +299,7 @@ private fun placementDay(
             requiresReservation = placement.type.requiresAttendanceReservations(),
             shiftCare = shiftCare,
             contractDays = contractDays,
-            operationTime = if (isHoliday) null else operationTime,
+            operationTime = if (isHoliday && !alwaysOpen) null else operationTime,
             shiftCareType = shiftCareType
         )
         .takeIf { shiftCare || isOperationDay && !isHoliday }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.reservations
 
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.serviceneed.ShiftCareType
 import fi.espoo.evaka.shared.AbsenceId
 import fi.espoo.evaka.shared.AttendanceReservationId
 import fi.espoo.evaka.shared.ChildId
@@ -14,6 +15,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.HolidayQuestionnaireId
 import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.Timeline
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -396,32 +398,72 @@ data class ReservationPlacement(
     val range: FiniteDateRange,
     val type: PlacementType,
     val operationDays: Set<Int>,
-    val operationTimes: List<TimeRange>
+    val operationTimes: List<TimeRange>,
+    val serviceNeeds: List<ReservationServiceNeed>
 )
+
+data class ReservationServiceNeed(val range: FiniteDateRange, val shiftCareType: ShiftCareType)
+
+data class ReservationPlacementRow(
+    val childId: ChildId,
+    val placementId: PlacementId,
+    val range: FiniteDateRange,
+    val type: PlacementType,
+    val operationDays: Set<Int>,
+    val operationTimes: List<TimeRange>,
+    val serviceNeedRange: FiniteDateRange?,
+    val shiftCareType: ShiftCareType?,
+) {
+    fun toReservationServiceNeed(): ReservationServiceNeed? {
+        return if (this.serviceNeedRange == null || this.shiftCareType == null) null
+        else
+            ReservationServiceNeed(
+                range = this.serviceNeedRange,
+                shiftCareType = this.shiftCareType
+            )
+    }
+}
 
 fun Database.Read.getReservationPlacements(
     childIds: Set<ChildId>,
     range: FiniteDateRange
 ): Map<ChildId, List<ReservationPlacement>> {
-    return createQuery(
-            """
+    val sql =
+        """
 SELECT
     pl.child_id,
+    pl.id as placement_id,
     daterange(pl.start_date, pl.end_date, '[]') * :range AS range,
     pl.type,
     u.operation_days,
-    u.operation_times
+    u.operation_times,
+    sn.shift_care as shift_care_type,
+    daterange(sn.start_date, sn.end_date, '[]') * :range AS service_need_range
 FROM placement pl
+LEFT JOIN service_need sn ON sn.placement_id = pl.id
+AND daterange(sn.start_date, sn.end_date, '[]') && :range
 JOIN daycare u ON pl.unit_id = u.id
 WHERE
     pl.child_id = ANY (:childIds) AND
     daterange(pl.start_date, pl.end_date, '[]') && :range AND
     'RESERVATIONS' = ANY(u.enabled_pilot_features)
 """
-        )
+
+    return createQuery(sql)
         .bind("childIds", childIds)
         .bind("range", range)
-        .mapTo<ReservationPlacement>()
+        .mapTo<ReservationPlacementRow>()
+        .groupBy { it.placementId }
+        .map { (_, serviceNeeds) ->
+            ReservationPlacement(
+                childId = serviceNeeds[0].childId,
+                range = serviceNeeds[0].range,
+                type = serviceNeeds[0].type,
+                operationDays = serviceNeeds[0].operationDays,
+                operationTimes = serviceNeeds[0].operationTimes,
+                serviceNeeds = serviceNeeds.mapNotNull { it.toReservationServiceNeed() }.toList()
+            )
+        }
         .groupBy { it.childId }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -454,14 +454,14 @@ WHERE
         .bind("range", range)
         .mapTo<ReservationPlacementRow>()
         .groupBy { it.placementId }
-        .map { (_, serviceNeeds) ->
+        .map { (_, rows) ->
             ReservationPlacement(
-                childId = serviceNeeds[0].childId,
-                range = serviceNeeds[0].range,
-                type = serviceNeeds[0].type,
-                operationDays = serviceNeeds[0].operationDays,
-                operationTimes = serviceNeeds[0].operationTimes,
-                serviceNeeds = serviceNeeds.mapNotNull { it.toReservationServiceNeed() }.toList()
+                childId = rows[0].childId,
+                range = rows[0].range,
+                type = rows[0].type,
+                operationDays = rows[0].operationDays,
+                operationTimes = rows[0].operationTimes,
+                serviceNeeds = rows.mapNotNull { it.toReservationServiceNeed() }.toList()
             )
         }
         .groupBy { it.childId }


### PR DESCRIPTION
### Implements intermittent shift care changes for citizen frontend:
- citizens with children that have intermittent shift care service needs can now:
  - make attendance reservations without time or day restrictions
    - only holiday period days without survey answers are unavailable

#### Changes for all configurations: 
- weekends are always visible in citizen calendar
- 2-part reservations are now enabled for all children; any reservable day can now have a 2-part reservation as well
- day modal display of reservations for a child is split on separate rows

#### Feature flagged changes:
- intermittent shift care reservations are exempt of time restrictions based on unit operation hours
- those reservations that exceed unit operation hours are marked with shift care notification text

**Note! Since many of the reservability changes are on the backend, disabling the feature will require both:**
- feature flag = false
- no intermittent shift care service needs active in the system (either expired or switched to another shift care type)