### PR TITLE
Fix intermittent shift care employee week calendar overflow

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -217,9 +217,7 @@ export default React.memo(function ChildDay({
         ) : day.isInHolidayPeriod && reservation == null ? (
           // holiday period, no reservation yet
           <Tooltip
-            tooltip={
-              i18n.unit.attendanceReservations.missingHolidayReservation
-            }
+            tooltip={i18n.unit.attendanceReservations.missingHolidayReservation}
             position="top"
           >
             <ReservationTime warning data-qa="holiday-reservation-missing">

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -23,6 +23,7 @@ import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { attendanceTimeDiffers, TimeRange } from 'lib-common/reservations'
+import Tooltip from 'lib-components/atoms/Tooltip'
 import { fontWeights, Light } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import { colors } from 'lib-customizations/common'
@@ -215,9 +216,16 @@ export default React.memo(function ChildDay({
           </>
         ) : day.isInHolidayPeriod && reservation == null ? (
           // holiday period, no reservation yet
-          <ReservationTime warning data-qa="holiday-reservation-missing">
-            {i18n.unit.attendanceReservations.missingHolidayReservation}
-          </ReservationTime>
+          <Tooltip
+            tooltip={
+              i18n.unit.attendanceReservations.missingHolidayReservation
+            }
+            position="top"
+          >
+            <ReservationTime warning data-qa="holiday-reservation-missing">
+              {i18n.unit.attendanceReservations.missingHolidayReservationShort}
+            </ReservationTime>
+          </Tooltip>
         ) : serviceTimeOfDay ? (
           // daily service times
           <>

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2302,6 +2302,7 @@ export const fi = {
         }
       },
       missingHolidayReservation: 'Lomavaraus puuttuu',
+      missingHolidayReservationShort: 'Lomavar. puuttuu',
       missingServiceTime: 'Sop.aika puuttuu',
       serviceTimeIndicator: '(s)',
       legend: {


### PR DESCRIPTION
Solves the issue of expanded week calendar overflowing due to long missing holiday reservation texts for all 7 days.
