### PR TITLE
Don't allow responding to an unfinished decision as employee

### DIFF
--- a/frontend/src/employee-frontend/components/application-page/ApplicationDecisionsSection.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationDecisionsSection.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from '../../state/i18n'
 const isPending = (decision: Decision, applicationStatus: ApplicationStatus) =>
   decision.status === 'PENDING' &&
   !(
+    applicationStatus === 'WAITING_DECISION' ||
     applicationStatus === 'WAITING_MAILING' ||
     applicationStatus === 'WAITING_UNIT_CONFIRMATION'
   )


### PR DESCRIPTION
#### Summary

If application is in `WAITING_DECISION` state, the decision exists in the database, but has not "been made yet" and is not visible to the citizen. Thus, it makes no sense to be able to respond to it.
