### PR TITLE
Update the "Missing head of family" report

### DIFF
--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -63,25 +63,19 @@ export class MissingHeadOfFamilyReport {
 
   async assertRows(
     expected: {
-      areaName: string
-      unitName: string
       childName: string
-      daysWithoutHead: string
+      rangesWithoutHead: string
     }[]
   ) {
     const rows = this.page.findAllByDataQa('missing-head-of-family-row')
     await rows.assertCount(expected.length)
-    await Promise.all(
-      expected.map(async (data, index) => {
-        const row = rows.nth(index)
-        await row.findByDataQa('area-name').assertTextEquals(data.areaName)
-        await row.findByDataQa('unit-name').assertTextEquals(data.unitName)
-        await row.findByDataQa('child-name').assertTextEquals(data.childName)
-        await row
-          .findByDataQa('days-without-head')
-          .assertTextEquals(data.daysWithoutHead)
-      })
-    )
+    for (const [index, data] of expected.entries()) {
+      const row = rows.nth(index)
+      await row.findByDataQa('child-name').assertTextEquals(data.childName)
+      await row
+        .findByDataQa('ranges-without-head')
+        .assertTextEquals(data.rangesWithoutHead)
+    }
   }
 }
 

--- a/frontend/src/e2e-test/specs/5_employee/missing-head-of-family-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/missing-head-of-family-report.spec.ts
@@ -59,36 +59,28 @@ describe('Missing head of family report', () => {
     const report = await navigateToReport(page, admin.data)
     await report.assertRows([
       {
-        areaName: area.data.name,
-        unitName: unit.data.name,
         childName: `${child.data.lastName} ${child.data.firstName}`,
-        daysWithoutHead: '5'
+        rangesWithoutHead: '12.06.2023 - 16.06.2023'
       }
     ])
 
     await report.toggleShowIntentionalDuplicates()
     await report.assertRows([
       {
-        areaName: area.data.name,
-        unitName: unit.data.name,
         childName: `${child.data.lastName} ${child.data.firstName}`,
-        daysWithoutHead: '5'
+        rangesWithoutHead: '12.06.2023 - 16.06.2023'
       },
       {
-        areaName: area.data.name,
-        unitName: unit.data.name,
         childName: `${duplicate.data.lastName} ${duplicate.data.firstName}`,
-        daysWithoutHead: '3'
+        rangesWithoutHead: '12.06.2023 - 14.06.2023'
       }
     ])
 
     await report.toggleShowIntentionalDuplicates()
     await report.assertRows([
       {
-        areaName: area.data.name,
-        unitName: unit.data.name,
         childName: `${child.data.lastName} ${child.data.firstName}`,
-        daysWithoutHead: '5'
+        rangesWithoutHead: '12.06.2023 - 16.06.2023'
       }
     ])
   })

--- a/frontend/src/employee-frontend/api/reports.ts
+++ b/frontend/src/employee-frontend/api/reports.ts
@@ -134,12 +134,13 @@ export async function getPresenceReport(
 export interface MissingHeadOfFamilyReportFilters {
   startDate: LocalDate
   endDate: LocalDate | null
+  showFosterChildren: boolean
   showIntentionalDuplicates: boolean
 }
 
 export async function getMissingHeadOfFamilyReport(
   filters: MissingHeadOfFamilyReportFilters
-): Promise<Result<MissingHeadOfFamilyReportRow[]>> {
+): Promise<MissingHeadOfFamilyReportRow[]> {
   return client
     .get<JsonOf<MissingHeadOfFamilyReportRow[]>>(
       '/reports/missing-head-of-family',
@@ -151,8 +152,14 @@ export async function getMissingHeadOfFamilyReport(
         }
       }
     )
-    .then((res) => Success.of(res.data))
-    .catch((e) => Failure.fromError(e))
+    .then((res) =>
+      res.data.map((row) => ({
+        ...row,
+        rangesWithoutHead: row.rangesWithoutHead.map((range) =>
+          FiniteDateRange.parseJson(range)
+        )
+      }))
+    )
 }
 
 export interface MissingServiceNeedReportFilters {
@@ -349,6 +356,7 @@ export async function getEndedPlacementsReport(
     )
     .catch((e) => Failure.fromError(e))
 }
+
 export interface DuplicatePeopleFilters {
   showIntentionalDuplicates: boolean
 }

--- a/frontend/src/employee-frontend/components/reports/queries.ts
+++ b/frontend/src/employee-frontend/components/reports/queries.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { query } from 'lib-common/query'
+
+import {
+  getMissingHeadOfFamilyReport,
+  MissingHeadOfFamilyReportFilters
+} from '../../api/reports'
+import { createQueryKeys } from '../../query'
+
+const queryKeys = createQueryKeys('reports', {
+  missingHeadOfFamily: (filters: MissingHeadOfFamilyReportFilters) => [
+    'missingHeadOfFamily',
+    filters
+  ]
+})
+
+export const missingHeadOfFamilyReportQuery = query({
+  api: getMissingHeadOfFamilyReport,
+  queryKey: queryKeys.missingHeadOfFamily
+})

--- a/frontend/src/employee-frontend/query.ts
+++ b/frontend/src/employee-frontend/query.ts
@@ -11,6 +11,7 @@ export type QueryKeyPrefix =
   | 'childInformation'
   | 'documentTemplates'
   | 'holidayPeriods'
+  | 'reports'
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -320,13 +320,10 @@ export type ManualDuplicationReportViewMode =
 * Generated from fi.espoo.evaka.reports.MissingHeadOfFamilyReportRow
 */
 export interface MissingHeadOfFamilyReportRow {
-  careAreaName: string
   childId: UUID
-  daysWithoutHead: number
-  firstName: string | null
-  lastName: string | null
-  unitId: UUID
-  unitName: string
+  firstName: string
+  lastName: string
+  rangesWithoutHead: FiniteDateRange[]
 }
 
 /**

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3362,7 +3362,10 @@ export const fi = {
       title: 'Puuttuvat päämiehet',
       description:
         'Raportti listaa lapset, joiden nykyisen sijoituksen ajalta puuttuu tieto päämiehestä.',
-      daysWithoutHeadOfFamily: 'Puutteellisia päiviä'
+      childLastName: 'Lapsen sukunimi',
+      childFirstName: 'Lapsen etunimi',
+      showFosterChildren: 'Näytä myös sijaislapset',
+      daysWithoutHeadOfFamily: 'Puutteelliset päivät'
     },
     missingServiceNeed: {
       title: 'Puuttuvat palveluntarpeet',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReportTest.kt
@@ -4,63 +4,106 @@
 
 package fi.espoo.evaka.reports
 
-import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.DatabaseTable
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.DevFosterParent
 import fi.espoo.evaka.shared.dev.DevFridgeChild
 import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.insertFosterParent
 import fi.espoo.evaka.shared.dev.insertFridgeChild
+import fi.espoo.evaka.shared.dev.insertTestEmployee
 import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.testAdult_1
-import fi.espoo.evaka.testArea
 import fi.espoo.evaka.testChild_1
+import fi.espoo.evaka.testChild_2
 import fi.espoo.evaka.testDaycare
+import fi.espoo.evaka.testDaycare2
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 
 class MissingHeadOfFamilyReportTest : FullApplicationTest(resetDbBeforeEach = true) {
+    @Autowired
+    private lateinit var missingHeadOfFamilyReportController: MissingHeadOfFamilyReportController
 
-    val today = LocalDate.now()
+    private val today: LocalDate = LocalDate.now()
+    private val employeeId = EmployeeId(UUID.randomUUID())
+    private val user = AuthenticatedUser.Employee(employeeId, setOf(UserRole.ADMIN))
 
     @BeforeEach
     fun beforeEach() {
-        db.transaction { tx -> tx.insertGeneralTestFixtures() }
+        db.transaction { tx ->
+            tx.insertGeneralTestFixtures()
+            tx.insertTestEmployee(
+                DevEmployee(
+                    id = employeeId,
+                    firstName = "Test",
+                    lastName = "Employee",
+                    roles = setOf(UserRole.ADMIN)
+                )
+            )
+        }
     }
 
     @Test
     fun `query with no results`() {
-        getAndAssert(today, today, listOf())
+        assertEquals(listOf(), getReport(today, today))
     }
 
     @Test
-    fun `child with placement without HOF is shown`() {
-        insertPlacement(testChild_1.id, today, today)
-        getAndAssert(today, today, listOf(toReportRow(testChild_1, 1)))
+    fun `child with placement without head of family is shown`() {
+        db.transaction {
+            it.insertTestPlacement(
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                startDate = today,
+                endDate = today,
+            )
+        }
+
+        assertEquals(
+            listOf(toReportRow(testChild_1, listOf(FiniteDateRange(today, today)))),
+            getReport(today, today)
+        )
     }
 
     @Test
     fun `child with placement who is deceased is not shown`() {
         db.transaction {
+            it.insertTestPlacement(
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                startDate = today,
+                endDate = today,
+            )
             it.createUpdate("UPDATE person set date_of_death = :dod")
                 .bind("dod", today.minusDays(1))
                 .execute()
         }
-        insertPlacement(testChild_1.id, today, today)
-        getAndAssert(today, today, listOf())
+
+        assertEquals(listOf(), getReport(today, today))
     }
 
     @Test
-    fun `child with HOF for each day is not shown`() {
-        insertPlacement(testChild_1.id, today, today)
+    fun `child with head of family for each day is not shown`() {
         db.transaction {
+            it.insertTestPlacement(
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                startDate = today,
+                endDate = today,
+            )
             it.insertFridgeChild(
                 DevFridgeChild(
                     childId = testChild_1.id,
@@ -70,49 +113,174 @@ class MissingHeadOfFamilyReportTest : FullApplicationTest(resetDbBeforeEach = tr
                 )
             )
         }
-        getAndAssert(today, today, listOf())
+
+        assertEquals(listOf(), getReport(today, today))
     }
 
-    private val testUser =
-        AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
-
-    private fun getAndAssert(
-        from: LocalDate,
-        to: LocalDate,
-        expected: List<MissingHeadOfFamilyReportRow>
-    ) {
-        val (_, response, result) =
-            http
-                .get("/reports/missing-head-of-family", listOf("from" to from, "to" to to))
-                .asUser(testUser)
-                .responseObject<List<MissingHeadOfFamilyReportRow>>(jsonMapper)
-
-        assertEquals(200, response.statusCode)
-        assertEquals(expected, result.get())
-    }
-
-    private fun insertPlacement(
-        childId: ChildId,
-        startDate: LocalDate,
-        endDate: LocalDate = startDate.plusYears(1)
-    ) =
-        db.transaction { tx ->
-            tx.insertTestPlacement(
-                childId = childId,
+    @Test
+    fun `child with foster parent is shown depending on query param`() {
+        db.transaction {
+            it.insertTestPlacement(
+                childId = testChild_1.id,
                 unitId = testDaycare.id,
-                startDate = startDate,
-                endDate = endDate
+                startDate = today,
+                endDate = today,
+            )
+            it.insertFosterParent(
+                DevFosterParent(
+                    childId = testChild_1.id,
+                    parentId = testAdult_1.id,
+                    validDuring = DateRange(today, today)
+                )
             )
         }
 
-    private fun toReportRow(child: DevPerson, daysWithoutHead: Int) =
+        assertEquals(listOf(), getReport(today, today, showFosterChildren = false))
+        assertEquals(
+            listOf(toReportRow(testChild_1, listOf(FiniteDateRange(today, today)))),
+            getReport(today, today, showFosterChildren = true)
+        )
+    }
+
+    @Test
+    fun `duplicate child is shown depending on query param`() {
+        db.transaction {
+            it.createUpdate<DatabaseTable> {
+                    sql(
+                        """
+                        UPDATE person
+                        SET duplicate_of = ${bind(testChild_2.id)}
+                        WHERE id = ${bind(testChild_1.id)}
+                        """
+                    )
+                }
+                .execute()
+            it.insertTestPlacement(
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                startDate = today,
+                endDate = today,
+            )
+        }
+
+        assertEquals(listOf(), getReport(today, today, showIntentionalDuplicates = false))
+        assertEquals(
+            listOf(toReportRow(testChild_1, listOf(FiniteDateRange(today, today)))),
+            getReport(today, today, showIntentionalDuplicates = true)
+        )
+    }
+
+    @Test
+    fun `ranges without head are computed correctly`() {
+        db.transaction {
+            it.insertTestPlacement(
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                startDate = today,
+                endDate = today.plusDays(10),
+            )
+            it.insertFridgeChild(
+                DevFridgeChild(
+                    childId = testChild_1.id,
+                    headOfChild = testAdult_1.id,
+                    startDate = today.plusDays(1),
+                    endDate = today.plusDays(2),
+                )
+            )
+            it.insertFridgeChild(
+                DevFridgeChild(
+                    childId = testChild_1.id,
+                    headOfChild = testAdult_1.id,
+                    startDate = today.plusDays(5),
+                    endDate = today.plusDays(6),
+                )
+            )
+            it.insertFosterParent(
+                DevFosterParent(
+                    childId = testChild_1.id,
+                    parentId = testAdult_1.id,
+                    validDuring = DateRange(today.plusDays(8), today.plusDays(8))
+                )
+            )
+        }
+
+        assertEquals(
+            listOf(
+                toReportRow(
+                    testChild_1,
+                    listOf(
+                        FiniteDateRange(today, today),
+                        FiniteDateRange(today.plusDays(3), today.plusDays(4)),
+                        FiniteDateRange(today.plusDays(7), today.plusDays(7)),
+                        FiniteDateRange(today.plusDays(9), today.plusDays(10))
+                    )
+                ),
+            ),
+            getReport(today, today.plusDays(11), showFosterChildren = false)
+        )
+        assertEquals(
+            listOf(
+                toReportRow(
+                    testChild_1,
+                    listOf(
+                        FiniteDateRange(today, today),
+                        FiniteDateRange(today.plusDays(3), today.plusDays(4)),
+                        FiniteDateRange(today.plusDays(7), today.plusDays(10))
+                    )
+                ),
+            ),
+            getReport(today, today.plusDays(11), showFosterChildren = true)
+        )
+    }
+
+    @Test
+    fun `works with multiple children`() {
+        db.transaction {
+            it.insertTestPlacement(
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                startDate = today,
+                endDate = today,
+            )
+            it.insertTestPlacement(
+                childId = testChild_2.id,
+                unitId = testDaycare2.id,
+                startDate = today,
+                endDate = today,
+            )
+        }
+
+        assertEquals(
+            listOf(
+                    toReportRow(testChild_1, listOf(FiniteDateRange(today, today))),
+                    toReportRow(testChild_2, listOf(FiniteDateRange(today, today))),
+                )
+                .sortedWith(compareBy({ it.lastName }, { it.firstName })),
+            getReport(today, today)
+        )
+    }
+
+    private fun getReport(
+        from: LocalDate,
+        to: LocalDate?,
+        showFosterChildren: Boolean = false,
+        showIntentionalDuplicates: Boolean = false
+    ): List<MissingHeadOfFamilyReportRow> =
+        missingHeadOfFamilyReportController.getMissingHeadOfFamilyReport(
+            dbInstance(),
+            user,
+            RealEvakaClock(),
+            from,
+            to,
+            showFosterChildren = showFosterChildren,
+            showIntentionalDuplicates = showIntentionalDuplicates
+        )
+
+    private fun toReportRow(child: DevPerson, rangesWithoutHead: List<FiniteDateRange>) =
         MissingHeadOfFamilyReportRow(
             childId = child.id,
             firstName = child.firstName,
             lastName = child.lastName,
-            daysWithoutHead = daysWithoutHead,
-            careAreaName = testArea.name,
-            unitId = testDaycare.id,
-            unitName = testDaycare.name
+            rangesWithoutHead = rangesWithoutHead
         )
 }


### PR DESCRIPTION
#### Summary

- Add a filter to include/exclude foster children
- Drop area and unit columns
- Show one row per child
- For each child, list date ranges that are missing a head of family instead of showing the day count

Technical changes:
- Use react-query, `renderResult` and form framework
- The SQL query now uses multiranges to compute date ranges neatly
