### PR TITLE
Income effects NOT_AVAILABLE and INCOMPLETE are equal

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionGeneratorIntegrationTest.kt
@@ -2599,7 +2599,7 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         db.transaction {
             generator.generateNewDecisionsForAdult(
                 it,
-                RealEvakaClock(),
+                mockedNow,
                 testAdult_1.id,
                 period.start
             )
@@ -2611,19 +2611,19 @@ class FeeDecisionGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEac
         feeDecisionController.confirmDrafts(
             dbInstance(),
             AuthenticatedUser.Employee(testDecisionMaker_2.id, setOf(UserRole.ADMIN)),
-            RealEvakaClock(),
+            mockedNow,
             listOf(decisions.get(0).id),
             null
         )
 
-        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+        asyncJobRunner.runPendingJobsSync(mockedNow)
 
         db.transaction { it.createUpdate("UPDATE income SET effect = 'INCOMPLETE'").execute() }
 
         db.transaction {
             generator.generateNewDecisionsForAdult(
                 it,
-                RealEvakaClock(),
+                mockedNow,
                 testAdult_1.id,
                 incomePeriod.start
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionGeneratorIntegrationTest.kt
@@ -818,7 +818,6 @@ class VoucherValueDecisionGeneratorIntegrationTest : FullApplicationTest(resetDb
             )
     }
 
-    // TODO
     @Test
     fun `no new draft is generated if the only difference is income type change from NOT_AVAILABLE to INCOMPLETE `() {
         val period = DateRange(LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31))

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/FeeDecisions.kt
@@ -63,21 +63,6 @@ data class FeeDecision(
         }
     }
 
-    private fun incomesAreEqualOrDiffOnlyByCertainEffects(
-        i1: DecisionIncome?,
-        i2: DecisionIncome?
-    ): Boolean {
-        if (i1 == null && i2 == null) return true
-        if (i1 != null && i2 != null) {
-            if (i1.effect == IncomeEffect.NOT_AVAILABLE && i2.effect == IncomeEffect.INCOMPLETE)
-                return i1.equals(i2.copy(effect = IncomeEffect.NOT_AVAILABLE))
-            if (i1.effect == IncomeEffect.INCOMPLETE && i2.effect == IncomeEffect.NOT_AVAILABLE)
-                return i1.equals(i2.copy(effect = IncomeEffect.INCOMPLETE))
-            return i1.equals(i2)
-        }
-        return false
-    }
-
     private fun incomeEffectiveTypesAreLogicallyEqual(d1: FeeDecision, d2: FeeDecision): Boolean {
         val headOfFamilyIncomesAreEffectivelyEqual =
             incomesAreEqualOrDiffOnlyByCertainEffects(d1.headOfFamilyIncome, d2.headOfFamilyIncome)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
@@ -73,6 +73,18 @@ data class DecisionIncome(
 fun incomeTotal(data: Map<String, IncomeValue>) =
     data.entries.sumOf { (_, value) -> value.multiplier * value.monthlyAmount() }
 
+fun incomesAreEqualOrDiffOnlyByCertainEffects(i1: DecisionIncome?, i2: DecisionIncome?): Boolean {
+    if (i1 == null && i2 == null) return true
+    if (i1 != null && i2 != null) {
+        if (i1.effect == IncomeEffect.NOT_AVAILABLE && i2.effect == IncomeEffect.INCOMPLETE)
+            return i1.equals(i2.copy(effect = IncomeEffect.NOT_AVAILABLE))
+        if (i1.effect == IncomeEffect.INCOMPLETE && i2.effect == IncomeEffect.NOT_AVAILABLE)
+            return i1.equals(i2.copy(effect = IncomeEffect.INCOMPLETE))
+        return i1.equals(i2)
+    }
+    return false
+}
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class IncomeValue(val amount: Int, val coefficient: IncomeCoefficient, val multiplier: Int) {
     @JsonProperty("monthlyAmount")


### PR DESCRIPTION
If there is a SENT decision and DRAFT diffs only by income effect NOT_AVAILABLE vs INCOMPLETE, consider it equal and thus do not generate new decision

BLOCKED: Current generator modifies SENT decisions. If the decision change detection logic is changed like in this PR, this causes conflicts with existing SENT data

Waiting for the new generator which does not modify SENT decisions.

