### PR TITLE
Increase Koski pending query timeout

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/koski/KoskiUpdateService.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
+import java.time.Duration
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 
@@ -39,6 +40,7 @@ class KoskiUpdateService(
     ) {
         if (env.koskiEnabled) {
             db.transaction { tx ->
+                tx.setStatementTimeout(Duration.ofMinutes(2))
                 val requests = tx.getPendingStudyRights(env.assistanceModel, clock.today(), params)
                 logger.info { "Scheduling ${requests.size} Koski upload requests" }
                 asyncJobRunner.plan(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This query already took ~30 seconds before the recent assistance model changes, and this is an acceptable trade-off for the functionality (= diffing based on real data vs for example timestamps only).

However, the view is currently much slower since Postgres doesn't seem to optimize out the unused assistance model...this problem will probably correct itself once we get rid of the old model